### PR TITLE
Fix incorrect current source root in `RepoIndexSourcePathResolver`

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -47,6 +47,7 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.ipc.SignalType",
   "datadog.trace.civisibility.ipc.SignalClient",
   "datadog.trace.civisibility.source.MethodLinesResolver.MethodLines",
+  "datadog.trace.civisibility.source.RepoIndexSourcePathResolver",
   "datadog.trace.civisibility.utils.ShellCommandExecutor",
   "datadog.trace.civisibility.utils.ShellCommandExecutor.OutputParser",
 ]

--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -47,7 +47,7 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.ipc.SignalType",
   "datadog.trace.civisibility.ipc.SignalClient",
   "datadog.trace.civisibility.source.MethodLinesResolver.MethodLines",
-  "datadog.trace.civisibility.source.RepoIndexSourcePathResolver",
+  "datadog.trace.civisibility.source.RepoIndexSourcePathResolver.RepoIndexingFileVisitor",
   "datadog.trace.civisibility.utils.ShellCommandExecutor",
   "datadog.trace.civisibility.utils.ShellCommandExecutor.OutputParser",
 ]


### PR DESCRIPTION
# Motivation
We noticed that _sometimes_ `@test.source.file` and therefore `@test.codeowners` fields are not set. It looks like it's related to the `currentSourceRoot` field is not being updated while visiting subdirectories.

https://github.com/DataDog/dd-trace-java/blob/de6aaed8c3392035b1e1265312be64974bf4b275/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java#L267-L268

In some cases, the repo index has only one source root.

```
Indexing took 1227 ms ... source roots found: 1
```

I suspect we set `currentSourceRoot` to the repo root folder and it never became `null` until we visit all directories and files. https://github.com/DataDog/dd-trace-java/blob/de6aaed8c3392035b1e1265312be64974bf4b275/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java#L298

Also added a log statement, and the [classNameWithExtension](https://github.com/DataDog/dd-trace-java/blob/de6aaed8c3392035b1e1265312be64974bf4b275/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/RepoIndexSourcePathResolver.java#L273) contains the subdirectories from the repo root (e.g., `domains.streaming-engine.apps...com.dd....`), whereas it should be `com.dd....`.

# What Does This Do

As mentioned in the [FileVisitor tutorial](https://docs.oracle.com/javase/tutorial/essential/io/walk.html), we cannot make assumptions on iteration order.

> A file tree is walked depth first, but you cannot make any assumptions about the iteration order that subdirectories are visited.

This PR sets `currentSourceRoot` unconditionally, and change `sourceRoots` to a `LinkedHashSet` so that we don't need to rely on directory visit order.
