### PR TITLE
Clearer API to taint non-Strings

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -161,7 +161,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taint(final byte origin, @Nullable final Object... toTaintArray) {
+  public void taintObjects(final byte origin, @Nullable final Object... toTaintArray) {
     if (toTaintArray == null || toTaintArray.length == 0) {
       return;
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -199,7 +199,8 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taint(final byte origin, @Nullable final Collection<Object> toTaintCollection) {
+  public void taintObjects(
+      final byte origin, @Nullable final Collection<Object> toTaintCollection) {
     if (toTaintCollection == null || toTaintCollection.isEmpty()) {
       return;
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -161,7 +161,20 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintObjects(final byte origin, @Nullable final Object... toTaintArray) {
+  public void taintObject(final byte origin, @Nullable final Object toTaint) {
+    if (toTaint == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = TaintedObjects.activeTaintedObjects(false);
+    if (taintedObjects == null) {
+      return;
+    }
+    final Source source = new Source(origin, null, null);
+    taintObject(taintedObjects, toTaint, source);
+  }
+
+  @Override
+  public void taintObjects(final byte origin, @Nullable final Object[] toTaintArray) {
     if (toTaintArray == null || toTaintArray.length == 0) {
       return;
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/PropagationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/PropagationModuleTest.groovy
@@ -75,7 +75,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', '']
     'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, null as Object[]]
     'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, [] as Object[]]
-    'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, null as Collection]
+    'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, null as Collection]
   }
 
   void '#method without span'() {
@@ -99,6 +99,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
     'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, [new Object()] as Object[]]
     'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, [new Object()]]
+    'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, [new Object()] as Collection<Object>]
   }
 
   void 'test propagation for #method'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/PropagationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/PropagationModuleTest.groovy
@@ -206,9 +206,9 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     'taint' | "param" | "value" | SourceTypes.REQUEST_PATH_PARAMETER
   }
 
-  void 'test taint'() {
+  void 'test taintObjects'() {
     given:
-    final method = module.&taint
+    final method = module.&taintObjects
 
     when:
     method.call(args.toArray())
@@ -290,7 +290,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     before == null
 
     when:
-    module.taint(origin, target)
+    module.taintObjects(origin, target)
     final after = module.firstTaintedSource(target)
 
     then:

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/PropagationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/PropagationModuleTest.groovy
@@ -73,8 +73,8 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', null as String]
     'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, null as String, null as String]
     'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', '']
-    'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, null as Object[]]
-    'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, [] as Object[]]
+    'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, null as Object[]]
+    'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, [] as Object[]]
     'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, null as Collection]
   }
 
@@ -97,8 +97,8 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, [key: 'value'].entrySet().toList(), new Object()]
     'taintIfAnyInputIsTainted' | ['value', ['test', 'test2'].toArray()]
     'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
-    'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, [new Object()] as Object[]]
-    'taint'                    | [SourceTypes.REQUEST_PARAMETER_VALUE, [new Object()]]
+    'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, [new Object()] as Object[]]
+    'taintObjects'             | [SourceTypes.REQUEST_PARAMETER_VALUE, [new Object()]]
   }
 
   void 'test propagation for #method'() {
@@ -123,30 +123,126 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
     where:
     method                     | args                                                                                            | toTaintClosure     | inputClosure
-    'taintIfInputIsTainted'    | [new Object(), 'I am an string']                                                                | { it[0] }          | { it[1] }
-    'taintIfInputIsTainted'    | [new Object(), new Object()]                                                                    | { it[0] }          | { it[1] }
-    'taintIfInputIsTainted'    | [new Object(), new MockTaintable()]                                                             | { it[0] }          | { it[1] }
-    'taintIfInputIsTainted'    | ['Hello', 'I am an string']                                                                     | { it[0] }          | { it[1] }
-    'taintIfInputIsTainted'    | ['Hello', new Object()]                                                                         | { it[0] }          | { it[1] }
-    'taintIfInputIsTainted'    | ['Hello', new MockTaintable()]                                                                  | { it[0] }          | { it[1] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value', 'I am an string']                        | { it[2] }          | { it[3] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value', new Object()]                            | { it[2] }          | { it[3] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value', new MockTaintable()]                     | { it[2] }          | { it[3] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', ['value'], 'I am an string']                      | { it[2][0] }       | { it[3] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', ['value'], new Object()]                          | { it[2][0] }       | { it[3] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', ['value'], new MockTaintable()]                   | { it[2][0] }       | { it[3] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, ['value'].toSet(), 'I am an string']                      | { it[1][0] }       | { it[2] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, ['value'].toSet(), new Object()]                          | { it[1][0] }       | { it[2] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, ['value'].toSet(), new MockTaintable()]                   | { it[1][0] }       | { it[2] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, [name: 'value'].entrySet().toList(), 'I am an string']    | { it[1][0].value } | { it[2] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, [name: 'value'].entrySet().toList(), new Object()]        | { it[1][0].value } | { it[2] }
-    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, [name: 'value'].entrySet().toList(), new MockTaintable()] | { it[1][0].value } | { it[2] }
-    'taintIfAnyInputIsTainted' | [new Object(), ['I am an string'].toArray()]                                                    | { it[0] }          | { it[1][0] }
-    'taintIfAnyInputIsTainted' | [new Object(), [new Object()].toArray()]                                                        | { it[0] }          | { it[1][0] }
-    'taintIfAnyInputIsTainted' | [new Object(), [new MockTaintable()].toArray()]                                                 | { it[0] }          | { it[1][0] }
-    'taintIfAnyInputIsTainted' | ['Hello', ['I am an string'].toArray()]                                                         | { it[0] }          | { it[1][0] }
-    'taintIfAnyInputIsTainted' | ['Hello', [new Object()].toArray()]                                                             | { it[0] }          | { it[1][0] }
-    'taintIfAnyInputIsTainted' | ['Hello', [new MockTaintable()].toArray()]                                                      | { it[0] }          | { it[1][0] }
+    'taintIfInputIsTainted'    | [new Object(), 'I am an string']                                                                | {
+      it[0]
+    }          | {
+      it[1]
+    }
+    'taintIfInputIsTainted'    | [new Object(), new Object()]                                                                    | {
+      it[0]
+    }          | {
+      it[1]
+    }
+    'taintIfInputIsTainted'    | [new Object(), new MockTaintable()]                                                             | {
+      it[0]
+    }          | {
+      it[1]
+    }
+    'taintIfInputIsTainted'    | ['Hello', 'I am an string']                                                                     | {
+      it[0]
+    }          | {
+      it[1]
+    }
+    'taintIfInputIsTainted'    | ['Hello', new Object()]                                                                         | {
+      it[0]
+    }          | {
+      it[1]
+    }
+    'taintIfInputIsTainted'    | ['Hello', new MockTaintable()]                                                                  | {
+      it[0]
+    }          | {
+      it[1]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value', 'I am an string']                        | {
+      it[2]
+    }          | {
+      it[3]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value', new Object()]                            | {
+      it[2]
+    }          | {
+      it[3]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value', new MockTaintable()]                     | {
+      it[2]
+    }          | {
+      it[3]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', ['value'], 'I am an string']                      | {
+      it[2][0]
+    }       | {
+      it[3]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', ['value'], new Object()]                          | {
+      it[2][0]
+    }       | {
+      it[3]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, 'name', ['value'], new MockTaintable()]                   | {
+      it[2][0]
+    }       | {
+      it[3]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, ['value'].toSet(), 'I am an string']                      | {
+      it[1][0]
+    }       | {
+      it[2]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, ['value'].toSet(), new Object()]                          | {
+      it[1][0]
+    }       | {
+      it[2]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, ['value'].toSet(), new MockTaintable()]                   | {
+      it[1][0]
+    }       | {
+      it[2]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, [name: 'value'].entrySet().toList(), 'I am an string']    | {
+      it[1][0].value
+    } | {
+      it[2]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, [name: 'value'].entrySet().toList(), new Object()]        | {
+      it[1][0].value
+    } | {
+      it[2]
+    }
+    'taintIfInputIsTainted'    | [SourceTypes.REQUEST_PARAMETER_VALUE, [name: 'value'].entrySet().toList(), new MockTaintable()] | {
+      it[1][0].value
+    } | {
+      it[2]
+    }
+    'taintIfAnyInputIsTainted' | [new Object(), ['I am an string'].toArray()]                                                    | {
+      it[0]
+    }          | {
+      it[1][0]
+    }
+    'taintIfAnyInputIsTainted' | [new Object(), [new Object()].toArray()]                                                        | {
+      it[0]
+    }          | {
+      it[1][0]
+    }
+    'taintIfAnyInputIsTainted' | [new Object(), [new MockTaintable()].toArray()]                                                 | {
+      it[0]
+    }          | {
+      it[1][0]
+    }
+    'taintIfAnyInputIsTainted' | ['Hello', ['I am an string'].toArray()]                                                         | {
+      it[0]
+    }          | {
+      it[1][0]
+    }
+    'taintIfAnyInputIsTainted' | ['Hello', [new Object()].toArray()]                                                             | {
+      it[0]
+    }          | {
+      it[1][0]
+    }
+    'taintIfAnyInputIsTainted' | ['Hello', [new MockTaintable()].toArray()]                                                      | {
+      it[0]
+    }          | {
+      it[1][0]
+    }
   }
 
   void 'test value source for #method'() {
@@ -206,21 +302,32 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     'taint' | "param" | "value" | SourceTypes.REQUEST_PATH_PARAMETER
   }
 
-  void 'test taintObjects'() {
-    given:
-    final method = module.&taintObjects
-
+  void 'test taintObject'() {
     when:
-    method.call(args.toArray())
+    module.taintObject(origin, toTaint)
 
     then:
-    final toTaint = toTaintClosure.call(args)
     assertTainted(toTaint)
 
     where:
-    args                                                       | toTaintClosure
-    [SourceTypes.REQUEST_PARAMETER_VALUE, new Object()]        | { it[1] }
-    [SourceTypes.REQUEST_PARAMETER_VALUE, new MockTaintable()] | { it[1] }
+    origin                              | toTaint
+    SourceTypes.REQUEST_PARAMETER_VALUE | new Object()
+    SourceTypes.REQUEST_PARAMETER_VALUE | new MockTaintable()
+  }
+
+  void 'test taintObjects[array]'() {
+    when:
+    module.taintObjects(origin, new Object[]{
+      toTaint
+    })
+
+    then:
+    assertTainted(toTaint)
+
+    where:
+    origin                              | toTaint
+    SourceTypes.REQUEST_PARAMETER_VALUE | new Object()
+    SourceTypes.REQUEST_PARAMETER_VALUE | new MockTaintable()
   }
 
   void 'onJsonFactoryCreateParser'() {
@@ -290,7 +397,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     before == null
 
     when:
-    module.taintObjects(origin, target)
+    module.taintObject(origin, target)
     final after = module.firstTaintedSource(target)
 
     then:

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
@@ -20,7 +20,7 @@ public class TaintRequestContextFunction
     if (mod == null || !(reqCtx instanceof Taintable)) {
       return v1;
     }
-    mod.taintObjects(SourceTypes.REQUEST_BODY, reqCtx);
+    mod.taintObject(SourceTypes.REQUEST_BODY, reqCtx);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
@@ -20,7 +20,7 @@ public class TaintRequestContextFunction
     if (mod == null || !(reqCtx instanceof Taintable)) {
       return v1;
     }
-    mod.taint(SourceTypes.REQUEST_BODY, reqCtx);
+    mod.taintObjects(SourceTypes.REQUEST_BODY, reqCtx);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
@@ -21,7 +21,7 @@ public class TaintRequestFunction implements JFunction1<Tuple1<HttpRequest>, Tup
     if (mod == null || !((Object) httpRequest instanceof Taintable)) {
       return v1;
     }
-    mod.taintObjects(SourceTypes.REQUEST_BODY, httpRequest);
+    mod.taintObject(SourceTypes.REQUEST_BODY, httpRequest);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
@@ -21,7 +21,7 @@ public class TaintRequestFunction implements JFunction1<Tuple1<HttpRequest>, Tup
     if (mod == null || !((Object) httpRequest instanceof Taintable)) {
       return v1;
     }
-    mod.taint(SourceTypes.REQUEST_BODY, httpRequest);
+    mod.taintObjects(SourceTypes.REQUEST_BODY, httpRequest);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUnmarshaller.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUnmarshaller.java
@@ -28,7 +28,7 @@ public class TaintUnmarshaller<A, B> implements Unmarshaller<A, B> {
 
   @Override
   public Future<B> apply(A value, ExecutionContext ec, Materializer materializer) {
-    propagationModule.taint(SourceTypes.REQUEST_BODY, value);
+    propagationModule.taintObjects(SourceTypes.REQUEST_BODY, value);
     return delegate.apply(value, ec, materializer);
   }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUnmarshaller.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUnmarshaller.java
@@ -28,7 +28,7 @@ public class TaintUnmarshaller<A, B> implements Unmarshaller<A, B> {
 
   @Override
   public Future<B> apply(A value, ExecutionContext ec, Materializer materializer) {
-    propagationModule.taintObjects(SourceTypes.REQUEST_BODY, value);
+    propagationModule.taintObject(SourceTypes.REQUEST_BODY, value);
     return delegate.apply(value, ec, materializer);
   }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
@@ -19,7 +19,7 @@ public class TaintUriFunction implements JFunction1<Tuple1<Uri>, Tuple1<Uri>> {
     if (mod == null || !(uri instanceof Taintable)) {
       return v1;
     }
-    mod.taint(SourceTypes.REQUEST_QUERY, uri);
+    mod.taintObjects(SourceTypes.REQUEST_QUERY, uri);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
@@ -19,7 +19,7 @@ public class TaintUriFunction implements JFunction1<Tuple1<Uri>, Tuple1<Uri>> {
     if (mod == null || !(uri instanceof Taintable)) {
       return v1;
     }
-    mod.taintObjects(SourceTypes.REQUEST_QUERY, uri);
+    mod.taintObject(SourceTypes.REQUEST_QUERY, uri);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
@@ -64,7 +64,7 @@ public class InboundMessageContextInstrumentation extends Instrumenter.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         for (Object cookie : cookies.values()) {
-          module.taint(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
+          module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
@@ -64,7 +64,7 @@ public class InboundMessageContextInstrumentation extends Instrumenter.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         for (Object cookie : cookies.values()) {
-          module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
+          module.taintObject(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ReaderInterceptorExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ReaderInterceptorExecutorInstrumentation.java
@@ -36,7 +36,7 @@ public class ReaderInterceptorExecutorInstrumentation extends Instrumenter.Iast
     static void after(@Advice.Return final InputStream inputStream) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObject(SourceTypes.REQUEST_BODY, inputStream);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ReaderInterceptorExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ReaderInterceptorExecutorInstrumentation.java
@@ -36,7 +36,7 @@ public class ReaderInterceptorExecutorInstrumentation extends Instrumenter.Iast
     static void after(@Advice.Return final InputStream inputStream) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
@@ -43,7 +43,9 @@ public class JSONObjectUtilsInstrumentation extends Instrumenter.Iast
       if (module != null) {
         for (Map.Entry entry : map.entrySet()) {
           if (entry.getValue() instanceof String) {
-            module.taint(SourceTypes.REQUEST_HEADER_VALUE, (String) entry.getValue());
+            // TODO: We could represent this source more accurately, perhaps tracking the original
+            // source, or using a special name.
+            module.taint(SourceTypes.REQUEST_HEADER_VALUE, null, (String) entry.getValue());
           }
         }
       }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
@@ -40,7 +40,9 @@ public class JWTParserInstrumentation extends Instrumenter.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
 
       if (module != null) {
-        module.taint(SourceTypes.REQUEST_HEADER_VALUE, json);
+        // TODO: We could represent this source more accurately, perhaps tracking the original
+        // source, or using a special name.
+        module.taint(SourceTypes.REQUEST_HEADER_VALUE, null, json);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
@@ -19,11 +19,11 @@ class JWTParserInstrumentationTest  extends AgentTestRunner {
     new com.auth0.jwt.impl.JWTParser().parsePayload(payload)
 
     then:
-    1 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, json)
+    1 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, payload)
     0 * _
   }
 
-  void 'jose JSONObjectUtils instrumentation'(){
+  void 'jose JSONObjectUtils instrumentation'() {
     setup:
     def json = "{\"iss\":\"http://foobar.com\",\"sub\":\"foo\",\"aud\":\"foobar\",\"name\":\"Mr Foo Bar\",\"scope\":\"read\",\"iat\":1516239022,\"exp\":2500000000}"
     final propagationModule = Mock(PropagationModule)
@@ -33,7 +33,11 @@ class JWTParserInstrumentationTest  extends AgentTestRunner {
     com.nimbusds.jose.util.JSONObjectUtils.parse(json)
 
     then:
-    5 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, json)
+    1 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, "http://foobar.com")
+    1 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, "foo")
+    1 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, "foobar")
+    1 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, "Mr Foo Bar")
+    1 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, "read")
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
@@ -1,5 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
 
 class JWTParserInstrumentationTest  extends AgentTestRunner {
@@ -18,7 +19,7 @@ class JWTParserInstrumentationTest  extends AgentTestRunner {
     new com.auth0.jwt.impl.JWTParser().parsePayload(payload)
 
     then:
-    1 * propagationModule.taintObjects(_, _)
+    1 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, json)
     0 * _
   }
 
@@ -32,7 +33,7 @@ class JWTParserInstrumentationTest  extends AgentTestRunner {
     com.nimbusds.jose.util.JSONObjectUtils.parse(json)
 
     then:
-    5 * propagationModule.taintObjects(_, _)
+    5 * propagationModule.taint(SourceTypes.REQUEST_HEADER_VALUE, null, json)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
@@ -18,7 +18,7 @@ class JWTParserInstrumentationTest  extends AgentTestRunner {
     new com.auth0.jwt.impl.JWTParser().parsePayload(payload)
 
     then:
-    1 * propagationModule.taint(_, _)
+    1 * propagationModule.taintObjects(_, _)
     0 * _
   }
 
@@ -32,7 +32,7 @@ class JWTParserInstrumentationTest  extends AgentTestRunner {
     com.nimbusds.jose.util.JSONObjectUtils.parse(json)
 
     then:
-    5 * propagationModule.taint(_, _)
+    5 * propagationModule.taintObjects(_, _)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
@@ -23,7 +23,7 @@ public class JakartaHttpServletRequestInputStreamCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taint(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetInputStream threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
@@ -23,7 +23,7 @@ public class JakartaHttpServletRequestInputStreamCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObject(SourceTypes.REQUEST_BODY, inputStream);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetInputStream threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
@@ -136,7 +136,7 @@ public class JakartaServletRequestCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObject(SourceTypes.REQUEST_BODY, inputStream);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetInputStream threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
@@ -136,7 +136,7 @@ public class JakartaServletRequestCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taint(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetInputStream threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaServletRequestCallSiteTest.groovy
@@ -125,7 +125,7 @@ class JakartaServletRequestCallSiteTest extends AgentTestRunner {
     testSuite.getInputStream()
 
     then:
-    1 * iastModule.taint(SourceTypes.REQUEST_BODY, stream)
+    1 * iastModule.taintObjects(SourceTypes.REQUEST_BODY, stream)
 
     where:
     testSuite                                       | clazz

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaServletRequestCallSiteTest.groovy
@@ -125,7 +125,7 @@ class JakartaServletRequestCallSiteTest extends AgentTestRunner {
     testSuite.getInputStream()
 
     then:
-    1 * iastModule.taintObjects(SourceTypes.REQUEST_BODY, stream)
+    1 * iastModule.taintObject(SourceTypes.REQUEST_BODY, stream)
 
     where:
     testSuite                                       | clazz

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -120,7 +120,7 @@ public class HttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, (Object[]) cookies);
+          module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookies);
         } catch (final Throwable e) {
           module.onUnexpectedException("afterGetCookies threw", e);
         }
@@ -227,7 +227,7 @@ public class HttpServletRequestCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintObjects(SourceTypes.REQUEST_BODY, bufferedReader);
+        module.taintObject(SourceTypes.REQUEST_BODY, bufferedReader);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetReader threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -120,7 +120,7 @@ public class HttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taint(SourceTypes.REQUEST_COOKIE_VALUE, (Object[]) cookies);
+          module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, (Object[]) cookies);
         } catch (final Throwable e) {
           module.onUnexpectedException("afterGetCookies threw", e);
         }
@@ -227,7 +227,7 @@ public class HttpServletRequestCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taint(SourceTypes.REQUEST_BODY, bufferedReader);
+        module.taintObjects(SourceTypes.REQUEST_BODY, bufferedReader);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetReader threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
@@ -23,7 +23,7 @@ public class HttpServletRequestInputStreamCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObject(SourceTypes.REQUEST_BODY, inputStream);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetInputStream threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
@@ -23,7 +23,7 @@ public class HttpServletRequestInputStreamCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taint(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetInputStream threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
@@ -103,7 +103,7 @@ public class ServletRequestCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taint(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetInputStream threw", e);
       }
@@ -120,7 +120,7 @@ public class ServletRequestCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taint(SourceTypes.REQUEST_BODY, bufferedReader);
+        module.taintObjects(SourceTypes.REQUEST_BODY, bufferedReader);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetReader threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
@@ -103,7 +103,7 @@ public class ServletRequestCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintObjects(SourceTypes.REQUEST_BODY, inputStream);
+        module.taintObject(SourceTypes.REQUEST_BODY, inputStream);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetInputStream threw", e);
       }
@@ -120,7 +120,7 @@ public class ServletRequestCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintObjects(SourceTypes.REQUEST_BODY, bufferedReader);
+        module.taintObject(SourceTypes.REQUEST_BODY, bufferedReader);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterGetReader threw", e);
       }

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
@@ -101,7 +101,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
 
     then:
     result == cookies
-    1 * iastModule.taint(SourceTypes.REQUEST_COOKIE_VALUE, cookies)
+    1 * iastModule.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookies)
 
     where:
     clazz                     | _

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/ServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/ServletRequestCallSiteTest.groovy
@@ -34,7 +34,7 @@ class ServletRequestCallSiteTest extends AgentTestRunner {
 
     then:
     result == is
-    1 * iastModule.taintObjects(SourceTypes.REQUEST_BODY, is)
+    1 * iastModule.taintObject(SourceTypes.REQUEST_BODY, is)
 
     where:
     testSuite                                     | clazz
@@ -60,7 +60,7 @@ class ServletRequestCallSiteTest extends AgentTestRunner {
 
     then:
     result == reader
-    1 * iastModule.taintObjects(SourceTypes.REQUEST_BODY, reader)
+    1 * iastModule.taintObject(SourceTypes.REQUEST_BODY, reader)
 
     where:
     testSuite                                     | clazz

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/ServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/ServletRequestCallSiteTest.groovy
@@ -34,7 +34,7 @@ class ServletRequestCallSiteTest extends AgentTestRunner {
 
     then:
     result == is
-    1 * iastModule.taint(SourceTypes.REQUEST_BODY, is)
+    1 * iastModule.taintObjects(SourceTypes.REQUEST_BODY, is)
 
     where:
     testSuite                                     | clazz
@@ -60,7 +60,7 @@ class ServletRequestCallSiteTest extends AgentTestRunner {
 
     then:
     result == reader
-    1 * iastModule.taint(SourceTypes.REQUEST_BODY, reader)
+    1 * iastModule.taintObjects(SourceTypes.REQUEST_BODY, reader)
 
     where:
     testSuite                                     | clazz

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintFluxElementsFunction.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintFluxElementsFunction.java
@@ -13,7 +13,7 @@ public class TaintFluxElementsFunction<T> implements Function<T, T> {
 
   @Override
   public T apply(T t) {
-    propagation.taint(SourceTypes.REQUEST_BODY, t);
+    propagation.taintObjects(SourceTypes.REQUEST_BODY, t);
     return t;
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintFluxElementsFunction.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintFluxElementsFunction.java
@@ -13,7 +13,7 @@ public class TaintFluxElementsFunction<T> implements Function<T, T> {
 
   @Override
   public T apply(T t) {
-    propagation.taintObjects(SourceTypes.REQUEST_BODY, t);
+    propagation.taintObject(SourceTypes.REQUEST_BODY, t);
     return t;
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintGetBodyAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintGetBodyAdvice.java
@@ -21,7 +21,7 @@ class TaintGetBodyAdvice {
     }
 
     // taint both the flux and the individual DataBuffers
-    propagation.taintObjects(SourceTypes.REQUEST_BODY, flux);
+    propagation.taintObject(SourceTypes.REQUEST_BODY, flux);
     flux = flux.map(new TaintFluxElementsFunction<>(propagation));
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintGetBodyAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintGetBodyAdvice.java
@@ -21,7 +21,7 @@ class TaintGetBodyAdvice {
     }
 
     // taint both the flux and the individual DataBuffers
-    propagation.taint(SourceTypes.REQUEST_BODY, flux);
+    propagation.taintObjects(SourceTypes.REQUEST_BODY, flux);
     flux = flux.map(new TaintFluxElementsFunction<>(propagation));
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
@@ -69,7 +69,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           try {
-            module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
+            module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
           } catch (final Throwable e) {
             module.onUnexpectedException("params threw", e);
           }
@@ -97,7 +97,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           try {
-            module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
+            module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
           } catch (final Throwable e) {
             module.onUnexpectedException("formAttributes threw", e);
           }
@@ -114,7 +114,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taint(SourceTypes.REQUEST_BODY, data);
+          module.taintObjects(SourceTypes.REQUEST_BODY, data);
         } catch (final Throwable e) {
           module.onUnexpectedException("handleData threw", e);
         }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
@@ -69,7 +69,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           try {
-            module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
+            module.taintObject(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
           } catch (final Throwable e) {
             module.onUnexpectedException("params threw", e);
           }
@@ -97,7 +97,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           try {
-            module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
+            module.taintObject(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
           } catch (final Throwable e) {
             module.onUnexpectedException("formAttributes threw", e);
           }
@@ -114,7 +114,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taintObjects(SourceTypes.REQUEST_BODY, data);
+          module.taintObject(SourceTypes.REQUEST_BODY, data);
         } catch (final Throwable e) {
           module.onUnexpectedException("handleData threw", e);
         }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
@@ -55,7 +55,7 @@ public class Http2ServerRequestInstrumentation extends AbstractHttpServerRequest
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           try {
-            module.taint(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
+            module.taintObjects(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
           } catch (final Throwable e) {
             module.onUnexpectedException("headers threw", e);
           }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
@@ -55,7 +55,7 @@ public class Http2ServerRequestInstrumentation extends AbstractHttpServerRequest
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           try {
-            module.taintObjects(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
+            module.taintObject(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
           } catch (final Throwable e) {
             module.onUnexpectedException("headers threw", e);
           }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
@@ -56,7 +56,7 @@ public class HttpServerRequestInstrumentation extends AbstractHttpServerRequestI
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           try {
-            module.taint(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
+            module.taintObjects(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
           } catch (final Throwable e) {
             module.onUnexpectedException("headers threw", e);
           }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
@@ -56,7 +56,7 @@ public class HttpServerRequestInstrumentation extends AbstractHttpServerRequestI
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           try {
-            module.taintObjects(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
+            module.taintObject(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
           } catch (final Throwable e) {
             module.onUnexpectedException("headers threw", e);
           }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
@@ -65,14 +65,12 @@ public class IastRoutingContextImplInstrumentation extends Instrumenter.Iast
   }
 
   public static class GetCookieAdvice {
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
     public static void onGetCookie(@Advice.Return final Object cookie) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
-      try {
-        module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
-      } catch (final Throwable e) {
-        module.onUnexpectedException("getCookie threw", e);
+      if (module != null) {
+        module.taintObject(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
@@ -57,7 +57,7 @@ public class IastRoutingContextImplInstrumentation extends Instrumenter.Iast
     public static void onCookies(@Advice.Return final Set<Object> cookies) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       try {
-        module.taint(SourceTypes.REQUEST_COOKIE_VALUE, cookies);
+        module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookies);
       } catch (final Throwable e) {
         module.onUnexpectedException("cookies threw", e);
       }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
@@ -70,7 +70,7 @@ public class IastRoutingContextImplInstrumentation extends Instrumenter.Iast
     public static void onGetCookie(@Advice.Return final Object cookie) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       try {
-        module.taint(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
+        module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
       } catch (final Throwable e) {
         module.onUnexpectedException("getCookie threw", e);
       }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
@@ -27,7 +27,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(SourceTypes.REQUEST_COOKIE_VALUE, _)
+    1 * module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, _)
   }
 
   void 'test that getCookie is instrumented'() {
@@ -41,7 +41,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(SourceTypes.REQUEST_COOKIE_VALUE, _)
+    1 * module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, _)
   }
 
   void 'test that cookie getName is instrumented'() {
@@ -84,7 +84,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(SourceTypes.REQUEST_HEADER_VALUE, _)
+    1 * module.taintObjects(SourceTypes.REQUEST_HEADER_VALUE, _)
   }
 
   void 'test that params() is instrumented'() {
@@ -98,7 +98,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, _)
+    1 * module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, _)
   }
 
   void 'test that formAttributes() is instrumented'() {
@@ -113,8 +113,8 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, _ as MultiMap) // once for formAttributes()
-    1 * module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, _ as MultiMap) // once for params()
+    1 * module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, _ as MultiMap) // once for formAttributes()
+    1 * module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, _ as MultiMap) // once for params()
     1 * module.taintIfInputIsTainted(SourceTypes.REQUEST_PARAMETER_VALUE, 'formAttribute', 'form', _ as MultiMap)
   }
 
@@ -130,7 +130,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(SourceTypes.REQUEST_BODY, _ as Buffer)
+    1 * module.taintObjects(SourceTypes.REQUEST_BODY, _ as Buffer)
     1 * module.taintIfInputIsTainted('{ "my_key": "my_value" }', _ as Buffer)
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
@@ -113,8 +113,8 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, _ as MultiMap) // once for formAttributes()
-    1 * module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, _ as MultiMap) // once for params()
+    1 * module.taintObject(SourceTypes.REQUEST_PARAMETER_VALUE, _ as MultiMap) // once for formAttributes()
+    1 * module.taintObject(SourceTypes.REQUEST_PARAMETER_VALUE, _ as MultiMap) // once for params()
     1 * module.taintIfInputIsTainted(SourceTypes.REQUEST_PARAMETER_VALUE, 'formAttribute', 'form', _ as MultiMap)
   }
 
@@ -130,7 +130,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintObjects(SourceTypes.REQUEST_BODY, _ as Buffer)
+    1 * module.taintObject(SourceTypes.REQUEST_BODY, _ as Buffer)
     1 * module.taintIfInputIsTainted('{ "my_key": "my_value" }', _ as Buffer)
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
@@ -41,7 +41,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, _)
+    1 * module.taintObject(SourceTypes.REQUEST_COOKIE_VALUE, _)
   }
 
   void 'test that cookie getName is instrumented'() {
@@ -84,7 +84,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintObjects(SourceTypes.REQUEST_HEADER_VALUE, _)
+    1 * module.taintObject(SourceTypes.REQUEST_HEADER_VALUE, _)
   }
 
   void 'test that params() is instrumented'() {
@@ -98,7 +98,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, _)
+    1 * module.taintObject(SourceTypes.REQUEST_PARAMETER_VALUE, _)
   }
 
   void 'test that formAttributes() is instrumented'() {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
@@ -138,7 +138,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     public static void onExit(@Advice.Return final Set<Object> cookies) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(SourceTypes.REQUEST_COOKIE_VALUE, cookies);
+        module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookies);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
@@ -77,7 +77,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       if (beforeParams != multiMap) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
+          module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
         }
       }
     }
@@ -101,7 +101,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       if (beforeAttributes != multiMap) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taint(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
+          module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
         }
       }
     }
@@ -114,7 +114,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     public static void onExit(@Advice.Return final Object multiMap) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
+        module.taintObjects(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
       }
     }
   }
@@ -126,7 +126,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     public static void onExit(@Advice.Argument(0) final Object data) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(SourceTypes.REQUEST_BODY, data);
+        module.taintObjects(SourceTypes.REQUEST_BODY, data);
       }
     }
   }
@@ -150,7 +150,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     public static void onExit(@Advice.Return final Object cookie) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
+        module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
@@ -77,7 +77,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       if (beforeParams != multiMap) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
+          module.taintObject(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
         }
       }
     }
@@ -101,7 +101,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       if (beforeAttributes != multiMap) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taintObjects(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
+          module.taintObject(SourceTypes.REQUEST_PARAMETER_VALUE, multiMap);
         }
       }
     }
