### PR TITLE
Replace reflection calls with method handle invocations in test utils

### DIFF
--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -11,7 +11,6 @@ import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
-import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -69,7 +68,7 @@ public class TracingListener implements TestExecutionListener {
     String testSuiteName =
         testClass != null ? testClass.getName() : testIdentifier.getLegacyReportingName();
 
-    String testEngineId = getTestEngineId(testIdentifier);
+    String testEngineId = TestFrameworkUtils.getTestEngineId(testIdentifier);
     String testFramework = getTestFramework(testEngineId);
     String testFrameworkVersion = versionByTestEngineId.get(testEngineId);
 
@@ -118,7 +117,7 @@ public class TracingListener implements TestExecutionListener {
 
     MethodSource methodSource = (MethodSource) testSource;
 
-    String testEngineId = getTestEngineId(testIdentifier);
+    String testEngineId = TestFrameworkUtils.getTestEngineId(testIdentifier);
     String testFramework = getTestFramework(testEngineId);
     String testFrameworkVersion = versionByTestEngineId.get(testEngineId);
 
@@ -154,7 +153,7 @@ public class TracingListener implements TestExecutionListener {
       return;
     }
 
-    String testEngineId = getTestEngineId(testIdentifier);
+    String testEngineId = TestFrameworkUtils.getTestEngineId(testIdentifier);
 
     MethodSource methodSource = (MethodSource) testSource;
     String testSuiteName = methodSource.getClassName();
@@ -197,7 +196,7 @@ public class TracingListener implements TestExecutionListener {
     String testSuiteName =
         testClass != null ? testClass.getName() : testIdentifier.getLegacyReportingName();
 
-    String testEngineId = getTestEngineId(testIdentifier);
+    String testEngineId = TestFrameworkUtils.getTestEngineId(testIdentifier);
     String testFramework = getTestFramework(testEngineId);
     String testFrameworkVersion = versionByTestEngineId.get(testEngineId);
 
@@ -217,7 +216,7 @@ public class TracingListener implements TestExecutionListener {
 
   private void testCaseExecutionSkipped(
       final TestIdentifier testIdentifier, final MethodSource methodSource, final String reason) {
-    String testEngineId = getTestEngineId(testIdentifier);
+    String testEngineId = TestFrameworkUtils.getTestEngineId(testIdentifier);
     String testFramework = getTestFramework(testEngineId);
     String testFrameworkVersion = versionByTestEngineId.get(testEngineId);
 
@@ -245,11 +244,6 @@ public class TracingListener implements TestExecutionListener {
         testMethodName,
         testMethod,
         reason);
-  }
-
-  private static @Nullable String getTestEngineId(final TestIdentifier testIdentifier) {
-    UniqueId uniqueId = UniqueId.parse(testIdentifier.getUniqueId());
-    return uniqueId.getEngineId().orElse(null);
   }
 
   private static @Nullable String getTestFramework(String testEngineId) {

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.testng;
 import datadog.trace.api.civisibility.config.SkippableTest;
 import datadog.trace.util.Strings;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
@@ -23,6 +25,19 @@ import org.testng.internal.ITestResultNotifier;
 import org.testng.xml.XmlTest;
 
 public abstract class TestNGUtils {
+
+  private static final MethodHandle XML_TEST_GET_PARALLEL = accessGetParallel();
+
+  private static MethodHandle accessGetParallel() {
+    try {
+      Method getParallel = XmlTest.class.getMethod("getParallel");
+      MethodHandles.Lookup lookup = MethodHandles.lookup();
+      return lookup.unreflect(getParallel);
+
+    } catch (Exception e) {
+      return null;
+    }
+  }
 
   public static Class<?> getTestClass(final ITestResult result) {
     IClass testClass = result.getTestClass();
@@ -121,16 +136,6 @@ public abstract class TestNGUtils {
     }
   }
 
-  private static final Method XML_TEST_GET_PARALLEL = getParallelMethod();
-
-  private static Method getParallelMethod() {
-    try {
-      return XmlTest.class.getMethod("getParallel");
-    } catch (NoSuchMethodException e) {
-      return null;
-    }
-  }
-
   public static boolean isParallelized(ITestClass testClass) {
     try {
       // reflection needs to be used since XmlTest#getParallel
@@ -143,7 +148,7 @@ public abstract class TestNGUtils {
               : null;
       return parallel != null
           && ("methods".equals(parallel.toString()) || "tests".equals(parallel.toString()));
-    } catch (Exception e) {
+    } catch (Throwable e) {
       return false;
     }
   }


### PR DESCRIPTION
# What Does This Do
Updates CI Visibility utility classes to use `MethodHandle` invocations instead of `Method` reflection calls.

# Motivation
Reducing performance overhead: method handles are considerably faster than "plain" reflection calls.

# Additional Notes
The reasons for using reflection in utility classes are the following:
* We have to compile our code against the minimum supported versions of the test frameworks that we instrument. Therefore we cannot directly invoke certain methods that were introduced to those frameworks in later releases. At the same time we would like to use those methods to get additional tests data, therefore we have to resort to runtime lookup.
* In certain environments (mainly Gradle) parts of the test frameworks are loaded using different classloaders, so we have to lookup the right classes and invoke their methods "dynamically".
