### PR TITLE
opensearch: naming conventions for v1

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
@@ -18,11 +18,19 @@ public class DatabaseNamingV1 implements NamingSchema.ForDatabase {
   @Nonnull
   @Override
   public String operation(@Nonnull String databaseType) {
-    if ("elasticsearch.rest".equals(databaseType)) {
-      return "elasticsearch.query";
+    final String prefix;
+    switch (databaseType) {
+      case "elasticsearch.rest":
+        prefix = "elasticsearch";
+        break;
+      case "opensearch.rest":
+        prefix = "opensearch";
+        break;
+      default:
+        prefix = databaseType;
     }
     // already normalized when calling dbType on the decorator. It saves one operation
-    return databaseType + ".query";
+    return prefix + ".query";
   }
 
   @Nonnull


### PR DESCRIPTION
# What Does This Do

Updates (similarly to elasticsearch) naming conventions for op names in v1 for opensearch

# Motivation

# Additional Notes
