### PR TITLE
Support test framework version extraction for legacy TestNG

### DIFF
--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGInstrumentation.java
@@ -49,11 +49,7 @@ public class TestNGInstrumentation extends Instrumenter.CiVisibility
         }
       }
 
-      final Package pkg = TestNG.class.getPackage();
-      final String version =
-          pkg.getImplementationVersion() != null
-              ? pkg.getImplementationVersion()
-              : pkg.getSpecificationVersion();
+      final String version = TestNGUtils.getTestNGVersion();
       final TracingListener tracingListener = new TracingListener(version);
       testNG.addListener((ITestNGListener) tracingListener);
 

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
@@ -1,17 +1,21 @@
 package datadog.trace.instrumentation.testng;
 
 import datadog.trace.util.Strings;
+import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import org.testng.IClass;
 import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
+import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.internal.ConstructorOrMethod;
 import org.testng.internal.ITestResultNotifier;
@@ -140,6 +144,41 @@ public abstract class TestNGUtils {
           && ("methods".equals(parallel.toString()) || "tests".equals(parallel.toString()));
     } catch (Exception e) {
       return false;
+    }
+  }
+
+  public static String getTestNGVersion() {
+    Class<TestNG> testNg = TestNG.class;
+    Package pkg = testNg.getPackage();
+
+    String implVersion = pkg.getImplementationVersion();
+    if (implVersion != null) {
+      return implVersion;
+    }
+
+    String specVersion = pkg.getSpecificationVersion();
+    if (specVersion != null) {
+      return specVersion;
+    }
+
+    try {
+      String className = testNg.getSimpleName() + ".class";
+      URL classResource = testNg.getResource(className);
+      if (classResource == null) {
+        return null;
+      }
+
+      String classPath = classResource.toString();
+      String manifestPath =
+          classPath.substring(0, classPath.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
+      try (InputStream manifestStream = new java.net.URL(manifestPath).openStream()) {
+        Properties manifestProperties = new Properties();
+        manifestProperties.load(manifestStream);
+        return manifestProperties.getProperty("Bundle-Version");
+      }
+
+    } catch (Exception e) {
+      return null;
     }
   }
 }

--- a/dd-java-agent/instrumentation/testng/testng-6.4/src/test/groovy/TestNG64Test.groovy
+++ b/dd-java-agent/instrumentation/testng/testng-6.4/src/test/groovy/TestNG64Test.groovy
@@ -4,9 +4,7 @@ class TestNG64Test extends TestNGTest {
 
   @Override
   String expectedTestFrameworkVersion() {
-    // For the TestNG version used for tests (minimum supported)
-    // it's not possible to extract the version.
-    return null
+    return "6.4.0"
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Supports test framework version extraction for older TestNG verisons.

# Motivation
Each test span should be tagged with test framework version according to CI Visibility spec.
