### PR TITLE
Gradle 8.2

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
   implementation("org.ow2.asm", "asm-tree", "9.5")
 
   testImplementation("org.spockframework", "spock-core", "2.0-groovy-3.0")
-  testImplementation("org.codehaus.groovy", "groovy-all", "3.0.15")
+  testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")
 }
 
 tasks.compileGroovy {

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
   testImplementation("net.bytebuddy", "byte-buddy", "1.11.10")
   testImplementation("org.spockframework", "spock-core", "2.0-groovy-3.0")
   testImplementation("org.objenesis", "objenesis", "3.0.1")
-  testImplementation("org.codehaus.groovy", "groovy-all", "3.0.15")
+  testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")
   testImplementation("javax.servlet", "javax.servlet-api", "3.0.1")
   testImplementation("com.github.spotbugs", "spotbugs-annotations", "4.2.0")
 }

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -207,7 +207,7 @@ class GradleDaemonSmokeTest extends Specification {
     ]
 
     where:
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2"]
   }
 
   // this is a separate test case since older Gradle versions need to declare dependencies differently
@@ -322,8 +322,8 @@ class GradleDaemonSmokeTest extends Specification {
     ]
 
     where:
-    // Gradle TestKit supports versions 2.6 and later
-    gradleVersion << ["2.6", "3.0"]
+    // Gradle TestKit supports versions 3.0 and later
+    gradleVersion << ["3.0"]
   }
 
   def "Successful multi-module build emits multiple module spans: Gradle v#gradleVersion"() {
@@ -482,7 +482,7 @@ class GradleDaemonSmokeTest extends Specification {
 
     where:
     //
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2"]
   }
 
   def "Failed build emits session and module spans: Gradle v#gradleVersion"() {
@@ -587,7 +587,7 @@ class GradleDaemonSmokeTest extends Specification {
     }
 
     where:
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2"]
   }
 
   def "Build without tests emits session and module spans: Gradle v#gradleVersion"() {
@@ -639,7 +639,7 @@ class GradleDaemonSmokeTest extends Specification {
     }
 
     where:
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2"]
   }
 
   def "Corrupted build emits session span: Gradle v#gradleVersion"() {
@@ -676,7 +676,7 @@ class GradleDaemonSmokeTest extends Specification {
     }
 
     where:
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2"]
   }
 
   private void givenGradleProperties() {

--- a/dd-smoke-tests/vertx-3.4/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.4/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-3.9-resteasy/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.9-resteasy/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-3.9/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-3.9/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/dd-smoke-tests/vertx-4.2/application/gradle/wrapper/gradle-wrapper.properties
+++ b/dd-smoke-tests/vertx-4.2/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 final class CachedData {
-  static groovyVer = "3.0.15"
+  static groovyVer = "3.0.17"
   static spockGroovyVer = groovyVer.replaceAll(/\.\d+$/, '')
 
   static versions = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,7 +3,7 @@ distributionPath=wrapper/dists
 # Please note that the version specific cache directory and distribution directory in
 # .circleci/config.yml needs to match this version.
 # Since this is a patch version the cache directory in .circleci/config.yml has date time suffix
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip
-distributionSha256Sum=2cbafcd2c47a101cb2165f636b4677fac0b954949c9429c1c988da399defe6a9
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionSha256Sum=5022b0b25fe182b0e50867e77f484501dba44feeea88f5c1f13b6b4660463640
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://docs.gradle.org/8.2/release-notes.html

Note: `TestKit` dropped support for testing Gradle 2.6: https://github.com/gradle/gradle/pull/24891/files