### PR TITLE
Update signal server and client with mechanism to send/receive signal responses

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -43,6 +43,7 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.events.TestSuiteDescriptor",
   "datadog.trace.civisibility.git.GitObject",
   "datadog.trace.civisibility.git.tree.*",
+  "datadog.trace.civisibility.ipc.ModuleExecutionResult",
   "datadog.trace.civisibility.ipc.SignalServer",
   "datadog.trace.civisibility.ipc.SignalType",
   "datadog.trace.civisibility.ipc.SignalClient",

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
@@ -18,6 +18,7 @@ import datadog.trace.civisibility.context.SpanTestContext;
 import datadog.trace.civisibility.context.TestContext;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.ipc.ModuleExecutionResult;
+import datadog.trace.civisibility.ipc.SignalResponse;
 import datadog.trace.civisibility.ipc.SignalServer;
 import datadog.trace.civisibility.ipc.SignalType;
 import datadog.trace.civisibility.source.MethodLinesResolver;
@@ -78,7 +79,7 @@ public class DDTestSessionImpl implements DDTestSession {
     signalServer.start();
   }
 
-  private void onModuleExecutionResultReceived(ModuleExecutionResult result) {
+  private SignalResponse onModuleExecutionResultReceived(ModuleExecutionResult result) {
     // We need to set coverage enabled to true on session span
     // if at least one of the children module has it enabled.
     // The same is true for the other flags below
@@ -91,7 +92,7 @@ public class DDTestSessionImpl implements DDTestSession {
     if (result.isItrTestsSkipped()) {
       setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
     }
-    testModuleRegistry.onModuleExecutionResultReceived(result);
+    return testModuleRegistry.onModuleExecutionResultReceived(result);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/AckResponse.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/AckResponse.java
@@ -1,0 +1,18 @@
+package datadog.trace.civisibility.ipc;
+
+import java.nio.ByteBuffer;
+
+public class AckResponse implements SignalResponse {
+
+  public static final SignalResponse INSTANCE = new AckResponse();
+
+  @Override
+  public SignalType getType() {
+    return SignalType.ACK;
+  }
+
+  @Override
+  public ByteBuffer serialize() {
+    return ByteBuffer.allocate(0);
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ErrorResponse.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ErrorResponse.java
@@ -1,0 +1,35 @@
+package datadog.trace.civisibility.ipc;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+public class ErrorResponse implements SignalResponse {
+
+  private final String message;
+
+  public ErrorResponse(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public SignalType getType() {
+    return SignalType.ERROR;
+  }
+
+  @Override
+  public ByteBuffer serialize() {
+    byte[] payload = message.getBytes(StandardCharsets.UTF_8);
+    return ByteBuffer.wrap(payload);
+  }
+
+  public static ErrorResponse deserialize(ByteBuffer buffer) {
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.get(bytes);
+    String message = new String(bytes, StandardCharsets.UTF_8);
+    return new ErrorResponse(message);
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 
 public class ModuleExecutionResult implements Signal {
 
-  private static final int SERIALIZED_LENGTH = 1 + Long.BYTES + Long.BYTES + 1;
+  private static final int SERIALIZED_LENGTH = Long.BYTES + Long.BYTES + 1;
   private static final int COVERAGE_ENABLED_FLAG = 1;
   private static final int ITR_ENABLED_FLAG = 2;
   private static final int ITR_TESTS_SKIPPED_FLAG = 4;
@@ -87,9 +87,13 @@ public class ModuleExecutionResult implements Signal {
   }
 
   @Override
+  public SignalType getType() {
+    return SignalType.MODULE_EXECUTION_RESULT;
+  }
+
+  @Override
   public ByteBuffer serialize() {
     ByteBuffer buffer = ByteBuffer.allocate(SERIALIZED_LENGTH);
-    buffer.put(SignalType.MODULE_EXECUTION_RESULT.getCode());
     buffer.putLong(sessionId);
     buffer.putLong(moduleId);
 
@@ -109,17 +113,12 @@ public class ModuleExecutionResult implements Signal {
   }
 
   public static ModuleExecutionResult deserialize(ByteBuffer buffer) {
-    int expectedLength = SERIALIZED_LENGTH;
-    if (buffer.remaining() != expectedLength) {
+    if (buffer.remaining() != SERIALIZED_LENGTH) {
       throw new IllegalArgumentException(
-          "Expected " + expectedLength + " bytes, got " + buffer.remaining() + ", " + buffer);
+          "Expected " + SERIALIZED_LENGTH + " bytes, got " + buffer.remaining() + ", " + buffer);
     }
-
-    buffer.get(); // signal type
     long sessionId = buffer.getLong();
     long moduleId = buffer.getLong();
-    ;
-
     int flags = buffer.get();
     boolean coverageEnabled = (flags & COVERAGE_ENABLED_FLAG) != 0;
     boolean itrEnabled = (flags & ITR_ENABLED_FLAG) != 0;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalClient.java
@@ -6,13 +6,28 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SocketChannel;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
 
 public class SignalClient implements AutoCloseable {
 
   private static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 10_000;
+  private static final int BUFFER_CAPACITY = 8192;
+
+  private static final Map<SignalType, Function<ByteBuffer, SignalResponse>> DESERIALIZERS =
+      new EnumMap<>(SignalType.class);
+
+  static {
+    DESERIALIZERS.put(SignalType.ERROR, ErrorResponse::deserialize);
+    DESERIALIZERS.put(SignalType.ACK, b -> AckResponse.INSTANCE);
+  }
 
   private final SocketChannel socketChannel;
+  private final ByteBuffer buffer;
 
   @SuppressForbidden
   public SignalClient(InetSocketAddress serverAddress) throws IOException {
@@ -29,6 +44,8 @@ public class SignalClient implements AutoCloseable {
     Socket socket = socketChannel.socket();
     socket.setSoTimeout(socketTimeoutMillis);
     socket.connect(serverAddress, socketTimeoutMillis);
+
+    buffer = ByteBuffer.allocate(BUFFER_CAPACITY);
   }
 
   @Override
@@ -36,21 +53,61 @@ public class SignalClient implements AutoCloseable {
     socketChannel.close();
   }
 
-  public void send(Signal signal) throws IOException {
+  public SignalResponse send(Signal signal) throws IOException {
     ByteBuffer message = signal.serialize();
-    if (message.remaining() > 0xFFFF) {
-      throw new IllegalArgumentException("Message too long: " + message.remaining());
-    }
-
-    ByteBuffer length = ByteBuffer.allocate(2);
-    length.putShort((short) message.remaining());
-    length.flip();
-    socketChannel.write(length);
+    ByteBuffer header = ByteBuffer.allocate(Integer.BYTES + 1);
+    header.putInt(message.remaining() + 1); // +1 is for signal type
+    header.put(signal.getType().getCode());
+    header.flip();
+    socketChannel.write(header);
     socketChannel.write(message);
 
     // reading is done this way to make socket channel respect timeout
     Socket socket = socketChannel.socket();
     InputStream inputStream = socket.getInputStream();
-    int ignored = inputStream.read(); // waiting for the ack byte
+    ReadableByteChannel inputChannel = Channels.newChannel(inputStream);
+
+    while (buffer.position() < Integer.BYTES) {
+      int read = inputChannel.read(buffer);
+      if (read == -1) {
+        throw new IOException("Stream closed before response length could be fully read");
+      }
+    }
+
+    buffer.flip();
+    int payloadLength = buffer.getInt();
+    ByteBuffer payload = ByteBuffer.allocate(payloadLength);
+    payload.put(buffer);
+    buffer.flip();
+
+    while (payload.hasRemaining()) {
+      int read = inputChannel.read(payload);
+      if (read == -1) {
+        throw new IOException("Stream closed before response payload could be fully read");
+      }
+    }
+
+    payload.flip();
+
+    byte signalTypeCode = payload.get();
+    SignalType signalType = SignalType.fromCode(signalTypeCode);
+    if (signalType == null) {
+      throw new IOException("Unknown signal type code " + signalTypeCode);
+    }
+
+    Function<ByteBuffer, SignalResponse> deserializer = DESERIALIZERS.get(signalType);
+    if (deserializer == null) {
+      throw new IOException("Could not find deserializer for signal type " + signalType);
+    }
+
+    SignalResponse response = deserializer.apply(payload);
+    if (response instanceof ErrorResponse) {
+      throw new IOException(getErrorMessage((ErrorResponse) response));
+    }
+    return response;
+  }
+
+  static String getErrorMessage(ErrorResponse response) {
+    return "Server returned an error: " + response.getMessage();
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalResponse.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalResponse.java
@@ -2,7 +2,7 @@ package datadog.trace.civisibility.ipc;
 
 import java.nio.ByteBuffer;
 
-public interface Signal {
+public interface SignalResponse {
   SignalType getType();
 
   ByteBuffer serialize();

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalServer.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalServer.java
@@ -9,7 +9,7 @@ import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +32,8 @@ public class SignalServer {
 
   private final int port;
   private final String address;
-  private final Map<SignalType, Consumer<Signal>> signalHandlers = new EnumMap<>(SignalType.class);
+  private final Map<SignalType, Function<Signal, SignalResponse>> signalHandlers =
+      new EnumMap<>(SignalType.class);
 
   public SignalServer() {
     this("127.0.0.1", 0);
@@ -95,11 +96,11 @@ public class SignalServer {
 
   @SuppressWarnings("unchecked")
   public synchronized <T extends Signal> void registerSignalHandler(
-      SignalType type, Consumer<T> handler) {
+      SignalType type, Function<T, SignalResponse> handler) {
     if (serverSocketChannel != null) {
       throw new IllegalStateException("Cannot register a signal handler after server has started");
     }
-    signalHandlers.put(type, (Consumer<Signal>) handler);
+    signalHandlers.put(type, (Function<Signal, SignalResponse>) handler);
   }
 
   public synchronized void stop() {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalType.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalType.java
@@ -1,7 +1,9 @@
 package datadog.trace.civisibility.ipc;
 
 public enum SignalType {
-  MODULE_EXECUTION_RESULT((byte) 0);
+  MODULE_EXECUTION_RESULT((byte) 0),
+  ACK((byte) 1),
+  ERROR((byte) 2);
 
   private static final SignalType[] VALUES = SignalType.values();
 


### PR DESCRIPTION
# What Does This Do
Updates `SignalServer` and `SignalClient` adding possibility of sending a response from the server to the client.

# Motivation
Clients (child processes - JVMs running tests) need to receive data from the server (parent process - build system): list of skippable tests, repository index, etc.