### PR TITLE
Provide instrumentation name context to span

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -124,8 +124,18 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     return tracer().propagate().extract(carrier, getter);
   }
 
+  /** Deprecated. Use {@link #startSpan(String, Object, AgentSpan.Context.Extracted)} instead. */
+  @Deprecated
   public AgentSpan startSpan(REQUEST_CARRIER carrier, AgentSpan.Context.Extracted context) {
-    AgentSpan span = tracer().startSpan(spanName(), callIGCallbackStart(context)).setMeasured(true);
+    return startSpan("http-server", carrier, context);
+  }
+
+  public AgentSpan startSpan(
+      String instrumentationName, REQUEST_CARRIER carrier, AgentSpan.Context.Extracted context) {
+    AgentSpan span =
+        tracer()
+            .startSpan(instrumentationName, spanName(), callIGCallbackStart(context))
+            .setMeasured(true);
     Flow<Void> flow = callIGCallbackRequestHeaders(span, carrier);
     if (flow.getAction() instanceof Flow.Action.RequestBlockingAction) {
       span.setRequestBlockingAction((Flow.Action.RequestBlockingAction) flow.getAction());

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -421,14 +421,14 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       getRequestContext() >> reqCtxt
     }
     def mTracer = Mock(TracerAPI) {
-      startSpan(_, _) >> mSpan
+      startSpan(_, _, _) >> mSpan
       getCallbackProvider(RequestContextSlot.APPSEC) >> cbpAppSec
       getCallbackProvider(RequestContextSlot.IAST) >> CallbackProvider.CallbackProviderNoop.INSTANCE
     }
     def decorator = newDecorator(mTracer)
 
     when:
-    decorator.startSpan(headers, null)
+    decorator.startSpan("test", headers, null)
 
     then:
     1 * mSpan.setMeasured(true) >> mSpan

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/http/HttpResourceDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/http/HttpResourceDecoratorTest.groovy
@@ -26,7 +26,7 @@ class HttpResourceDecoratorTest extends DDSpecification {
 
   def "test that resource name is not changed"() {
     given:
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", "test")
 
     when:
     def scope = AgentTracer.activateSpan(span)
@@ -40,7 +40,7 @@ class HttpResourceDecoratorTest extends DDSpecification {
 
   def "still uses the simple normalizer by default"() {
     given:
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", "test")
     String method = "GET"
     String path = "/asdf/1234"
 
@@ -55,7 +55,7 @@ class HttpResourceDecoratorTest extends DDSpecification {
     setup:
     injectSysConfig(TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING, "/asdf/*:/test")
 
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", "test")
     String method = "GET"
     String path = "/asdf/1234"
 
@@ -70,7 +70,7 @@ class HttpResourceDecoratorTest extends DDSpecification {
     setup:
     injectSysConfig(TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING, "/asdf/*:/test")
 
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", "test")
     String method = "GET"
     String path = "/unknown/1234"
 
@@ -86,7 +86,7 @@ class HttpResourceDecoratorTest extends DDSpecification {
     injectSysConfig(TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING, "/a/*:/test")
     injectSysConfig("trace.URLAsResourceNameRule.enabled", "false")
 
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", "test")
     String method = "GET"
     String path = "/unknown/1234"
 
@@ -101,7 +101,7 @@ class HttpResourceDecoratorTest extends DDSpecification {
     setup:
     injectSysConfig(TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING, "/a/*:/test")
 
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", "test")
 
     when:
     decorator().withClientPath(span, "GET", "/a/foo")
@@ -114,7 +114,7 @@ class HttpResourceDecoratorTest extends DDSpecification {
     setup:
     injectSysConfig(TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING, "/a/*:*")
 
-    AgentSpan span = tracer.startSpan("test")
+    AgentSpan span = tracer.startSpan("test", "test")
 
     when:
     decorator().withClientPath(span, "GET", "/a/foo")

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
@@ -49,7 +49,7 @@ public class DDTestImpl implements DDTest {
 
     AgentTracer.SpanBuilder spanBuilder =
         AgentTracer.get()
-            .buildSpan("ci-visibility", testDecorator.component() + ".test")
+            .buildSpan(testDecorator.component() + ".test")
             .ignoreActiveSpan()
             .asChildOf(null)
             .withRequestContextData(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
@@ -49,7 +49,7 @@ public class DDTestImpl implements DDTest {
 
     AgentTracer.SpanBuilder spanBuilder =
         AgentTracer.get()
-            .buildSpan(testDecorator.component() + ".test")
+            .buildSpan("ci-visibility", testDecorator.component() + ".test")
             .ignoreActiveSpan()
             .asChildOf(null)
             .withRequestContextData(

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -84,7 +84,7 @@ public class Reporter {
         new TagContext().withRequestContextDataIast(new IastRequestContext());
     final AgentSpan span =
         tracer()
-            .startSpan(VULNERABILITY_SPAN_NAME, tagContext)
+            .startSpan("iast", VULNERABILITY_SPAN_NAME, tagContext)
             .setSpanType(InternalSpanTypes.VULNERABILITY);
     ANALYZED.setTag(span);
     return span;

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -166,7 +166,7 @@ class ReporterTest extends DDSpecification {
 
     then:
     noExceptionThrown()
-    1 * tracerAPI.startSpan('vulnerability', _ as AgentSpan.Context) >> span
+    1 * tracerAPI.startSpan('iast', 'vulnerability', _ as AgentSpan.Context) >> span
     1 * tracerAPI.activateSpan(span, ScopeSource.MANUAL) >> scope
     1 * span.getSpanId() >> spanId
     1 * span.getRequestContext() >> reqCtx

--- a/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastAgentTestRunner.groovy
+++ b/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastAgentTestRunner.groovy
@@ -50,7 +50,7 @@ class IastAgentTestRunner extends AgentTestRunner implements IastRequestContextP
 
     def iastCtx = reqStartCb.get().result
     def ddctx = new TagContext().withRequestContextDataIast(iastCtx)
-    AgentSpan span = TEST_TRACER.startSpan("test-iast-span", ddctx)
+    AgentSpan span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
     try {
       AgentTracer.activateSpan(span).withCloseable cl
     } finally {

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
@@ -23,7 +23,7 @@ class ProcessImplStartAdvice {
 
     Map<String, String> tags = ProcessImplInstrumentationHelpers.createTags(command);
     TagContext tagContext = new TagContext("appsec", tags);
-    AgentSpan span = tracer.startSpan("command_execution", tagContext);
+    AgentSpan span = tracer.startSpan("appsec", "command_execution", tagContext);
     span.setSpanType("system");
     span.setResourceName(ProcessImplInstrumentationHelpers.determineResource(command));
     return span;

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class OtelTracer implements Tracer {
+  private static final String INSTRUMENTATION_NAME = "opentelemetry";
   private final String tracerName;
   private final AgentTracer.TracerAPI tracer;
   private final TypeConverter converter;
@@ -52,7 +53,7 @@ public class OtelTracer implements Tracer {
     private boolean parentSet = false;
 
     public SpanBuilder(final String spanName) {
-      delegate = tracer.buildSpan(tracerName).withResourceName(spanName);
+      delegate = tracer.buildSpan(INSTRUMENTATION_NAME, tracerName).withResourceName(spanName);
     }
 
     @Override

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelTracer.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class OtelTracer implements Tracer {
-  private static final String INSTRUMENTATION_NAME = "opentelemetry";
+  private static final String INSTRUMENTATION_NAME = "otel";
   private final String tracerName;
   private final AgentTracer.TracerAPI tracer;
   private final TypeConverter converter;

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
@@ -23,8 +23,8 @@ class TypeConverterTest extends AgentTestRunner {
 
   def "should avoid extra allocation for a span wrapper"() {
     def context = createTestSpanContext()
-    def span1 = new DDSpan(0, context)
-    def span2 = new DDSpan(0, context)
+    def span1 = new DDSpan("test", 0, context)
+    def span2 = new DDSpan("test", 0, context)
     expect:
     // return the same wrapper for the same span
     typeConverter.toSpan(span1) is typeConverter.toSpan(span1)
@@ -47,8 +47,8 @@ class TypeConverterTest extends AgentTestRunner {
   def "should avoid extra allocation for a scope wrapper"() {
     def scopeManager = new ContinuableScopeManager(0, false, true)
     def context = createTestSpanContext()
-    def span1 = new DDSpan(0, context)
-    def span2 = new DDSpan(0, context)
+    def span1 = new DDSpan("test", 0, context)
+    def span2 = new DDSpan("test", 0, context)
     def scope1 = scopeManager.activate(span1, ScopeSource.MANUAL)
     def scope2 = scopeManager.activate(span2, ScopeSource.MANUAL)
     expect:

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelTracer.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelTracer.java
@@ -7,6 +7,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 class OtelTracer implements Tracer {
+  private static final String INSTRUMENTATION_NAME = "opentelemetry";
   private final AgentTracer.TracerAPI tracer;
   private final String instrumentationScopeName;
 
@@ -17,7 +18,8 @@ class OtelTracer implements Tracer {
 
   @Override
   public SpanBuilder spanBuilder(String spanName) {
-    AgentTracer.SpanBuilder delegate = this.tracer.buildSpan(spanName).withResourceName(spanName);
+    AgentTracer.SpanBuilder delegate =
+        this.tracer.buildSpan(INSTRUMENTATION_NAME, spanName).withResourceName(spanName);
     return new OtelSpanBuilder(delegate);
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelTracer.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelTracer.java
@@ -7,7 +7,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 class OtelTracer implements Tracer {
-  private static final String INSTRUMENTATION_NAME = "opentelemetry";
+  private static final String INSTRUMENTATION_NAME = "otel";
   private final AgentTracer.TracerAPI tracer;
   private final String instrumentationScopeName;
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -372,7 +372,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     currentSpan == otelSpan
 
     when:
-    def ddSpan = TEST_TRACER.startSpan("other-name")
+    def ddSpan = TEST_TRACER.startSpan("dd-api", "other-name")
     def ddScope = TEST_TRACER.activateSpan(ddSpan, MANUAL)
     currentSpan = Span.current()
 
@@ -400,7 +400,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     DDSpanId.toHexStringPadded(activeSpan.spanId) == otelParentSpan.getSpanContext().spanId
 
     when:
-    def ddChildSpan = TEST_TRACER.startSpan("other-name")
+    def ddChildSpan = TEST_TRACER.startSpan("dd-api", "other-name")
     def ddChildScope = TEST_TRACER.activateSpan(ddChildSpan, MANUAL)
     def current = Span.current()
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OTTracer implements Tracer {
-
+  private static final String INSTRUMENTATION_NAME = "opentracing";
   private static final Logger log = LoggerFactory.getLogger(OTTracer.class);
 
   private final TypeConverter converter = new TypeConverter(new DefaultLogHandler());
@@ -41,7 +41,7 @@ public class OTTracer implements Tracer {
 
   @Override
   public SpanBuilder buildSpan(final String operationName) {
-    return new OTSpanBuilder(tracer.buildSpan(operationName));
+    return new OTSpanBuilder(tracer.buildSpan(INSTRUMENTATION_NAME, operationName));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
@@ -24,8 +24,8 @@ class TypeConverterTest extends AgentTestRunner {
 
   def "should avoid extra allocation for a span wrapper"() {
     def context = createTestSpanContext()
-    def span1 = new DDSpan(0, context)
-    def span2 = new DDSpan(0, context)
+    def span1 = new DDSpan("test", 0, context)
+    def span2 = new DDSpan("test", 0, context)
     expect:
     // return the same wrapper for the same span
     typeConverter.toSpan(span1) is typeConverter.toSpan(span1)
@@ -52,8 +52,8 @@ class TypeConverterTest extends AgentTestRunner {
   def "should avoid extra allocation for a scope wrapper"() {
     def scopeManager = new ContinuableScopeManager(0, false, true)
     def context = createTestSpanContext()
-    def span1 = new DDSpan(0, context)
-    def span2 = new DDSpan(0, context)
+    def span1 = new DDSpan("test", 0, context)
+    def span2 = new DDSpan("test", 0, context)
     def scope1 = scopeManager.activate(span1, ScopeSource.MANUAL)
     def scope2 = scopeManager.activate(span2, ScopeSource.MANUAL)
     expect:

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OTTracer implements Tracer {
-
+  private static final String INSTRUMENTATION_NAME = "opentracing";
   private static final Logger log = LoggerFactory.getLogger(OTTracer.class);
 
   private final TypeConverter converter = new TypeConverter(new DefaultLogHandler());
@@ -53,7 +53,7 @@ public class OTTracer implements Tracer {
 
   @Override
   public SpanBuilder buildSpan(final String operationName) {
-    return new OTSpanBuilder(tracer.buildSpan(operationName));
+    return new OTSpanBuilder(tracer.buildSpan(INSTRUMENTATION_NAME, operationName));
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
@@ -24,8 +24,8 @@ class TypeConverterTest extends AgentTestRunner {
 
   def "should avoid extra allocation for a span wrapper"() {
     def context = createTestSpanContext()
-    def span1 = new DDSpan(0, context)
-    def span2 = new DDSpan(0, context)
+    def span1 = new DDSpan("test", 0, context)
+    def span2 = new DDSpan("test", 0, context)
     expect:
     // return the same wrapper for the same span
     typeConverter.toSpan(span1) is typeConverter.toSpan(span1)
@@ -52,8 +52,8 @@ class TypeConverterTest extends AgentTestRunner {
   def "should avoid extra allocation for a scope wrapper"() {
     def scopeManager = new ContinuableScopeManager(0, false, true)
     def context = createTestSpanContext()
-    def span1 = new DDSpan(0, context)
-    def span2 = new DDSpan(0, context)
+    def span1 = new DDSpan("test", 0, context)
+    def span2 = new DDSpan("test", 0, context)
     def scope1 = scopeManager.activate(span1, ScopeSource.MANUAL)
     def scope2 = scopeManager.activate(span2, ScopeSource.MANUAL)
     expect:

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Method;
 
 public class TraceDecorator extends BaseDecorator {
   public static TraceDecorator DECORATE = new TraceDecorator();
+  private static final String INSTRUMENTATION_NAME = "trace-annotation";
 
   private static final boolean useLegacyOperationName =
       InstrumenterConfig.get().isLegacyInstrumentationEnabled(true, "trace.annotations");
@@ -73,7 +74,7 @@ public class TraceDecorator extends BaseDecorator {
       resourceName = DECORATE.spanNameForMethod(method);
     }
 
-    AgentSpan span = startSpan(operationName);
+    AgentSpan span = startSpan(INSTRUMENTATION_NAME, operationName);
     DECORATE.afterStart(span);
     span.setResourceName(resourceName);
 

--- a/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/TraceCorrelationTest.groovy
@@ -8,7 +8,7 @@ class TraceCorrelationTest extends AgentTestRunner {
 
   def "access trace correlation only under trace"() {
     when:
-    def span = TEST_TRACER.startSpan("myspan")
+    def span = TEST_TRACER.startSpan("test", "myspan")
     def scope = TEST_TRACER.activateSpan(span)
 
     then:

--- a/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/TraceMapperBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/common/writer/ddagent/TraceMapperBenchmark.java
@@ -124,7 +124,7 @@ public class TraceMapperBenchmark {
             false,
             propagationTags);
     DDSpanHelper.setAllTags(rootContext, tags);
-    DDSpan root = DDSpanHelper.create(System.currentTimeMillis() * 1000, rootContext);
+    DDSpan root = DDSpanHelper.create("benchmark", System.currentTimeMillis() * 1000, rootContext);
     root.setResourceName(UTF8BytesString.create("benchmark"));
     trace = Lists.newArrayList(root);
   }

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/DDSpanHelper.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/DDSpanHelper.java
@@ -4,8 +4,11 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 public interface DDSpanHelper {
-  static DDSpan create(final long timestampMicro, @Nonnull DDSpanContext context) {
-    return DDSpan.create(timestampMicro, context);
+  static DDSpan create(
+      @Nonnull String instrumentationName,
+      final long timestampMicro,
+      @Nonnull DDSpanContext context) {
+    return DDSpan.create(instrumentationName, timestampMicro, context);
   }
 
   static void setAllTags(@Nonnull DDSpanContext context, Map<String, ?> map) {

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/PendingTraceWrite.java
@@ -40,6 +40,7 @@ public class PendingTraceWrite {
     trace = tracer.createTrace(traceId);
     root =
         DDSpan.create(
+            "benchmark",
             System.currentTimeMillis() * 1000,
             new DDSpanContext(
                 traceId,
@@ -63,6 +64,7 @@ public class PendingTraceWrite {
                 null));
     span =
         DDSpan.create(
+            "benchmark",
             System.currentTimeMillis() * 1000,
             new DDSpanContext(
                 traceId,

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/TracerMapperMap.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/TracerMapperMap.java
@@ -98,6 +98,7 @@ public class TracerMapperMap {
     final DDTraceId traceId = DDTraceId.from(iter);
     final PendingTrace trace = tracer.createTrace(traceId);
     return DDSpan.create(
+        "benchmark",
         System.currentTimeMillis() * 1000,
         new DDSpanContext(
             traceId,

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -728,29 +728,35 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public CoreSpanBuilder buildSpan(final CharSequence operationName) {
-    return new CoreSpanBuilder(operationName, this);
+  public CoreSpanBuilder buildSpan(
+      final String instrumentationName, final CharSequence operationName) {
+    return new CoreSpanBuilder(instrumentationName, operationName, this);
   }
 
   @Override
-  public AgentSpan startSpan(final CharSequence spanName) {
-    return buildSpan(spanName).start();
-  }
-
-  @Override
-  public AgentSpan startSpan(final CharSequence spanName, final long startTimeMicros) {
-    return buildSpan(spanName).withStartTimestamp(startTimeMicros).start();
-  }
-
-  @Override
-  public AgentSpan startSpan(final CharSequence spanName, final AgentSpan.Context parent) {
-    return buildSpan(spanName).ignoreActiveSpan().asChildOf(parent).start();
+  public AgentSpan startSpan(final String instrumentationName, final CharSequence spanName) {
+    return buildSpan(instrumentationName, spanName).start();
   }
 
   @Override
   public AgentSpan startSpan(
-      final CharSequence spanName, final AgentSpan.Context parent, final long startTimeMicros) {
-    return buildSpan(spanName)
+      final String instrumentationName, final CharSequence spanName, final long startTimeMicros) {
+    return buildSpan(instrumentationName, spanName).withStartTimestamp(startTimeMicros).start();
+  }
+
+  @Override
+  public AgentSpan startSpan(
+      String instrumentationName, final CharSequence spanName, final AgentSpan.Context parent) {
+    return buildSpan(instrumentationName, spanName).ignoreActiveSpan().asChildOf(parent).start();
+  }
+
+  @Override
+  public AgentSpan startSpan(
+      final String instrumentationName,
+      final CharSequence spanName,
+      final AgentSpan.Context parent,
+      final long startTimeMicros) {
+    return buildSpan(instrumentationName, spanName)
         .ignoreActiveSpan()
         .asChildOf(parent)
         .withStartTimestamp(startTimeMicros)
@@ -1269,6 +1275,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   /** Spans are built using this builder */
   public class CoreSpanBuilder implements AgentTracer.SpanBuilder {
+    private final String instrumentationName;
     private final CharSequence operationName;
     private final CoreTracer tracer;
 
@@ -1285,7 +1292,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private Object builderRequestContextDataIast;
     private Object builderCiVisibilityContextData;
 
-    CoreSpanBuilder(final CharSequence operationName, CoreTracer tracer) {
+    CoreSpanBuilder(
+        final String instrumentationName, final CharSequence operationName, CoreTracer tracer) {
+      this.instrumentationName = instrumentationName;
       this.operationName = operationName;
       this.tracer = tracer;
     }
@@ -1297,7 +1306,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     private DDSpan buildSpan() {
-      DDSpan span = DDSpan.create(timestampMicro, buildSpanContext());
+      DDSpan span = DDSpan.create(instrumentationName, timestampMicro, buildSpanContext());
       if (span.isLocalRootSpan()) {
         EndpointTracker tracker = tracer.onRootSpanStarted(span);
         span.setEndpointTracker(tracker);

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -49,8 +49,9 @@ public class DDSpan
 
   public static final String CHECKPOINTED_TAG = "checkpointed";
 
-  static DDSpan create(final long timestampMicro, @Nonnull DDSpanContext context) {
-    final DDSpan span = new DDSpan(timestampMicro, context);
+  static DDSpan create(
+      final String instrumentationName, final long timestampMicro, @Nonnull DDSpanContext context) {
+    final DDSpan span = new DDSpan(instrumentationName, timestampMicro, context);
     log.debug("Started span: {}", span);
     context.getTrace().registerSpan(span);
     return span;
@@ -107,12 +108,16 @@ public class DDSpan
   /**
    * Spans should be constructed using the builder, not by calling the constructor directly.
    *
+   * @param instrumentationName instrumentation that creates the span
    * @param timestampMicro if greater than zero, use this time instead of the current time
    * @param context the context used for the span
    */
-  private DDSpan(final long timestampMicro, @Nonnull DDSpanContext context) {
+  private DDSpan(
+      @Nonnull String instrumentationName,
+      final long timestampMicro,
+      @Nonnull DDSpanContext context) {
     this.context = context;
-    this.metrics = SpanMetricRegistry.getInstance().get("default");
+    this.metrics = SpanMetricRegistry.getInstance().get(instrumentationName);
     this.metrics.onSpanCreated();
 
     if (timestampMicro <= 0L) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -290,7 +290,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
 
   def createMinimalTrace() {
     def context = createMinimalContext()
-    def minimalSpan = new DDSpan(0, context)
+    def minimalSpan = new DDSpan("test", 0, context)
     context.getTrace().getRootSpan() >> minimalSpan
     def minimalTrace = [minimalSpan]
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -217,6 +217,6 @@ class DDAgentWriterTest extends DDCoreSpecification {
       NoopPathwayContext.INSTANCE,
       false,
       PropagationTags.factory().empty())
-    return new DDSpan(0, context)
+    return new DDSpan("test", 0, context)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -745,7 +745,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
 
   def createMinimalTrace() {
     def context = createMinimalContext()
-    def minimalSpan = new DDSpan(0, context)
+    def minimalSpan = new DDSpan("test", 0, context)
     context.getTrace().getRootSpan() >> minimalSpan
     def minimalTrace = [minimalSpan]
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
@@ -210,7 +210,7 @@ class DDIntakeWriterTest extends DDCoreSpecification {
       AgentTracer.NoopPathwayContext.INSTANCE,
       false,
       PropagationTags.factory().empty())
-    return new DDSpan(0, context)
+    return new DDSpan("test", 0, context)
   }
 
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherImplTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherImplTest.groovy
@@ -172,6 +172,6 @@ class PayloadDispatcherImplTest extends DDSpecification {
       NoopPathwayContext.INSTANCE,
       false,
       PropagationTags.factory().empty())
-    return new DDSpan(0, context)
+    return new DDSpan("test", 0, context)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -396,7 +396,7 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
 
   def "can overwrite RequestContext data with builder from empty"() {
     when:
-    def span1 = tracer.startSpan("span1")
+    def span1 = tracer.startSpan("test", "span1")
 
     then:
     span1.getRequestContext().getData(RequestContextSlot.APPSEC) == null

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanSerializationTest.groovy
@@ -27,7 +27,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
     def traceId = DDTraceId.from(value)
     def spanId = DDSpanId.from(value)
     def context = createContext(spanType, tracer, traceId, spanId)
-    def span = DDSpan.create(0, context)
+    def span = DDSpan.create("test", 0, context)
     CaptureBuffer capture = new CaptureBuffer()
     def packer = new MsgPackWriter(new FlushingBuffer(1024, capture))
     packer.format(Collections.singletonList(span), new TraceMapperV0_4())
@@ -88,7 +88,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
     def traceId = DDTraceId.from(value)
     def spanId = DDSpanId.from(value)
     def context = createContext(spanType, tracer, traceId, spanId)
-    def span = DDSpan.create(0, context)
+    def span = DDSpan.create("test", 0, context)
     CaptureBuffer capture = new CaptureBuffer()
     def packer = new MsgPackWriter(new FlushingBuffer(1024, capture))
     def traceMapper = new TraceMapperV0_5()
@@ -172,7 +172,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       false,
       null)
     context.setAllTags(tags)
-    def span = DDSpan.create(0, context)
+    def span = DDSpan.create("test", 0, context)
     CaptureBuffer capture = new CaptureBuffer()
     def packer = new MsgPackWriter(new FlushingBuffer(1024, capture))
     packer.format(Collections.singletonList(span), new TraceMapperV0_4())
@@ -243,7 +243,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       false,
       null)
     context.setAllTags(tags)
-    def span = DDSpan.create(0, context)
+    def span = DDSpan.create("test", 0, context)
     CaptureBuffer capture = new CaptureBuffer()
     def packer = new MsgPackWriter(new FlushingBuffer(1024, capture))
     def mapper = new TraceMapperV0_5()
@@ -317,7 +317,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       'sub1': 'v1',
       'sub2': 'v2'
     ])
-    def span = DDSpan.create(0, context)
+    def span = DDSpan.create("test", 0, context)
 
     CaptureBuffer capture = new CaptureBuffer()
     def packer = new MsgPackWriter(new FlushingBuffer(1024, capture))
@@ -387,7 +387,7 @@ class DDSpanSerializationTest extends DDCoreSpecification {
       'sub1': 'v1',
       'sub2': 'v2'
     ])
-    def span = DDSpan.create(0, context)
+    def span = DDSpan.create("test", 0, context)
 
     CaptureBuffer capture = new CaptureBuffer()
     def packer = new MsgPackWriter(new FlushingBuffer(1024, capture))

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -467,7 +467,7 @@ class PendingTraceBufferTest extends DDSpecification {
       NoopPathwayContext.INSTANCE,
       false,
       PropagationTags.factory().empty())
-    return DDSpan.create(0, context)
+    return DDSpan.create("test", 0, context)
   }
 
   static DDSpan newSpanOf(DDSpan parent) {
@@ -492,6 +492,6 @@ class PendingTraceBufferTest extends DDSpecification {
       NoopPathwayContext.INSTANCE,
       false,
       PropagationTags.factory().empty())
-    return DDSpan.create(0, context)
+    return DDSpan.create("test", 0, context)
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -22,7 +22,7 @@ class PendingTraceTest extends PendingTraceTestBase {
   }
 
   protected DDSpan createSimpleSpanWithID(PendingTrace trace, long id){
-    return new DDSpan((long)0,new DDSpanContext(
+    return new DDSpan("test", 0L, new DDSpanContext(
       DDTraceId.from(1),
       id,
       0,
@@ -75,7 +75,7 @@ class PendingTraceTest extends PendingTraceTestBase {
     def healthMetrics = Mock(HealthMetrics)
     tracer.captureTraceConfig() >> traceConfig
     traceConfig.getServiceMapping() >> [:]
-    PendingTrace trace = new PendingTrace(tracer,DDTraceId.from(0),buffer,Mock(TimeSource),null,false,healthMetrics)
+    PendingTrace trace = new PendingTrace(tracer, DDTraceId.from(0), buffer, Mock(TimeSource), null, false, healthMetrics)
     when:
     rootSpan = createSimpleSpan(trace)
     trace.registerSpan(rootSpan)
@@ -96,7 +96,7 @@ class PendingTraceTest extends PendingTraceTestBase {
     def healthMetrics = Mock(HealthMetrics)
     tracer.captureTraceConfig() >> traceConfig
     traceConfig.getServiceMapping() >> [:]
-    PendingTrace trace = new PendingTrace(tracer,DDTraceId.from(0),buffer,Mock(TimeSource),null,false,healthMetrics)
+    PendingTrace trace = new PendingTrace(tracer, DDTraceId.from(0), buffer, Mock(TimeSource), null, false, healthMetrics)
     buffer.longRunningSpansEnabled() >> true
 
     def span1 = createSimpleSpanWithID(trace,39)
@@ -131,7 +131,7 @@ class PendingTraceTest extends PendingTraceTestBase {
     def healthMetrics = Mock(HealthMetrics)
     tracer.captureTraceConfig() >> traceConfig
     traceConfig.getServiceMapping() >> [:]
-    PendingTrace trace = new PendingTrace(tracer,DDTraceId.from(0),buffer,Mock(TimeSource),null, false,healthMetrics)
+    PendingTrace trace = new PendingTrace(tracer, DDTraceId.from(0), buffer, Mock(TimeSource), null, false, healthMetrics)
     buffer.longRunningSpansEnabled() >> true
 
     def span1 = createSimpleSpanWithID(trace,39)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
@@ -212,7 +212,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
 
     setup:
     def latch = new CountDownLatch(1)
-    def rootSpan = tracer.buildSpan("root").start()
+    def rootSpan = tracer.buildSpan("test", "root").start()
     PendingTrace trace = rootSpan.context().trace
     def exceptions = []
     def threads = (1..threadCount).collect {
@@ -220,7 +220,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
         try {
           latch.await()
           def spans = (1..spanCount).collect {
-            tracer.startSpan("child", rootSpan.context())
+            tracer.startSpan("test", "child", rootSpan.context())
           }
           spans.each {
             it.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
@@ -70,7 +70,7 @@ abstract class DDCoreSpecification extends DDSpecification {
       propagationTags,
       ProfilingContextIntegration.NoOp.INSTANCE)
 
-    def span = DDSpan.create(timestamp, context)
+    def span = DDSpan.create("test", timestamp, context)
     for (Map.Entry<String, Object> e : tags.entrySet()) {
       span.setTag(e.key, e.value)
     }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * traces and spans to Datadog using the OpenTracing API.
  */
 public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTracer {
-
+  private static final String INSTRUMENTATION_NAME = "opentracing";
   private static final Logger log = LoggerFactory.getLogger(DDTracer.class);
 
   static {
@@ -552,7 +552,7 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
     private final AgentTracer.SpanBuilder delegate;
 
     public DDSpanBuilder(final String operationName) {
-      delegate = tracer.buildSpan(operationName);
+      delegate = tracer.buildSpan(INSTRUMENTATION_NAME, operationName);
     }
 
     @Override

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
@@ -26,8 +26,8 @@ class TypeConverterTest extends DDSpecification {
 
   def "should avoid extra allocation for a span wrapper"() {
     def context = createTestSpanContext()
-    def span1 = new DDSpan(0, context)
-    def span2 = new DDSpan(0, context)
+    def span1 = new DDSpan("test", 0, context)
+    def span2 = new DDSpan("test", 0, context)
     expect:
     // return the same wrapper for the same span
     typeConverter.toSpan(span1) is typeConverter.toSpan(span1)
@@ -54,8 +54,8 @@ class TypeConverterTest extends DDSpecification {
   def "should avoid extra allocation for a scope wrapper"() {
     def scopeManager = new ContinuableScopeManager(0, false, true)
     def context = createTestSpanContext()
-    def span1 = new DDSpan(0, context)
-    def span2 = new DDSpan(0, context)
+    def span1 = new DDSpan("test", 0, context)
+    def span2 = new DDSpan("test", 0, context)
     def scope1 = scopeManager.activate(span1, ScopeSource.MANUAL)
     def scope2 = scopeManager.activate(span2, ScopeSource.MANUAL)
     expect:

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -57,6 +57,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentDataStreamsMonitoring",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentTrace",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI",
   "datadog.trace.bootstrap.instrumentation.api.NoopDataStreamsMonitoring",
   "datadog.trace.bootstrap.instrumentation.api.Backlog",
   "datadog.trace.bootstrap.instrumentation.api.StatsPoint",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -31,24 +31,60 @@ import java.util.function.Consumer;
 public class AgentTracer {
 
   // Implicit parent
+  /** Deprecated. Use {@link #startSpan(String, CharSequence)} instead. */
+  @Deprecated
   public static AgentSpan startSpan(final CharSequence spanName) {
-    return get().startSpan(spanName);
+    return startSpan("default", spanName);
+  }
+
+  /** @see TracerAPI#startSpan(String, CharSequence) */
+  public static AgentSpan startSpan(final String instrumentationName, final CharSequence spanName) {
+    return get().startSpan(instrumentationName, spanName);
   }
 
   // Implicit parent
+  /** Deprecated. Use {@link #startSpan(String, CharSequence, long)} instead. */
+  @Deprecated
   public static AgentSpan startSpan(final CharSequence spanName, final long startTimeMicros) {
-    return get().startSpan(spanName, startTimeMicros);
+    return startSpan("default", spanName, startTimeMicros);
+  }
+
+  /** @see TracerAPI#startSpan(String, CharSequence, long) */
+  public static AgentSpan startSpan(
+      final String instrumentationName, final CharSequence spanName, final long startTimeMicros) {
+    return get().startSpan(instrumentationName, spanName, startTimeMicros);
   }
 
   // Explicit parent
+  /** Deprecated. Use {@link #startSpan(String, CharSequence, AgentSpan.Context)} instead. */
+  @Deprecated
   public static AgentSpan startSpan(final CharSequence spanName, final AgentSpan.Context parent) {
-    return get().startSpan(spanName, parent);
+    return startSpan("default", spanName, parent);
+  }
+
+  /** @see TracerAPI#startSpan(String, CharSequence, AgentSpan.Context) */
+  public static AgentSpan startSpan(
+      final String instrumentationName,
+      final CharSequence spanName,
+      final AgentSpan.Context parent) {
+    return get().startSpan(instrumentationName, spanName, parent);
   }
 
   // Explicit parent
+  /** Deprecated. Use {@link #startSpan(String, CharSequence, AgentSpan.Context, long)} instead. */
+  @Deprecated
   public static AgentSpan startSpan(
       final CharSequence spanName, final AgentSpan.Context parent, final long startTimeMicros) {
-    return get().startSpan(spanName, parent, startTimeMicros);
+    return startSpan("default", spanName, parent, startTimeMicros);
+  }
+
+  /** @see TracerAPI#startSpan(String, CharSequence, AgentSpan.Context, long) */
+  public static AgentSpan startSpan(
+      final String instrumentationName,
+      final CharSequence spanName,
+      final AgentSpan.Context parent,
+      final long startTimeMicros) {
+    return get().startSpan(instrumentationName, spanName, parent, startTimeMicros);
   }
 
   public static AgentScope activateSpan(final AgentSpan span) {
@@ -142,13 +178,51 @@ public class AgentTracer {
           EndpointCheckpointer,
           DataStreamsCheckpointer,
           ScopeStateAware {
-    AgentSpan startSpan(CharSequence spanName);
 
-    AgentSpan startSpan(CharSequence spanName, long startTimeMicros);
+    /**
+     * Create and start a new span.
+     *
+     * @param instrumentationName The instrumentation creating the span.
+     * @param spanName The span operation name.
+     * @return The new started span.
+     */
+    AgentSpan startSpan(String instrumentationName, CharSequence spanName);
 
-    AgentSpan startSpan(CharSequence spanName, AgentSpan.Context parent);
+    /**
+     * Create and start a new span with a given start time.
+     *
+     * @param instrumentationName The instrumentation creating the span.
+     * @param spanName The span operation name.
+     * @param startTimeMicros The span start time, in microseconds.
+     * @return The new started span.
+     */
+    AgentSpan startSpan(String instrumentationName, CharSequence spanName, long startTimeMicros);
 
-    AgentSpan startSpan(CharSequence spanName, AgentSpan.Context parent, long startTimeMicros);
+    /**
+     * Create and start a new span with an explicit parent.
+     *
+     * @param instrumentationName The instrumentation creating the span.
+     * @param spanName The span operation name.
+     * @param parent The parent span context.
+     * @return The new started span.
+     */
+    AgentSpan startSpan(
+        String instrumentationName, CharSequence spanName, AgentSpan.Context parent);
+
+    /**
+     * Create and start a new span with an explicit parent and a given start time.
+     *
+     * @param instrumentationName The instrumentation creating the span.
+     * @param spanName The span operation name.
+     * @param parent The parent span context.
+     * @param startTimeMicros The span start time, in microseconds.
+     * @return The new started span.
+     */
+    AgentSpan startSpan(
+        String instrumentationName,
+        CharSequence spanName,
+        AgentSpan.Context parent,
+        long startTimeMicros);
 
     AgentScope activateSpan(AgentSpan span, ScopeSource source);
 
@@ -168,7 +242,13 @@ public class AgentTracer {
 
     AgentSpan noopSpan();
 
-    SpanBuilder buildSpan(CharSequence spanName);
+    /** Deprecated. Use {@link #buildSpan(String, CharSequence)} instead. */
+    @Deprecated
+    default SpanBuilder buildSpan(CharSequence spanName) {
+      return buildSpan("default", spanName);
+    }
+
+    SpanBuilder buildSpan(String instrumentationName, CharSequence spanName);
 
     void close();
 
@@ -244,23 +324,28 @@ public class AgentTracer {
     protected NoopTracerAPI() {}
 
     @Override
-    public AgentSpan startSpan(final CharSequence spanName) {
-      return NoopAgentSpan.INSTANCE;
-    }
-
-    @Override
-    public AgentSpan startSpan(final CharSequence spanName, final long startTimeMicros) {
-      return NoopAgentSpan.INSTANCE;
-    }
-
-    @Override
-    public AgentSpan startSpan(final CharSequence spanName, final Context parent) {
+    public AgentSpan startSpan(final String instrumentationName, final CharSequence spanName) {
       return NoopAgentSpan.INSTANCE;
     }
 
     @Override
     public AgentSpan startSpan(
-        final CharSequence spanName, final Context parent, final long startTimeMicros) {
+        final String instrumentationName, final CharSequence spanName, final long startTimeMicros) {
+      return NoopAgentSpan.INSTANCE;
+    }
+
+    @Override
+    public AgentSpan startSpan(
+        final String instrumentationName, final CharSequence spanName, final Context parent) {
+      return NoopAgentSpan.INSTANCE;
+    }
+
+    @Override
+    public AgentSpan startSpan(
+        final String instrumentationName,
+        final CharSequence spanName,
+        final Context parent,
+        final long startTimeMicros) {
       return NoopAgentSpan.INSTANCE;
     }
 
@@ -309,7 +394,7 @@ public class AgentTracer {
     }
 
     @Override
-    public SpanBuilder buildSpan(final CharSequence spanName) {
+    public SpanBuilder buildSpan(final String instrumentationName, final CharSequence spanName) {
       return null;
     }
 


### PR DESCRIPTION
# What Does This Do

This PR introduce instrumentation name as context to the span.
The context was added for the following cases:
* opentracing instrumentation
* opentelemetry instrumentation
* annotation instrumentation
* dd-trace-ot module

# Motivation

This is required for span metrics.

# Additional Notes

This PR is the third part of the Span Metrics PR https://github.com/DataDog/dd-trace-java/pull/5382

I might do a pass in most of instrumentations to add this context if needed in another PR.
There might be complication with common decorator though.
