### PR TITLE
More accurately report whether the request was blocked

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/blocking/BlockingServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/blocking/BlockingServiceImpl.java
@@ -88,7 +88,7 @@ public class BlockingServiceImpl implements BlockingService {
     if (res) {
       TraceSegment traceSegment = reqCtx.getTraceSegment();
       if (traceSegment != null) {
-        traceSegment.setTagTop("appsec.blocked", "true");
+        traceSegment.effectivelyBlocked();
       }
     }
     return res;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -118,9 +118,6 @@ public class GatewayBridge {
           if (traceSeg != null) {
             traceSeg.setTagTop("_dd.appsec.enabled", 1);
             traceSeg.setTagTop("_dd.runtime_family", "jvm");
-            if (spanInfo.getRequestBlockingAction() != null) {
-              traceSeg.setTagTop("appsec.blocked", "true");
-            }
 
             Collection<AppSecEvent100> collectedEvents = ctx.transferCollectedEvents();
 
@@ -226,7 +223,8 @@ public class GatewayBridge {
               DataBundle bundle =
                   new SingletonDataBundle<>(KnownAddresses.REQUEST_PATH_PARAMS, data);
               try {
-                return producerService.publishDataEvent(subInfo, ctx, bundle, false);
+                Flow<Void> flow = producerService.publishDataEvent(subInfo, ctx, bundle, false);
+                return flow;
               } catch (ExpiredSubscriberInfoException e) {
                 pathParamsSubInfo = null;
               }

--- a/dd-java-agent/appsec/src/main/resources/default_config.json
+++ b/dd-java-agent/appsec/src/main/resources/default_config.json
@@ -7074,6 +7074,32 @@
         }
       ],
       "transformers": []
+    },
+    {
+      "id": "__troubleshooting_rule",
+      "name": "troubleshooting rule for block on request body",
+      "tags": {
+        "type": "troubleshooting",
+        "category": "troubleshooting",
+        "confidence": "1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "regex": "ADKMFFpndcwHNnr2MW9W"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "block"
+      ]
     }
   ]
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/blocking/BlockingServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/blocking/BlockingServiceImplSpecification.groovy
@@ -109,7 +109,7 @@ class BlockingServiceImplSpecification extends DDSpecification {
     then:
     res == true
     1 * brf.tryCommitBlockingResponse(405, BlockingContentType.HTML, [:]) >> true
-    1 * mts.setTagTop('appsec.blocked', 'true')
+    1 * mts.effectivelyBlocked()
   }
 
   void 'tryCommitBlockingResponse without active span'() {

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -88,6 +88,7 @@ public class GrizzlyHttpHandlerInstrumentation extends Instrumenter.Tracing
       if (rba != null) {
         boolean success = GrizzlyBlockingHelper.block(request, response, rba, scope);
         if (success) {
+          span.getRequestContext().getTraceSegment().effectivelyBlocked();
           return true; /* skip body */
         }
       }

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -123,6 +123,7 @@ public class GrizzlyDecorator
 
     Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
     if (rba != null && thiz instanceof HttpServerFilter) {
+      span.getRequestContext().getTraceSegment().effectivelyBlocked();
       nextAction =
           GrizzlyHttpBlockingHelper.block(
               ctx, (HttpServerFilter) thiz, httpRequest, httpResponse, rba, nextAction);

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/ParsedBodyParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/ParsedBodyParametersInstrumentation.java
@@ -115,6 +115,7 @@ public class ParsedBodyParametersInstrumentation extends Instrumenter.AppSec
             if (t == null) {
               t = new BlockingException("Blocked request (for Parameters/processParameters)");
             }
+            reqCtx.getTraceSegment().effectivelyBlocked();
           }
         }
       } finally {

--- a/dd-java-agent/instrumentation/jersey-2-appsec/src/main/java/datadog/trace/instrumentation/jersey2/MessageBodyReaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey-2-appsec/src/main/java/datadog/trace/instrumentation/jersey2/MessageBodyReaderInstrumentation.java
@@ -88,6 +88,7 @@ public class MessageBodyReaderInstrumentation extends Instrumenter.AppSec
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for ReaderInterceptorExecutor/proceed)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey-2-appsec/src/main/java/datadog/trace/instrumentation/jersey2/MultiPartReaderServerSideInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey-2-appsec/src/main/java/datadog/trace/instrumentation/jersey2/MultiPartReaderServerSideInstrumentation.java
@@ -107,6 +107,7 @@ public class MultiPartReaderServerSideInstrumentation extends Instrumenter.AppSe
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for MultiPartReaderClientSide/readFrom)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey-2-appsec/src/main/java/datadog/trace/instrumentation/jersey2/UriRoutingContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey-2-appsec/src/main/java/datadog/trace/instrumentation/jersey2/UriRoutingContextInstrumentation.java
@@ -74,6 +74,7 @@ public class UriRoutingContextInstrumentation extends Instrumenter.AppSec
           t =
               new BlockingException(
                   "Blocked request (for UriRoutingContextInstrumentation/getPathParameters)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey-3-appsec/src/main/java/datadog/trace/instrumentation/jersey3/MessageBodyReaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey-3-appsec/src/main/java/datadog/trace/instrumentation/jersey3/MessageBodyReaderInstrumentation.java
@@ -87,6 +87,7 @@ public class MessageBodyReaderInstrumentation extends Instrumenter.AppSec
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for ReaderInterceptorExecutor/proceed)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey-3-appsec/src/main/java/datadog/trace/instrumentation/jersey3/MultiPartReaderServerSideInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey-3-appsec/src/main/java/datadog/trace/instrumentation/jersey3/MultiPartReaderServerSideInstrumentation.java
@@ -107,6 +107,7 @@ public class MultiPartReaderServerSideInstrumentation extends Instrumenter.AppSe
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for MultiPartReaderClientSide/readFrom)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/jetty-appsec-7/src/main/java/datadog/trace/instrumentation/jetty70/UrlEncodedInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-7/src/main/java/datadog/trace/instrumentation/jetty70/UrlEncodedInstrumentation.java
@@ -103,6 +103,7 @@ public class UrlEncodedInstrumentation extends Instrumenter.AppSec
                 rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
             if (t == null) {
               t = new BlockingException("Blocked request (for UrlEncoded/decodeTo)");
+              reqCtx.getTraceSegment().effectivelyBlocked();
             }
           }
         }

