### PR TITLE
Response header substitution in jetty

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -84,7 +84,9 @@ class MuzzlePlugin implements Plugin<Project> {
     def compileMuzzle = project.task('compileMuzzle')
     compileMuzzle.dependsOn(toolingProject.tasks.named("compileJava"))
     project.afterEvaluate {
-      project.tasks.matching { it.name in ['instrumentJava', 'instrumentScala', 'instrumentKotlin'] }.all {
+      project.tasks.matching {
+        it.name =~ /\Ainstrument(Main)?(_.+)?(Java|Scala|Kotlin)/
+      }.all {
         compileMuzzle.dependsOn(it)
       }
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -54,6 +54,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   public static final String DD_FIN_DISP_LIST_SPAN_ATTRIBUTE =
       "datadog.span.finish_dispatch_listener";
   public static final String DD_RESPONSE_ATTRIBUTE = "datadog.response";
+  public static final String DD_IGNORE_COMMIT_ATTRIBUTE = "datadog.commit.ignore";
 
   public static final LinkedHashMap<String, String> SERVER_PATHWAY_EDGE_TAGS;
 

--- a/dd-java-agent/instrumentation/jersey/build.gradle
+++ b/dd-java-agent/instrumentation/jersey/build.gradle
@@ -65,6 +65,7 @@ dependencies {
   jersey3JettyTestRuntimeOnly group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: jersey3Version
   jersey3JettyTestRuntimeOnly group: 'javax.activation', name: 'javax.activation-api', version: '1.2.0'
   jersey3JettyTestRuntimeOnly group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.3'
+  jersey3JettyTestRuntimeOnly project(':dd-java-agent:instrumentation:jetty-9')
   jersey3JettyTestRuntimeOnly project(':dd-java-agent:instrumentation:jetty-11')
   jersey3JettyTestRuntimeOnly project(':dd-java-agent:instrumentation:jersey-2-appsec')
   jersey3JettyTestRuntimeOnly project(':dd-java-agent:instrumentation:jersey-3-appsec')

--- a/dd-java-agent/instrumentation/jersey/src/jersey3JettyTest/groovy/datadog/trace/instrumentation/jersey3/Jersey3JettyTest.groovy
+++ b/dd-java-agent/instrumentation/jersey/src/jersey3JettyTest/groovy/datadog/trace/instrumentation/jersey3/Jersey3JettyTest.groovy
@@ -49,6 +49,11 @@ class Jersey3JettyTest extends HttpServerTest<JettyServer> {
   }
 
   @Override
+  boolean testBlockingOnResponse() {
+    true
+  }
+
+  @Override
   String testPathParam() {
     '/path/?/param'
   }

--- a/dd-java-agent/instrumentation/jetty-11/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-11/build.gradle
@@ -6,31 +6,25 @@ muzzle {
   pass {
     group = "org.eclipse.jetty"
     module = 'jetty-server'
-    versions = "[11,12)"
+    versions = "[11,)"
   }
 }
 
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
 
-// TODO latestDepTest only works on Java8 for now
-//addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('latestDepForkedTest', 'test')
 
-sourceSets {
-  "main_java11" {
-    java.srcDirs "${project.projectDir}/src/main/java11"
-  }
+tasks.withType(JavaCompile).configureEach {
+  setJavaVersion(it, 11)
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
-
-[compileMain_java11Java, compileTestJava].each {
-  it.configure {
-    setJavaVersion(it, 11)
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
+tasks.withType(GroovyCompile) {
+  javaLauncher = getJavaLauncherFor(11)
 }
-
-compileTestGroovy {
+tasks.withType(Test) {
   javaLauncher = getJavaLauncherFor(11)
 }
 
@@ -53,12 +47,16 @@ dependencies {
   }
   testImplementation(project(':dd-java-agent:instrumentation:jetty-appsec-9.3'))
   testImplementation testFixtures(project(':dd-java-agent:instrumentation:servlet:request-5'))
+  testImplementation testFixtures(project(':dd-java-agent:appsec'))
+  testRuntimeOnly project(':dd-java-agent:instrumentation:jetty-9')
+  testRuntimeOnly project(':dd-java-agent:instrumentation:servlet:request-5')
 
-  //latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '11.+'
-}
-
-jar {
-  from sourceSets.main_java11.output
+  latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '11.+',  {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
+  latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '11.+',  {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
 }
 
 idea {

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/JettyServerInstrumentation.java
@@ -1,10 +1,7 @@
 package datadog.trace.instrumentation.jetty11;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresMethod;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
-import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.google.auto.service.AutoService;
@@ -61,15 +58,7 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        takesNoArguments()
-            .and(
-                named("handle")
-                    .or(
-                        // In 9.0.3 the handle logic was extracted out to "handle"
-                        // but we still want to instrument run in case handle is missing
-                        // (without the risk of double instrumenting).
-                        named("run").and(isDeclaredBy(not(declaresMethod(named("handle"))))))),
-        packageName + ".JettyServerAdvice$HandleAdvice");
+        takesNoArguments().and(named("handle")), packageName + ".JettyServerAdvice$HandleAdvice");
     transformation.applyAdvice(
         named("recycle").and(takesNoArguments()), packageName + ".JettyServerAdvice$ResetAdvice");
   }

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyDecorator.java
@@ -73,6 +73,11 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
     return response.getStatus();
   }
 
+  @Override
+  protected boolean isAppSecOnResponseSeparate() {
+    return true;
+  }
+
   public AgentSpan onResponse(AgentSpan span, HttpChannel channel) {
     Request request = channel.getRequest();
     Response response = channel.getResponse();

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11InactiveAppSecTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11InactiveAppSecTest.groovy
@@ -1,0 +1,9 @@
+import com.datadog.appsec.AppSecInactiveHttpServerTest
+import datadog.trace.agent.test.base.HttpServer
+import datadog.trace.instrumentation.servlet5.TestServlet5
+
+class Jetty11InactiveAppSecTest extends AppSecInactiveHttpServerTest {
+  HttpServer server() {
+    new JettyServer(JettyServer.servletHandler(TestServlet5))
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
@@ -1,88 +1,38 @@
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
-import jakarta.servlet.http.HttpServletRequest
-import org.eclipse.jetty.server.Server
-import org.eclipse.jetty.server.handler.AbstractHandler
-import org.eclipse.jetty.server.handler.ErrorHandler
-import org.eclipse.jetty.servlet.ServletContextHandler
 import datadog.trace.instrumentation.servlet5.TestServlet5
+import org.eclipse.jetty.server.Handler
+import org.eclipse.jetty.server.Server
 
 abstract class Jetty11Test extends HttpServerTest<Server> {
-
-  class JettyServer implements HttpServer {
-    def port = 0
-    final server = new Server(0) // select random open port
-
-    JettyServer() {
-      server.setHandler(handler())
-      server.addBean(errorHandler)
-    }
-
-    @Override
-    void start() {
-      server.start()
-      port = server.connectors[0].localPort
-      assert port > 0
-    }
-
-    @Override
-    void stop() {
-      server.stop()
-    }
-
-    @Override
-    URI address() {
-      return new URI("http://localhost:$port/context-path/")
-    }
-
-    @Override
-    String toString() {
-      return this.class.name
-    }
-  }
-
-  static errorHandler = new ErrorHandler() {
-    @Override
-    protected void handleErrorPage(HttpServletRequest request, Writer writer, int code, String message) throws IOException {
-      Throwable th = (Throwable) request.getAttribute("jakarta.servlet.error.exception")
-      message = th ? th.message : message
-      if (message) {
-        writer.write(message)
-      }
-    }
-  }
-
   @Override
   HttpServer server() {
-    return new JettyServer()
+    new JettyServer(handler())
   }
 
-  AbstractHandler handler() {
-    ServletContextHandler handler = new ServletContextHandler(null, "/context-path")
-    handler.setErrorHandler(Jetty11Test.errorHandler)
-    handler.getServletHandler().addServletWithMapping(TestServlet5, "/*")
-    return handler
+  protected Handler handler() {
+    JettyServer.servletHandler(TestServlet5)
   }
 
   @Override
   Map<String, Serializable> expectedExtraServerTags(ServerEndpoint endpoint) {
-    return ["servlet.context": "/context-path", "servlet.path": endpoint.path]
+    ['servlet.context': '/context-path', 'servlet.path': endpoint.path]
   }
 
   @Override
   String component() {
-    return "jetty-server"
+    'jetty-server'
   }
 
   @Override
   String expectedOperationName() {
-    return operation()
+    operation()
   }
 
   @Override
   String expectedServiceName() {
-    return "context-path"
+    'context-path'
   }
 
   @Override
@@ -106,6 +56,11 @@ abstract class Jetty11Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testBodyMultipart() {
+    true
+  }
+
+  @Override
   boolean testBlocking() {
     true
   }
@@ -116,15 +71,18 @@ abstract class Jetty11Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testBlockingOnResponse() {
+    true
+  }
+
+  @Override
   boolean hasExtraErrorInformation() {
     true
   }
 }
 
 class Jetty11V0ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV0 {
-
 }
 
 class Jetty11V1ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV1 {
-
 }

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/JettyAsyncHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/JettyAsyncHandlerTest.groovy
@@ -1,0 +1,43 @@
+import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
+import jakarta.servlet.AsyncContext
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.eclipse.jetty.server.Handler
+import org.eclipse.jetty.server.Request
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+class JettyAsyncHandlerTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV0 {
+
+  @Override
+  protected Handler handler() {
+    new ContinuationTestHandler(super.handler())
+  }
+
+  static class ContinuationTestHandler implements Handler {
+    @Delegate
+    private final Handler delegate
+
+    ContinuationTestHandler(Handler delegate) {
+      this.delegate = delegate
+    }
+
+    final ExecutorService executorService = Executors.newSingleThreadExecutor()
+
+    @Override
+    void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) {
+      if (!request.getAttribute('datadog.suspended')) {
+        AsyncContext async = request.startAsync()
+        request.setAttribute('datadog.suspended', Boolean.TRUE)
+        executorService.execute {
+          async.dispatch() // no-args dispatch doesn't generate a new span
+        }
+        baseRequest.handled = true
+      } else {
+        this.delegate.handle(target, baseRequest, request, response)
+      }
+    }
+  }
+}
+

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/JettyServer.groovy
@@ -1,0 +1,75 @@
+import datadog.trace.agent.test.base.HttpServer
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.MultipartConfigElement
+import jakarta.servlet.Servlet
+import jakarta.servlet.ServletException
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import org.eclipse.jetty.server.Handler
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.handler.AbstractHandler
+import org.eclipse.jetty.server.handler.ErrorHandler
+import org.eclipse.jetty.servlet.FilterMapping
+import org.eclipse.jetty.servlet.ServletContextHandler
+
+class JettyServer implements HttpServer {
+  def port = 0
+  final server = new Server(0) // select random open port
+
+  JettyServer(Handler handler) {
+    server.handler = handler
+    server.addBean(errorHandler)
+  }
+
+  @Override
+  void start() {
+    server.start()
+    port = server.connectors[0].localPort
+    assert port > 0
+  }
+
+  @Override
+  void stop() {
+    server.stop()
+  }
+
+  @Override
+  URI address() {
+    return new URI("http://localhost:$port/context-path/")
+  }
+
+  @Override
+  String toString() {
+    return this.class.name
+  }
+
+  static AbstractHandler servletHandler(Class<? extends Servlet> servlet) {
+    ServletContextHandler handler = new ServletContextHandler(null, "/context-path")
+    handler.errorHandler = errorHandler
+    handler.servletHandler.addFilterWithMapping(EnableMultipartFilter, '/*', FilterMapping.ALL)
+    handler.servletHandler.addServletWithMapping(servlet, '/*')
+    handler
+  }
+
+  static class EnableMultipartFilter implements Filter {
+    static final MultipartConfigElement MULTIPART_CONFIG_ELEMENT = new MultipartConfigElement(System.getProperty('java.io.tmpdir'))
+    @Override
+    void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+      request.setAttribute('org.eclipse.jetty.multipartConfig', MULTIPART_CONFIG_ELEMENT)
+      chain.doFilter(request, response)
+    }
+  }
+
+  static errorHandler = new ErrorHandler() {
+    @Override
+    protected void handleErrorPage(HttpServletRequest request, Writer writer, int code, String message) throws IOException {
+      Throwable th = (Throwable) request.getAttribute("jakarta.servlet.error.exception")
+      message = th ? th.message : message
+      if (message) {
+        writer.write(message)
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,105 @@
+package datadog.trace.instrumentation.jetty70;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty70.JettyDecorator.DECORATE;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.http.Generator;
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpConnection";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ExtractAdapter",
+      packageName + ".ExtractAdapter$Request",
+      packageName + ".ExtractAdapter$Response",
+      packageName + ".JettyDecorator",
+      packageName + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("commitResponse")
+            .and(takesArguments(1))
+            .and(takesArgument(0, boolean.class))
+            .or(named("completeResponse").and(takesArguments(0))),
+        JettyCommitResponseInstrumentation.class.getName() + "$CommitResponseAdvice");
+  }
+
+  static class CommitResponseAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+    static boolean /* skip */ before(@Advice.This HttpConnection connection) {
+      Generator generator = connection.getGenerator();
+      if (generator.isCommitted()) {
+        return false;
+      }
+
+      Request req = connection.getRequest();
+
+      if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+        return false;
+      }
+
+      Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      if (!(existingSpan instanceof AgentSpan)) {
+        return false;
+      }
+      AgentSpan span = (AgentSpan) existingSpan;
+      RequestContext requestContext = span.getRequestContext();
+      if (requestContext == null) {
+        return false;
+      }
+
+      Response resp = connection.getResponse();
+
+      Flow<Void> flow =
+          DECORATE.callIGCallbackResponseAndHeaders(
+              span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+        BlockResponseFunction brf = requestContext.getBlockResponseFunction();
+        if (brf != null) {
+          boolean res =
+              brf.tryCommitBlockingResponse(
+                  rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          if (res) {
+            requestContext.getTraceSegment().effectivelyBlocked();
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyDecorator.java
@@ -72,6 +72,11 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
     return response.getStatus();
   }
 
+  @Override
+  protected boolean isAppSecOnResponseSeparate() {
+    return true;
+  }
+
   public AgentSpan onResponse(AgentSpan span, HttpConnection channel) {
     Request request = channel.getRequest();
     Response response = channel.getResponse();

--- a/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
@@ -113,6 +113,11 @@ abstract class Jetty70Test extends HttpServerTest<Server> {
     true
   }
 
+  @Override
+  boolean testBlockingOnResponse() {
+    true
+  }
+
   static class TestHandler extends AbstractHandler {
     private static final TestHandler INSTANCE = new TestHandler()
 

--- a/dd-java-agent/instrumentation/jetty-7.6/main/java/datadog/trace/instrumentation/jetty70/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/main/java/datadog/trace/instrumentation/jetty70/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,123 @@
+package datadog.trace.instrumentation.jetty70;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty70.JettyDecorator.DECORATE;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.ProductActivation;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.jetty.ConnectionHandleRequestVisitor;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.ClassWriter;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.pool.TypePool;
+import org.eclipse.jetty.http.Generator;
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpConnection";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ExtractAdapter",
+      packageName + ".ExtractAdapter$Request",
+      packageName + ".ExtractAdapter$Response",
+      packageName + ".JettyDecorator",
+      packageName + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("commitResponse").and(takesArguments(1)).and(takesArgument(0, boolean.class)).or(
+            named("completeResponse").and(takesArguments(0))
+        ),
+        JettyCommitResponseInstrumentation.class.getName() + "$CommitResponseAdvice"
+    );
+  }
+
+  static class CommitResponseAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+    static boolean /* skip */ before(@Advice.This HttpConnection connection) {
+      Generator generator = connection.getGenerator();
+      if (generator.isCommitted()) {
+        return false;
+      }
+
+      Request req = connection.getRequest();
+
+      if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+        return false;
+      }
+
+      Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      if (!(existingSpan instanceof AgentSpan)) {
+        return false;
+      }
+      AgentSpan span = (AgentSpan) existingSpan;
+      RequestContext requestContext = span.getRequestContext();
+      if (requestContext == null) {
+        return false;
+      }
+
+      Response resp = connection.getResponse();
+
+      Flow<Void> flow = DECORATE.callIGCallbackResponseAndHeaders(
+          span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+        BlockResponseFunction brf = requestContext.getBlockResponseFunction();
+        if (brf != null) {
+          boolean res = brf.tryCommitBlockingResponse(rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          if (res) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-7.6/main/java/datadog/trace/instrumentation/jetty76/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/main/java/datadog/trace/instrumentation/jetty76/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,123 @@
+package datadog.trace.instrumentation.jetty76;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty76.JettyDecorator.DECORATE;
+import static java.util.Collections.singletonMap;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.ProductActivation;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.jetty.ConnectionHandleRequestVisitor;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.ClassWriter;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.pool.TypePool;
+import org.eclipse.jetty.http.Generator;
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpConnection";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ExtractAdapter",
+      packageName + ".ExtractAdapter$Request",
+      packageName + ".ExtractAdapter$Response",
+      packageName + ".JettyDecorator",
+      packageName + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("commitResponse").and(takesArguments(1)).and(takesArgument(0, boolean.class)).or(
+            named("completeResponse").and(takesArguments(0))
+        ),
+        JettyCommitResponseInstrumentation.class.getName() + "$CommitResponseAdvice"
+    );
+  }
+
+  static class CommitResponseAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+    static boolean /* skip */ before(@Advice.This HttpConnection connection) {
+      Generator generator = connection.getGenerator();
+      if (generator.isCommitted()) {
+        return false;
+      }
+
+      Request req = connection.getRequest();
+
+      if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+        return false;
+      }
+
+      Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      if (!(existingSpan instanceof AgentSpan)) {
+        return false;
+      }
+      AgentSpan span = (AgentSpan) existingSpan;
+      RequestContext requestContext = span.getRequestContext();
+      if (requestContext == null) {
+        return false;
+      }
+
+      Response resp = connection.getResponse();
+
+      Flow<Void> flow = DECORATE.callIGCallbackResponseAndHeaders(
+          span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+        BlockResponseFunction brf = requestContext.getBlockResponseFunction();
+        if (brf != null) {
+          boolean res = brf.tryCommitBlockingResponse(rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          if (res) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,119 @@
+package datadog.trace.instrumentation.jetty76;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty76.JettyDecorator.DECORATE;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.http.Generator;
+import org.eclipse.jetty.server.AbstractHttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.AbstractHttpConnection";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ExtractAdapter",
+      packageName + ".ExtractAdapter$Request",
+      packageName + ".ExtractAdapter$Response",
+      packageName + ".JettyDecorator",
+      packageName + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {
+      new Reference.Builder("org.eclipse.jetty.server.AbstractHttpConnection")
+          .withMethod(new String[0], Reference.EXPECTS_NON_STATIC, "commitResponse", "V", "Z")
+          .withMethod(new String[0], Reference.EXPECTS_NON_STATIC, "completeResponse", "V")
+          .build(),
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("commitResponse")
+            .and(takesArguments(1))
+            .and(takesArgument(0, boolean.class))
+            .or(named("completeResponse").and(takesArguments(0))),
+        JettyCommitResponseInstrumentation.class.getName() + "$CommitResponseAdvice");
+  }
+
+  static class CommitResponseAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+    static boolean /* skip */ before(@Advice.This AbstractHttpConnection connection) {
+      Generator generator = connection.getGenerator();
+      if (generator.isCommitted()) {
+        return false;
+      }
+
+      Request req = connection.getRequest();
+
+      if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+        return false;
+      }
+
+      Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      if (!(existingSpan instanceof AgentSpan)) {
+        return false;
+      }
+      AgentSpan span = (AgentSpan) existingSpan;
+      RequestContext requestContext = span.getRequestContext();
+      if (requestContext == null) {
+        return false;
+      }
+
+      Response resp = connection.getResponse();
+      if (resp.getStatus() == 100) {
+        return false;
+      }
+
+      Flow<Void> flow =
+          DECORATE.callIGCallbackResponseAndHeaders(
+              span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+        BlockResponseFunction brf = requestContext.getBlockResponseFunction();
+        if (brf != null) {
+          boolean res =
+              brf.tryCommitBlockingResponse(
+                  rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          if (res) {
+            requestContext.getTraceSegment().effectivelyBlocked();
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyDecorator.java
@@ -72,6 +72,11 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
     return response.getStatus();
   }
 
+  @Override
+  protected boolean isAppSecOnResponseSeparate() {
+    return true;
+  }
+
   public AgentSpan onResponse(AgentSpan span, AbstractHttpConnection connection) {
     Request request = connection.getRequest();
     Response response = connection.getResponse();

--- a/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
@@ -113,6 +113,11 @@ abstract class Jetty76Test extends HttpServerTest<Server> {
     true
   }
 
+  @Override
+  boolean testBlockingOnResponse() {
+    true
+  }
+
   static class TestHandler extends AbstractHandler {
     private static final TestHandler INSTANCE = new TestHandler()
 

--- a/dd-java-agent/instrumentation/jetty-9/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-9/build.gradle
@@ -1,21 +1,156 @@
 muzzle {
   pass {
+    name = '9_full_series'
     group = "org.eclipse.jetty"
     module = 'jetty-server'
     versions = "[9,10)"
     assertInverse = true
   }
+  pass {
+    name = 'before_904'
+    group = "org.eclipse.jetty"
+    module = 'jetty-server'
+    versions = "[9,9.0.4)"
+    assertInverse = true
+  }
+  pass {
+    name = 'between_904_and_930'
+    group = "org.eclipse.jetty"
+    module = 'jetty-server'
+    versions = "[9.0.4,9.3.0.M1)"
+    assertInverse = true
+  }
+  pass {
+    name = 'between_930_and_9421'
+    group = "org.eclipse.jetty"
+    module = 'jetty-server'
+    versions = "[9.3.0.M1,9.4.21)"
+    assertInverse = true
+  }
+  pass {
+    name = 'between_9421_and_10'
+    group = "org.eclipse.jetty"
+    module = 'jetty-server'
+    versions = "[9.4.21,10)"
+    assertInverse = true
+  }
+  pass {
+    name = '10_series'
+    group = "org.eclipse.jetty"
+    module = 'jetty-server'
+    versions = "[10,11)"
+    assertInverse = true
+    javaVersion = 11
+  }
+  pass {
+    name = 'after_10'
+    group = "org.eclipse.jetty"
+    module = 'jetty-server'
+    versions = "[10,)"
+    assertInverse = true
+    javaVersion = 11
+  }
 }
 
 apply from: "$rootDir/gradle/java.gradle"
 
+sourceSets {
+  main_jetty904 {
+    java.srcDirs "${project.projectDir}/src/main/java_jetty904"
+  }
+  main_jetty93 {
+    java.srcDirs "${project.projectDir}/src/main/java_jetty93"
+  }
+  main_jetty9421 {
+    java.srcDirs "${project.projectDir}/src/main/java_jetty9421"
+  }
+  main_jetty10 {
+    java.srcDirs "${project.projectDir}/src/main/java_jetty10"
+  }
+}
+
+jar {
+  from sourceSets.main_jetty904.output
+  from sourceSets.main_jetty93.output
+  from sourceSets.main_jetty9421.output
+  from sourceSets.main_jetty10.output
+}
+
+List<DirectoryProperty> extraInstrumentJavaDirs = []
+['main_jetty904', 'main_jetty93', 'main_jetty9421', 'main_jetty10'].each {
+  JavaCompile compileTask = tasks["compile${it.capitalize()}Java"]
+  extraInstrumentJavaDirs << compileTask.destinationDirectory
+  compileTask.dependsOn tasks['compileJava']
+  project.afterEvaluate { p ->
+    tasks['instrumentJava'].dependsOn compileTask
+    tasks["forbiddenApis${it.capitalize()}"].dependsOn("instrument${it.capitalize()}Java")
+  }
+}
+
+instrument {
+  // the instrumenters are in main, but helpers/advice in possibly other sourceSets
+  // The muzzle generator of references run as part of InstrumentJava needs access to
+  // these extra classes. The task dependencies for instrumentJava are added above
+  additionalClasspath = [
+    instrumentJava: extraInstrumentJavaDirs
+  ]
+}
+
+tasks['compileMain_jetty10Java'].configure {
+  setJavaVersion(it, 11)
+}
+
 addTestSuiteForDir('jetty92ForkedTest', 'test')
 addTestSuiteForDir('jetty94ForkedTest', 'test')
+addTestSuiteForDir('latestDepJetty9ForkedTest', 'test')
 addTestSuiteForDir('latestDepForkedTest', 'test')
+
+tasks.named("latestDepForkedTest").configure {
+  javaLauncher = getJavaLauncherFor(11)
+}
+tasks.named("compileLatestDepForkedTestGroovy").configure {
+  setJavaVersion(it, 11)
+}
 
 dependencies {
   compileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.0.0.v20130308'
   implementation project(':dd-java-agent:instrumentation:jetty-common')
+
+  main_jetty904CompileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.0.4.v20130625'
+  main_jetty904CompileOnly project(':internal-api')
+  main_jetty904CompileOnly project(':dd-java-agent:agent-tooling')
+  main_jetty904CompileOnly project(':dd-java-agent:agent-bootstrap')
+  // not pretty, but we can't depend on sourceSets.main.output;
+  // that would make a dependency on the classes task due to the
+  // intermediation of the InstrumentPlugin, creating a circular
+  // dependency (the instrument plugin needs all the sourceSets
+  // compiled to properly generate References)
+  main_jetty904CompileOnly files("$project.buildDir/classes/java/raw")
+
+  main_jetty93CompileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.3.0.v20150612'
+  main_jetty93CompileOnly project(':internal-api')
+  main_jetty93CompileOnly project(':dd-java-agent:agent-tooling')
+  main_jetty93CompileOnly project(':dd-java-agent:agent-bootstrap')
+  main_jetty93CompileOnly files("$project.buildDir/classes/java/raw") {
+    builtBy = ['compileJava']
+  }
+
+  main_jetty9421CompileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.4.21.v20190926'
+  main_jetty9421CompileOnly project(':internal-api')
+  main_jetty9421CompileOnly project(':dd-java-agent:agent-tooling')
+  main_jetty9421CompileOnly project(':dd-java-agent:agent-bootstrap')
+  main_jetty9421CompileOnly files("$project.buildDir/classes/java/raw") {
+    builtBy = ['compileJava']
+  }
+
+  main_jetty10CompileOnly group: 'org.eclipse.jetty', name: 'jetty-server', version: '10.0.0'
+  main_jetty10CompileOnly project(':internal-api')
+  main_jetty10CompileOnly project(':dd-java-agent:agent-tooling')
+  main_jetty10CompileOnly project(':dd-java-agent:agent-bootstrap')
+  main_jetty10Implementation project(':dd-java-agent:instrumentation:jetty-common')
+  main_jetty10CompileOnly files("$project.buildDir/classes/java/raw") {
+    builtBy = ['compileJava']
+  }
 
   // Don't want to conflict with jetty from the test server.
   testImplementation(project(':dd-java-agent:testing')) {
@@ -43,12 +178,19 @@ dependencies {
   jetty94TestImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.4.15.v20190215'
   jetty94TestImplementation group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '9.4.15.v20190215'
   jetty94TestImplementation project(':dd-java-agent:instrumentation:jetty-appsec-9.3')
-  jetty92TestImplementation testFixtures(project(':dd-java-agent:instrumentation:servlet:request-3'))
+  jetty94TestImplementation testFixtures(project(':dd-java-agent:instrumentation:servlet:request-3'))
 
-  // Jetty 10.0 was not compiled for java 8.
-  latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.+'
-  latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.+'
-  latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '9.+'
+  latestDepJetty9TestImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.+'
+  latestDepJetty9TestImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '9.+'
+  latestDepJetty9TestImplementation group: 'org.eclipse.jetty', name: 'jetty-continuation', version: '9.+'
+  latestDepJetty9TestImplementation project(':dd-java-agent:instrumentation:jetty-appsec-9.3')
+  latestDepJetty9TestImplementation testFixtures(project(':dd-java-agent:instrumentation:servlet:request-3'))
+
+  latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-server', version: '10.+'
+  latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '10.+'
   latestDepTestImplementation project(':dd-java-agent:instrumentation:jetty-appsec-9.3')
   latestDepTestImplementation testFixtures(project(':dd-java-agent:instrumentation:servlet:request-3'))
+}
+configurations.getByName('latestDepForkedTestRuntimeClasspath').resolutionStrategy {
+  force "org.slf4j:slf4j-api:${versions.slf4j}"
 }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,100 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "after_10";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {
+      new Reference.Builder("org.eclipse.jetty.server.HttpChannel")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "sendResponse",
+              "Z",
+              "Lorg/eclipse/jetty/http/MetaData$Response;",
+              "Ljava/nio/ByteBuffer;",
+              "Z",
+              "Lorg/eclipse/jetty/util/Callback;")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "commit",
+              "V",
+              "Lorg/eclipse/jetty/http/MetaData$Response;")
+          .withField(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "_transport",
+              "Lorg/eclipse/jetty/server/HttpTransport;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.server.Response")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "newResponseMetaData",
+              "Lorg/eclipse/jetty/http/MetaData$Response;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.http.HttpFields$Mutable")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "put",
+              "Lorg/eclipse/jetty/http/HttpFields$Mutable;",
+              "Ljava/lang/String;",
+              "Ljava/lang/String;")
+          .build()
+    };
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpChannel";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ExtractAdapter",
+      packageName + ".ExtractAdapter$Request",
+      packageName + ".ExtractAdapter$Response",
+      packageName + ".JettyDecorator",
+      "datadog.trace.instrumentation.jetty9.RequestURIDataAdapter",
+      packageName + ".JettyCommitResponseHelper",
+      packageName + ".JettyOnCommitBlockingHelper",
+      packageName + ".JettyOnCommitBlockingHelper$CloseCallback",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("sendResponse")
+            .and(takesArguments(4))
+            .and(takesArgument(0, named("org.eclipse.jetty.http.MetaData$Response")))
+            .and(takesArgument(1, named("java.nio.ByteBuffer")))
+            .and(takesArgument(2, boolean.class))
+            .and(takesArgument(3, named("org.eclipse.jetty.util.Callback"))),
+        packageName + ".SendResponseCbAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/JettyServerInstrumentation.java
@@ -1,0 +1,148 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.ExcludeFilterProvider;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.Config;
+import datadog.trace.api.ProductActivation;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import datadog.trace.instrumentation.jetty9.HttpChannelHandleVisitor;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.ClassWriter;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.pool.TypePool;
+
+@AutoService(Instrumenter.class)
+public final class JettyServerInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType, ExcludeFilterProvider {
+
+  private boolean appSecNotFullyDisabled;
+
+  public JettyServerInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "10_series";
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpChannel";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ExtractAdapter",
+      packageName + ".ExtractAdapter$Request",
+      packageName + ".ExtractAdapter$Response",
+      packageName + ".JettyDecorator",
+      packageName + ".JettyDecorator$OnResponse",
+      "datadog.trace.instrumentation.jetty9.RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public boolean isApplicable(Set<TargetSystem> enabledSystems) {
+    this.appSecNotFullyDisabled = enabledSystems.contains(TargetSystem.APPSEC);
+    return super.isApplicable(enabledSystems);
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {
+      new Reference.Builder("org.eclipse.jetty.server.HttpChannel")
+          .withMethod(new String[0], Reference.EXPECTS_NON_STATIC, "handle", "Z")
+          .withMethod(new String[0], Reference.EXPECTS_NON_STATIC, "recycle", "V")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "handleException",
+              "V",
+              "Ljava/lang/Throwable;")
+          .build()
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        takesNoArguments().and(named("handle")), packageName + ".HandleAdvice");
+    transformation.applyAdvice(
+        named("recycle").and(takesNoArguments()), packageName + ".ResetAdvice");
+
+    if (appSecNotFullyDisabled) {
+      transformation.applyAdvice(
+          named("handleException").and(takesArguments(1)).and(takesArgument(0, Throwable.class)),
+          packageName + ".HandleExceptionAdvice");
+    }
+  }
+
+  @Override
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
+    return Collections.singletonMap(
+        RUNNABLE,
+        Arrays.asList(
+            "org.eclipse.jetty.util.thread.strategy.ProduceConsume",
+            "org.eclipse.jetty.util.thread.strategy.ExecuteProduceConsume",
+            "org.eclipse.jetty.io.ManagedSelector",
+            "org.eclipse.jetty.util.thread.TimerScheduler",
+            "org.eclipse.jetty.util.thread.TimerScheduler$SimpleTask"));
+  }
+
+  public AdviceTransformer transformer() {
+    return new VisitingTransformer(new HttpChannelHandleVisitorWrapper());
+  }
+
+  public static class HttpChannelHandleVisitorWrapper implements AsmVisitorWrapper {
+
+    @Override
+    public int mergeWriter(int flags) {
+      return flags | ClassWriter.COMPUTE_MAXS;
+    }
+
+    @Override
+    public int mergeReader(int flags) {
+      return flags;
+    }
+
+    @Override
+    public ClassVisitor wrap(
+        TypeDescription instrumentedType,
+        ClassVisitor classVisitor,
+        Implementation.Context implementationContext,
+        TypePool typePool,
+        FieldList<FieldDescription.InDefinedShape> fields,
+        MethodList<?> methods,
+        int writerFlags,
+        int readerFlags) {
+      if (Config.get().getAppSecActivation() == ProductActivation.FULLY_DISABLED) {
+        return classVisitor;
+      }
+
+      return new HttpChannelHandleVisitor(Opcodes.ASM7, classVisitor);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/RequestInstrumentation.java
@@ -1,0 +1,36 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+
+@AutoService(Instrumenter.class)
+public final class RequestInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+
+  public RequestInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "10_series";
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.Request";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("setContextPath").and(takesArgument(0, String.class)),
+        packageName + ".SetContextPathAdvice");
+    transformation.applyAdvice(
+        named("setServletPath").and(takesArgument(0, String.class)),
+        packageName + ".SetServletPathAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/ServerHandleInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/ServerHandleInstrumentation.java
@@ -1,0 +1,49 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+
+@AutoService(Instrumenter.class)
+public class ServerHandleInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+  public ServerHandleInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "after_10";
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.Server";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ExtractAdapter",
+      packageName + ".ExtractAdapter$Request",
+      packageName + ".ExtractAdapter$Response",
+      packageName + ".JettyDecorator",
+      "datadog.trace.instrumentation.jetty9.RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("handle")
+            .or(named("handleAsync"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("org.eclipse.jetty.server.HttpChannel"))),
+        packageName + ".ServerHandleAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,142 @@
+package datadog.trace.instrumentation.jetty9;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty9.JettyDecorator.DECORATE;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.http.HttpGenerator;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "before_904";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {
+      new Reference.Builder("org.eclipse.jetty.server.HttpChannel")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "commitResponse",
+              "Z",
+              "Lorg/eclipse/jetty/http/HttpGenerator$ResponseInfo;",
+              "Ljava/nio/ByteBuffer;",
+              "Z")
+          .build()
+    };
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpChannel";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ExtractAdapter",
+      packageName + ".ExtractAdapter$Request",
+      packageName + ".ExtractAdapter$Response",
+      packageName + ".JettyDecorator",
+      packageName + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("commitResponse")
+            .and(takesArguments(3))
+            .and(takesArgument(0, named("org.eclipse.jetty.http.HttpGenerator$ResponseInfo")))
+            .and(takesArgument(1, named("java.nio.ByteBuffer")))
+            .and(takesArgument(2, boolean.class)),
+        JettyCommitResponseInstrumentation.class.getName() + "$CommitResponseAdvice");
+  }
+
+  static class CommitResponseAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+    static boolean /* skip */ before(
+        @Advice.This HttpChannel connection,
+        @Advice.Argument(0) HttpGenerator.ResponseInfo responseInfo,
+        @Advice.FieldValue("_committed") AtomicBoolean _committed) {
+      if (responseInfo.getStatus() == 100) {
+        return false;
+      }
+      boolean wasCommitted = !_committed.compareAndSet(false, true);
+      if (wasCommitted) {
+        return false;
+      }
+
+      // henceforth we need to reset _committed to false when we don't want to skip the body
+
+      Request req = connection.getRequest();
+
+      if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+        _committed.set(false);
+        return false;
+      }
+
+      Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      if (!(existingSpan instanceof AgentSpan)) {
+        _committed.set(false);
+        return false;
+      }
+      AgentSpan span = (AgentSpan) existingSpan;
+      RequestContext requestContext = span.getRequestContext();
+      if (requestContext == null) {
+        _committed.set(false);
+        return false;
+      }
+
+      Response resp = connection.getResponse();
+
+      Flow<Void> flow =
+          DECORATE.callIGCallbackResponseAndHeaders(
+              span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+        BlockResponseFunction brf = requestContext.getBlockResponseFunction();
+        if (brf != null) {
+          _committed.set(false);
+          boolean res =
+              brf.tryCommitBlockingResponse(
+                  rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          if (res && _committed.get()) {
+            requestContext.getTraceSegment().effectivelyBlocked();
+            return true;
+          }
+        }
+      }
+
+      _committed.set(false);
+      return false;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyDecorator.java
@@ -72,6 +72,11 @@ public class JettyDecorator extends HttpServerDecorator<Request, Request, Respon
     return response.getStatus();
   }
 
+  @Override
+  protected boolean isAppSecOnResponseSeparate() {
+    return true;
+  }
+
   public AgentSpan onResponse(AgentSpan span, HttpChannel<?> channel) {
     Request request = channel.getRequest();
     Response response = channel.getResponse();

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -55,6 +55,11 @@ public final class JettyServerInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public String muzzleDirective() {
+    return "9_full_series";
+  }
+
+  @Override
   public String instrumentedType() {
     return "org.eclipse.jetty.server.HttpChannel";
   }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/RequestInstrumentation.java
@@ -27,6 +27,11 @@ public final class RequestInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public String muzzleDirective() {
+    return "9_full_series";
+  }
+
+  @Override
   public String instrumentedType() {
     return "org.eclipse.jetty.server.Request";
   }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/RequestURIDataAdapter.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/RequestURIDataAdapter.java
@@ -1,13 +1,13 @@
 package datadog.trace.instrumentation.jetty9;
 
 import datadog.trace.bootstrap.instrumentation.api.URIRawDataAdapter;
-import javax.servlet.http.HttpServletRequest;
+import org.eclipse.jetty.server.Request;
 
-final class RequestURIDataAdapter extends URIRawDataAdapter {
+public final class RequestURIDataAdapter extends URIRawDataAdapter {
 
-  private final HttpServletRequest request;
+  private final Request request;
 
-  RequestURIDataAdapter(HttpServletRequest request) {
+  public RequestURIDataAdapter(Request request) {
     this.request = request;
   }
 

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/ServerHandleInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/ServerHandleInstrumentation.java
@@ -23,6 +23,11 @@ public class ServerHandleInstrumentation extends Instrumenter.Tracing
   }
 
   @Override
+  public String muzzleDirective() {
+    return "9_full_series";
+  }
+
+  @Override
   public String instrumentedType() {
     return "org.eclipse.jetty.server.Server";
   }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty904/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty904/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,94 @@
+package datadog.trace.instrumentation.jetty904;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "between_904_and_930";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {
+      new Reference.Builder("org.eclipse.jetty.server.HttpChannel")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "sendResponse",
+              "Z",
+              "Lorg/eclipse/jetty/http/HttpGenerator$ResponseInfo;",
+              "Ljava/nio/ByteBuffer;",
+              "Z",
+              "Lorg/eclipse/jetty/util/Callback;")
+          .withField(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "_committed",
+              "Ljava/util/concurrent/atomic/AtomicBoolean;")
+          .withField(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "_transport",
+              "Lorg/eclipse/jetty/server/HttpTransport;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.server.Response")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "newResponseInfo",
+              "Lorg/eclipse/jetty/http/HttpGenerator$ResponseInfo;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.server.HttpOutput")
+          .withMethod(new String[0], Reference.EXPECTS_NON_STATIC, "closed", "V")
+          .build(),
+    };
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpChannel";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    String pkg9 = "datadog.trace.instrumentation.jetty9";
+    return new String[] {
+      pkg9 + ".ExtractAdapter",
+      pkg9 + ".ExtractAdapter$Request",
+      pkg9 + ".ExtractAdapter$Response",
+      pkg9 + ".JettyDecorator",
+      pkg9 + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+      packageName + ".JettyCommitResponseHelper",
+      packageName + ".JettyOnCommitBlockingHelper",
+      packageName + ".JettyOnCommitBlockingHelper$CloseCallback",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("sendResponse")
+            .and(takesArguments(4))
+            .and(takesArgument(0, named("org.eclipse.jetty.http.HttpGenerator$ResponseInfo")))
+            .and(takesArgument(1, named("java.nio.ByteBuffer")))
+            .and(takesArgument(2, boolean.class))
+            .and(takesArgument(3, named("org.eclipse.jetty.util.Callback"))),
+        packageName + ".SendResponseCbAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty93/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty93/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,100 @@
+package datadog.trace.instrumentation.jetty93;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "between_930_and_9421";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {
+      new Reference.Builder("org.eclipse.jetty.server.HttpChannel")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "sendResponse",
+              "Z",
+              "Lorg/eclipse/jetty/http/MetaData$Response;",
+              "Ljava/nio/ByteBuffer;",
+              "Z",
+              "Lorg/eclipse/jetty/util/Callback;")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "commit",
+              "V",
+              "Lorg/eclipse/jetty/http/MetaData$Response;")
+          .withField(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "_committed",
+              "Ljava/util/concurrent/atomic/AtomicBoolean;")
+          .withField(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "_transport",
+              "Lorg/eclipse/jetty/server/HttpTransport;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.server.Response")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "newResponseMetaData",
+              "Lorg/eclipse/jetty/http/MetaData$Response;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.server.HttpOutput")
+          .withMethod(new String[0], Reference.EXPECTS_NON_STATIC, "closed", "V")
+          .build(),
+    };
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpChannel";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    String pkg9 = "datadog.trace.instrumentation.jetty9";
+    return new String[] {
+      pkg9 + ".ExtractAdapter",
+      pkg9 + ".ExtractAdapter$Request",
+      pkg9 + ".ExtractAdapter$Response",
+      pkg9 + ".JettyDecorator",
+      pkg9 + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+      packageName + ".JettyCommitResponseHelper",
+      packageName + ".JettyOnCommitBlockingHelper",
+      packageName + ".JettyOnCommitBlockingHelper$CloseCallback",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("sendResponse")
+            .and(takesArguments(4))
+            .and(takesArgument(0, named("org.eclipse.jetty.http.MetaData$Response")))
+            .and(takesArgument(1, named("java.nio.ByteBuffer")))
+            .and(takesArgument(2, boolean.class))
+            .and(takesArgument(3, named("org.eclipse.jetty.util.Callback"))),
+        packageName + ".SendResponseCbAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9421/JettyCommitResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9421/JettyCommitResponseInstrumentation.java
@@ -1,0 +1,102 @@
+package datadog.trace.instrumentation.jetty9421;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+
+@AutoService(Instrumenter.class)
+public final class JettyCommitResponseInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+
+  public JettyCommitResponseInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "between_9421_and_10";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {
+      new Reference.Builder("org.eclipse.jetty.server.HttpChannel")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "sendResponse",
+              "Z",
+              "Lorg/eclipse/jetty/http/MetaData$Response;",
+              "Ljava/nio/ByteBuffer;",
+              "Z",
+              "Lorg/eclipse/jetty/util/Callback;")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "commit",
+              "V",
+              "Lorg/eclipse/jetty/http/MetaData$Response;")
+          .withField(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "_transport",
+              "Lorg/eclipse/jetty/server/HttpTransport;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.server.Response")
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_PUBLIC_OR_PROTECTED | Reference.EXPECTS_NON_STATIC,
+              "newResponseMetaData",
+              "Lorg/eclipse/jetty/http/MetaData$Response;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.server.HttpOutput")
+          .withMethod(new String[0], Reference.EXPECTS_NON_STATIC, "closed", "V")
+          .or()
+          .withMethod(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "completed",
+              "V",
+              "Ljava/lang/Throwable;")
+          .build(),
+    };
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.server.HttpChannel";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    String pkg9 = "datadog.trace.instrumentation.jetty9";
+    return new String[] {
+      pkg9 + ".ExtractAdapter",
+      pkg9 + ".ExtractAdapter$Request",
+      pkg9 + ".ExtractAdapter$Response",
+      pkg9 + ".JettyDecorator",
+      pkg9 + ".RequestURIDataAdapter",
+      "datadog.trace.instrumentation.jetty.JettyBlockResponseFunction",
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+      packageName + ".JettyCommitResponseHelper",
+      packageName + ".JettyOnCommitBlockingHelper",
+      packageName + ".JettyOnCommitBlockingHelper$CloseCallback",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("sendResponse")
+            .and(takesArguments(4))
+            .and(takesArgument(0, named("org.eclipse.jetty.http.MetaData$Response")))
+            .and(takesArgument(1, named("java.nio.ByteBuffer")))
+            .and(takesArgument(2, boolean.class))
+            .and(takesArgument(3, named("org.eclipse.jetty.util.Callback"))),
+        packageName + ".SendResponseCbAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/ExtractAdapter.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/ExtractAdapter.java
@@ -1,0 +1,43 @@
+package datadog.trace.instrumentation.jetty10;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+
+// source code is identical to the one in jetty9, but result is not
+// binary compatible because HttpFields became an interface
+public abstract class ExtractAdapter<T> implements AgentPropagation.ContextVisitor<T> {
+  abstract HttpFields getHttpFields(T t);
+
+  @Override
+  public void forEachKey(T carrier, AgentPropagation.KeyClassifier classifier) {
+    HttpFields headers = getHttpFields(carrier);
+    if (headers == null) {
+      return;
+    }
+    for (int i = 0; i < headers.size(); ++i) {
+      HttpField field = headers.getField(i);
+      if (field != null && !classifier.accept(field.getName(), field.getValue())) {
+        return;
+      }
+    }
+  }
+
+  public static final class Request extends ExtractAdapter<org.eclipse.jetty.server.Request> {
+    public static final Request GETTER = new Request();
+
+    @Override
+    HttpFields getHttpFields(org.eclipse.jetty.server.Request request) {
+      return request.getHttpFields();
+    }
+  }
+
+  public static final class Response extends ExtractAdapter<org.eclipse.jetty.server.Response> {
+    public static final Response GETTER = new Response();
+
+    @Override
+    HttpFields getHttpFields(org.eclipse.jetty.server.Response response) {
+      return response.getHttpFields();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
@@ -1,0 +1,44 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty10.JettyDecorator.DECORATE;
+
+import datadog.trace.api.CorrelationIdentifier;
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Request;
+
+public class HandleAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static AgentScope onEnter(
+      @Advice.This final HttpChannel channel, @Advice.Local("agentSpan") AgentSpan span) {
+    Request req = channel.getRequest();
+
+    Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+    if (existingSpan instanceof AgentSpan) {
+      return activateSpan((AgentSpan) existingSpan);
+    }
+
+    final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(req);
+    span = DECORATE.startSpan(req, extractedContext);
+    DECORATE.afterStart(span);
+    DECORATE.onRequest(span, req, req, extractedContext);
+
+    final AgentScope scope = activateSpan(span);
+    scope.setAsyncPropagation(true);
+    req.setAttribute(DD_SPAN_ATTRIBUTE, span);
+    req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
+    req.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());
+    return scope;
+  }
+
+  @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  public static void closeScope(@Advice.Enter final AgentScope scope) {
+    scope.close();
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleExceptionAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleExceptionAdvice.java
@@ -1,0 +1,21 @@
+package datadog.trace.instrumentation.jetty10;
+
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import net.bytebuddy.asm.Advice;
+
+class HandleExceptionAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  static void enter(@Advice.Argument(0) Throwable t) {
+    if (!(t instanceof BlockingException)) {
+      return;
+    }
+
+    AgentSpan agentSpan = AgentTracer.activeSpan();
+    if (agentSpan == null) {
+      return;
+    }
+    JettyDecorator.DECORATE.onError(agentSpan, t);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/JettyCommitResponseHelper.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/JettyCommitResponseHelper.java
@@ -1,0 +1,98 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpChannelState;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyCommitResponseHelper {
+  private static final Logger log = LoggerFactory.getLogger(JettyCommitResponseHelper.class);
+
+  public static boolean /* skip */ before(
+      HttpChannel connection,
+      MetaData.Response metaDataResponse /* nullable */,
+      HttpTransport transport,
+      Callback cb) {
+
+    HttpChannelState state = connection.getState();
+    boolean committing = state.commitResponse();
+    if (!committing) {
+      return false;
+    }
+    // henceforth we need to reset the state
+
+    if (metaDataResponse == null) {
+      metaDataResponse = newMetaDataResponse(connection.getResponse());
+      if (metaDataResponse == null) {
+        state.partialResponse();
+        return false;
+      }
+    }
+
+    if (metaDataResponse.getStatus() >= 100 && metaDataResponse.getStatus() < 200) {
+      state.partialResponse();
+      return false;
+    }
+
+    Request req = connection.getRequest();
+
+    if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+      state.partialResponse();
+      return false;
+    }
+
+    Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+    if (!(existingSpan instanceof AgentSpan)) {
+      state.partialResponse();
+      return false;
+    }
+    AgentSpan span = (AgentSpan) existingSpan;
+    RequestContext requestContext = span.getRequestContext();
+    if (requestContext == null) {
+      state.partialResponse();
+      return false;
+    }
+
+    Response resp = connection.getResponse();
+    Flow<Void> flow =
+        JettyDecorator.DECORATE.callIGCallbackResponseAndHeaders(
+            span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      boolean success = JettyOnCommitBlockingHelper.block(connection, transport, rba, cb);
+      if (success) {
+        requestContext.getTraceSegment().effectivelyBlocked();
+        return true;
+      }
+    }
+
+    state.partialResponse();
+    return false;
+  }
+
+  private static MetaData.Response newMetaDataResponse(Response resp) {
+    Method newMetaDataResponse;
+    try {
+      newMetaDataResponse = Response.class.getDeclaredMethod("newResponseMetaData");
+      newMetaDataResponse.setAccessible(true);
+      return (MetaData.Response) newMetaDataResponse.invoke(resp);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.debug("Failed creating new MetaData.Response", e);
+      return null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/JettyDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/JettyDecorator.java
@@ -1,0 +1,104 @@
+package datadog.trace.instrumentation.jetty10;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.instrumentation.jetty.JettyBlockResponseFunction;
+import datadog.trace.instrumentation.jetty9.RequestURIDataAdapter;
+import javax.servlet.ServletException;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+public class JettyDecorator extends HttpServerDecorator<Request, Request, Response, Request> {
+  public static final CharSequence JETTY_SERVER = UTF8BytesString.create("jetty-server");
+  public static final JettyDecorator DECORATE = new JettyDecorator();
+  public static final CharSequence SERVLET_REQUEST =
+      UTF8BytesString.create(DECORATE.operationName());
+  public static final String DD_CONTEXT_PATH_ATTRIBUTE = "datadog.context.path";
+  public static final String DD_SERVLET_PATH_ATTRIBUTE = "datadog.servlet.path";
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"jetty"};
+  }
+
+  @Override
+  protected CharSequence component() {
+    return JETTY_SERVER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Request> getter() {
+    return ExtractAdapter.Request.GETTER;
+  }
+
+  @Override
+  protected AgentPropagation.ContextVisitor<Response> responseGetter() {
+    return ExtractAdapter.Response.GETTER;
+  }
+
+  @Override
+  public CharSequence spanName() {
+    return SERVLET_REQUEST;
+  }
+
+  @Override
+  protected String method(final Request request) {
+    return request.getMethod();
+  }
+
+  @Override
+  protected URIDataAdapter url(final Request request) {
+    return new RequestURIDataAdapter(request);
+  }
+
+  @Override
+  protected String peerHostIP(final Request request) {
+    return request.getRemoteAddr();
+  }
+
+  @Override
+  protected int peerPort(final Request request) {
+    return request.getRemotePort();
+  }
+
+  @Override
+  protected int status(final Response response) {
+    return response.getStatus();
+  }
+
+  @Override
+  protected boolean isAppSecOnResponseSeparate() {
+    return true;
+  }
+
+  @Override
+  protected BlockResponseFunction createBlockResponseFunction(Request request, Request connection) {
+    return new JettyBlockResponseFunction(request);
+  }
+
+  public static final class OnResponse {
+    public static AgentSpan onResponse(AgentSpan span, HttpChannel channel) {
+      Request request = channel.getRequest();
+      Response response = channel.getResponse();
+      if (Config.get().isServletPrincipalEnabled() && request.getUserPrincipal() != null) {
+        span.setTag(DDTags.USER_NAME, request.getUserPrincipal().getName());
+      }
+      Object ex = request.getAttribute("javax.servlet.error.exception");
+      if (ex instanceof Throwable) {
+        Throwable throwable = (Throwable) ex;
+        if (throwable instanceof ServletException) {
+          throwable = ((ServletException) throwable).getRootCause();
+        }
+        JettyDecorator.DECORATE.onError(span, throwable);
+      }
+      return DECORATE.onResponse(span, response);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/JettyOnCommitBlockingHelper.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/JettyOnCommitBlockingHelper.java
@@ -1,0 +1,176 @@
+package datadog.trace.instrumentation.jetty10;
+
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.bootstrap.blocking.BlockingActionHelper;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyOnCommitBlockingHelper {
+
+  private static final Logger log = LoggerFactory.getLogger(JettyOnCommitBlockingHelper.class);
+  private static final ByteBuffer EMPTY_BB = ByteBuffer.allocate(0);
+
+  public static boolean block(
+      HttpChannel channel,
+      HttpTransport transport,
+      Flow.Action.RequestBlockingAction rba,
+      Callback cb) {
+    if (!isInitialized()) {
+      return false;
+    }
+
+    Request request = channel.getRequest();
+    Response response = channel.getResponse();
+    request.setAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
+
+    try {
+      int statusCode = BlockingActionHelper.getHttpCode(rba.getStatusCode());
+
+      String acceptHeader = request.getHeader("Accept");
+      HttpFields fields = HttpFields.build();
+      for (Map.Entry<String, String> e : rba.getExtraHeaders().entrySet()) {
+        putHeader(fields, e.getKey(), e.getValue());
+      }
+
+      BlockingContentType bct = rba.getBlockingContentType();
+      MetaData.Response info;
+      Callback closeCb = new CloseCallback(cb, channel);
+      if (bct != BlockingContentType.NONE && !request.isHead()) {
+        BlockingActionHelper.TemplateType type =
+            BlockingActionHelper.determineTemplateType(bct, acceptHeader);
+        putHeader(fields, "Content-type", BlockingActionHelper.getContentType(type));
+        byte[] template = BlockingActionHelper.getTemplate(type);
+        putHeader(fields, "Content-length", Integer.toString(template.length));
+
+        info = new MetaData.Response(request.getHttpVersion(), statusCode, fields, template.length);
+        if (!commit(channel, info)) {
+          return false;
+        }
+
+        // we need to update the upper layers too
+        // so that the correct status code/headers get reported correctly on the span`
+        reset(channel);
+        response.setStatus(statusCode);
+        response.setContentType(BlockingActionHelper.getContentType(type));
+        response.setContentLength(template.length);
+
+        request.onResponseCommit();
+        log.debug("Sending blocking response (non-empty body)");
+        transport.send(request.getMetaData(), info, ByteBuffer.wrap(template), true, closeCb);
+      } else {
+        info = new MetaData.Response(request.getHttpVersion(), statusCode, fields);
+
+        reset(channel);
+        response.setStatus(statusCode);
+
+        request.onResponseCommit();
+        transport.send(request.getMetaData(), info, EMPTY_BB, true, closeCb);
+      }
+    } catch (Exception x) {
+      log.warn("Error committing blocking response", x);
+      return false;
+    }
+    return true;
+  }
+
+  private static final MethodHandle PUT_HEADER;
+
+  static {
+    MethodHandle mh = null;
+    try {
+      Class<?> mutableCls =
+          Class.forName(
+              "org.eclipse.jetty.http.HttpFields$Mutable",
+              false,
+              JettyOnCommitBlockingHelper.class.getClassLoader());
+      Method put = mutableCls.getDeclaredMethod("put", String.class, String.class);
+      put.setAccessible(true);
+      mh = MethodHandles.lookup().unreflect(put);
+    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+      log.warn(
+          "Could not find method HttpFields$Mutable.put(String,String). "
+              + "Blocking on responses will be unavailable");
+    }
+    PUT_HEADER = mh;
+  }
+
+  public static boolean isInitialized() {
+    return PUT_HEADER != null;
+  }
+
+  private static void putHeader(HttpFields fields, String key, String value) {
+    try {
+      PUT_HEADER.invoke(fields, key, value);
+    } catch (Throwable e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void reset(HttpChannel channel) {
+    if (channel.getState().partialResponse()) {
+      channel.getResponse().reset();
+      channel.getState().commitResponse();
+    } else {
+      log.debug("Failed resetting response");
+    }
+  }
+
+  private static boolean commit(HttpChannel channel, MetaData.Response info) {
+    try {
+      Method commit = HttpChannel.class.getDeclaredMethod("commit", MetaData.Response.class);
+      commit.setAccessible(true);
+      commit.invoke(channel, info);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.warn("Failed calling commit(MetaData.Response) when writing blocking response", e);
+      return false;
+    }
+    return true;
+  }
+
+  public static final class CloseCallback implements Callback {
+    private static final Logger log = LoggerFactory.getLogger(CloseCallback.class);
+
+    private final Callback delegate;
+    private final HttpChannel channel;
+
+    public CloseCallback(Callback delegate, HttpChannel channel) {
+      this.delegate = delegate;
+      this.channel = channel;
+    }
+
+    private void close() {
+      channel.getResponse().getHttpOutput().completed(null);
+      channel.getEndPoint().close();
+    }
+
+    @Override
+    public void succeeded() {
+      close();
+      delegate.succeeded();
+      log.debug("State after blocking {}", channel.getState());
+    }
+
+    @Override
+    public void failed(final Throwable x) {
+      log.debug("Exception sending blocking response", x);
+      close();
+      delegate.failed(x);
+      log.debug("State after blocking {}", channel.getState());
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/ResetAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/ResetAdvice.java
@@ -1,0 +1,27 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty10.JettyDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Request;
+
+/**
+ * Jetty ensures that connections are reset immediately after the response is sent. This provides a
+ * reliable point to finish the server span at the last possible moment.
+ */
+public class ResetAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void stopSpan(@Advice.This final HttpChannel channel) {
+    Request req = channel.getRequest();
+    Object spanObj = req.getAttribute(DD_SPAN_ATTRIBUTE);
+    if (spanObj instanceof AgentSpan) {
+      final AgentSpan span = (AgentSpan) spanObj;
+      JettyDecorator.OnResponse.onResponse(span, channel);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SendResponseCbAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SendResponseCbAdvice.java
@@ -1,0 +1,18 @@
+package datadog.trace.instrumentation.jetty10;
+
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.util.Callback;
+
+public class SendResponseCbAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+  public static boolean /* skip */ before(
+      @Advice.This HttpChannel connection,
+      @Advice.Argument(0) MetaData.Response responseInfo,
+      @Advice.Argument(3) Callback cb,
+      @Advice.FieldValue("_transport") HttpTransport _transport) {
+    return JettyCommitResponseHelper.before(connection, responseInfo, _transport, cb);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/ServerHandleAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/ServerHandleAdvice.java
@@ -1,0 +1,57 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty10.JettyDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Request;
+
+class ServerHandleAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  static AgentScope onEnter(
+      @Advice.Argument(0) HttpChannel channel, @Advice.Local("agentSpan") AgentSpan span) {
+    Request req = channel.getRequest();
+
+    // same logic as in Servlet3Advice. We need to activate/finish the dispatch span here
+    // because we don't know if a servlet is going to be called and therefore whether
+    // Servlet3Advice will have an opportunity to run.
+    // If there is no servlet involved, the span would not be finished.
+    Object dispatchSpan;
+    synchronized (req) {
+      dispatchSpan = req.getAttribute(DD_DISPATCH_SPAN_ATTRIBUTE);
+    }
+    if (dispatchSpan instanceof AgentSpan) {
+      // this is not great, but we leave the attribute. This is because
+      // Set{Servlet,Context}PathAdvice
+      // looks for this attribute, and we need a way to tell Servlet3Advice not to activate
+      // the root span, stored in DD_SPAN_ATTRIBUTE.
+      // req.removeAttribute(DD_DISPATCH_SPAN_ATTRIBUTE);
+      span = (AgentSpan) dispatchSpan;
+      AgentScope scope = activateSpan(span);
+      return scope;
+    }
+
+    return null;
+  }
+
+  @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  public static void onExit(
+      @Advice.Enter final AgentScope scope,
+      @Advice.Local("agentSpan") AgentSpan span,
+      @Advice.Thrown Throwable t) {
+    if (scope == null) {
+      return;
+    }
+
+    if (t != null) {
+      DECORATE.onError(span, t);
+    }
+    DECORATE.beforeFinish(span);
+    span.finish();
+    scope.close();
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SetContextPathAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SetContextPathAdvice.java
@@ -1,0 +1,29 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty10.JettyDecorator.DD_CONTEXT_PATH_ATTRIBUTE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.server.Request;
+
+/**
+ * Because we are processing the initial request before the contextPath is set, we must update it
+ * when it is actually set.
+ */
+public class SetContextPathAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void updateContextPath(
+      @Advice.This final Request req, @Advice.Argument(0) final String contextPath) {
+    if (contextPath != null) {
+      Object span = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      // Don't want to update while being dispatched to new servlet
+      if (span instanceof AgentSpan && req.getAttribute(DD_DISPATCH_SPAN_ATTRIBUTE) == null) {
+        ((AgentSpan) span).setTag(SERVLET_CONTEXT, contextPath);
+        req.setAttribute(DD_CONTEXT_PATH_ATTRIBUTE, contextPath);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SetServletPathAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SetServletPathAdvice.java
@@ -1,0 +1,38 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty10.JettyDecorator.DD_SERVLET_PATH_ATTRIBUTE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import javax.servlet.http.HttpServletRequest;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Request;
+
+/**
+ * Because we are processing the initial request before the servletPath is set, we must update it
+ * when it is actually set.
+ */
+public class SetServletPathAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void updateServletPath(
+      @Advice.This final Request req, @Advice.Argument(0) final String servletPath) {
+    if (servletPath != null && !servletPath.isEmpty()) { // bypass cleanup
+      Object span = req.getAttribute(DD_SPAN_ATTRIBUTE);
+      // Don't want to update while being dispatched to new servlet
+      if (span instanceof AgentSpan && req.getAttribute(DD_DISPATCH_SPAN_ATTRIBUTE) == null) {
+        ((AgentSpan) span).setTag(SERVLET_PATH, servletPath);
+        req.setAttribute(DD_SERVLET_PATH_ATTRIBUTE, servletPath);
+      }
+    }
+  }
+
+  private void muzzleCheck(HttpChannel connection, HttpServletRequest request, HttpFields fields) {
+    connection.run();
+    request.getContextPath();
+    fields.getField(0);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty904/datadog/trace/instrumentation/jetty904/JettyCommitResponseHelper.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty904/datadog/trace/instrumentation/jetty904/JettyCommitResponseHelper.java
@@ -1,0 +1,101 @@
+package datadog.trace.instrumentation.jetty904;
+
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty9.JettyDecorator.DECORATE;
+
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.jetty9.ExtractAdapter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.jetty.http.HttpGenerator;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyCommitResponseHelper {
+  private static final Logger log = LoggerFactory.getLogger(JettyCommitResponseHelper.class);
+
+  public static boolean /* skip */ before(
+      HttpChannel connection,
+      HttpGenerator.ResponseInfo responseInfo /* nullable */,
+      HttpTransport transport,
+      AtomicBoolean _committed,
+      Callback cb) {
+    if (responseInfo == null) {
+      responseInfo = newResponseInfo(connection);
+      if (responseInfo == null) {
+        return false;
+      }
+    }
+
+    if (responseInfo.getStatus() == 100) {
+      return false;
+    }
+    boolean wasCommitted = !_committed.compareAndSet(false, true);
+    if (wasCommitted) {
+      return false;
+    }
+
+    // henceforth we need to reset _committed to false when we don't want to skip the body
+
+    Request req = connection.getRequest();
+
+    if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+      _committed.set(false);
+      return false;
+    }
+
+    Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+    if (!(existingSpan instanceof AgentSpan)) {
+      _committed.set(false);
+      return false;
+    }
+    AgentSpan span = (AgentSpan) existingSpan;
+    RequestContext requestContext = span.getRequestContext();
+    if (requestContext == null) {
+      _committed.set(false);
+      return false;
+    }
+
+    Response resp = connection.getResponse();
+
+    Flow<Void> flow =
+        DECORATE.callIGCallbackResponseAndHeaders(
+            span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      _committed.set(false);
+      boolean success = JettyOnCommitBlockingHelper.block(connection, transport, rba, cb);
+      if (success) {
+        _committed.set(true);
+        requestContext.getTraceSegment().effectivelyBlocked();
+        return true;
+      }
+    }
+
+    _committed.set(false);
+    return false;
+  }
+
+  private static HttpGenerator.ResponseInfo newResponseInfo(HttpChannel connection) {
+    Response response = connection.getResponse();
+    Method newResponseInfo;
+    try {
+      newResponseInfo = Response.class.getDeclaredMethod("newResponseInfo");
+      newResponseInfo.setAccessible(true);
+      return (HttpGenerator.ResponseInfo) newResponseInfo.invoke(response);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.debug("Failed creating new ResponseInfo", e);
+      return null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty904/datadog/trace/instrumentation/jetty904/JettyOnCommitBlockingHelper.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty904/datadog/trace/instrumentation/jetty904/JettyOnCommitBlockingHelper.java
@@ -1,0 +1,149 @@
+package datadog.trace.instrumentation.jetty904;
+
+import static datadog.trace.instrumentation.jetty904.JettyOnCommitBlockingHelper.CloseCallback.isInitialized;
+
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.bootstrap.blocking.BlockingActionHelper;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpGenerator;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpOutput;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyOnCommitBlockingHelper {
+
+  private static final Logger log = LoggerFactory.getLogger(JettyOnCommitBlockingHelper.class);
+  private static final ByteBuffer EMPTY_BB = ByteBuffer.allocate(0);
+
+  public static boolean block(
+      HttpChannel channel,
+      HttpTransport transport,
+      Flow.Action.RequestBlockingAction rba,
+      Callback cb) {
+    if (!isInitialized()) {
+      return false;
+    }
+
+    Request request = channel.getRequest();
+    Response response = channel.getResponse();
+    request.setAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
+
+    try {
+      int statusCode = BlockingActionHelper.getHttpCode(rba.getStatusCode());
+
+      String acceptHeader = request.getHeader("Accept");
+      HttpFields fields = new HttpFields();
+      for (Map.Entry<String, String> e : rba.getExtraHeaders().entrySet()) {
+        fields.put(e.getKey(), e.getValue());
+      }
+
+      BlockingContentType bct = rba.getBlockingContentType();
+      HttpGenerator.ResponseInfo info;
+      Callback closeCb = new CloseCallback(cb, channel);
+      if (bct != BlockingContentType.NONE && !request.isHead()) {
+        BlockingActionHelper.TemplateType type =
+            BlockingActionHelper.determineTemplateType(bct, acceptHeader);
+        fields.put("Content-type", BlockingActionHelper.getContentType(type));
+        byte[] template = BlockingActionHelper.getTemplate(type);
+        fields.put("Content-length", Integer.toString(template.length));
+
+        info =
+            new HttpGenerator.ResponseInfo(
+                request.getHttpVersion(), fields, template.length, statusCode, null, false);
+
+        // we need to update the upper layers too
+        // so that the correct status code/headers get reported correctly on the span`
+        response.reset();
+        response.setStatus(statusCode);
+        response.setContentType(BlockingActionHelper.getContentType(type));
+        response.setContentLength(template.length);
+
+        log.debug("Sending blocking response (non-empty body)");
+        transport.send(info, ByteBuffer.wrap(template), true, closeCb);
+      } else {
+        info =
+            new HttpGenerator.ResponseInfo(
+                request.getHttpVersion(), fields, 0, statusCode, null, request.isHead());
+
+        response.reset();
+        response.setStatus(statusCode);
+
+        transport.send(info, EMPTY_BB, true, closeCb);
+      }
+    } catch (Exception x) {
+      log.warn("Error committing blocking response", x);
+      return false;
+    }
+    return true;
+  }
+
+  public static final class CloseCallback implements org.eclipse.jetty.util.Callback {
+    private static final Logger log = LoggerFactory.getLogger(CloseCallback.class);
+    private final Callback delegate;
+    private final HttpChannel channel;
+
+    public CloseCallback(Callback delegate, HttpChannel channel) {
+      this.delegate = delegate;
+      this.channel = channel;
+    }
+
+    /** @see org.eclipse.jetty.server.HttpChannel.CommitCallback */
+    private void close() {
+      closed(channel.getResponse().getHttpOutput());
+      channel.getEndPoint().close();
+    }
+
+    private static final MethodHandle CLOSED;
+
+    static {
+      MethodHandle mh = null;
+      try {
+        Method closed = HttpOutput.class.getDeclaredMethod("closed");
+        closed.setAccessible(true);
+        mh = MethodHandles.lookup().unreflect(closed);
+      } catch (NoSuchMethodException | IllegalAccessException e) {
+        log.warn(
+            "Could not find HttpOutput#closed(). " + "Blocking for responses will not be available",
+            e);
+      }
+      CLOSED = mh;
+    }
+
+    public static boolean isInitialized() {
+      return CLOSED != null;
+    }
+
+    private void closed(HttpOutput httpOutput) {
+      try {
+        CLOSED.invoke(httpOutput);
+      } catch (Throwable e) {
+        log.debug("Error invoked closed()", e);
+      }
+    }
+
+    @Override
+    public void succeeded() {
+      close();
+      delegate.succeeded();
+    }
+
+    @Override
+    public void failed(final Throwable x) {
+      log.debug("Exception sending blocking response", x);
+      close();
+      delegate.failed(x);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty904/datadog/trace/instrumentation/jetty904/SendResponseCbAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty904/datadog/trace/instrumentation/jetty904/SendResponseCbAdvice.java
@@ -1,0 +1,20 @@
+package datadog.trace.instrumentation.jetty904;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.http.HttpGenerator;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.util.Callback;
+
+public class SendResponseCbAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+  public static boolean /* skip */ before(
+      @Advice.This HttpChannel connection,
+      @Advice.Argument(0) HttpGenerator.ResponseInfo responseInfo,
+      @Advice.Argument(3) Callback cb,
+      @Advice.FieldValue("_committed") AtomicBoolean _committed,
+      @Advice.FieldValue("_transport") HttpTransport _transport) {
+    return JettyCommitResponseHelper.before(connection, responseInfo, _transport, _committed, cb);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty93/datadog/trace/instrumentation/jetty93/JettyCommitResponseHelper.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty93/datadog/trace/instrumentation/jetty93/JettyCommitResponseHelper.java
@@ -1,0 +1,99 @@
+package datadog.trace.instrumentation.jetty93;
+
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty9.JettyDecorator.DECORATE;
+
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.jetty9.ExtractAdapter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyCommitResponseHelper {
+  private static final Logger log = LoggerFactory.getLogger(JettyCommitResponseHelper.class);
+
+  public static boolean /* skip */ before(
+      HttpChannel connection,
+      MetaData.Response metaDataResponse /* nullable */,
+      HttpTransport transport,
+      AtomicBoolean _committed,
+      Callback cb) {
+    if (metaDataResponse == null) {
+      metaDataResponse = newMetaDataResponse(connection.getResponse());
+      if (metaDataResponse == null) {
+        return false;
+      }
+    }
+
+    if (metaDataResponse.getStatus() == 100) {
+      return false;
+    }
+    boolean wasCommitted = !_committed.compareAndSet(false, true);
+    if (wasCommitted) {
+      return false;
+    }
+
+    // henceforth we need to reset _committed to false when we don't want to skip the body
+
+    Request req = connection.getRequest();
+
+    if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+      _committed.set(false);
+      return false;
+    }
+
+    Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+    if (!(existingSpan instanceof AgentSpan)) {
+      _committed.set(false);
+      return false;
+    }
+    AgentSpan span = (AgentSpan) existingSpan;
+    RequestContext requestContext = span.getRequestContext();
+    if (requestContext == null) {
+      _committed.set(false);
+      return false;
+    }
+
+    Response resp = connection.getResponse();
+    Flow<Void> flow =
+        DECORATE.callIGCallbackResponseAndHeaders(
+            span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      _committed.set(false);
+      boolean success = JettyOnCommitBlockingHelper.block(connection, transport, rba, cb);
+      if (success) {
+        _committed.set(true);
+        requestContext.getTraceSegment().effectivelyBlocked();
+        return true;
+      }
+    }
+
+    _committed.set(false);
+    return false;
+  }
+
+  private static MetaData.Response newMetaDataResponse(Response resp) {
+    Method newMetaDataResponse;
+    try {
+      newMetaDataResponse = Response.class.getDeclaredMethod("newResponseMetaData");
+      newMetaDataResponse.setAccessible(true);
+      return (MetaData.Response) newMetaDataResponse.invoke(resp);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.debug("Failed creating new MetaData.Response", e);
+      return null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty93/datadog/trace/instrumentation/jetty93/JettyOnCommitBlockingHelper.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty93/datadog/trace/instrumentation/jetty93/JettyOnCommitBlockingHelper.java
@@ -1,0 +1,157 @@
+package datadog.trace.instrumentation.jetty93;
+
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.bootstrap.blocking.BlockingActionHelper;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpOutput;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyOnCommitBlockingHelper {
+
+  private static final Logger log = LoggerFactory.getLogger(JettyOnCommitBlockingHelper.class);
+  private static final ByteBuffer EMPTY_BB = ByteBuffer.allocate(0);
+
+  public static boolean block(
+      HttpChannel channel,
+      HttpTransport transport,
+      Flow.Action.RequestBlockingAction rba,
+      Callback cb) {
+    if (!CloseCallback.isInitialized()) {
+      return false;
+    }
+
+    Request request = channel.getRequest();
+    Response response = channel.getResponse();
+    request.setAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
+
+    try {
+      int statusCode = BlockingActionHelper.getHttpCode(rba.getStatusCode());
+
+      String acceptHeader = request.getHeader("Accept");
+      HttpFields fields = new HttpFields();
+      for (Map.Entry<String, String> e : rba.getExtraHeaders().entrySet()) {
+        fields.put(e.getKey(), e.getValue());
+      }
+
+      BlockingContentType bct = rba.getBlockingContentType();
+      MetaData.Response info;
+      Callback closeCb = new CloseCallback(cb, channel);
+      if (bct != BlockingContentType.NONE && !request.isHead()) {
+        BlockingActionHelper.TemplateType type =
+            BlockingActionHelper.determineTemplateType(bct, acceptHeader);
+        fields.put("Content-type", BlockingActionHelper.getContentType(type));
+        byte[] template = BlockingActionHelper.getTemplate(type);
+        fields.put("Content-length", Integer.toString(template.length));
+
+        info = new MetaData.Response(request.getHttpVersion(), statusCode, fields, template.length);
+        if (!commit(channel, info)) {
+          return false;
+        }
+
+        // we need to update the upper layers too
+        // so that the correct status code/headers get reported correctly on the span`
+        response.reset();
+        response.setStatus(statusCode);
+        response.setContentType(BlockingActionHelper.getContentType(type));
+        response.setContentLength(template.length);
+
+        log.debug("Sending blocking response (non-empty body)");
+        transport.send(info, false, ByteBuffer.wrap(template), true, closeCb);
+      } else {
+        info = new MetaData.Response(request.getHttpVersion(), statusCode, fields);
+
+        response.reset();
+        response.setStatus(statusCode);
+
+        transport.send(info, request.isHead(), EMPTY_BB, true, closeCb);
+      }
+    } catch (Exception x) {
+      log.warn("Error committing blocking response", x);
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean commit(HttpChannel channel, MetaData.Response info) {
+    try {
+      Method commit = HttpChannel.class.getDeclaredMethod("commit", MetaData.Response.class);
+      commit.setAccessible(true);
+      commit.invoke(channel, info);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.warn("Failed calling commit(MetaData.Response) when writing blocking response", e);
+      return false;
+    }
+    return true;
+  }
+
+  public static final class CloseCallback implements Callback {
+    private static final Logger log = LoggerFactory.getLogger(CloseCallback.class);
+    private static final MethodHandle CLOSED;
+    private final Callback delegate;
+    private final HttpChannel channel;
+
+    static {
+      MethodHandle mh = null;
+      try {
+        Method closed = HttpOutput.class.getDeclaredMethod("closed");
+        closed.setAccessible(true);
+        mh = MethodHandles.lookup().unreflect(closed);
+      } catch (NoSuchMethodException | IllegalAccessException e) {
+        log.warn(
+            "Could not find HttpOutput#closed(). " + "Blocking for responses will not be available",
+            e);
+      }
+      CLOSED = mh;
+    }
+
+    public static boolean isInitialized() {
+      return CLOSED != null;
+    }
+
+    public CloseCallback(Callback delegate, HttpChannel channel) {
+      this.delegate = delegate;
+      this.channel = channel;
+    }
+
+    private void close() {
+      closed(channel.getResponse().getHttpOutput());
+      channel.getEndPoint().close();
+    }
+
+    private void closed(HttpOutput httpOutput) {
+      try {
+        CLOSED.invoke(httpOutput);
+      } catch (Throwable e) {
+        log.debug("Error invoked closed()", e);
+      }
+    }
+
+    @Override
+    public void succeeded() {
+      close();
+      delegate.succeeded();
+    }
+
+    @Override
+    public void failed(final Throwable x) {
+      log.debug("Exception sending blocking response", x);
+      close();
+      delegate.failed(x);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty93/datadog/trace/instrumentation/jetty93/SendResponseCbAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty93/datadog/trace/instrumentation/jetty93/SendResponseCbAdvice.java
@@ -1,0 +1,20 @@
+package datadog.trace.instrumentation.jetty93;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.util.Callback;
+
+public class SendResponseCbAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+  public static boolean /* skip */ before(
+      @Advice.This HttpChannel connection,
+      @Advice.Argument(0) MetaData.Response responseInfo,
+      @Advice.Argument(3) Callback cb,
+      @Advice.FieldValue("_committed") AtomicBoolean _committed,
+      @Advice.FieldValue("_transport") HttpTransport _transport) {
+    return JettyCommitResponseHelper.before(connection, responseInfo, _transport, _committed, cb);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty9421/datadog/trace/instrumentation/jetty9421/JettyCommitResponseHelper.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty9421/datadog/trace/instrumentation/jetty9421/JettyCommitResponseHelper.java
@@ -1,0 +1,100 @@
+package datadog.trace.instrumentation.jetty9421;
+
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.instrumentation.jetty9.JettyDecorator.DECORATE;
+
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.jetty9.ExtractAdapter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpChannelState;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyCommitResponseHelper {
+  private static final Logger log = LoggerFactory.getLogger(JettyCommitResponseHelper.class);
+
+  public static boolean /* skip */ before(
+      HttpChannel connection,
+      MetaData.Response metaDataResponse /* nullable */,
+      HttpTransport transport,
+      Callback cb) {
+
+    HttpChannelState state = connection.getState();
+    boolean committing = state.commitResponse();
+    if (!committing) {
+      return false;
+    }
+    // henceforth we need to reset the state
+
+    if (metaDataResponse == null) {
+      metaDataResponse = newMetaDataResponse(connection.getResponse());
+      if (metaDataResponse == null) {
+        state.partialResponse();
+        return false;
+      }
+    }
+
+    if (metaDataResponse.getStatus() >= 100 && metaDataResponse.getStatus() < 200) {
+      state.partialResponse();
+      return false;
+    }
+
+    Request req = connection.getRequest();
+
+    if (req.getAttribute(DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
+      state.partialResponse();
+      return false;
+    }
+
+    Object existingSpan = req.getAttribute(DD_SPAN_ATTRIBUTE);
+    if (!(existingSpan instanceof AgentSpan)) {
+      state.partialResponse();
+      return false;
+    }
+    AgentSpan span = (AgentSpan) existingSpan;
+    RequestContext requestContext = span.getRequestContext();
+    if (requestContext == null) {
+      state.partialResponse();
+      return false;
+    }
+
+    Response resp = connection.getResponse();
+    Flow<Void> flow =
+        DECORATE.callIGCallbackResponseAndHeaders(
+            span, resp, resp.getStatus(), ExtractAdapter.Response.GETTER);
+    Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+      boolean success = JettyOnCommitBlockingHelper.block(connection, transport, rba, cb);
+      if (success) {
+        requestContext.getTraceSegment().effectivelyBlocked();
+        return true;
+      }
+    }
+
+    state.partialResponse();
+    return false;
+  }
+
+  private static MetaData.Response newMetaDataResponse(Response resp) {
+    Method newMetaDataResponse;
+    try {
+      newMetaDataResponse = Response.class.getDeclaredMethod("newResponseMetaData");
+      newMetaDataResponse.setAccessible(true);
+      return (MetaData.Response) newMetaDataResponse.invoke(resp);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      log.debug("Failed creating new MetaData.Response", e);
+      return null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty9421/datadog/trace/instrumentation/jetty9421/JettyOnCommitBlockingHelper.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty9421/datadog/trace/instrumentation/jetty9421/JettyOnCommitBlockingHelper.java
@@ -1,0 +1,200 @@
+package datadog.trace.instrumentation.jetty9421;
+
+import datadog.appsec.api.blocking.BlockingContentType;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.bootstrap.blocking.BlockingActionHelper;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpOutput;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyOnCommitBlockingHelper {
+
+  private static final Logger log = LoggerFactory.getLogger(JettyOnCommitBlockingHelper.class);
+  private static final ByteBuffer EMPTY_BB = ByteBuffer.allocate(0);
+
+  public static boolean block(
+      HttpChannel channel,
+      HttpTransport transport,
+      Flow.Action.RequestBlockingAction rba,
+      Callback cb) {
+    if (!isInitialized()) {
+      return false;
+    }
+
+    Request request = channel.getRequest();
+    Response response = channel.getResponse();
+    request.setAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
+
+    try {
+      int statusCode = BlockingActionHelper.getHttpCode(rba.getStatusCode());
+
+      String acceptHeader = request.getHeader("Accept");
+      HttpFields fields = new HttpFields();
+      for (Map.Entry<String, String> e : rba.getExtraHeaders().entrySet()) {
+        fields.put(e.getKey(), e.getValue());
+      }
+
+      BlockingContentType bct = rba.getBlockingContentType();
+      MetaData.Response info;
+      Callback closeCb = new CloseCallback(cb, channel);
+      if (bct != BlockingContentType.NONE && !request.isHead()) {
+        BlockingActionHelper.TemplateType type =
+            BlockingActionHelper.determineTemplateType(bct, acceptHeader);
+        fields.put("Content-type", BlockingActionHelper.getContentType(type));
+        byte[] template = BlockingActionHelper.getTemplate(type);
+        fields.put("Content-length", Integer.toString(template.length));
+
+        info = new MetaData.Response(request.getHttpVersion(), statusCode, fields, template.length);
+        if (!commit(channel, info)) {
+          return false;
+        }
+
+        // we need to update the upper layers too
+        // so that the correct status code/headers get reported correctly on the span`
+        reset(channel);
+        response.setStatus(statusCode);
+        response.setContentType(BlockingActionHelper.getContentType(type));
+        response.setContentLength(template.length);
+
+        request.onResponseCommit();
+        log.debug("Sending blocking response (non-empty body)");
+        transport.send(info, false, ByteBuffer.wrap(template), true, closeCb);
+      } else {
+        info = new MetaData.Response(request.getHttpVersion(), statusCode, fields);
+
+        reset(channel);
+        response.setStatus(statusCode);
+
+        request.onResponseCommit();
+        transport.send(info, request.isHead(), EMPTY_BB, true, closeCb);
+      }
+    } catch (Exception x) {
+      log.warn("Error committing blocking response", x);
+      return false;
+    }
+    return true;
+  }
+
+  private static final MethodHandle COMMIT_METADATA;
+
+  static {
+    MethodHandle commitMh = null;
+    try {
+      Method commit = HttpChannel.class.getDeclaredMethod("commit", MetaData.Response.class);
+      commit.setAccessible(true);
+      commitMh = MethodHandles.lookup().unreflect(commit);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      log.warn(
+          "Could not find method HttpChannel#commit(MetaData.Response). "
+              + "Blocking on responses will be unavailable");
+    }
+    COMMIT_METADATA = commitMh;
+  }
+
+  public static boolean isInitialized() {
+    return COMMIT_METADATA != null;
+  }
+
+  private static void reset(HttpChannel channel) {
+    if (channel.getState().partialResponse()) {
+      channel.getResponse().reset();
+      channel.getState().commitResponse();
+    } else {
+      log.debug("Failed resetting response");
+    }
+  }
+
+  private static boolean commit(HttpChannel channel, MetaData.Response info) {
+    try {
+      COMMIT_METADATA.invoke(channel, info);
+    } catch (Throwable t) {
+      log.warn("Failed calling commit(MetaData.Response) when writing blocking response", t);
+      return false;
+    }
+    return true;
+  }
+
+  public static final class CloseCallback implements Callback {
+    private static final Logger log = LoggerFactory.getLogger(CloseCallback.class);
+    private final Callback delegate;
+    private final HttpChannel channel;
+
+    public CloseCallback(Callback delegate, HttpChannel channel) {
+      this.delegate = delegate;
+      this.channel = channel;
+    }
+
+    private void close() {
+      closed(channel.getResponse().getHttpOutput());
+      channel.getEndPoint().close();
+    }
+
+    private static final MethodHandle CLOSED;
+
+    static {
+      MethodHandle mh = null;
+      try {
+        mh =
+            MethodHandles.lookup()
+                .findVirtual(HttpOutput.class, "closed", MethodType.methodType(void.class));
+      } catch (NoSuchMethodException | IllegalAccessException e) {
+        try {
+          mh =
+              MethodHandles.lookup()
+                  .findVirtual(
+                      HttpOutput.class,
+                      "completed",
+                      MethodType.methodType(void.class, Throwable.class));
+          mh = MethodHandles.insertArguments(mh, 1, new Object[] {null});
+        } catch (NoSuchMethodException | IllegalAccessException e2) {
+          log.warn(
+              "Can't find either closed() or completed() on HttpOutput. "
+                  + "No blocking on responses will be possible",
+              e2);
+        }
+      }
+      CLOSED = mh;
+    }
+
+    public static boolean isInitialized() {
+      return CLOSED != null;
+    }
+
+    private void closed(HttpOutput httpOutput) {
+      try {
+        CLOSED.invoke(httpOutput);
+      } catch (Throwable e) {
+        log.debug("Call to closed()/completed() failed", e);
+      }
+    }
+
+    @Override
+    public void succeeded() {
+      close();
+      delegate.succeeded();
+      log.debug("State after blocking {}", channel.getState());
+    }
+
+    @Override
+    public void failed(final Throwable x) {
+      log.debug("Exception sending blocking response", x);
+      close();
+      delegate.failed(x);
+      log.debug("State after blocking {}", channel.getState());
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty9421/datadog/trace/instrumentation/jetty9421/SendResponseCbAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty9421/datadog/trace/instrumentation/jetty9421/SendResponseCbAdvice.java
@@ -1,0 +1,18 @@
+package datadog.trace.instrumentation.jetty9421;
+
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.HttpTransport;
+import org.eclipse.jetty.util.Callback;
+
+public class SendResponseCbAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+  public static boolean /* skip */ before(
+      @Advice.This HttpChannel connection,
+      @Advice.Argument(0) MetaData.Response responseInfo,
+      @Advice.Argument(3) Callback cb,
+      @Advice.FieldValue("_transport") HttpTransport _transport) {
+    return JettyCommitResponseHelper.before(connection, responseInfo, _transport, cb);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-9/src/test/groovy/Jetty9Test.groovy
@@ -56,6 +56,11 @@ abstract class Jetty9Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testBlockingOnResponse() {
+    true
+  }
+
+  @Override
   boolean hasExtraErrorInformation() {
     true
   }

--- a/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty/JettyBlockingHelper.java
+++ b/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty/JettyBlockingHelper.java
@@ -10,6 +10,7 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.lang.invoke.MethodHandle;
@@ -165,6 +166,8 @@ public class JettyBlockingHelper {
       return true;
     }
 
+    request.setAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
+
     try {
       response.reset();
       response.setStatus(BlockingActionHelper.getHttpCode(statusCode));
@@ -177,6 +180,7 @@ public class JettyBlockingHelper {
       if (bct != BlockingContentType.NONE) {
         BlockingActionHelper.TemplateType type =
             BlockingActionHelper.determineTemplateType(bct, acceptHeader);
+        response.setCharacterEncoding("utf-8");
         response.setHeader("Content-type", BlockingActionHelper.getContentType(type));
         byte[] template = BlockingActionHelper.getTemplate(type);
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -107,6 +107,11 @@ abstract class JettyServlet2Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testBlockingOnResponse() {
+    true
+  }
+
+  @Override
   boolean hasExtraErrorInformation() {
     true
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -37,6 +37,11 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
   }
 
   @Override
+  boolean testBlockingOnResponse() {
+    true
+  }
+
+  @Override
   URI buildAddress(int port) {
     if (dispatch) {
       return new URI("http://localhost:$port/$context/dispatch/")

--- a/dd-java-agent/instrumentation/tomcat-5.5-common/src/main/java/datadog/trace/instrumentation/tomcat/TomcatBlockingHelper.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5-common/src/main/java/datadog/trace/instrumentation/tomcat/TomcatBlockingHelper.java
@@ -4,6 +4,7 @@ import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper.TemplateType;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -20,7 +21,6 @@ import org.slf4j.LoggerFactory;
 public class TomcatBlockingHelper {
   private static final Logger log = LoggerFactory.getLogger(TomcatBlockingHelper.class);
   private static final MethodHandle GET_OUTPUT_STREAM;
-  public static final String TOMCAT_IGNORE_COMMIT_ATTRIBUTE = "datadog.commit.ignore";
 
   static {
     MethodHandle mh = null;
@@ -116,7 +116,7 @@ public class TomcatBlockingHelper {
     log.debug("Committing blocking response");
 
     resp.reset();
-    resp.getRequest().setAttribute(TOMCAT_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
+    resp.getRequest().setAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
     resp.setStatus(statusCode);
 
     return true;

--- a/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/CommitActionInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/CommitActionInstrumentation.java
@@ -12,8 +12,8 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import datadog.trace.instrumentation.tomcat.ExtractAdapter;
-import datadog.trace.instrumentation.tomcat.TomcatBlockingHelper;
 import datadog.trace.instrumentation.tomcat.TomcatDecorator;
 import net.bytebuddy.asm.Advice;
 import org.apache.coyote.ActionCode;
@@ -86,10 +86,10 @@ public class CommitActionInstrumentation extends Instrumenter.AppSec
         return false;
       }
       Request request = coyoteResponse.getRequest();
-      if (request.getAttribute(TomcatBlockingHelper.TOMCAT_IGNORE_COMMIT_ATTRIBUTE) != null) {
+      if (request.getAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
         return false;
       }
-      request.setAttribute(TomcatBlockingHelper.TOMCAT_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
+      request.setAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
 
       AgentSpan agentSpan = AgentTracer.activeSpan();
       if (agentSpan == null) {

--- a/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/CommitActionInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/CommitActionInstrumentation.java
@@ -13,7 +13,6 @@ import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import datadog.trace.instrumentation.tomcat.ExtractAdapter;
-import datadog.trace.instrumentation.tomcat.TomcatBlockingHelper;
 import datadog.trace.instrumentation.tomcat.TomcatDecorator;
 import net.bytebuddy.asm.Advice;
 import org.apache.coyote.ActionCode;
@@ -86,10 +85,10 @@ public class CommitActionInstrumentation extends Instrumenter.AppSec
         return false;
       }
       Request request = coyoteResponse.getRequest();
-      if (request.getAttribute(TomcatBlockingHelper.TOMCAT_IGNORE_COMMIT_ATTRIBUTE) != null) {
+      if (request.getAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE) != null) {
         return false;
       }
-      request.setAttribute(TomcatBlockingHelper.TOMCAT_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
+      request.setAttribute(HttpServerDecorator.DD_IGNORE_COMMIT_ATTRIBUTE, Boolean.TRUE);
 
       // on async requests AgentTracer.activeSpan() may return null
       AgentSpan agentSpan = (AgentSpan) request.getAttribute(HttpServerDecorator.DD_SPAN_ATTRIBUTE);

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1787,6 +1787,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
     response.code() == 413
     response.header('Content-type') =~ /(?i)\Aapplication\/json(?:;\s?charset=utf-8)?\z/
+    response.header(IG_RESPONSE_HEADER) == null // the header should've been cleared
     response.body().charStream().text.contains('"title":"You\'ve been blocked"')
     TEST_WRITER.waitForTraces(1)
 


### PR DESCRIPTION
Adds the capability of blocking requests based on response headers.