### PR TITLE
Add required callsites for String.format

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
@@ -9,10 +9,9 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import groovy.transform.CompileDynamic
 import org.junit.jupiter.api.Assertions
 
-import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
-import static com.datadog.iast.taint.TaintUtils.fromTaintFormat
-import static com.datadog.iast.taint.TaintUtils.getStringFromTaintFormat
-import static com.datadog.iast.taint.TaintUtils.taintFormat
+import java.text.SimpleDateFormat
+
+import static com.datadog.iast.taint.TaintUtils.*
 
 @CompileDynamic
 class StringModuleTest extends IastModuleImplTestBase {
@@ -21,9 +20,21 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   private List<Object> objectHolder
 
+  private AgentSpan span
+
+  private IastRequestContext ctx
+
+  private RequestContext reqCtx
+
   def setup() {
     module = new StringModuleImpl()
     objectHolder = []
+    span = Mock(AgentSpan)
+    tracer.activeSpan() >> span
+    reqCtx = Mock(RequestContext)
+    span.getRequestContext() >> reqCtx
+    ctx = new IastRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
   }
 
   void 'onStringBuilderAppend null or empty (#builder, #param)'() {
@@ -61,14 +72,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'onStringBuilderAppend (#builder, #param)'() {
     given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-
-    and:
     final taintedObjects = ctx.getTaintedObjects()
     builder = addFromTaintFormat(taintedObjects, builder)
     objectHolder.add(builder)
@@ -145,14 +148,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'onStringBuilderInit (#builder, #param)'() {
     given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-
-    and:
     final taintedObjects = ctx.getTaintedObjects()
     builder = addFromTaintFormat(taintedObjects, builder)
     objectHolder.add(builder)
@@ -205,14 +200,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'onStringBuilderToString (#builder)'() {
     given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-
-    and:
     final taintedObjects = ctx.getTaintedObjects()
     builder = addFromTaintFormat(taintedObjects, builder)
     objectHolder.add(builder)
@@ -247,10 +234,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     sb('==>123<==456') | '==>123<==456'
   }
 
-  void 'onStringConcatFactory null or empty (#args)'(final List<String> args,
-    final String recipe,
-    final List<Object> constants,
-    final List<Integer> recipeOffsets) {
+  void 'onStringConcatFactory null or empty (#args)'() {
     given:
     final result = args.inject('') { res, item -> res + item }
 
@@ -270,10 +254,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     ['', '']     | '\u0001 \u0001' | null      | [0, -1, 1]
   }
 
-  void 'onStringConcatFactory without span (#args)'(final List<String> args,
-    final String recipe,
-    final List<Object> constants,
-    final List<Integer> recipeOffsets) {
+  void 'onStringConcatFactory without span (#args)'() {
     given:
     final result = args.inject('') { res, item -> res + item }
 
@@ -291,20 +272,8 @@ class StringModuleTest extends IastModuleImplTestBase {
     ['3', '4']  | '\u0001 \u0001' | null      | [0, -1, 1]
   }
 
-  void 'onStringConcatFactory (#args, #recipe, #constants)'(List<String> args,
-    final String recipe,
-    final List<Object> constants,
-    final List<Integer> recipeOffsets,
-    final String expected) {
+  void 'onStringConcatFactory (#args, #recipe, #constants)'() {
     given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-
-    and:
     final taintedObjects = ctx.getTaintedObjects()
     args = args.collect {
       final item = addFromTaintFormat(taintedObjects, it)
@@ -377,7 +346,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     ""   | ""
   }
 
-  void 'onStringConcat without span (#left, #right)'(final String left, final String right) {
+  void 'onStringConcat without span (#left, #right)'() {
     given:
     final result = left + right
 
@@ -394,16 +363,8 @@ class StringModuleTest extends IastModuleImplTestBase {
     "3"  | "4"
   }
 
-  void 'onStringConcat (#left, #right)'(String left, String right, final String expected) {
+  void 'onStringConcat (#left, #right)'() {
     given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-
-    and:
     final taintedObjects = ctx.getTaintedObjects()
     left = addFromTaintFormat(taintedObjects, left)
     objectHolder.add(left)
@@ -442,7 +403,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     "==>123<==" | "==>456<==" | "==>123<====>456<=="
   }
 
-  void 'onStringSubSequence null ,empty or string not changed after subsequence (#self, #beginIndex, #endIndex)'(final String self, final int beginIndex, final int endIndex) {
+  void 'onStringSubSequence null ,empty or string not changed after subsequence (#self, #beginIndex, #endIndex)'() {
     given:
     final result = self?.substring(beginIndex, endIndex)
 
@@ -459,7 +420,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     "not_changed" | 0          | 11
   }
 
-  void 'onStringSubSequence without span (#self, #beginIndex, #endIndex)'(final String self, final int beginIndex, final int endIndex, final int mockCalls) {
+  void 'onStringSubSequence without span (#self, #beginIndex, #endIndex)'() {
     given:
     final result = self?.substring(beginIndex, endIndex)
 
@@ -479,14 +440,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'onStringSubSequence (#self, #beginIndex, #endIndex)'() {
     given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-
-    and:
     final taintedObjects = ctx.getTaintedObjects()
     self = addFromTaintFormat(taintedObjects, self)
     objectHolder.add(self)
@@ -548,7 +501,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     "01==>234<==5==>678<==90" | 4          | 8        | "==>4<==5==>67<=="
   }
 
-  void 'onStringJoin without null delimiter or elements (#delimiter, #elements)'(final CharSequence delimiter, final CharSequence[] elements) {
+  void 'onStringJoin without null delimiter or elements (#delimiter, #elements)'() {
     when:
     String.join(delimiter, elements)
 
@@ -589,16 +542,8 @@ class StringModuleTest extends IastModuleImplTestBase {
     new StringBuilder("-") | [new StringBuilder("123"), new StringBuilder("456")] | 1
   }
 
-  void 'onStringJoin (#delimiter, #elements)'(final CharSequence delimiter, final CharSequence[] elements, final String expected) {
+  void 'onStringJoin (#delimiter, #elements)'() {
     given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-
-    and:
     final result = getStringFromTaintFormat(expected)
     objectHolder.add(expected)
     final shouldBeTainted = fromTaintFormat(expected) != null
@@ -609,7 +554,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     objectHolder.add(fromTaintedDelimiter)
 
     and:
-    final fromTaintedElements = new CharSequence[elements.length]
+    final fromTaintedElements = new CharSequence[elements.size()]
     elements.eachWithIndex { element, i ->
       def el = addFromTaintFormat(taintedObjects, element)
       objectHolder.add(el)
@@ -622,9 +567,6 @@ class StringModuleTest extends IastModuleImplTestBase {
     then:
     assert result == String.join(fromTaintedDelimiter, fromTaintedElements)
     1 * tracer.activeSpan() >> span
-    1 * span.getRequestContext() >> reqCtx
-    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
-    0 * _
     def to = ctx.getTaintedObjects().get(result)
     if (shouldBeTainted) {
       assert to != null
@@ -693,14 +635,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'onStringRepeat (#self, #count)'() {
     given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-
-    and:
     final taintedObjects = ctx.getTaintedObjects()
     self = addFromTaintFormat(taintedObjects, self)
     objectHolder.add(self)
@@ -715,9 +649,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
     then:
     1 * tracer.activeSpan() >> span
-    1 * span.getRequestContext() >> reqCtx
-    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
-    0 * _
     def to = ctx.getTaintedObjects().get(result)
     if (shouldBeTainted) {
       assert to != null
@@ -747,13 +678,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'onStringToUpperCase calls IastRequestContext'() {
     given:
-
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final taintedObjects = ctx.getTaintedObjects()
     def self = addFromTaintFormat(taintedObjects, testString)
     def result = self.toUpperCase()
@@ -765,8 +689,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
     then:
     1 * tracer.activeSpan() >> span
-    1 * span.getRequestContext() >> reqCtx
-    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
     taintFormat(result, taintedObject.getRanges()) == expected
 
     where:
@@ -776,13 +698,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'test toUpperCase for not empty string cases'() {
     given:
-
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final taintedObjects = ctx.getTaintedObjects()
     def self = addFromTaintFormat(taintedObjects, testString)
     def result = self.toUpperCase()
@@ -803,17 +718,9 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'test toUpperCase corner and pathologic cases'() {
     given:
-
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final taintedObjects = ctx.getTaintedObjects()
     def self = addFromTaintFormat(taintedObjects, testString)
     def result = self.toUpperCase(new Locale(locale))
-
 
     when:
     module.onStringToUpperCase(self, result)
@@ -837,26 +744,19 @@ class StringModuleTest extends IastModuleImplTestBase {
     "a==>123<==b==>123<==c"               | "A==>123<==B==>123<==C"     | "en"   | 9          | 9            | [[1, 3], [5, 3]]
     "a==>123<==b"                         | "A==>123<==B"               | "en"   | 5          | 5            | [[1, 3]]
     "a==>def<==b"                         | "A==>DEF<==B"               | "en"   | 5          | 5            | [[1, 3]]
-    "i̇̀==>def<==b"                         | "ÌD==>EFB<=="               | "lt"   | 7          | 6            | [[3, 3]]
-    "i̇̀==>def<==b"                         | "İ̀==>DEF<==B"               | "en"   | 7          | 7            | [[3, 3]]
-    "i̇̀==>def<==b==>def<=="                | "İ̀==>DEF<==B==>DEF<=="      | "en"   | 10         | 10           | [[3, 3], [7, 3]]
+    "i̇̀==>def<==b"                       | "ÌD==>EFB<=="              | "lt"   | 7          | 6            | [[3, 3]]
+    "i̇̀==>def<==b"                       | "İ̀==>DEF<==B"             | "en"   | 7          | 7            | [[3, 3]]
+    "i̇̀==>def<==b==>def<=="              | "İ̀==>DEF<==B==>DEF<=="    | "en"   | 10         | 10           | [[3, 3], [7, 3]]
     "\u00cc==>def<==b"                    | "\u00cc==>DEF<==B"          | "lt"   | 5          | 5            | [[1, 3]]
-    "i̇̀i̇̀==>fff<==f123b"                    | "ÌÌFF==>FF1<==23B"          | "lt"   | 14         | 12           | [[6, 3]]
-    "i̇̀i̇̀i̇̀i̇̀EEEE==>fff<=="                   | "ÌÌÌÌEEEEFFF"               | "lt"   | 19         | 15           | []
-    "i̇̀i̇̀i̇̀i̇̀EEEE==>fff<==H==>GGG<=="         | "ÌÌÌÌEEEEFFFH==>GGG<=="     | "lt"   | 23         | 19           | [[16, 3]]
-    "i̇̀i̇̀i̇̀EEEE==>fffgggg<=="                | "ÌÌÌEEEEFFF==>GGGG<=="      | "lt"   | 20         | 17           | [[13, 4]]
+    "i̇̀i̇̀==>fff<==f123b"                | "ÌÌFF==>FF1<==23B"        | "lt"   | 14         | 12           | [[6, 3]]
+    "i̇̀i̇̀i̇̀i̇̀EEEE==>fff<=="           | "ÌÌÌÌEEEEFFF"           | "lt"   | 19         | 15           | []
+    "i̇̀i̇̀i̇̀i̇̀EEEE==>fff<==H==>GGG<==" | "ÌÌÌÌEEEEFFFH==>GGG<==" | "lt"   | 23         | 19           | [[16, 3]]
+    "i̇̀i̇̀i̇̀EEEE==>fffgggg<=="          | "ÌÌÌEEEEFFF==>GGGG<=="   | "lt"   | 20         | 17           | [[13, 4]]
   }
 
 
   void 'test toLowerCase corner and pathologic cases'() {
     given:
-
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final taintedObjects = ctx.getTaintedObjects()
     def self = addFromTaintFormat(taintedObjects, testString)
     def result = self.toLowerCase(new Locale(locale))
@@ -882,24 +782,16 @@ class StringModuleTest extends IastModuleImplTestBase {
     testString                   | expected               | locale | lengthSelf | lengthResult | expectedRanges
     "A==>123<==B"                | "a==>123<==b"          | "en"   | 5          | 5            | [[1, 3]]
     "\u00cc\u00cc==>123<==B"     | "ìì==>123<==b"         | "en"   | 6          | 6            | [[2, 3]]
-    "\u00cc\u00cc==>123<==B"     | "i̇==>̀i̇<==̀123b"         | "lt"   | 6          | 10           | [[2, 3]]
-    "\u00cc\u00ccFFFF==>123<==B" | "i̇̀i̇̀==>fff<==f123b"     | "lt"   | 10         | 14           | [[6, 3]]
+    "\u00cc\u00cc==>123<==B"     | "i̇==>̀i̇<==̀123b"     | "lt"   | 6          | 10           | [[2, 3]]
+    "\u00cc\u00ccFFFF==>123<==B" | "i̇̀i̇̀==>fff<==f123b" | "lt"   | 10         | 14           | [[6, 3]]
     "A==>\u00cc\u00cc\u00cc<==B" | "a==>ììì<==b"          | "en"   | 5          | 5            | [[1, 3]]
   }
 
   void 'test trim and make sure IastRequestContext is called'() {
     given:
-
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final taintedObjects = ctx.getTaintedObjects()
     def self = addFromTaintFormat(taintedObjects, testString)
     def result = self.trim()
-
 
     when:
     module.onStringTrim(self, result)
@@ -907,8 +799,6 @@ class StringModuleTest extends IastModuleImplTestBase {
 
     then:
     1 * tracer.activeSpan() >> span
-    1 * span.getRequestContext() >> reqCtx
-    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
     taintFormat(result, taintedObject.getRanges()) == expected
 
     where:
@@ -918,17 +808,9 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'test trim for not empty string cases'() {
     given:
-
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final taintedObjects = ctx.getTaintedObjects()
     def self = addFromTaintFormat(taintedObjects, testString)
     def result = self.trim()
-
 
     when:
     module.onStringTrim(self, result)
@@ -960,17 +842,9 @@ class StringModuleTest extends IastModuleImplTestBase {
 
   void 'test trim for empty string cases'() {
     given:
-
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final taintedObjects = ctx.getTaintedObjects()
     def self = addFromTaintFormat(taintedObjects, testString)
     def result = self.trim()
-
 
     when:
     module.onStringTrim(self, result)
@@ -987,6 +861,51 @@ class StringModuleTest extends IastModuleImplTestBase {
     "==>   <== ==>   <=="   | ""
     "123"                   | "123"
     " 123 "                 | "123"
+  }
+
+  void 'onStringFormat fmt: #formatTainted args: #argsTainted'() {
+    given:
+    final to = ctx.getTaintedObjects()
+    final format = addFromTaintFormat(to, formatTainted)
+    final args = argsTainted.collect {
+      final value = taint(to, it)
+      objectHolder.add(value)
+      return value
+    }
+    final formatted = String.format(format, args as Object[])
+    final expected = getStringFromTaintFormat(expectedTainted)
+    assert expected == formatted // validate expectation is OK
+
+    when:
+    module.onStringFormat(format, args as Object[], formatted)
+
+    then:
+    final tainted = to.get(formatted)
+    final formattedResult = taintFormat(formatted, tainted?.ranges)
+    assert formattedResult == expectedTainted: tainted?.ranges
+
+    where:
+    formatTainted                   | argsTainted                         | expectedTainted
+    'Hello World!'                  | []                                  | 'Hello World!'
+    '%s %s'                         | ['Hello', 'World!']                 | 'Hello World!'
+    '%s %s'                         | ['He==>ll<==o', 'World==>!<==']     | 'He==>ll<==o World==>!<=='
+    'He==>ll<==o %s'                | ['World==>!<==']                    | 'He==>ll<==o World==>!<=='
+    'Hello %.6s'                    | ['Wor==>ld!!!<==']                  | 'Hello ==>World!<==' // limiting width
+    'Hello %10s'                    | ['Wor==>ld!<==']                    | 'Hello ==>    World!<==' // padding left
+    'Hello %-10s'                   | ['Wor==>ld!<==']                    | 'Hello ==>World!    <==' // padding right
+    '%2$s %1$s'                     | ['World==>!<==', 'He==>ll<==o']     | 'He==>ll<==o World==>!<==' // indexed arguments
+    '%s %3$s%s'                     | ['He==>ll<==o', 'ld==>!<==', 'Wor'] | 'He==>ll<==o World==>!<==' // mixed indexed arguments
+    'I have %+.4f$'                 | [23.5D]                             | 'I have ==>+23.5000<==$' // numeric
+    'The date is %1$td/%1$tm/%1$ty' | [date('yyyy.MM.dd', '2012.11.23')]  | 'The date is ==>23<==/==>11<==/==>12<==' // date
+    'The time is %tT'               | [date('HH:mm ss', '12:00 00')]      | 'The time is ==>12:00:00<==' // time
+    'Tainted not used %s'           | ['He==>ll<==o', 'World==>!<==']     | 'Tainted not used He==>ll<==o' // extra args
+    'Hello ==>%s<=='                | ['World!']                          | 'Hello ==>World!<==' // tainted placeholder [non tainted parameter]
+    'He==>llo %s!<=='               | ['World']                           | 'He==>llo <====>World<====>!<==' // tainted placeholder (2) [non tainted parameter]
+    'He==>llo %s!<=='               | ['W==>or<==ld']                     | 'He==>llo <==W==>or<==ld==>!<==' // tainted placeholder (3) [mixing with tainted parameter]
+  }
+
+  private static Date date(final String pattern, final String value) {
+    return new SimpleDateFormat(pattern).parse(value)
   }
 
   private static StringBuilder sb() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintUtils.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintUtils.groovy
@@ -66,6 +66,14 @@ class TaintUtils {
     new String(s.replace(OPEN_MARK, "").replace(CLOSE_MARK, ""))
   }
 
+  static <E> E taint(final TaintedObjects tos, final E value) {
+    if (value instanceof String) {
+      return addFromTaintFormat(tos, value as String)
+    }
+    tos.taintInputObject(value, new Source(SourceTypes.NONE, null, null))
+    return value
+  }
+
   static String addFromTaintFormat(final TaintedObjects tos, final String s) {
     final ranges = fromTaintFormat(s)
     if (ranges == null || ranges.length == 0) {

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -285,4 +285,38 @@ public class StringCallSite {
     }
     return result;
   }
+
+  @CallSite.After("java.lang.String java.lang.String.format(java.lang.String, java.lang.Object[])")
+  public static String afterFormat(
+      @CallSite.Argument(0) @Nullable final String pattern,
+      @CallSite.Argument(1) @Nonnull final Object[] args,
+      @CallSite.Return @Nonnull final String result) {
+    final StringModule module = InstrumentationBridge.STRING;
+    try {
+      if (module != null && pattern != null) {
+        module.onStringFormat(pattern, args, result);
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afterFormat threw", e);
+    }
+    return result;
+  }
+
+  @CallSite.After(
+      "java.lang.String java.lang.String.format(java.util.Locale, java.lang.String, java.lang.Object[])")
+  public static String afterFormat(
+      @CallSite.Argument(0) @Nullable final Locale locale,
+      @CallSite.Argument(1) @Nullable final String pattern,
+      @CallSite.Argument(2) @Nonnull final Object[] args,
+      @CallSite.Return @Nonnull final String result) {
+    final StringModule module = InstrumentationBridge.STRING;
+    try {
+      if (module != null && pattern != null) {
+        module.onStringFormat(locale, pattern, args, result);
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afterFormat threw", e);
+    }
+    return result;
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
@@ -222,4 +222,41 @@ class StringCallSiteTest extends AgentTestRunner {
     'UTF-8'                         | ['Hello'.getBytes(charset), charset]
     Charset.defaultCharset().name() | ['Hello'.getBytes(charset), Charset.forName(charset)]
   }
+
+  void 'test string format'() {
+    given:
+    final module = Mock(StringModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    TestStringSuite.format(pattern, args == null ? null : args as Object[])
+
+    then:
+    1 * module.onStringFormat(pattern, args, _ as String)
+
+    where:
+    pattern | args
+    ''      | []
+    ''      | null
+    '%s'    | ['Hello']
+  }
+
+  void 'test string format with locale'() {
+    given:
+    final module = Mock(StringModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    TestStringSuite.format(Locale.getDefault(), pattern, args == null ? null : args as Object[])
+
+    then:
+    1 * module.onStringFormat(_, pattern, args, _ as String)
+
+    where:
+    locale              | pattern | args
+    null                | ''      | []
+    null                | ''      | null
+    null                | '%s'    | ['Hello']
+    Locale.getDefault() | '%s'    | ['Hello']
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
@@ -135,4 +135,18 @@ public class TestStringSuite {
     LOGGER.debug("After string getBytes {}", result);
     return result;
   }
+
+  public static String format(final String pattern, final Object... args) {
+    LOGGER.debug("Before format {} {}", pattern, args);
+    final String result = String.format(pattern, args);
+    LOGGER.debug("After format {}", result);
+    return result;
+  }
+
+  public static String format(final Locale locale, final String pattern, final Object... args) {
+    LOGGER.debug("Before format {} {} {}", locale, pattern, args);
+    final String result = String.format(locale, pattern, args);
+    LOGGER.debug("After format {}", result);
+    return result;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.iast.propagation;
 
 import datadog.trace.api.iast.IastModule;
+import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -36,4 +37,12 @@ public interface StringModule extends IastModule {
   void onStringRepeat(@Nonnull String self, int count, @Nonnull String result);
 
   void onStringConstructor(@Nonnull String self, @Nonnull String result);
+
+  void onStringFormat(@Nonnull String pattern, @Nonnull Object[] params, @Nonnull String result);
+
+  void onStringFormat(
+      @Nullable Locale locale,
+      @Nonnull String pattern,
+      @Nonnull Object[] params,
+      @Nonnull String result);
 }


### PR DESCRIPTION
# What Does This Do
Adds callsites for propagation of `String.format`

# Motivation

# Additional Notes