--- a/dd-java-agent/instrumentation/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
@@ -182,6 +182,7 @@ public class RequestGetPartsInstrumentation extends Instrumenter.AppSec
         if (blockResponseFunction != null) {
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          reqCtx.getTraceSegment().effectivelyBlocked();
           if (t == null) {
             t = new BlockingException("Blocked request (for Request/parsePart(s))");
           }

--- a/dd-java-agent/instrumentation/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/RequestExtractContentParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-9.2/src/main/java/datadog/trace/instrumentation/jetty92/RequestExtractContentParametersInstrumentation.java
@@ -86,6 +86,7 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for Request/extractContentParameters)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }
@@ -129,6 +130,7 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           if (t == null) {
             t = new BlockingException("Blocked request (for Request/getParts)");
+            reqCtx.getTraceSegment().effectivelyBlocked();
           }
         }
       }

--- a/dd-java-agent/instrumentation/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/RequestExtractContentParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-9.3/src/main/java/datadog/trace/instrumentation/jetty93/RequestExtractContentParametersInstrumentation.java
@@ -93,6 +93,7 @@ public class RequestExtractContentParametersInstrumentation extends Instrumenter
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           if (t == null) {
             t = new BlockingException("Blocked request (for Request/extractContentParameters)");
+            reqCtx.getTraceSegment().effectivelyBlocked();
           }
         }
       }

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
@@ -104,6 +104,7 @@ public final class LibertyServerInstrumentation extends Instrumenter.Tracing
         // prevent caching of the handler
         req.setAttribute(
             "javax.servlet.error.status_code", ((SRTServletResponse) resp).getStatusCode());
