### PR TITLE
Fix exploration tests

### DIFF
--- a/.gitlab/exploration-tests.yml
+++ b/.gitlab/exploration-tests.yml
@@ -14,13 +14,18 @@ build-exploration-tests-image:
 .common-exploration-tests: &common-exploration-tests
   before_script:
     - source $HOME/.sdkman/bin/sdkman-init.sh
+    - export JAVA_HOME=$JAVA_8_HOME
+    - ./gradlew :dd-java-agent:shadowJar --no-scan
+    - cp workspace/dd-java-agent/build/libs/*.jar /exploration-tests/dd-java-agent.jar
     - cp dd-java-agent/agent-debugger/exploration-tests/run-exploration-tests.sh /exploration-tests
-    - cp dd-java-agent/agent-debugger/exploration-tests/exclude.txt /exploration-tests
+    - cp dd-java-agent/agent-debugger/exploration-tests/exclude*.txt /exploration-tests
     - cd /exploration-tests
   after_script:
     - cd $CI_PROJECT_DIR
     - cp /exploration-tests/$PROJECT/agent.log agent.log
     - gzip agent.log
+    - tar czf surefire-reports.tar.gz /exploration-tests/$PROJECT/target/surefire-reports
+    - tar czf debugger-dumps.tar.gz /tmp/debugger
   stage: exploration-tests
   when: manual
   tags: [ "runner:main"]
@@ -29,6 +34,8 @@ build-exploration-tests-image:
   artifacts:
     paths:
       - agent.log.gz
+      - surefire-reports.tar.gz
+      - debugger-dumps.tar.gz
 
 
 exploration-tests-jackson-core:
@@ -36,11 +43,11 @@ exploration-tests-jackson-core:
   variables:
     PROJECT: jackson-core
   script:
-    - ./run-exploration-tests.sh "$PROJECT" "./mvnw verify" || exit_code=$?
+    - ./run-exploration-tests.sh "$PROJECT" "./mvnw verify"
 
 exploration-tests-jackson-databind:
   <<: *common-exploration-tests
   variables:
     PROJECT: jackson-databind
   script:
-    - ./run-exploration-tests.sh "$PROJECT" "./mvnw verify" || exit_code=$?
+    - ./run-exploration-tests.sh "$PROJECT" "./mvnw verify" "exclude_$PROJECT.txt"

--- a/dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests
+++ b/dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests
@@ -1,6 +1,8 @@
 FROM debian:bookworm-slim
 
-ARG JAVA_VERSION="8.0.332-tem"
+ARG JAVA_8_VERSION="8.0.372-tem"
+ARG JAVA_11_VERSION="11.0.19-tem"
+ARG JAVA_17_VERSION="17.0.7-tem"
 ARG MAVEN_VERSION=3.8.4
 
 RUN apt-get update && \
@@ -11,10 +13,15 @@ RUN apt-get update && \
 # install sdkman
 RUN curl -s "https://get.sdkman.io" | bash
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
-    yes | sdk install java $JAVA_VERSION && \
+    yes | sdk install java $JAVA_8_VERSION && \
+    yes | sdk install java $JAVA_11_VERSION && \
+    yes | sdk install java $JAVA_17_VERSION && \
     yes | sdk install maven $MAVEN_VERSION && \
     rm -rf $HOME/.sdkman/archives/* && \
     rm -rf $HOME/.sdkman/tmp/*"
+ENV JAVA_8_HOME=/root/.sdkman/candidates/java/$JAVA_8_VERSION
+ENV JAVA_11_HOME=/root/.sdkman/candidates/java/$JAVA_11_VERSION
+ENV JAVA_17_HOME=/root/.sdkman/candidates/java/$JAVA_17_VERSION
 
 RUN mkdir exploration-tests
 WORKDIR /exploration-tests

--- a/dd-java-agent/agent-debugger/exploration-tests/exclude.txt
+++ b/dd-java-agent/agent-debugger/exploration-tests/exclude.txt
@@ -5,3 +5,11 @@ datadog/slf4j/*
 datadog/trace/logging/*
 datadog/trace/api/sampling/*
 datadog/trace/util/*
+com/sun/tools/javac/*
+# excluded class for local var scope bug from javac < 1.6
+org/apache/maven/scm/manager/AbstractScmManager
+org/apache/maven/doxia/siterenderer/DefaultSiteRenderer
+org/apache/commons/lang/StringUtils
+org/junit/runners/BlockJUnit4ClassRunner
+junit/framework/TestSuite
+org/jacoco/report/internal/html/page/SourceHighlighter

--- a/dd-java-agent/agent-debugger/exploration-tests/exclude_jackson-databind.txt
+++ b/dd-java-agent/agent-debugger/exploration-tests/exclude_jackson-databind.txt
@@ -1,0 +1,4 @@
+com/fasterxml/jackson/databind/deser/lazy/LazyIgnoralForNumbers3730Test
+com/fasterxml/jackson/databind/BaseMapTest
+com/fasterxml/jackson/databind/BaseTest
+com/fasterxml/jackson/databind/type/TypeFactory

--- a/dd-java-agent/agent-debugger/exploration-tests/run-exploration-tests.sh
+++ b/dd-java-agent/agent-debugger/exploration-tests/run-exploration-tests.sh
@@ -2,15 +2,26 @@
 set -uo pipefail
 NAME=$1
 COMMAND=$2
+PROJECT_EXCLUDE_FILE=${3:-}
 echo " === running debugger java exploration tests === "
-echo "Downloading java agent..."
-curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
-export JAVA_TOOL_OPTIONS="-javaagent:`pwd`/dd-java-agent.jar -Ddatadog.slf4j.simpleLogger.log.com.datadog.debugger=debug -Ddd.trace.enabled=false -Ddd.dynamic.instrumentation.enabled=true -Ddd.dynamic.instrumentation.instrument.the.world=true -Ddd.dynamic.instrumentation.classfile.dump.enabled=false -Ddd.dynamic.instrumentation.verify.bytecode=true -Ddd.dynamic.instrumentation.exclude.file=/exploration-tests/exclude.txt"
+export JAVA_TOOL_OPTIONS="-javaagent:`pwd`/dd-java-agent.jar -Ddatadog.slf4j.simpleLogger.log.com.datadog.debugger=debug -Ddd.trace.enabled=false -Ddd.dynamic.instrumentation.enabled=true -Ddd.dynamic.instrumentation.instrument.the.world=true -Ddd.dynamic.instrumentation.classfile.dump.enabled=true -Ddd.dynamic.instrumentation.verify.bytecode=true -Ddd.dynamic.instrumentation.exclude.files=/exploration-tests/exclude.txt,/exploration-tests/$PROJECT_EXCLUDE_FILE"
 echo "$JAVA_TOOL_OPTIONS"
 cd $NAME
 echo "Building repository $NAME..."
 eval "$COMMAND 2>agent.log"
 exit_code=$?
 echo "exit_code=$exit_code"
-if [ -n "$exit_code" ] && [ $exit_code -ne 0 ]; then cat $NAME/target/surefire-reports/*.dumpstream; fi
-
+if [ -n "$exit_code" ] && [ $exit_code -ne 0 ];
+then
+  cat $NAME/target/surefire-reports/*.dumpstream;
+fi
+if [ ! -f "/tmp/debugger/instrumentation.log" ]; then
+  echo "no instrumentation error"
+  exit $exit_code;
+fi
+instrumentation_errors=`wc -l /tmp/debugger/instrumentation.log | cut -d' ' -f1`
+if [ -n "$instrumentation_errors" ] && [ $instrumentation_errors -ne 0 ]; then
+  echo "$instrumentation_errors errors in instrumentation.log"
+  cat /tmp/debugger/instrumentation.log
+  exit 1;
+fi

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -13,14 +13,17 @@ import datadog.trace.agent.tooling.AgentStrategies;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.instrument.ClassFileTransformer;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.pool.TypePool;
 import org.objectweb.asm.ClassReader;
@@ -56,6 +60,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
   private static final Logger log = LoggerFactory.getLogger(DebuggerTransformer.class);
   private static final String CANNOT_FIND_METHOD = "Cannot find method %s::%s";
   private static final String CANNOT_FIND_LINE = "No executable code was found at %s:L%s";
+  private static final Pattern COMMA_PATTERN = Pattern.compile(",");
 
   private final Config config;
   private final TransformerDefinitionMatcher definitonMatcher;
@@ -81,7 +86,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
     this.instrumentTheWorld = config.isDebuggerInstrumentTheWorld();
     if (this.instrumentTheWorld) {
       instrumentTheWorldProbes = new ConcurrentHashMap<>();
-      readExcludeFile(config.getDebuggerExcludeFile());
+      readExcludeFiles(config.getDebuggerExcludeFiles());
     } else {
       instrumentTheWorldProbes = null;
     }
@@ -91,27 +96,34 @@ public class DebuggerTransformer implements ClassFileTransformer {
     this(config, configuration, null);
   }
 
-  private void readExcludeFile(String fileName) {
-    if (fileName == null) {
+  private void readExcludeFiles(String commaSeparatedFileNames) {
+    if (commaSeparatedFileNames == null) {
       return;
     }
-    Path excludePath = Paths.get(fileName);
-    if (!Files.exists(excludePath)) {
-      log.warn("Cannot find exclude file: {}", excludePath);
-      return;
-    }
-    try {
-      Files.lines(excludePath)
-          .forEach(
-              line -> {
-                if (line.endsWith("*")) {
-                  excludeTrie.insert(line.substring(0, line.length() - 1));
-                } else {
-                  excludeClasses.add(line);
-                }
-              });
-    } catch (IOException ex) {
-      log.warn("Error reading exclude file '{}' for Instrument-The-World: ", fileName, ex);
+    String[] fileNames = COMMA_PATTERN.split(commaSeparatedFileNames);
+    for (String fileName : fileNames) {
+      Path excludePath = Paths.get(fileName);
+      if (!Files.exists(excludePath)) {
+        log.warn("Cannot find exclude file: {}", excludePath);
+        continue;
+      }
+      try {
+        Files.lines(excludePath)
+            .forEach(
+                line -> {
+                  if (line.startsWith("#")) {
+                    return;
+                  }
+                  if (line.endsWith("*")) {
+                    excludeTrie.insert(line.substring(0, line.length() - 1));
+                  } else {
+                    log.debug("add exclude class: {}", line);
+                    excludeClasses.add(line);
+                  }
+                });
+      } catch (IOException ex) {
+        log.warn("Error reading exclude file '{}' for Instrument-The-World: ", fileName, ex);
+      }
     }
   }
 
@@ -204,7 +216,19 @@ public class DebuggerTransformer implements ClassFileTransformer {
       if (isExcludedFromTransformation(classFilePath)) {
         return null;
       }
-      log.debug("Parsing class '{}' loaded from '{}'", classFilePath, loader);
+      URL location = null;
+      if (protectionDomain != null) {
+        CodeSource codeSource = protectionDomain.getCodeSource();
+        if (codeSource != null) {
+          location = codeSource.getLocation();
+        }
+      }
+      log.debug(
+          "Parsing class '{}' {}B loaded from loader='{}' location={}",
+          classFilePath,
+          classfileBuffer.length,
+          loader,
+          location);
       ClassNode classNode = parseClassFile(classFilePath, classfileBuffer);
       List<ProbeDefinition> probes = new ArrayList<>();
       Set<String> methodNames = new HashSet<>();
@@ -227,8 +251,18 @@ public class DebuggerTransformer implements ClassFileTransformer {
       }
     } catch (Throwable ex) {
       log.warn("Cannot transform: ", ex);
+      writeToInstrumentationLog(classFilePath);
     }
     return null;
+  }
+
+  private void writeToInstrumentationLog(String classFilePath) {
+    try (FileWriter writer = new FileWriter("/tmp/debugger/instrumentation.log", true)) {
+      writer.write(classFilePath);
+      writer.write("\n");
+    } catch (Exception ex) {
+      log.warn("Cannot write to instrumentation.log", ex);
+    }
   }
 
   public ProbeImplementation instrumentTheWorldResolver(String id, Class<?> callingClass) {
@@ -318,7 +352,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
         try {
           analyzer.analyze(classNode.name, method);
         } catch (AnalyzerException e) {
-          printWriter.printf("Error analyzing method '%s.%s':%n", classNode.name, method.name);
+          printWriter.printf(
+              "Error analyzing method '%s.%s%s':%n", classNode.name, method.name, method.desc);
           e.printStackTrace(printWriter);
         }
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -117,7 +117,6 @@ public class DebuggerTransformer implements ClassFileTransformer {
                   if (line.endsWith("*")) {
                     excludeTrie.insert(line.substring(0, line.length() - 1));
                   } else {
-                    log.debug("add exclude class: {}", line);
                     excludeClasses.add(line);
                   }
                 });
@@ -256,7 +255,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
     return null;
   }
 
-  private void writeToInstrumentationLog(String classFilePath) {
+  private synchronized void writeToInstrumentationLog(String classFilePath) {
     try (FileWriter writer = new FileWriter("/tmp/debugger/instrumentation.log", true)) {
       writer.write(classFilePath);
       writer.write("\n");

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 
 /** Collects snapshots that needs to be sent to the backend */
 public class SnapshotSink {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DebuggerSink.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotSink.class);
   private static final int CAPACITY = 1000;
   public static final int MAX_SNAPSHOT_SIZE = 1024 * 1024;
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
@@ -74,7 +74,7 @@ public class SnapshotSink {
       currentMaxDepth -= 1;
       str = SnapshotSlicer.slice(currentMaxDepth, str);
     }
