### PR TITLE
Add support for distribution metrics

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -30,6 +30,13 @@ public class DebuggerContext {
     boolean isDenied(String fullyQualifiedClassName);
   }
 
+  public enum MetricKind {
+    COUNT,
+    GAUGE,
+    HISTOGRAM,
+    DISTRIBUTION;
+  }
+
   public interface MetricForwarder {
     void count(String name, long delta, String[] tags);
 
@@ -40,6 +47,10 @@ public class DebuggerContext {
     void histogram(String name, long value, String[] tags);
 
     void histogram(String name, double value, String[] tags);
+
+    void distribution(String name, long value, String[] tags);
+
+    void distribution(String name, double value, String[] tags);
   }
 
   public interface Tracer {
@@ -98,68 +109,55 @@ public class DebuggerContext {
     return filter.isDenied(fullyQualifiedClassName);
   }
 
-  /** Increments the specified counter metric No-op if no implementation is available */
-  public static void count(String name, long delta, String[] tags) {
+  /** Increments or updates the specified metric No-op if no implementation is available */
+  public static void metric(MetricKind kind, String name, long value, String[] tags) {
     try {
       MetricForwarder forwarder = metricForwarder;
       if (forwarder == null) {
         return;
       }
-      forwarder.count(name, delta, tags);
+      switch (kind) {
+        case COUNT:
+          forwarder.count(name, value, tags);
+          break;
+        case GAUGE:
+          forwarder.gauge(name, value, tags);
+          break;
+        case HISTOGRAM:
+          forwarder.histogram(name, value, tags);
+          break;
+        case DISTRIBUTION:
+          forwarder.distribution(name, value, tags);
+        default:
+          throw new IllegalArgumentException("Unsupported metric kind: " + kind);
+      }
     } catch (Exception ex) {
-      LOGGER.debug("Error in count method: ", ex);
+      LOGGER.debug("Error in metric method: ", ex);
     }
   }
 
-  /** Updates the specified gauge metric No-op if no implementation is available */
-  public static void gauge(String name, long value, String[] tags) {
+  /** Updates the specified metric No-op if no implementation is available */
+  public static void metric(MetricKind kind, String name, double value, String[] tags) {
     try {
       MetricForwarder forwarder = metricForwarder;
       if (forwarder == null) {
         return;
       }
-      forwarder.gauge(name, value, tags);
-    } catch (Exception ex) {
-      LOGGER.debug("Error in gauge: ", ex);
-    }
-  }
-
-  /** Updates the specified gauge metric No-op if no implementation is available */
-  public static void gauge(String name, double value, String[] tags) {
-    try {
-      MetricForwarder forwarder = metricForwarder;
-      if (forwarder == null) {
-        return;
+      switch (kind) {
+        case GAUGE:
+          forwarder.gauge(name, value, tags);
+          break;
+        case HISTOGRAM:
+          forwarder.histogram(name, value, tags);
+          break;
+        case DISTRIBUTION:
+          forwarder.distribution(name, value, tags);
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported metric kind: " + kind);
       }
-      forwarder.gauge(name, value, tags);
     } catch (Exception ex) {
-      LOGGER.debug("Error in gauge: ", ex);
-    }
-  }
-
-  /** Updates the specified histogram metric No-op if no implementation is available */
-  public static void histogram(String name, long value, String[] tags) {
-    try {
-      MetricForwarder forwarder = metricForwarder;
-      if (forwarder == null) {
-        return;
-      }
-      forwarder.histogram(name, value, tags);
-    } catch (Exception ex) {
-      LOGGER.debug("Error in histogram: ", ex);
-    }
-  }
-
-  /** Updates the specified histogram metric No-op if no implementation is available */
-  public static void histogram(String name, double value, String[] tags) {
-    try {
-      MetricForwarder forwarder = metricForwarder;
-      if (forwarder == null) {
-        return;
-      }
-      forwarder.histogram(name, value, tags);
-    } catch (Exception ex) {
-      LOGGER.debug("Error in histogram: ", ex);
+      LOGGER.debug("Error in metric method: ", ex);
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
@@ -53,6 +53,16 @@ public class StatsdMetricForwarder
   }
 
   @Override
+  public void distribution(String name, long value, String[] tags) {
+    statsd.distribution(name, value, tags);
+  }
+
+  @Override
+  public void distribution(String name, double value, String[] tags) {
+    statsd.distribution(name, value, tags);
+  }
+
+  @Override
   public void handle(Exception exception) {
     LOGGER.warn("Error when sending metrics: ", exception);
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -9,8 +9,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
+import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InsnNode;
@@ -88,6 +90,12 @@ public class ASMHelper {
 
   public static void ldc(InsnList insnList, Object val) {
     insnList.add(val == null ? new InsnNode(Opcodes.ACONST_NULL) : new LdcInsnNode(val));
+  }
+
+  public static void getStatic(InsnList insnList, org.objectweb.asm.Type owner, String fieldName) {
+    insnList.add(
+        new FieldInsnNode(
+            Opcodes.GETSTATIC, owner.getInternalName(), fieldName, owner.getDescriptor()));
   }
 
   public static Type decodeSignature(String signature) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.instrumentation;
 
+import static com.datadog.debugger.instrumentation.ASMHelper.getStatic;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeStatic;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeVirtual;
 import static com.datadog.debugger.instrumentation.ASMHelper.isStaticField;
@@ -883,12 +884,6 @@ public class CapturedContextInstrumentor extends Instrumentor {
             Type.getMethodDescriptor(Type.VOID_TYPE, argTypes),
             false));
     // stack: []
-  }
-
-  private static void getStatic(InsnList insnList, Type owner, String fieldName) {
-    insnList.add(
-        new FieldInsnNode(
-            Opcodes.GETSTATIC, owner.getInternalName(), fieldName, owner.getDescriptor()));
   }
 
   private static void newInstance(InsnList insnList, Type type) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.instrumentation;
 
 import static com.datadog.debugger.instrumentation.ASMHelper.decodeSignature;
 import static com.datadog.debugger.instrumentation.ASMHelper.ensureSafeClassLoad;
+import static com.datadog.debugger.instrumentation.ASMHelper.getStatic;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeInterface;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeStatic;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeVirtual;
@@ -181,19 +182,24 @@ public class MetricInstrumentor extends Instrumentor {
     if (metricProbe.getValue() == null) {
       InsnList insnList = new InsnList();
       // consider the metric as an increment counter one
+      getStatic(insnList, METRICKIND_TYPE, metricProbe.getKind().name());
+      // stack [MetricKind]
       insnList.add(new LdcInsnNode(metricProbe.getMetricName()));
-      ldc(insnList, 1L); // stack [long]
-      pushTags(
-          insnList,
-          addProbeIdWithTags(metricProbe.getId(), metricProbe.getTags())); // stack [long, array]
+      // stack [MetricKind, string]
+      ldc(insnList, 1L);
+      // stack [MetricKind, string, long]
+      pushTags(insnList, addProbeIdWithTags(metricProbe.getId(), metricProbe.getTags()));
+      // stack [MetricKind, string, long, array]
       invokeStatic(
           insnList,
           DEBUGGER_CONTEXT_TYPE,
-          metricProbe.getKind().getMetricMethodName(),
+          "metric",
           Type.VOID_TYPE,
+          METRICKIND_TYPE,
           STRING_TYPE,
           Type.LONG_TYPE,
           Types.asArray(STRING_TYPE, 1));
+      // stack []
       return insnList;
     }
     return internalCallMetric(metricProbe);
@@ -201,8 +207,6 @@ public class MetricInstrumentor extends Instrumentor {
 
   private InsnList internalCallMetric(MetricProbe metricProbe) {
     InsnList insnList = new InsnList();
-    insnList.add(new LdcInsnNode(metricProbe.getMetricName()));
-    // stack [string]
     InsnList nullBranch = new InsnList();
     VisitorResult result;
     Type resultType;
@@ -225,17 +229,21 @@ public class MetricInstrumentor extends Instrumentor {
               resultType.getClassName(), expectedTypes));
       return EMPTY_INSN_LIST;
     }
-    // stack [string, int|long|float|double]
     resultType = convertIfRequired(resultType, result.insnList);
-    // stack [string, long|double]
+    getStatic(insnList, METRICKIND_TYPE, metricProbe.getKind().name());
+    // stack [MetricKind]
+    insnList.add(new LdcInsnNode(metricProbe.getMetricName()));
+    // stack [MetricKind, string]
     insnList.add(result.insnList);
+    // stack [MetricKind, string, long|double]
     pushTags(insnList, addProbeIdWithTags(metricProbe.getId(), metricProbe.getTags()));
-    // stack [string, long|double, array]
+    // stack [MetricKind, string, long|double, array]
     invokeStatic(
         insnList,
         DEBUGGER_CONTEXT_TYPE,
-        kind.getMetricMethodName(),
+        "metric",
         Type.VOID_TYPE,
+        METRICKIND_TYPE,
         STRING_TYPE,
         resultType,
         Types.asArray(STRING_TYPE, 1));
@@ -256,28 +264,17 @@ public class MetricInstrumentor extends Instrumentor {
     return currentType;
   }
 
-  private InsnList callGauge(MetricProbe metricProbe) {
-    if (metricProbe.getValue() == null) {
-      return EMPTY_INSN_LIST;
-    }
-    return internalCallMetric(metricProbe);
-  }
-
-  private InsnList callHistogram(MetricProbe metricProbe) {
-    if (metricProbe.getValue() == null) {
-      return EMPTY_INSN_LIST;
-    }
-    return internalCallMetric(metricProbe);
-  }
-
   private InsnList callMetric(MetricProbe metricProbe) {
     switch (metricProbe.getKind()) {
       case COUNT:
         return callCount(metricProbe);
       case GAUGE:
-        return callGauge(metricProbe);
       case HISTOGRAM:
-        return callHistogram(metricProbe);
+      case DISTRIBUTION:
+        if (metricProbe.getValue() == null) {
+          return EMPTY_INSN_LIST;
+        }
+        return internalCallMetric(metricProbe);
       default:
         reportError(String.format("Unknown metric kind: %s", metricProbe.getKind()));
     }
@@ -313,13 +310,6 @@ public class MetricInstrumentor extends Instrumentor {
         methodNode.instructions.insert(afterLabel, insnList);
       }
     }
-  }
-
-  private boolean isCompatible(Type argType, Type expectedType) {
-    if (expectedType == Type.LONG_TYPE) {
-      return argType == expectedType || argType == Type.INT_TYPE;
-    }
-    return argType == expectedType;
   }
 
   private static class VisitorResult {
@@ -719,8 +709,9 @@ public class MetricInstrumentor extends Instrumentor {
         LabelNode gotoNode = new LabelNode();
         nullBranch.add(new JumpInsnNode(Opcodes.GOTO, gotoNode));
         nullBranch.add(nullNode);
-        nullBranch.add(new InsnNode(Opcodes.POP));
-        nullBranch.add(new InsnNode(Opcodes.POP));
+        nullBranch.add(new InsnNode(Opcodes.POP)); // target_object
+        nullBranch.add(new InsnNode(Opcodes.POP)); // metric name
+        nullBranch.add(new InsnNode(Opcodes.POP)); // metric kind
         nullBranch.add(gotoNode);
       } catch (Exception e) {
         String message = "Cannot resolve field " + fieldName;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Types.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Types.java
@@ -67,6 +67,7 @@ public final class Types {
   public static final Type DEBUGGER_SPAN_TYPE = Type.getType(DebuggerSpan.class);
   public static final Type REFLECTIVE_FIELD_VALUE_RESOLVER_TYPE =
       Type.getType(ReflectiveFieldValueResolver.class);
+  public static final Type METRICKIND_TYPE = Type.getType(DebuggerContext.MetricKind.class);
 
   // special initialization methods
   public static final String CONSTRUCTOR = "<init>";

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -19,7 +19,7 @@ import org.objectweb.asm.tree.MethodNode;
 public class MetricProbe extends ProbeDefinition {
 
   public enum MetricKind {
-    COUNT("count") {
+    COUNT {
       @Override
       public boolean isCompatible(Type type) {
         return type == Type.INT_TYPE || type == Type.LONG_TYPE;
@@ -30,7 +30,7 @@ public class MetricProbe extends ProbeDefinition {
         return Collections.singleton(Type.LONG_TYPE);
       }
     },
-    GAUGE("gauge") {
+    GAUGE {
       @Override
       public boolean isCompatible(Type type) {
         return type == Type.INT_TYPE
@@ -44,7 +44,21 @@ public class MetricProbe extends ProbeDefinition {
         return Arrays.asList(Type.LONG_TYPE, Type.DOUBLE_TYPE);
       }
     },
-    HISTOGRAM("histogram") {
+    HISTOGRAM {
+      @Override
+      public boolean isCompatible(Type type) {
+        return type == Type.INT_TYPE
+            || type == Type.LONG_TYPE
+            || type == Type.FLOAT_TYPE
+            || type == Type.DOUBLE_TYPE;
+      }
+
+      @Override
+      public Collection<Type> getSupportedTypes() {
+        return Arrays.asList(Type.LONG_TYPE, Type.DOUBLE_TYPE);
+      }
+    },
+    DISTRIBUTION {
       @Override
       public boolean isCompatible(Type type) {
         return type == Type.INT_TYPE
@@ -58,16 +72,6 @@ public class MetricProbe extends ProbeDefinition {
         return Arrays.asList(Type.LONG_TYPE, Type.DOUBLE_TYPE);
       }
     };
-
-    MetricKind(String metricMethodName) {
-      this.metricMethodName = metricMethodName;
-    }
-
-    private final String metricMethodName;
-
-    public String getMetricMethodName() {
-      return metricMethodName;
-    }
 
     public abstract boolean isCompatible(Type type);
 


### PR DESCRIPTION
add a new kind of metric: Distribution that is already supported by DogStatsD, but was not exposed before to the tracer metric interface

# What Does This Do

# Motivation

# Additional Notes
