### PR TITLE
Only check CLIENT/SERVER_ERROR_STATUSES when we know we have a status to check

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -89,9 +89,9 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends UriBasedCli
       final int status = status(response);
       if (status > UNSET_STATUS) {
         span.setHttpStatusCode(status);
-      }
-      if (CLIENT_ERROR_STATUSES.get(status)) {
-        span.setError(true);
+        if (CLIENT_ERROR_STATUSES.get(status)) {
+          span.setError(true);
+        }
       }
     }
     return span;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -294,14 +294,14 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   public AgentSpan onResponseStatus(final AgentSpan span, final int status) {
     if (status > UNSET_STATUS) {
       span.setHttpStatusCode(status);
-    }
-    // explicitly set here because some other decorators might already set an error without
-    // looking at the status code
-    // XXX: the logic is questionable: span.error becomes equivalent to status 5xx,
-    // even if the server chooses not to respond with 5xx to an error.
-    // Anyway, we def don't want it applied to blocked requests
-    if (!BlockingException.class.getName().equals(span.getTag("error.type"))) {
-      span.setError(SERVER_ERROR_STATUSES.get(status), ErrorPriorities.HTTP_SERVER_DECORATOR);
+      // explicitly set here because some other decorators might already set an error without
+      // looking at the status code
+      // XXX: the logic is questionable: span.error becomes equivalent to status 5xx,
+      // even if the server chooses not to respond with 5xx to an error.
+      // Anyway, we def don't want it applied to blocked requests
+      if (!BlockingException.class.getName().equals(span.getTag("error.type"))) {
+        span.setError(SERVER_ERROR_STATUSES.get(status), ErrorPriorities.HTTP_SERVER_DECORATOR);
+      }
     }
 
     if (SHOULD_SET_404_RESOURCE_NAME && status == 404) {

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -303,8 +303,6 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     then:
     if (status) {
       1 * this.span.setHttpStatusCode(status)
-    }
-    if (resp) {
       1 * this.span.setError(error, ErrorPriorities.HTTP_SERVER_DECORATOR)
     }
     if (status == 404) {


### PR DESCRIPTION
Avoids a potential exception if the status retrieved by an instrumentation was ever negative.