-    if (currentMaxDepth < 0) {
+    if (str.length() > MAX_SNAPSHOT_SIZE) {
       ratelimitedLogger.warn(
           "Snapshot is too large even after reducing depth to 0: {}", str.length());
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1457,7 +1457,7 @@ public class CapturedSnapshotTest {
     when(config.isDebuggerEnabled()).thenReturn(true);
     when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
     when(config.isDebuggerInstrumentTheWorld()).thenReturn(true);
-    when(config.getDebuggerExcludeFile()).thenReturn(excludeFileName);
+    when(config.getDebuggerExcludeFiles()).thenReturn(excludeFileName);
     DebuggerTransformerTest.TestSnapshotListener listener =
         new DebuggerTransformerTest.TestSnapshotListener();
     DebuggerAgentHelper.injectSink(listener);

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -20,7 +20,7 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_VERIFY_BYTECODE = "dynamic.instrumentation.verify.bytecode";
   public static final String DEBUGGER_INSTRUMENT_THE_WORLD =
       "dynamic.instrumentation.instrument.the.world";
-  public static final String DEBUGGER_EXCLUDE_FILE = "dynamic.instrumentation.exclude.file";
+  public static final String DEBUGGER_EXCLUDE_FILES = "dynamic.instrumentation.exclude.files";
   public static final String DEBUGGER_CAPTURE_TIMEOUT = "dynamic.instrumentation.capture.timeout";
 
   private DebuggerConfig() {}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -149,7 +149,7 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CAPTURE_TIMEOUT;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CLASSFILE_DUMP_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_DIAGNOSTICS_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_ENABLED;
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILE;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_INSTRUMENT_THE_WORLD;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_PAYLOAD_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_METRICS_ENABLED;
@@ -654,7 +654,7 @@ public class Config {
   private final long debuggerMaxPayloadSize;
   private final boolean debuggerVerifyByteCode;
   private final boolean debuggerInstrumentTheWorld;
-  private final String debuggerExcludeFile;
+  private final String debuggerExcludeFiles;
   private final int debuggerCaptureTimeout;
 
   private final boolean awsPropagationEnabled;
@@ -1530,7 +1530,7 @@ public class Config {
     debuggerInstrumentTheWorld =
         configProvider.getBoolean(
             DEBUGGER_INSTRUMENT_THE_WORLD, DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD);
-    debuggerExcludeFile = configProvider.getString(DEBUGGER_EXCLUDE_FILE);
+    debuggerExcludeFiles = configProvider.getString(DEBUGGER_EXCLUDE_FILES);
     debuggerCaptureTimeout =
         configProvider.getInteger(DEBUGGER_CAPTURE_TIMEOUT, DEFAULT_DEBUGGER_CAPTURE_TIMEOUT);
 
@@ -2501,8 +2501,8 @@ public class Config {
     return debuggerInstrumentTheWorld;
   }
 
-  public String getDebuggerExcludeFile() {
-    return debuggerExcludeFile;
+  public String getDebuggerExcludeFiles() {
+    return debuggerExcludeFiles;
   }
 
   public int getDebuggerCaptureTimeout() {
@@ -3628,7 +3628,7 @@ public class Config {
         + ", debuggerInstrumentTheWorld="
         + debuggerInstrumentTheWorld
         + ", debuggerExcludeFile="
-        + debuggerExcludeFile
+        + debuggerExcludeFiles
         + ", awsPropagationEnabled="
         + awsPropagationEnabled
         + ", sqsPropagationEnabled="

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -29,7 +29,7 @@ import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CLASSFILE_DUMP_ENABLED
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_DIAGNOSTICS_INTERVAL
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_ENABLED
-import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILE
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILES
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_INSTRUMENT_THE_WORLD
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_METRICS_ENABLED
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_POLL_INTERVAL
@@ -236,7 +236,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(DEBUGGER_DIAGNOSTICS_INTERVAL, "60")
     prop.setProperty(DEBUGGER_VERIFY_BYTECODE, "true")
     prop.setProperty(DEBUGGER_INSTRUMENT_THE_WORLD, "true")
-    prop.setProperty(DEBUGGER_EXCLUDE_FILE, "exclude file")
+    prop.setProperty(DEBUGGER_EXCLUDE_FILES, "exclude file")
     prop.setProperty(TRACE_X_DATADOG_TAGS_MAX_LENGTH, "128")
 
     when:
@@ -325,7 +325,7 @@ class ConfigTest extends DDSpecification {
     config.debuggerDiagnosticsInterval == 60
     config.debuggerVerifyByteCode == true
     config.debuggerInstrumentTheWorld == true
-    config.debuggerExcludeFile == "exclude file"
+    config.debuggerExcludeFiles == "exclude file"
 
     config.xDatadogTagsMaxLength == 128
   }
@@ -413,7 +413,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + DEBUGGER_DIAGNOSTICS_INTERVAL, "60")
     System.setProperty(PREFIX + DEBUGGER_VERIFY_BYTECODE, "true")
     System.setProperty(PREFIX + DEBUGGER_INSTRUMENT_THE_WORLD, "true")
-    System.setProperty(PREFIX + DEBUGGER_EXCLUDE_FILE, "exclude file")
+    System.setProperty(PREFIX + DEBUGGER_EXCLUDE_FILES, "exclude file")
     System.setProperty(PREFIX + TRACE_X_DATADOG_TAGS_MAX_LENGTH, "128")
 
     when:
@@ -500,7 +500,7 @@ class ConfigTest extends DDSpecification {
     config.debuggerDiagnosticsInterval == 60
     config.debuggerVerifyByteCode == true
     config.debuggerInstrumentTheWorld == true
-    config.debuggerExcludeFile == "exclude file"
+    config.debuggerExcludeFiles == "exclude file"
 
     config.xDatadogTagsMaxLength == 128
   }


### PR DESCRIPTION
Introduced multiple exclude files for known issue with some classes one exclude file general, and one specific per project. If an instrumentation error is detected it is reported into instrumentation.log file that is tested at the end of the job for indicating if a failure occurred.

# What Does This Do

# Motivation

# Additional Notes
