### PR TITLE
profiler config ergonomics improvements

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/JfpUtils.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/JfpUtils.java
@@ -33,6 +33,8 @@ import java.util.Properties;
  */
 public final class JfpUtils {
   public static final String DEFAULT_JFP = "jfr/dd.jfp";
+
+  public static final String SAFEPOINTS_JFP = "jfr/safepoints.jfp";
   private static final String OVERRIDES_PATH = "jfr/overrides/";
   public static final String JFP_EXTENSION = ".jfp";
 

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/resources/jfr/safepoints.jfp
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/resources/jfr/safepoints.jfp
@@ -1,0 +1,10 @@
+jdk.SafepointBegin#enabled=true
+jdk.SafepointBegin#threshold=0 ms
+jdk.SafepointStateSynchronization#enabled=true
+jdk.SafepointStateSynchronization#threshold=0 ms
+jdk.SafepointWaitBlocked#enabled=false
+jdk.SafepointCleanup#enabled=false
+jdk.SafepointCleanupTask#enabled=false
+jdk.SafepointEnd#enabled=true
+jdk.SafepointEnd#threshold=0 ms
+jdk.ExecuteVMOperation#enabled=true

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -17,6 +17,7 @@ package com.datadog.profiling.controller.openjdk;
 
 import static com.datadog.profiling.controller.ProfilingSupport.*;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ULTRA_MINIMAL;
 
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
@@ -64,10 +65,14 @@ public final class OpenJdkController implements Controller {
     Class.forName("jdk.jfr.Recording");
     Class.forName("jdk.jfr.FlightRecorder");
 
+    boolean ultraMinimal = configProvider.getBoolean(PROFILING_ULTRA_MINIMAL, false);
+
     Map<String, String> recordingSettings;
 
     try {
-      recordingSettings = JfpUtils.readNamedJfpResource(JfpUtils.DEFAULT_JFP);
+      recordingSettings =
+          JfpUtils.readNamedJfpResource(
+              ultraMinimal ? JfpUtils.SAFEPOINTS_JFP : JfpUtils.DEFAULT_JFP);
     } catch (final IOException e) {
       throw new ConfigurationException(e);
     }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -1,6 +1,7 @@
 package com.datadog.profiling.ddprof;
 
 import static datadog.trace.api.Platform.isJ9;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED;
@@ -37,11 +38,12 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_CONTEXT_FILTER;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_CONTEXT_FILTER_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_INTERVAL_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_ULTRA_MINIMAL;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
 
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.lang.management.ManagementFactory;
@@ -101,10 +103,11 @@ public class DatadogProfilerConfig {
   }
 
   public static boolean isWallClockProfilerEnabled(ConfigProvider configProvider) {
+    boolean isUltraMinimal = getBoolean(configProvider, PROFILING_ULTRA_MINIMAL, false);
+    boolean isTracingEnabled = configProvider.getBoolean(TRACE_ENABLED, true);
+    boolean disableUnlessOptedIn = isUltraMinimal || !isTracingEnabled || isJ9();
     return getBoolean(
-        configProvider,
-        PROFILING_DATADOG_PROFILER_WALL_ENABLED,
-        !isJ9() && PROFILING_DATADOG_PROFILER_WALL_ENABLED_DEFAULT);
+        configProvider, PROFILING_DATADOG_PROFILER_WALL_ENABLED, disableUnlessOptedIn);
   }
 
   public static int getWallInterval(ConfigProvider configProvider) {
@@ -133,10 +136,13 @@ public class DatadogProfilerConfig {
   }
 
   public static boolean isAllocationProfilingEnabled(ConfigProvider configProvider) {
-    return getBoolean(
-        configProvider,
-        PROFILING_DATADOG_PROFILER_ALLOC_ENABLED,
-        PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT);
+    boolean userOptedIn =
+        getBoolean(configProvider, PROFILING_DATADOG_PROFILER_ALLOC_ENABLED, false);
+    // once DD allocation profiling is GA use the longstanding allocation flag to toggle it
+    if (PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT) {
+      return getBoolean(configProvider, PROFILING_ALLOCATION_ENABLED, userOptedIn);
+    }
+    return userOptedIn;
   }
 
   public static boolean isAllocationProfilingEnabled() {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -11,6 +11,8 @@ import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import datadog.trace.agent.tooling.muzzle.ReferenceProvider;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.config.ProfilingConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.util.Strings;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -308,6 +310,12 @@ public interface Instrumenter {
     @Override
     public boolean isApplicable(Set<TargetSystem> enabledSystems) {
       return enabledSystems.contains(TargetSystem.PROFILING);
+    }
+
+    @Override
+    public boolean isEnabled() {
+      return !ConfigProvider.getInstance()
+          .getBoolean(ProfilingConfig.PROFILING_ULTRA_MINIMAL, false);
     }
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskUnwrappingInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskUnwrappingInstrumentation.java
@@ -14,11 +14,12 @@ public class TaskUnwrappingInstrumentation extends Instrumenter.Profiling
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return ConfigProvider.getInstance()
-        .getBoolean(
-            ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED,
-            ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
+  public boolean isEnabled() {
+    return super.isEnabled()
+        && ConfigProvider.getInstance()
+            .getBoolean(
+                ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED,
+                ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
   }
 
   private static final String[] TYPES_WITH_FIELDS = {

--- a/dd-java-agent/instrumentation/java-directbytebuffer/src/main/java/datadog/trace/instrumentation/directbytebuffer/ByteBufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-directbytebuffer/src/main/java/datadog/trace/instrumentation/directbytebuffer/ByteBufferInstrumentation.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.directbytebuffer;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -8,8 +10,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.Platform;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 
 @AutoService(Instrumenter.class)
 public final class ByteBufferInstrumentation extends Instrumenter.Profiling
@@ -21,12 +23,12 @@ public final class ByteBufferInstrumentation extends Instrumenter.Profiling
 
   @Override
   public boolean isEnabled() {
-    return Platform.isJavaVersionAtLeast(11) && super.isEnabled() && Platform.hasJfr();
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return InstrumenterConfig.get().isDirectAllocationProfilingEnabled();
+    return Platform.isJavaVersionAtLeast(11)
+        && super.isEnabled()
+        && ConfigProvider.getInstance()
+            .getBoolean(
+                PROFILING_DIRECT_ALLOCATION_ENABLED, PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT)
+        && Platform.hasJfr();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-directbytebuffer/src/main/java/datadog/trace/instrumentation/directbytebuffer/DirectByteBufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-directbytebuffer/src/main/java/datadog/trace/instrumentation/directbytebuffer/DirectByteBufferInstrumentation.java
@@ -1,13 +1,15 @@
 package datadog.trace.instrumentation.directbytebuffer;
 
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.Platform;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 
 @AutoService(Instrumenter.class)
 public final class DirectByteBufferInstrumentation extends Instrumenter.Profiling
@@ -19,12 +21,12 @@ public final class DirectByteBufferInstrumentation extends Instrumenter.Profilin
 
   @Override
   public boolean isEnabled() {
-    return Platform.isJavaVersionAtLeast(11) && super.isEnabled() && Platform.hasJfr();
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return InstrumenterConfig.get().isDirectAllocationProfilingEnabled();
+    return Platform.isJavaVersionAtLeast(11)
+        && super.isEnabled()
+        && ConfigProvider.getInstance()
+            .getBoolean(
+                PROFILING_DIRECT_ALLOCATION_ENABLED, PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT)
+        && Platform.hasJfr();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-directbytebuffer/src/main/java/datadog/trace/instrumentation/directbytebuffer/FileChannelImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-directbytebuffer/src/main/java/datadog/trace/instrumentation/directbytebuffer/FileChannelImplInstrumentation.java
@@ -1,14 +1,16 @@
 package datadog.trace.instrumentation.directbytebuffer;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.Platform;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
 
 @AutoService(Instrumenter.class)
 public final class FileChannelImplInstrumentation extends Instrumenter.Profiling
@@ -20,12 +22,12 @@ public final class FileChannelImplInstrumentation extends Instrumenter.Profiling
 
   @Override
   public boolean isEnabled() {
-    return Platform.isJavaVersionAtLeast(11) && super.isEnabled() && Platform.hasJfr();
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return InstrumenterConfig.get().isDirectAllocationProfilingEnabled();
+    return Platform.isJavaVersionAtLeast(11)
+        && super.isEnabled()
+        && ConfigProvider.getInstance()
+            .getBoolean(
+                PROFILING_DIRECT_ALLOCATION_ENABLED, PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT)
+        && Platform.hasJfr();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/java-directbytebuffer/src/test/groovy/DirectAllocationTrackingTest.groovy
+++ b/dd-java-agent/instrumentation/java-directbytebuffer/src/test/groovy/DirectAllocationTrackingTest.groovy
@@ -24,7 +24,7 @@ class DirectAllocationTrackingTest extends AgentTestRunner {
     super.configurePreAgent()
     injectSysConfig("dd.profiling.enabled", "true")
     injectSysConfig("dd.integration.mmap.enabled", "true")
-    injectSysConfig("dd.integration.allocatedirect.enabled", "true")
+    injectSysConfig("dd.profiling.directallocation.enabled", "true")
   }
 
   def "test track memory mapped file"() {

--- a/dd-java-agent/instrumentation/netty-concurrent-4/src/main/java/datadog/trace/instrumentation/netty40/concurrent/SingleThreadEventExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-concurrent-4/src/main/java/datadog/trace/instrumentation/netty40/concurrent/SingleThreadEventExecutorInstrumentation.java
@@ -29,11 +29,12 @@ public class SingleThreadEventExecutorInstrumentation extends Instrumenter.Profi
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return ConfigProvider.getInstance()
-        .getBoolean(
-            ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED,
-            ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
+  public boolean isEnabled() {
+    return super.isEnabled()
+        && ConfigProvider.getInstance()
+            .getBoolean(
+                ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED,
+                ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT);
   }
 
   @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -176,5 +176,7 @@ public final class ProfilingConfig {
 
   public static final long PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS_DEFAULT = 50;
 
+  public static final String PROFILING_ULTRA_MINIMAL = "profiling.ultra.minimal";
+
   private ProfilingConfig() {}
 }


### PR DESCRIPTION
# What Does This Do

* Introduces an ultra minimal mode: it just traces safepoints and only the CPU profiler will be enabled. All profiling instrumentation is disabled in this mode. The motivation is profiling middleware and users are discouraged from enabling this mode because it doesn't collect much information.
* Wallclock profiler automatically disabled whenever tracing is disabled, because without tracing no threads are sampled anyway. The motivation is to avoid starting the wallclock sampler thread unnecessarily.
* DD allocation profiling controlled by `dd.profiling.allocation.enabled` unless the user explicitly opts in with `dd.profiling.ddprof.alloc.enabled` which is now deprecated. The motivation is the user should not need to know to which allocation profiler is enabled, and once the new allocation profiler is production ready, we will switch them over seamlessly.

# Motivation

# Additional Notes
