### PR TITLE
Fix Maven instrumentation for parallel builds

### DIFF
--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/module-a/pom.xml
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/module-a/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.datadog.ci.test</groupId>
+    <artifactId>maven-integration-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>maven-integration-test-module-a</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>module-a</name>
+
+</project>

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/module-a/src/test/java/com/example/TestSucceed.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/module-a/src/test/java/com/example/TestSucceed.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TestSucceed {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/module-b/pom.xml
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/module-b/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.datadog.ci.test</groupId>
+    <artifactId>maven-integration-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>maven-integration-test-module-b</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>module-b</name>
+
+</project>

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/module-b/src/test/java/com/example/TestSucceed.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/module-b/src/test/java/com/example/TestSucceed.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TestSucceed {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/pom.xml
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/resources/test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.datadog.ci.test</groupId>
+  <artifactId>maven-integration-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>Maven Integration Tests Project</name>
+
+  <modules>
+    <module>module-a</module>
+    <module>module-b</module>
+  </modules>
+
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
# What Does This Do
Changes Maven test session key from `MavenSession` to `MavenExecutionRequest`.

# Motivation
CI Visibility has a registry of currently executed builds.
Test session key is used to lookup a build in the registry.
The key has to be immutable and has to uniquely identify its corresponding build.
When a Maven build is executed in parallel mode (`-T N` arg), different threads will have different `MavenSession` instance associated with them, even though they service the same build.
Because of that `MavenSession` is not a suitable test session key.
There is a one-to-one relationship between the build and `MavenExecutionRequest` instance, so the latter is a suitable session key.