### PR TITLE
Add a config to enable/disable live heap size tracking

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -14,6 +14,7 @@ import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallContextF
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallInterval;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isAllocationProfilingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isCpuProfilerEnabled;
+import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isLiveHeapSizeTrackingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isMemoryLeakProfilingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isSpanNameContextAttributeEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isWallClockProfilerEnabled;
@@ -338,7 +339,7 @@ public final class DatadogProfiler {
         cmd.append('a');
       }
       if (profilingModes.contains(MEMLEAK)) {
-        cmd.append('l');
+        cmd.append(isLiveHeapSizeTrackingEnabled(configProvider) ? 'L' : 'l');
       }
     }
     String cmdString = cmd.toString();

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -19,6 +19,8 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_INTERVAL;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_TRACK_HEAPSIZE;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LIVEHEAP_TRACK_HEAPSIZE_DEFAFULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LOG_LEVEL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_LOG_LEVEL_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_MEMLEAK_CAPACITY;
@@ -162,6 +164,13 @@ public class DatadogProfilerConfig {
 
   public static boolean isMemoryLeakProfilingEnabled() {
     return isMemoryLeakProfilingEnabled(ConfigProvider.getInstance());
+  }
+
+  public static boolean isLiveHeapSizeTrackingEnabled(ConfigProvider configProvider) {
+    return getBoolean(
+        configProvider,
+        PROFILING_DATADOG_PROFILER_LIVEHEAP_TRACK_HEAPSIZE,
+        PROFILING_DATADOG_PROFILER_LIVEHEAP_TRACK_HEAPSIZE_DEFAFULT);
   }
 
   public static long getMemleakInterval(ConfigProvider configProvider) {

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerTest.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/test/java/com/datadog/profiling/ddprof/DatadogProfilerTest.java
@@ -91,7 +91,7 @@ class DatadogProfilerTest {
       assertTrue(cmd.matches(".*?memory=[0-9]+b?:.*?a.*"), cmd);
     }
     if (profiler.enabledModes().contains(ProfilingMode.MEMLEAK)) {
-      assertTrue(cmd.matches(".*?memory=[0-9]+b?:.*?l.*"), cmd);
+      assertTrue(cmd.matches(".*?memory=[0-9]+b?:.*?[lL].*"), cmd);
     }
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -137,6 +137,9 @@ public final class ProfilingConfig {
   public static final String PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY =
       "profiling.ddprof.liveheap.capacity";
   public static final int PROFILING_DATADOG_PROFILER_LIVEHEAP_CAPACITY_DEFAULT = 1024;
+  public static final String PROFILING_DATADOG_PROFILER_LIVEHEAP_TRACK_HEAPSIZE =
+      "profiling.ddprof.liveheap.track_size.enabled";
+  public static final boolean PROFILING_DATADOG_PROFILER_LIVEHEAP_TRACK_HEAPSIZE_DEFAFULT = true;
   public static final String PROFILING_ENDPOINT_COLLECTION_ENABLED =
       "profiling.endpoint.collection.enabled";
   public static final boolean PROFILING_ENDPOINT_COLLECTION_ENABLED_DEFAULT = true;


### PR DESCRIPTION
# What Does This Do
Adds a configuration option to enable/disable the live heap size tracking

# Motivation
The live heap size tracking is using JVM internals and may rarely cause an issue in a particular environment.
We want the users to be able to disable the live heap size tracking without sacrificing the whole live heap profiling capability. 
When the tracking is disabled, the live heap size will be estimated from the statistical distribution of the collected samples instead - which is less precise but does not depend on JVM internals.

# Additional Notes
