### PR TITLE
Add span metrics

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -17,6 +17,8 @@ import datadog.trace.api.EndpointTracker;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.metrics.SpanMetricRegistry;
+import datadog.trace.api.metrics.SpanMetrics;
 import datadog.trace.api.profiling.TransientProfilingContextHolder;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
@@ -53,6 +55,9 @@ public class DDSpan
     context.getTrace().registerSpan(span);
     return span;
   }
+
+  /** The metrics for this span instance. */
+  private final SpanMetrics metrics;
 
   /** The context attached to the span */
   private final DDSpanContext context;
@@ -107,6 +112,8 @@ public class DDSpan
    */
   private DDSpan(final long timestampMicro, @Nonnull DDSpanContext context) {
     this.context = context;
+    this.metrics = SpanMetricRegistry.getInstance().get("default");
+    this.metrics.onSpanCreated();
 
     if (timestampMicro <= 0L) {
       // note: getting internal time from the trace implicitly 'touches' it
@@ -127,6 +134,7 @@ public class DDSpan
     // ensure a min duration of 1
     if (DURATION_NANO_UPDATER.compareAndSet(this, 0, Math.max(1, durationNano))) {
       setLongRunningVersion(-this.longRunningVersion);
+      this.metrics.onSpanFinished();
       PendingTrace.PublishState publishState = context.getTrace().onPublish(this);
       log.debug("Finished span ({}): {}", publishState, this);
     } else {

--- a/internal-api/src/main/java/datadog/trace/api/metrics/CoreCounter.java
+++ b/internal-api/src/main/java/datadog/trace/api/metrics/CoreCounter.java
@@ -1,0 +1,18 @@
+package datadog.trace.api.metrics;
+
+/** This interface describes a core counter metric. */
+public interface CoreCounter {
+  /**
+   * Get the counter name.
+   *
+   * @return The counter name.
+   */
+  String getName();
+
+  /**
+   * Get the value and reset the counter.
+   *
+   * @return The current counter value.
+   */
+  long getValueAndReset();
+}

--- a/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricRegistry.java
+++ b/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricRegistry.java
@@ -1,0 +1,28 @@
+package datadog.trace.api.metrics;
+
+import datadog.trace.api.InstrumenterConfig;
+
+/** This class holds the {@link SpanMetrics} instances. */
+@FunctionalInterface
+public interface SpanMetricRegistry {
+  SpanMetricRegistry NOOP = instrumentationName -> SpanMetrics.NOOP;
+
+  /**
+   * Get the span metrics for an instrumentation.
+   *
+   * @param instrumentationName The instrumentation name to get span metrics.
+   * @return The related span metrics instance.
+   */
+  SpanMetrics get(String instrumentationName);
+
+  /**
+   * Get the registry instance according the telemetry status.
+   *
+   * @return The registry instance.
+   */
+  static SpanMetricRegistry getInstance() {
+    return InstrumenterConfig.get().isTelemetryEnabled()
+        ? SpanMetricRegistryImpl.getInstance()
+        : SpanMetricRegistry.NOOP;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricRegistryImpl.java
+++ b/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricRegistryImpl.java
@@ -1,0 +1,33 @@
+package datadog.trace.api.metrics;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** The default {@link SpanMetricRegistry} implementation. */
+public class SpanMetricRegistryImpl implements SpanMetricRegistry {
+  private static final SpanMetricRegistryImpl INSTANCE = new SpanMetricRegistryImpl();
+  private final Map<String, SpanMetrics> spanMetrics;
+
+  public static SpanMetricRegistryImpl getInstance() {
+    return INSTANCE;
+  }
+
+  private SpanMetricRegistryImpl() {
+    this.spanMetrics = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public SpanMetrics get(String instrumentationName) {
+    return this.spanMetrics.computeIfAbsent(instrumentationName, SpanMetricsImpl::new);
+  }
+
+  /**
+   * Get all span metrics.
+   *
+   * @return All span metrics registered instances.
+   */
+  public Collection<SpanMetrics> getSpanMetrics() {
+    return this.spanMetrics.values();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetrics.java
+++ b/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetrics.java
@@ -1,0 +1,19 @@
+package datadog.trace.api.metrics;
+
+/** The core metrics related to a span./ */
+public interface SpanMetrics {
+  SpanMetrics NOOP =
+      new SpanMetrics() {
+        @Override
+        public void onSpanCreated() {}
+
+        @Override
+        public void onSpanFinished() {}
+      };
+
+  /** Increment span created counter. */
+  void onSpanCreated();
+
+  /** Increment span finished counter. */
+  void onSpanFinished();
+}

--- a/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricsImpl.java
+++ b/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricsImpl.java
@@ -1,0 +1,63 @@
+package datadog.trace.api.metrics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** The default implementation of {@link SpanMetrics} based on atomic counters. */
+public class SpanMetricsImpl implements SpanMetrics {
+  private final String instrumentationName;
+  private final AtomicLong spanCreatedCounter;
+  private final AtomicLong spanFinishedCounter;
+  private final Collection<CoreCounter> coreCounters;
+
+  public SpanMetricsImpl(String instrumentationName) {
+    this.instrumentationName = instrumentationName;
+    this.spanCreatedCounter = new AtomicLong(0);
+    this.spanFinishedCounter = new AtomicLong(0);
+    List<CoreCounter> coreCounters = new ArrayList<>(2);
+    coreCounters.add(new SpanCounter("span_created", this.spanCreatedCounter));
+    coreCounters.add(new SpanCounter("span_finished", this.spanFinishedCounter));
+    this.coreCounters = Collections.unmodifiableList(coreCounters);
+  }
+
+  @Override
+  public void onSpanCreated() {
+    this.spanCreatedCounter.incrementAndGet();
+  }
+
+  @Override
+  public void onSpanFinished() {
+    this.spanFinishedCounter.incrementAndGet();
+  }
+
+  public String getInstrumentationName() {
+    return this.instrumentationName;
+  }
+
+  public Collection<CoreCounter> getCounters() {
+    return this.coreCounters;
+  }
+
+  private static class SpanCounter implements CoreCounter {
+    private final String name;
+    private final AtomicLong counter;
+
+    private SpanCounter(String name, AtomicLong counter) {
+      this.name = name;
+      this.counter = counter;
+    }
+
+    @Override
+    public String getName() {
+      return this.name;
+    }
+
+    @Override
+    public long getValueAndReset() {
+      return this.counter.getAndSet(0);
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/CoreMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/CoreMetricCollector.java
@@ -1,0 +1,72 @@
+package datadog.trace.api.telemetry;
+
+import datadog.trace.api.metrics.CoreCounter;
+import datadog.trace.api.metrics.SpanMetricRegistryImpl;
+import datadog.trace.api.metrics.SpanMetrics;
+import datadog.trace.api.metrics.SpanMetricsImpl;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+
+/** This class is in charge of draining core metrics for telemetry. */
+public class CoreMetricCollector implements MetricCollector<CoreMetricCollector.CoreMetric> {
+  private static final String METRIC_NAMESPACE = "tracers";
+  private static final CoreMetricCollector INSTANCE = new CoreMetricCollector();
+  private final SpanMetricRegistryImpl spanMetricRegistry = SpanMetricRegistryImpl.getInstance();
+
+  private final BlockingQueue<CoreMetric> metricsQueue;
+
+  public static CoreMetricCollector getInstance() {
+    return INSTANCE;
+  }
+
+  private CoreMetricCollector() {
+    this.metricsQueue = new ArrayBlockingQueue<>(RAW_QUEUE_SIZE);
+  }
+
+  @Override
+  public void prepareMetrics() {
+    for (SpanMetrics spanMetric : this.spanMetricRegistry.getSpanMetrics()) {
+      SpanMetricsImpl spanMetricsImpl = (SpanMetricsImpl) spanMetric;
+      String tag = spanMetricsImpl.getInstrumentationName();
+      for (CoreCounter counter : spanMetricsImpl.getCounters()) {
+        long value = counter.getValueAndReset();
+        if (value == 0) {
+          // Skip not updated counters
+          continue;
+        }
+        CoreMetric metric =
+            new CoreMetric(METRIC_NAMESPACE, true, counter.getName(), "count", value, tag);
+        if (!this.metricsQueue.offer(metric)) {
+          // Stop adding metrics if the queue is full
+          break;
+        }
+      }
+    }
+  }
+
+  @Override
+  public Collection<CoreMetric> drain() {
+    if (this.metricsQueue.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<CoreMetric> drained = new ArrayList<>(this.metricsQueue.size());
+    this.metricsQueue.drainTo(drained);
+    return drained;
+  }
+
+  public static class CoreMetric extends MetricCollector.Metric {
+    public CoreMetric(
+        String namespace,
+        boolean common,
+        String metricName,
+        String type,
+        Number value,
+        String tag) {
+      super(namespace, common, metricName, type, value, tag);
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/MetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/MetricCollector.java
@@ -13,6 +13,9 @@ public interface MetricCollector<M extends Metric> {
 
   int RAW_QUEUE_SIZE = 1024;
 
+  // TODO All implementations are based on queueing metrics and never care when the queue is full.
+  // TODO This leads to always resetting counters even if the related metrics could not be enqueued.
+  // TODO So we may loose metric information during this call.
   void prepareMetrics();
 
   Collection<M> drain();

--- a/internal-api/src/test/groovy/datadog/trace/api/metrics/SpanMetricRegistryTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/metrics/SpanMetricRegistryTest.groovy
@@ -1,0 +1,53 @@
+package datadog.trace.api.metrics
+
+import datadog.trace.test.util.DDSpecification
+
+class SpanMetricRegistryTest extends DDSpecification {
+  def 'test registry not crash if telemetry is disabled'() {
+    setup:
+    injectSysConfig('instrumentation.telemetry.enabled', telemetryEnabled)
+
+    when:
+    def spanMetricRegistry = SpanMetricRegistry.getInstance()
+    def spanMetrics = spanMetricRegistry.get('test-api')
+    spanMetrics.onSpanCreated()
+    spanMetrics.onSpanFinished()
+
+    then:
+    noExceptionThrown()
+
+    cleanup:
+    if (spanMetricRegistry instanceof SpanMetricRegistryImpl) {
+      ((SpanMetricRegistryImpl) spanMetricRegistry).getSpanMetrics().forEach {
+        if (it instanceof SpanMetricsImpl) {
+          ((SpanMetricsImpl) it).getCounters().forEach {
+            it.valueAndReset
+          }
+        }
+      }
+    }
+
+    where:
+    telemetryEnabled << ['true', 'false']
+  }
+
+  def 'test registry API'() {
+    setup:
+    def spanMetricRegistry = new SpanMetricRegistryImpl()
+
+    when:
+    def metrics1 = spanMetricRegistry.get('test1')
+    def metrics1Ref = spanMetricRegistry.get('test1')
+
+    then:
+    metrics1 == metrics1Ref
+
+    when:
+    def metrics2 = spanMetricRegistry.get('test2')
+    def metricsCollection = spanMetricRegistry.getSpanMetrics()
+
+    then:
+    metricsCollection.size() == 2
+    metricsCollection.toSet() == [metrics1, metrics2].toSet()
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -5,6 +5,7 @@ import datadog.telemetry.TelemetryRunnable.TelemetryPeriodicAction;
 import datadog.telemetry.dependency.DependencyPeriodicAction;
 import datadog.telemetry.dependency.DependencyService;
 import datadog.telemetry.integration.IntegrationPeriodicAction;
+import datadog.telemetry.metric.CoreMetricsPeriodicAction;
 import datadog.telemetry.metric.IastMetricPeriodicAction;
 import datadog.telemetry.metric.WafMetricPeriodicAction;
 import datadog.trace.api.Config;
@@ -39,6 +40,7 @@ public class TelemetrySystem {
     DEPENDENCY_SERVICE = dependencyService;
 
     List<TelemetryPeriodicAction> actions = new ArrayList<>();
+    actions.add(new CoreMetricsPeriodicAction());
     actions.add(new IntegrationPeriodicAction());
     actions.add(new WafMetricPeriodicAction());
     if (Verbosity.OFF != Config.get().getIastTelemetryVerbosity()) {

--- a/telemetry/src/main/java/datadog/telemetry/metric/CoreMetricsPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/CoreMetricsPeriodicAction.java
@@ -1,0 +1,13 @@
+package datadog.telemetry.metric;
+
+import datadog.trace.api.telemetry.CoreMetricCollector;
+import datadog.trace.api.telemetry.MetricCollector;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class CoreMetricsPeriodicAction extends MetricPeriodicAction {
+  @NonNull
+  @Override
+  public MetricCollector collector() {
+    return CoreMetricCollector.getInstance();
+  }
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/CoreMetricsPeriodActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/CoreMetricsPeriodActionTest.groovy
@@ -1,0 +1,176 @@
+package datadog.telemetry.metric
+
+import datadog.telemetry.TelemetryService
+import datadog.telemetry.api.Metric
+import datadog.trace.api.metrics.SpanMetricRegistry
+import datadog.trace.api.metrics.SpanMetrics
+import spock.lang.Specification
+
+class CoreMetricsPeriodActionTest extends Specification {
+
+  void 'test span metrics with multiple occurrence events'() {
+    given:
+    final telemetryService = Mock(TelemetryService)
+    final action = new CoreMetricsPeriodicAction()
+    final SpanMetricRegistry spanMetricRegistry = SpanMetricRegistry.getInstance()
+    final SpanMetrics instr1SpanMetric = spanMetricRegistry.get('instr-1')
+    final SpanMetrics instr2SpanMetric = spanMetricRegistry.get('instr-2')
+
+    when:
+    instr1SpanMetric.onSpanCreated()
+    instr2SpanMetric.onSpanCreated()
+    instr1SpanMetric.onSpanCreated()
+    instr2SpanMetric.onSpanCreated()
+    instr2SpanMetric.onSpanCreated()
+    instr2SpanMetric.onSpanFinished()
+    instr2SpanMetric.onSpanFinished()
+    instr2SpanMetric.onSpanFinished()
+    instr2SpanMetric.onSpanFinished()
+
+    action.collector().prepareMetrics()
+    action.doIteration(telemetryService)
+
+    then:
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-1', 2)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-2', 3)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-2', 4)
+    })
+    0 * _
+  }
+
+  void 'test span metrics with interleaved events'() {
+    given:
+    final telemetryService = Mock(TelemetryService)
+    final action = new CoreMetricsPeriodicAction()
+    final SpanMetricRegistry spanMetricRegistry = SpanMetricRegistry.getInstance()
+    final SpanMetrics instr1SpanMetric = spanMetricRegistry.get('instr-1')
+    final SpanMetrics instr2SpanMetric = spanMetricRegistry.get('instr-2')
+    final SpanMetrics instr3SpanMetric = spanMetricRegistry.get('instr-3')
+    final SpanMetrics instrASpanMetric = spanMetricRegistry.get('instr-a')
+    final SpanMetrics instrBSpanMetric = spanMetricRegistry.get('instr-b')
+
+    when:
+    instr1SpanMetric.onSpanCreated()
+    instr2SpanMetric.onSpanCreated()
+    instr3SpanMetric.onSpanCreated()
+    instr3SpanMetric.onSpanFinished()
+    instrASpanMetric.onSpanCreated()
+    instrBSpanMetric.onSpanCreated()
+    instrBSpanMetric.onSpanFinished()
+    instr2SpanMetric.onSpanFinished()
+    instrASpanMetric.onSpanFinished()
+    instr1SpanMetric.onSpanFinished()
+
+    action.collector().prepareMetrics()
+    action.doIteration(telemetryService)
+
+    then:
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-1', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-2', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-3', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-3', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-a', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-b', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-b', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-2', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-a', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-1', 1)
+    })
+    0 * _
+  }
+
+  void 'test span metrics'() {
+    given:
+    final telemetryService = Mock(TelemetryService)
+    final action = new CoreMetricsPeriodicAction()
+    final SpanMetricRegistry spanMetricRegistry = SpanMetricRegistry.getInstance()
+    final SpanMetrics instr1SpanMetric = spanMetricRegistry.get('instr-1')
+    final SpanMetrics instr2SpanMetric = spanMetricRegistry.get('instr-2')
+    final SpanMetrics instr3SpanMetric = spanMetricRegistry.get('instr-3')
+    final SpanMetrics instrASpanMetric = spanMetricRegistry.get('instr-a')
+    final SpanMetrics instrBSpanMetric = spanMetricRegistry.get('instr-b')
+
+    when:
+    instr1SpanMetric.onSpanCreated()
+    instr2SpanMetric.onSpanCreated()
+    instr3SpanMetric.onSpanCreated()
+    instr3SpanMetric.onSpanFinished()
+    instrASpanMetric.onSpanCreated()
+    instrBSpanMetric.onSpanCreated()
+    instrBSpanMetric.onSpanFinished()
+    instr2SpanMetric.onSpanFinished()
+    instrASpanMetric.onSpanFinished()
+    instr1SpanMetric.onSpanFinished()
+
+    action.collector().prepareMetrics()
+    action.doIteration(telemetryService)
+
+    then:
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-1', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-2', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-3', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-3', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-a', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_created', 'instr-b', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-b', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-2', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-a', 1)
+    })
+    1 * telemetryService.addMetric({ Metric metric ->
+      assertMetric(metric, 'span_finished', 'instr-1', 1)
+    })
+    0 * _
+  }
+
+  void assertMetric(Metric metric, String metricName, String instrumentationName, long count) {
+    assert metric.namespace == 'tracers'
+    assert metric.common
+    assert metric.metric == metricName
+    assert metric.points.size() == 1
+    assert metric.points[0].size() == 2
+    assert metric.points[0][1] == count
+    assert metric.tags == [instrumentationName]
+    assert metric.type == Metric.TypeEnum.COUNT
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR introduces span metrics.
The first to metrics available are:
* Span created
* Span finish

Those metrics are connected to telemetry by a new core metrics collector and period action.

# Motivation

# Additional Notes

This PR is the second part of the Span Metrics PR https://github.com/DataDog/dd-trace-java/pull/5382
