### PR TITLE
Add GitHub actions documentation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,107 @@
+# GitHub Actions Documentation
+
+This lists and describes the repository GitHub actions.
+
+## Release Management
+
+### add-assets-to-release
+
+_Trigger:_ When a release is published
+
+_Actions:_
+* Ensure the release name is properly formatted (using `x.y.z` format),
+* Download `dd-java-agent`, `dd-trace-api` and `dd-trace-ot` artifacts from Sonatype (aka _Maven Central_ and upload them to the release (`dd-java-agent` will also be uploaded without version number).
+
+_Recovery:_ Download artifacts and upload them manually to the release.
+
+### add-milestone-to-pull-requests
+
+_Trigger:_ When a PR to `master` is closed
+
+_Action:_ Get the last (by name) opened milestone and affect it to the closed pull request.
+
+_Recovery:_ Attach the milestone by hand to the PR.
+
+### create-next-milestone
+
+_Trigger:_ When closing a milestone
+
+_Action:_ Create a new milestone by incrementing minor version.
+
+_Comment:_ Already done when closing a tag. To delete?
+
+### draft-release-notes-on-tag
+
+_Trigger:_ When creating a tag, or manually (providing a tag)
+
+_Actions:_
+
+* Fetch merged pull requests from the related tag milestone,
+* Generate changelog draft,
+* Create a new draft release for given tag with the generated changelog.
+
+_Recovery:_ Manually trigger the action again on the relevant tag.
+
+## increment-milestone-on-tag
+
+_Trigger:_ When creating a tag
+
+_Actions:_
+* Close the milestone related to the tag,
+* Create a new milestone by incrementing minor version.
+
+_Recovery:_ Manually close the related milestone and create a new one.
+
+_Notes:_ This actions will handle _minor_ releases only.
+As there is no milestone for _patch_ releases, it won't close and create _patch_ releated milestone.
+
+## update-download-releases
+
+_Trigger:_ When a release is published
+
+_Action:_ Update the _download releases_ with the latest release artifact.
+
+_Recovery:_ Download artifacts and upload them manually to the related _download release_.
+
+_Notes:_ _Download releases_ are special GitHub releases with fixed URL and tags, but rolling artifacts to provided stable download links (ex [latest](https://github.com/DataDog/dd-trace-java/releases/tag/download-latest) and [latest-v1](https://github.com/DataDog/dd-trace-java/releases/tag/download-latest-v1)).
+
+## update-issues-on-release
+
+_Trigger:_ When a release is published
+
+_Action:_
+* Find all issues related to the release by checking the related milestone,
+* Add a comment to let know the issue was addressed by the newly published release,
+* Close all those issues.
+
+_Recovery:_ Check at the milestone for the related issues and update them manually.
+
+## Code Quality
+
+### codeql-analysis
+
+_Trigger:_ When pushing commits to `master` or any pull request to `master`
+
+_Action:_ Run GitHub CodeQL action and upload result to GitHub security tab.
+
+### gradle-wrapper-validation
+
+**DISABLED** - GitHub provides a way to disable actions rather than changing their extensions.
+
+_Comment:_ To delete?
+
+### lib-injection
+
+_Trigger:_ When pushing commits to `master`, release branches or any PR targetting `master`, and when creating tags
+
+_Actions:_
+* Build and publish to GHCR a Docker image with the Java tracer agent,
+* Build lib-injection and run its system tests with the build Java agent.
+
+### lib-inject-manual-release
+
+_Trigger:_ When manually triggered
+
+_Action:_ Build and publish to GHCR a Docker image with the given Java tracer version.
+
+## Disabled


### PR DESCRIPTION
# What Does This Do

This PR adds a README about installed GitHub actions and their usage.

# Motivation

# Additional Notes

`create-next-milestone` action looks suspicious.
Should we clean the `gradle-wrapper-validation` action?
