### PR TITLE
Fix support for small type metric values

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -253,15 +253,20 @@ public class MetricInstrumentor extends Instrumentor {
   }
 
   private Type convertIfRequired(Type currentType, InsnList insnList) {
-    if (currentType == Type.INT_TYPE) {
-      insnList.add(new InsnNode(Opcodes.I2L));
-      return Type.LONG_TYPE;
+    switch (currentType.getSort()) {
+      case Type.BYTE:
+      case Type.SHORT:
+      case Type.CHAR:
+      case Type.INT:
+      case Type.BOOLEAN:
+        insnList.add(new InsnNode(Opcodes.I2L));
+        return Type.LONG_TYPE;
+      case Type.FLOAT:
+        insnList.add(new InsnNode(Opcodes.F2D));
+        return Type.DOUBLE_TYPE;
+      default:
+        return currentType;
     }
-    if (currentType == Type.FLOAT_TYPE) {
-      insnList.add(new InsnNode(Opcodes.F2D));
-      return Type.DOUBLE_TYPE;
-    }
-    return currentType;
   }
 
   private InsnList callMetric(MetricProbe metricProbe) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -22,7 +22,7 @@ public class MetricProbe extends ProbeDefinition {
     COUNT {
       @Override
       public boolean isCompatible(Type type) {
-        return type == Type.INT_TYPE || type == Type.LONG_TYPE;
+        return isLongOnlyCompatible(type);
       }
 
       @Override
@@ -33,10 +33,7 @@ public class MetricProbe extends ProbeDefinition {
     GAUGE {
       @Override
       public boolean isCompatible(Type type) {
-        return type == Type.INT_TYPE
-            || type == Type.LONG_TYPE
-            || type == Type.FLOAT_TYPE
-            || type == Type.DOUBLE_TYPE;
+        return isLongAndDoubleCompatible(type);
       }
 
       @Override
@@ -47,10 +44,7 @@ public class MetricProbe extends ProbeDefinition {
     HISTOGRAM {
       @Override
       public boolean isCompatible(Type type) {
-        return type == Type.INT_TYPE
-            || type == Type.LONG_TYPE
-            || type == Type.FLOAT_TYPE
-            || type == Type.DOUBLE_TYPE;
+        return isLongAndDoubleCompatible(type);
       }
 
       @Override
@@ -61,10 +55,7 @@ public class MetricProbe extends ProbeDefinition {
     DISTRIBUTION {
       @Override
       public boolean isCompatible(Type type) {
-        return type == Type.INT_TYPE
-            || type == Type.LONG_TYPE
-            || type == Type.FLOAT_TYPE
-            || type == Type.DOUBLE_TYPE;
+        return isLongAndDoubleCompatible(type);
       }
 
       @Override
@@ -76,6 +67,34 @@ public class MetricProbe extends ProbeDefinition {
     public abstract boolean isCompatible(Type type);
 
     public abstract Collection<Type> getSupportedTypes();
+
+    protected boolean isLongOnlyCompatible(Type type) {
+      switch (type.getSort()) {
+        case Type.BYTE:
+        case Type.SHORT:
+        case Type.CHAR:
+        case Type.INT:
+        case Type.LONG:
+        case Type.BOOLEAN:
+          return true;
+      }
+      return false;
+    }
+
+    protected boolean isLongAndDoubleCompatible(Type type) {
+      switch (type.getSort()) {
+        case Type.BYTE:
+        case Type.SHORT:
+        case Type.CHAR:
+        case Type.INT:
+        case Type.LONG:
+        case Type.FLOAT:
+        case Type.DOUBLE:
+        case Type.BOOLEAN:
+          return true;
+      }
+      return false;
+    }
   }
 
   private final MetricKind kind;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -1087,7 +1087,7 @@ public class MetricProbesInstrumentationTest {
     Assertions.assertEquals(1001, listener.counters.get(METRIC_NAME_SHORT));
     result = Reflect.on(testClass).call("main", "char").get();
     Assertions.assertEquals(42, result);
-    Assertions.assertEquals(31, listener.counters.get(METRIC_NAME_CHAR));
+    Assertions.assertEquals(97, listener.counters.get(METRIC_NAME_CHAR));
   }
 
   private MetricForwarderListener installSingleMetric(

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot25.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot25.java
@@ -27,20 +27,20 @@ public class CapturedSnapshot25 {
     return arg;
   }
 
-  private boolean booleanFunction(int arg) {
-    return true;
+  private boolean booleanFunction(boolean arg) {
+    return arg;
   }
 
-  private byte byteFunction(int arg) {
-    return (byte)arg;
+  private byte byteFunction(byte arg) {
+    return arg;
   }
 
-  private short shortFunction(int arg) {
-    return (short)arg;
+  private short shortFunction(short arg) {
+    return arg;
   }
 
-  private char charFunction(int arg) {
-    return (char)arg;
+  private char charFunction(char arg) {
+    return arg;
   }
 
   public static int main(String arg) {
@@ -59,16 +59,16 @@ public class CapturedSnapshot25 {
         cs25.doubleField = cs25.doubleFunction(Math.E);
         break;
       case "boolean":
-        cs25.booleanField = cs25.booleanFunction(1);
+        cs25.booleanField = cs25.booleanFunction(true);
         break;
       case "byte":
-        cs25.byteField = cs25.byteFunction(0x42);
+        cs25.byteField = cs25.byteFunction((byte)0x42);
         break;
       case "short":
-        cs25.shortField = cs25.shortFunction(1001);
+        cs25.shortField = cs25.shortFunction((short)1001);
         break;
       case "char":
-        cs25.charField = cs25.charFunction(31);
+        cs25.charField = cs25.charFunction('a');
         break;
     }
     return 42;


### PR DESCRIPTION
byte, short, char and boolean are treated as int so we can handle them
 in metric values

# What Does This Do

# Motivation

# Additional Notes
