### PR TITLE
wait until the remote-config change is committed before deciding we didn't receive any dynamic-config overrides

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -458,6 +458,7 @@ class CoreTracerTest extends DDCoreSpecification {
         }
       }
       '''.getBytes(StandardCharsets.UTF_8), null)
+    updater.commit()
 
     then:
     tracer.captureTraceConfig().serviceMapping == ['foobar':'bar', 'snafu':'foo']
@@ -466,6 +467,7 @@ class CoreTracerTest extends DDCoreSpecification {
 
     when:
     updater.remove(key, null)
+    updater.commit()
 
     then:
     tracer.captureTraceConfig().serviceMapping == [:]


### PR DESCRIPTION
This fixes an issue seen during system-tests where the remote-config id may change between updates, leading to remote-config calling 'accept' for the new id before calling 'remove' for the old id.