### PR TITLE
Fix empty string attribute value

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
@@ -41,7 +41,7 @@ public class OtelSpan implements Span {
 
   @Override
   public <T> Span setAttribute(AttributeKey<T> key, T value) {
-    this.delegate.setAttribute(key.getKey(), value);
+    this.delegate.setTag(key.getKey(), value);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanBuilder.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanBuilder.java
@@ -51,7 +51,8 @@ public class OtelSpanBuilder implements SpanBuilder {
 
   @Override
   public SpanBuilder setAttribute(String key, String value) {
-    this.delegate.withTag(key, value);
+    // Store as object to prevent delegate to remove tag when value is empty
+    this.delegate.withTag(key, (Object) value);
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -16,7 +16,6 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
 import io.opentelemetry.context.propagation.TextMapGetter
 import io.opentelemetry.context.propagation.TextMapSetter
-import spock.lang.Ignore
 import spock.lang.Subject
 
 import javax.annotation.Nullable
@@ -155,7 +154,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
     }
   }
 
-  @Ignore("https://github.com/DataDog/dd-trace-java/pull/5213")
   def "test span attributes"() {
     setup:
     def builder = tracer.spanBuilder("some-name")

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1395,6 +1395,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     @Override
     public CoreSpanBuilder withTag(final String tag, final Object value) {
+      if (tag == null) {
+        return this;
+      }
       Map<String, Object> tagMap = tags;
       if (tagMap == null) {
         tags = tagMap = new LinkedHashMap<>(); // Insertion order is important

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -375,15 +375,6 @@ public class DDSpan
   }
 
   @Override
-  public AgentSpan setAttribute(String key, Object value) {
-    if (key == null || key.isEmpty() || value == null) {
-      return this;
-    }
-    this.context.setTag(key, value);
-    return this;
-  }
-
-  @Override
   public void setRequestBlockingAction(Flow.Action.RequestBlockingAction rba) {
     this.requestBlockingAction = rba;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -646,6 +646,9 @@ public class DDSpanContext
    * @param value The nullable tag value.
    */
   public void setTag(final String tag, final Object value) {
+    if (null == tag) {
+      return;
+    }
     if (null == value) {
       synchronized (unsafeTags) {
         unsafeTags.remove(tag);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -33,18 +33,6 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
   @Override
   AgentSpan setTag(String key, Number value);
 
-  /**
-   * Set a span attribute.
-   *
-   * <p>Existing attributes with the same name will be replaced. Setting a {@code null} value will
-   * do nothing.
-   *
-   * @param key The span attribute key.
-   * @param value The span attribute value.
-   * @return The span instance.
-   */
-  AgentSpan setAttribute(String key, Object value);
-
   @Override
   AgentSpan setMetric(CharSequence key, int value);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -625,11 +625,6 @@ public class AgentTracer {
     }
 
     @Override
-    public AgentSpan setAttribute(String key, Object value) {
-      return this;
-    }
-
-    @Override
     public AgentSpan setMetric(final CharSequence key, final int value) {
       return this;
     }


### PR DESCRIPTION
# What Does This Do

This PR fixes empty string as OpenTelemetry Span attribute values.
Empty string attribute values are [meaningful for OpenTelemetry](https://opentelemetry.io/docs/specs/otel/common/#attribute):

> Attribute values expressing a numerical value of zero, an empty string, or an empty array are considered meaningful and MUST be stored and passed on to processors / exporters.

It also:
* Restore the related broken unit tests
* Remove previous work-around (based on `setAttributes()` method)
* Add tag key null check

# Motivation

Fix the OpenTelemetry API instrumentation behavior.

# Additional Notes
