### PR TITLE
Add span links support to OpenTelemetry instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/build.gradle
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/build.gradle
@@ -17,5 +17,6 @@ dependencies {
   compileOnly group: 'com.google.auto.value', name: 'auto-value-annotations', version: '1.6.6'
 
   testImplementation group: 'io.opentelemetry', name: 'opentelemetry-api', version: openTelemetryVersion
+  testImplementation group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.1'
   latestDepTestImplementation group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1+'
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
@@ -73,6 +73,8 @@ public class OpenTelemetryInstrumentation extends Instrumenter.Tracing
       packageName + ".trace.OtelSpanBuilder",
       packageName + ".trace.OtelSpanBuilder$1",
       packageName + ".trace.OtelSpanContext",
+      packageName + ".trace.OtelSpanLink",
+      packageName + ".trace.OtelSpanLink$1",
       packageName + ".trace.OtelTracer",
       packageName + ".trace.OtelTracerBuilder",
       packageName + ".trace.OtelTracerProvider",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextInstrumentation.java
@@ -65,6 +65,8 @@ public class OpenTelemetryContextInstrumentation extends Instrumenter.Tracing
       ROOT_PACKAGE_NAME + ".trace.OtelSpanBuilder",
       ROOT_PACKAGE_NAME + ".trace.OtelSpanBuilder$1",
       ROOT_PACKAGE_NAME + ".trace.OtelSpanContext",
+      ROOT_PACKAGE_NAME + ".trace.OtelSpanLink",
+      ROOT_PACKAGE_NAME + ".trace.OtelSpanLink$1",
       ROOT_PACKAGE_NAME + ".trace.OtelTracer",
       ROOT_PACKAGE_NAME + ".trace.OtelTracerBuilder",
       ROOT_PACKAGE_NAME + ".trace.OtelTracerProvider",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextStorageInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextStorageInstrumentation.java
@@ -71,6 +71,8 @@ public class OpenTelemetryContextStorageInstrumentation extends Instrumenter.Tra
       ROOT_PACKAGE_NAME + ".trace.OtelSpanBuilder",
       ROOT_PACKAGE_NAME + ".trace.OtelSpanBuilder$1",
       ROOT_PACKAGE_NAME + ".trace.OtelSpanContext",
+      ROOT_PACKAGE_NAME + ".trace.OtelSpanLink",
+      ROOT_PACKAGE_NAME + ".trace.OtelSpanLink$1",
       ROOT_PACKAGE_NAME + ".trace.OtelTracer",
       ROOT_PACKAGE_NAME + ".trace.OtelTracerBuilder",
       ROOT_PACKAGE_NAME + ".trace.OtelTracerProvider",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanBuilder.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanBuilder.java
@@ -42,13 +42,17 @@ public class OtelSpanBuilder implements SpanBuilder {
 
   @Override
   public SpanBuilder addLink(SpanContext spanContext) {
-    // Not supported
+    if (spanContext.isValid()) {
+      this.delegate.withLink(new OtelSpanLink(spanContext));
+    }
     return this;
   }
 
   @Override
   public SpanBuilder addLink(SpanContext spanContext, Attributes attributes) {
-    // Not supported
+    if (spanContext.isValid()) {
+      this.delegate.withLink(new OtelSpanLink(spanContext, attributes));
+    }
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanLink.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanLink.java
@@ -1,0 +1,86 @@
+package datadog.trace.instrumentation.opentelemetry14.trace;
+
+import datadog.trace.api.DDSpanId;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.bootstrap.instrumentation.api.SpanLink;
+import datadog.trace.bootstrap.instrumentation.api.SpanLinkAttributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceState;
+import java.util.List;
+
+public class OtelSpanLink extends SpanLink {
+  private static final int TRACESTATE_MAX_SIZE = 512;
+  private static final char TRACESTATE_ENTRY_DELIMITER = ',';
+  private static final char TRACESTATE_KEY_VALUE_DELIMITER = '=';
+
+  public OtelSpanLink(SpanContext spanContext) {
+    this(spanContext, io.opentelemetry.api.common.Attributes.empty());
+  }
+
+  public OtelSpanLink(SpanContext spanContext, io.opentelemetry.api.common.Attributes attributes) {
+    super(
+        DDTraceId.fromHex(spanContext.getTraceId()),
+        DDSpanId.fromHex(spanContext.getSpanId()),
+        spanContext.isSampled() ? SAMPLED_FLAG : DEFAULT_FLAGS,
+        encodeTraceState(spanContext.getTraceState()),
+        convertAttributes(attributes));
+  }
+
+  // Inspired from W3CTraceContextEncoding.encodeTraceState only available in API later versions.
+  private static String encodeTraceState(TraceState traceState) {
+    if (traceState.isEmpty()) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder(TRACESTATE_MAX_SIZE);
+    traceState.forEach(
+        (key, value) -> {
+          if (builder.length() != 0) {
+            builder.append(TRACESTATE_ENTRY_DELIMITER);
+          }
+          builder.append(key).append(TRACESTATE_KEY_VALUE_DELIMITER).append(value);
+        });
+    return builder.toString();
+  }
+
+  private static Attributes convertAttributes(io.opentelemetry.api.common.Attributes attributes) {
+    if (attributes.isEmpty()) {
+      return SpanLinkAttributes.EMPTY;
+    }
+    SpanLinkAttributes.Builder builder = SpanLinkAttributes.builder();
+    attributes.forEach(
+        (attributeKey, value) -> {
+          String key = attributeKey.getKey();
+          switch (attributeKey.getType()) {
+            case STRING:
+              builder.put(key, (String) value);
+              break;
+            case BOOLEAN:
+              builder.put(key, (boolean) value);
+              break;
+            case LONG:
+              builder.put(key, (long) value);
+              break;
+            case DOUBLE:
+              builder.put(key, (double) value);
+              break;
+            case STRING_ARRAY:
+              //noinspection unchecked
+              builder.putStringArray(key, (List<String>) value);
+              break;
+            case BOOLEAN_ARRAY:
+              //noinspection unchecked
+              builder.putBooleanArray(key, (List<Boolean>) value);
+              break;
+            case LONG_ARRAY:
+              //noinspection unchecked
+              builder.putLongArray(key, (List<Long>) value);
+              break;
+            case DOUBLE_ARRAY:
+              //noinspection unchecked
+              builder.putDoubleArray(key, (List<Double>) value);
+              break;
+          }
+        });
+    return builder.build();
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -3,9 +3,14 @@ import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.SpanContext
 import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ThreadLocalContextStorage
+import org.skyscreamer.jsonassert.JSONAssert
 import spock.lang.Subject
 
 import java.security.InvalidParameterException
@@ -139,8 +144,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
     anotherSpan.end()
 
     when:
-    // Adding link is not supported
-    builder.addLink(anotherSpan.getSpanContext())
     // Adding event is not supported
     def result = builder.startSpan()
     result.addEvent("some-event")
@@ -155,6 +158,153 @@ class OpenTelemetry14Test extends AgentTestRunner {
         span {}
       }
     }
+  }
+
+  def "test simple span links"() {
+    setup:
+    def traceId = "1234567890abcdef1234567890abcdef" as String
+    def spanId = "fedcba0987654321" as String
+    def traceState = TraceState.builder().put("string-key", "string-value").build()
+
+    def expectedLinksTag = """
+    [
+      { traceId: "${traceId}",
+        spanId: "${spanId}",
+        traceFlags: 1,
+        traceState: "string-key=string-value"}
+    ]"""
+
+    when:
+    def span1 =tracer.spanBuilder("some-name")
+      .addLink(SpanContext.getInvalid())  // Should not be added
+      .addLink(SpanContext.create(traceId, spanId, TraceFlags.getSampled(), traceState))
+      .startSpan()
+    span1.end()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          tags {
+            defaultTags()
+            tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
+          }
+        }
+      }
+    }
+  }
+
+  def "test multiple span links"() {
+    setup:
+    def spanBuilder = tracer.spanBuilder("some-name")
+
+    when:
+    def links = []
+    0..9.each {
+      def traceId = "1234567890abcdef1234567890abcde$it" as String
+      def spanId = "fedcba098765432$it" as String
+      def traceState = TraceState.builder().put('string-key', 'string-value'+it).build()
+      links << """{ traceId: "${traceId}",
+        spanId: "${spanId}",
+        traceFlags: 1,
+        traceState: "string-key=string-value$it"}"""
+      spanBuilder.addLink(SpanContext.create(traceId, spanId, TraceFlags.getSampled(), traceState))
+    }
+    def expectedLinksTag = "[${links.join(',')}]" as String
+
+    spanBuilder.startSpan().end()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          tags {
+            defaultTags()
+            tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
+          }
+        }
+      }
+    }
+  }
+
+  def "test span link attributes"() {
+    setup:
+    def traceId = "1234567890abcdef1234567890abcdef" as String
+    def spanId = "fedcba0987654321" as String
+    def traceState = TraceState.builder().put("string-key", "string-value").build()
+
+    def expectedLinksTag = """
+    [
+      { traceId: "${traceId}",
+        spanId: "${spanId}",
+        traceFlags: 1,
+        traceState: "string-key=string-value"
+        ${ expectedAttributes == null ? "" : ", attributes: " + expectedAttributes }}
+    ]"""
+
+    when:
+    def span1 =tracer.spanBuilder("some-name")
+      .addLink(SpanContext.create(traceId, spanId, TraceFlags.getSampled(), traceState), attributes)
+      .startSpan()
+    span1.end()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          tags {
+            defaultTags()
+            tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
+          }
+        }
+      }
+    }
+
+    where:
+    attributes | expectedAttributes
+    Attributes.empty() | null
+    Attributes.builder().put("string-key", "string-value").put("long-key", 123456789L).put("double-key", 1234.5678D).put("boolean-key-true", true).put("boolean-key-false", false).build() | '{ string-key: "string-value", long-key: "123456789", double-key: "1234.5678", boolean-key-true: "true", boolean-key-false: "false" }'
+    Attributes.builder().put("string-key-array", "string-value1", "string-value2", "string-value3").put("long-key-array", 123456L, 1234567L, 12345678L).put("double-key-array", 1234.5D, 1234.56D, 1234.567D).put("boolean-key-array", true, false, true).build() | '{ string-key-array.0: "string-value1", string-key-array.1: "string-value2", string-key-array.2: "string-value3", long-key-array.0: "123456", long-key-array.1: "1234567", long-key-array.2: "12345678", double-key-array.0: "1234.5", double-key-array.1: "1234.56", double-key-array.2: "1234.567", boolean-key-array.0: "true", boolean-key-array.1: "false", boolean-key-array.2: "true" }'
+  }
+
+  def "test span links trace state"() {
+    setup:
+    def traceId = "1234567890abcdef1234567890abcdef" as String
+    def spanId = "fedcba0987654321" as String
+
+    def expectedTraceStateJson = expectedTraceState == null ? '' : ", traceState: \"$expectedTraceState\""
+    def expectedLinksTag = """
+    [
+      { traceId: "${traceId}",
+        spanId: "${spanId}",
+        traceFlags: 1
+        $expectedTraceStateJson
+      }
+    ]"""
+
+    when:
+    def span1 =tracer.spanBuilder("some-name")
+      .addLink(SpanContext.create(traceId, spanId, TraceFlags.getSampled(), traceState))
+      .startSpan()
+    span1.end()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          tags {
+            defaultTags()
+            tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
+          }
+        }
+      }
+    }
+
+    where:
+    traceState                                                                                                                                 | expectedTraceState
+    TraceState.getDefault()                                                                                                                    | null
+    TraceState.builder().put("key", "value").build()                                                                                           | 'key=value'
+    TraceState.builder().put("key1", "value1").put("key2", "value2").put("key3", "value3").put("key4", "value4").put("key5", "value5").build() | 'key5=value5,key4=value4,key3=value3,key2=value2,key1=value1'
   }
 
   def "test span attributes"() {


### PR DESCRIPTION
# What Does This Do

This PR adds OpenTelemetry span links support for its instrumentation.

# Motivation

This should improve OpenTelemetry API support and compatibility.

# Additional Notes

This relies on [the past span links to core addition](https://github.com/DataDog/dd-trace-java/pull/5569) and [its update](https://github.com/DataDog/dd-trace-java/pull/6009).

JIRA ticket: [APMJAVA-1087]

[APMJAVA-1087]: https://datadoghq.atlassian.net/browse/APMJAVA-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