+        span.getRequestContext().getTraceSegment().effectivelyBlocked();
         return true; // skip method body
       }
 

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ParseParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ParseParametersInstrumentation.java
@@ -113,6 +113,7 @@ public class ParseParametersInstrumentation extends Instrumenter.AppSec
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for SRTServletRequest/parseParameters)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ParsePostDataInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/ParsePostDataInstrumentation.java
@@ -76,6 +76,7 @@ public class ParsePostDataInstrumentation extends Instrumenter.AppSec
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for SRTServletRequest/parsePostData)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
@@ -59,6 +59,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
 
       Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
       if (rba != null) {
+        span.getRequestContext().getTraceSegment().effectivelyBlocked();
         ctx.getPipeline()
             .addAfter(ctx.getName(), "blocking_handler", new BlockingResponseHandler(rba));
       }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -49,6 +49,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
 
       Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
       if (rba != null) {
+        span.getRequestContext().getTraceSegment().effectivelyBlocked();
         ctx.pipeline().addAfter(ctx.name(), "blocking_handler", new BlockingResponseHandler(rba));
       }
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/HttpPostRequestDecoderInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/HttpPostRequestDecoderInstrumentation.java
@@ -123,6 +123,7 @@ public class HttpPostRequestDecoderInstrumentation extends Instrumenter.AppSec
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
         }
         thr = new BlockingException("Blocked request (multipart/urlencoded post data)");
