### PR TITLE
uupgrade ddprof to 0.55.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.53.0",
+    ddprof        : "0.55.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

Adds defensive buffer flushes to native code paths invoked since 1.15.0 (changes introduced in #5250 and #5251)

# Motivation

# Additional Notes
