### PR TITLE
Add capture of inherited (static) fields

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
@@ -22,9 +22,19 @@ public class ReflectiveFieldValueResolver {
     return getField(target, fieldName).get(target);
   }
 
+  public static Object getFieldValue(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).get(null);
+  }
+
   public static long getFieldValueAsLong(Object target, String fieldName)
       throws NoSuchFieldException, IllegalAccessException {
     return getField(target, fieldName).getLong(target);
+  }
+
+  public static long getFieldValueAsLong(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).getLong(null);
   }
 
   public static int getFieldValueAsInt(Object target, String fieldName)
@@ -32,9 +42,19 @@ public class ReflectiveFieldValueResolver {
     return getField(target, fieldName).getInt(target);
   }
 
+  public static int getFieldValueAsInt(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).getInt(null);
+  }
+
   public static double getFieldValueAsDouble(Object target, String fieldName)
       throws NoSuchFieldException, IllegalAccessException {
     return getField(target, fieldName).getDouble(target);
+  }
+
+  public static double getFieldValueAsDouble(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).getDouble(null);
   }
 
   public static float getFieldValueAsFloat(Object target, String fieldName)
@@ -42,9 +62,19 @@ public class ReflectiveFieldValueResolver {
     return getField(target, fieldName).getFloat(target);
   }
 
+  public static float getFieldValueAsFloat(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).getFloat(null);
+  }
+
   public static float getFieldValueAsShort(Object target, String fieldName)
       throws NoSuchFieldException, IllegalAccessException {
     return getField(target, fieldName).getShort(target);
+  }
+
+  public static float getFieldValueAsShort(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).getShort(null);
   }
 
   public static char getFieldValueAsChar(Object target, String fieldName)
@@ -52,14 +82,29 @@ public class ReflectiveFieldValueResolver {
     return getField(target, fieldName).getChar(target);
   }
 
+  public static char getFieldValueAsChar(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).getChar(null);
+  }
+
   public static byte getFieldValueAsByte(Object target, String fieldName)
       throws NoSuchFieldException, IllegalAccessException {
     return getField(target, fieldName).getByte(target);
   }
 
+  public static byte getFieldValueAsByte(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).getByte(null);
+  }
+
   public static boolean getFieldValueAsBoolean(Object target, String fieldName)
       throws NoSuchFieldException, IllegalAccessException {
     return getField(target, fieldName).getBoolean(target);
+  }
+
+  public static boolean getFieldValueAsBoolean(Class<?> targetClass, String fieldName)
+      throws IllegalAccessException {
+    return getField(targetClass, fieldName).getBoolean(null);
   }
 
   private static Field getField(Object target, String name) throws NoSuchFieldException {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -183,7 +183,7 @@ public class LogProbe extends ProbeDefinition {
 
     public static Limits toLimits(Capture capture) {
       if (capture == null) {
-        return null;
+        return Limits.DEFAULT;
       }
       return new Limits(
           capture.maxReferenceDepth,

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot19.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot19.java
@@ -7,6 +7,41 @@ public class CapturedSnapshot19 {
   private static int[] intArrayField = new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   public static int main(String arg) {
+    if ("inherited".equals(arg)) {
+      return new Inherited().f();
+    }
     return 42;
+  }
+
+  static class Base {
+    private static int intValue = 24;
+    protected static double doubleValue = 3.14;
+    private static Object obj1;
+
+    public Base(Object obj1) {
+      this.obj1 = obj1;
+    }
+
+    public int f() {
+      intValue *= 2;
+      return 42;
+    }
+  }
+
+  static class Inherited extends Base {
+    private static final Object OBJ = new Object();
+    private static String strValue = "foobar";
+    private static Object obj2;
+
+    public Inherited() {
+      super(new Base(OBJ));
+      this.obj2 = new Base(new Object());
+    }
+
+    public int f() {
+      strValue = "barfoo";
+      doubleValue *= 2;
+      return super.f();
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do
lookup for inherited (static) fields and capture them to be able evaluate expressions on it.
Inherited instance fields were captured through `this`, but evaluation required to capture them with `CapturedContext::addFields`

# Motivation
Capture instance & static inherited fields

# Additional Notes
