### PR TITLE
Latest dynamic-config schema changes

### DIFF
--- a/dd-smoke-tests/dynamic-config/src/test/groovy/datadog/smoketest/DynamicServiceMappingSmokeTest.groovy
+++ b/dd-smoke-tests/dynamic-config/src/test/groovy/datadog/smoketest/DynamicServiceMappingSmokeTest.groovy
@@ -29,7 +29,7 @@ class DynamicServiceMappingSmokeTest extends AbstractSmokeTest {
         {
           "lib_config": {
             "tracing_service_mapping": [{
-              "from_name": "${ServiceMappingApplication.ORIGINAL_SERVICE_NAME}",
+              "from_key": "${ServiceMappingApplication.ORIGINAL_SERVICE_NAME}",
               "to_name": "${ServiceMappingApplication.MAPPED_SERVICE_NAME}"
             }]
           }

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -221,7 +221,7 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
 
     def newConfig = """
         {"lib_config":
-          {"logs_injection_enabled":false}
+          {"log_injection_enabled":false}
         }
      """.toString()
     setRemoteConfig("datadog/2/APM_TRACING/config_overrides/config", newConfig)

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -125,7 +125,7 @@ final class TracingConfigPoller {
     @Json(name = "runtime_metrics_enabled")
     public Boolean runtimeMetricsEnabled;
 
-    @Json(name = "logs_injection_enabled")
+    @Json(name = "log_injection_enabled")
     public Boolean logsInjectionEnabled;
 
     @Json(name = "data_streams_enabled")
@@ -142,15 +142,15 @@ final class TracingConfigPoller {
   }
 
   static final class ServiceMappingEntry implements Map.Entry<String, String> {
-    @Json(name = "from_name")
-    public String fromName;
+    @Json(name = "from_key")
+    public String fromKey;
 
     @Json(name = "to_name")
     public String toName;
 
     @Override
     public String getKey() {
-      return fromName;
+      return fromKey;
     }
 
     @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -438,10 +438,10 @@ class CoreTracerTest extends DDCoreSpecification {
         {
           "tracing_service_mapping":
           [{
-             "from_name": "foobar",
+             "from_key": "foobar",
              "to_name": "bar"
           }, {
-             "from_name": "snafu",
+             "from_key": "snafu",
              "to_name": "foo"
           }]
           ,


### PR DESCRIPTION
`log_injection_enabled` instead of `logs_injection_enabled`

inside `tracing_service_mapping`...`from_key` instead of `from_name`