### PR TITLE
Update TestNG instrumentation to differentiate between identical test cases executed concurrently

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestDescriptor.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestDescriptor.java
@@ -1,6 +1,7 @@
 package datadog.trace.civisibility.events;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 final class TestDescriptor {
   private final String testSuiteName;
@@ -8,11 +9,23 @@ final class TestDescriptor {
   private final String testName;
   private final String testParameters;
 
-  TestDescriptor(String testSuiteName, Class<?> testClass, String testName, String testParameters) {
+  /**
+   * A test-framework-specific "tie-breaker" that helps to differentiate between tests that would
+   * otherwise be considered identical.
+   */
+  private final @Nullable Object testQualifier;
+
+  TestDescriptor(
+      String testSuiteName,
+      Class<?> testClass,
+      String testName,
+      String testParameters,
+      @Nullable Object testQualifier) {
     this.testSuiteName = testSuiteName;
     this.testClass = testClass;
     this.testName = testName;
     this.testParameters = testParameters;
+    this.testQualifier = testQualifier;
   }
 
   @Override
@@ -27,11 +40,12 @@ final class TestDescriptor {
     return Objects.equals(testSuiteName, that.testSuiteName)
         && Objects.equals(testClass, that.testClass)
         && Objects.equals(testName, that.testName)
-        && Objects.equals(testParameters, that.testParameters);
+        && Objects.equals(testParameters, that.testParameters)
+        && Objects.equals(testQualifier, that.testQualifier);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(testSuiteName, testClass, testName, testParameters);
+    return Objects.hash(testSuiteName, testClass, testName, testParameters, testQualifier);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -194,6 +194,7 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
   public void onTestStart(
       final String testSuiteName,
       final String testName,
+      final @Nullable Object testQualifier,
       final @Nullable String testFramework,
       final @Nullable String testFrameworkVersion,
       final @Nullable String testParameters,
@@ -240,7 +241,7 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
     }
 
     TestDescriptor descriptor =
-        new TestDescriptor(testSuiteName, testClass, testName, testParameters);
+        new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
     inProgressTests.put(descriptor, test);
   }
 
@@ -249,10 +250,11 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
       String testSuiteName,
       Class<?> testClass,
       String testName,
+      @Nullable Object testQualifier,
       @Nullable String testParameters,
       @Nullable String reason) {
     TestDescriptor descriptor =
-        new TestDescriptor(testSuiteName, testClass, testName, testParameters);
+        new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
     DDTest test = inProgressTests.get(descriptor);
     if (test == null) {
       log.debug(
@@ -270,10 +272,11 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
       String testSuiteName,
       Class<?> testClass,
       String testName,
+      @Nullable Object testQualifier,
       @Nullable String testParameters,
       @Nullable Throwable throwable) {
     TestDescriptor descriptor =
-        new TestDescriptor(testSuiteName, testClass, testName, testParameters);
+        new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
     DDTest test = inProgressTests.get(descriptor);
     if (test == null) {
       log.debug(
@@ -291,9 +294,10 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
       final String testSuiteName,
       final Class<?> testClass,
       final String testName,
+      final @Nullable Object testQualifier,
       final @Nullable String testParameters) {
     TestDescriptor descriptor =
-        new TestDescriptor(testSuiteName, testClass, testName, testParameters);
+        new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
     DDTest test = inProgressTests.remove(descriptor);
     if (test == null) {
       log.debug(
@@ -310,6 +314,7 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
   public void onTestIgnore(
       final String testSuiteName,
       final String testName,
+      final @Nullable Object testQualifier,
       final @Nullable String testFramework,
       final @Nullable String testFrameworkVersion,
       final @Nullable String testParameters,
@@ -320,14 +325,15 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
     onTestStart(
         testSuiteName,
         testName,
+        testQualifier,
         testFramework,
         testFrameworkVersion,
         testParameters,
         categories,
         testClass,
         testMethod);
-    onTestSkip(testSuiteName, testClass, testName, testParameters, reason);
-    onTestFinish(testSuiteName, testClass, testName, testParameters);
+    onTestSkip(testSuiteName, testClass, testName, testQualifier, testParameters, reason);
+    onTestFinish(testSuiteName, testClass, testName, testQualifier, testParameters);
   }
 
   private static boolean skipTrace(final Class<?> testClass) {

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -98,7 +98,15 @@ public class TracingListener extends RunListener {
     List<String> categories = JUnit4Utils.getCategories(testClass, testMethod);
 
     testEventsHandler.onTestStart(
-        testSuiteName, testName, null, null, testParameters, categories, testClass, testMethod);
+        testSuiteName,
+        testName,
+        null,
+        null,
+        null,
+        testParameters,
+        categories,
+        testClass,
+        testMethod);
   }
 
   @Override
@@ -108,7 +116,7 @@ public class TracingListener extends RunListener {
     Method testMethod = JUnit4Utils.getTestMethod(description);
     String testName = JUnit4Utils.getTestName(description, testMethod);
     String testParameters = JUnit4Utils.getParameters(description);
-    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, testParameters);
+    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, null, testParameters);
   }
 
   // same callback is executed both for test cases and test suites (for setup/teardown errors)
@@ -126,7 +134,7 @@ public class TracingListener extends RunListener {
       String testParameters = JUnit4Utils.getParameters(description);
       Throwable throwable = failure.getException();
       testEventsHandler.onTestFailure(
-          testSuiteName, testClass, testName, testParameters, throwable);
+          testSuiteName, testClass, testName, null, testParameters, throwable);
     }
   }
 
@@ -156,7 +164,8 @@ public class TracingListener extends RunListener {
       String testName = JUnit4Utils.getTestName(description, testMethod);
       String testParameters = JUnit4Utils.getParameters(description);
 
-      testEventsHandler.onTestSkip(testSuiteName, testClass, testName, testParameters, reason);
+      testEventsHandler.onTestSkip(
+          testSuiteName, testClass, testName, null, testParameters, reason);
     }
   }
 
@@ -199,6 +208,7 @@ public class TracingListener extends RunListener {
     testEventsHandler.onTestIgnore(
         testSuiteName,
         testName,
+        null,
         null,
         null,
         testParameters,

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -150,6 +150,7 @@ public class TracingListener implements TestExecutionListener {
     testEventsHandler.onTestStart(
         testSuitName,
         testName,
+        null,
         testFramework,
         testFrameworkVersion,
         testParameters,
@@ -178,14 +179,14 @@ public class TracingListener implements TestExecutionListener {
     if (throwable != null) {
       if (JUnit5Utils.isAssumptionFailure(throwable)) {
         testEventsHandler.onTestSkip(
-            testSuiteName, testClass, testName, testParameters, throwable.getMessage());
+            testSuiteName, testClass, testName, null, testParameters, throwable.getMessage());
       } else {
         testEventsHandler.onTestFailure(
-            testSuiteName, testClass, testName, testParameters, throwable);
+            testSuiteName, testClass, testName, null, testParameters, throwable);
       }
     }
 
-    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, testParameters);
+    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, null, testParameters);
   }
 
   @Override
@@ -245,6 +246,7 @@ public class TracingListener implements TestExecutionListener {
     testEventsHandler.onTestIgnore(
         testSuiteName,
         testName,
+        null,
         testFramework,
         testFrameworkVersion,
         testParameters,

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -83,6 +83,7 @@ public class TracingListener extends TestNGClassListener
     String testSuiteName = result.getInstanceName();
     String testName =
         (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
+    String testQualifier = result.getTestContext().getName();
     String testParameters = TestNGUtils.getParameters(result);
     List<String> groups = TestNGUtils.getGroups(result);
 
@@ -90,7 +91,15 @@ public class TracingListener extends TestNGClassListener
     Method testMethod = TestNGUtils.getTestMethod(result);
 
     testEventsHandler.onTestStart(
-        testSuiteName, testName, null, null, testParameters, groups, testClass, testMethod);
+        testSuiteName,
+        testName,
+        testQualifier,
+        null,
+        null,
+        testParameters,
+        groups,
+        testClass,
+        testMethod);
   }
 
   @Override
@@ -99,8 +108,10 @@ public class TracingListener extends TestNGClassListener
     final Class<?> testClass = TestNGUtils.getTestClass(result);
     String testName =
         (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
+    String testQualifier = result.getTestContext().getName();
     String testParameters = TestNGUtils.getParameters(result);
-    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, testParameters);
+    testEventsHandler.onTestFinish(
+        testSuiteName, testClass, testName, testQualifier, testParameters);
   }
 
   @Override
@@ -109,11 +120,14 @@ public class TracingListener extends TestNGClassListener
     final Class<?> testClass = TestNGUtils.getTestClass(result);
     String testName =
         (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
+    String testQualifier = result.getTestContext().getName();
     String testParameters = TestNGUtils.getParameters(result);
 
     final Throwable throwable = result.getThrowable();
-    testEventsHandler.onTestFailure(testSuiteName, testClass, testName, testParameters, throwable);
-    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, testParameters);
+    testEventsHandler.onTestFailure(
+        testSuiteName, testClass, testName, testQualifier, testParameters, throwable);
+    testEventsHandler.onTestFinish(
+        testSuiteName, testClass, testName, testQualifier, testParameters);
   }
 
   @Override
@@ -127,12 +141,15 @@ public class TracingListener extends TestNGClassListener
     final Class<?> testClass = TestNGUtils.getTestClass(result);
     String testName =
         (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
+    String testQualifier = result.getTestContext().getName();
     String testParameters = TestNGUtils.getParameters(result);
 
     // Typically the way of skipping a TestNG test is throwing a SkipException
     Throwable throwable = result.getThrowable();
     String reason = throwable != null ? throwable.getMessage() : null;
-    testEventsHandler.onTestSkip(testSuiteName, testClass, testName, testParameters, reason);
-    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, testParameters);
+    testEventsHandler.onTestSkip(
+        testSuiteName, testClass, testName, testQualifier, testParameters, reason);
+    testEventsHandler.onTestFinish(
+        testSuiteName, testClass, testName, testQualifier, testParameters);
   }
 }

--- a/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
@@ -662,6 +662,72 @@ abstract class TestNGTest extends CiVisibilityTest {
     })
   }
 
