### PR TITLE
Move taint methods from WebModule to PropagationModule (first batch)

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -2,6 +2,7 @@ package com.datadog.iast.propagation;
 
 import static com.datadog.iast.taint.Tainteds.canBeTainted;
 
+import com.datadog.iast.IastRequestContext;
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.Source;
 import com.datadog.iast.taint.TaintedObject;
@@ -130,6 +131,19 @@ public class PropagationModuleImpl implements PropagationModule {
         return;
       }
     }
+  }
+
+  @Override
+  public void taint(final byte source, @Nullable final String name, @Nullable final String value) {
+    if (!canBeTainted(value)) {
+      return;
+    }
+    final IastRequestContext ctx = IastRequestContext.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    taintedObjects.taintInputString(value, new Source(source, name, value));
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -147,6 +147,20 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
+  public void taint(
+      @Nullable final Object ctx_,
+      final byte source,
+      @Nullable final String name,
+      @Nullable final String value) {
+    if (ctx_ == null || !canBeTainted(value)) {
+      return;
+    }
+    final IastRequestContext ctx = (IastRequestContext) ctx_;
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    taintedObjects.taintInputString(value, new Source(source, name, value));
+  }
+
+  @Override
   public void taint(final byte origin, @Nullable final Object... toTaintArray) {
     if (toTaintArray == null || toTaintArray.length == 0) {
       return;
@@ -185,7 +199,7 @@ public class PropagationModuleImpl implements PropagationModule {
 
   @Override
   public void taint(
-      @Nullable Taintable t, byte origin, @Nullable String name, @Nullable String value) {
+      byte origin, @Nullable String name, @Nullable String value, @Nullable Taintable t) {
     if (t == null) {
       return;
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -21,12 +21,6 @@ public class WebModuleImpl implements WebModule {
   }
 
   @Override
-  public void onParameterValue(
-      @Nullable final String paramName, @Nullable final String paramValue) {
-    onNamed(paramName, paramValue, SourceTypes.REQUEST_PARAMETER_VALUE);
-  }
-
-  @Override
   public void onPathParameterValue(
       @Nullable final String paramName, @Nullable final String paramValue) {
     onNamed(paramName, paramValue, SourceTypes.REQUEST_PATH_PARAMETER);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -54,11 +54,6 @@ public class WebModuleImpl implements WebModule {
   }
 
   @Override
-  public void onCookieValue(@Nullable final String cookieName, @Nullable final String cookieValue) {
-    onNamed(cookieName, cookieValue, SourceTypes.REQUEST_COOKIE_VALUE);
-  }
-
-  @Override
   public void onQueryString(@Nullable final String queryString) {
     if (!canBeTainted(queryString)) {
       return;

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -53,20 +53,6 @@ public class WebModuleImpl implements WebModule {
     onNamed(cookieNames, SourceTypes.REQUEST_COOKIE_NAME);
   }
 
-  @Override
-  public void onQueryString(@Nullable final String queryString) {
-    if (!canBeTainted(queryString)) {
-      return;
-    }
-    final IastRequestContext ctx = IastRequestContext.get();
-    if (ctx == null) {
-      return;
-    }
-    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
-    taintedObjects.taintInputString(
-        queryString, new Source(SourceTypes.REQUEST_QUERY, null, queryString));
-  }
-
   private static void onNamed(
       @Nullable final String name, @Nullable final String value, final byte source) {
     if (!canBeTainted(value)) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -152,30 +152,6 @@ public class WebModuleImpl implements WebModule {
   }
 
   @Override
-  public void onRequestPathParameter(
-      @Nullable String paramName, @Nullable String value, @Nonnull Object ctx_) {
-    if (ctx_ == null || !canBeTainted(value)) {
-      return;
-    }
-    final IastRequestContext ctx = (IastRequestContext) ctx_;
-    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
-    taintedObjects.taintInputString(
-        value, new Source(SourceTypes.REQUEST_PATH_PARAMETER, paramName, value));
-  }
-
-  @Override
-  public void onRequestMatrixParameter(
-      @Nonnull String paramName, @Nullable String value, @Nonnull Object ctx_) {
-    if (ctx_ == null || paramName == null || !canBeTainted(value)) {
-      return;
-    }
-    final IastRequestContext ctx = (IastRequestContext) ctx_;
-    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
-    taintedObjects.taintInputString(
-        value, new Source(SourceTypes.REQUEST_MATRIX_PARAMETER, paramName, value));
-  }
-
-  @Override
   public void onInjectedParameter(
       @Nullable String name, @Nullable String value, @Nonnull byte sourceType) {
     onNamed(name, value, sourceType);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -10,7 +10,6 @@ import datadog.trace.api.iast.source.WebModule;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class WebModuleImpl implements WebModule {
@@ -149,11 +148,5 @@ public class WebModuleImpl implements WebModule {
         }
       }
     }
-  }
-
-  @Override
-  public void onInjectedParameter(
-      @Nullable String name, @Nullable String value, @Nonnull byte sourceType) {
-    onNamed(name, value, sourceType);
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -43,11 +43,6 @@ public class WebModuleImpl implements WebModule {
   }
 
   @Override
-  public void onHeaderValue(@Nullable final String headerName, @Nullable final String headerValue) {
-    onNamed(headerName, headerValue, SourceTypes.REQUEST_HEADER_VALUE);
-  }
-
-  @Override
   public void onHeaderValues(
       @Nullable final String headerName, @Nullable final Collection<String> headerValues) {
     onNamed(headerName, headerValues, SourceTypes.REQUEST_HEADER_VALUE);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -52,19 +52,6 @@ public class WebModuleImpl implements WebModule {
     onNamed(cookieNames, SourceTypes.REQUEST_COOKIE_NAME);
   }
 
-  private static void onNamed(
-      @Nullable final String name, @Nullable final String value, final byte source) {
-    if (!canBeTainted(value)) {
-      return;
-    }
-    final IastRequestContext ctx = IastRequestContext.get();
-    if (ctx == null) {
-      return;
-    }
-    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
-    taintedObjects.taintInputString(value, new Source(source, name, value));
-  }
-
   private static void onNamed(@Nullable final Iterable<String> names, final byte source) {
     if (names == null) {
       return;

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -21,12 +21,6 @@ public class WebModuleImpl implements WebModule {
   }
 
   @Override
-  public void onPathParameterValue(
-      @Nullable final String paramName, @Nullable final String paramValue) {
-    onNamed(paramName, paramValue, SourceTypes.REQUEST_PATH_PARAMETER);
-  }
-
-  @Override
   public void onParameterValues(
       @Nullable final String paramName, @Nullable final String[] paramValues) {
     onNamed(paramName, paramValues, SourceTypes.REQUEST_PARAMETER_VALUE);

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
@@ -128,48 +128,6 @@ class WebModuleTest extends IastModuleImplTestBase {
     'onCookieNames'    | 'param' | SourceTypes.REQUEST_COOKIE_NAME
   }
 
-  void 'onRequestPath and Matrix Parameter null or empty'() {
-    when:
-    module.onRequestPathParameter(name, value, ctx)
-    module.onRequestMatrixParameter(name, value, ctx)
-
-    then:
-    0 * _
-    where:
-    name    | value   | ctx
-    null    | null    | Mock(IastRequestContext)
-    null    | ''      | Mock(IastRequestContext)
-    'param' | null    | Mock(IastRequestContext)
-    'param' | ''      | Mock(IastRequestContext)
-    'param' | 'value' | null
-  }
-
-  void '#method — normal operation'() {
-    setup:
-    def ctx = new IastRequestContext()
-
-    when:
-    module."$method"(name, value, ctx)
-
-    then:
-    ctx.getTaintedObjects().get(name) == null
-    def to = ctx.getTaintedObjects().get(value)
-    to != null
-    to.get() == value
-    to.ranges.size() == 1
-    to.ranges[0].start == 0
-    to.ranges[0].length == value.length()
-    to.ranges[0].source == new Source(source, name, value)
-    0 * _
-
-    where:
-    method                     | name    | value   | source
-    'onRequestPathParameter'   | ""      | "value" | SourceTypes.REQUEST_PATH_PARAMETER
-    'onRequestPathParameter'   | "param" | "value" | SourceTypes.REQUEST_PATH_PARAMETER
-    'onRequestMatrixParameter' | ""      | "value" | SourceTypes.REQUEST_MATRIX_PARAMETER
-    'onRequestMatrixParameter' | "param" | "value" | SourceTypes.REQUEST_MATRIX_PARAMETER
-  }
-
   void 'test onInjectedParameter'(){
     given:
     final span = Mock(AgentSpan)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
@@ -127,29 +127,4 @@ class WebModuleTest extends IastModuleImplTestBase {
     'onHeaderNames'    | 'param' | SourceTypes.REQUEST_HEADER_NAME
     'onCookieNames'    | 'param' | SourceTypes.REQUEST_COOKIE_NAME
   }
-
-  void 'test onInjectedParameter'(){
-    given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-    String value = "value"
-
-    when:
-    module.onInjectedParameter("name", value, SourceTypes.REQUEST_BODY)
-
-    then:
-    1 * tracer.activeSpan() >> span
-    1 * span.getRequestContext() >> reqCtx
-    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
-    0 * _
-
-    final tainted = ctx.getTaintedObjects().get(value)
-    tainted != null
-    tainted.ranges.length == 1
-    tainted.ranges.first().source.origin == SourceTypes.REQUEST_BODY
-  }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
@@ -170,53 +170,6 @@ class WebModuleTest extends IastModuleImplTestBase {
     'onRequestMatrixParameter' | "param" | "value" | SourceTypes.REQUEST_MATRIX_PARAMETER
   }
 
-  void 'test onQueryString without span'() {
-    when:
-    module.onQueryString('query string')
-
-    then:
-    1 * tracer.activeSpan() >> null
-    0 * _
-  }
-
-  void 'test onQueryString with null or empty query string'() {
-    when:
-    module.onQueryString(value)
-
-    then:
-    0 * _
-
-    where:
-    value | _
-    null  | _
-    ''    | _
-  }
-
-  void 'test onQueryString'() {
-    given:
-    final span = Mock(AgentSpan)
-    tracer.activeSpan() >> span
-    final reqCtx = Mock(RequestContext)
-    span.getRequestContext() >> reqCtx
-    final ctx = new IastRequestContext()
-    reqCtx.getData(RequestContextSlot.IAST) >> ctx
-    final value = 'key=value'
-
-    when:
-    module.onQueryString(value)
-
-    then:
-    1 * tracer.activeSpan() >> span
-    1 * span.getRequestContext() >> reqCtx
-    1 * reqCtx.getData(RequestContextSlot.IAST) >> ctx
-    0 * _
-
-    final tainted = ctx.getTaintedObjects().get(value)
-    tainted != null
-    tainted.ranges.length == 1
-    tainted.ranges.first().source.origin == SourceTypes.REQUEST_QUERY
-  }
-
   void 'test onInjectedParameter'(){
     given:
     final span = Mock(AgentSpan)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
@@ -41,8 +41,6 @@ class WebModuleTest extends IastModuleImplTestBase {
     'onHeaderValues'    | ['', []]
     'onCookieNames'     | [null]
     'onCookieNames'     | [[]]
-    'onCookieValue'     | [null, null]
-    'onCookieValue'     | ['', '']
   }
 
   void 'test #method: without span'() {
@@ -62,7 +60,6 @@ class WebModuleTest extends IastModuleImplTestBase {
     'onHeaderNames'     | [['header']]
     'onHeaderValues'    | ['name', ['value']]
     'onCookieNames'     | [['name']]
-    'onCookieValue'     | ['name', 'value']
     'onNamed'           | ['name', ['v1'], (byte)0]
     'onNamed'           | ['name', ['v1'] as String[], (byte)0]
     'onNamed'           | [[name: 'v1'], (byte)0]

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/source/WebModuleTest.groovy
@@ -30,8 +30,6 @@ class WebModuleTest extends IastModuleImplTestBase {
     method              | args
     'onParameterNames'  | [null]
     'onParameterNames'  | [[]]
-    'onParameterValue'  | [null, null]
-    'onParameterValue'  | ['', '']
     'onParameterValues' | [null, null]
     'onParameterValues' | ['', []]
     'onParameterValues' | [null, null as String[]]
@@ -60,7 +58,6 @@ class WebModuleTest extends IastModuleImplTestBase {
     where:
     method              | args
     'onParameterNames'  | [['param']]
-    'onParameterValue'  | ['name', 'value']
     'onParameterValues' | ['name', ['value']]
     'onParameterValues' | ['name', ['value'] as String[]]
     'onParameterValues' | [[name: ['value'] as String[]]]
@@ -146,12 +143,6 @@ class WebModuleTest extends IastModuleImplTestBase {
 
     where:
     method                   | name    | value
-    'onParameterValue'       | null    | null
-    'onParameterValue'       | null    | ""
-    'onParameterValue'       | ""      | null
-    'onParameterValue'       | ""      | ""
-    'onParameterValue'       | "param" | null
-    'onParameterValue'       | "param" | ""
     'onHeaderValue'          | null    | null
     'onHeaderValue'          | null    | ""
     'onHeaderValue'          | ""      | null
@@ -186,9 +177,6 @@ class WebModuleTest extends IastModuleImplTestBase {
 
     where:
     method                   | name    | value
-    'onParameterValue'       | null    | "value"
-    'onParameterValue'       | ""      | "value"
-    'onParameterValue'       | "param" | "value"
     'onHeaderValue'          | null    | "value"
     'onHeaderValue'          | ""      | "value"
     'onHeaderValue'          | "param" | "value"
@@ -222,9 +210,6 @@ class WebModuleTest extends IastModuleImplTestBase {
 
     where:
     method                   | name    | value   | source
-    'onParameterValue'       | null    | "value" | SourceTypes.REQUEST_PARAMETER_VALUE
-    'onParameterValue'       | ""      | "value" | SourceTypes.REQUEST_PARAMETER_VALUE
-    'onParameterValue'       | "param" | "value" | SourceTypes.REQUEST_PARAMETER_VALUE
     'onHeaderValue'          | null    | "value" | SourceTypes.REQUEST_HEADER_VALUE
     'onHeaderValue'          | ""      | "value" | SourceTypes.REQUEST_HEADER_VALUE
     'onHeaderValue'          | "param" | "value" | SourceTypes.REQUEST_HEADER_VALUE

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
@@ -70,7 +70,7 @@ public class CookieHeaderInstrumentation extends Instrumenter.Iast
       while (iterator.hasNext()) {
         HttpCookiePair pair = iterator.next();
         cookieNames.add(pair.name());
-        mod.onCookieValue(pair.name(), pair.value());
+        prop.taint(SourceTypes.REQUEST_COOKIE_VALUE, pair.name(), pair.value());
       }
       mod.onCookieNames(cookieNames);
     }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
@@ -87,7 +87,7 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
         }
         // unfortunately, the call to h.value() is instrumented, but
         // because the call to taint() only happens after, the call is a noop
-        propagation.taint(t, SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value());
+        propagation.taint(SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value(), t);
       }
     }
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
@@ -94,7 +94,7 @@ public class UriInstrumentation extends Instrumenter.Iast implements Instrumente
       while (iterator.hasNext()) {
         Tuple2<String, String> pair = iterator.next();
         web.onParameterNames(Collections.singleton(pair._1()));
-        web.onParameterValue(pair._1(), pair._2());
+        prop.taint(SourceTypes.REQUEST_PARAMETER_VALUE, pair._1(), pair._2());
       }
     }
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintCookieFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintCookieFunction.java
@@ -2,7 +2,8 @@ package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import akka.http.scaladsl.model.headers.HttpCookiePair;
 import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
 
@@ -14,12 +15,11 @@ public class TaintCookieFunction
   public Tuple1<HttpCookiePair> apply(Tuple1<HttpCookiePair> v1) {
     HttpCookiePair httpCookiePair = v1._1();
 
-    WebModule mod = InstrumentationBridge.WEB;
+    PropagationModule mod = InstrumentationBridge.PROPAGATION;
     if (mod == null) {
       return v1;
     }
-
-    mod.onCookieValue(httpCookiePair.name(), httpCookiePair.value());
+    mod.taint(SourceTypes.REQUEST_COOKIE_VALUE, httpCookiePair.name(), httpCookiePair.value());
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMapFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMapFunction.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
 import scala.Tuple1;
 import scala.Tuple2;
@@ -16,18 +18,19 @@ public class TaintMapFunction
   public Tuple1<Map<String, String>> apply(Tuple1<Map<String, String>> v1) {
     Map<String, String> m = v1._1;
 
-    WebModule mod = InstrumentationBridge.WEB;
-    if (mod == null || m == null) {
+    PropagationModule prop = InstrumentationBridge.PROPAGATION;
+    WebModule web = InstrumentationBridge.WEB;
+    if (web == null || prop == null || m == null) {
       return v1;
     }
 
     java.util.List<String> keysAsCollection = ScalaToJava.keySetAsCollection(m);
-    mod.onParameterNames(keysAsCollection);
+    web.onParameterNames(keysAsCollection);
 
     Iterator<Tuple2<String, String>> iterator = m.iterator();
     while (iterator.hasNext()) {
       Tuple2<String, String> e = iterator.next();
-      mod.onParameterValue(e._1(), e._2());
+      prop.taint(SourceTypes.REQUEST_PARAMETER_VALUE, e._1(), e._2());
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintOptionalCookieFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintOptionalCookieFunction.java
@@ -2,7 +2,8 @@ package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import akka.http.scaladsl.model.headers.HttpCookiePair;
 import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import scala.Option;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
@@ -15,12 +16,14 @@ public class TaintOptionalCookieFunction
   public Tuple1<Option<HttpCookiePair>> apply(Tuple1<Option<HttpCookiePair>> v1) {
     Option<HttpCookiePair> httpCookiePair = v1._1();
 
-    WebModule mod = InstrumentationBridge.WEB;
+    PropagationModule mod = InstrumentationBridge.PROPAGATION;
     if (mod == null || httpCookiePair.isEmpty()) {
       return v1;
     }
-
-    mod.onCookieValue(httpCookiePair.get().name(), httpCookiePair.get().value());
+    mod.taint(
+        SourceTypes.REQUEST_COOKIE_VALUE,
+        httpCookiePair.get().name(),
+        httpCookiePair.get().value());
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSeqFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSeqFunction.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -20,8 +22,9 @@ public class TaintSeqFunction
   public Tuple1<Seq<Tuple2<String, String>>> apply(Tuple1<Seq<Tuple2<String, String>>> v1) {
     Seq<Tuple2<String, String>> seq = v1._1;
 
-    WebModule mod = InstrumentationBridge.WEB;
-    if (mod == null || seq == null) {
+    WebModule web = InstrumentationBridge.WEB;
+    PropagationModule prop = InstrumentationBridge.PROPAGATION;
+    if (web == null || prop == null || seq == null) {
       return v1;
     }
 
@@ -32,9 +35,9 @@ public class TaintSeqFunction
       String name = t._1();
       String value = t._2();
       if (seenKeys.add(name)) {
-        mod.onParameterNames(Collections.singleton(name));
+        web.onParameterNames(Collections.singleton(name));
       }
-      mod.onParameterValue(name, value);
+      prop.taint(SourceTypes.REQUEST_PARAMETER_VALUE, name, value);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSingleParameterFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSingleParameterFunction.java
@@ -1,7 +1,8 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import scala.Option;
@@ -24,7 +25,7 @@ public class TaintSingleParameterFunction<Magnet>
 
   @Override
   public Tuple1<Object> apply(Tuple1<Object> v1) {
-    WebModule mod = InstrumentationBridge.WEB;
+    PropagationModule mod = InstrumentationBridge.PROPAGATION;
     if (mod == null || v1 == null) {
       return v1;
     }
@@ -43,11 +44,11 @@ public class TaintSingleParameterFunction<Magnet>
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.onParameterValue(paramName, (String) o);
+          mod.taint(SourceTypes.REQUEST_PARAMETER_VALUE, paramName, (String) o);
         }
       }
     } else if (value instanceof String) {
-      mod.onParameterValue(paramName, (String) value);
+      mod.taint(SourceTypes.REQUEST_PARAMETER_VALUE, paramName, (String) value);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/helpers/TaintParametersFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/helpers/TaintParametersFunction.java
@@ -1,7 +1,8 @@
 package datadog.trace.instrumentation.akkahttp102.iast.helpers;
 
 import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import scala.Function1;
 import scala.Option;
 import scala.Tuple1;
@@ -17,7 +18,7 @@ public class TaintParametersFunction<T> implements Function1<Tuple1<T>, Tuple1<T
 
   @Override
   public Tuple1<T> apply(Tuple1<T> v1) {
-    WebModule mod = InstrumentationBridge.WEB;
+    PropagationModule mod = InstrumentationBridge.PROPAGATION;
     if (mod == null) {
       return v1;
     }
@@ -36,11 +37,11 @@ public class TaintParametersFunction<T> implements Function1<Tuple1<T>, Tuple1<T
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.onParameterValue(paramName, (String) o);
+          mod.taint(SourceTypes.REQUEST_PARAMETER_VALUE, paramName, (String) o);
         }
       }
     } else if (value instanceof String) {
-      mod.onParameterValue(paramName, (String) value);
+      mod.taint(SourceTypes.REQUEST_PARAMETER_VALUE, paramName, (String) value);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
@@ -9,6 +9,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.List;
 import java.util.Map;
@@ -39,11 +40,12 @@ public class AbstractFormProviderInstrumentation extends Instrumenter.Iast
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
     public static void onExit(@Advice.Return Map<String, List<String>> result) {
       final WebModule module = InstrumentationBridge.WEB;
-      if (module != null) {
+      final PropagationModule prop = InstrumentationBridge.PROPAGATION;
+      if (module != null && prop != null) {
         module.onParameterNames(result.keySet());
         for (Map.Entry<String, List<String>> entry : result.entrySet()) {
           for (String value : entry.getValue()) {
-            module.onParameterValue(entry.getKey(), value);
+            prop.taint(SourceTypes.REQUEST_PARAMETER_VALUE, entry.getKey(), value);
           }
         }
       }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
@@ -8,7 +8,7 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -40,12 +40,11 @@ public class AbstractParamValueExtractorInstrumentation extends Instrumenter.Ias
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void onExit(
-        @Advice.Return(readOnly = true) Object result,
-        @Advice.FieldValue("parameterName") String parameterName) {
+        @Advice.Return Object result, @Advice.FieldValue("parameterName") String parameterName) {
       if (result instanceof String) {
-        final WebModule module = InstrumentationBridge.WEB;
+        final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.onInjectedParameter(parameterName, (String) result, ThreadLocalSourceType.get());
+          module.taint(ThreadLocalSourceType.get(), parameterName, (String) result);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
@@ -3,22 +3,17 @@ package datadog.trace.instrumentation.jersey;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
 public class AbstractStringReaderAdvice {
-  @Advice.OnMethodExit
+  @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void onExit(@Advice.Return(readOnly = true) Object result) {
     if (result instanceof String) {
-      final WebModule module = InstrumentationBridge.WEB;
-
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        try {
-          module.onParameterValue(null, (String) result);
-        } catch (final Throwable e) {
-          module.onUnexpectedException("AbstractStringReaderAdvice.exit threw", e);
-        }
+        module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, null, (String) result);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
@@ -44,12 +44,13 @@ public class InboundMessageContextInstrumentation extends Instrumenter.Iast
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
     public static void onExit(@Advice.Return Map<String, List<String>> headers) {
-      final WebModule module = InstrumentationBridge.WEB;
-      if (module != null) {
-        module.onHeaderNames(headers.keySet());
+      final PropagationModule prop = InstrumentationBridge.PROPAGATION;
+      final WebModule web = InstrumentationBridge.WEB;
+      if (prop != null && web != null) {
+        web.onHeaderNames(headers.keySet());
         for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
           for (String value : entry.getValue()) {
-            module.onHeaderValue(entry.getKey(), value);
+            prop.taint(SourceTypes.REQUEST_HEADER_VALUE, entry.getKey(), value);
           }
         }
       }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
@@ -3,35 +3,27 @@ package datadog.trace.instrumentation.resteasy;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
-import org.jboss.resteasy.core.CookieParamInjector;
 
 public class CookieParamInjectorAdvice {
-  @Advice.OnMethodExit
+  @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
   public static void onExit(
-      @Advice.This CookieParamInjector self,
-      @Advice.Return(readOnly = true) Object result,
-      @Advice.FieldValue("paramName") String paramName) {
+      @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
     if (result instanceof String || result instanceof Collection) {
-      final WebModule module = InstrumentationBridge.WEB;
-
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        try {
-          if (result instanceof Collection) {
-            Collection collection = (Collection) result;
-            for (Object o : collection) {
-              if (o instanceof String) {
-                module.onCookieValue(paramName, (String) o);
-              }
+        if (result instanceof Collection) {
+          Collection collection = (Collection) result;
+          for (Object o : collection) {
+            if (o instanceof String) {
+              module.taint(SourceTypes.REQUEST_COOKIE_VALUE, paramName, (String) o);
             }
-          } else {
-            module.onCookieValue(paramName, (String) result);
           }
-        } catch (final Throwable e) {
-          module.onUnexpectedException("CookieParamInjectorAdvice.onExit threw", e);
+        } else {
+          module.taint(SourceTypes.REQUEST_COOKIE_VALUE, paramName, (String) result);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
@@ -3,34 +3,27 @@ package datadog.trace.instrumentation.resteasy;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
-import org.jboss.resteasy.core.FormParamInjector;
 
 public class FormParamInjectorAdvice {
-  @Advice.OnMethodExit
+  @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void onExit(
-      @Advice.This FormParamInjector self,
-      @Advice.Return(readOnly = true) Object result,
-      @Advice.FieldValue("paramName") String paramName) {
+      @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
     if (result instanceof String || result instanceof Collection) {
-      final WebModule module = InstrumentationBridge.WEB;
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        try {
-          if (result instanceof Collection) {
-            Collection collection = (Collection) result;
-            for (Object o : collection) {
-              if (o instanceof String) {
-                module.onParameterValue(paramName, (String) o);
-              }
+        if (result instanceof Collection) {
+          Collection<?> collection = (Collection<?>) result;
+          for (Object o : collection) {
+            if (o instanceof String) {
+              module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, paramName, (String) o);
             }
-          } else {
-            module.onParameterValue(paramName, (String) result);
           }
-        } catch (final Throwable e) {
-          module.onUnexpectedException("FormParamInjectorAdvice.onExit threw", e);
+        } else {
+          module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, paramName, (String) result);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
@@ -3,32 +3,28 @@ package datadog.trace.instrumentation.resteasy;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
-import org.jboss.resteasy.core.HeaderParamInjector;
 
 public class HeaderParamInjectorAdvice {
-  @Advice.OnMethodExit
+  @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void onExit(
-      @Advice.This HeaderParamInjector self,
-      @Advice.Return(readOnly = true) Object result,
-      @Advice.FieldValue("paramName") String paramName) {
+      @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
     if (result instanceof String || result instanceof Collection) {
-      final WebModule module = InstrumentationBridge.WEB;
-
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
           if (result instanceof Collection) {
             Collection collection = (Collection) result;
             for (Object o : collection) {
               if (o instanceof String) {
-                module.onHeaderValue(paramName, (String) o);
+                module.taint(SourceTypes.REQUEST_HEADER_VALUE, paramName, (String) o);
               }
             }
           } else {
-            module.onHeaderValue(paramName, (String) result);
+            module.taint(SourceTypes.REQUEST_HEADER_VALUE, paramName, (String) result);
           }
         } catch (final Throwable e) {
           module.onUnexpectedException("HeaderParamInjectorAdvice.onExit threw", e);

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
@@ -3,36 +3,27 @@ package datadog.trace.instrumentation.resteasy;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
-import org.jboss.resteasy.core.PathParamInjector;
 
 public class PathParamInjectorAdvice {
-  @Advice.OnMethodExit
+  @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void onExit(
-      @Advice.This PathParamInjector self,
-      @Advice.Return(readOnly = true) Object result,
-      @Advice.FieldValue("paramName") String paramName) {
+      @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
     if (result instanceof String || result instanceof Collection) {
-      final WebModule module = InstrumentationBridge.WEB;
-
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        try {
-          if (result instanceof Collection) {
-            Collection collection = (Collection) result;
-            for (Object o : collection) {
-              if (o instanceof String) {
-
-                module.onPathParameterValue(paramName, (String) o);
-              }
+        if (result instanceof Collection) {
+          Collection<?> collection = (Collection<?>) result;
+          for (Object o : collection) {
+            if (o instanceof String) {
+              module.taint(SourceTypes.REQUEST_PATH_PARAMETER, paramName, (String) o);
             }
-          } else {
-            module.onPathParameterValue(paramName, (String) result);
           }
-        } catch (final Throwable e) {
-          module.onUnexpectedException("PathParamInjectorAdvice.onExit threw", e);
+        } else {
+          module.taint(SourceTypes.REQUEST_PATH_PARAMETER, paramName, (String) result);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
@@ -3,35 +3,27 @@ package datadog.trace.instrumentation.resteasy;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
-import org.jboss.resteasy.core.QueryParamInjector;
 
 public class QueryParamInjectorAdvice {
-  @Advice.OnMethodExit
+  @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
   public static void onExit(
-      @Advice.This QueryParamInjector self,
-      @Advice.Return(readOnly = true) Object result,
-      @Advice.FieldValue("encodedName") String paramName) {
+      @Advice.Return Object result, @Advice.FieldValue("encodedName") String paramName) {
     if (result instanceof String || result instanceof Collection) {
-      final WebModule module = InstrumentationBridge.WEB;
-
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        try {
-          if (result instanceof Collection) {
-            Collection collection = (Collection) result;
-            for (Object o : collection) {
-              if (o instanceof String) {
-                module.onParameterValue(paramName, (String) o);
-              }
+        if (result instanceof Collection) {
+          Collection<?> collection = (Collection<?>) result;
+          for (Object o : collection) {
+            if (o instanceof String) {
+              module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, paramName, (String) o);
             }
-          } else {
-            module.onParameterValue(paramName, (String) result);
           }
-        } catch (final Throwable e) {
-          module.onUnexpectedException("QueryParamInjectorAdvice.onExit threw", e);
+        } else {
+          module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, paramName, (String) result);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.VulnerabilityTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule;
 import datadog.trace.api.iast.source.WebModule;
 import datadog.trace.util.stacktrace.StackUtils;
@@ -27,17 +28,17 @@ public class JakartaHttpServletRequestCallSite {
       "java.lang.String jakarta.servlet.http.HttpServletRequestWrapper.getParameter(java.lang.String)")
   public static String afterGetParameter(
       @CallSite.This final HttpServletRequest self,
-      @CallSite.Argument final String paramName,
-      @CallSite.Return final String paramValue) {
-    final WebModule module = InstrumentationBridge.WEB;
+      @CallSite.Argument final String name,
+      @CallSite.Return final String value) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.onParameterValue(paramName, paramValue);
+        module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, name, value);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetParameter threw", e);
       }
     }
-    return paramValue;
+    return value;
   }
 
   @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
@@ -28,17 +28,17 @@ public class JakartaServletRequestCallSite {
       "java.lang.String jakarta.servlet.ServletRequestWrapper.getParameter(java.lang.String)")
   public static String afterGetParameter(
       @CallSite.This final ServletRequest self,
-      @CallSite.Argument final String paramName,
-      @CallSite.Return final String paramValue) {
-    final WebModule module = InstrumentationBridge.WEB;
+      @CallSite.Argument final String name,
+      @CallSite.Return final String value) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.onParameterValue(paramName, paramValue);
+        module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, name, value);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetParameter threw", e);
       }
     }
-    return paramValue;
+    return value;
   }
 
   @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -134,10 +134,10 @@ public class HttpServletRequestCallSite {
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequestWrapper.getQueryString()")
   public static String afterGetQueryString(
       @CallSite.This final HttpServletRequest self, @CallSite.Return final String queryString) {
-    final WebModule module = InstrumentationBridge.WEB;
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.onQueryString(queryString);
+        module.taint(SourceTypes.REQUEST_QUERY, null, queryString);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetQueryString threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -152,17 +152,17 @@ public class HttpServletRequestCallSite {
       "java.lang.String javax.servlet.http.HttpServletRequestWrapper.getParameter(java.lang.String)")
   public static String afterGetParameter(
       @CallSite.This final HttpServletRequest self,
-      @CallSite.Argument final String paramName,
-      @CallSite.Return final String paramValue) {
-    final WebModule module = InstrumentationBridge.WEB;
+      @CallSite.Argument final String name,
+      @CallSite.Return final String value) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.onParameterValue(paramName, paramValue);
+        module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, name, value);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetParameter threw", e);
       }
     }
-    return paramValue;
+    return value;
   }
 
   @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -29,17 +29,17 @@ public class HttpServletRequestCallSite {
       "java.lang.String javax.servlet.http.HttpServletRequestWrapper.getHeader(java.lang.String)")
   public static String afterGetHeader(
       @CallSite.This final HttpServletRequest self,
-      @CallSite.Argument final String headerName,
-      @CallSite.Return final String headerValue) {
-    final WebModule module = InstrumentationBridge.WEB;
+      @CallSite.Argument final String name,
+      @CallSite.Return final String value) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.onHeaderValue(headerName, headerValue);
+        module.taint(SourceTypes.REQUEST_HEADER_VALUE, name, value);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetHeader threw", e);
       }
     }
-    return headerValue;
+    return value;
   }
 
   @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
@@ -28,17 +28,17 @@ public class ServletRequestCallSite {
       "java.lang.String javax.servlet.ServletRequestWrapper.getParameter(java.lang.String)")
   public static String afterGetParameter(
       @CallSite.This final ServletRequest self,
-      @CallSite.Argument final String paramName,
-      @CallSite.Return final String paramValue) {
-    final WebModule module = InstrumentationBridge.WEB;
+      @CallSite.Argument final String name,
+      @CallSite.Return final String value) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.onParameterValue(paramName, paramValue);
+        module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, name, value);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetParameter threw", e);
       }
     }
-    return paramValue;
+    return value;
   }
 
   @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
@@ -19,9 +19,13 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
     injectSysConfig('dd.iast.enabled', 'true')
   }
 
+  def cleanup() {
+    InstrumentationBridge.clearIastModules()
+  }
+
   def 'test getHeader'(final Class<? extends HttpServletRequest> clazz) {
     setup:
-    final iastModule = Mock(WebModule)
+    final iastModule = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(iastModule)
     final testSuite = new TestHttpServletRequestCallSiteSuite(Mock(clazz) {
       getHeader('header') >> 'value'
@@ -32,7 +36,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
 
     then:
     result == 'value'
-    1 * iastModule.onHeaderValue('header', 'value')
+    1 * iastModule.taint(SourceTypes.REQUEST_HEADER_VALUE, 'header', 'value')
 
     where:
     clazz                     | _
@@ -97,7 +101,6 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
 
     then:
     result == cookies
-
     1 * iastModule.taint(SourceTypes.REQUEST_COOKIE_VALUE, cookies)
 
     where:

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
@@ -159,7 +159,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
 
   void 'test get query string'() {
     setup:
-    final iastModule = Mock(WebModule)
+    final iastModule = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(iastModule)
     final testSuite = new TestHttpServletRequestCallSiteSuite(Mock(clazz) {
       getQueryString() >> 'paramName=paramValue'
@@ -170,7 +170,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
 
     then:
 
-    1 * iastModule.onQueryString('paramName=paramValue')
+    1 * iastModule.taint(SourceTypes.REQUEST_QUERY, null, 'paramName=paramValue')
 
     where:
     clazz                     | _

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/RequestHeaderMapResolveAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/RequestHeaderMapResolveAdvice.java
@@ -5,6 +5,7 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,8 @@ public class RequestHeaderMapResolveAdvice {
   @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void after(@Advice.Return(typing = Assigner.Typing.DYNAMIC) Map<String, ?> values) {
     WebModule module = InstrumentationBridge.WEB;
-    if (module == null || values == null) {
+    PropagationModule prop = InstrumentationBridge.PROPAGATION;
+    if (module == null || prop == null || values == null) {
       return;
     }
 
@@ -28,12 +30,12 @@ public class RequestHeaderMapResolveAdvice {
       for (Map.Entry<String, List<String>> e :
           ((MultiValueMap<String, String>) values).entrySet()) {
         for (String v : e.getValue()) {
-          module.onHeaderValue(e.getKey(), v);
+          prop.taint(SourceTypes.REQUEST_HEADER_VALUE, e.getKey(), v);
         }
       }
     } else {
       for (Map.Entry<String, String> e : ((Map<String, String>) values).entrySet()) {
-        module.onHeaderValue(e.getKey(), e.getValue());
+        prop.taint(SourceTypes.REQUEST_HEADER_VALUE, e.getKey(), e.getValue());
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintCookiesAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintCookiesAdvice.java
@@ -3,7 +3,8 @@ package datadog.trace.instrumentation.springwebflux.server.iast;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
 import org.springframework.http.HttpCookie;
@@ -14,14 +15,14 @@ class TaintCookiesAdvice {
 
   @Advice.OnMethodExit(suppress = Throwable.class)
   public static void after(@Advice.Return MultiValueMap<String, HttpCookie> cookies) {
-    WebModule module = InstrumentationBridge.WEB;
+    PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null) {
       return;
     }
 
     for (List<HttpCookie> cookieList : cookies.values()) {
       for (HttpCookie cookie : cookieList) {
-        module.onCookieValue(cookie.getName(), cookie.getValue());
+        module.taint(SourceTypes.REQUEST_COOKIE_VALUE, cookie.getName(), cookie.getValue());
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
@@ -5,7 +5,7 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.List;
 import java.util.Locale;
 import net.bytebuddy.asm.Advice;
@@ -16,7 +16,7 @@ class TaintHttpHeadersGetAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void after(@Advice.Argument(0) Object arg, @Advice.Return List<String> values) {
-    WebModule module = InstrumentationBridge.WEB;
+    PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || values == null) {
       return;
     }
@@ -25,7 +25,7 @@ class TaintHttpHeadersGetAdvice {
     }
     String lc = ((String) arg).toLowerCase(Locale.ROOT);
     for (String value : values) {
-      module.onHeaderValue(lc, value);
+      module.taint(SourceTypes.REQUEST_HEADER_VALUE, lc, value);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
@@ -5,7 +5,7 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
 /** @see org.springframework.http.HttpHeaders#getFirst(String) */
@@ -14,10 +14,10 @@ class TaintHttpHeadersGetFirstAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
   public static void after(@Advice.Argument(0) String arg, @Advice.Return String value) {
-    WebModule module = InstrumentationBridge.WEB;
+    PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || arg == null || value == null) {
       return;
     }
-    module.onHeaderValue(arg, value);
+    module.taint(SourceTypes.REQUEST_HEADER_VALUE, arg, value);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
@@ -25,7 +25,7 @@ class TaintHttpHeadersToSingleValueMapAdvice {
 
     module.onHeaderNames(values.keySet());
     for (Map.Entry<String, String> e : values.entrySet()) {
-      module.onHeaderValue(e.getKey(), e.getValue());
+      propModule.taint(SourceTypes.REQUEST_HEADER_VALUE, e.getKey(), e.getValue());
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -19,7 +19,7 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Map;
@@ -128,7 +128,7 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.Def
       { // iast
         Object iastRequestContext = reqCtx.getData(RequestContextSlot.IAST);
         if (iastRequestContext != null) {
-          WebModule module = InstrumentationBridge.WEB;
+          PropagationModule module = InstrumentationBridge.PROPAGATION;
           if (module != null) {
             for (Map.Entry<String, String> e : map.entrySet()) {
               String parameterName = e.getKey();
@@ -136,7 +136,8 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.Def
               if (parameterName == null || value == null) {
                 continue; // should not happen
               }
-              module.onRequestPathParameter(parameterName, value, iastRequestContext);
+              module.taint(
+                  iastRequestContext, SourceTypes.REQUEST_PATH_PARAMETER, parameterName, value);
             }
           }
         }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -7,7 +7,6 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
-import datadog.trace.api.iast.source.WebModule
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -5,6 +5,8 @@ import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.api.iast.source.WebModule
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
@@ -238,7 +240,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
   void 'tainting on template var'() {
     setup:
-    WebModule mod = Mock()
+    PropagationModule mod = Mock()
     InstrumentationBridge.registerIastModule(mod)
     Request request = this.request(PATH_PARAM, 'GET', null).build()
 
@@ -249,7 +251,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     TEST_WRITER.waitForTraces(1)
 
     then:
-    1 * mod.onRequestPathParameter('id', '123', _)
+    1 * mod.taint(_, SourceTypes.REQUEST_PATH_PARAMETER, 'id', '123')
     0 * mod._
 
     cleanup:
@@ -274,7 +276,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
   void 'tainting on matrix var'() {
     setup:
-    WebModule mod = Mock()
+    PropagationModule mod = Mock()
     InstrumentationBridge.registerIastModule(mod)
     Request request = this.request(MATRIX_PARAM, 'GET', null).build()
 
@@ -285,11 +287,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     TEST_WRITER.waitForTraces(1)
 
     then:
-    1 * mod.onRequestPathParameter('var', 'a=x,y;a=z', _)
-    1 * mod.onRequestMatrixParameter('var', 'a', _)
-    1 * mod.onRequestMatrixParameter('var', 'x', _)
-    1 * mod.onRequestMatrixParameter('var', 'y', _)
-    1 * mod.onRequestMatrixParameter('var', 'z', _)
+    1 * mod.taint(_, SourceTypes.REQUEST_PATH_PARAMETER, 'var', 'a=x,y;a=z')
+    1 * mod.taint(_, SourceTypes.REQUEST_MATRIX_PARAMETER, 'var', 'a')
+    1 * mod.taint(_, SourceTypes.REQUEST_MATRIX_PARAMETER, 'var', 'x')
+    1 * mod.taint(_, SourceTypes.REQUEST_MATRIX_PARAMETER, 'var', 'y')
+    1 * mod.taint(_, SourceTypes.REQUEST_MATRIX_PARAMETER, 'var', 'z')
     0 * mod._
 
     cleanup:

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/urlhandlermapping/UrlHandlerMappingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/urlhandlermapping/UrlHandlerMappingTest.groovy
@@ -5,7 +5,8 @@ import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.iast.InstrumentationBridge
-import datadog.trace.api.iast.source.WebModule
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.servlet3.Servlet3Decorator
@@ -181,7 +182,7 @@ class UrlHandlerMappingTest extends HttpServerTest<ConfigurableApplicationContex
 
   void 'tainting on template var'() {
     setup:
-    WebModule mod = Mock()
+    PropagationModule mod = Mock()
     InstrumentationBridge.registerIastModule(mod)
     Request request = this.request(PATH_PARAM, 'GET', null).build()
 
@@ -192,7 +193,7 @@ class UrlHandlerMappingTest extends HttpServerTest<ConfigurableApplicationContex
     TEST_WRITER.waitForTraces(1)
 
     then:
-    1 * mod.onRequestPathParameter('id', '123', _)
+    1 * mod.taint(_, SourceTypes.REQUEST_PATH_PARAMETER, 'id', '123')
     0 * mod._
 
     cleanup:

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
@@ -11,7 +11,7 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.instrumentation.springweb.PairList;
@@ -112,7 +112,7 @@ public class HandleMatchAdvice {
     { // iast
       Object iastRequestContext = reqCtx.getData(RequestContextSlot.IAST);
       if (iastRequestContext != null) {
-        WebModule module = InstrumentationBridge.WEB;
+        PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           if (templateVars instanceof Map) {
             for (Map.Entry<String, String> e : ((Map<String, String>) templateVars).entrySet()) {
@@ -121,7 +121,8 @@ public class HandleMatchAdvice {
               if (parameterName == null || value == null) {
                 continue; // should not happen
               }
-              module.onRequestPathParameter(parameterName, value, iastRequestContext);
+              module.taint(
+                  iastRequestContext, SourceTypes.REQUEST_PATH_PARAMETER, parameterName, value);
             }
           }
 
@@ -137,12 +138,20 @@ public class HandleMatchAdvice {
               for (Map.Entry<String, Iterable<String>> ie : value.entrySet()) {
                 String innerKey = ie.getKey();
                 if (innerKey != null) {
-                  module.onRequestMatrixParameter(parameterName, innerKey, iastRequestContext);
+                  module.taint(
+                      iastRequestContext,
+                      SourceTypes.REQUEST_MATRIX_PARAMETER,
+                      parameterName,
+                      innerKey);
                 }
                 Iterable<String> innerValues = ie.getValue();
                 if (innerValues != null) {
                   for (String iv : innerValues) {
-                    module.onRequestMatrixParameter(parameterName, iv, iastRequestContext);
+                    module.taint(
+                        iastRequestContext,
+                        SourceTypes.REQUEST_MATRIX_PARAMETER,
+                        parameterName,
+                        iv);
                   }
                 }
               }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
@@ -11,7 +11,7 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import jakarta.servlet.http.HttpServletRequest;
@@ -79,7 +79,7 @@ public class InterceptorPreHandleAdvice {
     { // iast
       Object iastRequestContext = reqCtx.getData(RequestContextSlot.IAST);
       if (iastRequestContext != null) {
-        WebModule module = InstrumentationBridge.WEB;
+        PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           for (Map.Entry<String, String> e : map.entrySet()) {
             String parameterName = e.getKey();
@@ -87,7 +87,8 @@ public class InterceptorPreHandleAdvice {
             if (parameterName == null || value == null) {
               continue; // should not happen
             }
-            module.onRequestPathParameter(parameterName, value, iastRequestContext);
+            module.taint(
+                iastRequestContext, SourceTypes.REQUEST_PATH_PARAMETER, parameterName, value);
           }
         }
       }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
@@ -6,6 +6,8 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.ConfigDefaults
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.api.iast.source.WebModule
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
@@ -257,7 +259,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
   void 'tainting on template var'() {
     setup:
-    WebModule mod = Mock()
+    PropagationModule mod = Mock()
     InstrumentationBridge.registerIastModule(mod)
     Request request = this.request(PATH_PARAM, 'GET', null).build()
 
@@ -269,7 +271,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
     then:
     // spring-security filter causes uri matching to happen twice
-    2 * mod.onRequestPathParameter('id', '123', _)
+    2 * mod.taint(_, SourceTypes.REQUEST_PATH_PARAMETER, 'id', '123')
     0 * mod._
 
     cleanup:
@@ -296,7 +298,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
   void 'tainting on matrix var'() {
     setup:
-    WebModule mod = Mock()
+    PropagationModule mod = Mock()
     InstrumentationBridge.registerIastModule(mod)
     Request request = this.request(MATRIX_PARAM, 'GET', null).build()
 
@@ -308,11 +310,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
     then:
     // spring-security filter (AuthorizationFilter.java:95) causes uri matching to happen twice
-    2 * mod.onRequestPathParameter('var', 'a=x,y', _) // this version of spring removes ;a=z
-    2 * mod.onRequestMatrixParameter('var', 'a', _)
-    2 * mod.onRequestMatrixParameter('var', 'x', _)
-    2 * mod.onRequestMatrixParameter('var', 'y', _)
-    2 * mod.onRequestMatrixParameter('var', 'z', _)
+    2 * mod.taint(_, SourceTypes.REQUEST_PATH_PARAMETER, 'var', 'a=x,y') // this version of spring removes ;a=z
+    2 * mod.taint(_, SourceTypes.REQUEST_MATRIX_PARAMETER, 'var', 'a')
+    2 * mod.taint(_, SourceTypes.REQUEST_MATRIX_PARAMETER, 'var', 'x')
+    2 * mod.taint(_, SourceTypes.REQUEST_MATRIX_PARAMETER, 'var', 'y')
+    2 * mod.taint(_, SourceTypes.REQUEST_MATRIX_PARAMETER, 'var', 'z')
     0 * mod._
 
     cleanup:

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
@@ -8,7 +8,6 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
-import datadog.trace.api.iast.source.WebModule
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.springweb6.SetupSpecHelper

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/urlhandlermapping/UrlHandlerMappingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/urlhandlermapping/UrlHandlerMappingTest.groovy
@@ -6,6 +6,8 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.api.ConfigDefaults
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.api.iast.source.WebModule
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
@@ -191,7 +193,7 @@ class UrlHandlerMappingTest extends HttpServerTest<ConfigurableApplicationContex
 
   void 'tainting on template var'() {
     setup:
-    WebModule mod = Mock()
+    PropagationModule mod = Mock()
     InstrumentationBridge.registerIastModule(mod)
     Request request = this.request(PATH_PARAM, 'GET', null).build()
 
@@ -202,7 +204,7 @@ class UrlHandlerMappingTest extends HttpServerTest<ConfigurableApplicationContex
     TEST_WRITER.waitForTraces(1)
 
     then:
-    1 * mod.onRequestPathParameter('id', '123', _)
+    1 * mod.taint(_, SourceTypes.REQUEST_PATH_PARAMETER, 'id', '123')
     0 * mod._
 
     cleanup:

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/urlhandlermapping/UrlHandlerMappingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/urlhandlermapping/UrlHandlerMappingTest.groovy
@@ -8,7 +8,6 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
-import datadog.trace.api.iast.source.WebModule
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
 import datadog.trace.instrumentation.springweb6.SetupSpecHelper

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/PathParameterPublishingHelper.java
@@ -10,7 +10,8 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Map;
@@ -59,7 +60,7 @@ public class PathParameterPublishingHelper {
     { // iast
       Object iastRequestContext = requestContext.getData(RequestContextSlot.IAST);
       if (iastRequestContext != null) {
-        WebModule module = InstrumentationBridge.WEB;
+        PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           for (Map.Entry<String, String> e : params.entrySet()) {
             String parameterName = e.getKey();
@@ -67,7 +68,8 @@ public class PathParameterPublishingHelper {
             if (parameterName == null || value == null) {
               continue; // should not happen
             }
-            module.onRequestPathParameter(parameterName, value, iastRequestContext);
+            module.taint(
+                iastRequestContext, SourceTypes.REQUEST_PATH_PARAMETER, parameterName, value);
           }
         }
       }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
@@ -10,7 +10,8 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
-import datadog.trace.api.iast.source.WebModule;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Map;
@@ -57,7 +58,7 @@ public class PathParameterPublishingHelper {
     { // iast
       Object iastRequestContext = requestContext.getData(RequestContextSlot.IAST);
       if (iastRequestContext != null) {
-        WebModule module = InstrumentationBridge.WEB;
+        PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           for (Map.Entry<String, String> e : params.entrySet()) {
             String parameterName = e.getKey();
@@ -65,7 +66,8 @@ public class PathParameterPublishingHelper {
             if (parameterName == null || value == null) {
               continue; // should not happen
             }
-            module.onRequestPathParameter(parameterName, value, iastRequestContext);
+            module.taint(
+                iastRequestContext, SourceTypes.REQUEST_PATH_PARAMETER, parameterName, value);
           }
         }
       }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -30,6 +30,8 @@ public interface PropagationModule extends IastModule {
 
   void taintIfAnyInputIsTainted(@Nullable Object toTaint, @Nullable Object... inputs);
 
+  void taint(final byte source, @Nullable final String name, @Nullable final String value);
+
   void taint(byte origin, @Nullable Object... toTaint);
 
   void taint(byte origin, @Nullable Collection<Object> toTaint);

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -30,13 +30,15 @@ public interface PropagationModule extends IastModule {
 
   void taintIfAnyInputIsTainted(@Nullable Object toTaint, @Nullable Object... inputs);
 
-  void taint(final byte source, @Nullable final String name, @Nullable final String value);
+  void taint(byte source, @Nullable String name, @Nullable String value);
+
+  void taint(@Nullable Object ctx_, byte source, @Nullable String name, @Nullable String value);
 
   void taint(byte origin, @Nullable Object... toTaint);
 
   void taint(byte origin, @Nullable Collection<Object> toTaint);
 
-  void taint(@Nullable Taintable t, byte origin, @Nullable String name, @Nullable String value);
+  void taint(byte origin, @Nullable String name, @Nullable String value, @Nullable Taintable t);
 
   boolean isTainted(@Nullable Object obj);
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -24,6 +24,4 @@ public interface WebModule extends IastModule {
   void onHeaderValues(@Nullable String headerName, @Nullable Collection<String> headerValue);
 
   void onCookieNames(@Nullable Iterable<String> cookieNames);
-
-  void onInjectedParameter(String parameterName, String result, byte b);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -3,7 +3,6 @@ package datadog.trace.api.iast.source;
 import datadog.trace.api.iast.IastModule;
 import java.util.Collection;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface WebModule extends IastModule {
@@ -25,12 +24,6 @@ public interface WebModule extends IastModule {
   void onHeaderValues(@Nullable String headerName, @Nullable Collection<String> headerValue);
 
   void onCookieNames(@Nullable Iterable<String> cookieNames);
-
-  void onRequestPathParameter(
-      @Nullable String paramName, @Nullable String value, @Nonnull Object iastRequestContext);
-
-  void onRequestMatrixParameter(
-      @Nonnull String paramName, @Nullable String value, @Nonnull Object iastRequestContext);
 
   void onInjectedParameter(String parameterName, String result, byte b);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -22,8 +22,6 @@ public interface WebModule extends IastModule {
 
   void onHeaderNames(@Nullable Collection<String> headerNames);
 
-  void onHeaderValue(@Nullable String headerName, @Nullable String headerValue);
-
   void onHeaderValues(@Nullable String headerName, @Nullable Collection<String> headerValue);
 
   void onQueryString(@Nullable String queryString);

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -14,8 +14,6 @@ public interface WebModule extends IastModule {
    */
   void onParameterNames(@Nullable Collection<String> paramNames);
 
-  void onPathParameterValue(@Nullable String paramName, @Nullable String paramValue);
-
   void onParameterValues(@Nullable String paramName, @Nullable String[] paramValue);
 
   void onParameterValues(@Nullable String paramName, @Nullable Collection<String> paramValues);

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -28,8 +28,6 @@ public interface WebModule extends IastModule {
 
   void onCookieNames(@Nullable Iterable<String> cookieNames);
 
-  void onCookieValue(@Nullable String cookieName, @Nullable String cookieValue);
-
   void onRequestPathParameter(
       @Nullable String paramName, @Nullable String value, @Nonnull Object iastRequestContext);
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -24,8 +24,6 @@ public interface WebModule extends IastModule {
 
   void onHeaderValues(@Nullable String headerName, @Nullable Collection<String> headerValue);
 
-  void onQueryString(@Nullable String queryString);
-
   void onCookieNames(@Nullable Iterable<String> cookieNames);
 
   void onRequestPathParameter(

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -13,11 +13,6 @@ public interface WebModule extends IastModule {
    * whether the parameter comes in the query string or body (e.g. servlet's getParameter).
    */
   void onParameterNames(@Nullable Collection<String> paramNames);
-  /**
-   * An HTTP request parameter value is used. This should be used when it cannot be determined
-   * whether the parameter comes in the query string or body (e.g. servlet's getParameter).
-   */
-  void onParameterValue(@Nullable String paramName, @Nullable String paramValue);
 
   void onPathParameterValue(@Nullable String paramName, @Nullable String paramValue);
 


### PR DESCRIPTION
# What Does This Do

# Motivation
We are deprecating `WebModule` (see https://github.com/DataDog/dd-trace-java/pull/5031) in favor of simpler methods in `PropagationModule`. For sources, we just need a few variations of the `PropagationModule#taint` methods, rather than different callbacks for each source type.

This will reduce the amount of code we use here, and allow us to focus on streamlining the propagation API.

# Additional Notes
This PR covers a first batch of methods to taint value sources (e.g. not parameter names). PRs will follow to cover the rest of methods and eventually remove `WebModule` altogether.