### PR TITLE
Improve external agent process supervision on Azure

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/ExternalAgentLauncher.java
+++ b/communication/src/main/java/datadog/communication/ddagent/ExternalAgentLauncher.java
@@ -1,13 +1,18 @@
 package datadog.communication.ddagent;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.Platform;
 import datadog.trace.util.ProcessSupervisor;
 import java.io.Closeable;
+import java.io.File;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ExternalAgentLauncher implements Closeable {
   private static final Logger log = LoggerFactory.getLogger(ExternalAgentLauncher.class);
+
+  private static final ProcessBuilder.Redirect DISCARD =
+      ProcessBuilder.Redirect.to(new File((Platform.isWindows() ? "NUL" : "/dev/null")));
 
   private ProcessSupervisor traceProcessSupervisor;
   private ProcessSupervisor dogStatsDProcessSupervisor;
@@ -16,6 +21,8 @@ public class ExternalAgentLauncher implements Closeable {
     if (config.isAzureAppServices()) {
       if (config.getTraceAgentPath() != null) {
         ProcessBuilder traceProcessBuilder = new ProcessBuilder(config.getTraceAgentPath());
+        traceProcessBuilder.redirectOutput(DISCARD);
+        traceProcessBuilder.redirectError(DISCARD);
         traceProcessBuilder.command().addAll(config.getTraceAgentArgs());
 
         traceProcessSupervisor = new ProcessSupervisor("datadog-trace-agent", traceProcessBuilder);
@@ -25,6 +32,8 @@ public class ExternalAgentLauncher implements Closeable {
 
       if (config.getDogStatsDPath() != null) {
         ProcessBuilder dogStatsDProcessBuilder = new ProcessBuilder(config.getDogStatsDPath());
+        dogStatsDProcessBuilder.redirectOutput(DISCARD);
+        dogStatsDProcessBuilder.redirectError(DISCARD);
         dogStatsDProcessBuilder.command().addAll(config.getDogStatsDArgs());
 
         dogStatsDProcessSupervisor = new ProcessSupervisor("dogstatsd", dogStatsDProcessBuilder);

--- a/communication/src/main/java/datadog/communication/ddagent/ExternalAgentLauncher.java
+++ b/communication/src/main/java/datadog/communication/ddagent/ExternalAgentLauncher.java
@@ -18,7 +18,7 @@ public class ExternalAgentLauncher implements Closeable {
         ProcessBuilder traceProcessBuilder = new ProcessBuilder(config.getTraceAgentPath());
         traceProcessBuilder.command().addAll(config.getTraceAgentArgs());
 
-        traceProcessSupervisor = new ProcessSupervisor("Trace Agent", traceProcessBuilder);
+        traceProcessSupervisor = new ProcessSupervisor("datadog-trace-agent", traceProcessBuilder);
       } else {
         log.warn("Trace agent path not set. Will not start trace agent process");
       }
@@ -27,7 +27,7 @@ public class ExternalAgentLauncher implements Closeable {
         ProcessBuilder dogStatsDProcessBuilder = new ProcessBuilder(config.getDogStatsDPath());
         dogStatsDProcessBuilder.command().addAll(config.getDogStatsDArgs());
 
-        dogStatsDProcessSupervisor = new ProcessSupervisor("DogStatsD", dogStatsDProcessBuilder);
+        dogStatsDProcessSupervisor = new ProcessSupervisor("dogstatsd", dogStatsDProcessBuilder);
       } else {
         log.warn("DogStatsD path not set. Will not start DogStatsD process");
       }

--- a/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
+++ b/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
@@ -1,78 +1,143 @@
 package datadog.trace.util;
 
 import static datadog.trace.util.AgentThreadFactory.AgentThread.PROCESS_SUPERVISOR;
+import static datadog.trace.util.AgentThreadFactory.THREAD_JOIN_TIMOUT_MS;
+import static datadog.trace.util.ProcessSupervisor.Health.FAULTED;
+import static datadog.trace.util.ProcessSupervisor.Health.HEALTHY;
+import static datadog.trace.util.ProcessSupervisor.Health.INTERRUPTED;
+import static datadog.trace.util.ProcessSupervisor.Health.READY_TO_START;
 
 import java.io.Closeable;
-import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Starts an external process and restarts the process if it dies */
 public class ProcessSupervisor implements Closeable {
-  private static final Logger log = LoggerFactory.getLogger(ProcessSupervisor.class);
-  private static final long MIN_RESTART_INTERVAL_MS = 10 * 1000;
 
-  private final String name;
-  private final ProcessBuilder processBuilder;
-  private final Thread supervisorThread;
-
-  private long nextRestartTime = 0;
-  private volatile Process currentProcess;
-  private volatile boolean stopped = false;
-
-  /**
-   * @param name For logging purposes
-   * @param processBuilder Builder to create the process
-   */
-  public ProcessSupervisor(String name, ProcessBuilder processBuilder) {
-    this.name = name;
-    this.processBuilder = processBuilder;
-    supervisorThread = AgentThreadFactory.newAgentThread(PROCESS_SUPERVISOR, new SupervisorLoop());
-    supervisorThread.start();
+  public enum Health {
+    NEVER_CHECKED,
+    READY_TO_START,
+    INTERRUPTED,
+    FAULTED,
+    HEALTHY
   }
 
-  private class SupervisorLoop implements Runnable {
-    @Override
-    public void run() {
-      try {
-        while (!stopped) {
-          try {
-            if (currentProcess == null) {
-              long restartDelay = nextRestartTime - System.currentTimeMillis();
-              if (restartDelay > 0) {
-                Thread.sleep(restartDelay);
-                continue;
-              }
+  @FunctionalInterface
+  public interface HealthCheck {
+    Health run(Health previousHealth) throws InterruptedException;
+  }
 
-              log.debug("Starting process: [{}]", name);
-              nextRestartTime = System.currentTimeMillis() + MIN_RESTART_INTERVAL_MS;
-              currentProcess = processBuilder.start();
-            }
+  private static final Logger log = LoggerFactory.getLogger(ProcessSupervisor.class);
 
-            // Block until the process exits
-            int code = currentProcess.waitFor();
-            log.debug("Process [{}] has exited with code {}", name, code);
+  private static final long HEALTHY_DELAY_MILLIS = 10_000;
+  private static final long FAULTED_DELAY_MILLIS = 2_000;
+  private static final int MAX_FAULTS = 5;
 
-            // Process is dead, no longer needs to be tracked
-            currentProcess = null;
-          } catch (InterruptedException ignored) {
-          } catch (IOException e) {
-            log.error("Exception starting process: [{}]", name, e);
+  private final String imageName;
+  private final ProcessBuilder processBuilder;
+  private final HealthCheck healthCheck;
+  private final Thread supervisorThread;
+
+  private long nextCheckMillis = 0;
+  private Health currentHealth = Health.NEVER_CHECKED;
+  private Process currentProcess;
+  private int faults;
+
+  private volatile boolean stopping = false;
+
+  /**
+   * @param imageName For logging purposes
+   * @param processBuilder Builder to create the process
+   */
+  public ProcessSupervisor(String imageName, ProcessBuilder processBuilder) {
+    this(imageName, processBuilder, health -> READY_TO_START);
+  }
+
+  public ProcessSupervisor(
+      String imageName, ProcessBuilder processBuilder, HealthCheck healthCheck) {
+    this.imageName = imageName;
+    this.processBuilder = processBuilder;
+    this.healthCheck = healthCheck;
+    this.supervisorThread = AgentThreadFactory.newAgentThread(PROCESS_SUPERVISOR, this::mainLoop);
+    this.supervisorThread.start();
+  }
+
+  private void mainLoop() {
+    try {
+      while (!stopping) {
+        if (currentHealth == FAULTED && ++faults >= MAX_FAULTS) {
+          log.warn("Failed to start process [{}] after {} attempts", imageName, faults);
+          break;
+        }
+        try {
+          long delayMillis = nextCheckMillis - System.currentTimeMillis();
+          if (delayMillis > 0) {
+            Thread.sleep(delayMillis);
           }
+          currentHealth = healthCheck.run(currentHealth);
+          if (currentHealth == READY_TO_START) {
+            startProcessAndWait();
+          }
+        } catch (InterruptedException e) {
+          currentHealth = INTERRUPTED;
+        } catch (Throwable e) {
+          log.warn("Exception starting process: [{}]", imageName, e);
+          currentHealth = FAULTED;
         }
-      } finally {
-        if (currentProcess != null) {
-          log.debug("Stopping process [{}]", name);
-          currentProcess.destroy();
-        }
+        scheduleNextHealthCheck();
       }
+    } finally {
+      stopProcess();
+    }
+  }
+
+  private void scheduleNextHealthCheck() {
+    long now = System.currentTimeMillis();
+    if (currentHealth == HEALTHY) {
+      nextCheckMillis = now + HEALTHY_DELAY_MILLIS;
+    } else if (currentHealth == FAULTED) {
+      nextCheckMillis = now + FAULTED_DELAY_MILLIS;
+    } else { // interrupted
+      nextCheckMillis = Long.max(nextCheckMillis, now + 100);
+    }
+  }
+
+  private void startProcessAndWait() throws Exception {
+    if (currentProcess == null) {
+      log.debug("Starting process: [{}]", imageName);
+      currentProcess = processBuilder.start();
+      currentHealth = HEALTHY;
+      faults = 0;
+    }
+
+    // Block until the process exits
+    int code = currentProcess.waitFor();
+    log.debug("Process [{}] has exited with code {}", imageName, code);
+    currentHealth = code == 0 ? INTERRUPTED : FAULTED;
+
+    // Process is dead, no longer needs to be tracked
+    currentProcess = null;
+  }
+
+  private void stopProcess() {
+    if (currentProcess != null) {
+      log.debug("Stopping process: [{}]", imageName);
+      currentProcess.destroy();
+      if (currentProcess.isAlive()) {
+        currentProcess.destroyForcibly();
+      }
+      currentProcess = null;
     }
   }
 
   @Override
   public void close() {
-    stopped = true;
+    stopping = true;
     supervisorThread.interrupt();
+    try {
+      supervisorThread.join(THREAD_JOIN_TIMOUT_MS);
+    } catch (Throwable ignored) {
+    }
   }
 
   // Package reachable for testing


### PR DESCRIPTION
# What Does This Do

Refactors `ProcessSupervisor` so we can provide more detailed health-checks to decide when to spawn external agent processes on Azure. Note this feature is not used yet in this PR, this is preparing the ground and making the process supervision more robust.

Other improvements:
* Automatically discard output from the external processes. We're not interested in this output and discarding it means we don't have to have additional threads consuming the output. It also avoids a potential issue where the external process could get stuck if nothing is consuming the output.
* Waits a short time for the supervisor thread to stop, giving it a chance to destroy the child process.
* If the original call to `destroy` doesn't stop the child process then try `destroyForcibly`
* Use a shorter delay when the last attempt to start the process failed
* Stop trying to launch the process after 5 sequential failures (this matches the .NET tracers limit for failed attempts)
