### PR TITLE
disable queue time instrumentations unless feature enabled

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskUnwrappingInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskUnwrappingInstrumentation.java
@@ -3,12 +3,22 @@ package datadog.trace.instrumentation.java.concurrent;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.bytebuddy.profiling.UnwrappingVisitor;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 
 @AutoService(Instrumenter.class)
 public class TaskUnwrappingInstrumentation extends Instrumenter.Profiling
     implements Instrumenter.ForKnownTypes {
   public TaskUnwrappingInstrumentation() {
     super("java_concurrent", "task-unwrapping");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return ConfigProvider.getInstance()
+        .getBoolean(
+            ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED,
+            ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
   }
 
   private static final String[] TYPES_WITH_FIELDS = {

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -501,3 +501,10 @@ class ExecutorInstrumentationLegacyForkedTest extends ExecutorInstrumentationTes
     System.setProperty("dd.trace.thread-pool-executors.legacy.tracing.enabled", "true")
   }
 }
+
+class ExecutorInstrumentationQueueTimeForkedTest extends ExecutorInstrumentationTest {
+  def setupSpec() {
+    System.setProperty("dd.profiling.enabled", "true")
+    System.setProperty("dd.profiling.experimental.queueing.time.enabled", "true")
+  }
+}

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/TaskUnwrappingForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/TaskUnwrappingForkedTest.groovy
@@ -10,6 +10,7 @@ class TaskUnwrappingForkedTest extends AgentTestRunner {
   @Override
   protected void configurePreAgent() {
     injectSysConfig("dd.profiling.enabled", "true")
+    injectSysConfig("dd.profiling.experimental.queueing.time.enabled", "true")
     super.configurePreAgent()
   }
 

--- a/dd-java-agent/instrumentation/netty-concurrent-4/src/main/java/datadog/trace/instrumentation/netty40/concurrent/SingleThreadEventExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-concurrent-4/src/main/java/datadog/trace/instrumentation/netty40/concurrent/SingleThreadEventExecutorInstrumentation.java
@@ -8,8 +8,10 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.QueueTimerHelper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import io.netty.util.concurrent.EventExecutor;
@@ -24,6 +26,14 @@ public class SingleThreadEventExecutorInstrumentation extends Instrumenter.Profi
     implements Instrumenter.ForKnownTypes {
   public SingleThreadEventExecutorInstrumentation() {
     super("netty-concurrent", "netty-event-executor");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    return ConfigProvider.getInstance()
+        .getBoolean(
+            ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED,
+            ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/netty-concurrent-4/src/test/groovy/TimingTest.groovy
+++ b/dd-java-agent/instrumentation/netty-concurrent-4/src/test/groovy/TimingTest.groovy
@@ -11,6 +11,7 @@ class TimingTest extends AgentTestRunner {
   @Override
   protected void configurePreAgent() {
     injectSysConfig("dd.profiling.enabled", "true")
+    injectSysConfig("dd.profiling.experimental.queueing.time.enabled", "true")
     super.configurePreAgent()
   }
 


### PR DESCRIPTION
# What Does This Do

This minimises the footprint from queue time instrumentation unless the feature is enabled

# Motivation

# Additional Notes
