### PR TITLE
Apply default tag name when setting header tags via dynamic-config

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -311,6 +311,12 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     }
   }
 
+  @Override
+  void rebuildConfig() {
+    super.rebuildConfig()
+    TEST_TRACER?.rebuildTraceConfig(Config.get())
+  }
+
   void cleanup() {
     if (isTestAgentEnabled()) {
       // save Datadog environment to DDAgentWriter header

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -662,6 +662,21 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.profilingContextIntegration = profilingContextIntegration;
   }
 
+  /** Used by AgentTestRunner to inject configuration into the test tracer. */
+  public void rebuildTraceConfig(Config config) {
+    dynamicConfig
+        .initial()
+        .setDebugEnabled(config.isDebugEnabled())
+        .setRuntimeMetricsEnabled(config.isRuntimeMetricsEnabled())
+        .setLogsInjectionEnabled(config.isLogsInjectionEnabled())
+        .setDataStreamsEnabled(config.isDataStreamsEnabled())
+        .setServiceMapping(config.getServiceMapping())
+        .setHeaderTags(config.getRequestHeaderTags())
+        .setBaggageMapping(config.getBaggageMapping())
+        .setTraceSampleRate(config.getTraceSampleRate())
+        .apply();
+  }
+
   @Override
   protected void finalize() {
     try {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -221,7 +221,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     collectIpHeaders =
         this.clientIpWithoutAppSec
             || this.clientIpResolutionEnabled && ActiveSubsystems.APPSEC_ACTIVE;
-    headerTags = traceConfig.getHeaderTags();
+    headerTags = traceConfig.getRequestHeaderTags();
     baggageMapping = traceConfig.getBaggageMapping();
     return this;
   }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -175,7 +175,7 @@ class CoreTracerTest extends DDCoreSpecification {
     when:
     def tracer = tracerBuilder().build()
     // Datadog extractor gets placed first
-    def taggedHeaders = tracer.extractor.extractors[0].traceConfigSupplier.get().getRequestHeaderTags
+    def taggedHeaders = tracer.extractor.extractors[0].traceConfigSupplier.get().requestHeaderTags
 
     then:
     tracer.defaultSpanTags == map
@@ -429,6 +429,7 @@ class CoreTracerTest extends DDCoreSpecification {
     and:
     tracer.captureTraceConfig().serviceMapping == [:]
     tracer.captureTraceConfig().requestHeaderTags == [:]
+    tracer.captureTraceConfig().responseHeaderTags == [:]
     tracer.captureTraceConfig().traceSampleRate == null
 
     when:
@@ -447,8 +448,8 @@ class CoreTracerTest extends DDCoreSpecification {
           ,
           "tracing_header_tags":
           [{
-             "header": "User-Agent",
-             "tag_name": "http.user_agent"
+             "header": "Cookie",
+             "tag_name": ""
           }, {
              "header": "Referer",
              "tag_name": "http.referer"
@@ -462,7 +463,8 @@ class CoreTracerTest extends DDCoreSpecification {
 
     then:
     tracer.captureTraceConfig().serviceMapping == ['foobar':'bar', 'snafu':'foo']
-    tracer.captureTraceConfig().requestHeaderTags == ['user-agent':'http.user_agent', 'referer':'http.referer']
+    tracer.captureTraceConfig().requestHeaderTags == ['cookie':'http.request.headers.cookie', 'referer':'http.referer']
+    tracer.captureTraceConfig().responseHeaderTags == ['cookie':'http.response.headers.cookie', 'referer':'http.referer']
     tracer.captureTraceConfig().traceSampleRate == 0.5
 
     when:
@@ -472,6 +474,7 @@ class CoreTracerTest extends DDCoreSpecification {
     then:
     tracer.captureTraceConfig().serviceMapping == [:]
     tracer.captureTraceConfig().requestHeaderTags == [:]
+    tracer.captureTraceConfig().responseHeaderTags == [:]
     tracer.captureTraceConfig().traceSampleRate == null
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -175,7 +175,7 @@ class CoreTracerTest extends DDCoreSpecification {
     when:
     def tracer = tracerBuilder().build()
     // Datadog extractor gets placed first
-    def taggedHeaders = tracer.extractor.extractors[0].traceConfigSupplier.get().headerTags
+    def taggedHeaders = tracer.extractor.extractors[0].traceConfigSupplier.get().getRequestHeaderTags
 
     then:
     tracer.defaultSpanTags == map
@@ -428,7 +428,7 @@ class CoreTracerTest extends DDCoreSpecification {
     }
     and:
     tracer.captureTraceConfig().serviceMapping == [:]
-    tracer.captureTraceConfig().headerTags == [:]
+    tracer.captureTraceConfig().requestHeaderTags == [:]
     tracer.captureTraceConfig().traceSampleRate == null
 
     when:
@@ -462,7 +462,7 @@ class CoreTracerTest extends DDCoreSpecification {
 
     then:
     tracer.captureTraceConfig().serviceMapping == ['foobar':'bar', 'snafu':'foo']
-    tracer.captureTraceConfig().headerTags == ['user-agent':'http.user_agent', 'referer':'http.referer']
+    tracer.captureTraceConfig().requestHeaderTags == ['user-agent':'http.user_agent', 'referer':'http.referer']
     tracer.captureTraceConfig().traceSampleRate == 0.5
 
     when:
@@ -471,7 +471,7 @@ class CoreTracerTest extends DDCoreSpecification {
 
     then:
     tracer.captureTraceConfig().serviceMapping == [:]
-    tracer.captureTraceConfig().headerTags == [:]
+    tracer.captureTraceConfig().requestHeaderTags == [:]
     tracer.captureTraceConfig().traceSampleRate == null
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -453,6 +453,12 @@ class CoreTracerTest extends DDCoreSpecification {
           }, {
              "header": "Referer",
              "tag_name": "http.referer"
+          }, {
+             "header": "  Some.Header  ",
+             "tag_name": ""
+          }, {
+             "header": "C!!!ont_____ent----tYp!/!e",
+             "tag_name": ""
           }]
           ,
           "tracing_sampling_rate": 0.5
@@ -463,8 +469,18 @@ class CoreTracerTest extends DDCoreSpecification {
 
     then:
     tracer.captureTraceConfig().serviceMapping == ['foobar':'bar', 'snafu':'foo']
-    tracer.captureTraceConfig().requestHeaderTags == ['cookie':'http.request.headers.cookie', 'referer':'http.referer']
-    tracer.captureTraceConfig().responseHeaderTags == ['cookie':'http.response.headers.cookie', 'referer':'http.referer']
+    tracer.captureTraceConfig().requestHeaderTags == [
+      'cookie':'http.request.headers.cookie',
+      'referer':'http.referer',
+      'some.header':'http.request.headers.some_header',
+      'c!!!ont_____ent----typ!/!e':'http.request.headers.c___ont_____ent----typ_/_e'
+    ]
+    tracer.captureTraceConfig().responseHeaderTags == [
+      'cookie':'http.response.headers.cookie',
+      'referer':'http.referer',
+      'some.header':'http.response.headers.some_header',
+      'c!!!ont_____ent----typ!/!e':'http.response.headers.c___ont_____ent----typ_/_e'
+    ]
     tracer.captureTraceConfig().traceSampleRate == 0.5
 
     when:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -459,6 +459,9 @@ class CoreTracerTest extends DDCoreSpecification {
           }, {
              "header": "C!!!ont_____ent----tYp!/!e",
              "tag_name": ""
+          }, {
+             "header": "this.header",
+             "tag_name": "whatever.the.user.wants.this.header"
           }]
           ,
           "tracing_sampling_rate": 0.5
@@ -473,13 +476,15 @@ class CoreTracerTest extends DDCoreSpecification {
       'cookie':'http.request.headers.cookie',
       'referer':'http.referer',
       'some.header':'http.request.headers.some_header',
-      'c!!!ont_____ent----typ!/!e':'http.request.headers.c___ont_____ent----typ_/_e'
+      'c!!!ont_____ent----typ!/!e':'http.request.headers.c___ont_____ent----typ_/_e',
+      'this.header':'whatever.the.user.wants.this.header'
     ]
     tracer.captureTraceConfig().responseHeaderTags == [
       'cookie':'http.response.headers.cookie',
       'referer':'http.referer',
       'some.header':'http.response.headers.some_header',
-      'c!!!ont_____ent----typ!/!e':'http.response.headers.c___ont_____ent----typ_/_e'
+      'c!!!ont_____ent----typ!/!e':'http.response.headers.c___ont_____ent----typ_/_e',
+      'this.header':'whatever.the.user.wants.this.header'
     ]
     tracer.captureTraceConfig().traceSampleRate == 0.5
 

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -11,6 +11,7 @@ import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
 
+import datadog.trace.util.Strings;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -196,16 +197,12 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     }
   }
 
-  static String clean(String s) {
-    return null == s ? "" : s.trim();
-  }
-
   static String key(Map.Entry<String, String> association) {
-    return clean(association.getKey());
+    return Strings.trim(association.getKey());
   }
 
   static String value(Map.Entry<String, String> association) {
-    return clean(association.getValue());
+    return Strings.trim(association.getValue());
   }
 
   static String lowerKey(Map.Entry<String, String> association) {
@@ -215,7 +212,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
   static String requestTag(Map.Entry<String, String> association) {
     String requestTag = value(association);
     if (requestTag.isEmpty()) {
-      requestTag = "http.request.headers." + lowerKey(association);
+      requestTag = "http.request.headers." + Strings.normalizedHeaderTag(association.getKey());
     }
     return requestTag;
   }
@@ -223,7 +220,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
   static String responseTag(Map.Entry<String, String> association) {
     String responseTag = value(association);
     if (responseTag.isEmpty()) {
-      responseTag = "http.response.headers." + lowerKey(association);
+      responseTag = "http.response.headers." + Strings.normalizedHeaderTag(association.getKey());
     }
     return responseTag;
   }

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -212,6 +212,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
   static String requestTag(Map.Entry<String, String> association) {
     String requestTag = value(association);
     if (requestTag.isEmpty()) {
+      // normalization is only applied when generating default tag names; see ConfigConverter
       requestTag = "http.request.headers." + Strings.normalizedHeaderTag(association.getKey());
     }
     return requestTag;
@@ -220,6 +221,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
   static String responseTag(Map.Entry<String, String> association) {
     String responseTag = value(association);
     if (responseTag.isEmpty()) {
+      // normalization is only applied when generating default tag names; see ConfigConverter
       responseTag = "http.response.headers." + Strings.normalizedHeaderTag(association.getKey());
     }
     return responseTag;

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -276,7 +276,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     }
 
     @Override
-    public Map<String, String> getHeaderTags() {
+    public Map<String, String> getRequestHeaderTags() {
       return headerTags;
     }
 

--- a/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
@@ -15,7 +15,7 @@ public interface TraceConfig {
 
   Map<String, String> getServiceMapping();
 
-  Map<String, String> getHeaderTags();
+  Map<String, String> getRequestHeaderTags();
 
   Map<String, String> getResponseHeaderTags();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
@@ -249,7 +249,7 @@ final class ConfigConverter {
               }
             } else {
               if (Character.isLetter(key.charAt(0))) {
-                value = defaultPrefix + normalizedHeaderTag(key);
+                value = defaultPrefix + Strings.normalizedHeaderTag(key);
               } else {
                 // tags must start with a letter
                 throw new BadFormatException(
@@ -298,36 +298,6 @@ final class ConfigConverter {
       return "";
     } else {
       str = builder.substring(firstNonWhiteSpace - start, lastNonWhitespace - start + 1);
-      return str;
-    }
-  }
-
-  @Nonnull
-  private static String normalizedHeaderTag(String str) {
-    if (str.isEmpty()) {
-      return "";
-    }
-    StringBuilder builder = new StringBuilder(str.length());
-    int firstNonWhiteSpace = -1;
-    int lastNonWhitespace = -1;
-    for (int i = 0; i < str.length(); i++) {
-      char c = str.charAt(i);
-      if (Character.isWhitespace(c)) {
-        builder.append('_');
-      } else {
-        firstNonWhiteSpace = firstNonWhiteSpace == -1 ? i : firstNonWhiteSpace;
-        lastNonWhitespace = i;
-        if (Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '/') {
-          builder.append(Character.toLowerCase(c));
-        } else {
-          builder.append('_');
-        }
-      }
-    }
-    if (firstNonWhiteSpace == -1) {
-      return "";
-    } else {
-      str = builder.substring(firstNonWhiteSpace, lastNonWhitespace + 1);
       return str;
     }
   }

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -205,6 +205,36 @@ public final class Strings {
   }
 
   @Nonnull
+  public static String normalizedHeaderTag(String str) {
+    if (str.isEmpty()) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder(str.length());
+    int firstNonWhiteSpace = -1;
+    int lastNonWhitespace = -1;
+    for (int i = 0; i < str.length(); i++) {
+      char c = str.charAt(i);
+      if (Character.isWhitespace(c)) {
+        builder.append('_');
+      } else {
+        firstNonWhiteSpace = firstNonWhiteSpace == -1 ? i : firstNonWhiteSpace;
+        lastNonWhitespace = i;
+        if (Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '/') {
+          builder.append(Character.toLowerCase(c));
+        } else {
+          builder.append('_');
+        }
+      }
+    }
+    if (firstNonWhiteSpace == -1) {
+      return "";
+    } else {
+      str = builder.substring(firstNonWhiteSpace, lastNonWhitespace + 1);
+      return str;
+    }
+  }
+
+  @Nonnull
   public static String trim(final String string) {
     return null == string ? "" : string.trim();
   }

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
@@ -218,13 +218,15 @@ abstract class DDSpecification extends Specification {
   /**
    * Reset the global configuration. Please note that Runtime ID is preserved to the pre-existing value.
    */
-  synchronized static void rebuildConfig() {
-    checkConfigTransformation()
+  void rebuildConfig() {
+    synchronized (DDSpecification) {
+      checkConfigTransformation()
 
-    def newInstConfig = instConfigConstructor.newInstance()
-    instConfigInstanceField.set(null, newInstConfig)
-    def newConfig = configConstructor.newInstance()
-    configInstanceField.set(null, newConfig)
+      def newInstConfig = instConfigConstructor.newInstance()
+      instConfigInstanceField.set(null, newInstConfig)
+      def newConfig = configConstructor.newInstance()
+      configInstanceField.set(null, newConfig)
+    }
   }
 
   private static void checkConfigTransformation() {


### PR DESCRIPTION
# What Does This Do

Apply the same `http.request.headers.<header>` and `http.response.headers.<header>` default tag names to header tags configured via dynamic-config as we currently apply to the static-config. These default tag names are only used when no tag name is provided in the header tag mapping.

# Additional Notes

This PR also updates `AgentTestRunner` to rebuild the test tracer's dynamic-config when it rebuilds the static-config.