+  def "test successful test cases executed in parallel with TESTS parallel mode and same test case running concurrently"() {
+    setup:
+    def suiteXml = """
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<suite name="API Test Suite" parallel="tests" configfailurepolicy="continue">
+    <test name="Test A">
+        <classes>
+            <class name="org.example.TestSucceed">
+                <methods>
+                    <include name="test_succeed"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+    <test name="Test B">
+        <classes>
+            <class name="org.example.TestSucceed">
+                <methods>
+                    <include name="test_succeed"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+    
+    <test name="Test C">
+        <classes>
+            <class name="org.example.TestSucceed">
+                <methods>
+                    <include name="test_succeed"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+</suite>
+    """
+
+    def parser = new SuiteXmlParser()
+    def xmlSuite = parser.parse("testng.xml", new ByteArrayInputStream(suiteXml.bytes), true)
+
+    def testNG = new TestNG()
+    testNG.setOutputDirectory(testOutputDir)
+    testNG.setParallel("tests")
+    testNG.setXmlSuites(Collections.singletonList(xmlSuite))
+    testNG.run()
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 4, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testModuleId
+      long testSuiteId
+      trace(2, true) {
+        testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestSucceed", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testModuleId, testSuiteId, "org.example.TestSucceed", "test_succeed", CIConstants.TEST_PASS)
+      }
+    })
+  }
+
   def "test ITR skipping"() {
     setup:
     injectSysConfig(CiVisibilityConfig.CIVISIBILITY_SKIPPABLE_TESTS, SkippableTestsSerializer.serialize([

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
@@ -29,6 +29,7 @@ public interface TestEventsHandler {
   void onTestStart(
       String testSuiteName,
       String testName,
+      @Nullable Object testQualifier,
       @Nullable String testFramework,
       @Nullable String testFrameworkVersion,
       @Nullable String testParameters,
@@ -40,6 +41,7 @@ public interface TestEventsHandler {
       String testSuiteName,
       Class<?> testClass,
       String testName,
+      @Nullable Object testQualifier,
       @Nullable String testParameters,
       @Nullable String reason);
 
@@ -47,15 +49,21 @@ public interface TestEventsHandler {
       String testSuiteName,
       Class<?> testClass,
       String testName,
+      @Nullable Object testQualifier,
       @Nullable String testParameters,
       @Nullable Throwable throwable);
 
   void onTestFinish(
-      String testSuiteName, Class<?> testClass, String testName, @Nullable String testParameters);
+      String testSuiteName,
+      Class<?> testClass,
+      String testName,
+      @Nullable Object testQualifier,
+      @Nullable String testParameters);
 
   void onTestIgnore(
       String testSuiteName,
       String testName,
+      @Nullable Object testQualifier,
       @Nullable String testFramework,
       @Nullable String testFrameworkVersion,
       @Nullable String testParameters,


### PR DESCRIPTION
# What Does This Do
Updates TestNG instrumentation to correctly handle scenarios where the same test case is executed concurrently from multiple threads.

# Motivation
It is possible to create a TestNG XML configuration that will have the same test case included in multiple "tests".
In its simplest form such configuration will look like this:
```
<suite name="API Test Suite" configfailurepolicy="continue">
    <test name="Test A">
        <classes>
            <class name="org.example.TestSucceed">
                <methods>
                    <include name="test_succeed"/>
                </methods>
            </class>
        </classes>
    </test>

    <test name="Test B">
        <classes>
            <class name="org.example.TestSucceed">
                <methods>
                    <include name="test_succeed"/>
                </methods>
            </class>
        </classes>
    </test>
</suite>
```

It is then possible to set `parallel="tests"` attribute on the suite, which will result in two test cases being executed concurrently in two threads.

When a test case finishes, CI Visibility logic locates corresponding `DDTestImpl` instance in its internal registry.
This lookup is done using a `TestDescriptor` key that is supposed to uniquely identify a test case.
The problem is that two test cases from the suite above will have identical descriptors, so when one of them finishes looking up the right `DDTestImpl` instance will be impossible.

# Additional Notes
The issue is addressed by extending `TestDescriptor` with an opaque "test qualifier" that acts as a tie-breaker in cases when two descriptors are otherwise identical.
In the case of Test NG the role of qualifier is played by `name` attribute of the `<test/>` tag
