### PR TITLE
Implement ITR skippable tests request for Gradle

### DIFF
--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListener.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListener.java
@@ -2,11 +2,16 @@ package datadog.trace.instrumentation.gradle;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.InstrumentationBridge;
+import datadog.trace.api.civisibility.config.ModuleExecutionSettings;
 import datadog.trace.api.civisibility.events.BuildEventsHandler;
 import datadog.trace.api.config.CiVisibilityConfig;
 import datadog.trace.util.Strings;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.Project;
@@ -52,19 +57,9 @@ public class GradleBuildListener extends BuildAdapter {
     Project rootProject = gradle.getRootProject();
 
     if (config.isCiVisibilityAutoConfigurationEnabled()) {
-      for (Project project : rootProject.getAllprojects()) {
-        GradleProjectConfigurator.INSTANCE.configureTracer(project);
-
-        if (config.isCiVisibilityCompilerPluginAutoConfigurationEnabled()) {
-          String compilerPluginVersion = config.getCiVisibilityCompilerPluginVersion();
-          GradleProjectConfigurator.INSTANCE.configureCompilerPlugin(
-              project, compilerPluginVersion);
-        }
-
-        if (config.isCiVisibilityCodeCoverageEnabled()) {
-          GradleProjectConfigurator.INSTANCE.configureJacoco(project);
-        }
-      }
+      Set<Project> projects = rootProject.getAllprojects();
+      Map<Path, Collection<Task>> testExecutions = configureProjects(projects);
+      configureTestExecutions(gradle, testExecutions);
     }
 
     Collection<GradleUtils.TestFramework> testFrameworks =
@@ -80,6 +75,51 @@ public class GradleBuildListener extends BuildAdapter {
     }
 
     gradle.addListener(new TestTaskExecutionListener(buildEventsHandler));
+  }
+
+  private Map<Path, Collection<Task>> configureProjects(Set<Project> projects) {
+    Map<Path, Collection<Task>> testExecutions = new HashMap<>();
+    for (Project project : projects) {
+      try {
+        Map<Path, Collection<Task>> projectExecutions =
+            GradleProjectConfigurator.INSTANCE.configureProject(project);
+        for (Map.Entry<Path, Collection<Task>> e : projectExecutions.entrySet()) {
+          Path path = e.getKey();
+          Collection<Task> executions = e.getValue();
+          testExecutions.computeIfAbsent(path, k -> new ArrayList<>()).addAll(executions);
+        }
+      } catch (Exception e) {
+        log.error("Error while configuring projects", e);
+      }
+    }
+    return testExecutions;
+  }
+
+  private void configureTestExecutions(Gradle gradle, Map<Path, Collection<Task>> testExecutions) {
+    for (Map.Entry<Path, Collection<Task>> e : testExecutions.entrySet()) {
+      try {
+        Path jvmExecutablePath = e.getKey();
+        Collection<Task> executions = e.getValue();
+        configureTestExecutions(gradle, jvmExecutablePath, executions);
+
+      } catch (Exception ex) {
+        log.error("Error while configuring test executions", ex);
+      }
+    }
+  }
+
+  private void configureTestExecutions(
+      Gradle gradle, Path jvmExecutablePath, Collection<Task> testExecutions) {
+    ModuleExecutionSettings moduleExecutionSettings =
+        buildEventsHandler.getModuleExecutionSettings(gradle, jvmExecutablePath);
+
+    for (Task testExecution : testExecutions) {
+      Path modulePath = testExecution.getProject().getProjectDir().toPath();
+      GradleProjectConfigurator.INSTANCE.configureTracer(
+          testExecution,
+          moduleExecutionSettings.getSystemProperties(),
+          moduleExecutionSettings.getSkippableTests(modulePath));
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListenerInstrumentation.java
@@ -28,11 +28,11 @@ public class GradleBuildListenerInstrumentation extends Instrumenter.CiVisibilit
       packageName + ".GradleUtils",
       packageName + ".GradleUtils$TestFramework",
       packageName + ".GradleProjectConfigurator",
-      packageName + ".GradleProjectConfigurator$_configureTracer_closure1",
-      packageName + ".GradleProjectConfigurator$_configureCompilerPlugin_closure2",
+      packageName + ".GradleProjectConfigurator$_configureCompilerPlugin_closure1",
+      packageName + ".GradleProjectConfigurator$_configureJacoco_closure2",
       packageName + ".GradleProjectConfigurator$_configureJacoco_closure3",
-      packageName + ".GradleProjectConfigurator$_configureJacoco_closure4",
-      packageName + ".GradleProjectConfigurator$_forEveryTestTask_closure5",
+      packageName + ".GradleProjectConfigurator$_forEveryTestTask_closure4",
+      packageName + ".GradleProjectConfigurator$_configureProject_closure5",
       packageName + ".GradleBuildListener",
       packageName + ".GradleBuildListener$TestTaskExecutionListener"
     };

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleProjectConfigurator.groovy
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleProjectConfigurator.groovy
@@ -1,10 +1,19 @@
 package datadog.trace.instrumentation.gradle
 
 import datadog.trace.api.Config
+import datadog.trace.api.civisibility.config.SkippableTest
+import datadog.trace.api.civisibility.config.SkippableTestsSerializer
+import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.bootstrap.DatadogClassLoader
+import datadog.trace.util.Strings
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.internal.jvm.Jvm
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.regex.Pattern
 
@@ -29,6 +38,8 @@ import java.util.regex.Pattern
  */
 class GradleProjectConfigurator {
 
+  private static final Logger log = LoggerFactory.getLogger(GradleProjectConfigurator.class)
+
   /**
    * Each Groovy Closure in here is a separate class.
    * When adding or removing a closure, be sure to update {@link datadog.trace.instrumentation.gradle.GradleBuildListenerInstrumentation#helperClassNames()}
@@ -36,29 +47,29 @@ class GradleProjectConfigurator {
 
   public static final GradleProjectConfigurator INSTANCE = new GradleProjectConfigurator()
 
-  void configureTracer(Project project) {
-    forEveryTestTask project, { task ->
-      List<String> jvmArgs = new ArrayList<>(task.jvmArgs != null ? task.jvmArgs : Collections.<String> emptyList())
+  void configureTracer(Task task, Map<String, String> propagatedSystemProperties, Collection<SkippableTest> skippableTests) {
+    List<String> jvmArgs = new ArrayList<>(task.jvmArgs != null ? task.jvmArgs : Collections.<String> emptyList())
 
-      // propagate to child process all "dd." system properties available in current process
-      def systemProperties = System.getProperties()
-      for (def e : systemProperties.entrySet()) {
-        if (e.key.startsWith(Config.PREFIX)) {
-          jvmArgs.add("-D" + e.key + '=' + e.value)
-        }
-      }
-
-      def ciVisibilityDebugPort = Config.get().ciVisibilityDebugPort
-      if (ciVisibilityDebugPort != null) {
-        jvmArgs.add(
-          "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address="
-          + ciVisibilityDebugPort)
-      }
-
-      jvmArgs.add("-javaagent:" + Config.get().ciVisibilityAgentJarFile.toPath())
-
-      task.jvmArgs(jvmArgs)
+    // propagate to child process all "dd." system properties available in current process
+    for (def e : propagatedSystemProperties.entrySet()) {
+      jvmArgs.add("-D" + e.key + '=' + e.value)
     }
+
+    if (skippableTests != null && !skippableTests.isEmpty()) {
+      String skippableTestsString = SkippableTestsSerializer.serialize(skippableTests)
+      jvmArgs.add("-D" + Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_SKIPPABLE_TESTS) + '=' + skippableTestsString)
+    }
+
+    def ciVisibilityDebugPort = Config.get().ciVisibilityDebugPort
+    if (ciVisibilityDebugPort != null) {
+      jvmArgs.add(
+        "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address="
+        + ciVisibilityDebugPort)
+    }
+
+    jvmArgs.add("-javaagent:" + Config.get().ciVisibilityAgentJarFile.toPath())
+
+    task.jvmArgs(jvmArgs)
   }
 
   void configureCompilerPlugin(Project project, String compilerPluginVersion) {
@@ -186,5 +197,37 @@ class GradleProjectConfigurator {
       // for legacy Gradle versions
       project.tasks.all c
     }
+  }
+
+  Map<Path, Collection<Task>> configureProject(Project project) {
+    def config = Config.get()
+    if (config.ciVisibilityCompilerPluginAutoConfigurationEnabled) {
+      String compilerPluginVersion = config.getCiVisibilityCompilerPluginVersion()
+      configureCompilerPlugin(project, compilerPluginVersion)
+    }
+
+    configureJacoco(project)
+
+    Map<Path, Collection<Task>> testExecutions = new HashMap<>()
+    for (Task task : project.tasks) {
+      if (GradleUtils.isTestTask(task)) {
+        def executable = Paths.get(getEffectiveExecutable(task))
+        testExecutions.computeIfAbsent(executable, k -> new ArrayList<>()).add(task)
+      }
+    }
+    return testExecutions
+  }
+
+  private static String getEffectiveExecutable(Task task) {
+    if (task.hasProperty('javaLauncher') && task.javaLauncher.isPresent()) {
+      try {
+        return task.javaLauncher.get().getExecutablePath().toString()
+      } catch (Exception e) {
+        log.error("Could not get Java launcher for test task", e)
+      }
+    }
+    return task.hasProperty('executable') && task.executable != null
+      ? task.executable
+      : Jvm.current().getJavaExecutable().getAbsolutePath()
   }
 }

--- a/dd-smoke-tests/gradle/build.gradle
+++ b/dd-smoke-tests/gradle/build.gradle
@@ -12,3 +12,9 @@ dependencies {
   testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
   testImplementation group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.20'
 }
+
+test {
+  testLogging {
+    events "passed", "skipped", "failed", "standardOut", "standardError"
+  }
+}

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -102,6 +102,10 @@ class GradleDaemonSmokeTest extends Specification {
     }
   }
 
+  def setupSpec() {
+    givenGradleProperties()
+  }
+
   def setup() {
     receivedTraces.clear()
     receivedCoverages.clear()
@@ -703,7 +707,7 @@ class GradleDaemonSmokeTest extends Specification {
     String agentShadowJar = System.getProperty("datadog.smoketest.agent.shadowJar.path")
     assert new File(agentShadowJar).isFile()
 
-    def ddApiKeyPath = projectFolder.resolve(".dd.api.key")
+    def ddApiKeyPath = testKitFolder.resolve(".dd.api.key")
     Files.write(ddApiKeyPath, "dummy".getBytes())
 
     def ddApplicationKeyPath = testKitFolder.resolve(".dd.application.key")
@@ -723,7 +727,7 @@ class GradleDaemonSmokeTest extends Specification {
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_JACOCO_PLUGIN_INCLUDES)}=datadog.smoke.*," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL)}=${intakeServer.address.toString()}"
 
-    Files.write(projectFolder.resolve("gradle.properties"), gradleProperties.getBytes())
+    Files.write(testKitFolder.resolve("gradle.properties"), gradleProperties.getBytes())
   }
 
   private void givenGradleProjectFiles(String projectFilesSources) {
@@ -744,8 +748,6 @@ class GradleDaemonSmokeTest extends Specification {
   }
 
   private BuildResult runGradleTests(String gradleVersion, boolean successExpected = true) {
-    givenGradleProperties()
-
     def arguments = ["test", "--stacktrace"]
     if (gradleVersion > "5.6") {
       // fail on warnings is available starting from Gradle 5.6

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -95,6 +95,14 @@ class GradleDaemonSmokeTest extends Specification {
 
         response.status(202).send()
       }
+
+      prefix("/api/v2/libraries/tests/services/setting") {
+        response.status(200).send('{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { "code_coverage": true, "tests_skipping": true } } }')
+      }
+
+      prefix("/api/v2/ci/tests/skippable") {
+        response.status(200).send('{ "data": [] }')
+      }
     }
   }
 
@@ -702,12 +710,16 @@ class GradleDaemonSmokeTest extends Specification {
     def ddApiKeyPath = projectFolder.resolve(".dd.api.key")
     Files.write(ddApiKeyPath, "dummy".getBytes())
 
+    def ddApplicationKeyPath = testKitFolder.resolve(".dd.application.key")
+    Files.write(ddApplicationKeyPath, "dummy".getBytes())
+
     def gradleProperties =
       "org.gradle.jvmargs=" +
       "-javaagent:${agentShadowJar}=" +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.ENV)}=${TEST_ENVIRONMENT_NAME}," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.SERVICE_NAME)}=${TEST_SERVICE_NAME}," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.API_KEY_FILE)}=${ddApiKeyPath.toAbsolutePath().toString()}," +
+      "${Strings.propertyNameToSystemPropertyName(GeneralConfig.APPLICATION_KEY_FILE)}=${ddApplicationKeyPath.toAbsolutePath().toString()}," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_ENABLED)}=true," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED)}=true," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_ENABLED)}=true," +

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -18,6 +18,7 @@ import org.gradle.wrapper.Install
 import org.gradle.wrapper.PathAssembler
 import org.gradle.wrapper.WrapperConfiguration
 import org.junit.jupiter.api.Assumptions
+import org.junit.platform.commons.util.StringUtils
 import org.msgpack.jackson.dataformat.MessagePackFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory


### PR DESCRIPTION
# What Does This Do
Implements Intelligent Test Runner in Gradle builds.
Parent process (Gradle) requests remote settings (code coverage enabled, intelligent test runner enabled), and the list of skippable tests from the backend. Then the settings and the skippable tests are propagated to the children processes (JVMs forked to run tests).

# Motivation
Intelligent Test Runner is a feature of CI Visibility product.

# Additional Notes
Request for settings and skippable tests must include JVM executable details.
It is possible to use multiple JVMs during the build (e.g. some tests are run with Java 8, while others are run with Java 11).
Calculating the list of skippable tests is an expensive operation, therefore in order to make as few requests as possible, first all the Gradle test tasks are grouped by the JVM that they use, then a single settings request and a single skippable tests request is issued for each group.