### PR TITLE
Fix GraalVM version detection

### DIFF
--- a/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-  id 'org.graalvm.buildtools.native' version '0.9.18'
+  id 'org.graalvm.buildtools.native' version '0.9.23'
   id 'com.diffplug.spotless' version "6.11.0"
 }
 


### PR DESCRIPTION
# What Does This Do

Upgrade gradle `native-build-tools` to fix this issue: https://github.com/graalvm/native-build-tools/issues/359

# Motivation

https://github.com/DataDog/dd-trace-java-docker-build/commit/8821ea94e0aae0592341643ed38a2241eed259fc introduces a regression in `native-image` smoke tests.

# Additional Notes
