### PR TITLE
Support HTTP client header tagging

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
 import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.trace.api.Config;
@@ -15,6 +16,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.BitSet;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,11 +36,17 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
 
   private static final UTF8BytesString DEFAULT_RESOURCE_NAME = UTF8BytesString.create("/");
 
+  private static final boolean CLIENT_TAG_HEADERS = Config.get().isHttpClientTagHeaders();
+
   protected abstract String method(REQUEST request);
 
   protected abstract URI url(REQUEST request) throws URISyntaxException;
 
   protected abstract int status(RESPONSE response);
+
+  protected abstract String getRequestHeader(REQUEST request, String headerName);
+
+  protected abstract String getResponseHeader(RESPONSE response, String headerName);
 
   @Override
   protected CharSequence spanType() {
@@ -80,6 +88,16 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
       } catch (final Exception e) {
         log.debug("Error tagging url", e);
       }
+
+      if (CLIENT_TAG_HEADERS) {
+        for (Map.Entry<String, String> headerTag :
+            traceConfig(span).getRequestHeaderTags().entrySet()) {
+          String headerValue = getRequestHeader(request, headerTag.getKey());
+          if (null != headerValue) {
+            span.setTag(headerTag.getValue(), headerValue);
+          }
+        }
+      }
     }
     return span;
   }
@@ -91,6 +109,16 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
         span.setHttpStatusCode(status);
         if (CLIENT_ERROR_STATUSES.get(status)) {
           span.setError(true);
+        }
+      }
+
+      if (CLIENT_TAG_HEADERS) {
+        for (Map.Entry<String, String> headerTag :
+            traceConfig(span).getResponseHeaderTags().entrySet()) {
+          String headerValue = getResponseHeader(response, headerTag.getKey());
+          if (null != headerValue) {
+            span.setTag(headerTag.getValue(), headerValue);
+          }
         }
       }
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
@@ -1,12 +1,15 @@
 package datadog.trace.bootstrap.instrumentation.httpurlconnection;
 