@@ -114,7 +114,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     public static void onExit(@Advice.Return final Object multiMap) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintObjects(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
+        module.taintObject(SourceTypes.REQUEST_HEADER_VALUE, multiMap);
       }
     }
   }
@@ -126,7 +126,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     public static void onExit(@Advice.Argument(0) final Object data) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintObjects(SourceTypes.REQUEST_BODY, data);
+        module.taintObject(SourceTypes.REQUEST_BODY, data);
       }
     }
   }
@@ -150,7 +150,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     public static void onExit(@Advice.Return final Object cookie) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintObjects(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
+        module.taintObject(SourceTypes.REQUEST_COOKIE_VALUE, cookie);
       }
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -46,7 +46,7 @@ public interface PropagationModule extends IastModule {
    */
   void taintObjects(byte origin, @Nullable Object[] toTaint);
 
-  void taint(byte origin, @Nullable Collection<Object> toTaint);
+  void taintObjects(byte origin, @Nullable Collection<Object> toTaint);
 
   void taint(byte origin, @Nullable String name, @Nullable String value, @Nullable Taintable t);
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -34,7 +34,11 @@ public interface PropagationModule extends IastModule {
 
   void taint(@Nullable Object ctx_, byte source, @Nullable String name, @Nullable String value);
 
-  void taint(byte origin, @Nullable Object... toTaint);
+  /**
+   * Taint one or more non-String objects. They might be {@link Taintable} or not. These are tainted
+   * with source with no name or value.
+   */
+  void taintObjects(byte origin, @Nullable Object... toTaint);
 
   void taint(byte origin, @Nullable Collection<Object> toTaint);
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -35,10 +35,16 @@ public interface PropagationModule extends IastModule {
   void taint(@Nullable Object ctx_, byte source, @Nullable String name, @Nullable String value);
 
   /**
+   * Taint a non-String object. It might be {@link Taintable} or not. It is tainted with a source
+   * with no name or value.
+   */
+  void taintObject(byte origin, @Nullable Object toTaint);
+
+  /**
    * Taint one or more non-String objects. They might be {@link Taintable} or not. These are tainted
    * with source with no name or value.
    */
-  void taintObjects(byte origin, @Nullable Object... toTaint);
+  void taintObjects(byte origin, @Nullable Object[] toTaint);
 
   void taint(byte origin, @Nullable Collection<Object> toTaint);
 


### PR DESCRIPTION
# What Does This Do

Use `taintObject` (single `Object`) and `taintObjects` (array or collection of `Object`) to taint non-Strings.

# Motivation

* Too many overloads for `taint`, sometimes leading to calls to the incorrect versions.
* It is easy to call a taint method that is meant for non-Strings (and does not handle range sizes for strings appropriately).
* Avoid some unnecessary work at runtime when these are called with single objects (most calls).

# Additional Notes
