### PR TITLE
Fix NoSameSiteCookie vulnerability name

### DIFF
--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -127,6 +127,40 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     }
   }
 
+  void 'no HttpOnly cookie vulnerability is present'() {
+    setup:
+    String url = "http://localhost:${httpPort}/insecure_cookie"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    response.isSuccessful()
+    response.header('Set-Cookie').contains('user-id')
+    hasVulnerability { vul ->
+      vul.type == 'NO_HTTPONLY_COOKIE' &&
+        vul.evidence.value == 'user-id'
+    }
+  }
+
+  void 'no SameSite cookie vulnerability is present'() {
+    setup:
+    String url = "http://localhost:${httpPort}/insecure_cookie"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    response.isSuccessful()
+    response.header('Set-Cookie').contains('user-id')
+    hasVulnerability { vul ->
+      vul.type == 'NO_SAMESITE_COOKIE' &&
+        vul.evidence.value == 'user-id'
+    }
+  }
+
   void 'insecure cookie  vulnerability from addheader is present'() {
     setup:
     String url = "http://localhost:${httpPort}/insecure_cookie_from_header"

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -13,7 +13,7 @@ public abstract class VulnerabilityTypes {
   public static final String SSRF = "SSRF";
   public static final String INSECURE_COOKIE = "INSECURE_COOKIE";
   public static final String NO_HTTPONLY_COOKIE = "NO_HTTPONLY_COOKIE";
-  public static final String NO_SAMESITE_COOKIE = "NO_HTTPONLY_COOKIE";
+  public static final String NO_SAMESITE_COOKIE = "NO_SAMESITE_COOKIE";
   public static final String UNVALIDATED_REDIRECT = "UNVALIDATED_REDIRECT";
   public static final String WEAK_RANDOMNESS = "WEAK_RANDOMNESS";
 


### PR DESCRIPTION
# What Does This Do
Implements smoke tests for No SameSite and No HttpOnly cookie vulnerabilities. It also fixes the description string for NoSameSite cookie.

# Motivation

# Additional Notes
