### PR TITLE
Support native-image using latest GraalVM JDK

### DIFF
--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
@@ -10,6 +10,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -47,6 +48,12 @@ public class RmiClientContextInstrumentation extends Instrumenter.Tracing
 
   public RmiClientContextInstrumentation() {
     super("rmi", "rmi-context-propagator", "rmi-client-context-propagator");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return super.defaultEnabled()
+        && !Platform.isNativeImageBuilder(); // not applicable in native-image
   }
 
   @Override

--- a/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/context/server/RmiServerContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/rmi/src/main/java/datadog/trace/instrumentation/rmi/context/server/RmiServerContextInstrumentation.java
@@ -9,6 +9,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.instrumentation.rmi.ContextDispatcher;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -21,6 +22,12 @@ public class RmiServerContextInstrumentation extends Instrumenter.Tracing
 
   public RmiServerContextInstrumentation() {
     super("rmi", "rmi-context-propagator", "rmi-server-context-propagator");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return super.defaultEnabled()
+        && !Platform.isNativeImageBuilder(); // not applicable in native-image
   }
 
   @Override

--- a/dd-smoke-tests/spring-boot-3.0-native/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-native/build.gradle
@@ -28,7 +28,8 @@ if (matcher.size() == 1 && Integer.parseInt(matcher[0][1]) >= 17) {
       'GRADLE_OPTS': "-Dorg.gradle.jvmargs='-Xmx512M'",
       'JAVA_HOME': testJvmHome,
       'GRAALVM_HOME': testJvmHome,
-      'DD_TRACE_METHODS' : 'datadog.smoketest.springboot.controller.WebController[sayHello]'
+      'DD_TRACE_METHODS' : 'datadog.smoketest.springboot.controller.WebController[sayHello]',
+      'NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION' : 'true'
     ]
     commandLine(
       "$rootDir/${gradlewCommand}",


### PR DESCRIPTION
Disable RMI client/server context instrumentation during native-image
* This instrumentation is no longer compatible with the latest native-image process 

Grant native-image process access to complete test environment, so it can see `DD_TRACE_METHODS`
* the latest GraalVM JDK only passes selected environment values onto the `native-image` process
* we use `NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION` to restore the old behaviour (no filtering)
* we could also have used a system property to pass the test `dd.trace.methods` setting to `native-image`
