### PR TITLE
JMXFetch 0.47.9 + DogStatsD 4.2.0

### DIFF
--- a/dd-java-agent/agent-jmxfetch/build.gradle
+++ b/dd-java-agent/agent-jmxfetch/build.gradle
@@ -11,7 +11,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.47.5') {
+  api('com.datadoghq:jmxfetch:0.47.9') {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.slf4j', module: 'slf4j-jdk14'
     exclude group: 'com.beust', module: 'jcommander'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ final class CachedData {
     truth         : "1.1.3",
     kotlin        : "1.6.21",
     coroutines    : "1.3.0",
-    dogstatsd     : "4.1.0",
+    dogstatsd     : "4.2.0",
     jnr_unixsocket: "0.38.17",
     jnr_posix     : '3.1.15',
     commons       : "3.2",


### PR DESCRIPTION
# Important Note

After this is merged be careful switching to old branches that predate this PR, because `git` does not automatically update submodules when switching branches.

I would recommend setting:
```
git config --local submodule.recurse true
```
for the `dd-trace-java` repository

Otherwise you will need to remember to add `--recurse-submodules` to `git checkout` when switching to old branches.

--------

# Dependency Updates

https://github.com/DataDog/jmxfetch/releases/tag/0.47.9
https://github.com/DataDog/java-dogstatsd-client/releases/tag/v4.2.0

This PR also updates the `dd-java-agent/agent-jmxfetch/integrations-core` submodule from 7.19.0 to 7.45.0

New metrics configs:
* hazelcast.yaml
* hivemq.yaml
* hudi.yaml
* ignite.yaml
* sonarqube.yaml
* weblogic.yaml

Updated metrics configs:
* activemq.yaml
* cassandra.yaml
* confluent_platform.yaml
* hive.yaml
* jboss_wildfly.yaml
* kafka.yaml
* solr.yaml
* tomcat.yaml
