### PR TITLE
Add span links support

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -39,6 +39,7 @@ public class DDTags {
   public static final String LANGUAGE_TAG_KEY = "language";
   public static final String LANGUAGE_TAG_VALUE = "jvm";
   public static final String ORIGIN_KEY = "_dd.origin";
+  public static final String SPAN_LINKS = "_dd.span_links";
   public static final String LIBRARY_VERSION_TAG_KEY = "library_version";
   public static final String CI_ENV_VARS = "_dd.ci.env_vars";
   public static final String CI_ITR_TESTS_SKIPPED = "_dd.ci.itr.tests_skipped";

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -3,6 +3,7 @@ package datadog.trace.core;
 import static datadog.communication.monitor.DDAgentStatsDClientManager.statsDClientManager;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 import static datadog.trace.api.DDTags.PATHWAY_HASH;
+import static datadog.trace.api.DDTags.SPAN_LINKS;
 import static datadog.trace.common.metrics.MetricsAggregatorFactory.createMetricsAggregator;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_IN;
 import static datadog.trace.core.datastreams.TagsProcessor.DIRECTION_OUT;
@@ -54,6 +55,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScopeManager;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
@@ -1307,6 +1309,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private Object builderRequestContextDataAppSec;
     private Object builderRequestContextDataIast;
     private Object builderCiVisibilityContextData;
+    private List<AgentSpanLink> links;
 
     CoreSpanBuilder(
         final String instrumentationName, final CharSequence operationName, CoreTracer tracer) {
@@ -1420,6 +1423,15 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           builderRequestContextDataIast = data;
           break;
       }
+      return this;
+    }
+
+    @Override
+    public AgentTracer.SpanBuilder withLink(AgentSpanLink link) {
+      if (this.links == null) {
+        this.links = new ArrayList<>();
+      }
+      this.links.add(link);
       return this;
     }
 
@@ -1567,7 +1579,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           (null == tags ? 0 : tags.size())
               + defaultSpanTags.size()
               + (null == coreTags ? 0 : coreTags.size())
