### PR TITLE
disable wallclock profiling during Socket.connect

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -47,6 +47,7 @@
 0 java.lang.ProcessImpl
 0 java.net.http.*
 0 java.net.HttpURLConnection
+0 java.net.Socket
 0 java.net.URL
 0 java.nio.DirectByteBuffer
 0 java.nio.ByteBuffer

--- a/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SocketConnectInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslsocket/src/main/java/datadog/trace/instrumentation/sslsocket/SocketConnectInstrumentation.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.sslsocket;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED_DEFAULT;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class SocketConnectInstrumentation extends Instrumenter.Profiling
+    implements Instrumenter.ForSingleType {
+
+  public SocketConnectInstrumentation() {
+    super("socket");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "java.net.Socket";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    // only needed if wallclock profiling is enabled, which requires tracing
+    return super.isEnabled()
+        && ConfigProvider.getInstance()
+            .getBoolean(
+                PROFILING_DATADOG_PROFILER_WALL_ENABLED,
+                PROFILING_DATADOG_PROFILER_WALL_ENABLED_DEFAULT)
+        && InstrumenterConfig.get().isTraceEnabled();
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("connect"))
+            .and(takesArgument(0, named("java.net.SocketAddress")))
+            .and(takesArgument(1, int.class)),
+        getClass().getName() + "$DisableWallclockSampling");
+  }
+
+  public static final class DisableWallclockSampling {
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static boolean before() {
+      AgentScope active = AgentTracer.activeScope();
+      if (active != null) {
+        AgentTracer.get().getProfilingContext().onDetach();
+        return true;
+      }
+      return false;
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void after(@Advice.Enter boolean wasEnabled) {
+      if (wasEnabled) {
+        AgentTracer.get().getProfilingContext().onAttach();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/sslsocket/src/test/groovy/SocketForkedTest.groovy
+++ b/dd-java-agent/instrumentation/sslsocket/src/test/groovy/SocketForkedTest.groovy
@@ -1,0 +1,28 @@
+import datadog.trace.agent.test.AgentTestRunner
+
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+class SocketForkedTest extends AgentTestRunner {
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig("dd.profiling.enabled", "true")
+  }
+
+  def "wallclock sampling disabled during Socket.connect"() {
+    when:
+    runUnderTrace("parent") {
+      try {
+        // calls connect internally, and will fail
+        new Socket("localhost", 0)
+      } catch(Throwable expected) {
+      }
+    }
+    then:
+    // expect one pair of attach and detach for the span, another for Socket.connect
+    TEST_PROFILING_CONTEXT_INTEGRATION.detachments.get() == 2
+    TEST_PROFILING_CONTEXT_INTEGRATION.attachments.get() == 2
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -35,7 +35,6 @@ import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.experimental.DataStreamsCheckpointer;
 import datadog.trace.api.experimental.DataStreamsContextCarrier;
-import datadog.trace.api.experimental.Profiling;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.InstrumentationGateway;
 import datadog.trace.api.gateway.RequestContext;
@@ -1202,7 +1201,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public Profiling getProfilingContext() {
+  public ProfilingContextIntegration getProfilingContext() {
     return profilingContextIntegration;
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -10,7 +10,6 @@ import datadog.trace.api.TraceConfig;
 import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.experimental.DataStreamsCheckpointer;
 import datadog.trace.api.experimental.DataStreamsContextCarrier;
-import datadog.trace.api.experimental.Profiling;
 import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
@@ -300,6 +299,8 @@ public class AgentTracer {
     String getSpanId(AgentSpan span);
 
     TraceConfig captureTraceConfig();
+
+    ProfilingContextIntegration getProfilingContext();
   }
 
   public interface SpanBuilder {
@@ -423,8 +424,8 @@ public class AgentTracer {
     public void flushMetrics() {}
 
     @Override
-    public Profiling getProfilingContext() {
-      return Profiling.NoOp.INSTANCE;
+    public ProfilingContextIntegration getProfilingContext() {
+      return ProfilingContextIntegration.NoOp.INSTANCE;
     }
 
     @Override


### PR DESCRIPTION
# What Does This Do

`Socket.connect` does not currently support interruption properly (see [JDK-8312065](https://bugs.openjdk.org/browse/JDK-8312065)) so this instrumentation prevents the profiler from sampling threads during the method.

# Motivation

# Additional Notes
