### PR TITLE
avoid having duplicates in db.cassandra.contact.points

### DIFF
--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/ContactPointsUtil.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/ContactPointsUtil.java
@@ -26,6 +26,7 @@ public class ContactPointsUtil {
                     }
                     return inetSocketAddress.getHostString();
                   })
+              .distinct() // avoid duplicates
               .collect(Collectors.joining(","));
 
   public static String fromEndPointSet(@Nullable final Set<EndPoint> contactPoints) {


### PR DESCRIPTION
# What Does This Do

Tested as a real case, even if the contact points are a set, once mapped to a string representation, the guarantee of uniqueness is no more valid. Hence explicitly adding it.

Tested in a real situation, I got duplicates on this host list tag

# Motivation

# Additional Notes