-              + (null == rootSpanTags ? 0 : rootSpanTags.size());
+              + (null == rootSpanTags ? 0 : rootSpanTags.size())
+              + (null == links ? 0 : 1);
 
       if (builderRequestContextDataAppSec != null) {
         requestContextDataAppSec = builderRequestContextDataAppSec;
@@ -1611,6 +1624,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       context.setAllTags(tags);
       context.setAllTags(coreTags);
       context.setAllTags(rootSpanTags);
+      if (links != null) {
+        context.setTag(SPAN_LINKS, DDSpanLink.toTag(links));
+      }
       return context;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java
@@ -1,0 +1,98 @@
+package datadog.trace.core;
+
+import com.squareup.moshi.FromJson;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.ToJson;
+import com.squareup.moshi.Types;
+import datadog.trace.api.DDSpanId;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
+import datadog.trace.bootstrap.instrumentation.api.SpanLink;
+import datadog.trace.core.propagation.ExtractedContext;
+import datadog.trace.core.propagation.PropagationTags;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** This class holds helper methods to encode span links into span context. */
+public class DDSpanLink extends SpanLink {
+  private static final Moshi MOSHI = new Moshi.Builder().add(new SpanLinkAdapter()).build();
+  private static final JsonAdapter<List<AgentSpanLink>> SPAN_LINKS_ADAPTER =
+      MOSHI.adapter(Types.newParameterizedType(List.class, AgentSpanLink.class));
+
+  protected DDSpanLink(
+      DDTraceId traceId, long spanId, String traceState, Map<String, String> attributes) {
+    super(traceId, spanId, traceState, attributes);
+  }
+
+  /**
+   * Creates a span link from an {@link ExtractedContext}. Gathers the trace and span identifiers,
+   * and the W3C trace state from the given instance.
+   *
+   * @param context The context of the span to get the link to.
+   * @return A span link to the given context.
+   */
+  public static SpanLink from(ExtractedContext context) {
+    return from(context, Collections.emptyMap());
+  }
+
+  /**
+   * Creates a span link from an {@link ExtractedContext} with custom attributes. Gathers the trace
+   * and span identifiers, and the W3C trace state from the given instance.
+   *
+   * @param context The context of the span to get the link to.
+   * @param attributes The span link attributes.
+   * @return A span link to the given context with custom attributes.
+   */
+  public static SpanLink from(ExtractedContext context, Map<String, String> attributes) {
+    String traceState =
+        context.getPropagationTags() == null
+            ? ""
+            : context.getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
+    return new DDSpanLink(context.getTraceId(), context.getSpanId(), traceState, attributes);
+  }
+
+  /**
+   * Encode a span link collection into a tag value.
+   *
+   * @param links The span link collection to encode.
+   * @return The encoded tag value, {@code null} if no links.
+   */
+  public static String toTag(List<AgentSpanLink> links) {
+    if (links == null || links.isEmpty()) {
+      return null;
+    }
+    return SPAN_LINKS_ADAPTER.toJson(links);
+  }
+
+  private static class SpanLinkAdapter {
+    @ToJson
+    SpanLinkJson toSpanLinkJson(AgentSpanLink link) {
+      SpanLinkJson json = new SpanLinkJson();
+      json.traceId = link.traceId().toHexString();
+      json.spanId = DDSpanId.toHexString(link.spanId());
+      json.traceState = link.traceState();
+      if (!link.attributes().isEmpty()) {
+        json.attributes = link.attributes();
+      }
+      return json;
+    }
+
+    @FromJson
+    AgentSpanLink fromSpanLinkJson(SpanLinkJson json) {
+      return new DDSpanLink(
+          DDTraceId.fromHex(json.traceId),
+          DDSpanId.fromHex(json.spanId),
+          json.traceState,
+          json.attributes);
+    }
+  }
+
+  private static class SpanLinkJson {
+    String traceId;
+    String spanId;
+    String traceState;
+    Map<String, String> attributes;
+  }
+}

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -63,6 +63,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.StatsPoint",
   "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
   "datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes",
+  "datadog.trace.bootstrap.instrumentation.api.SpanLink",
   "datadog.trace.bootstrap.instrumentation.api.TagContext",
   "datadog.trace.bootstrap.instrumentation.api.TagContext.HttpHeaders",
   "datadog.trace.bootstrap.instrumentation.api.ForwardedTagContext",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpanLink.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpanLink.java
@@ -1,0 +1,40 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import datadog.trace.api.DDTraceId;
+import java.util.Map;
+
+/**
+ * This interface describes a link to another span. The linked span could be part of the same trace
+ * or not.
+ */
+public interface AgentSpanLink {
+  /**
+   * Gets the trace identifier of the linked span.
+   *
+   * @return The trace identifier of the linked span.
+   */
+  DDTraceId traceId();
+
+  /**
+   * Gets the span identifier of the linked span.
+   *
+   * @return The span identifier of the linked span as an unsigned 64-bit long.
+   */
+  long spanId();
+
+  /**
+   * Gets the vendor-specific trace information as defined per W3C standard.
+   *
+   * @return The vendor-specific trace state.
+   * @see <a href="https://www.w3.org/TR/trace-context/#tracestate-header">Trace state header W3C
+   *     Specification</a>
+   */
+  String traceState();
+
+  /**
+   * Gets an immutable collection of the link attributes.
+   *
+   * @return The link attributes, wrapped into an immutable collection.
+   */
+  Map<String, String> attributes();
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -328,6 +328,8 @@ public class AgentTracer {
     SpanBuilder withSpanType(CharSequence spanType);
 
     <T> SpanBuilder withRequestContextData(RequestContextSlot slot, T data);
+
+    SpanBuilder withLink(AgentSpanLink link);
   }
 
   static class NoopTracerAPI implements TracerAPI {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanLink.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanLink.java
@@ -1,0 +1,66 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import datadog.trace.api.DDTraceId;
+import java.util.Collections;
+import java.util.Map;
+
+/** This class is a base implementation of {@link AgentSpanLink}. */
+public class SpanLink implements AgentSpanLink {
+  private final DDTraceId traceId;
+  private final long spanId;
+  private final String traceState;
+  private final Map<String, String> attributes;
+
+  protected SpanLink(
+      DDTraceId traceId, long spanId, String traceState, Map<String, String> attributes) {
+    this.traceId = traceId;
+    this.spanId = spanId;
+    this.traceState = traceState;
+    this.attributes = attributes == null ? Collections.emptyMap() : attributes;
+  }
+
+  /**
+   * Creates a span link from a span context. Gathers the trace and span identifiers from the given
+   * instance.
+   *
+   * @param context The context of the span to get the link to.
+   * @return A span link to the given context.
+   */
+  public static SpanLink from(AgentSpan.Context context) {
+    return from(context, "", Collections.emptyMap());
+  }
+
+  /**
+   * Creates a span link from a span context with W3C trace state and custom attributes. Gathers the
+   * trace and span identifiers from the given instance.
+   *
+   * @param context The context of the span to get the link to.
+   * @param traceState The W3C formatted trace state.
+   * @param attributes The link attributes.
+   * @return A span link to the given context.
+   */
+  public static SpanLink from(
+      AgentSpan.Context context, String traceState, Map<String, String> attributes) {
+    return new SpanLink(context.getTraceId(), context.getSpanId(), traceState, attributes);
+  }
+
+  @Override
+  public DDTraceId traceId() {
+    return this.traceId;
+  }
+
+  @Override
+  public long spanId() {
+    return this.spanId;
+  }
+
+  @Override
+  public String traceState() {
+    return this.traceState;
+  }
+
+  @Override
+  public Map<String, String> attributes() {
+    return this.attributes;
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR introduce span links features.
It allows linking spans to each others. Linked spans do not have to be part of the same trace.

# Motivation

Span links feature will help to implement OpenTelemetry span links.

# Additional Notes

OpenTelemetry span link feature is coming in another PR to ease code review.