### PR TITLE
Add capture of static fields

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -23,6 +23,7 @@ public class CapturedContext implements ValueReferenceResolver {
   private Map<String, CapturedValue> arguments;
   private Map<String, CapturedValue> locals;
   private CapturedThrowable throwable;
+  private Map<String, CapturedValue> staticFields;
   private Map<String, CapturedValue> fields;
   private Limits limits = Limits.DEFAULT;
   private String thisClassName;
@@ -150,6 +151,12 @@ public class CapturedContext implements ValueReferenceResolver {
     if (fields != null && !fields.isEmpty()) {
       result = fields.get(name);
     }
+    if (result != null) {
+      return result;
+    }
+    if (staticFields != null && !staticFields.isEmpty()) {
+      result = staticFields.get(name);
+    }
     return result != null ? result : Values.UNDEFINED_OBJECT;
   }
 
@@ -205,6 +212,18 @@ public class CapturedContext implements ValueReferenceResolver {
     this.throwable = capturedThrowable;
   }
 
+  public void addStaticFields(CapturedValue[] values) {
+    if (values == null) {
+      return;
+    }
+    if (staticFields == null) {
+      staticFields = new HashMap<>();
+    }
+    for (CapturedValue value : values) {
+      staticFields.put(value.name, value);
+    }
+  }
+
   public void addFields(CapturedValue[] values) {
     if (values == null) {
       return;
@@ -245,6 +264,10 @@ public class CapturedContext implements ValueReferenceResolver {
     return throwable;
   }
 
+  public Map<String, CapturedValue> getStaticFields() {
+    return staticFields;
+  }
+
   public Map<String, CapturedValue> getFields() {
     return fields;
   }
@@ -275,6 +298,9 @@ public class CapturedContext implements ValueReferenceResolver {
     }
     if (locals != null) {
       locals.values().forEach(capturedValue -> capturedValue.freeze(timeoutChecker));
+    }
+    if (staticFields != null) {
+      staticFields.values().forEach(capturedValue -> capturedValue.freeze(timeoutChecker));
     }
     if (fields != null) {
       fields.values().forEach(capturedValue -> capturedValue.freeze(timeoutChecker));

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -64,6 +64,10 @@ public class ASMHelper {
     return (fieldNode.access & Opcodes.ACC_STATIC) != 0;
   }
 
+  public static boolean isFinalField(FieldNode fieldNode) {
+    return (fieldNode.access & Opcodes.ACC_FINAL) != 0;
+  }
+
   public static void invokeStatic(
       InsnList insnList,
       org.objectweb.asm.Type owner,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -36,6 +36,7 @@ public class MoshiSnapshotHelper {
   public static final String ARGUMENTS = "arguments";
   public static final String LOCALS = "locals";
   public static final String THROWABLE = "throwable";
+  public static final String STATIC_FIELDS = "staticFields";
   public static final String THIS = "this";
   public static final String NOT_CAPTURED_REASON = "notCapturedReason";
   public static final String FIELD_COUNT_REASON = "fieldCount";
@@ -162,11 +163,18 @@ public class MoshiSnapshotHelper {
           toJsonCapturedValues(
               jsonWriter, capturedContext.getLocals(), capturedContext.getLimits(), timeoutChecker);
       jsonWriter.endObject(); // LOCALS
-      handleSerializationResult(jsonWriter, resultLocals, resultArgs);
+      jsonWriter.name(STATIC_FIELDS);
+      jsonWriter.beginObject();
+      SerializationResult resultStaticFields =
+          toJsonCapturedValues(
+              jsonWriter,
+              capturedContext.getStaticFields(),
+              capturedContext.getLimits(),
+              timeoutChecker);
+      jsonWriter.endObject();
+      handleSerializationResult(jsonWriter, resultLocals, resultArgs, resultStaticFields);
       jsonWriter.name(THROWABLE);
       throwableAdapter.toJson(jsonWriter, capturedContext.getThrowable());
-      // TODO add static fields
-      // jsonWriter.name("staticFields");
       jsonWriter.endObject();
     }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
@@ -14,6 +14,7 @@ import static com.datadog.debugger.util.MoshiSnapshotHelper.LOCATION;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.NOT_CAPTURED_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.RETURN;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.SIZE;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.STATIC_FIELDS;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.THROWABLE;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.TRUNCATED;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.TYPE;
@@ -150,6 +151,9 @@ public class MoshiSnapshotTestHelper {
             break;
           case LOCALS:
             capturedContext.addLocals(fromJsonCapturedValues(jsonReader));
+            break;
+          case STATIC_FIELDS:
+            capturedContext.addStaticFields(fromJsonCapturedValues(jsonReader));
             break;
           case THROWABLE:
             capturedContext.addThrowable(throwableAdapter.fromJson(jsonReader));

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot19.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot19.java
@@ -1,0 +1,12 @@
+package com.datadog.debugger;
+
+public class CapturedSnapshot19 {
+  private static String strField = "foo";
+  private static int intField = 1001;
+  private static double doubleField = Math.PI;
+  private static int[] intArrayField = new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  public static int main(String arg) {
+    return 42;
+  }
+}


### PR DESCRIPTION
# What Does This Do
Capture static fields in dedicated section in snapshots. Static final fields are not captured.
Only static fields of the class of the instrumented methods are captured, not for every instance.

# Motivation

# Additional Notes