+        requestContext.getTraceSegment().effectivelyBlocked();
       }
 
       if (exc != null) {

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
@@ -48,6 +48,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
 
       Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
       if (rba != null) {
+        span.getRequestContext().getTraceSegment().effectivelyBlocked();
         ctx.pipeline().addAfter(ctx.name(), "blocking_handler", new BlockingResponseHandler(rba));
       }
 

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ContextParseAdvice.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ContextParseAdvice.java
@@ -49,6 +49,7 @@ public class ContextParseAdvice {
             rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
 
         t = new BlockingException("Blocked request (for DefaultContext/parse)");
+        reqCtx.getTraceSegment().effectivelyBlocked();
       }
     }
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/PathBindingPublishingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/PathBindingPublishingHandler.java
@@ -25,13 +25,14 @@ public class PathBindingPublishingHandler implements Handler {
 
   @Override
   public void handle(Context ctx) {
-    boolean delegate = true;
+    boolean doDelegation = true;
     try {
-      delegate = maybePublishTokens(ctx);
+      doDelegation = maybePublishTokens(ctx);
     } finally {
-      if (delegate) {
+      if (doDelegation) {
         ctx.next();
       } else {
+        activeSpan().getRequestContext().getTraceSegment().effectivelyBlocked();
         throw new BlockingException("Blocking request");
       }
     }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/RatpackRequestBodyCallGetBufferAdvice.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/RatpackRequestBodyCallGetBufferAdvice.java
@@ -55,7 +55,14 @@ public class RatpackRequestBodyCallGetBufferAdvice {
 
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
   static void after(
-      @Advice.Enter Throwable enterThr, @Advice.Thrown(readOnly = false) Throwable t) {
+      @Advice.Enter Throwable enterThr,
+      @Advice.Thrown(readOnly = false) Throwable t,
+      @ActiveRequestContext RequestContext reqCtx) {
+    if (enterThr == null) {
+      return;
+    }
+
+    reqCtx.getTraceSegment().effectivelyBlocked();
     // it's questionable, but we don't replace existing exceptions with our BlockingException
     if (t == null) {
       t = enterThr;

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/RatpackRequestBodyGetTextCalledAdvice.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/RatpackRequestBodyGetTextCalledAdvice.java
@@ -40,6 +40,7 @@ public class RatpackRequestBodyGetTextCalledAdvice {
           rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
       if (throwable == null) {
         throwable = new BlockingException("Blocked request (for ByteBufBackedTypedData/getText)");
+        reqCtx.getTraceSegment().effectivelyBlocked();
       }
     }
   }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/DecodedFormParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/DecodedFormParametersInstrumentation.java
@@ -136,6 +136,7 @@ public class DecodedFormParametersInstrumentation extends Instrumenter.AppSec
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for getDecodedFormParameters)");
+          requestContext.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/MessageBodyReaderInvocationInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/MessageBodyReaderInvocationInstrumentation.java
@@ -84,6 +84,7 @@ public class MessageBodyReaderInvocationInstrumentation extends Instrumenter.App
           t =
               new BlockingException(
                   "Blocked request (for AbstractReaderInterceptorContext/readFrom)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/MethodExpressionInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/MethodExpressionInstrumentation.java
@@ -82,6 +82,7 @@ public class MethodExpressionInstrumentation extends Instrumenter.AppSec
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for MethodExpression/populatePathParams)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/MultipartFormDataReaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/MultipartFormDataReaderInstrumentation.java
@@ -93,6 +93,7 @@ public class MultipartFormDataReaderInstrumentation extends Instrumenter.AppSec
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
           t = new BlockingException("Blocked request (for MultipartFormDataInput/readFrom)");
+          reqCtx.getTraceSegment().effectivelyBlocked();
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -65,6 +65,7 @@ public class Servlet2Advice {
     if (rba != null) {
       ServletBlockingHelper.commitBlockingResponse(
           httpServletRequest, (HttpServletResponse) response, rba);
+      span.getRequestContext().getTraceSegment().effectivelyBlocked();
       return true; // skip method body
     }
 

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -82,6 +82,7 @@ public class Servlet3Advice {
     Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
     if (rba != null) {
       ServletBlockingHelper.commitBlockingResponse(httpServletRequest, httpServletResponse, rba);
+      span.getRequestContext().getTraceSegment().effectivelyBlocked();
       return true; // skip method body
     }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HttpMessageConverterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HttpMessageConverterInstrumentation.java
@@ -98,6 +98,7 @@ public class HttpMessageConverterInstrumentation extends Instrumenter.AppSec
           brf.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
         }
+        reqCtx.getTraceSegment().effectivelyBlocked();
         t = new BlockingException("Blocked request (for HttpMessageConverter/read)");
       }
     }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
@@ -156,6 +156,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends Instrumenter.Defa
                   brf.tryCommitBlockingResponse(
                       rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
                 }
+                reqCtx.getTraceSegment().effectivelyBlocked();
                 t =
                     new BlockingException(
                         "Blocked request (for RequestMappingInfoHandlerMapping/handleMatch)");

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -117,6 +117,7 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.Def
                 brf.tryCommitBlockingResponse(
                     rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
               }
+              reqCtx.getTraceSegment().effectivelyBlocked();
               t =
                   new BlockingException(
                       "Blocked request (for UriTemplateVariablesHandlerInterceptor/preHandle)");

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SetupSpecHelper.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SetupSpecHelper.groovy
@@ -46,6 +46,7 @@ class SetupSpecHelper {
         ServletBlockingHelper
           .commitBlockingResponse(attributes.request, attributes.response, statusCode, templateType, extraHeaders)
       }
+      true
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
@@ -100,6 +100,7 @@ public class HandleMatchAdvice {
                 brf.tryCommitBlockingResponse(
                     rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
               }
+              reqCtx.getTraceSegment().effectivelyBlocked();
               t =
                   new BlockingException(
                       "Blocked request (for RequestMappingInfoHandlerMapping/handleMatch)");

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
@@ -68,6 +68,7 @@ public class InterceptorPreHandleAdvice {
               brf.tryCommitBlockingResponse(
                   rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
             }
+            reqCtx.getTraceSegment().effectivelyBlocked();
             t =
                 new BlockingException(
                     "Blocked request (for UriTemplateVariablesHandlerInterceptor/preHandle)");

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/SetupSpecHelper.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/SetupSpecHelper.groovy
@@ -46,6 +46,7 @@ class SetupSpecHelper {
         ServletBlockingHelper
           .commitBlockingResponse(attributes.request, attributes.response, statusCode, templateType, extraHeaders)
       }
+      true
     }
   }
 }

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
@@ -172,6 +172,7 @@ public final class TomcatServerInstrumentation extends Instrumenter.Tracing
         DECORATE.onRequest(span, req, req, ctx);
         Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
         if (rba != null) {
+          span.getRequestContext().getTraceSegment().effectivelyBlocked();
           TomcatBlockingHelper.commitBlockingResponse(req, resp, rba);
           ret = false; // skip pipeline
         }

--- a/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/CommitActionInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/CommitActionInstrumentation.java
@@ -113,6 +113,7 @@ public class CommitActionInstrumentation extends Instrumenter.AppSec
         if (brf != null) {
           brf.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          requestContext.getTraceSegment().effectivelyBlocked();
           thiz.action(ActionCode.ACTION_CLOSE, null);
           return true;
         }

--- a/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/ParsedBodyParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/ParsedBodyParametersInstrumentation.java
@@ -146,6 +146,7 @@ public class ParsedBodyParametersInstrumentation extends Instrumenter.AppSec
                 rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
             if (t == null) {
               t = new BlockingException("Blocked request (for processParameters)");
+              reqCtx.getTraceSegment().effectivelyBlocked();
             }
           }
         }

