### PR TITLE
[Spark] Instrument SparkSubmit to capture errors outside of SparkListener interface

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -6,6 +6,7 @@ import datadog.trace.instrumentation.spark.DatadogSparkListener
 import datadog.trace.test.util.Flaky
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus
 import org.apache.hadoop.yarn.conf.YarnConfiguration
+import org.apache.spark.deploy.SparkSubmit
 import org.apache.spark.deploy.yarn.ApplicationMaster
 import org.apache.spark.deploy.yarn.ApplicationMasterArguments
 import org.apache.spark.sql.SparkSession
@@ -170,6 +171,36 @@ class SparkTest extends AgentTestRunner {
         }
       }
     }
+  }
+
+  def "capture SparkSubmit.runMain() errors"() {
+    setup:
+    def sparkSession = SparkSession.builder()
+      .config("spark.master", "local[2]")
+      .getOrCreate()
+
+    try {
+      // Generating a fake spark submit to trigger the runMain() method
+      def sparkSubmit = new SparkSubmit()
+      sparkSubmit.doSubmit(["--class", "TestClass", "test-jar.jar"] as String[])
+    }
+    catch (Exception ignored) {}
+
+    expect:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spark.application"
+          resourceName "spark.application"
+          spanType "spark"
+          errored true
+          parent()
+        }
+      }
+    }
+
+    cleanup:
+    sparkSession.stop()
   }
 
   def "generate databricks spans"() {

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -181,6 +181,7 @@ class SparkTest extends AgentTestRunner {
 
     try {
       // Generating a fake spark submit to trigger the runMain() method
+      // it will fail since TestClass and test-jar.jar don't exist
       def sparkSubmit = new SparkSubmit()
       sparkSubmit.doSubmit(["--class", "TestClass", "test-jar.jar"] as String[])
     }
@@ -194,6 +195,8 @@ class SparkTest extends AgentTestRunner {
           resourceName "spark.application"
           spanType "spark"
           errored true
+          assert span.tags["error.type"] == "org.apache.spark.SparkUserAppException"
+          assert span.tags["error.message"] == "User application exited with 101"
           parent()
         }
       }


### PR DESCRIPTION
# What Does This Do

Instrument the `SparkSubmit.runMain(...)` function to capture all errors occurring in a spark application

This SparkSubmit class is used by spark to launch the application in non YARN/Mesos environnements. The YARN case is already covered by instrumenting the `ApplicationMaster.finish()` function (from this PR https://github.com/DataDog/dd-trace-java/pull/5267)

# Motivation

We are currently using the interface `SparkListener` to receive events from spark. However, this interface is only capturing errors that occur during the spark computations, but not in arbitrary user code

```scala
def main() = {
  val spark = SparkSession.builder.getOrCreate()
  val df = spark.read.parquet("...")
  
  // Exception will be captured because it's happening during spark computations
  df.map(x => new RuntimeException("Some exception"))

  // Exception currently not captured because it is thrown outside of spark computations
  throw new RuntimeException("Some exception")
}
```
