### PR TITLE
Split DDTestModuleImpl into parent process and child process implementations

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -11,7 +11,9 @@ minimumInstructionCoverage = 0.8
 
 excludedClassesCoverage += [
   "datadog.trace.civisibility.CiVisibilitySystem",
+  "datadog.trace.civisibility.DDTestModuleChild",
   "datadog.trace.civisibility.DDTestModuleImpl",
+  "datadog.trace.civisibility.DDTestModuleParent",
   "datadog.trace.civisibility.DDTestSessionImpl",
   "datadog.trace.civisibility.DDTestSuiteImpl",
   "datadog.trace.civisibility.DDTestImpl",

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleChild.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleChild.java
@@ -1,0 +1,88 @@
+package datadog.trace.civisibility;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.source.SourcePathResolver;
+import datadog.trace.civisibility.codeowners.Codeowners;
+import datadog.trace.civisibility.context.ParentProcessTestContext;
+import datadog.trace.civisibility.decorator.TestDecorator;
+import datadog.trace.civisibility.ipc.ModuleExecutionResult;
+import datadog.trace.civisibility.ipc.SignalClient;
+import datadog.trace.civisibility.source.MethodLinesResolver;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Representation of a test module in a child process (JVM that is forked by build system to run the
+ * tests)
+ */
+public class DDTestModuleChild extends DDTestModuleImpl {
+
+  private static final Logger log = LoggerFactory.getLogger(DDTestModuleChild.class);
+
+  private final ParentProcessTestContext context;
+
+  public DDTestModuleChild(
+      Long parentProcessSessionId,
+      Long parentProcessModuleId,
+      String moduleName,
+      Config config,
+      TestDecorator testDecorator,
+      SourcePathResolver sourcePathResolver,
+      Codeowners codeowners,
+      MethodLinesResolver methodLinesResolver,
+      @Nullable InetSocketAddress signalServerAddress) {
+    super(
+        moduleName,
+        config,
+        testDecorator,
+        sourcePathResolver,
+        codeowners,
+        methodLinesResolver,
+        signalServerAddress);
+    context = new ParentProcessTestContext(parentProcessSessionId, parentProcessModuleId);
+  }
+
+  @Override
+  protected ParentProcessTestContext getContext() {
+    return context;
+  }
+
+  @Override
+  public void setTag(String key, Object value) {
+    throw new UnsupportedOperationException("Setting tags is not supported: " + key + ", " + value);
+  }
+
+  @Override
+  public void setErrorInfo(Throwable error) {
+    throw new UnsupportedOperationException("Setting error info is not supported: " + error);
+  }
+
+  @Override
+  public void setSkipReason(String skipReason) {
+    throw new UnsupportedOperationException("Setting skip reason is not supported: " + skipReason);
+  }
+
+  @Override
+  public void end(@Nullable Long endTime, boolean testsSkipped) {
+    // we have no span locally,
+    // send execution result to parent process that has the span
+    sendModuleExecutionResult(testsSkipped);
+  }
+
+  private void sendModuleExecutionResult(boolean testsSkipped) {
+    long moduleId = context.getId();
+    long sessionId = context.getParentId();
+    boolean coverageEnabled = config.isCiVisibilityCodeCoverageEnabled();
+    boolean itrEnabled = config.isCiVisibilityItrEnabled();
+    ModuleExecutionResult moduleExecutionResult =
+        new ModuleExecutionResult(sessionId, moduleId, coverageEnabled, itrEnabled, testsSkipped);
+
+    try (SignalClient signalClient = new SignalClient(signalServerAddress)) {
+      signalClient.send(moduleExecutionResult);
+    } catch (Exception e) {
+      log.error("Error while reporting module execution result", e);
+    }
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleImpl.java
@@ -1,215 +1,44 @@
 package datadog.trace.civisibility;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
-
 import datadog.trace.api.Config;
-import datadog.trace.api.civisibility.CIConstants;
 import datadog.trace.api.civisibility.DDTestModule;
 import datadog.trace.api.civisibility.events.BuildEventsHandler;
 import datadog.trace.api.civisibility.source.SourcePathResolver;
-import datadog.trace.api.config.CiVisibilityConfig;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
-import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.codeowners.Codeowners;
-import datadog.trace.civisibility.context.ParentProcessTestContext;
-import datadog.trace.civisibility.context.SpanTestContext;
 import datadog.trace.civisibility.context.TestContext;
 import datadog.trace.civisibility.decorator.TestDecorator;
-import datadog.trace.civisibility.ipc.ModuleExecutionResult;
-import datadog.trace.civisibility.ipc.SignalClient;
 import datadog.trace.civisibility.source.MethodLinesResolver;
-import datadog.trace.util.Strings;
 import java.net.InetSocketAddress;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class DDTestModuleImpl implements DDTestModule {
+public abstract class DDTestModuleImpl implements DDTestModule {
 
-  private static final Logger log = LoggerFactory.getLogger(DDTestModuleImpl.class);
+  protected final String moduleName;
+  protected final Config config;
+  protected final TestDecorator testDecorator;
+  protected final SourcePathResolver sourcePathResolver;
+  protected final Codeowners codeowners;
+  protected final MethodLinesResolver methodLinesResolver;
+  @Nullable protected final InetSocketAddress signalServerAddress;
 
-  private final String moduleName;
-  private final AgentSpan span;
-  private final TestContext context;
-  @Nullable private final TestContext sessionContext;
-  private final Config config;
-  private final TestDecorator testDecorator;
-  @Nullable private final TestModuleRegistry testModuleRegistry;
-  private final SourcePathResolver sourcePathResolver;
-  private final Codeowners codeowners;
-  private final MethodLinesResolver methodLinesResolver;
-  @Nullable private final InetSocketAddress signalServerAddress;
-
-  public DDTestModuleImpl(
-      @Nullable TestContext sessionContext,
+  protected DDTestModuleImpl(
       String moduleName,
-      @Nullable Long startTime,
       Config config,
-      @Nullable TestModuleRegistry testModuleRegistry,
       TestDecorator testDecorator,
       SourcePathResolver sourcePathResolver,
       Codeowners codeowners,
       MethodLinesResolver methodLinesResolver,
-      @Nullable InetSocketAddress signalServerAddress) {
-    this.sessionContext = sessionContext;
+      InetSocketAddress signalServerAddress) {
     this.moduleName = moduleName;
     this.config = config;
-    this.testModuleRegistry = testModuleRegistry;
     this.testDecorator = testDecorator;
     this.sourcePathResolver = sourcePathResolver;
     this.codeowners = codeowners;
     this.methodLinesResolver = methodLinesResolver;
-
-    if (signalServerAddress != null) {
-      this.signalServerAddress = signalServerAddress;
-    } else {
-      String host =
-          System.getProperty(
-              Strings.propertyNameToSystemPropertyName(
-                  CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_HOST));
-      String port =
-          System.getProperty(
-              Strings.propertyNameToSystemPropertyName(
-                  CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_PORT));
-      if (host != null && port != null) {
-        this.signalServerAddress = new InetSocketAddress(host, Integer.parseInt(port));
-      } else {
-        this.signalServerAddress = null;
-      }
-    }
-
-    // fallbacks to System.getProperty below are needed for cases when
-    // system variables are set after config was initialized
-
-    Long parentProcessSessionId = config.getCiVisibilitySessionId();
-    if (parentProcessSessionId == null) {
-      String systemProp =
-          System.getProperty(
-              Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_SESSION_ID));
-      if (systemProp != null) {
-        parentProcessSessionId = Long.parseLong(systemProp);
-      }
-    }
-
-    Long parentProcessModuleId = config.getCiVisibilityModuleId();
-    if (parentProcessModuleId == null) {
-      String systemProp =
-          System.getProperty(
-              Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_MODULE_ID));
-      if (systemProp != null) {
-        parentProcessModuleId = Long.parseLong(systemProp);
-      }
-    }
-
-    if (parentProcessSessionId != null && parentProcessModuleId != null) {
-      // we do not create a local span, because it was created in the parent process
-      context = new ParentProcessTestContext(parentProcessSessionId, parentProcessModuleId);
-      span = null;
-
-    } else {
-      AgentSpan sessionSpan = sessionContext != null ? sessionContext.getSpan() : null;
-      AgentSpan.Context sessionSpanContext = sessionSpan != null ? sessionSpan.context() : null;
-
-      if (startTime != null) {
-        span = startSpan(testDecorator.component() + ".test_module", sessionSpanContext, startTime);
-      } else {
-        span = startSpan(testDecorator.component() + ".test_module", sessionSpanContext);
-      }
-
-      Long sessionId = sessionContext != null ? sessionContext.getId() : null;
-      context = new SpanTestContext(span, sessionId);
-
-      span.setSpanType(InternalSpanTypes.TEST_MODULE_END);
-      span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_TEST_MODULE);
-
-      span.setResourceName(moduleName);
-      span.setTag(Tags.TEST_MODULE, moduleName);
-
-      span.setTag(Tags.TEST_MODULE_ID, context.getId());
-      span.setTag(Tags.TEST_SESSION_ID, sessionId);
-
-      if (sessionContext != null) {
-        span.setTag(Tags.TEST_STATUS, CIConstants.TEST_PASS);
-      }
-
-      testDecorator.afterStart(span);
-    }
+    this.signalServerAddress = signalServerAddress;
   }
 
-  @Override
-  public void setTag(String key, Object value) {
-    if (span == null) {
-      log.debug(
-          "Ignoring tag {} with value {}: there is no local span for test module", key, value);
-      return;
-    }
-    span.setTag(key, value);
-  }
-
-  @Override
-  public void setErrorInfo(Throwable error) {
-    if (span == null) {
-      log.debug("Ignoring error, there is no local span for test module", error);
-      return;
-    }
-    span.setError(true);
-    span.addThrowable(error);
-    span.setTag(Tags.TEST_STATUS, CIConstants.TEST_FAIL);
-  }
-
-  @Override
-  public void setSkipReason(String skipReason) {
-    if (span == null) {
-      log.debug("Ignoring skip reason {}: there is no local span for test module", skipReason);
-      return;
-    }
-    span.setTag(Tags.TEST_STATUS, CIConstants.TEST_SKIP);
-    if (skipReason != null) {
-      span.setTag(Tags.TEST_SKIP_REASON, skipReason);
-    }
-  }
-
-  @Override
-  public void end(@Nullable Long endTime, boolean testsSkipped) {
-    if (testModuleRegistry != null) {
-      testModuleRegistry.removeModule(this);
-    }
-
-    if (span == null) {
-      // we have no span locally,
-      // send execution result to parent process that has the span
-      sendModuleExecutionResult(testsSkipped);
-      return;
-    }
-
-    if (sessionContext != null) {
-      sessionContext.reportChildStatus(context.getStatus());
-    }
-    span.setTag(Tags.TEST_STATUS, context.getStatus());
-    testDecorator.beforeFinish(span);
-
-    if (endTime != null) {
-      span.finish(endTime);
-    } else {
-      span.finish();
-    }
-  }
-
-  private void sendModuleExecutionResult(boolean testsSkipped) {
-    long moduleId = context.getId();
-    long sessionId = sessionContext != null ? sessionContext.getId() : context.getParentId();
-    boolean coverageEnabled = config.isCiVisibilityCodeCoverageEnabled();
-    boolean itrEnabled = config.isCiVisibilityItrEnabled();
-    ModuleExecutionResult moduleExecutionResult =
-        new ModuleExecutionResult(sessionId, moduleId, coverageEnabled, itrEnabled, testsSkipped);
-
-    try (SignalClient signalClient = new SignalClient(signalServerAddress)) {
-      signalClient.send(moduleExecutionResult);
-    } catch (Exception e) {
-      log.error("Error while reporting module execution result", e);
-    }
-  }
+  protected abstract TestContext getContext();
 
   @Override
   public DDTestSuiteImpl testSuiteStart(
@@ -218,7 +47,7 @@ public class DDTestModuleImpl implements DDTestModule {
       @Nullable Long startTime,
       boolean parallelized) {
     return new DDTestSuiteImpl(
-        context,
+        getContext(),
         moduleName,
         testSuiteName,
         testClass,
@@ -232,8 +61,9 @@ public class DDTestModuleImpl implements DDTestModule {
   }
 
   public BuildEventsHandler.ModuleInfo getModuleInfo() {
+    TestContext context = getContext();
     Long moduleId = context.getId();
-    Long sessionId = sessionContext != null ? sessionContext.getId() : context.getParentId();
+    Long sessionId = context.getParentId();
     String signalServerHost =
         signalServerAddress != null ? signalServerAddress.getHostName() : null;
     int signalServerPort = signalServerAddress != null ? signalServerAddress.getPort() : 0;
@@ -241,7 +71,7 @@ public class DDTestModuleImpl implements DDTestModule {
         moduleId, sessionId, signalServerHost, signalServerPort);
   }
 
-  long getId() {
-    return context.getId();
+  public long getId() {
+    return getContext().getId();
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleParent.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleParent.java
@@ -1,0 +1,120 @@
+package datadog.trace.civisibility;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.CIConstants;
+import datadog.trace.api.civisibility.source.SourcePathResolver;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.civisibility.codeowners.Codeowners;
+import datadog.trace.civisibility.context.SpanTestContext;
+import datadog.trace.civisibility.context.TestContext;
+import datadog.trace.civisibility.decorator.TestDecorator;
+import datadog.trace.civisibility.source.MethodLinesResolver;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+
+/** Representation of a test module in a parent process (JVM that runs the build system) */
+public class DDTestModuleParent extends DDTestModuleImpl {
+
+  private final AgentSpan span;
+  private final SpanTestContext context;
+  @Nullable private final TestContext sessionContext;
+  @Nullable private final TestModuleRegistry testModuleRegistry;
+
+  public DDTestModuleParent(
+      @Nullable TestContext sessionContext,
+      String moduleName,
+      @Nullable Long startTime,
+      Config config,
+      @Nullable TestModuleRegistry testModuleRegistry,
+      TestDecorator testDecorator,
+      SourcePathResolver sourcePathResolver,
+      Codeowners codeowners,
+      MethodLinesResolver methodLinesResolver,
+      @Nullable InetSocketAddress signalServerAddress) {
+    super(
+        moduleName,
+        config,
+        testDecorator,
+        sourcePathResolver,
+        codeowners,
+        methodLinesResolver,
+        signalServerAddress);
+    this.sessionContext = sessionContext;
+    this.testModuleRegistry = testModuleRegistry;
+
+    AgentSpan sessionSpan = sessionContext != null ? sessionContext.getSpan() : null;
+    AgentSpan.Context sessionSpanContext = sessionSpan != null ? sessionSpan.context() : null;
+
+    if (startTime != null) {
+      span = startSpan(testDecorator.component() + ".test_module", sessionSpanContext, startTime);
+    } else {
+      span = startSpan(testDecorator.component() + ".test_module", sessionSpanContext);
+    }
+
+    Long sessionId = sessionContext != null ? sessionContext.getId() : null;
+    context = new SpanTestContext(span, sessionId);
+
+    span.setSpanType(InternalSpanTypes.TEST_MODULE_END);
+    span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_TEST_MODULE);
+
+    span.setResourceName(moduleName);
+    span.setTag(Tags.TEST_MODULE, moduleName);
+
+    span.setTag(Tags.TEST_MODULE_ID, context.getId());
+    span.setTag(Tags.TEST_SESSION_ID, sessionId);
+
+    if (sessionContext != null) {
+      span.setTag(Tags.TEST_STATUS, CIConstants.TEST_PASS);
+    }
+
+    testDecorator.afterStart(span);
+  }
+
+  @Override
+  protected SpanTestContext getContext() {
+    return context;
+  }
+
+  @Override
+  public void setTag(String key, Object value) {
+    span.setTag(key, value);
+  }
+
+  @Override
+  public void setErrorInfo(Throwable error) {
+    span.setError(true);
+    span.addThrowable(error);
+    span.setTag(Tags.TEST_STATUS, CIConstants.TEST_FAIL);
+  }
+
+  @Override
+  public void setSkipReason(String skipReason) {
+    span.setTag(Tags.TEST_STATUS, CIConstants.TEST_SKIP);
+    if (skipReason != null) {
+      span.setTag(Tags.TEST_SKIP_REASON, skipReason);
+    }
+  }
+
+  @Override
+  public void end(@Nullable Long endTime, boolean testsSkipped) {
+    if (testModuleRegistry != null) {
+      testModuleRegistry.removeModule(this);
+    }
+
+    if (sessionContext != null) {
+      sessionContext.reportChildStatus(context.getStatus());
+    }
+    span.setTag(Tags.TEST_STATUS, context.getStatus());
+    testDecorator.beforeFinish(span);
+
+    if (endTime != null) {
+      span.finish(endTime);
+    } else {
+      span.finish();
+    }
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
@@ -151,8 +151,8 @@ public class DDTestSessionImpl implements DDTestSession {
 
   @Override
   public DDTestModule testModuleStart(String moduleName, @Nullable Long startTime) {
-    DDTestModuleImpl module =
-        new DDTestModuleImpl(
+    DDTestModuleParent module =
+        new DDTestModuleParent(
             context,
             moduleName,
             startTime,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/ParentProcessTestContext.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/ParentProcessTestContext.java
@@ -1,6 +1,7 @@
 package datadog.trace.civisibility.context;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ParentProcessTestContext extends AbstractTestContext implements TestContext {
@@ -18,6 +19,7 @@ public class ParentProcessTestContext extends AbstractTestContext implements Tes
     return moduleId;
   }
 
+  @Nonnull
   @Override
   public Long getParentId() {
     return sessionId;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -6,15 +6,20 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DisableTestTrace;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
 import datadog.trace.api.civisibility.source.SourcePathResolver;
+import datadog.trace.api.config.CiVisibilityConfig;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.DDTestImpl;
+import datadog.trace.civisibility.DDTestModuleChild;
 import datadog.trace.civisibility.DDTestModuleImpl;
+import datadog.trace.civisibility.DDTestModuleParent;
 import datadog.trace.civisibility.DDTestSuiteImpl;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.context.EmptyTestContext;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.source.MethodLinesResolver;
+import datadog.trace.util.Strings;
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -62,37 +67,80 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
 
     // some framework/build system combinations fire "onTestModuleStart" event, some cannot do it,
     // hence creating a module here
-    testModule =
-        new DDTestModuleImpl(
-            null,
-            moduleName,
-            null,
-            config,
-            null,
-            testDecorator,
-            sourcePathResolver,
-            codeowners,
-            methodLinesResolver,
-            null);
+    testModule = createTestModule();
   }
 
   @Override
   public void onTestModuleStart() {
     // needed to support JVMs that run tests for multiple modules, e.g. Maven in non-forking mode
     if (testModule == null) {
-      testModule =
-          new DDTestModuleImpl(
-              null,
-              moduleName,
-              null,
-              config,
-              null,
-              testDecorator,
-              sourcePathResolver,
-              codeowners,
-              methodLinesResolver,
-              null);
+      testModule = createTestModule();
     }
+  }
+
+  private DDTestModuleImpl createTestModule() {
+    // fallbacks to System.getProperty below are needed for cases when
+    // system variables are set after config was initialized
+
+    Long parentProcessSessionId = config.getCiVisibilitySessionId();
+    if (parentProcessSessionId == null) {
+      String systemProp =
+          System.getProperty(
+              Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_SESSION_ID));
+      if (systemProp != null) {
+        parentProcessSessionId = Long.parseLong(systemProp);
+      }
+    }
+
+    Long parentProcessModuleId = config.getCiVisibilityModuleId();
+    if (parentProcessModuleId == null) {
+      String systemProp =
+          System.getProperty(
+              Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_MODULE_ID));
+      if (systemProp != null) {
+        parentProcessModuleId = Long.parseLong(systemProp);
+      }
+    }
+
+    if (parentProcessSessionId == null || parentProcessModuleId == null) {
+      // it is likely that parent process (build system) is not instrumented
+      // since session and module IDs are not provided to us
+      return new DDTestModuleParent(
+          null,
+          moduleName,
+          null,
+          config,
+          null,
+          testDecorator,
+          sourcePathResolver,
+          codeowners,
+          methodLinesResolver,
+          null);
+    }
+
+    InetSocketAddress signalServerAddress = null;
+    String host =
+        System.getProperty(
+            Strings.propertyNameToSystemPropertyName(
+                CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_HOST));
+    String port =
+        System.getProperty(
+            Strings.propertyNameToSystemPropertyName(
+                CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_PORT));
+    if (host != null && port != null) {
+      signalServerAddress = new InetSocketAddress(host, Integer.parseInt(port));
+    }
+
+    return new DDTestModuleChild(
+        parentProcessSessionId,
+        parentProcessModuleId,
+        moduleName,
+        config,
+        testDecorator,
+        sourcePathResolver,
+        codeowners,
+        methodLinesResolver,
+        signalServerAddress);
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Splits `DDTestModuleImpl` class into two different classes: one that is used in the parent process (build system) and the other that is used in the child process (JVM forked to run tests).

# Motivation
Test module tracking logic differs based on which process the tracer is attached to: when build system is instrumented, module span is created in the build system process, and module abstraction in the child process is used only for accumulating execution results and reporting them to the parent process.
Before this change `DDTestModuleImpl` class hosted both the parent and the child logic.
Splitting the class in two results in code that is easier to understand and maintain.