### PR TITLE
[Spark] Compute distribution of task metrics for each stage

### DIFF
--- a/dd-java-agent/instrumentation/spark/build.gradle
+++ b/dd-java-agent/instrumentation/spark/build.gradle
@@ -21,6 +21,8 @@ ext {
 dependencies {
   compileOnly group: 'org.apache.spark', name: 'spark-core_2.12', version: '2.4.0'
 
+  testImplementation group: 'com.datadoghq', name: 'sketches-java', version: '0.8.2'
+  testImplementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.14.0'
   testImplementation group: 'org.apache.spark', name: 'spark-core_2.12', version: '2.4.0'
   testImplementation group: 'org.apache.spark', name: 'spark-sql_2.12', version: '2.4.0' // Needed to instantiate spark in tests
   testImplementation group: 'org.apache.spark', name: 'spark-yarn_2.12', version: '2.4.0'

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -320,6 +320,7 @@ public class DatadogSparkListener extends SparkListener {
 
     SparkAggregatedTaskMetrics stageMetric = stageMetrics.remove(stageSpanKey);
     if (stageMetric != null) {
+      stageMetric.computeSkew();
       stageMetric.setSpanMetrics(span, "spark_stage_metrics");
       applicationMetrics.accumulateStageMetrics(stageMetric);
 

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkAggregatedTaskMetrics.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkAggregatedTaskMetrics.java
@@ -223,10 +223,7 @@ class SparkAggregatedTaskMetrics {
     span.setMetric(prefix + ".skew_time", skewTime);
 
     if (taskRunTimeHistogram.getCount() > 0) {
-      String base64hist = histogramToBase64(taskRunTimeHistogram);
-      span.setTag("_dd.spark.task_run_time", base64hist);
-      span.setMetric(prefix + ".histogram_serialized_length", base64hist.length());
-      span.setMetric(prefix + ".max_task_run_time", taskRunTimeHistogram.getMaxValue());
+      span.setTag("_dd.spark.task_run_time", histogramToBase64(taskRunTimeHistogram));
     }
     if (inputBytesHistogram.getCount() > 0) {
       span.setTag("_dd.spark.input_bytes", histogramToBase64(inputBytesHistogram));

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkAggregatedTaskMetrics.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkAggregatedTaskMetrics.java
@@ -282,8 +282,14 @@ class SparkAggregatedTaskMetrics {
 
   private static String histogramToBase64(AgentHistogram hist) {
     ByteBuffer bb = hist.serialize();
-    byte[] bytes = new byte[bb.remaining()];
-    bb.get(bytes);
+
+    byte[] bytes;
+    if (bb.hasArray()) {
+      bytes = bb.array();
+    } else {
+      bytes = new byte[bb.remaining()];
+      bb.get(bytes);
+    }
 
     return Base64.getEncoder().encodeToString(bytes);
   }

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkAggregatedTaskMetrics.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkAggregatedTaskMetrics.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.spark;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentHistogram;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -112,19 +113,21 @@ class SparkAggregatedTaskMetrics {
       long taskRunTime = computeTaskRunTime(taskMetrics);
       taskRunTimeSinceLastStage += taskRunTime;
 
-      taskRunTimeHistogram = lazyHistogramAccept(taskRunTimeHistogram, taskRunTime);
-      inputBytesHistogram =
-          lazyHistogramAccept(inputBytesHistogram, taskMetrics.inputMetrics().bytesRead());
-      outputBytesHistogram =
-          lazyHistogramAccept(outputBytesHistogram, taskMetrics.outputMetrics().bytesWritten());
-      shuffleReadBytesHistogram =
-          lazyHistogramAccept(
-              shuffleReadBytesHistogram, taskMetrics.shuffleReadMetrics().totalBytesRead());
-      shuffleWriteBytesHistogram =
-          lazyHistogramAccept(
-              shuffleWriteBytesHistogram, taskMetrics.shuffleWriteMetrics().bytesWritten());
-      diskBytesSpilledHistogram =
-          lazyHistogramAccept(diskBytesSpilledHistogram, taskMetrics.diskBytesSpilled());
+      if (Config.get().isSparkTaskHistogramEnabled()) {
+        taskRunTimeHistogram = lazyHistogramAccept(taskRunTimeHistogram, taskRunTime);
+        inputBytesHistogram =
+            lazyHistogramAccept(inputBytesHistogram, taskMetrics.inputMetrics().bytesRead());
+        outputBytesHistogram =
+            lazyHistogramAccept(outputBytesHistogram, taskMetrics.outputMetrics().bytesWritten());
+        shuffleReadBytesHistogram =
+            lazyHistogramAccept(
+                shuffleReadBytesHistogram, taskMetrics.shuffleReadMetrics().totalBytesRead());
+        shuffleWriteBytesHistogram =
+            lazyHistogramAccept(
+                shuffleWriteBytesHistogram, taskMetrics.shuffleWriteMetrics().bytesWritten());
+        diskBytesSpilledHistogram =
+            lazyHistogramAccept(diskBytesSpilledHistogram, taskMetrics.diskBytesSpilled());
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkListenerTest.groovy
@@ -304,6 +304,9 @@ class SparkListenerTest extends AgentTestRunner {
     listener.onJobStart(jobStartEvent(1, 1900L, [1, 2]))
 
     listener.onStageSubmitted(stageSubmittedEvent(1, 1900L))
+    for(int i = 1; i <= 100; i++) {
+      listener.onTaskEnd(taskEndEvent(1,1900L, 0))
+    }
     for(int i = 1; i <= 300; i++) {
       listener.onTaskEnd(taskEndEvent(1,1900L, i))
     }
@@ -324,13 +327,13 @@ class SparkListenerTest extends AgentTestRunner {
       trace(4) {
         span {
           operationName "spark.application"
-          validateRelativeError(span.tags["spark_application_metrics.skew_time"] as double, 7650, relativeAccuracy)
+          validateRelativeError(span.tags["spark_application_metrics.skew_time"] as double, 7700, relativeAccuracy)
           spanType "spark"
         }
         span {
           operationName "spark.job"
           spanType "spark"
-          validateRelativeError(span.tags["spark_job_metrics.skew_time"] as double, 7650, relativeAccuracy)
+          validateRelativeError(span.tags["spark_job_metrics.skew_time"] as double, 7700, relativeAccuracy)
           childOf(span(0))
         }
         span {
@@ -344,8 +347,8 @@ class SparkListenerTest extends AgentTestRunner {
         span {
           operationName "spark.stage"
           assert span.tags["stage_id"] == 1
-          validateRelativeError(span.tags["spark_stage_metrics.skew_time"] as double, 150, relativeAccuracy)
-          validateSerializedHistogram(span.tags["_dd.spark.task_run_time"] as String, 150, 225, 300, relativeAccuracy)
+          validateRelativeError(span.tags["spark_stage_metrics.skew_time"] as double, 200, relativeAccuracy)
+          validateSerializedHistogram(span.tags["_dd.spark.task_run_time"] as String, 100, 200, 300, relativeAccuracy)
           spanType "spark"
           childOf(span(1))
         }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -184,5 +184,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED = true;
 
+  static final boolean DEFAULT_SPARK_TASK_HISTOGRAM_ENABLED = true;
+
   private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -113,5 +113,7 @@ public final class TraceInstrumentationConfig {
   public static final String ELASTICSEARCH_BODY_AND_PARAMS_ENABLED =
       "trace.elasticsearch.body-and-params.enabled";
 
+  public static final String SPARK_TASK_HISTOGRAM_ENABLED = "spark.task-histogram.enabled";
+
   private TraceInstrumentationConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/AggregateMetric.java
@@ -1,6 +1,6 @@
 package datadog.trace.common.metrics;
 
-import com.datadoghq.sketch.ddsketch.DDSketch;
+import datadog.trace.core.histogram.Histogram;
 import datadog.trace.core.histogram.Histograms;
 import java.util.concurrent.atomic.AtomicLongArray;
 
@@ -10,8 +10,8 @@ public final class AggregateMetric {
   static final long ERROR_TAG = 0x8000000000000000L;
   static final long TOP_LEVEL_TAG = 0x4000000000000000L;
 
-  private final DDSketch okLatencies;
-  private final DDSketch errorLatencies;
+  private final Histogram okLatencies;
+  private final Histogram errorLatencies;
   private int errorCount;
   private int hitCount;
   private int topLevelCount;
@@ -59,11 +59,11 @@ public final class AggregateMetric {
     return duration;
   }
 
-  public DDSketch getOkLatencies() {
+  public Histogram getOkLatencies() {
     return okLatencies;
   }
 
-  public DDSketch getErrorLatencies() {
+  public Histogram getErrorLatencies() {
     return errorLatencies;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -49,6 +49,7 @@ import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.api.time.TimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentDataStreamsMonitoring;
+import datadog.trace.bootstrap.instrumentation.api.AgentHistogram;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
@@ -73,6 +74,7 @@ import datadog.trace.core.datastreams.DataStreamsContextCarrierAdapter;
 import datadog.trace.core.datastreams.DataStreamsMonitoring;
 import datadog.trace.core.datastreams.DefaultDataStreamsMonitoring;
 import datadog.trace.core.datastreams.NoopDataStreamsMonitoring;
+import datadog.trace.core.histogram.Histograms;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.monitor.MonitoringImpl;
 import datadog.trace.core.monitor.TracerHealthMetrics;
@@ -216,6 +218,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   @Override
   public ConfigSnapshot captureTraceConfig() {
     return dynamicConfig.captureTraceConfig();
+  }
+
+  @Override
+  public AgentHistogram newHistogram(double relativeAccuracy, int maxNumBins) {
+    return Histograms.newHistogram(relativeAccuracy, maxNumBins);
   }
 
   PropagationTags.Factory getPropagationTagsFactory() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsGroup.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/StatsGroup.java
@@ -1,6 +1,6 @@
 package datadog.trace.core.datastreams;
 
-import com.datadoghq.sketch.ddsketch.DDSketch;
+import datadog.trace.core.histogram.Histogram;
 import datadog.trace.core.histogram.Histograms;
 import java.util.List;
 
@@ -10,8 +10,8 @@ public class StatsGroup {
   private final List<String> edgeTags;
   private final long hash;
   private final long parentHash;
-  private final DDSketch pathwayLatency;
-  private final DDSketch edgeLatency;
+  private final Histogram pathwayLatency;
+  private final Histogram edgeLatency;
 
   public StatsGroup(List<String> edgeTags, long hash, long parentHash) {
     this.edgeTags = edgeTags;
@@ -38,11 +38,11 @@ public class StatsGroup {
     return parentHash;
   }
 
-  public DDSketch getPathwayLatency() {
+  public Histogram getPathwayLatency() {
     return pathwayLatency;
   }
 
-  public DDSketch getEdgeLatency() {
+  public Histogram getEdgeLatency() {
     return edgeLatency;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/histogram/Histogram.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/histogram/Histogram.java
@@ -28,6 +28,11 @@ public class Histogram implements AgentHistogram {
   }
 
   @Override
+  public void accept(double value, double count) {
+    sketch.accept(value, count);
+  }
+
+  @Override
   public double getValueAtQuantile(double quantile) {
     return sketch.getValueAtQuantile(quantile);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/histogram/Histogram.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/histogram/Histogram.java
@@ -1,0 +1,54 @@
+package datadog.trace.core.histogram;
+
+import com.datadoghq.sketch.ddsketch.DDSketch;
+import datadog.trace.bootstrap.instrumentation.api.AgentHistogram;
+import java.nio.ByteBuffer;
+
+/** Wrapper around the DDSketch library so that it can be used in an instrumentation */
+public class Histogram implements AgentHistogram {
+  private final DDSketch sketch;
+
+  public Histogram(DDSketch sketch) {
+    this.sketch = sketch;
+  }
+
+  @Override
+  public double getCount() {
+    return sketch.getCount();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return sketch.isEmpty();
+  }
+
+  @Override
+  public void accept(double value) {
+    sketch.accept(value);
+  }
+
+  @Override
+  public double getValueAtQuantile(double quantile) {
+    return sketch.getValueAtQuantile(quantile);
+  }
+
+  @Override
+  public double getMinValue() {
+    return sketch.getMinValue();
+  }
+
+  @Override
+  public double getMaxValue() {
+    return sketch.getMaxValue();
+  }
+
+  @Override
+  public void clear() {
+    sketch.clear();
+  }
+
+  @Override
+  public ByteBuffer serialize() {
+    return sketch.serialize();
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/histogram/Histograms.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/histogram/Histograms.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.histogram;
 
 import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.DDSketches;
 import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
 import com.datadoghq.sketch.ddsketch.store.CollapsingLowestDenseStore;
 
@@ -9,7 +10,13 @@ public final class Histograms {
   private static final BitwiseLinearlyInterpolatedMapping INDEX_MAPPING =
       new BitwiseLinearlyInterpolatedMapping(1.0 / 128.0);
 
-  public static DDSketch newHistogram() {
-    return new DDSketch(INDEX_MAPPING, () -> new CollapsingLowestDenseStore(1024));
+  public static Histogram newHistogram() {
+    DDSketch sketch = new DDSketch(INDEX_MAPPING, () -> new CollapsingLowestDenseStore(1024));
+    return new Histogram(sketch);
+  }
+
+  public static Histogram newHistogram(double relativeAccuracy, int maxNumBins) {
+    DDSketch sketch = DDSketches.logarithmicCollapsingLowestDense(relativeAccuracy, maxNumBins);
+    return new Histogram(sketch);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/Timer.java
@@ -4,9 +4,9 @@ import static datadog.trace.core.monitor.Utils.mergeTags;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.datadoghq.sketch.ddsketch.DDSketch;
 import datadog.communication.monitor.Recording;
 import datadog.trace.api.StatsDClient;
+import datadog.trace.core.histogram.Histogram;
 import datadog.trace.core.histogram.Histograms;
 
 /**
@@ -23,7 +23,7 @@ public class Timer extends Recording {
 
   private final String name;
   private final StatsDClient statsd;
-  private final DDSketch histogram;
+  private final Histogram histogram;
   private final long flushAfterNanos;
 
   private final String[] p50Tags;

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -58,6 +58,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentDataStreamsMonitoring",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentTrace",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentHistogram",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI",
   "datadog.trace.bootstrap.instrumentation.api.NoopDataStreamsMonitoring",
   "datadog.trace.bootstrap.instrumentation.api.Backlog",

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -304,6 +304,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGA
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SPARK_TASK_HISTOGRAM_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SPRING_DATA_REPOSITORY_INTERFACE_RESOURCE_NAME;
 import static datadog.trace.api.config.TracerConfig.AGENT_HOST;
 import static datadog.trace.api.config.TracerConfig.AGENT_NAMED_PIPE;
@@ -763,6 +764,7 @@ public class Config {
   private final boolean longRunningTraceEnabled;
   private final long longRunningTraceFlushInterval;
   private final boolean elasticsearchBodyAndParamsEnabled;
+  private final boolean sparkTaskHistogramEnabled;
 
   private final float traceFlushIntervalSeconds;
 
@@ -1689,6 +1691,10 @@ public class Config {
     }
     longRunningTraceEnabled = longRunningEnabled;
     this.longRunningTraceFlushInterval = longRunningTraceFlushInterval;
+
+    this.sparkTaskHistogramEnabled =
+        configProvider.getBoolean(
+            SPARK_TASK_HISTOGRAM_ENABLED, ConfigDefaults.DEFAULT_SPARK_TASK_HISTOGRAM_ENABLED);
 
     this.traceFlushIntervalSeconds =
         configProvider.getFloat(
@@ -2763,6 +2769,10 @@ public class Config {
     return elasticsearchBodyAndParamsEnabled;
   }
 
+  public boolean isSparkTaskHistogramEnabled() {
+    return sparkTaskHistogramEnabled;
+  }
+
   /** @return A map of tags to be applied only to the local application root span. */
   public Map<String, Object> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
@@ -3773,6 +3783,8 @@ public class Config {
         + traceFlushIntervalSeconds
         + ", logsInjectionEnabled="
         + logsInjectionEnabled
+        + ", sparkTaskHistogramEnabled="
+        + sparkTaskHistogramEnabled
         + '}';
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentHistogram.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentHistogram.java
@@ -10,6 +10,8 @@ public interface AgentHistogram {
 
   void accept(double value);
 
+  void accept(double value, double count);
+
   double getValueAtQuantile(double quantile);
 
   double getMinValue();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentHistogram.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentHistogram.java
@@ -1,0 +1,22 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import java.nio.ByteBuffer;
+
+public interface AgentHistogram {
+
+  double getCount();
+
+  boolean isEmpty();
+
+  void accept(double value);
+
+  double getValueAtQuantile(double quantile);
+
+  double getMinValue();
+
+  double getMaxValue();
+
+  void clear();
+
+  ByteBuffer serialize();
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -22,6 +22,7 @@ import datadog.trace.api.profiling.Timer;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -301,6 +302,8 @@ public class AgentTracer {
     TraceConfig captureTraceConfig();
 
     ProfilingContextIntegration getProfilingContext();
+
+    AgentHistogram newHistogram(double relativeAccuracy, int maxNumBins);
   }
 
   public interface SpanBuilder {
@@ -564,6 +567,11 @@ public class AgentTracer {
     @Override
     public TraceConfig captureTraceConfig() {
       return null;
+    }
+
+    @Override
+    public AgentHistogram newHistogram(double relativeAccuracy, int maxNumBins) {
+      return NoopAgentHistogram.INSTANCE;
     }
   }
 
@@ -1112,6 +1120,46 @@ public class AgentTracer {
 
     @Override
     public String strEncode() {
+      return null;
+    }
+  }
+
+  public static class NoopAgentHistogram implements AgentHistogram {
+    public static final NoopAgentHistogram INSTANCE = new NoopAgentHistogram();
+
+    @Override
+    public double getCount() {
+      return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return true;
+    }
+
+    @Override
+    public void accept(double value) {}
+
+    @Override
+    public double getValueAtQuantile(double quantile) {
+      return 0;
+    }
+
+    @Override
+    public double getMinValue() {
+      return 0;
+    }
+
+    @Override
+    public double getMaxValue() {
+      return 0;
+    }
+
+    @Override
+    public void clear() {}
+
+    @Override
+    public ByteBuffer serialize() {
       return null;
     }
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1141,6 +1141,9 @@ public class AgentTracer {
     public void accept(double value) {}
 
     @Override
+    public void accept(double value, double count) {}
+
+    @Override
     public double getValueAtQuantile(double quantile) {
       return 0;
     }


### PR DESCRIPTION
# What Does This Do

- Expose a new tracer interface `AgentHistogram` backed by a DDSketch, that can be used inside an instrumentation
- Use a `LogarithmicMapping` since it is the mapping supported by the most languages, with a relative error of 3%
- Serialize the DDSketch and encode it in base64 to add it as an hidden span tag

Using a total of 6 histogram to capture the most important spark metrics. For most of the stages, only 3 histograms will contain non-zero values (stages generally only have either input/output or shuffle read/write)
- Duration
- Input bytes
- Output bytes
- Shuffle Read bytes
- Shuffle Write bytes
- Spill

Added the histogram behind the feature flag `-Ddd.spark.task-histogram.enabled` (or `DD_SPARK_TASK_HISTOGRAM_ENABLED`). It is enabled by default, but can be disabled if histograms are generating a big amount of data

# Motivation

Expose imbalance in the tasks duration (also referred as skew) for each spark stages