### PR TITLE
Implement Intelligent Test Runner metadata tags

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
@@ -150,6 +150,9 @@ public class DDTestImpl implements DDTest {
     span.setTag(Tags.TEST_STATUS, CIConstants.TEST_SKIP);
     if (skipReason != null) {
       span.setTag(Tags.TEST_SKIP_REASON, skipReason);
+      if (skipReason.equals(InstrumentationBridge.ITR_SKIP_REASON)) {
+        span.setTag(Tags.TEST_SKIPPED_BY_ITR, true);
+      }
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleChild.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleChild.java
@@ -82,8 +82,10 @@ public class DDTestModuleChild extends DDTestModuleImpl {
     long sessionId = context.getParentId();
     boolean coverageEnabled = config.isCiVisibilityCodeCoverageEnabled();
     boolean itrEnabled = config.isCiVisibilityItrEnabled();
+    long testsSkippedTotal = testsSkipped.sum();
     ModuleExecutionResult moduleExecutionResult =
-        new ModuleExecutionResult(sessionId, moduleId, coverageEnabled, itrEnabled, testsSkipped);
+        new ModuleExecutionResult(
+            sessionId, moduleId, coverageEnabled, itrEnabled, testsSkippedTotal);
 
     try (SignalClient signalClient = new SignalClient(signalServerAddress)) {
       signalClient.send(moduleExecutionResult);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleImpl.java
@@ -11,6 +11,7 @@ import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.source.MethodLinesResolver;
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.concurrent.atomic.LongAdder;
 import javax.annotation.Nullable;
 
 public abstract class DDTestModuleImpl implements DDTestModule {
@@ -23,7 +24,7 @@ public abstract class DDTestModuleImpl implements DDTestModule {
   protected final MethodLinesResolver methodLinesResolver;
   @Nullable protected final InetSocketAddress signalServerAddress;
 
-  protected volatile boolean testsSkipped;
+  protected final LongAdder testsSkipped = new LongAdder();
   private volatile Collection<SkippableTest> skippableTests;
   private final Object skippableTestsInitLock = new Object();
 
@@ -81,7 +82,7 @@ public abstract class DDTestModuleImpl implements DDTestModule {
     }
 
     if (skippableTests.contains(test)) {
-      testsSkipped = true;
+      testsSkipped.increment();
       return true;
     } else {
       return false;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleParent.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleParent.java
@@ -129,8 +129,11 @@ public class DDTestModuleParent extends DDTestModuleImpl {
     }
     span.setTag(Tags.TEST_STATUS, context.getStatus());
 
-    if (testsSkipped) {
+    long testsSkippedTotal = testsSkipped.sum();
+    if (testsSkippedTotal > 0) {
       setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
+      setTag(Tags.TEST_ITR_TESTS_SKIPPING_TYPE, "test");
+      setTag(Tags.TEST_ITR_TESTS_SKIPPING_COUNT, testsSkippedTotal);
     }
 
     Object testFramework = context.getChildTag(Tags.TEST_FRAMEWORK);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleParent.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleParent.java
@@ -18,6 +18,7 @@ import datadog.trace.civisibility.config.ModuleExecutionSettingsFactory;
 import datadog.trace.civisibility.context.SpanTestContext;
 import datadog.trace.civisibility.context.TestContext;
 import datadog.trace.civisibility.decorator.TestDecorator;
+import datadog.trace.civisibility.ipc.ModuleExecutionResult;
 import datadog.trace.civisibility.source.MethodLinesResolver;
 import java.net.InetSocketAddress;
 import java.util.Collection;
@@ -40,6 +41,8 @@ public class DDTestModuleParent extends DDTestModuleImpl {
   @Nullable private final TestContext sessionContext;
   @Nullable private final TestModuleRegistry testModuleRegistry;
   private final ModuleExecutionSettingsFactory moduleExecutionSettingsFactory;
+  private volatile boolean codeCoverageEnabled;
+  private volatile boolean itrEnabled;
 
   public DDTestModuleParent(
       @Nullable TestContext sessionContext,
@@ -129,11 +132,18 @@ public class DDTestModuleParent extends DDTestModuleImpl {
     }
     span.setTag(Tags.TEST_STATUS, context.getStatus());
 
-    long testsSkippedTotal = testsSkipped.sum();
-    if (testsSkippedTotal > 0) {
-      setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
+    if (codeCoverageEnabled) {
+      setTag(Tags.TEST_CODE_COVERAGE_ENABLED, true);
+    }
+    if (itrEnabled) {
+      setTag(Tags.TEST_ITR_TESTS_SKIPPING_ENABLED, true);
       setTag(Tags.TEST_ITR_TESTS_SKIPPING_TYPE, "test");
+
+      long testsSkippedTotal = testsSkipped.sum();
       setTag(Tags.TEST_ITR_TESTS_SKIPPING_COUNT, testsSkippedTotal);
+      if (testsSkippedTotal > 0) {
+        setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
+      }
     }
 
     Object testFramework = context.getChildTag(Tags.TEST_FRAMEWORK);
@@ -159,18 +169,20 @@ public class DDTestModuleParent extends DDTestModuleImpl {
     ModuleExecutionSettings moduleExecutionSettings =
         moduleExecutionSettingsFactory.create(JvmInfo.CURRENT_JVM, moduleName);
     Map<String, String> systemProperties = moduleExecutionSettings.getSystemProperties();
-    if (propertyEnabled(systemProperties, CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_ENABLED)) {
-      setTag(Tags.TEST_CODE_COVERAGE_ENABLED, true);
-    }
-    if (propertyEnabled(systemProperties, CiVisibilityConfig.CIVISIBILITY_ITR_ENABLED)) {
-      setTag(Tags.TEST_ITR_TESTS_SKIPPING_ENABLED, true);
-    }
-
+    codeCoverageEnabled =
+        propertyEnabled(systemProperties, CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_ENABLED);
+    itrEnabled = propertyEnabled(systemProperties, CiVisibilityConfig.CIVISIBILITY_ITR_ENABLED);
     return new HashSet<>(moduleExecutionSettings.getSkippableTests(moduleName));
   }
 
   private boolean propertyEnabled(Map<String, String> systemProperties, String propertyName) {
     String property = systemProperties.get(propertyName);
     return Boolean.parseBoolean(property);
+  }
+
+  public void onModuleExecutionResultReceived(ModuleExecutionResult result) {
+    codeCoverageEnabled = result.isCoverageEnabled();
+    itrEnabled = result.isItrEnabled();
+    testsSkipped.add(result.getTestsSkippedTotal());
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
@@ -32,6 +32,7 @@ import datadog.trace.civisibility.source.MethodLinesResolver;
 import datadog.trace.civisibility.source.index.RepoIndex;
 import datadog.trace.civisibility.source.index.RepoIndexBuilder;
 import java.util.Collection;
+import java.util.concurrent.atomic.LongAdder;
 import javax.annotation.Nullable;
 
 public class DDTestSessionImpl implements DDTestSession {
@@ -47,6 +48,7 @@ public class DDTestSessionImpl implements DDTestSession {
   private final ModuleExecutionSettingsFactory moduleExecutionSettingsFactory;
   private final SignalServer signalServer;
   private final RepoIndexBuilder repoIndexBuilder;
+  protected final LongAdder testsSkipped = new LongAdder();
 
   public DDTestSessionImpl(
       String projectName,
@@ -105,9 +107,7 @@ public class DDTestSessionImpl implements DDTestSession {
     if (result.isItrEnabled()) {
       setTag(Tags.TEST_ITR_TESTS_SKIPPING_ENABLED, true);
     }
-    if (result.isItrTestsSkipped()) {
-      setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
-    }
+    testsSkipped.add(result.getTestsSkippedTotal());
     return testModuleRegistry.onModuleExecutionResultReceived(result);
   }
 
@@ -161,6 +161,13 @@ public class DDTestSessionImpl implements DDTestSession {
     String status = context.getStatus();
     span.setTag(Tags.TEST_STATUS, status != null ? status : CIConstants.TEST_SKIP);
     testDecorator.beforeFinish(span);
+
+    long testsSkippedTotal = testsSkipped.sum();
+    if (testsSkippedTotal > 0) {
+      setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
+      setTag(Tags.TEST_ITR_TESTS_SKIPPING_TYPE, "test");
+      setTag(Tags.TEST_ITR_TESTS_SKIPPING_COUNT, testsSkippedTotal);
+    }
 
     if (endTime != null) {
       span.finish(endTime);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
@@ -47,8 +47,11 @@ public class TestModuleRegistry {
     if (result.isItrEnabled()) {
       module.setTag(Tags.TEST_ITR_TESTS_SKIPPING_ENABLED, true);
     }
-    if (result.isItrTestsSkipped()) {
+    long testsSkippedTotal = result.getTestsSkippedTotal();
+    if (testsSkippedTotal > 0) {
       module.setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
+      module.setTag(Tags.TEST_ITR_TESTS_SKIPPING_TYPE, "test");
+      module.setTag(Tags.TEST_ITR_TESTS_SKIPPING_COUNT, testsSkippedTotal);
     }
     return AckResponse.INSTANCE;
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
@@ -5,28 +5,27 @@ import java.util.Objects;
 
 public class ModuleExecutionResult implements Signal {
 
-  private static final int SERIALIZED_LENGTH = Long.BYTES + Long.BYTES + 1;
+  private static final int SERIALIZED_LENGTH = Long.BYTES + Long.BYTES + Long.BYTES + 1;
   private static final int COVERAGE_ENABLED_FLAG = 1;
   private static final int ITR_ENABLED_FLAG = 2;
-  private static final int ITR_TESTS_SKIPPED_FLAG = 4;
 
   private final long sessionId;
   private final long moduleId;
   private final boolean coverageEnabled;
   private final boolean itrEnabled;
-  private final boolean itrTestsSkipped;
+  private final long testsSkippedTotal;
 
   public ModuleExecutionResult(
       long sessionId,
       long moduleId,
       boolean coverageEnabled,
       boolean itrEnabled,
-      boolean itrTestsSkipped) {
+      long testsSkippedTotal) {
     this.sessionId = sessionId;
     this.moduleId = moduleId;
     this.coverageEnabled = coverageEnabled;
     this.itrEnabled = itrEnabled;
-    this.itrTestsSkipped = itrTestsSkipped;
+    this.testsSkippedTotal = testsSkippedTotal;
   }
 
   public long getSessionId() {
@@ -45,8 +44,8 @@ public class ModuleExecutionResult implements Signal {
     return itrEnabled;
   }
 
-  public boolean isItrTestsSkipped() {
-    return itrTestsSkipped;
+  public long getTestsSkippedTotal() {
+    return testsSkippedTotal;
   }
 
   @Override
@@ -62,12 +61,12 @@ public class ModuleExecutionResult implements Signal {
         && moduleId == that.moduleId
         && coverageEnabled == that.coverageEnabled
         && itrEnabled == that.itrEnabled
-        && itrTestsSkipped == that.itrTestsSkipped;
+        && testsSkippedTotal == that.testsSkippedTotal;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(sessionId, moduleId, coverageEnabled, itrEnabled, itrEnabled);
+    return Objects.hash(sessionId, moduleId, coverageEnabled, itrEnabled, testsSkippedTotal);
   }
 
   @Override
@@ -82,7 +81,7 @@ public class ModuleExecutionResult implements Signal {
         + ", itrEnabled="
         + itrEnabled
         + ", itrTestsSkipped="
-        + itrTestsSkipped
+        + testsSkippedTotal
         + '}';
   }
 
@@ -96,6 +95,7 @@ public class ModuleExecutionResult implements Signal {
     ByteBuffer buffer = ByteBuffer.allocate(SERIALIZED_LENGTH);
     buffer.putLong(sessionId);
     buffer.putLong(moduleId);
+    buffer.putLong(testsSkippedTotal);
 
     byte flags = 0;
     if (coverageEnabled) {
@@ -103,9 +103,6 @@ public class ModuleExecutionResult implements Signal {
     }
     if (itrEnabled) {
       flags |= ITR_ENABLED_FLAG;
-    }
-    if (itrTestsSkipped) {
-      flags |= ITR_TESTS_SKIPPED_FLAG;
     }
     buffer.put(flags);
     buffer.flip();
@@ -119,11 +116,11 @@ public class ModuleExecutionResult implements Signal {
     }
     long sessionId = buffer.getLong();
     long moduleId = buffer.getLong();
+    long testsSkippedTotal = buffer.getLong();
     int flags = buffer.get();
     boolean coverageEnabled = (flags & COVERAGE_ENABLED_FLAG) != 0;
     boolean itrEnabled = (flags & ITR_ENABLED_FLAG) != 0;
-    boolean itrTestsSkipped = (flags & ITR_TESTS_SKIPPED_FLAG) != 0;
     return new ModuleExecutionResult(
-        sessionId, moduleId, coverageEnabled, itrEnabled, itrTestsSkipped);
+        sessionId, moduleId, coverageEnabled, itrEnabled, testsSkippedTotal);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
@@ -16,11 +16,11 @@ class ModuleExecutionResultTest extends Specification {
 
     where:
     signal << [
-      new ModuleExecutionResult(12345, 67890, false, false, false),
-      new ModuleExecutionResult(12345, 67890, true, false, false),
-      new ModuleExecutionResult(12345, 67890, false, true, false),
-      new ModuleExecutionResult(12345, 67890, false, false, true),
-      new ModuleExecutionResult(12345, 67890, true, true, true)
+      new ModuleExecutionResult(12345, 67890, false, false, 0),
+      new ModuleExecutionResult(12345, 67890, true, false, 1),
+      new ModuleExecutionResult(12345, 67890, false, true, 2),
+      new ModuleExecutionResult(12345, 67890, false, false, 3),
+      new ModuleExecutionResult(12345, 67890, true, true, Integer.MAX_VALUE)
     ]
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
@@ -9,7 +9,7 @@ class SignalServerTest extends Specification {
   def "test message send and receive"() {
     given:
     def signalProcessed = new AtomicBoolean(false)
-    def signal = new ModuleExecutionResult(123, 456, true, true, true)
+    def signal = new ModuleExecutionResult(123, 456, true, true, 1)
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -38,8 +38,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple messages send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(123, 456, false, false, false)
-    def signalB = new ModuleExecutionResult(234, 567, true, true, true)
+    def signalA = new ModuleExecutionResult(123, 456, false, false, 0)
+    def signalB = new ModuleExecutionResult(234, 567, true, true, 1)
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -67,8 +67,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple clients send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(123, 456, true, false, true)
-    def signalB = new ModuleExecutionResult(234, 567, false, true, false)
+    def signalA = new ModuleExecutionResult(123, 456, true, false, 1)
+    def signalB = new ModuleExecutionResult(234, 567, false, true, 0)
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -115,7 +115,7 @@ class SignalServerTest extends Specification {
     when:
     def address = server.getAddress()
     try (def client = new SignalClient(address, clientTimeoutMillis)) {
-      client.send(new ModuleExecutionResult(123, 456, false, false, false))
+      client.send(new ModuleExecutionResult(123, 456, false, false, 0))
     }
 
     then:
@@ -127,7 +127,7 @@ class SignalServerTest extends Specification {
 
   def "test error response receipt"() {
     given:
-    def signal = new ModuleExecutionResult(123, 456, true, true, true)
+    def signal = new ModuleExecutionResult(123, 456, true, true, 1)
     def server = new SignalServer()
 
     def errorResponse = new ErrorResponse("An error occurred while processing the signal")

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
@@ -106,8 +106,12 @@ abstract class CiVisibilityTest extends AgentTestRunner {
     InstrumentationBridge.registerCoverageProbeStoreFactory(new NoopCoverageProbeStore.NoopCoverageProbeStoreFactory())
   }
 
-  def givenSkippableTests(List<SkippableTest> tests) {
+  @Override
+  void setup() {
     skippableTests.clear()
+  }
+
+  def givenSkippableTests(List<SkippableTest> tests) {
     skippableTests.addAll(tests)
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
@@ -63,9 +63,13 @@ abstract class CiVisibilityTest extends AgentTestRunner {
     def methodLinesResolver = Stub(MethodLinesResolver)
     methodLinesResolver.getLines(_) >> new MethodLinesResolver.MethodLines(DUMMY_TEST_METHOD_START, DUMMY_TEST_METHOD_END)
 
-    def moduleExecutionSettings = new ModuleExecutionSettings(Collections.emptyMap(), Collections.singletonMap(dummyModule, skippableTests))
     def moduleExecutionSettingsFactory = Stub(ModuleExecutionSettingsFactory)
-    moduleExecutionSettingsFactory.create(_, _) >> moduleExecutionSettings
+    moduleExecutionSettingsFactory.create(_, _) >> {
+      Map<String, String> properties = [
+        (CiVisibilityConfig.CIVISIBILITY_ITR_ENABLED) : String.valueOf(!skippableTests.isEmpty())
+      ]
+      return new ModuleExecutionSettings(properties, Collections.singletonMap(dummyModule, skippableTests))
+    }
 
     CIVisibility.registerSessionFactory (String projectName, Path projectRoot, String component, Long startTime) -> {
       def ciTags = [(DUMMY_CI_TAG): DUMMY_CI_TAG_VALUE]

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
@@ -325,7 +325,7 @@ abstract class CiVisibilityTest extends AgentTestRunner {
   final String testName,
   final String testMethod,
   final String testStatus,
-  final Map<String, String> testTags = null,
+  final Map<String, Object> testTags = null,
   final Throwable exception = null,
   final boolean emptyDuration = false, final Collection<String> categories = null) {
     def testFramework = expectedTestFramework()

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/SkippedByItr.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/SkippedByItr.java
@@ -1,12 +1,13 @@
 package datadog.trace.instrumentation.junit4;
 
+import datadog.trace.api.civisibility.InstrumentationBridge;
 import java.lang.annotation.Annotation;
 import org.junit.Ignore;
 
 public final class SkippedByItr implements Ignore {
   @Override
   public String value() {
-    return "Skipped by Datadog Intelligent Test Runner";
+    return InstrumentationBridge.ITR_SKIP_REASON;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -438,6 +438,7 @@ class JUnit4Test extends CiVisibilityTest {
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
           (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
           (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
           (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 2,
         ])
@@ -471,6 +472,7 @@ class JUnit4Test extends CiVisibilityTest {
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
           (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
           (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
           (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -437,7 +437,9 @@ class JUnit4Test extends CiVisibilityTest {
       long testSuiteId
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
-          (DDTags.CI_ITR_TESTS_SKIPPED): true
+          (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 2,
         ])
         testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestFailedAndSucceed", CIConstants.TEST_PASS)
       }
@@ -468,7 +470,9 @@ class JUnit4Test extends CiVisibilityTest {
       long testSuiteId
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
-          (DDTags.CI_ITR_TESTS_SKIPPED): true
+          (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])
         testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestParameterized", CIConstants.TEST_PASS)
       }

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -453,7 +453,7 @@ class JUnit4Test extends CiVisibilityTest {
     })
 
     where:
-    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner", (Tags.TEST_SKIPPED_BY_ITR): true ]
   }
 
   def "test ITR skipping for parameterized"() {
@@ -483,7 +483,8 @@ class JUnit4Test extends CiVisibilityTest {
     where:
     testTags_0 = [
       (Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}',
-      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"
+      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner",
+      (Tags.TEST_SKIPPED_BY_ITR): true
     ]
     testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
   }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5ItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5ItrInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.config.SkippableTest;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Set;
@@ -72,7 +73,7 @@ public class JUnit5ItrInstrumentation extends Instrumenter.CiVisibility
 
       SkippableTest test = TestFrameworkUtils.toSkippableTest(testDescriptor);
       if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(test)) {
-        skipResult = Node.SkipResult.skip("Skipped by Datadog Intelligent Test Runner");
+        skipResult = Node.SkipResult.skip(InstrumentationBridge.ITR_SKIP_REASON);
       }
     }
 

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -591,6 +591,7 @@ class JUnit5Test extends CiVisibilityTest {
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
           (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
           (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
           (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 2,
         ])
@@ -625,6 +626,7 @@ class JUnit5Test extends CiVisibilityTest {
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
           (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
           (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
           (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -590,7 +590,9 @@ class JUnit5Test extends CiVisibilityTest {
       long testSuiteId
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
-          (DDTags.CI_ITR_TESTS_SKIPPED): true
+          (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 2,
         ])
         testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestFailedAndSucceed", CIConstants.TEST_PASS)
       }
@@ -622,7 +624,9 @@ class JUnit5Test extends CiVisibilityTest {
       long testSuiteId
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
-          (DDTags.CI_ITR_TESTS_SKIPPED): true
+          (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])
         testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestParameterized", CIConstants.TEST_PASS)
       }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -606,7 +606,7 @@ class JUnit5Test extends CiVisibilityTest {
     })
 
     where:
-    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner", (Tags.TEST_SKIPPED_BY_ITR): true]
   }
 
   def "test ITR skipping for parameterized tests"() {
@@ -637,7 +637,8 @@ class JUnit5Test extends CiVisibilityTest {
     where:
     testTags_0 = [
       (Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"[1] 0, 0, 0, some:\\\"parameter\\\""}}',
-      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"
+      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner",
+      (Tags.TEST_SKIPPED_BY_ITR): true
     ]
     testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"[2] 1, 1, 2, some:\\\"parameter\\\""}}']
   }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
@@ -78,7 +78,9 @@ class SpockTest extends CiVisibilityTest {
       long testSuiteId
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_SKIP, [
-          (DDTags.CI_ITR_TESTS_SKIPPED): true
+          (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])
         testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestSucceedSpock", CIConstants.TEST_SKIP)
       }
@@ -104,7 +106,9 @@ class SpockTest extends CiVisibilityTest {
       long testSuiteId
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
-          (DDTags.CI_ITR_TESTS_SKIPPED): true
+          (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])
         testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestParameterizedSpock", CIConstants.TEST_PASS)
       }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
@@ -88,7 +88,7 @@ class SpockTest extends CiVisibilityTest {
     })
 
     where:
-    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner", (Tags.TEST_SKIPPED_BY_ITR): true]
   }
 
   def "test ITR skipping for parameterized tests"() {
@@ -119,7 +119,8 @@ class SpockTest extends CiVisibilityTest {
     where:
     testTags_0 = [
       (Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"test add 1 and 2"}}',
-      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"
+      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner",
+      (Tags.TEST_SKIPPED_BY_ITR): true
     ]
     testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"test add 4 and 4"}}']
   }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
@@ -79,6 +79,7 @@ class SpockTest extends CiVisibilityTest {
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_SKIP, [
           (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
           (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
           (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])
@@ -107,6 +108,7 @@ class SpockTest extends CiVisibilityTest {
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
           (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
           (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
           (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGItrInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.config.SkippableTest;
 import java.lang.reflect.Method;
 import java.util.Set;
@@ -62,7 +63,7 @@ public class TestNGItrInstrumentation extends Instrumenter.CiVisibility
         @Advice.Argument(2) final Object[] parameters) {
       SkippableTest skippableTest = TestNGUtils.toSkippableTest(method, instance, parameters);
       if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(skippableTest)) {
-        throw new SkipException("Skipped by Datadog Intelligent Test Runner");
+        throw new SkipException(InstrumentationBridge.ITR_SKIP_REASON);
       }
     }
 

--- a/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
@@ -761,7 +761,7 @@ abstract class TestNGTest extends CiVisibilityTest {
     })
 
     where:
-    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"]
+    testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner", (Tags.TEST_SKIPPED_BY_ITR): true]
   }
 
   def "test ITR skipping for parameterized tests"() {
@@ -796,7 +796,8 @@ abstract class TestNGTest extends CiVisibilityTest {
     where:
     testTags_0 = [
       (Tags.TEST_PARAMETERS): '{"arguments":{"0":"hello","1":"true"}}',
-      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner"
+      (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner",
+      (Tags.TEST_SKIPPED_BY_ITR): true
     ]
     testTags_1 = [(Tags.TEST_PARAMETERS): '{"arguments":{"0":"\\\"goodbye\\\"","1":"false"}}']
   }

--- a/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
@@ -746,6 +746,7 @@ abstract class TestNGTest extends CiVisibilityTest {
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
           (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
           (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
           (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 2,
         ])
@@ -784,6 +785,7 @@ abstract class TestNGTest extends CiVisibilityTest {
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
           (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
           (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
           (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])

--- a/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
@@ -745,7 +745,9 @@ abstract class TestNGTest extends CiVisibilityTest {
       long testSuiteId
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
-          (DDTags.CI_ITR_TESTS_SKIPPED): true
+          (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 2,
         ])
         testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestFailedAndSucceed", CIConstants.TEST_PASS)
       }
@@ -781,7 +783,9 @@ abstract class TestNGTest extends CiVisibilityTest {
       long testSuiteId
       trace(2, true) {
         testModuleId = testModuleSpan(it, 0, CIConstants.TEST_PASS, [
-          (DDTags.CI_ITR_TESTS_SKIPPED): true
+          (DDTags.CI_ITR_TESTS_SKIPPED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 1,
         ])
         testSuiteId = testSuiteSpan(it, 1, testModuleId, "org.example.TestParameterized", CIConstants.TEST_PASS)
       }

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -155,7 +155,11 @@ class GradleDaemonSmokeTest extends Specification {
           it["test.toolchain"] == "gradle:${gradleVersion}" // only applied to session events
           it["test.code_coverage.enabled"] == "true"
           it["test.itr.tests_skipping.enabled"] == "true"
+          it["test.itr.tests_skipping.type"] == "test"
           it["_dd.ci.itr.tests_skipped"] == "true"
+        }
+        verifyAll(metrics) {
+          it["test.itr.tests_skipping.count"] == 1
         }
       }
     }
@@ -171,6 +175,12 @@ class GradleDaemonSmokeTest extends Specification {
         verifyAll(meta) {
           it["span.kind"] == "test_module_end"
           it["test.module"] == ":test" // task path
+          it["test.itr.tests_skipping.enabled"] == "true"
+          it["test.itr.tests_skipping.type"] == "test"
+          it["_dd.ci.itr.tests_skipped"] == "true"
+        }
+        verifyAll(metrics) {
+          it["test.itr.tests_skipping.count"] == 1
         }
       }
     }
@@ -305,6 +315,12 @@ class GradleDaemonSmokeTest extends Specification {
           it["span.kind"] == "test_session_end"
           it["language"] == "jvm" // only applied to root spans
           it["test.toolchain"] == "gradle:${gradleVersion}" // only applied to session events
+          it["test.itr.tests_skipping.enabled"] == "true"
+          it["test.itr.tests_skipping.type"] == "test"
+          it["_dd.ci.itr.tests_skipped"] == "true"
+        }
+        verifyAll(metrics) {
+          it["test.itr.tests_skipping.count"] == 1
         }
       }
     }
@@ -320,6 +336,12 @@ class GradleDaemonSmokeTest extends Specification {
         verifyAll(meta) {
           it["span.kind"] == "test_module_end"
           it["test.module"] == ":test" // task path
+          it["test.itr.tests_skipping.enabled"] == "true"
+          it["test.itr.tests_skipping.type"] == "test"
+          it["_dd.ci.itr.tests_skipped"] == "true"
+        }
+        verifyAll(metrics) {
+          it["test.itr.tests_skipping.count"] == 1
         }
       }
     }

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -240,6 +240,7 @@ class GradleDaemonSmokeTest extends Specification {
           it["test.name"] == "test_to_skip_with_itr"
           it["test.source.file"] == "src/test/java/datadog/smoke/TestSucceed.java"
           it["test.skip_reason"] == "Skipped by Datadog Intelligent Test Runner"
+          it["test.skipped_by_itr"] == "true"
         }
       }
     }
@@ -388,6 +389,7 @@ class GradleDaemonSmokeTest extends Specification {
           it["test.name"] == "test_to_skip_with_itr"
           it["test.source.file"] == "src/test/java/datadog/smoke/TestSucceed.java"
           it["test.skip_reason"] == "Skipped by Datadog Intelligent Test Runner"
+          it["test.skipped_by_itr"] == "true"
         }
       }
     }

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -218,6 +218,7 @@ class MavenSmokeTest extends Specification {
           it["test.source.file"] == "src/test/java/datadog/smoke/TestSucceed.java"
           it["test.status"] == "skip"
           it["test.skip_reason"] == "Skipped by Datadog Intelligent Test Runner"
+          it["test.skipped_by_itr"] == "true"
         }
       }
     }

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -127,7 +127,11 @@ class MavenSmokeTest extends Specification {
           it["test.status"] == "pass"
           it["test.code_coverage.enabled"] == "true"
           it["test.itr.tests_skipping.enabled"] == "true"
+          it["test.itr.tests_skipping.type"] == "test"
           it["_dd.ci.itr.tests_skipped"] == "true"
+        }
+        verifyAll(metrics) {
+          it["test.itr.tests_skipping.count"] == 1
         }
       }
     }
@@ -145,6 +149,13 @@ class MavenSmokeTest extends Specification {
           it["span.kind"] == "test_module_end"
           it["test.module"] == "Maven Smoke Tests Project test" // project name + execution goal
           it["test.status"] == "pass"
+          it["test.code_coverage.enabled"] == "true"
+          it["test.itr.tests_skipping.enabled"] == "true"
+          it["test.itr.tests_skipping.type"] == "test"
+          it["_dd.ci.itr.tests_skipped"] == "true"
+        }
+        verifyAll(metrics) {
+          it["test.itr.tests_skipping.count"] == 1
         }
       }
     }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
@@ -13,6 +13,8 @@ import java.nio.file.Path;
 
 public abstract class InstrumentationBridge {
 
+  public static final String ITR_SKIP_REASON = "Skipped by Datadog Intelligent Test Runner";
+
   private static volatile TestEventsHandler.Factory TEST_EVENTS_HANDLER_FACTORY;
   private static volatile BuildEventsHandler.Factory BUILD_EVENTS_HANDLER_FACTORY;
   private static volatile CoverageProbeStore.Factory COVERAGE_PROBE_STORE_FACTORY;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -49,6 +49,7 @@ public class Tags {
   public static final String TEST_FRAMEWORK = "test.framework";
   public static final String TEST_FRAMEWORK_VERSION = "test.framework_version";
   public static final String TEST_SKIP_REASON = "test.skip_reason";
+  public static final String TEST_SKIPPED_BY_ITR = "test.skipped_by_itr";
   public static final String TEST_TYPE = "test.type";
   public static final String TEST_PARAMETERS = "test.parameters";
   public static final String TEST_CODEOWNERS = "test.codeowners";

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -68,6 +68,8 @@ public class Tags {
   public static final String TEST_SUITE_ID = "test_suite_id";
   public static final String TEST_CODE_COVERAGE_ENABLED = "test.code_coverage.enabled";
   public static final String TEST_ITR_TESTS_SKIPPING_ENABLED = "test.itr.tests_skipping.enabled";
+  public static final String TEST_ITR_TESTS_SKIPPING_TYPE = "test.itr.tests_skipping.type";
+  public static final String TEST_ITR_TESTS_SKIPPING_COUNT = "test.itr.tests_skipping.count";
 
   public static final String CI_PROVIDER_NAME = "ci.provider.name";
   public static final String CI_PIPELINE_ID = "ci.pipeline.id";


### PR DESCRIPTION
# What Does This Do
Adds ITR (Intelligent Test Runner) metadata tags to test session and test module spans:
* `test.itr.tests_skipping.type`: `"test"` - to indicate that Java tracer skips individual test cases when ITR is enabled
* `test.itr.tests_skipping.count`: `number` - to tell how many test cases were skipped in a given session / module

And to test spans:
`test.skipped_by_itr`: `true` - if the test was skipped by ITR

# Motivation
The tracer needs to provide this info so that it could be displayed to the customers in the UI.
More details can be found in the [RFC](https://docs.google.com/document/d/105YXO2r2hQqwkbEgKOoO8MuT2OAawa5Wh8PwujJC9LY/edit).
