### PR TITLE
Stabilise flaky Gradle smoke test 

### DIFF
--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListenerInstrumentation.java
@@ -31,7 +31,8 @@ public class GradleBuildListenerInstrumentation extends Instrumenter.CiVisibilit
       packageName + ".GradleProjectConfigurator$_configureTracer_closure1",
       packageName + ".GradleProjectConfigurator$_configureCompilerPlugin_closure2",
       packageName + ".GradleProjectConfigurator$_configureJacoco_closure3",
-      packageName + ".GradleProjectConfigurator$_forEveryTestTask_closure4",
+      packageName + ".GradleProjectConfigurator$_configureJacoco_closure4",
+      packageName + ".GradleProjectConfigurator$_forEveryTestTask_closure5",
       packageName + ".GradleBuildListener",
       packageName + ".GradleBuildListener$TestTaskExecutionListener"
     };


### PR DESCRIPTION
# What Does This Do
Stabilises Gradle Daemon smoke test which is currently flaky.

Gradle itself and project dependencies cannot be downloaded sometimes because of intermittent network problems
This is addressed by repeatedly running a "warmup build" (that triggers downloading Gradle and project dependencies) before starting the build with the tracer. The warmup build is run up to five times until either downloading is successful, or all attempts have been exhausted.

# Motivation
Reduce test flakiness.

# Additional Notes
Warmup build runs in "dependency verification" mode in order to trigger downloading of all dependencies.
Component that automatically configures instrumented project with DD Javac Plugin and Jacoco plugin was updated to disable verification for corresponding dependencies.
