### PR TITLE
Add support for tycho-surefire-plugin instrumentation in Maven builds

### DIFF
--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
@@ -47,11 +47,6 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MavenLifecycleParticipant.class);
 
-  private static final String MAVEN_SUREFIRE_PLUGIN_KEY =
-      "org.apache.maven.plugins:maven-surefire-plugin";
-  private static final String MAVEN_FAILSAFE_PLUGIN_KEY =
-      "org.apache.maven.plugins:maven-failsafe-plugin";
-
   private final BuildEventsHandler<MavenSession> buildEventsHandler =
       InstrumentationBridge.createBuildEventsHandler();
 
@@ -200,9 +195,7 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
         Plugin plugin = mojoExecution.getPlugin();
         String pluginKey = plugin.getKey();
 
-        if (MAVEN_SUREFIRE_PLUGIN_KEY.equals(pluginKey)
-            || MAVEN_FAILSAFE_PLUGIN_KEY.equals(pluginKey)) {
-
+        if (MavenUtils.isTestExecution(mojoExecution)) {
           MojoDescriptor mojoDescriptor = mojoExecution.getMojoDescriptor();
           PluginDescriptor pluginDescriptor = mojoDescriptor.getPluginDescriptor();
           // ensure plugin realm is loaded in container

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
@@ -214,18 +214,20 @@ public abstract class MavenUtils {
     }
   }
 
-  public static boolean isMavenSurefireTest(MojoExecution mojoExecution) {
+  public static boolean isTestExecution(MojoExecution mojoExecution) {
     Plugin plugin = mojoExecution.getPlugin();
-    return "maven-surefire-plugin".equals(plugin.getArtifactId())
-        && "org.apache.maven.plugins".equals(plugin.getGroupId())
-        && "test".equals(mojoExecution.getGoal());
-  }
-
-  public static boolean isMavenFailsafeTest(MojoExecution mojoExecution) {
-    Plugin plugin = mojoExecution.getPlugin();
-    return "maven-failsafe-plugin".equals(plugin.getArtifactId())
-        && "org.apache.maven.plugins".equals(plugin.getGroupId())
-        && "integration-test".equals(mojoExecution.getGoal());
+    String artifactId = plugin.getArtifactId();
+    String groupId = plugin.getGroupId();
+    String goal = mojoExecution.getGoal();
+    return "maven-surefire-plugin".equals(artifactId)
+            && "org.apache.maven.plugins".equals(groupId)
+            && "test".equals(goal)
+        || "maven-failsafe-plugin".equals(artifactId)
+            && "org.apache.maven.plugins".equals(groupId)
+            && "integration-test".equals(goal)
+        || "tycho-surefire-plugin".equals(artifactId)
+            && "org.eclipse.tycho".equals(groupId)
+            && ("test".equals(goal) || "plugin-test".equals(goal) || "bnd-test".equals(goal));
   }
 
   public static String getConfigurationValue(Xpp3Dom configuration, String... path) {


### PR DESCRIPTION
# What Does This Do
Adds support for instrumenting `tycho-surefire-plugin` in Maven builds.
When a Maven build is run with the tracer attached, `tycho-surefire-plugin` executions are identified and their configuration is updated so that the JVMs that are forked by the plugin also run with the tracer attached (similar to the way this is already done for standard Surefire and Failsafe plugins).

# Motivation
`tycho-surefire-plugin` is an alternative to standard Surefire and Failsafe plugins that is used for testing Eclipse plugins.
There are CI Visibility customers that are using this plugin and would like to have visibility into tests that are run with it.