### PR TITLE
Add OpenTelemetry span name tests

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -64,10 +64,12 @@ class OpenTelemetry14Test extends AgentTestRunner {
         span {
           parent()
           operationName "some-name"
+          resourceName "some-name"
         }
         span {
           childOfPrevious()
           operationName "other-name"
+          resourceName "other-name"
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

This minor PR updates the existing test cases to ensure the current beharior: spans generated from OpenTelemetry instrumentation should have their operation name and resource name set with the OpenTelemetry span name.

# Motivation

Ensure consistant behavior between tracer implementations.

# Additional Notes
