### PR TITLE
Enable/disable embedded JMXFetch with dynamic config

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -31,7 +31,7 @@ public class JMXFetch {
   public static final List<String> DEFAULT_CONFIGS =
       Collections.singletonList("jmxfetch-config.yaml");
 
-  private static final int SLEEP_AFTER_JMXFETCH_EXITS = 5000;
+  private static final int DELAY_BETWEEN_RUN_ATTEMPTS = 5000;
 
   public static void run(final StatsDClientManager statsDClientManager) {
     run(statsDClientManager, Config.get());
@@ -139,7 +139,7 @@ public class JMXFetch {
                   }
                   // always wait before next attempt
                   try {
-                    Thread.sleep(SLEEP_AFTER_JMXFETCH_EXITS);
+                    Thread.sleep(DELAY_BETWEEN_RUN_ATTEMPTS);
                   } catch (final InterruptedException ignore) {
                   }
                 }

--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/TraceConfigExitWatcher.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/TraceConfigExitWatcher.java
@@ -1,0 +1,14 @@
+package datadog.trace.agent.jmxfetch;
+
+import datadog.trace.api.TraceConfig;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import org.datadog.jmxfetch.ExitWatcher;
+
+public final class TraceConfigExitWatcher extends ExitWatcher {
+  @Override
+  public boolean shouldExit() {
+    TraceConfig traceConfig = AgentTracer.traceConfig();
+    // assume JMXFetch shouldn't exit if tracer hasn't been installed yet
+    return null != traceConfig && !traceConfig.isRuntimeMetricsEnabled();
+  }
+}


### PR DESCRIPTION
# What Does This Do

Stops the embedded JMXFetch instance when dynamic-config disables runtime metrics.

The JMXFetch thread will then poll the dynamic-config until runtime metrics are re-enabled.

# Additional Notes

Assumes JMXFetch starts enabled in static config, otherwise the necessary hooks will not be in place to (re)enable it later.