### PR TITLE
Fix source of flakiness in logs injection smoke test

### DIFF
--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -207,7 +207,7 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     // there's a race with stdout where lines get combined
     // this fixes that
     def lineStart = line.indexOf("TRACEID")
-    def startOfNextLine = line.indexOf("[")
+    def startOfNextLine = line.indexOf("[", lineStart)
     def lineEnd = startOfNextLine == -1 ? line.length() : startOfNextLine
 
     def unmangled = line.substring(lineStart, lineEnd)

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -206,8 +206,11 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     }
     // there's a race with stdout where lines get combined
     // this fixes that
-    def startOfMangle = line.indexOf("[")
-    def unmangled = startOfMangle != -1 ? line.substring(0, startOfMangle) : line
+    def lineStart = line.indexOf("TRACEID")
+    def startOfNextLine = line.indexOf("[")
+    def lineEnd = startOfNextLine == -1 ? line.length() : startOfNextLine
+
+    def unmangled = line.substring(lineStart, lineEnd)
 
     return unmangled.split(" ")[1..2]
   }
@@ -239,10 +242,10 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
     println "json log lines: " + jsonLogLines
 
     def stdOutLines = new File(logFilePath).readLines()
-    def (String firstTraceId, String firstSpanId) = parseTraceFromStdOut(stdOutLines.find { it.startsWith("FIRSTTRACEID")})
-    def (String secondTraceId, String secondSpanId) = parseTraceFromStdOut(stdOutLines.find { it.startsWith("SECONDTRACEID")})
-    def (String thirdTraceId, String thirdSpanId) = parseTraceFromStdOut(stdOutLines.find { it.startsWith("THIRDTRACEID")})
-    def (String forthTraceId, String forthSpanId) = parseTraceFromStdOut(stdOutLines.find { it.startsWith("FORTHTRACEID")})
+    def (String firstTraceId, String firstSpanId) = parseTraceFromStdOut(stdOutLines.find { it.contains("FIRSTTRACEID")})
+    def (String secondTraceId, String secondSpanId) = parseTraceFromStdOut(stdOutLines.find { it.contains("SECONDTRACEID")})
+    def (String thirdTraceId, String thirdSpanId) = parseTraceFromStdOut(stdOutLines.find { it.contains("THIRDTRACEID")})
+    def (String forthTraceId, String forthSpanId) = parseTraceFromStdOut(stdOutLines.find { it.contains("FORTHTRACEID")})
 
     then:
     exitValue == 0


### PR DESCRIPTION
# What Does This Do
The log inject test rely on a specific format to parse out log details from `stdout`. These are correlated with the log files generated by the logger.

Lines in `stdout` sometimes get merged together in a racy manner. The previous code handled the next line getting merged into the important line, but not vice versa. IE, it handled:

```
SECONDTRACEID 2799463272611004066 2799463272611004067[dd.trace 2023-06-26 19:26:17:127 +0000]next line of text
```

but not
```
[dd.trace 2023-06-26 19:26:17:127 +0000]previous linetextSECONDTRACEID 2799463272611004066 2799463272611004067

```

This lead to rare, but annoying, test failures.