### PR TITLE
Disabling `spring-path-filter' integration should remove all path-related filters

### DIFF
--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/WebApplicationContextInstrumentation.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 public class WebApplicationContextInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForTypeHierarchy {
   public WebApplicationContextInstrumentation() {
-    super("spring-web");
+    super("spring-web", "spring-path-filter");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/WebApplicationContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/WebApplicationContextInstrumentation.java
@@ -19,7 +19,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class WebApplicationContextInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForTypeHierarchy {
   public WebApplicationContextInstrumentation() {
-    super("spring-web");
+    super("spring-web", "spring-path-filter");
   }
 
   @Override


### PR DESCRIPTION
This helps triage issues where the tracer's path filtering might be having a side-effect on the application, without having to disable all `spring-web` tracing.

Environment variable:
`DD_INTEGRATION_SPRING_PATH_FILTER_ENABLED=false`

JVM option:
`-Ddd.integration.spring-path-filter.enabled=false`
