### PR TITLE
Speed up HttpServerDecorator onRequest

### DIFF
--- a/dd-java-agent/agent-bootstrap/build.gradle
+++ b/dd-java-agent/agent-bootstrap/build.gradle
@@ -1,6 +1,7 @@
 // The shadowJar of this project will be injected into the JVM's bootstrap classloader
 plugins {
   id "com.github.johnrengelman.shadow"
+  id 'me.champeau.jmh'
 }
 
 ext {
@@ -56,4 +57,9 @@ idea {
   module {
     jdkName = '11'
   }
+}
+
+jmh {
+  jmhVersion = '1.32'
+  duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/dd-java-agent/agent-bootstrap/src/jmh/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorBenchmark.java
+++ b/dd-java-agent/agent-bootstrap/src/jmh/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorBenchmark.java
@@ -1,0 +1,167 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ContextVisitors;
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.common.writer.Writer;
+import datadog.trace.core.CoreTracer;
+import datadog.trace.core.DDSpan;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 4, time = 30, timeUnit = SECONDS)
+@Measurement(iterations = 4, time = 30, timeUnit = SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(value = 1)
+public class HttpServerDecoratorBenchmark {
+
+  @Param({"https://foo.bar:4711/normal/path", "https://foo.bar:4711/numb3r/path"})
+  String url;
+
+  Request request;
+  BenchmarkHttpServerDecorator decorator;
+  AgentSpan span;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    request = new Request("GET", URI.create(url));
+    CoreTracer tracer =
+        CoreTracer.builder()
+            .strictTraceWrites(
+                true) // Avoid any extra bookkeeping for traces since we write directly
+            .writer(new NoOpWriter()) // Avoid writing
+            .build();
+    GlobalTracer.forceRegister(tracer);
+    decorator = new BenchmarkHttpServerDecorator();
+    span = decorator.startSpan(Collections.emptyMap(), null);
+  }
+
+  @Benchmark
+  public AgentSpan onRequest() {
+    return decorator.onRequest(span, null, request, null);
+  }
+
+  public static class Request {
+    private final String method;
+    private final URI uri;
+    private final URIDataAdapter uriDataAdapter;
+
+    public Request(String method, URI uri) {
+      this.method = method;
+      this.uri = uri;
+      this.uriDataAdapter = new URIDefaultDataAdapter(uri);
+    }
+
+    public String method() {
+      return method;
+    }
+
+    public URIDataAdapter uriDataAdapter() {
+      return uriDataAdapter;
+    }
+  }
+
+  public static class BenchmarkHttpServerDecorator
+      extends HttpServerDecorator<Request, Void, Void, Map<String, String>> {
+
+    private static final CharSequence COMPONENT = UTF8BytesString.create("benchmark");
+
+    private final CharSequence SPAN_NAME;
+
+    public BenchmarkHttpServerDecorator() {
+      this.SPAN_NAME = UTF8BytesString.create(this.operationName());
+    }
+
+    @Override
+    protected String[] instrumentationNames() {
+      return new String[0];
+    }
+
+    @Override
+    protected CharSequence component() {
+      return COMPONENT;
+    }
+
+    @Override
+    protected AgentPropagation.ContextVisitor<Map<String, String>> getter() {
+      return ContextVisitors.stringValuesMap();
+    }
+
+    @Override
+    protected AgentPropagation.ContextVisitor<Void> responseGetter() {
+      return null;
+    }
+
+    @Override
+    public CharSequence spanName() {
+      return SPAN_NAME;
+    }
+
+    @Override
+    protected String method(Request request) {
+      return request.method();
+    }
+
+    @Override
+    protected URIDataAdapter url(Request request) {
+      return request.uriDataAdapter();
+    }
+
+    @Override
+    protected String peerHostIP(Void connection) {
+      return null;
+    }
+
+    @Override
+    protected int peerPort(Void connection) {
+      return 0;
+    }
+
+    @Override
+    protected int status(Void response) {
+      return 0;
+    }
+  }
+
+  private static class NoOpWriter implements Writer {
+    @Override
+    public void write(final List<DDSpan> trace) {}
+
+    @Override
+    public void start() {}
+
+    @Override
+    public boolean flush() {
+      return false;
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public void incrementDropCounts(final int spanCount) {}
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -66,7 +66,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
           onURI(span, url);
           span.setTag(
               Tags.HTTP_URL,
-              URIUtils.buildURL(url.getScheme(), url.getHost(), url.getPort(), url.getPath()));
+              URIUtils.lazyValidURL(url.getScheme(), url.getHost(), url.getPort(), url.getPath()));
           if (Config.get().isHttpClientTagQueryString()) {
             span.setTag(DDTags.HTTP_QUERY, url.getQuery());
             span.setTag(DDTags.HTTP_FRAGMENT, url.getFragment());

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -210,9 +210,9 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
           String path = encoded ? url.rawPath() : url.path();
           if (valid) {
             span.setTag(
-                Tags.HTTP_URL, URIUtils.buildURL(url.scheme(), url.host(), url.port(), path));
+                Tags.HTTP_URL, URIUtils.lazyValidURL(url.scheme(), url.host(), url.port(), path));
           } else if (supportsRaw) {
-            span.setTag(Tags.HTTP_URL, url.raw());
+            span.setTag(Tags.HTTP_URL, URIUtils.lazyInvalidUrl(url.raw()));
           }
           if (context != null && context.getXForwardedHost() != null) {
             span.setTag(Tags.HTTP_HOSTNAME, context.getXForwardedHost());

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -204,7 +204,6 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
       try {
         final URIDataAdapter url = url(request);
         if (url != null) {
-
           boolean supportsRaw = url.supportsRaw();
           boolean encoded = supportsRaw && config.isHttpServerRawResource();
           boolean valid = url.isValid();

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -27,7 +27,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     then:
     if (req) {
       1 * span.setTag(Tags.HTTP_METHOD, req.method)
-      1 * span.setTag(Tags.HTTP_URL, "$req.url")
+      1 * span.setTag(Tags.HTTP_URL, {it.toString() == "$req.url"})
       1 * span.setTag(Tags.PEER_HOSTNAME, req.url.host)
       1 * span.setTag(Tags.PEER_PORT, req.url.port)
       1 * span.setResourceName({ it as String == req.method.toUpperCase() + " " + req.path }, ResourceNamePriorities.HTTP_PATH_NORMALIZER)
@@ -55,7 +55,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
 
     then:
     if (expectedUrl) {
-      1 * span.setTag(Tags.HTTP_URL, expectedUrl)
+      1 * span.setTag(Tags.HTTP_URL, {it.toString() == expectedUrl})
     }
     if (expectedUrl && tagQueryString) {
       1 * span.setTag(DDTags.HTTP_QUERY, expectedQuery)

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -55,7 +55,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       1 * this.span.setTag(Tags.HTTP_METHOD, "test-method")
       1 * this.span.setTag(DDTags.HTTP_QUERY, _)
       1 * this.span.setTag(DDTags.HTTP_FRAGMENT, _)
-      1 * this.span.setTag(Tags.HTTP_URL, url)
+      1 * this.span.setTag(Tags.HTTP_URL, {it.toString() == url})
       1 * this.span.setTag(Tags.HTTP_HOSTNAME, req.url.host)
       2 * this.span.getRequestContext()
       1 * this.span.setResourceName({ it as String == req.method.toUpperCase() + " " + req.path }, ResourceNamePriorities.HTTP_PATH_NORMALIZER)
@@ -84,7 +84,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
     then:
     if (expectedUrl) {
-      1 * this.span.setTag(Tags.HTTP_URL, expectedUrl)
+      1 * this.span.setTag(Tags.HTTP_URL, {it.toString() == expectedUrl})
       2 * this.span.getRequestContext()
     }
     if (expectedUrl && tagQueryString) {
@@ -133,7 +133,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     decorator.onRequest(this.span, null, req, null)
 
     then:
-    1 * this.span.setTag(Tags.HTTP_URL, expectedUrl)
+    1 * this.span.setTag(Tags.HTTP_URL, {it.toString() == expectedUrl})
     1 * this.span.setTag(Tags.HTTP_HOSTNAME, req.url.host)
     1 * this.span.setTag(DDTags.HTTP_QUERY, expectedQuery)
     1 * this.span.setTag(DDTags.HTTP_FRAGMENT, null)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -5,7 +5,6 @@ import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
 import datadog.trace.api.naming.SpanNaming
 import datadog.trace.bootstrap.instrumentation.api.Tags
-import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
 import datadog.trace.common.sampling.RateByServiceTraceSampler
 import datadog.trace.common.writer.ddagent.TraceMapper
 import datadog.trace.core.DDSpan
@@ -127,7 +126,7 @@ class TagsAssert {
       assert ((Class) expected).isInstance(value): "Tag \"$name\": instance check $expected failed for \"${value.toString()}\" of class \"${value.class}\""
     } else if (expected instanceof Closure) {
       assert ((Closure) expected).call(value): "Tag \"$name\": closure call ${expected.toString()} failed with \"$value\""
-    } else if (expected instanceof UTF8BytesString) {
+    } else if (expected instanceof CharSequence) {
       assert value == expected.toString(): "Tag \"$name\": \"$value\" != \"${expected.toString()}\""
     } else {
       assert value == expected: "Tag \"$name\": \"$value\" != \"$expected\""
@@ -136,7 +135,7 @@ class TagsAssert {
 
   def tag(String name) {
     def t = tags[name]
-    return (t instanceof UTF8BytesString) ? t.toString() : t
+    return (t instanceof CharSequence) ? t.toString() : t
   }
 
   def methodMissing(String name, args) {

--- a/internal-api/src/main/java/datadog/trace/api/normalize/SimpleHttpPathNormalizer.java
+++ b/internal-api/src/main/java/datadog/trace/api/normalize/SimpleHttpPathNormalizer.java
@@ -11,7 +11,7 @@ public final class SimpleHttpPathNormalizer extends HttpPathNormalizer {
     if (null == path || path.isEmpty()) {
       return "/";
     }
-    StringBuilder sb = new StringBuilder();
+    StringBuilder sb = null;
     int inEncoding = 0;
     for (int i = 0; i < path.length(); ) {
       int nextSlash = path.indexOf('/', i);
@@ -22,15 +22,18 @@ public final class SimpleHttpPathNormalizer extends HttpPathNormalizer {
         if ((segmentLength <= 3 && segmentLength > 1 && (path.charAt(i) | ' ') == 'v')) {
           boolean numeric = true;
           for (int j = i + 1; j < endOfSegment; ++j) {
-            numeric &= Character.isDigit(path.charAt(j));
+            numeric &= isDigit(path.charAt(j));
           }
           if (numeric) {
-            sb.append(path, i, endOfSegment);
+            if (sb != null) {
+              sb.append(path, i, endOfSegment);
+            }
           } else {
+            sb = ensureStringBuilder(sb, path, i);
             sb.append('?');
           }
         } else {
-          int snapshot = sb.length();
+          int snapshot = sb != null ? sb.length() : i;
           boolean numeric = false;
           for (int j = i; j < endOfSegment && !numeric; ++j) {
             final char c = path.charAt(j);
@@ -38,12 +41,17 @@ public final class SimpleHttpPathNormalizer extends HttpPathNormalizer {
               inEncoding = 3;
             }
             inEncoding--;
-            numeric = inEncoding < 0 && Character.isDigit(c);
-            if (!numeric && !Character.isWhitespace(c)) {
-              sb.append(c);
+            numeric = inEncoding < 0 && isDigit(c);
+            if (!numeric) {
+              if (Character.isWhitespace(c)) {
+                sb = ensureStringBuilder(sb, path, j);
+              } else if (sb != null) {
+                sb.append(c);
+              }
             }
           }
           if (numeric) {
+            sb = ensureStringBuilder(sb, path, snapshot);
             sb.setLength(snapshot);
             sb.append('?');
           }
@@ -53,9 +61,24 @@ public final class SimpleHttpPathNormalizer extends HttpPathNormalizer {
         ++i;
       }
       if (nextSlash != -1) {
-        sb.append('/');
+        if (sb != null) {
+          sb.append('/');
+        }
       }
     }
-    return sb.length() == 0 ? "/" : sb.toString();
+    return sb == null ? path : sb.length() == 0 ? "/" : sb.toString();
+  }
+
+  private static boolean isDigit(char c) {
+    return c <= '9' && c >= '0';
+  }
+
+  private static StringBuilder ensureStringBuilder(StringBuilder sb, String path, int position) {
+    if (sb == null) {
+      sb = new StringBuilder();
+      sb.append(path, 0, position);
+    }
+
+    return sb;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIUtils.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/URIUtils.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,6 +128,125 @@ public class URIUtils {
     } catch (final IllegalArgumentException exception) {
       LOGGER.debug("Unable to parse request uri {}", unparsed, exception);
       return null;
+    }
+  }
+
+  /**
+   * Builds a lazily evaluated valid URL based on the scheme, host, port and path.
+   *
+   * <p>Will remove the port if it is <= 0 or if its the default http/https port.
+   *
+   * @param scheme The scheme
+   * @param host The host
+   * @param port The port
+   * @param path The path
+   * @return The {@code LazyUrl}
+   */
+  public static LazyUrl lazyValidURL(String scheme, String host, int port, String path) {
+    return new ValidUrl(scheme, host, port, path);
+  }
+
+  /**
+   * Builds an invalid URL from a raw string representation.
+   *
+   * @param raw The raw {@code String} representation of the invalid URL
+   * @return The {@code LazyUrl}
+   */
+  public static LazyUrl lazyInvalidUrl(String raw) {
+    return new InvalidUrl(raw);
+  }
+
+  /**
+   * A lazily evaluated URL that can also return its path. If the URL is invalid the path will be
+   * {@code null}.
+   */
+  public abstract static class LazyUrl implements CharSequence, Supplier<String> {
+    protected String lazy;
+
+    protected LazyUrl(String lazy) {
+      this.lazy = lazy;
+    }
+
+    /**
+     * The path component of this URL.
+     *
+     * @return The path if valid or {@code null} if invalid
+     */
+    public abstract String path();
+
+    @Override
+    public String toString() {
+      String str = lazy;
+      if (str == null) {
+        str = lazy = get();
+      }
+      return str;
+    }
+
+    @Override
+    public int length() {
+      return toString().length();
+    }
+
+    @Override
+    public char charAt(int index) {
+      return toString().charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      return toString().subSequence(start, end);
+    }
+
+    @Override
+    public int hashCode() {
+      return toString().hashCode();
+    }
+  }
+
+  private static class ValidUrl extends LazyUrl {
+    private final String scheme;
+    private final String host;
+    private final int port;
+    private final String path;
+
+    private ValidUrl(String scheme, String host, int port, String path) {
+      super(null);
+      this.scheme = scheme;
+      this.host = host;
+      this.port = port;
+      if (null == path || path.isEmpty()) {
+        this.path = "";
+      } else {
+        this.path = path;
+      }
+    }
+
+    @Override
+    public String path() {
+      return path;
+    }
+
+    @Override
+    public String get() {
+      String res = lazy;
+      return res != null ? res : buildURL(scheme, host, port, path);
+    }
+  }
+
+  private static class InvalidUrl extends LazyUrl {
+    public InvalidUrl(String raw) {
+      super(String.valueOf(raw));
+    }
+
+    @Override
+    public String path() {
+      return null;
+    }
+
+    @Override
+    public String get() {
+      return lazy;
     }
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/URIUtilsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/URIUtilsTest.groovy
@@ -11,9 +11,13 @@ class URIUtilsTest extends DDSpecification {
     setup:
     def uri = new URI(input)
     def url = URIUtils.buildURL(uri.scheme, uri.host, uri.port, uri.path)
+    def lazyUrl = URIUtils.lazyValidURL(uri.scheme, uri.host, uri.port, uri.path)
 
     expect:
     url == expected
+    lazyUrl.path() == uri.path
+    lazyUrl.get() == expected
+    lazyUrl.toString() == expected
 
     where:
     input                         | expected
@@ -30,9 +34,13 @@ class URIUtilsTest extends DDSpecification {
   def "should build urls from corner cases \"#scheme\" \"#host\" #port \"#path\""() {
     setup:
     def url = URIUtils.buildURL(scheme, host, port, path)
+    def lazyUrl = URIUtils.lazyValidURL(scheme, host, port, path)
 
     expect:
     url == expected
+    lazyUrl.path() == (path != null ? path : '')
+    lazyUrl.toString() == expected
+    lazyUrl.get() == expected
 
     where:
     scheme | host | port | path          | expected
@@ -92,5 +100,20 @@ class URIUtilsTest extends DDSpecification {
     "%C3%BEungur%20hn%C3%ADfur"                      | "þungur hnífur"
     "v%C3%A4ldigt+tr%C3%A5kig%20str%C3%A4ng+med+%2B" | "väldigt tråkig sträng med +"
     "very+boring+string+with+only+plus"              | "very boring string with only plus"
+  }
+
+  def "test LazyUrl for code coverage"() {
+    when:
+    def raw = 'weird'
+    def invalid = URIUtils.lazyInvalidUrl(raw)
+
+    then:
+    invalid.path() == null
+    invalid.toString() == raw
+    invalid.get() == raw
+    invalid.length() == raw.length()
+    invalid.hashCode() == raw.hashCode()
+    invalid.subSequence(1,3) == 'ei'
+    invalid.charAt(3) == 'r' as char
   }
 }


### PR DESCRIPTION
# What Does This Do

Optimizes some of the code called by `HttpServerDecorator.onRequest`, by making String creation lazy and reusing information that exists in the `HttpServerDecorator` when doing processing in the `TagInterceptor`.

# Motivation

Path normalization and re-added URL parsing has introduced unnecessary overhead.

# Additional Notes

## Benchmark Results

### Java 8

```
Base
HttpServerDecoratorBenchmark                               (url)  Mode  Cnt     Score    Error   Units
onRequest                       https://foo.bar:4711/normal/path  avgt    4     0.124 ±  0.002   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/normal/path  avgt    4   304.000 ±  0.001    B/op
onRequest                       https://foo.bar:4711/numb3r/path  avgt    4     0.127 ±  0.002   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/numb3r/path  avgt    4   296.000 ±  0.001    B/op

Lazy Normalizer
HttpServerDecoratorBenchmark                               (url)  Mode  Cnt     Score    Error   Units
onRequest                       https://foo.bar:4711/normal/path  avgt    4     0.063 ±  0.001   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/normal/path  avgt    4   168.000 ±  0.001    B/op
onRequest                       https://foo.bar:4711/numb3r/path  avgt    4     0.142 ±  0.003   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/numb3r/path  avgt    4   320.000 ±  0.001    B/op

Lazy Normalizer & Lazy URL
HttpServerDecoratorBenchmark                               (url)  Mode  Cnt     Score    Error   Units
onRequest                       https://foo.bar:4711/normal/path  avgt    4     0.042 ±  0.001   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/normal/path  avgt    4    32.000 ±  0.001    B/op
onRequest                       https://foo.bar:4711/numb3r/path  avgt    4     0.098 ±  0.001   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/numb3r/path  avgt    4   184.000 ±  0.001    B/op
```

### Java 17
```
Base
HttpServerDecoratorBenchmark                               (url)  Mode  Cnt     Score    Error   Units
onRequest                       https://foo.bar:4711/normal/path  avgt    4     0.132 ±  0.003   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/normal/path  avgt    4   216.031 ±  0.001    B/op
onRequest                       https://foo.bar:4711/numb3r/path  avgt    4     0.161 ±  0.005   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/numb3r/path  avgt    4   256.036 ±  0.001    B/op

Lazy Normalizer
HttpServerDecoratorBenchmark                               (url)  Mode  Cnt     Score    Error   Units
onRequest                       https://foo.bar:4711/normal/path  avgt    4     0.064 ±  0.001   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/normal/path  avgt    4   128.018 ±  0.001    B/op
onRequest                       https://foo.bar:4711/numb3r/path  avgt    4     0.143 ±  0.003   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/numb3r/path  avgt    4   232.033 ±  0.001    B/op

Lazy Normalizer & Lazy URL
HttpServerDecoratorBenchmark                               (url)  Mode  Cnt     Score    Error   Units
onRequest                       https://foo.bar:4711/normal/path  avgt    4     0.033 ±  0.001   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/normal/path  avgt    4    24.003 ±  0.001    B/op
onRequest                       https://foo.bar:4711/numb3r/path  avgt    4     0.062 ±  0.001   us/op
onRequest:·gc.alloc.rate.norm   https://foo.bar:4711/numb3r/path  avgt    4   128.018 ±  0.001    B/op
```