--- a/dd-java-agent/instrumentation/tomcat-appsec-6/src/main/java/datadog/trace/instrumentation/tomcat6/ParsedBodyParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-6/src/main/java/datadog/trace/instrumentation/tomcat6/ParsedBodyParametersInstrumentation.java
@@ -130,10 +130,14 @@ public class ParsedBodyParametersInstrumentation extends Instrumenter.AppSec
           Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
           BlockResponseFunction blockResponseFunction = reqCtx.getBlockResponseFunction();
           if (blockResponseFunction != null) {
-            blockResponseFunction.tryCommitBlockingResponse(
-                rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
-            if (t == null) {
-              t = new BlockingException("Blocked request (for processParameters)");
+            boolean committedBlockingResponse =
+                blockResponseFunction.tryCommitBlockingResponse(
+                    rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+            if (committedBlockingResponse) {
+              reqCtx.getTraceSegment().effectivelyBlocked();
+              if (t == null) {
+                t = new BlockingException("Blocked request (for processParameters)");
+              }
             }
           }
         }

--- a/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/CommitActionInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/CommitActionInstrumentation.java
@@ -114,6 +114,7 @@ public class CommitActionInstrumentation extends Instrumenter.AppSec
         if (brf != null) {
           brf.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          requestContext.getTraceSegment().effectivelyBlocked();
           thiz.action(ActionCode.CLOSE, null);
           return true;
         }

--- a/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/ParsePartsInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/ParsePartsInstrumentation.java
@@ -118,6 +118,7 @@ public class ParsePartsInstrumentation extends Instrumenter.AppSec
         if (blockResponseFunction != null) {
           blockResponseFunction.tryCommitBlockingResponse(
               rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+          reqCtx.getTraceSegment().effectivelyBlocked();
           if (t == null) {
             t = new BlockingException("Blocked request (for Request/parseParts)");
           }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/PathParameterPublishingHelper.java
@@ -52,6 +52,7 @@ public class PathParameterPublishingHelper {
                 rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
 
             be = new BlockingException("Blocked request (for route/matches)");
+            requestContext.getTraceSegment().effectivelyBlocked();
           }
         }
       }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextJsonAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextJsonAdvice.java
@@ -47,6 +47,7 @@ class RoutingContextJsonAdvice {
       Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
       blockResponseFunction.tryCommitBlockingResponse(
           rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+      reqCtx.getTraceSegment().effectivelyBlocked();
       if (throwable == null) {
         throwable = new BlockingException("Blocked request (for RoutingContextImpl/getBodyAsJson)");
       }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/WafPublishingBodyHandler.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/WafPublishingBodyHandler.java
@@ -72,6 +72,7 @@ public class WafPublishingBodyHandler implements Handler<Buffer> {
         Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
         blockResponseFunction.tryCommitBlockingResponse(
             rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+        reqCtx.getTraceSegment().effectivelyBlocked();
         throw new BlockingException(
             "Blocked request (for Buffer/toString or Buffer/toJson{Object,Array})");
       }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
@@ -49,6 +49,7 @@ public class PathParameterPublishingHelper {
             brf.tryCommitBlockingResponse(
                 rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
 
+            requestContext.getTraceSegment().effectivelyBlocked();
             return new BlockingException("Blocked request (for route/matches)");
           }
         }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextJsonAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextJsonAdvice.java
@@ -47,6 +47,7 @@ class RoutingContextJsonAdvice {
       Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
       blockResponseFunction.tryCommitBlockingResponse(
           rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+      reqCtx.getTraceSegment().effectivelyBlocked();
       if (throwable == null) {
         throwable = new BlockingException("Blocked request (for RoutingContextImpl/getBodyAsJson)");
       }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/WafPublishingBodyHandler.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/WafPublishingBodyHandler.java
@@ -72,6 +72,7 @@ public class WafPublishingBodyHandler implements Handler<Buffer> {
         Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
         blockResponseFunction.tryCommitBlockingResponse(
             rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
+        reqCtx.getTraceSegment().effectivelyBlocked();
         throw new BlockingException(
             "Blocked request (for Buffer/toString or Buffer/toJson{Object,Array})");
       }

--- a/dd-trace-api/src/main/java/datadog/appsec/api/blocking/Blocking.java
+++ b/dd-trace-api/src/main/java/datadog/appsec/api/blocking/Blocking.java
@@ -70,8 +70,10 @@ public class Blocking {
    */
   public static boolean tryCommitBlockingResponse(int statusCode, BlockingContentType contentType) {
     try {
-      return SERVICE.tryCommitBlockingResponse(
-          statusCode, BlockingContentType.NONE, Collections.emptyMap());
+      boolean committedBlockingResponse =
+          SERVICE.tryCommitBlockingResponse(
+              statusCode, BlockingContentType.NONE, Collections.emptyMap());
+      return committedBlockingResponse;
     } catch (Exception e) {
       return false;
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
@@ -55,6 +55,9 @@ public interface TraceSegment {
    */
   void setDataTop(String key, Object value);
 
+  /** Mark the request as effectively blocked, by setting the tag appsec.blocked */
+  void effectivelyBlocked();
+
   /**
    * Add data to the current span in this {@code TraceSegment}. The {@code toString} representation
    * of the {@code value} must be valid top level JSON, i.e. an {@code Object} or an {@code Array}.
@@ -77,6 +80,9 @@ public interface TraceSegment {
 
     @Override
     public void setDataTop(String key, Object value) {}
+
+    @Override
+    public void effectivelyBlocked() {}
 
     @Override
     public void setDataCurrent(String key, Object value) {}

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -857,6 +857,11 @@ public class DDSpanContext
   }
 
   @Override
+  public void effectivelyBlocked() {
+    setTag("appsec.blocked", "true");
+  }
+
+  @Override
   public void setDataCurrent(String key, Object value) {
     // TODO is this decided?
     String tagKey = "_dd." + key + ".json";

--- a/internal-api/src/main/java/datadog/trace/api/http/StoredCharBody.java
+++ b/internal-api/src/main/java/datadog/trace/api/http/StoredCharBody.java
@@ -160,6 +160,7 @@ public class StoredCharBody implements StoredBodySupplier {
         blockResponseFunction.tryCommitBlockingResponse(
             rba.getStatusCode(), rba.getBlockingContentType(), rba.getExtraHeaders());
       }
+      httpContext.getTraceSegment().effectivelyBlocked();
       throw new BlockingException("Blocked request (for request body stream read)");
     }
   }


### PR DESCRIPTION
The tag `appsec.blocked` was being set only in code paths where decorator would invoke the WAF and call `datadog.trace.api.gateway.IGSpanInfo#setRequestBlockingAction`. This was both underinclusive (many blocking advice would not call `setRequestBlockingAction`) and overinclusive (there was no guarantee that the advice would call `datadog.trace.api.gateway.IGSpanInfo#getRequestBlockingAction` or that it would be able to block).

So set the tag closer to where the blocking is actually happening so that the value `appsec.blocked` is more accurate.