### PR TITLE
Fix scanDependencies CLI

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentCLI.java
@@ -89,7 +89,7 @@ public final class AgentCLI {
   public static void scanDependencies(final String[] args) throws Exception {
     Class depClass =
         Class.forName(
-            "datadog.telemetry.dependency.DependencyServiceImpl",
+            "datadog.telemetry.dependency.DependencyService",
             true,
             AgentCLI.class.getClassLoader());
     Object depService = depClass.getConstructor().newInstance();


### PR DESCRIPTION


# What Does This Do

# Motivation
Broken by previous class move.
# Additional Notes
