### PR TITLE
Update test agent configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,6 +628,7 @@ jobs:
           - DD_SUPPRESS_TRACE_PARSE_ERRORS=true
           - DD_POOL_TRACE_CHECK_FAILURES=true
           - DD_DISABLE_ERROR_RESPONSES=true
+          - ENABLED_CHECKS=trace_count_header,meta_tracer_version_header,trace_content_length
     resource_class: xlarge
 
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/TracerConnectionReliabilityTest.groovy
@@ -114,6 +114,7 @@ class TracerConnectionReliabilityTest extends DDSpecification {
     //noinspection GrDeprecatedAPIUsage Use FixedHostPortGenericContainer against deprecation because we need to know the exposed to configure the tracer at start
     def agentContainer = new FixedHostPortGenericContainer("ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest")
       .withFixedExposedPort(agentContainerPort, DEFAULT_TRACE_AGENT_PORT)
+      .withEnv("ENABLED_CHECKS", "trace_count_header,meta_tracer_version_header,trace_content_length")
       .waitingFor(Wait.forHttp("/test/traces"))
     agentContainer.start()
     return agentContainer


### PR DESCRIPTION
### What does this PR do?

Update test agent configuration to opt into checks

### Motivation

As of the latest image, test agent checks have been change to opt-in. See https://github.com/DataDog/dd-apm-test-agent/blob/3833182b3d864d93c41550ab645c47af8fd855eb/releasenotes/notes/Checks-changed-to-opt-in-8716cac4ecdbb1c2.yaml