### PR TITLE
Fix TestNG instrumentation to use immutable ITestResult.getName() instead of mutable ITestResult.getTestName()

### DIFF
--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -82,8 +82,7 @@ public class TracingListener extends TestNGClassListener
   public void onTestStart(final ITestResult result) {
     String testSuiteName = result.getInstanceName();
     String testName =
-        (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
-    String testQualifier = result.getTestContext().getName();
+        (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
     String testParameters = TestNGUtils.getParameters(result);
     List<String> groups = TestNGUtils.getGroups(result);
 
@@ -94,7 +93,7 @@ public class TracingListener extends TestNGClassListener
     testEventsHandler.onTestStart(
         testSuiteName,
         testName,
-        testQualifier,
+        result,
         null,
         null,
         testParameters,
@@ -109,11 +108,9 @@ public class TracingListener extends TestNGClassListener
     final String testSuiteName = result.getInstanceName();
     final Class<?> testClass = TestNGUtils.getTestClass(result);
     String testName =
-        (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
-    String testQualifier = result.getTestContext().getName();
+        (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
     String testParameters = TestNGUtils.getParameters(result);
-    testEventsHandler.onTestFinish(
-        testSuiteName, testClass, testName, testQualifier, testParameters);
+    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, result, testParameters);
   }
 
   @Override
@@ -121,15 +118,13 @@ public class TracingListener extends TestNGClassListener
     final String testSuiteName = result.getInstanceName();
     final Class<?> testClass = TestNGUtils.getTestClass(result);
     String testName =
-        (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
-    String testQualifier = result.getTestContext().getName();
+        (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
     String testParameters = TestNGUtils.getParameters(result);
 
     final Throwable throwable = result.getThrowable();
     testEventsHandler.onTestFailure(
-        testSuiteName, testClass, testName, testQualifier, testParameters, throwable);
-    testEventsHandler.onTestFinish(
-        testSuiteName, testClass, testName, testQualifier, testParameters);
+        testSuiteName, testClass, testName, result, testParameters, throwable);
+    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, result, testParameters);
   }
 
   @Override
@@ -142,16 +137,14 @@ public class TracingListener extends TestNGClassListener
     final String testSuiteName = result.getInstanceName();
     final Class<?> testClass = TestNGUtils.getTestClass(result);
     String testName =
-        (result.getTestName() != null) ? result.getTestName() : result.getMethod().getMethodName();
-    String testQualifier = result.getTestContext().getName();
+        (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
     String testParameters = TestNGUtils.getParameters(result);
 
     // Typically the way of skipping a TestNG test is throwing a SkipException
     Throwable throwable = result.getThrowable();
     String reason = throwable != null ? throwable.getMessage() : null;
     testEventsHandler.onTestSkip(
-        testSuiteName, testClass, testName, testQualifier, testParameters, reason);
-    testEventsHandler.onTestFinish(
-        testSuiteName, testClass, testName, testQualifier, testParameters);
+        testSuiteName, testClass, testName, result, testParameters, reason);
+    testEventsHandler.onTestFinish(testSuiteName, testClass, testName, result, testParameters);
   }
 }


### PR DESCRIPTION
# What Does This Do
Fixes two issues in TestNG instrumentation:
* `ITestResult.getName()` is used for test case names instead of `ITestResult.getTestName()`: the latter is mutable - if a customer modifies test name during execution (for instance, using TestNG event hooks), the same test might have a different name on start and on finish, which breaks CI Vis logic
* Entire `ITestResult` is used as test qualifier instead of `ITestResult.getTestContext().getName()`: it is possible to have test cases with the same test case name in the same TestNG Test (for instance, if the test class overrides `ITest` and supplies the same name for each of its test case methods)

# Motivation
If these issues are not addressed, it is not always possible to look up the correct test span when test finish event is triggered in TestNG