### PR TITLE
Fix span metric names

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricsImpl.java
+++ b/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricsImpl.java
@@ -18,8 +18,8 @@ public class SpanMetricsImpl implements SpanMetrics {
     this.spanCreatedCounter = new AtomicLong(0);
     this.spanFinishedCounter = new AtomicLong(0);
     List<CoreCounter> coreCounters = new ArrayList<>(2);
-    coreCounters.add(new SpanCounter("span_created", this.spanCreatedCounter));
-    coreCounters.add(new SpanCounter("span_finished", this.spanFinishedCounter));
+    coreCounters.add(new SpanCounter("spans_created", this.spanCreatedCounter));
+    coreCounters.add(new SpanCounter("spans_finished", this.spanFinishedCounter));
     this.coreCounters = Collections.unmodifiableList(coreCounters);
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/TelemetryCollectorsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/TelemetryCollectorsTest.groovy
@@ -208,14 +208,14 @@ class TelemetryCollectorsTest extends DDSpecification {
     spanCreatedMetric.type == 'count'
     spanCreatedMetric.value == 2
     spanCreatedMetric.namespace == 'tracers'
-    spanCreatedMetric.metricName == 'span_created'
+    spanCreatedMetric.metricName == 'spans_created'
     spanCreatedMetric.tags == ['test-update-drain']
 
     def spanFinishedMetric = metrics[1]
     spanFinishedMetric.type == 'count'
     spanFinishedMetric.value == 1
     spanFinishedMetric.namespace == 'tracers'
-    spanFinishedMetric.metricName == 'span_finished'
+    spanFinishedMetric.metricName == 'spans_finished'
     spanFinishedMetric.tags == ['test-update-drain']
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/CoreMetricsPeriodActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/CoreMetricsPeriodActionTest.groovy
@@ -32,13 +32,13 @@ class CoreMetricsPeriodActionTest extends Specification {
 
     then:
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-1', 2)
+      assertMetric(metric, 'spans_created', 'instr-1', 2)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-2', 3)
+      assertMetric(metric, 'spans_created', 'instr-2', 3)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-2', 4)
+      assertMetric(metric, 'spans_finished', 'instr-2', 4)
     })
     0 * _
   }
@@ -71,34 +71,34 @@ class CoreMetricsPeriodActionTest extends Specification {
 
     then:
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-1', 1)
+      assertMetric(metric, 'spans_created', 'instr-1', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-2', 1)
+      assertMetric(metric, 'spans_created', 'instr-2', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-3', 1)
+      assertMetric(metric, 'spans_created', 'instr-3', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-3', 1)
+      assertMetric(metric, 'spans_finished', 'instr-3', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-a', 1)
+      assertMetric(metric, 'spans_created', 'instr-a', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-b', 1)
+      assertMetric(metric, 'spans_created', 'instr-b', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-b', 1)
+      assertMetric(metric, 'spans_finished', 'instr-b', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-2', 1)
+      assertMetric(metric, 'spans_finished', 'instr-2', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-a', 1)
+      assertMetric(metric, 'spans_finished', 'instr-a', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-1', 1)
+      assertMetric(metric, 'spans_finished', 'instr-1', 1)
     })
     0 * _
   }
@@ -131,34 +131,34 @@ class CoreMetricsPeriodActionTest extends Specification {
 
     then:
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-1', 1)
+      assertMetric(metric, 'spans_created', 'instr-1', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-2', 1)
+      assertMetric(metric, 'spans_created', 'instr-2', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-3', 1)
+      assertMetric(metric, 'spans_created', 'instr-3', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-3', 1)
+      assertMetric(metric, 'spans_finished', 'instr-3', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-a', 1)
+      assertMetric(metric, 'spans_created', 'instr-a', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_created', 'instr-b', 1)
+      assertMetric(metric, 'spans_created', 'instr-b', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-b', 1)
+      assertMetric(metric, 'spans_finished', 'instr-b', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-2', 1)
+      assertMetric(metric, 'spans_finished', 'instr-2', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-a', 1)
+      assertMetric(metric, 'spans_finished', 'instr-a', 1)
     })
     1 * telemetryService.addMetric({ Metric metric ->
-      assertMetric(metric, 'span_finished', 'instr-1', 1)
+      assertMetric(metric, 'spans_finished', 'instr-1', 1)
     })
     0 * _
   }


### PR DESCRIPTION
# What Does This Do

This PR fixes the metric names for created and finished spans.

# Motivation

This span metric names changes from the RFC to comply with _telemetry naming conventions_.

# Additional Notes
