### PR TITLE
increase unwrapping depth, add new test

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/TaskWrapper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/TaskWrapper.java
@@ -4,7 +4,7 @@ public interface TaskWrapper {
   static Class<?> getUnwrappedType(Object task) {
     int depth = 0;
     Object inspected = task;
-    while (depth < 3 && inspected instanceof TaskWrapper) {
+    while (depth < 5 && inspected instanceof TaskWrapper) {
       inspected = ((TaskWrapper) inspected).$$DD$$__unwrap();
       depth++;
     }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/TaskWrapperTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/TaskWrapperTest.groovy
@@ -29,7 +29,11 @@ class TaskWrapperTest extends DDSpecification {
     l3.wrapped = l2
     def l4 = new RecursiveWrapper()
     l4.wrapped = l3
-    def deepRecursiveWrapper = l4
+    def l5 = new RecursiveWrapper()
+    l5.wrapped = l4
+    def l6 = new RecursiveWrapper()
+    l6.wrapped = l5
+    def deepRecursiveWrapper = l6
     then: "terminate at max depth"
     TaskWrapper.getUnwrappedType(deepRecursiveWrapper) == DirectWrapper
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskWrapperInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskWrapperInstrumentation.java
@@ -22,7 +22,13 @@ public class TaskWrapperInstrumentation extends Instrumenter.Profiling
             "java.util.concurrent.CompletableFuture$AsyncSupply",
             "fn",
             "java.util.concurrent.CompletableFuture$AsyncRun",
-            "fn"));
+            "fn",
+            "java.util.concurrent.ForkJoinTask$AdaptedRunnable",
+            "runnable",
+            "java.util.concurrent.ForkJoinTask$AdaptedCallable",
+            "callable",
+            "java.util.concurrent.ForkJoinTask$AdaptedRunnableAction",
+            "runnable"));
   }
 
   @Override
@@ -31,7 +37,13 @@ public class TaskWrapperInstrumentation extends Instrumenter.Profiling
   @Override
   public String[] knownMatchingTypes() {
     return new String[] {
-      "java.util.concurrent.FutureTask", "java.util.concurrent.Executors$RunnableAdapter"
+      "java.util.concurrent.FutureTask",
+      "java.util.concurrent.Executors$RunnableAdapter",
+      "java.util.concurrent.CompletableFuture$AsyncSupply",
+      "java.util.concurrent.CompletableFuture$AsyncRun",
+      "java.util.concurrent.ForkJoinTask$AdaptedRunnable",
+      "java.util.concurrent.ForkJoinTask$AdaptedCallable",
+      "java.util.concurrent.ForkJoinTask$AdaptedRunnableAction"
     };
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/TaskWrapperTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/TaskWrapperTest.groovy
@@ -1,0 +1,56 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.bootstrap.TaskWrapper
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ForkJoinTask
+import java.util.concurrent.FutureTask
+import java.util.function.Supplier
+
+class TaskWrapperTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.profiling.enabled", "true")
+    injectSysConfig("dd.profiling.experimental.queueing.time.enabled", "true")
+    super.configurePreAgent()
+  }
+
+  def "check expected types instrumented and can be unwrapped"() {
+    verify(new CompletableFuture.AsyncSupply(null, new TestSupplier()), TestSupplier)
+    verify(new CompletableFuture.AsyncRun(null, new TestRunnable()), TestRunnable)
+    verify(new FutureTask(new TestRunnable(), null), TestRunnable)
+    verify(new FutureTask(new TestCallable()), TestCallable)
+    verify(ForkJoinTask.adapt(new TestCallable()), TestCallable)
+    verify(ForkJoinTask.adapt(new TestRunnable()), TestRunnable)
+    verify(ForkJoinTask.adapt(new TestRunnable(), null), TestRunnable)
+  }
+
+  def verify(Object task, Class wrappedClass) {
+    assert task instanceof TaskWrapper
+    assert wrappedClass.isAssignableFrom(TaskWrapper.getUnwrappedType(task))
+  }
+
+  class TestSupplier implements Supplier {
+
+    @Override
+    Object get() {
+      return null
+    }
+  }
+
+  class TestRunnable implements Runnable {
+
+    @Override
+    void run() {
+    }
+  }
+
+  class TestCallable implements Callable {
+
+    @Override
+    Object call() throws Exception {
+      return null
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

* Instruments some more concurrency carriers so they can be unwrapped to access the user-submitted task
* Increases the maximum depth of unwrapping from 3 to 5
* Adds some testing for the application of the instrumentation for key concurrency carrier types

# Motivation

# Additional Notes
