### PR TITLE
fix: Fix release creation

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -155,7 +155,7 @@ jobs:
             }
 
             // Create release with the draft changelog
-            await github.repos.createRelease({
+            await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: '${{ github.event.ref }}',

--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -1,11 +1,12 @@
 name: Draft release notes on tag
 on:
-  create
+  create:
+  workflow_dispatch:
 
 jobs:
   draft_release_notes:
     name: Draft release notes
-    if: github.event.ref_type == 'tag' && github.event.master_branch == 'master'
+    if: (github.event.ref_type == 'tag' && github.event.master_branch == 'master') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Get milestone title


### PR DESCRIPTION
# What Does This Do

This should fix the release creation. It will also brings the capability of rerunning the action on an existing tag.
This step was not tested on repository to prevent creating test releases...

# Motivation

# Additional Notes
