### PR TITLE
rework queue time profiling

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -24,11 +24,13 @@ public class AdviceUtils {
 
   public static AgentScope startTaskScope(State state, boolean migrated) {
     if (state != null) {
-      state.stopTiming();
       final AgentScope.Continuation continuation = state.getAndResetContinuation();
       if (continuation != null) {
         final AgentScope scope = continuation.activate();
         scope.setAsyncPropagation(true);
+        // important - stop timing after the scope has been activated so the time in the queue can
+        // be attributed to the correct context without duplicating the propagated information
+        state.stopTiming();
         return scope;
       }
     }

--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerTimer.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerTimer.java
@@ -4,8 +4,6 @@ import com.datadog.profiling.ddprof.DatadogProfiler;
 import com.datadog.profiling.ddprof.QueueTimeTracker;
 import datadog.trace.api.profiling.Timer;
 import datadog.trace.api.profiling.Timing;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 
 public class DatadogProfilerTimer implements Timer {
 
@@ -21,16 +19,8 @@ public class DatadogProfilerTimer implements Timer {
 
   @Override
   public Timing start(TimerType type) {
-    long localRootSpanId = 0;
-    long spanId = 0;
-    AgentSpan activeSpan = AgentTracer.activeSpan();
-    if (activeSpan != null) {
-      spanId = activeSpan.getSpanId();
-      AgentSpan rootSpan = activeSpan.getLocalRootSpan();
-      localRootSpanId = rootSpan == null ? spanId : rootSpan.getSpanId();
-    }
     if (type == TimerType.QUEUEING) {
-      QueueTimeTracker tracker = profiler.newQueueTimeTracker(localRootSpanId, spanId);
+      QueueTimeTracker tracker = profiler.newQueueTimeTracker();
       if (tracker != null) {
         return tracker;
       }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -448,9 +448,9 @@ public final class DatadogProfiler {
     }
   }
 
-  public QueueTimeTracker newQueueTimeTracker(long localRootSpanId, long spanId) {
+  public QueueTimeTracker newQueueTimeTracker() {
     if (profiler != null) {
-      return new QueueTimeTracker(profiler, queueTimeThreshold, localRootSpanId, spanId);
+      return new QueueTimeTracker(profiler, queueTimeThreshold);
     }
     return null;
   }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/QueueTimeTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/QueueTimeTracker.java
@@ -8,23 +8,16 @@ public class QueueTimeTracker implements QueueTiming {
   private final JavaProfiler profiler;
   private final Thread origin;
   private final long threshold;
-  private final long startMillis;
   private final long startTicks;
-  private final long localRootSpanId;
-  private final long spanId;
   private Class<?> task;
   private Class<?> scheduler;
 
-  public QueueTimeTracker(
-      JavaProfiler profiler, long threshold, long localRootSpanId, long spanId) {
+  public QueueTimeTracker(JavaProfiler profiler, long threshold) {
     this.profiler = profiler;
     this.origin = Thread.currentThread();
     this.threshold = threshold;
-    this.startMillis = System.currentTimeMillis();
     // TODO get this from JFR if available instead of making a JNI call
     this.startTicks = profiler.getCurrentTicks();
-    this.localRootSpanId = localRootSpanId;
-    this.spanId = spanId;
   }
 
   @Override
@@ -39,11 +32,8 @@ public class QueueTimeTracker implements QueueTiming {
 
   @Override
   public void close() {
-    long endMillis = System.currentTimeMillis();
-    if (endMillis - startMillis >= threshold) {
-      assert task != null && scheduler != null;
-      profiler.recordQueueTime(
-          localRootSpanId, spanId, startTicks, profiler.getCurrentTicks(), task, scheduler, origin);
-    }
+    assert task != null && scheduler != null;
+    profiler.recordQueueTime(
+        threshold, startTicks, profiler.getCurrentTicks(), task, scheduler, origin);
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskWrapperInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskWrapperInstrumentation.java
@@ -18,7 +18,11 @@ public class TaskWrapperInstrumentation extends Instrumenter.Profiling
             "java.util.concurrent.FutureTask",
             "callable",
             "java.util.concurrent.Executors$RunnableAdapter",
-            "task"));
+            "task",
+            "java.util.concurrent.CompletableFuture$AsyncSupply",
+            "fn",
+            "java.util.concurrent.CompletableFuture$AsyncRun",
+            "fn"));
   }
 
   @Override

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.61.0",
+    ddprof        : "0.62.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

* Makes the time threshold decision within the profiler, where we know the TSC frequency so can convert ticks to millis
* Makes application of context to queue time events implicit, which means we don't need to duplicate propagated information.
* Makes `CompletableFuture$AsyncSupply` and `CompletableFuture$AsyncRun` unwrappable so we can get back to the user's code to report as the task which waited in the queue.

# Motivation

# Additional Notes
