### PR TITLE
Refactor dynamic-config internals to be more null-safe

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/TraceConfigExitWatcher.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/TraceConfigExitWatcher.java
@@ -1,14 +1,12 @@
 package datadog.trace.agent.jmxfetch;
 
-import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import org.datadog.jmxfetch.ExitWatcher;
 
 public final class TraceConfigExitWatcher extends ExitWatcher {
   @Override
   public boolean shouldExit() {
-    TraceConfig traceConfig = AgentTracer.traceConfig();
-    // assume JMXFetch shouldn't exit if tracer hasn't been installed yet
-    return null != traceConfig && !traceConfig.isRuntimeMetricsEnabled();
+    // only stop JMXFetch when the registered tracer says that metrics have been disabled
+    return AgentTracer.isRegistered() && !AgentTracer.traceConfig().isRuntimeMetricsEnabled();
   }
 }

--- a/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/LoggerNodeInstrumentation.java
+++ b/dd-java-agent/instrumentation/jboss-logmanager/src/main/java/datadog/trace/instrumentation/jbosslogmanager/LoggerNodeInstrumentation.java
@@ -2,13 +2,13 @@ package datadog.trace.instrumentation.jbosslogmanager;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -52,12 +52,9 @@ public class LoggerNodeInstrumentation extends Instrumenter.Tracing
 
       AgentSpan span = activeSpan();
 
-      if (span != null) {
-        TraceConfig traceConfig = span.traceConfig();
-        if (traceConfig != null && traceConfig.isLogsInjectionEnabled()) {
-          InstrumentationContext.get(ExtLogRecord.class, AgentSpan.Context.class)
-              .put(record, span.context());
-        }
+      if (span != null && traceConfig(span).isLogsInjectionEnabled()) {
+        InstrumentationContext.get(ExtLogRecord.class, AgentSpan.Context.class)
+            .put(record, span.context());
       }
 
       return true;

--- a/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/SpanDecoratingContextDataInjector.java
+++ b/dd-java-agent/instrumentation/log4j-2.7/src/main/java/datadog/trace/instrumentation/log4j27/SpanDecoratingContextDataInjector.java
@@ -5,6 +5,7 @@
 package datadog.trace.instrumentation.log4j27;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.CorrelationIdentifier;
@@ -12,7 +13,6 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.util.List;
 import org.apache.logging.log4j.core.ContextDataInjector;
@@ -34,7 +34,7 @@ public final class SpanDecoratingContextDataInjector implements ContextDataInjec
 
     AgentSpan span = activeSpan();
 
-    if (!AgentTracer.traceConfig(span).isLogsInjectionEnabled()) {
+    if (!traceConfig(span).isLogsInjectionEnabled()) {
       return contextData;
     }
 

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/CategoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/CategoryInstrumentation.java
@@ -7,6 +7,7 @@ package datadog.trace.instrumentation.log4j1;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -15,7 +16,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -55,13 +55,9 @@ public class CategoryInstrumentation extends Instrumenter.Tracing
     public static void onEnter(@Advice.Argument(0) LoggingEvent event) {
       AgentSpan span = activeSpan();
 
-      if (span != null) {
-        TraceConfig traceConfig = span.traceConfig();
-
-        if (traceConfig != null && traceConfig.isLogsInjectionEnabled()) {
-          InstrumentationContext.get(LoggingEvent.class, AgentSpan.Context.class)
-              .put(event, span.context());
-        }
+      if (span != null && traceConfig(span).isLogsInjectionEnabled()) {
+        InstrumentationContext.get(LoggingEvent.class, AgentSpan.Context.class)
+            .put(event, span.context());
       }
     }
   }

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LogbackLoggerInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LogbackLoggerInstrumentation.java
@@ -7,6 +7,7 @@ package datadog.trace.instrumentation.logback;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.traceConfig;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -16,7 +17,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -57,13 +57,9 @@ public class LogbackLoggerInstrumentation extends Instrumenter.Tracing
     public static void onEnter(@Advice.Argument(0) ILoggingEvent event) {
       AgentSpan span = activeSpan();
 
-      if (span != null) {
-        TraceConfig traceConfig = span.traceConfig();
-
-        if (traceConfig != null && traceConfig.isLogsInjectionEnabled()) {
-          InstrumentationContext.get(ILoggingEvent.class, AgentSpan.Context.class)
-              .put(event, span.context());
-        }
+      if (span != null && traceConfig(span).isLogsInjectionEnabled()) {
+        InstrumentationContext.get(ILoggingEvent.class, AgentSpan.Context.class)
+            .put(event, span.context());
       }
     }
   }

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -59,6 +59,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentTrace",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentHistogram",
+  "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopTraceConfig",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI",
   "datadog.trace.bootstrap.instrumentation.api.NoopDataStreamsMonitoring",
   "datadog.trace.bootstrap.instrumentation.api.Backlog",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -117,13 +117,7 @@ public class AgentTracer {
   }
 
   public static TraceConfig traceConfig(final AgentSpan span) {
-    if (null != span) {
-      TraceConfig traceConfig = span.traceConfig();
-      if (null != traceConfig) {
-        return traceConfig;
-      }
-    }
-    return get().captureTraceConfig();
+    return null != span ? span.traceConfig() : traceConfig();
   }
 
   public static TraceConfig traceConfig() {
@@ -568,7 +562,7 @@ public class AgentTracer {
 
     @Override
     public TraceConfig captureTraceConfig() {
-      return null;
+      return NoopTraceConfig.INSTANCE;
     }
 
     @Override
@@ -865,7 +859,7 @@ public class AgentTracer {
 
     @Override
     public TraceConfig traceConfig() {
-      return null;
+      return NoopTraceConfig.INSTANCE;
     }
   }
 
@@ -1165,6 +1159,56 @@ public class AgentTracer {
 
     @Override
     public ByteBuffer serialize() {
+      return null;
+    }
+  }
+
+  /** TraceConfig when there is no tracer; this is not the same as a default config. */
+  public static final class NoopTraceConfig implements TraceConfig {
+    public static final NoopTraceConfig INSTANCE = new NoopTraceConfig();
+
+    @Override
+    public boolean isDebugEnabled() {
+      return false;
+    }
+
+    @Override
+    public boolean isRuntimeMetricsEnabled() {
+      return false;
+    }
+
+    @Override
+    public boolean isLogsInjectionEnabled() {
+      return false;
+    }
+
+    @Override
+    public boolean isDataStreamsEnabled() {
+      return false;
+    }
+
+    @Override
+    public Map<String, String> getServiceMapping() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<String, String> getRequestHeaderTags() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<String, String> getResponseHeaderTags() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public Map<String, String> getBaggageMapping() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public Double getTraceSampleRate() {
       return null;
     }
   }


### PR DESCRIPTION
* Introduce `NoopTraceConfig` for when there is no tracer
* Remove redundant null-checks to simplify the code