### PR TITLE
[DSM] - calculate edge latency using message timestamp

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -132,7 +132,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     }
     AgentPropagation.ContextVisitor<REQUEST_CARRIER> getter = getter();
     if (null != carrier && null != getter) {
-      tracer().setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS);
+      tracer().setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -67,7 +67,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     CallbackProvider cbp = tracer.getCallbackProvider(RequestContextSlot.APPSEC);
     final AgentSpan span = startSpan(GRPC_SERVER, spanContext).setMeasured(true);
 
-    AgentTracer.get().setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS);
+    AgentTracer.get().setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
 
     RequestContext reqContext = span.getRequestContext();
     if (reqContext != null) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -89,7 +89,8 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           sortedTags.put(GROUP_TAG, group);
           sortedTags.put(TOPIC_TAG, val.topic());
           sortedTags.put(TYPE_TAG, "kafka");
-          AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);
+
+          AgentTracer.get().setDataStreamCheckpoint(span, sortedTags, val.timestamp());
         } else {
           span = startSpan(operationName, null);
         }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -242,7 +242,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         }
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
-        AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);
+        AgentTracer.get().setDataStreamCheckpoint(span, sortedTags, record.timestamp);
       } else {
         span = startSpan(KAFKA_CONSUME, null);
       }
@@ -305,7 +305,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         }
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
-        AgentTracer.get().setDataStreamCheckpoint(span, sortedTags);
+        AgentTracer.get().setDataStreamCheckpoint(span, sortedTags, record.timestamp());
       } else {
         span = startSpan(KAFKA_CONSUME, null);
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -896,7 +896,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {
+  public void setDataStreamCheckpoint(
+      AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {
     PathwayContext pathwayContext = span.context().getPathwayContext();
     if (pathwayContext != null) {
       pathwayContext.setCheckpoint(sortedTags, dataStreamsMonitoring::add, defaultTimestamp);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -896,10 +896,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags) {
+  public void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {
     PathwayContext pathwayContext = span.context().getPathwayContext();
     if (pathwayContext != null) {
-      pathwayContext.setCheckpoint(sortedTags, dataStreamsMonitoring::add);
+      pathwayContext.setCheckpoint(sortedTags, dataStreamsMonitoring::add, defaultTimestamp);
       injectPathwayTags(span, pathwayContext);
     }
   }
@@ -1084,7 +1084,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     sortedTags.put(TOPIC_TAG, source);
     sortedTags.put(TYPE_TAG, type);
 
-    setDataStreamCheckpoint(span, sortedTags);
+    setDataStreamCheckpoint(span, sortedTags, 0);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -2,6 +2,7 @@ package datadog.trace.core.datastreams;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.datadoghq.sketch.ddsketch.encoding.ByteArrayInput;
 import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
@@ -94,6 +95,12 @@ public class DefaultPathwayContext implements PathwayContext {
   @Override
   public void setCheckpoint(
       LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer) {
+    setCheckpoint(sortedTags, pointConsumer, 0);
+  }
+
+  @Override
+  public void setCheckpoint(
+      LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer, long defaultTimestamp) {
     long startNanos = timeSource.getCurrentTimeNanos();
     long nanoTicks = timeSource.getNanoTicks();
     lock.lock();
@@ -104,9 +111,16 @@ public class DefaultPathwayContext implements PathwayContext {
       PathwayHashBuilder pathwayHashBuilder = new PathwayHashBuilder(wellKnownTags);
 
       if (!started) {
-        pathwayStartNanos = startNanos;
-        pathwayStartNanoTicks = nanoTicks;
-        edgeStartNanoTicks = nanoTicks;
+        if (defaultTimestamp == 0) {
+          pathwayStartNanos = startNanos;
+          pathwayStartNanoTicks = nanoTicks;
+          edgeStartNanoTicks = nanoTicks;
+        } else {
+          pathwayStartNanos = MILLISECONDS.toNanos(defaultTimestamp);
+          pathwayStartNanoTicks = startNanos - MILLISECONDS.toNanos(timeSource.getCurrentTimeMillis() - defaultTimestamp);
+          edgeStartNanoTicks = pathwayStartNanoTicks;
+        }
+
         hash = 0;
         started = true;
         log.debug("Started {}", this);

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -100,7 +100,9 @@ public class DefaultPathwayContext implements PathwayContext {
 
   @Override
   public void setCheckpoint(
-      LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer, long defaultTimestamp) {
+      LinkedHashMap<String, String> sortedTags,
+      Consumer<StatsPoint> pointConsumer,
+      long defaultTimestamp) {
     long startNanos = timeSource.getCurrentTimeNanos();
     long nanoTicks = timeSource.getNanoTicks();
     lock.lock();
@@ -117,7 +119,9 @@ public class DefaultPathwayContext implements PathwayContext {
           edgeStartNanoTicks = nanoTicks;
         } else {
           pathwayStartNanos = MILLISECONDS.toNanos(defaultTimestamp);
-          pathwayStartNanoTicks = startNanos - MILLISECONDS.toNanos(timeSource.getCurrentTimeMillis() - defaultTimestamp);
+          pathwayStartNanoTicks =
+              nanoTicks
+                  - MILLISECONDS.toNanos(timeSource.getCurrentTimeMillis() - defaultTimestamp);
           edgeStartNanoTicks = pathwayStartNanoTicks;
         }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
@@ -159,6 +159,26 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
     }
   }
 
+  def "Set checkpoint with timestamp"() {
+    given:
+    def timeSource = new ControllableTimeSource()
+    def context = new DefaultPathwayContext(timeSource, wellKnownTags)
+    def timeFromQueue = timeSource.getCurrentTimeMillis() - 200
+    when:
+    context.setCheckpoint(["type": "internal"], pointConsumer, timeFromQueue)
+    then:
+    context.isStarted()
+    pointConsumer.points.size() == 1
+    with(pointConsumer.points[0]) {
+      edgeTags == ["type:internal"]
+      edgeTags.size() == 1
+      parentHash == 0
+      hash != 0
+      pathwayLatencyNano == MILLISECONDS.toNanos(200)
+      edgeLatencyNano == MILLISECONDS.toNanos(200)
+    }
+  }
+
   def "Encoding and decoding (base64) with contexts and checkpoints"() {
     // Timesource needs to be advanced in milliseconds because encoding truncates to millis
     given:

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -199,10 +199,10 @@ public class AgentTracer {
      *
      * @param span active span
      * @param sortedTags alphabetically sorted tags for the checkpoint (direction, queue type etc)
-     * @param defaultTimestamp unix timestamp to use as a start of the pathway if this is the first checkpoint in the chain.
-     *                         Zero should be passed if we can't extract the timestamp from the message / payload itself (for instance:
-     *                         produce operations; http produce / consume etc). Value will be ignored for checkpoints happening not at the start
-     *                         of the pipeline.
+     * @param defaultTimestamp unix timestamp to use as a start of the pathway if this is the first
+     *     checkpoint in the chain. Zero should be passed if we can't extract the timestamp from the
+     *     message / payload itself (for instance: produce operations; http produce / consume etc).
+     *     Value will be ignored for checkpoints happening not at the start of the pipeline.
      */
     void setDataStreamCheckpoint(
         AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -194,6 +194,16 @@ public class AgentTracer {
 
     CallbackProvider getUniversalCallbackProvider();
 
+    /**
+     * Sets data streams checkpoint, used for both produce and consume operations.
+     *
+     * @param span active span
+     * @param sortedTags alphabetically sorted tags for the checkpoint (direction, queue type etc)
+     * @param defaultTimestamp unix timestamp to use as a start of the pathway if this is the first checkpoint in the chain.
+     *                         Zero should be passed if we can't extract the timestamp from the message / payload itself (for instance:
+     *                         produce operations; http produce / consume etc). Value will be ignored for checkpoints happening not at the start
+     *                         of the pipeline.
+     */
     void setDataStreamCheckpoint(
         AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -194,7 +194,7 @@ public class AgentTracer {
 
     CallbackProvider getUniversalCallbackProvider();
 
-    void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags);
+    void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
 
     AgentSpan.Context notifyExtensionStart(Object event);
 
@@ -430,7 +430,7 @@ public class AgentTracer {
     }
 
     @Override
-    public void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags) {}
+    public void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
 
     @Override
     public AgentSpan.Context notifyExtensionStart(Object event) {
@@ -1001,6 +1001,10 @@ public class AgentTracer {
     public long getHash() {
       return 0L;
     }
+
+    @Override
+    public void setCheckpoint(
+        LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer, long defaultTimestamp) {}
 
     @Override
     public void setCheckpoint(

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -194,7 +194,8 @@ public class AgentTracer {
 
     CallbackProvider getUniversalCallbackProvider();
 
-    void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
+    void setDataStreamCheckpoint(
+        AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
 
     AgentSpan.Context notifyExtensionStart(Object event);
 
@@ -430,7 +431,8 @@ public class AgentTracer {
     }
 
     @Override
-    public void setDataStreamCheckpoint(AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
+    public void setDataStreamCheckpoint(
+        AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
 
     @Override
     public AgentSpan.Context notifyExtensionStart(Object event) {
@@ -1004,7 +1006,9 @@ public class AgentTracer {
 
     @Override
     public void setCheckpoint(
-        LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer, long defaultTimestamp) {}
+        LinkedHashMap<String, String> sortedTags,
+        Consumer<StatsPoint> pointConsumer,
+        long defaultTimestamp) {}
 
     @Override
     public void setCheckpoint(

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PathwayContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PathwayContext.java
@@ -12,6 +12,8 @@ public interface PathwayContext {
 
   long getHash();
 
+  void setCheckpoint(LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer, long defaultTimestamp);
+
   // The input tags should be sorted.
   void setCheckpoint(LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PathwayContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PathwayContext.java
@@ -12,7 +12,10 @@ public interface PathwayContext {
 
   long getHash();
 
-  void setCheckpoint(LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer, long defaultTimestamp);
+  void setCheckpoint(
+      LinkedHashMap<String, String> sortedTags,
+      Consumer<StatsPoint> pointConsumer,
+      long defaultTimestamp);
 
   // The input tags should be sorted.
   void setCheckpoint(LinkedHashMap<String, String> sortedTags, Consumer<StatsPoint> pointConsumer);


### PR DESCRIPTION
# What Does This Do
DSM will now use message timestamp to measure latency at the beginning on the pathway.

#  Motivation
When the customer has consumer instrumented, but not producer they will see `0` as edge latency.  At the same time, most of the queueing tech have a way of injecting message timestamp, which shows the time when the message was produced. We want to use this timestamp if we can't calculate the latency in any other way.

# Additional Notes
Changes affect DSM only, in particular DSM instrumentation for Kafka and RabbitMQ.
