### PR TITLE
Report test framework data from child processes instead of parsing project dependencies

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleChild.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleChild.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.config.JvmInfo;
 import datadog.trace.api.civisibility.config.SkippableTest;
 import datadog.trace.api.civisibility.source.SourcePathResolver;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.context.ParentProcessTestContext;
 import datadog.trace.civisibility.decorator.TestDecorator;
@@ -83,9 +84,18 @@ public class DDTestModuleChild extends DDTestModuleImpl {
     boolean coverageEnabled = config.isCiVisibilityCodeCoverageEnabled();
     boolean itrEnabled = config.isCiVisibilityItrEnabled();
     long testsSkippedTotal = testsSkipped.sum();
+    String testFramework = String.valueOf(context.getChildTag(Tags.TEST_FRAMEWORK));
+    String testFrameworkVersion = String.valueOf(context.getChildTag(Tags.TEST_FRAMEWORK_VERSION));
+
     ModuleExecutionResult moduleExecutionResult =
         new ModuleExecutionResult(
-            sessionId, moduleId, coverageEnabled, itrEnabled, testsSkippedTotal);
+            sessionId,
+            moduleId,
+            coverageEnabled,
+            itrEnabled,
+            testsSkippedTotal,
+            testFramework,
+            testFrameworkVersion);
 
     try (SignalClient signalClient = new SignalClient(signalServerAddress)) {
       signalClient.send(moduleExecutionResult);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleParent.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestModuleParent.java
@@ -166,5 +166,15 @@ public class DDTestModuleParent extends DDTestModuleImpl {
     codeCoverageEnabled = result.isCoverageEnabled();
     itrEnabled = result.isItrEnabled();
     testsSkipped.add(result.getTestsSkippedTotal());
+
+    String testFramework = result.getTestFramework();
+    if (testFramework != null) {
+      span.setTag(Tags.TEST_FRAMEWORK, testFramework);
+    }
+
+    String testFrameworkVersion = result.getTestFrameworkVersion();
+    if (testFrameworkVersion != null) {
+      span.setTag(Tags.TEST_FRAMEWORK_VERSION, testFrameworkVersion);
+    }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionParent.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionParent.java
@@ -104,6 +104,15 @@ public class DDTestSessionParent extends DDTestSessionImpl {
     if (result.isItrEnabled()) {
       itrEnabled = true;
     }
+    String testFramework = result.getTestFramework();
+    if (testFramework != null) {
+      setTag(Tags.TEST_FRAMEWORK, testFramework);
+    }
+    String testFrameworkVersion = result.getTestFrameworkVersion();
+    if (testFrameworkVersion != null) {
+      setTag(Tags.TEST_FRAMEWORK_VERSION, testFrameworkVersion);
+    }
+
     testsSkipped.add(result.getTestsSkippedTotal());
     return testModuleRegistry.onModuleExecutionResultReceived(result);
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/AbstractTestContext.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/AbstractTestContext.java
@@ -34,9 +34,4 @@ abstract class AbstractTestContext implements TestContext {
   public synchronized String getStatus() {
     return status;
   }
-
-  @Override
-  public void reportChildTag(String key, Object value) {
-    // no op
-  }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/ParentProcessTestContext.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/ParentProcessTestContext.java
@@ -38,8 +38,8 @@ public class ParentProcessTestContext extends AbstractTestContext implements Tes
   public void reportChildTag(String key, Object value) {
     // the method leaves room for a
     // proper implementation using a thread-safe map,
-    // but for not it's just this,
-    // in order to save some performance costs
+    // but for now it's just this,
+    // to save some performance costs
     switch (key) {
       case Tags.TEST_FRAMEWORK:
         testFramework = String.valueOf(value);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/ParentProcessTestContext.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/context/ParentProcessTestContext.java
@@ -1,11 +1,14 @@
 package datadog.trace.civisibility.context;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ParentProcessTestContext extends AbstractTestContext implements TestContext {
 
+  private volatile String testFramework;
+  private volatile String testFrameworkVersion;
   private final long sessionId;
   private final long moduleId;
 
@@ -29,5 +32,35 @@ public class ParentProcessTestContext extends AbstractTestContext implements Tes
   @Override
   public AgentSpan getSpan() {
     return null;
+  }
+
+  @Override
+  public void reportChildTag(String key, Object value) {
+    // the method leaves room for a
+    // proper implementation using a thread-safe map,
+    // but for not it's just this,
+    // in order to save some performance costs
+    switch (key) {
+      case Tags.TEST_FRAMEWORK:
+        testFramework = String.valueOf(value);
+        break;
+      case Tags.TEST_FRAMEWORK_VERSION:
+        testFrameworkVersion = String.valueOf(value);
+        break;
+      default:
+        throw new IllegalArgumentException("Unexpected child tag reported: " + key);
+    }
+  }
+
+  @Nullable
+  public Object getChildTag(String key) {
+    switch (key) {
+      case Tags.TEST_FRAMEWORK:
+        return testFramework;
+      case Tags.TEST_FRAMEWORK_VERSION:
+        return testFrameworkVersion;
+      default:
+        return null;
+    }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/BuildEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/BuildEventsHandlerImpl.java
@@ -46,14 +46,6 @@ public class BuildEventsHandlerImpl<T> implements BuildEventsHandler<T> {
   }
 
   @Override
-  public void onTestFrameworkDetected(
-      final T sessionKey, final String frameworkName, final String frameworkVersion) {
-    DDTestSessionImpl testSession = getTestSession(sessionKey);
-    testSession.setTag(Tags.TEST_FRAMEWORK, frameworkName);
-    testSession.setTag(Tags.TEST_FRAMEWORK_VERSION, frameworkVersion);
-  }
-
-  @Override
   public void onTestSessionFail(final T sessionKey, final Throwable throwable) {
     DDTestSessionImpl testSession = getTestSession(sessionKey);
     testSession.setErrorInfo(throwable);
@@ -98,17 +90,6 @@ public class BuildEventsHandlerImpl<T> implements BuildEventsHandler<T> {
     inProgressTestModules.put(testModuleDescriptor, testModule);
 
     return testModule.getModuleInfo();
-  }
-
-  @Override
-  public void onModuleTestFrameworkDetected(
-      final T sessionKey,
-      final String moduleName,
-      final String frameworkName,
-      final String frameworkVersion) {
-    DDTestModuleImpl testModule = getTestModule(sessionKey, moduleName);
-    testModule.setTag(Tags.TEST_FRAMEWORK, frameworkName);
-    testModule.setTag(Tags.TEST_FRAMEWORK_VERSION, frameworkVersion);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
@@ -2,10 +2,11 @@ package datadog.trace.civisibility.ipc;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 public class ModuleExecutionResult implements Signal {
 
-  private static final int SERIALIZED_LENGTH = Long.BYTES + Long.BYTES + Long.BYTES + 1;
+  private static final int FIXED_LENGTH = Long.BYTES + Long.BYTES + Long.BYTES + 1;
   private static final int COVERAGE_ENABLED_FLAG = 1;
   private static final int ITR_ENABLED_FLAG = 2;
 
@@ -14,18 +15,24 @@ public class ModuleExecutionResult implements Signal {
   private final boolean coverageEnabled;
   private final boolean itrEnabled;
   private final long testsSkippedTotal;
+  @Nullable private final String testFramework;
+  @Nullable private final String testFrameworkVersion;
 
   public ModuleExecutionResult(
       long sessionId,
       long moduleId,
       boolean coverageEnabled,
       boolean itrEnabled,
-      long testsSkippedTotal) {
+      long testsSkippedTotal,
+      @Nullable String testFramework,
+      @Nullable String testFrameworkVersion) {
     this.sessionId = sessionId;
     this.moduleId = moduleId;
     this.coverageEnabled = coverageEnabled;
     this.itrEnabled = itrEnabled;
     this.testsSkippedTotal = testsSkippedTotal;
+    this.testFramework = testFramework;
+    this.testFrameworkVersion = testFrameworkVersion;
   }
 
   public long getSessionId() {
@@ -48,6 +55,16 @@ public class ModuleExecutionResult implements Signal {
     return testsSkippedTotal;
   }
 
+  @Nullable
+  public String getTestFramework() {
+    return testFramework;
+  }
+
+  @Nullable
+  public String getTestFrameworkVersion() {
+    return testFrameworkVersion;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -61,12 +78,21 @@ public class ModuleExecutionResult implements Signal {
         && moduleId == that.moduleId
         && coverageEnabled == that.coverageEnabled
         && itrEnabled == that.itrEnabled
-        && testsSkippedTotal == that.testsSkippedTotal;
+        && testsSkippedTotal == that.testsSkippedTotal
+        && Objects.equals(testFramework, that.testFramework)
+        && Objects.equals(testFrameworkVersion, that.testFrameworkVersion);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(sessionId, moduleId, coverageEnabled, itrEnabled, testsSkippedTotal);
+    return Objects.hash(
+        sessionId,
+        moduleId,
+        coverageEnabled,
+        itrEnabled,
+        testsSkippedTotal,
+        testFramework,
+        testFrameworkVersion);
   }
 
   @Override
@@ -92,7 +118,16 @@ public class ModuleExecutionResult implements Signal {
 
   @Override
   public ByteBuffer serialize() {
-    ByteBuffer buffer = ByteBuffer.allocate(SERIALIZED_LENGTH);
+    byte[] testFrameworkBytes = testFramework != null ? testFramework.getBytes() : null;
+    byte[] testFrameworkVersionBytes =
+        testFrameworkVersion != null ? testFrameworkVersion.getBytes() : null;
+
+    int testFrameworkLength = testFrameworkBytes != null ? testFrameworkBytes.length : 0;
+    int testFrameworkVersionLength =
+        testFrameworkVersionBytes != null ? testFrameworkVersionBytes.length : 0;
+    int variableLength = Integer.BYTES * 2 + testFrameworkLength + testFrameworkVersionLength;
+
+    ByteBuffer buffer = ByteBuffer.allocate(FIXED_LENGTH + variableLength);
     buffer.putLong(sessionId);
     buffer.putLong(moduleId);
     buffer.putLong(testsSkippedTotal);
@@ -105,14 +140,30 @@ public class ModuleExecutionResult implements Signal {
       flags |= ITR_ENABLED_FLAG;
     }
     buffer.put(flags);
+
+    buffer.putInt(testFrameworkLength);
+    if (testFrameworkLength != 0) {
+      buffer.put(testFrameworkBytes);
+    }
+
+    buffer.putInt(testFrameworkVersionLength);
+    if (testFrameworkVersionLength != 0) {
+      buffer.put(testFrameworkVersionBytes);
+    }
+
     buffer.flip();
     return buffer;
   }
 
   public static ModuleExecutionResult deserialize(ByteBuffer buffer) {
-    if (buffer.remaining() != SERIALIZED_LENGTH) {
+    if (buffer.remaining() < FIXED_LENGTH) {
       throw new IllegalArgumentException(
-          "Expected " + SERIALIZED_LENGTH + " bytes, got " + buffer.remaining() + ", " + buffer);
+          "Expected at least "
+              + FIXED_LENGTH
+              + " bytes, got "
+              + buffer.remaining()
+              + ", "
+              + buffer);
     }
     long sessionId = buffer.getLong();
     long moduleId = buffer.getLong();
@@ -120,7 +171,34 @@ public class ModuleExecutionResult implements Signal {
     int flags = buffer.get();
     boolean coverageEnabled = (flags & COVERAGE_ENABLED_FLAG) != 0;
     boolean itrEnabled = (flags & ITR_ENABLED_FLAG) != 0;
+
+    String testFramework;
+    int testFrameworkLength = buffer.getInt();
+    if (testFrameworkLength != 0) {
+      byte[] testFrameworkBytes = new byte[testFrameworkLength];
+      buffer.get(testFrameworkBytes);
+      testFramework = new String(testFrameworkBytes);
+    } else {
+      testFramework = null;
+    }
+
+    String testFrameworkVersion;
+    int testFrameworkVersionLength = buffer.getInt();
+    if (testFrameworkVersionLength != 0) {
+      byte[] testFrameworkVersionBytes = new byte[testFrameworkVersionLength];
+      buffer.get(testFrameworkVersionBytes);
+      testFrameworkVersion = new String(testFrameworkVersionBytes);
+    } else {
+      testFrameworkVersion = null;
+    }
+
     return new ModuleExecutionResult(
-        sessionId, moduleId, coverageEnabled, itrEnabled, testsSkippedTotal);
+        sessionId,
+        moduleId,
+        coverageEnabled,
+        itrEnabled,
+        testsSkippedTotal,
+        testFramework,
+        testFrameworkVersion);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
@@ -16,11 +16,11 @@ class ModuleExecutionResultTest extends Specification {
 
     where:
     signal << [
-      new ModuleExecutionResult(12345, 67890, false, false, 0),
-      new ModuleExecutionResult(12345, 67890, true, false, 1),
-      new ModuleExecutionResult(12345, 67890, false, true, 2),
-      new ModuleExecutionResult(12345, 67890, false, false, 3),
-      new ModuleExecutionResult(12345, 67890, true, true, Integer.MAX_VALUE)
+      new ModuleExecutionResult(12345, 67890, false, false, 0, null, null),
+      new ModuleExecutionResult(12345, 67890, true, false, 1, "abc", "def"),
+      new ModuleExecutionResult(12345, 67890, false, true, 2, null, "def"),
+      new ModuleExecutionResult(12345, 67890, false, false, 3, "abc", null),
+      new ModuleExecutionResult(12345, 67890, true, true, Integer.MAX_VALUE, "abc", "def")
     ]
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
@@ -17,10 +17,10 @@ class ModuleExecutionResultTest extends Specification {
     where:
     signal << [
       new ModuleExecutionResult(12345, 67890, false, false, 0, null, null),
-      new ModuleExecutionResult(12345, 67890, true, false, 1, "abc", "def"),
-      new ModuleExecutionResult(12345, 67890, false, true, 2, null, "def"),
-      new ModuleExecutionResult(12345, 67890, false, false, 3, "abc", null),
-      new ModuleExecutionResult(12345, 67890, true, true, Integer.MAX_VALUE, "abc", "def")
+      new ModuleExecutionResult(12345, 67890, true, false, 1, "junit", "4.13.2"),
+      new ModuleExecutionResult(12345, 67890, false, true, 2, null, "4.13.2"),
+      new ModuleExecutionResult(12345, 67890, false, false, 3, "junit", null),
+      new ModuleExecutionResult(12345, 67890, true, true, Integer.MAX_VALUE, "junit", "4.13.2")
     ]
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
@@ -9,7 +9,7 @@ class SignalServerTest extends Specification {
   def "test message send and receive"() {
     given:
     def signalProcessed = new AtomicBoolean(false)
-    def signal = new ModuleExecutionResult(123, 456, true, true, 1, "abc", "def")
+    def signal = new ModuleExecutionResult(123, 456, true, true, 1, "junit", "4.13.2")
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -38,8 +38,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple messages send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(123, 456, false, false, 0, "abc", "def")
-    def signalB = new ModuleExecutionResult(234, 567, true, true, 1, "abc", "def")
+    def signalA = new ModuleExecutionResult(123, 456, false, false, 0, "junit", "4.13.2")
+    def signalB = new ModuleExecutionResult(234, 567, true, true, 1, "junit", "4.13.2")
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -67,8 +67,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple clients send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(123, 456, true, false, 1, "abc", "def")
-    def signalB = new ModuleExecutionResult(234, 567, false, true, 0, "abc", "def")
+    def signalA = new ModuleExecutionResult(123, 456, true, false, 1, "junit", "4.13.2")
+    def signalB = new ModuleExecutionResult(234, 567, false, true, 0, "junit", "4.13.2")
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -115,7 +115,7 @@ class SignalServerTest extends Specification {
     when:
     def address = server.getAddress()
     try (def client = new SignalClient(address, clientTimeoutMillis)) {
-      client.send(new ModuleExecutionResult(123, 456, false, false, 0, "abc", "def"))
+      client.send(new ModuleExecutionResult(123, 456, false, false, 0, "junit", "4.13.2"))
     }
 
     then:
@@ -127,7 +127,7 @@ class SignalServerTest extends Specification {
 
   def "test error response receipt"() {
     given:
-    def signal = new ModuleExecutionResult(123, 456, true, true, 1, "abc", "def")
+    def signal = new ModuleExecutionResult(123, 456, true, true, 1, "junit", "4.13.2")
     def server = new SignalServer()
 
     def errorResponse = new ErrorResponse("An error occurred while processing the signal")

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
@@ -9,7 +9,7 @@ class SignalServerTest extends Specification {
   def "test message send and receive"() {
     given:
     def signalProcessed = new AtomicBoolean(false)
-    def signal = new ModuleExecutionResult(123, 456, true, true, 1)
+    def signal = new ModuleExecutionResult(123, 456, true, true, 1, "abc", "def")
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -38,8 +38,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple messages send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(123, 456, false, false, 0)
-    def signalB = new ModuleExecutionResult(234, 567, true, true, 1)
+    def signalA = new ModuleExecutionResult(123, 456, false, false, 0, "abc", "def")
+    def signalB = new ModuleExecutionResult(234, 567, true, true, 1, "abc", "def")
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -67,8 +67,8 @@ class SignalServerTest extends Specification {
 
   def "test multiple clients send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(123, 456, true, false, 1)
-    def signalB = new ModuleExecutionResult(234, 567, false, true, 0)
+    def signalA = new ModuleExecutionResult(123, 456, true, false, 1, "abc", "def")
+    def signalB = new ModuleExecutionResult(234, 567, false, true, 0, "abc", "def")
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -115,7 +115,7 @@ class SignalServerTest extends Specification {
     when:
     def address = server.getAddress()
     try (def client = new SignalClient(address, clientTimeoutMillis)) {
-      client.send(new ModuleExecutionResult(123, 456, false, false, 0))
+      client.send(new ModuleExecutionResult(123, 456, false, false, 0, "abc", "def"))
     }
 
     then:
@@ -127,7 +127,7 @@ class SignalServerTest extends Specification {
 
   def "test error response receipt"() {
     given:
-    def signal = new ModuleExecutionResult(123, 456, true, true, 1)
+    def signal = new ModuleExecutionResult(123, 456, true, true, 1, "abc", "def")
     def server = new SignalServer()
 
     def errorResponse = new ErrorResponse("An error occurred while processing the signal")

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListener.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListener.java
@@ -62,18 +62,6 @@ public class GradleBuildListener extends BuildAdapter {
       configureTestExecutions(gradle, testExecutions);
     }
 
-    Collection<GradleUtils.TestFramework> testFrameworks =
-        GradleUtils.collectTestFrameworks(rootProject);
-    if (testFrameworks.size() == 1) {
-      // if the project uses multiple test frameworks, we do not set the tags
-      GradleUtils.TestFramework testFramework = testFrameworks.iterator().next();
-      buildEventsHandler.onTestFrameworkDetected(gradle, testFramework.name, testFramework.version);
-    } else if (testFrameworks.size() > 1) {
-      log.info(
-          "Multiple test frameworks detected: {}. Test framework data will not be populated",
-          testFrameworks);
-    }
-
     gradle.addListener(new TestTaskExecutionListener(buildEventsHandler));
   }
 
@@ -154,15 +142,6 @@ public class GradleBuildListener extends BuildAdapter {
       String startCommand = GradleUtils.recreateStartCommand(gradle.getStartParameter());
       BuildEventsHandler.ModuleInfo moduleInfo =
           buildEventsHandler.onTestModuleStart(gradle, taskPath, startCommand, null);
-
-      Collection<GradleUtils.TestFramework> testFrameworks =
-          GradleUtils.collectTestFrameworks(project);
-      if (testFrameworks.size() == 1) {
-        // if the module uses multiple test frameworks, we do not set the tags
-        GradleUtils.TestFramework testFramework = testFrameworks.iterator().next();
-        buildEventsHandler.onModuleTestFrameworkDetected(
-            gradle, taskPath, testFramework.name, testFramework.version);
-      }
 
       JavaForkOptions taskForkOptions = (JavaForkOptions) task;
       taskForkOptions.jvmArgs(

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListenerInstrumentation.java
@@ -26,7 +26,6 @@ public class GradleBuildListenerInstrumentation extends Instrumenter.CiVisibilit
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".GradleUtils",
-      packageName + ".GradleUtils$TestFramework",
       packageName + ".GradleProjectConfigurator",
       packageName + ".GradleProjectConfigurator$_configureCompilerPlugin_closure1",
       packageName + ".GradleProjectConfigurator$_configureJacoco_closure2",

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleUtils.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleUtils.java
@@ -1,15 +1,8 @@
 package datadog.trace.instrumentation.gradle;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import org.gradle.StartParameter;
-import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.process.JavaForkOptions;
 
 public abstract class GradleUtils {
@@ -66,63 +59,5 @@ public abstract class GradleUtils {
     }
 
     return command.toString();
-  }
-
-  public static Collection<TestFramework> collectTestFrameworks(Project project) {
-    Collection<TestFramework> testFrameworks = new HashSet<>();
-
-    ConfigurationContainer configurations = project.getConfigurations();
-    for (Configuration configuration : configurations.getAsMap().values()) {
-      for (Dependency dependency : configuration.getAllDependencies()) {
-        String group = dependency.getGroup();
-        String name = dependency.getName();
-        if ("junit".equals(group) && "junit".equals(name)) {
-          testFrameworks.add(new TestFramework("junit4", dependency.getVersion()));
-
-        } else if ("org.junit.jupiter".equals(group)) {
-          testFrameworks.add(new TestFramework("junit5", dependency.getVersion()));
-
-        } else if ("org.testng".equals(group) && "testng".equals(name)) {
-          testFrameworks.add(new TestFramework("testng", dependency.getVersion()));
-        }
-      }
-    }
-
-    for (Project childProject : project.getChildProjects().values()) {
-      testFrameworks.addAll(collectTestFrameworks(childProject));
-    }
-    return testFrameworks;
-  }
-
-  public static final class TestFramework {
-    public final String name;
-    public final String version;
-
-    TestFramework(String name, String version) {
-      this.name = name;
-      this.version = version;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      TestFramework that = (TestFramework) o;
-      return Objects.equals(name, that.name) && Objects.equals(version, that.version);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(name, version);
-    }
-
-    @Override
-    public String toString() {
-      return "TestFramework{" + "name='" + name + '\'' + ", version='" + version + '\'' + '}';
-    }
   }
 }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenExecutionListener.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenExecutionListener.java
@@ -4,7 +4,6 @@ import datadog.trace.api.civisibility.events.BuildEventsHandler;
 import datadog.trace.api.config.CiVisibilityConfig;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.util.Strings;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.maven.execution.AbstractExecutionListener;
@@ -87,19 +86,6 @@ public class MavenExecutionListener extends AbstractExecutionListener {
 
       BuildEventsHandler.ModuleInfo moduleInfo =
           buildEventsHandler.onTestModuleStart(request, moduleName, startCommand, additionalTags);
-
-      Collection<MavenUtils.TestFramework> testFrameworks =
-          MavenUtils.collectTestFrameworks(project);
-      if (testFrameworks.size() == 1) {
-        // if the module uses multiple test frameworks, we do not set the tags
-        MavenUtils.TestFramework testFramework = testFrameworks.iterator().next();
-        buildEventsHandler.onModuleTestFrameworkDetected(
-            request, moduleName, testFramework.name, testFramework.version);
-      } else if (testFrameworks.size() > 1) {
-        log.info(
-            "Multiple test frameworks detected: {}. Test framework data will not be populated",
-            testFrameworks);
-      }
 
       Xpp3Dom configuration = mojoExecution.getConfiguration();
       boolean forkTestVm =

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenInstrumentation.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenInstrumentation.java
@@ -36,7 +36,6 @@ public class MavenInstrumentation extends Instrumenter.CiVisibility
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".MavenUtils",
-      packageName + ".MavenUtils$TestFramework",
       packageName + ".MavenExecutionListener",
       packageName + ".MavenProjectConfigurator",
       packageName + ".MavenLifecycleParticipant",

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
@@ -96,19 +96,6 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
     buildEventsHandler.onTestSessionStart(
         request, projectName, projectRoot, startCommand, "maven", mavenVersion);
 
-    Collection<MavenUtils.TestFramework> testFrameworks =
-        MavenUtils.collectTestFrameworks(rootProject);
-    if (testFrameworks.size() == 1) {
-      MavenUtils.TestFramework testFramework = testFrameworks.iterator().next();
-      buildEventsHandler.onTestFrameworkDetected(
-          request, testFramework.name, testFramework.version);
-    } else if (testFrameworks.size() > 1) {
-      // if the module uses multiple test frameworks, we do not set the tags
-      LOGGER.info(
-          "Multiple test frameworks detected: {}. Test framework data will not be populated",
-          testFrameworks);
-    }
-
     if (!config.isCiVisibilityAutoConfigurationEnabled()) {
       return;
     }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
@@ -1,7 +1,5 @@
 package datadog.trace.instrumentation.maven3;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -12,7 +10,6 @@ import org.apache.maven.cli.CLIManager;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionResult;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
@@ -265,61 +262,5 @@ public abstract class MavenUtils {
       current = child;
     }
     return current;
-  }
-
-  public static Collection<TestFramework> collectTestFrameworks(MavenProject project) {
-    Collection<TestFramework> testFrameworks = new HashSet<>();
-
-    for (Dependency dependency : project.getDependencies()) {
-      String group = dependency.getGroupId();
-      String name = dependency.getArtifactId();
-      if ("junit".equals(group) && "junit".equals(name)) {
-        testFrameworks.add(new TestFramework("junit4", dependency.getVersion()));
-
-      } else if ("org.junit.jupiter".equals(group)) {
-        testFrameworks.add(new TestFramework("junit5", dependency.getVersion()));
-
-      } else if ("org.testng".equals(group) && "testng".equals(name)) {
-        testFrameworks.add(new TestFramework("testng", dependency.getVersion()));
-      }
-    }
-
-    for (MavenProject collectedProject : project.getCollectedProjects()) {
-      testFrameworks.addAll(collectTestFrameworks(collectedProject));
-    }
-
-    return testFrameworks;
-  }
-
-  public static final class TestFramework {
-    public final String name;
-    public final String version;
-
-    TestFramework(String name, String version) {
-      this.name = name;
-      this.version = version;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      TestFramework that = (TestFramework) o;
-      return Objects.equals(name, that.name) && Objects.equals(version, that.version);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(name, version);
-    }
-
-    @Override
-    public String toString() {
-      return name + ":" + version;
-    }
   }
 }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/MavenTest.groovy
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/MavenTest.groovy
@@ -315,11 +315,15 @@ class MavenTest extends CiVisibilityTest {
 
   @Override
   String expectedTestFramework() {
+    // Test framework data is supplied by test framework instrumentations,
+    // that are not available in the context of this test
     return null
   }
 
   @Override
   String expectedTestFrameworkVersion() {
+    // Test framework version data is supplied by test framework instrumentations,
+    // that are not available in the context of this test
     return null
   }
 

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/MavenTest.groovy
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/MavenTest.groovy
@@ -315,12 +315,12 @@ class MavenTest extends CiVisibilityTest {
 
   @Override
   String expectedTestFramework() {
-    return "junit4"
+    return null
   }
 
   @Override
   String expectedTestFrameworkVersion() {
-    return "4.13.2"
+    return null
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/BuildEventsHandler.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/BuildEventsHandler.java
@@ -13,17 +13,12 @@ public interface BuildEventsHandler<T> {
       String buildSystemName,
       String buildSystemVersion);
 
-  void onTestFrameworkDetected(T sessionKey, String frameworkName, String frameworkVersion);
-
   void onTestSessionFail(T sessionKey, Throwable throwable);
 
   void onTestSessionFinish(T sessionKey);
 
   ModuleInfo onTestModuleStart(
       T sessionKey, String moduleName, String startCommand, Map<String, Object> additionalTags);
-
-  void onModuleTestFrameworkDetected(
-      T sessionKey, String moduleName, String frameworkName, String frameworkVersion);
 
   void onTestModuleSkip(T sessionKey, String moduleName, String reason);
 


### PR DESCRIPTION
# What Does This Do
Update CI Visibility: test framework name and version are now sent from children processes to the parent process using signal server.

# Motivation
Improving the accuracy of test framework name and version detection.

Test session and test modules spans are created by the parent process.
These spans need to be tagged with test framework name and version.
Previous implementation attempted to extract that data by parsing the list of project's Maven or Gradle dependencies.
That approach often gave inaccurate results (for instance, in cases when a project had JUnit dependency but ran another framework such as Spock or Cucumber on top of JUnit).
The new approach is more accurate since the data is obtained from test framework instrumentations.
