### PR TITLE
Add IBM Informix support to JDBC instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DBMCompatibleConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DBMCompatibleConnectionInstrumentation.java
@@ -69,6 +69,8 @@ public class DBMCompatibleConnectionInstrumentation extends AbstractConnectionIn
     "net.sourceforge.jtds.jdbc.JtdsConnection", // 1.3
     // aws-mysql-jdbc
     "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.jdbc.ConnectionImpl",
+    // IBM Informix
+    "com.informix.jdbc.IfmxConnection",
   };
 
   @Override

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -114,6 +114,8 @@ public final class PreparedStatementInstrumentation extends AbstractPreparedStat
     "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.jdbc.PreparedStatement",
     "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.jdbc.ServerPreparedStatement",
     "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.JdbcCallableStatement",
+    // IBM Informix
+    "com.informix.jdbc.IfxPreparedStatement",
     // for testing purposes
     "test.TestPreparedStatement"
   };


### PR DESCRIPTION
# What Does This Do

This PR adds IBM Informix to JBDC instrumentation.

# Motivation

A customer asked for supporting this database and tested the change using `dd.trace.jdbc.connection.class.name=com.informix.jdbc.IfmxConnection` and `dd.trace.jdbc.prepared.statement.class.name=com.informix.jdbc.IfxPreparedStatement` properties.

# Additional Notes
