### PR TITLE
Add context propagation diagnostic information to debug logs

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -2,6 +2,7 @@ package datadog.trace.core.propagation;
 
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
+import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Map;
 
@@ -57,5 +58,32 @@ public class ExtractedContext extends TagContext {
 
   public PropagationTags getPropagationTags() {
     return propagationTags;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder("ExtractedContext{");
+    if (traceId != null) {
+      builder.append("traceId=").append(traceId).append(", ");
+    }
+    if (spanId != 0) {
+      builder.append("endToEndStartTime=").append(spanId).append(", ");
+    }
+    if (endToEndStartTime != 0) {
+      builder.append("spanId=").append(spanId).append(", ");
+    }
+    if (getOrigin() != null) {
+      builder.append("origin=").append(getOrigin()).append(", ");
+    }
+    if (getTags() != null) {
+      builder.append("tags=").append(getTags()).append(", ");
+    }
+    if (getBaggage() != null) {
+      builder.append("baggage=").append(getBaggage()).append(", ");
+    }
+    if (getSamplingPriority() != PrioritySampling.UNSET) {
+      builder.append("samplingPriority=").append(getSamplingPriority()).append(", ");
+    }
+    return builder.append('}').toString();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -150,6 +150,7 @@ public class HttpCodec {
     @Override
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
+      log.debug("Inject context {}", context);
       for (final Injector injector : injectors) {
         injector.inject(context, carrier, setter);
       }
@@ -172,10 +173,12 @@ public class HttpCodec {
         context = extractor.extract(carrier, getter);
         // Use incomplete TagContext only as last resort
         if (context instanceof ExtractedContext) {
+          log.debug("Extract complete context {}", context);
           return context;
         }
       }
 
+      log.debug("Extract incomplete context {}", context);
       return context;
     }
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -207,6 +207,24 @@ public class TagContext implements AgentSpan.Context.Extracted {
     return this;
   }
 
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder("TagContext{");
+    if (origin != null) {
+      builder.append("origin=").append(origin).append(", ");
+    }
+    if (tags != null) {
+      builder.append("tags=").append(tags).append(", ");
+    }
+    if (baggage != null) {
+      builder.append("baggage=").append(baggage).append(", ");
+    }
+    if (samplingPriority != PrioritySampling.UNSET) {
+      builder.append("samplingPriority=").append(samplingPriority).append(", ");
+    }
+    return builder.append('}').toString();
+  }
+
   public static class HttpHeaders {
     public String fastlyClientIp;
     public String cfConnectingIp;


### PR DESCRIPTION
# What Does This Do

This PR will add diagnostic information to debug logs for context propagation investigation issues.

# Motivation

I had to address few context propagation issues the past weeks and it feels this kind of information will be helpful.

# Additional Notes

I don't think logging this kind of information will be problematic as they are send/receive from outside.