+import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
+
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-public class HttpUrlConnectionDecorator extends HttpClientDecorator<HttpURLConnection, Integer> {
+public class HttpUrlConnectionDecorator
+    extends HttpClientDecorator<HttpURLConnection, HttpURLConnection> {
 
   public static final CharSequence HTTP_URL_CONNECTION =
       UTF8BytesString.create("http-url-connection");
@@ -37,7 +40,21 @@ public class HttpUrlConnectionDecorator extends HttpClientDecorator<HttpURLConne
   }
 
   @Override
-  protected int status(final Integer status) {
-    return status;
+  protected int status(final HttpURLConnection connection) {
+    try {
+      return connection.getResponseCode();
+    } catch (Exception ignored) {
+      return UNSET_STATUS;
+    }
+  }
+
+  @Override
+  protected String getRequestHeader(HttpURLConnection connection, String headerName) {
+    return connection.getRequestProperty(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(HttpURLConnection connection, String headerName) {
+    return connection.getHeaderField(headerName);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/httpurlconnection/HttpUrlState.java
@@ -36,10 +36,12 @@ public class HttpUrlState {
     finished = true;
   }
 
-  public void finishSpan(final int responseCode, final Throwable throwable) {
+  public void finishSpan(
+      final HttpURLConnection connection, final int responseCode, final Throwable throwable) {
     try (final AgentScope scope = activateSpan(span)) {
       if (responseCode > 0) {
-        DECORATE.onResponse(span, responseCode);
+        // safe to access response data as 'responseCode' is set
+        DECORATE.onResponse(span, connection);
       } else {
         // Ignoring the throwable if we have response code
         // to have consistent behavior with other http clients.
@@ -52,7 +54,7 @@ public class HttpUrlState {
     }
   }
 
-  public void finishSpan(final int responseCode) {
+  public void finishSpan(final HttpURLConnection connection, final int responseCode) {
     /*
      * responseCode field is sometimes not populated.
      * We can't call getResponseCode() due to some unwanted side-effects
@@ -60,7 +62,8 @@ public class HttpUrlState {
      */
     if (responseCode > 0) {
       try (final AgentScope scope = activateSpan(span)) {
-        DECORATE.onResponse(span, responseCode);
+        // safe to access response data as 'responseCode' is set
+        DECORATE.onResponse(span, connection);
         DECORATE.beforeFinish(span);
         span.finish();
         span = null;

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.decorator
 
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import spock.lang.Shared
@@ -34,6 +35,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       if (renameService) {
         1 * span.setServiceName(req.url.host)
       }
+      1 * span.traceConfig() >> AgentTracer.traceConfig()
     }
     0 * _
 
@@ -73,6 +75,9 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     } else {
       1 * span.setResourceName({ it as String == expectedPath })
     }
+    if (req) {
+      1 * span.traceConfig() >> AgentTracer.traceConfig()
+    }
     0 * _
 
     where:
@@ -110,6 +115,9 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     } else {
       1 * span.setResourceName(_)
     }
+    if (req) {
+      1 * span.traceConfig() >> AgentTracer.traceConfig()
+    }
     _ * span.setTag(_, _)
     0 * _
 
@@ -141,6 +149,9 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     }
     if (error) {
       1 * span.setError(true)
+    }
+    if (resp) {
+      1 * span.traceConfig() >> AgentTracer.traceConfig()
     }
     0 * _
 
@@ -191,8 +202,19 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
           null == m.status ? 0 : m.status.intValue()
         }
 
+        @Override
         protected boolean traceAnalyticsDefault() {
           return true
+        }
+
+        @Override
+        protected String getRequestHeader(Map map, String headerName) {
+          return null
+        }
+
+        @Override
+        protected String getResponseHeader(Map map, String headerName) {
+          return null
         }
       }
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpClientDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.akkahttp;
 
+import akka.http.javadsl.model.HttpHeader;
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
 import datadog.trace.bootstrap.instrumentation.api.URIUtils;
@@ -37,5 +38,15 @@ public class AkkaHttpClientDecorator extends HttpClientDecorator<HttpRequest, Ht
   @Override
   protected int status(final HttpResponse httpResponse) {
     return httpResponse.status().intValue();
+  }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    return request.getHeader(headerName).map(HttpHeader::value).orElse(null);
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse response, String headerName) {
+    return response.getHeader(headerName).map(HttpHeader::value).orElse(null);
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
@@ -5,6 +5,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
 import java.net.URISyntaxException;
+import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.RequestLine;
@@ -67,5 +68,26 @@ public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequ
       }
     }
     return 0;
+  }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    Header header = request.getFirstHeader(headerName);
+    if (header != null) {
+      return header.getValue();
+    }
+    return null;
+  }
+
+  @Override
+  protected String getResponseHeader(HttpContext context, String headerName) {
+    final Object responseObject = context.getAttribute(HttpCoreContext.HTTP_RESPONSE);
+    if (responseObject instanceof HttpResponse) {
+      Header header = ((HttpResponse) responseObject).getFirstHeader(headerName);
+      if (header != null) {
+        return header.getValue();
+      }
+    }
+    return null;
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.apachehttpclient;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 
@@ -36,5 +37,23 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriReques
   @Override
   protected int status(final HttpResponse httpResponse) {
     return httpResponse.getStatusLine().getStatusCode();
+  }
+
+  @Override
+  protected String getRequestHeader(HttpUriRequest request, String headerName) {
+    Header header = request.getFirstHeader(headerName);
+    if (null != header) {
+      return header.getValue();
+    }
+    return null;
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse response, String headerName) {
+    Header header = response.getFirstHeader(headerName);
+    if (null != header) {
+      return header.getValue();
+    }
+    return null;
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HostAndRequestAsHttpUriRequest.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HostAndRequestAsHttpUriRequest.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.apachehttpclient;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.ProtocolVersion;
@@ -68,6 +69,11 @@ public class HostAndRequestAsHttpUriRequest extends AbstractHttpMessage implemen
   @Override
   public java.net.URI getURI() {
     return uri;
+  }
+
+  @Override
+  public Header getFirstHeader(String name) {
+    return actualRequest.getFirstHeader(name);
   }
 
   public HttpRequest getActualRequest() {

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientDecorator.java
@@ -4,6 +4,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
 import java.net.URISyntaxException;
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 
@@ -37,5 +38,23 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   @Override
   protected int status(final HttpResponse httpResponse) {
     return httpResponse.getCode();
+  }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    Header header = request.getFirstHeader(headerName);
+    if (null != header) {
+      return header.getValue();
+    }
+    return null;
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse response, String headerName) {
+    Header header = response.getFirstHeader(headerName);
+    if (null != header) {
+      return header.getValue();
+    }
+    return null;
   }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HostAndRequestAsHttpUriRequest.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HostAndRequestAsHttpUriRequest.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
@@ -17,5 +18,10 @@ public class HostAndRequestAsHttpUriRequest extends BasicClassicHttpRequest {
   @Override
   public void setHeader(String name, Object value) {
     actualRequest.setHeader(name, value);
+  }
+
+  @Override
+  public Header getFirstHeader(String name) {
+    return actualRequest.getFirstHeader(name);
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -195,4 +195,18 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   public void set(Request<?> carrier, String key, String value) {
     carrier.addHeader(key, value);
   }
+
+  @Override
+  protected String getRequestHeader(Request request, String headerName) {
+    Object header = request.getHeaders().get(headerName);
+    if (null != header) {
+      return header.toString();
+    }
+    return null;
+  }
+
+  @Override
+  protected String getResponseHeader(Response response, String headerName) {
+    return response.getHttpResponse().getHeaders().get(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -204,4 +204,14 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
   public void set(SdkHttpRequest.Builder carrier, String key, String value) {
     carrier.putHeader(key, value);
   }
+
+  @Override
+  protected String getRequestHeader(SdkHttpRequest request, String headerName) {
+    return request.firstMatchingHeader(headerName).orElse(null);
+  }
+
+  @Override
+  protected String getResponseHeader(SdkHttpResponse response, String headerName) {
+    return response.firstMatchingHeader(headerName).orElse(null);
+  }
 }

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/CommonsHttpClientDecorator.java
@@ -4,6 +4,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
 import java.net.URISyntaxException;
+import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpMethod;
 import org.apache.commons.httpclient.StatusLine;
 import org.apache.commons.httpclient.URIException;
@@ -44,5 +45,23 @@ public class CommonsHttpClientDecorator extends HttpClientDecorator<HttpMethod, 
   protected int status(final HttpMethod httpMethod) {
     final StatusLine statusLine = httpMethod.getStatusLine();
     return statusLine == null ? 0 : statusLine.getStatusCode();
+  }
+
+  @Override
+  protected String getRequestHeader(HttpMethod request, String headerName) {
+    Header header = request.getRequestHeader(headerName);
+    if (null != header) {
+      return header.getValue();
+    }
+    return null;
+  }
+
+  @Override
+  protected String getResponseHeader(HttpMethod response, String headerName) {
+    Header header = response.getResponseHeader(headerName);
+    if (null != header) {
+      return header.getValue();
+    }
+    return null;
   }
 }

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -57,4 +57,14 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   protected CharSequence component() {
     return GOOGLE_HTTP_CLIENT;
   }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    return request.getHeaders().getFirstHeaderStringValue(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse response, String headerName) {
+    return response.getHeaders().getFirstHeaderStringValue(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientDecorator.java
@@ -39,4 +39,14 @@ public class ClientDecorator extends HttpClientDecorator<Request, Response> {
   protected int status(final Response response) {
     return response.getStatusCode();
   }
+
+  @Override
+  protected String getRequestHeader(Request request, String headerName) {
+    return request.getHeaders().getFirstValue(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(Response response, String headerName) {
+    return response.getHeader(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -85,6 +85,7 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void methodExit(
         @Advice.Enter final HttpUrlState state,
+        @Advice.This final HttpURLConnection thiz,
         @Advice.FieldValue("responseCode") final int responseCode,
         @Advice.Thrown final Throwable throwable,
         @Advice.Origin("#m") final String methodName) {
@@ -96,9 +97,9 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing
       synchronized (state) {
         if (state.hasSpan() && !state.isFinished()) {
           if (throwable != null) {
-            state.finishSpan(responseCode, throwable);
+            state.finishSpan(thiz, responseCode, throwable);
           } else if ("getInputStream".equals(methodName)) {
-            state.finishSpan(responseCode);
+            state.finishSpan(thiz, responseCode);
           }
         }
       }

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/JavaNetClientDecorator.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java11/datadog/trace/instrumentation/httpclient/JavaNetClientDecorator.java
@@ -40,4 +40,14 @@ public class JavaNetClientDecorator extends HttpClientDecorator<HttpRequest, Htt
   protected int status(HttpResponse<?> httpResponse) {
     return httpResponse.statusCode();
   }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    return request.headers().firstValue(headerName).orElse(null);
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse<?> response, String headerName) {
+    return response.headers().firstValue(headerName).orElse(null);
+  }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Decorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/main/java/datadog/trace/instrumentation/jaxrs/v1/JaxRsClientV1Decorator.java
@@ -38,4 +38,18 @@ public class JaxRsClientV1Decorator extends HttpClientDecorator<ClientRequest, C
   protected int status(final ClientResponse clientResponse) {
     return clientResponse.getStatus();
   }
+
+  @Override
+  protected String getRequestHeader(ClientRequest request, String headerName) {
+    Object headerValue = request.getHeaders().getFirst(headerName);
+    if (null != headerValue) {
+      return headerValue.toString();
+    }
+    return null;
+  }
+
+  @Override
+  protected String getResponseHeader(ClientResponse response, String headerName) {
+    return response.getHeaders().getFirst(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsClientDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsClientDecorator.java
@@ -38,4 +38,14 @@ public class JaxRsClientDecorator
   protected int status(final ClientResponseContext httpResponse) {
     return httpResponse.getStatus();
   }
+
+  @Override
+  protected String getRequestHeader(ClientRequestContext request, String headerName) {
+    return request.getHeaderString(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(ClientResponseContext response, String headerName) {
+    return response.getHeaderString(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/JettyClientDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-client-9.1/src/main/java/datadog/trace/instrumentation/jetty_client/JettyClientDecorator.java
@@ -35,4 +35,14 @@ public class JettyClientDecorator extends HttpClientDecorator<Request, Response>
   protected int status(final Response httpResponse) {
     return httpResponse.getStatus();
   }
+
+  @Override
+  protected String getRequestHeader(Request request, String headerName) {
+    return request.getHeaders().get(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(Response response, String headerName) {
+    return response.getHeaders().get(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/NettyHttpClientDecorator.java
@@ -54,4 +54,14 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   protected int status(final HttpResponse httpResponse) {
     return httpResponse.getStatus().getCode();
   }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    return request.headers().get(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse response, String headerName) {
+    return response.headers().get(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/NettyHttpClientDecorator.java
@@ -59,4 +59,14 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   protected int status(final HttpResponse httpResponse) {
     return httpResponse.getStatus().code();
   }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    return request.headers().get(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse response, String headerName) {
+    return response.headers().get(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/NettyHttpClientDecorator.java
@@ -59,4 +59,14 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   protected int status(final HttpResponse httpResponse) {
     return httpResponse.status().code();
   }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    return request.headers().get(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse response, String headerName) {
+    return response.headers().get(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/OkHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/OkHttpClientDecorator.java
@@ -37,4 +37,14 @@ public class OkHttpClientDecorator extends HttpClientDecorator<Request, Response
   protected CharSequence component() {
     return OKHTTP;
   }
+
+  @Override
+  protected String getRequestHeader(Request request, String headerName) {
+    return request.header(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(Response response, String headerName) {
+    return response.header(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/OkHttpClientDecorator.java
@@ -42,4 +42,14 @@ public class OkHttpClientDecorator extends HttpClientDecorator<Request, Response
   protected int status(final Response httpResponse) {
     return httpResponse.code();
   }
+
+  @Override
+  protected String getRequestHeader(Request request, String headerName) {
+    return request.header(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(Response response, String headerName) {
+    return response.header(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/play-ws/src/main/java/datadog/trace/instrumentation/playws/PlayWSClientDecorator.java
+++ b/dd-java-agent/instrumentation/play-ws/src/main/java/datadog/trace/instrumentation/playws/PlayWSClientDecorator.java
@@ -37,4 +37,14 @@ public class PlayWSClientDecorator extends HttpClientDecorator<Request, Response
   protected CharSequence component() {
     return PLAY_WS;
   }
+
+  @Override
+  protected String getRequestHeader(Request request, String headerName) {
+    return request.getHeaders().get(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(Response response, String headerName) {
+    return response.getHeaders().get(headerName);
+  }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
@@ -61,6 +61,16 @@ public class SpringWebfluxHttpClientDecorator
     return httpResponse.statusCode().value();
   }
 
+  @Override
+  protected String getRequestHeader(ClientRequest request, String headerName) {
+    return request.headers().getFirst(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(ClientResponse response, String headerName) {
+    return response.headers().asHttpHeaders().getFirst(headerName);
+  }
+
   private static MethodHandle findRawStatusCode() {
     try {
       return MethodHandles.publicLookup()

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -61,9 +61,21 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements Tes
 
   @Override
   // parent spanRef must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void clientSpan(TraceAssert trace, Object parentSpan, String method = "GET", boolean renameService = false, boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, boolean error = false, Throwable exception = null) {
+  void clientSpan(
+    TraceAssert trace,
+    Object parentSpan,
+    String method = "GET",
+    boolean renameService = false,
+    boolean tagQueryString = false,
+    URI uri = server.address.resolve("/success"),
+    Integer status = 200,
+    boolean error = false,
+    Throwable exception = null,
+    boolean ignorePeer = false,
+    Map<String, Serializable> extraTags = null) {
+
     def leafParentId = trace.spanAssertCount.get()
-    super.clientSpan(trace, parentSpan, method, renameService, tagQueryString, uri, status, error, exception)
+    super.clientSpan(trace, parentSpan, method, renameService, tagQueryString, uri, status, error, exception, ignorePeer, extraTags)
     if (!exception) {
       def expectedQuery = tagQueryString ? uri.query : null
       def expectedUrl = URIUtils.buildURL(uri.scheme, uri.host, uri.port, uri.path)
@@ -102,6 +114,9 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements Tes
             "$DDTags.PATHWAY_HASH" { String }
           }
           defaultTags()
+          if (extraTags) {
+            it.addTags(extraTags)
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/main/java17/datadog/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/main/java17/datadog/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDecorator.java
@@ -62,6 +62,16 @@ public class SpringWebfluxHttpClientDecorator
     return httpResponse.statusCode().value();
   }
 
+  @Override
+  protected String getRequestHeader(ClientRequest request, String headerName) {
+    return request.headers().getFirst(headerName);
+  }
+
+  @Override
+  protected String getResponseHeader(ClientResponse response, String headerName) {
+    return response.headers().asHttpHeaders().getFirst(headerName);
+  }
+
   private static MethodHandle findRawStatusCode() {
     try {
       return MethodHandles.publicLookup()

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
@@ -60,9 +60,20 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements Tes
 
   @Override
   // parent spanRef must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void clientSpan(TraceAssert trace, Object parentSpan, String method = "GET", boolean renameService = false, boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, boolean error = false, Throwable exception = null) {
+  void clientSpan(
+    TraceAssert trace,
+    Object parentSpan,
+    String method = "GET",
+    boolean renameService = false,
+    boolean tagQueryString = false,
+    URI uri = server.address.resolve("/success"),
+    Integer status = 200,
+    boolean error = false,
+    Throwable exception = null,
+    boolean ignorePeer = false,
+    Map<String, Serializable> extraTags = null) {
     def leafParentId = trace.spanAssertCount.get()
-    super.clientSpan(trace, parentSpan, method, renameService, tagQueryString, uri, status, error, exception)
+    super.clientSpan(trace, parentSpan, method, renameService, tagQueryString, uri, status, error, exception, ignorePeer, extraTags)
     if (!exception) {
       def expectedQuery = tagQueryString ? uri.query : null
       def expectedUrl = URIUtils.buildURL(uri.scheme, uri.host, uri.port, uri.path)
@@ -101,6 +112,9 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements Tes
             "$DDTags.PATHWAY_HASH" { String }
           }
           defaultTags()
+          if (extraTags) {
+            it.addTags(extraTags)
+          }
         }
       }
     }

--- a/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientDecorator.java
+++ b/dd-java-agent/instrumentation/synapse-3/src/main/java/datadog/trace/instrumentation/synapse3/SynapseClientDecorator.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.cache.RadixTreeCache.UNSET_STATUS;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
+import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 
@@ -42,5 +43,23 @@ public final class SynapseClientDecorator extends HttpClientDecorator<HttpReques
       return response.getStatusLine().getStatusCode();
     }
     return UNSET_STATUS;
+  }
+
+  @Override
+  protected String getRequestHeader(HttpRequest request, String headerName) {
+    Header header = request.getFirstHeader(headerName);
+    if (null != header) {
+      return header.getValue();
+    }
+    return null;
+  }
+
+  @Override
+  protected String getResponseHeader(HttpResponse response, String headerName) {
+    Header header = response.getFirstHeader(headerName);
+    if (null != header) {
+      return header.getValue();
+    }
+    return null;
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
@@ -204,7 +204,7 @@ class TestHttpServer implements AutoCloseable {
     clone(handlers)
   }
 
-  static distributedRequestTrace(ListWriterAssert traces, DDSpan parentSpan = null) {
+  static distributedRequestTrace(ListWriterAssert traces, DDSpan parentSpan = null, Map<String, Serializable> extraTags = null) {
     traces.trace(1) {
       span {
         operationName "test-http-server"
@@ -218,6 +218,9 @@ class TestHttpServer implements AutoCloseable {
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
           "path" String
           defaultTags(parentSpan != null)
+          if (extraTags) {
+            it.addTags(extraTags)
+          }
         }
       }
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -39,6 +39,7 @@ public final class TraceInstrumentationConfig {
   public static final String HTTP_SERVER_RAW_RESOURCE = "http.server.raw.resource";
   public static final String HTTP_SERVER_ROUTE_BASED_NAMING = "http.server.route-based-naming";
   public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
+  public static final String HTTP_CLIENT_TAG_HEADERS = "http.client.tag.headers";
   public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
   public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -279,6 +279,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_O
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_TRIM_PACKAGE_RESOURCE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TAG_HEADERS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_TAG_QUERY_STRING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_QUERY_STRING;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_SERVER_RAW_RESOURCE;
@@ -508,6 +509,7 @@ public class Config {
   private final Map<String, String> httpClientPathResourceNameMapping;
   private final boolean httpResourceRemoveTrailingSlash;
   private final boolean httpClientTagQueryString;
+  private final boolean httpClientTagHeaders;
   private final boolean httpClientSplitByDomain;
   private final boolean dbClientSplitByInstance;
   private final boolean dbClientSplitByInstanceTypeSuffix;
@@ -1026,6 +1028,8 @@ public class Config {
     httpClientTagQueryString =
         configProvider.getBoolean(
             HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
+
+    httpClientTagHeaders = configProvider.getBoolean(HTTP_CLIENT_TAG_HEADERS, true);
 
     httpClientSplitByDomain =
         configProvider.getBoolean(
@@ -1913,6 +1917,10 @@ public class Config {
 
   public boolean isHttpClientTagQueryString() {
     return httpClientTagQueryString;
+  }
+
+  public boolean isHttpClientTagHeaders() {
+    return httpClientTagHeaders;
   }
 
   public boolean isHttpClientSplitByDomain() {


### PR DESCRIPTION
This PR adds support for tagging headers in HTTP client request and response spans, like we already do for server spans.

The existing configuration option for deciding which headers to tag can be found at https://docs.datadoghq.com/tracing/trace_collection/library_config/java under `dd.trace.header.tags`

If necessary this new feature can be turned off with this JVM option:
```
-Ddd.http.client.tag.headers=false
```
or this environment variable:
```
DD_HTTP_CLIENT_TAG_HEADERS=false
```