### PR TITLE
Remove warning about unknown grpc.server.request.metadata address

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -93,6 +93,9 @@ public interface KnownAddresses {
 
   Address<Object> GRPC_SERVER_REQUEST_MESSAGE = new Address<>("grpc.server.request.message");
 
+  // XXX: Not really used yet, but it's a known address and we should not treat it as unknown.
+  Address<Object> GRPC_SERVER_REQUEST_METADATA = new Address<>("grpc.server.request.metadata");
+
   Address<String> USER_ID = new Address<>("usr.id");
 
   static Address<?> forName(String name) {
@@ -137,6 +140,8 @@ public interface KnownAddresses {
         return HEADERS_NO_COOKIES;
       case "grpc.server.request.message":
         return GRPC_SERVER_REQUEST_MESSAGE;
+      case "grpc.server.request.metadata":
+        return GRPC_SERVER_REQUEST_METADATA;
       case "usr.id":
         return USER_ID;
       default:

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -29,13 +29,14 @@ class KnownAddressesSpecification extends Specification {
       'server.request.query',
       'server.request.headers.no_cookies',
       'grpc.server.request.message',
+      'grpc.server.request.metadata',
       'usr.id',
     ]
   }
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 21
+    Address.instanceCount() == 22
     KnownAddresses.USER_ID.serial == Address.instanceCount() - 1
   }
 }


### PR DESCRIPTION
# What Does This Do

# Motivation
Whenever we load the WAF, we issue a warning `WAF has rule against unknown address grpc.server.request.metadata`. This is not actionable: it is a known address, even if we don't support it yet.

# Additional Notes
