### PR TITLE
Introduce permanent errors

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/PermanentEvaluationException.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/PermanentEvaluationException.java
@@ -1,0 +1,11 @@
+package com.datadog.debugger.el;
+
+public class PermanentEvaluationException extends EvaluationException {
+  public PermanentEvaluationException(String message, String expr) {
+    super(message, expr);
+  }
+
+  public PermanentEvaluationException(String message, String expr, Throwable cause) {
+    super(message, expr, cause);
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
@@ -1,7 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Generated;
+import com.datadog.debugger.el.PermanentEvaluationException;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -25,7 +25,7 @@ public class GetMemberExpression implements ValueExpression<Value<?>> {
     try {
       return Value.of(valueRefResolver.getMember(targetValue.getValue(), memberName));
     } catch (RuntimeException ex) {
-      throw new EvaluationException(ex.getMessage(), memberName, ex);
+      throw new PermanentEvaluationException(ex.getMessage(), memberName, ex);
     }
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -24,6 +24,10 @@ public class IndexExpression implements ValueExpression<Value<?>> {
     if (targetValue == Value.undefined()) {
       return targetValue;
     }
+    if (targetValue.isNull()) {
+      throw new EvaluationException(
+          NullPointerException.class.getName(), PrettyPrintVisitor.print(this));
+    }
     Value<?> result = Value.undefinedValue();
     Value<?> keyValue = key.evaluate(valueRefResolver);
     if (keyValue == Value.undefined()) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
@@ -1,7 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
-import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Generated;
+import com.datadog.debugger.el.PermanentEvaluationException;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -20,7 +20,7 @@ public final class ValueRefExpression implements ValueExpression<Value<?>> {
     try {
       return Value.of(valueRefResolver.lookup(symbolName));
     } catch (RuntimeException ex) {
-      throw new EvaluationException(ex.getMessage(), symbolName);
+      throw new PermanentEvaluationException(ex.getMessage(), symbolName);
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -410,7 +410,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
           }
           List<DiagnosticMessage> diagnosticMessages =
               result.getDiagnostics().get(definition.getProbeId());
-          if (!result.getDiagnostics().isEmpty()) {
+          if (!diagnosticMessages.isEmpty()) {
             DebuggerAgent.getSink().addDiagnostics(definition.getProbeId(), diagnosticMessages);
           }
         }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateBuilder.java
@@ -1,27 +1,29 @@
 package com.datadog.debugger.agent;
 
 import static com.datadog.debugger.util.ValueScriptHelper.serializeValue;
+import static java.util.Collections.singletonList;
 
 import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.PermanentEvaluationException;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.ValueScript;
+import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.probe.LogProbe;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.EvaluationError;
+import datadog.trace.bootstrap.debugger.ProbeId;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LogMessageTemplateBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(LogMessageTemplateBuilder.class);
-  /**
-   * Serialization limits for log messages. Most values are lower than snapshot because you can
-   * directly reference values that are in your interest with Expression Language:
-   * obj.field.deepfield or array[1001]
-   */
+
+  private final ProbeId probeId;
   private final List<LogProbe.Segment> segments;
 
-  public LogMessageTemplateBuilder(List<LogProbe.Segment> segments) {
+  public LogMessageTemplateBuilder(ProbeId probeId, List<LogProbe.Segment> segments) {
+    this.probeId = probeId;
     this.segments = segments;
   }
 
@@ -45,6 +47,10 @@ public class LogMessageTemplateBuilder {
             } else {
               serializeValue(sb, segment.getParsedExpr().getDsl(), result.getValue(), status);
             }
+          } catch (PermanentEvaluationException ex) {
+            DiagnosticMessage diagnosticMessage =
+                new DiagnosticMessage(DiagnosticMessage.Kind.ERROR, ex.getMessage());
+            DebuggerAgent.getSink().addDiagnostics(probeId, singletonList(diagnosticMessage));
           } catch (EvaluationException ex) {
             LOGGER.debug("Evaluation error: ", ex);
             status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ValueScriptHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ValueScriptHelper.java
@@ -9,6 +9,11 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 
 public class ValueScriptHelper {
+  /**
+   * Serialization limits for log messages. Most values are lower than snapshot because you can
+   * directly reference values that are in your interest with Expression Language:
+   * obj.field.deepfield or array[1001]
+   */
   private static final Limits LIMITS = new Limits(1, 3, 255, 5);
 
   public static void serializeValue(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -261,11 +261,10 @@ public class LogProbesInstrumentationTest {
     Assertions.assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
+    assertEquals("this is log line with local var=", snapshot.getMessage());
+    assertEquals(1, listener.errors.size());
     assertEquals(
-        "this is log line with local var={Cannot find symbol: var42}", snapshot.getMessage());
-    assertEquals(1, snapshot.getEvaluationErrors().size());
-    assertEquals("var42", snapshot.getEvaluationErrors().get(0).getExpr());
-    assertEquals("Cannot find symbol: var42", snapshot.getEvaluationErrors().get(0).getMessage());
+        "Cannot find symbol: var42", listener.errors.get(LOG_ID.getId()).get(0).getMessage());
   }
 
   @Test
@@ -279,14 +278,11 @@ public class LogProbesInstrumentationTest {
     Assertions.assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCapturesNull(snapshot);
-    assertEquals(
-        "this is log line with field={Cannot dereference to field: intValue}",
-        snapshot.getMessage());
-    assertEquals(1, snapshot.getEvaluationErrors().size());
-    assertEquals("intValue", snapshot.getEvaluationErrors().get(0).getExpr());
+    assertEquals("this is log line with field=", snapshot.getMessage());
+    assertEquals(1, listener.errors.size());
     assertEquals(
         "Cannot dereference to field: intValue",
-        snapshot.getEvaluationErrors().get(0).getMessage());
+        listener.errors.get(LOG_ID.getId()).get(0).getMessage());
   }
 
   @Test
@@ -342,50 +338,50 @@ public class LogProbesInstrumentationTest {
     Snapshot snapshot = listener.snapshots.get(0);
     Assertions.assertNotNull(snapshot.getCaptures().getEntry());
     Assertions.assertEquals(2, snapshot.getCaptures().getEntry().getArguments().size());
-    Assertions.assertEquals(1, snapshot.getEvaluationErrors().size());
+    Assertions.assertEquals(1, listener.errors.size());
     Assertions.assertEquals(
-        "Cannot find symbol: typoArg", snapshot.getEvaluationErrors().get(0).getMessage());
+        "Cannot find symbol: typoArg", listener.errors.get(LOG_ID.getId()).get(0).getMessage());
   }
 
   @Test
   public void mergedMethodTemplateMainNoErrorAdditionalLogError()
       throws IOException, URISyntaxException {
-    List<Snapshot> snapshots =
+    DebuggerTransformerTest.TestSnapshotListener listener =
         doMergedMethodTemplateMixLogError(
             "this is log line #1 with arg={arg}", "this is log line #2 with arg={typoArg}");
-    Snapshot snapshot0 = snapshots.get(0);
+    Assertions.assertEquals(2, listener.snapshots.size());
+    Snapshot snapshot0 = listener.snapshots.get(0);
     assertEquals(LOG_ID1.getId(), snapshot0.getProbe().getId());
     assertNotNull(snapshot0.getCaptures().getEntry());
     assertNotNull(snapshot0.getCaptures().getReturn());
     assertNull(snapshot0.getEvaluationErrors());
     assertEquals("this is log line #1 with arg=1", snapshot0.getMessage());
-    Snapshot snapshot1 = snapshots.get(1);
+    Snapshot snapshot1 = listener.snapshots.get(1);
     assertEquals(LOG_ID2.getId(), snapshot1.getProbe().getId());
     assertNotNull(snapshot1.getCaptures().getEntry());
     assertNotNull(snapshot1.getCaptures().getReturn());
+    assertEquals("this is log line #2 with arg=", snapshot1.getMessage());
+    assertEquals(1, listener.errors.size());
     assertEquals(
-        "this is log line #2 with arg={Cannot find symbol: typoArg}", snapshot1.getMessage());
-    assertEquals(1, snapshot1.getEvaluationErrors().size());
-    assertEquals(
-        "Cannot find symbol: typoArg", snapshot1.getEvaluationErrors().get(0).getMessage());
+        "Cannot find symbol: typoArg", listener.errors.get(LOG_ID2.getId()).get(0).getMessage());
   }
 
   @Test
   public void mergedMethodTemplateMainLogErrorAdditionalNoError()
       throws IOException, URISyntaxException {
-    List<Snapshot> snapshots =
+    DebuggerTransformerTest.TestSnapshotListener listener =
         doMergedMethodTemplateMixLogError(
             "this is log line #1 with arg={typoArg}", "this is log line #2 with arg={arg}");
-    Snapshot snapshot0 = snapshots.get(0);
+    Assertions.assertEquals(2, listener.snapshots.size());
+    Snapshot snapshot0 = listener.snapshots.get(0);
     assertEquals(LOG_ID1.getId(), snapshot0.getProbe().getId());
     assertNotNull(snapshot0.getCaptures().getEntry());
     assertNotNull(snapshot0.getCaptures().getReturn());
+    assertEquals("this is log line #1 with arg=", snapshot0.getMessage());
+    assertEquals(1, listener.errors.size());
     assertEquals(
-        "this is log line #1 with arg={Cannot find symbol: typoArg}", snapshot0.getMessage());
-    assertEquals(1, snapshot0.getEvaluationErrors().size());
-    assertEquals(
-        "Cannot find symbol: typoArg", snapshot0.getEvaluationErrors().get(0).getMessage());
-    Snapshot snapshot1 = snapshots.get(1);
+        "Cannot find symbol: typoArg", listener.errors.get(LOG_ID.getId()).get(0).getMessage());
+    Snapshot snapshot1 = listener.snapshots.get(1);
     assertEquals(LOG_ID2.getId(), snapshot1.getProbe().getId());
     assertNotNull(snapshot1.getCaptures().getEntry());
     assertNotNull(snapshot1.getCaptures().getReturn());
@@ -396,30 +392,28 @@ public class LogProbesInstrumentationTest {
   @Test
   public void mergedMethodTemplateMainLogErrorAdditionalLogError()
       throws IOException, URISyntaxException {
-    List<Snapshot> snapshots =
+    DebuggerTransformerTest.TestSnapshotListener listener =
         doMergedMethodTemplateMixLogError(
             "this is log line #1 with arg={typoArg1}", "this is log line #2 with arg={typoArg2}");
-    Snapshot snapshot0 = snapshots.get(0);
+    Assertions.assertEquals(2, listener.snapshots.size());
+    Snapshot snapshot0 = listener.snapshots.get(0);
     assertEquals(LOG_ID1.getId(), snapshot0.getProbe().getId());
     assertNotNull(snapshot0.getCaptures().getEntry());
     assertNotNull(snapshot0.getCaptures().getReturn());
+    assertEquals("this is log line #1 with arg=", snapshot0.getMessage());
+    assertEquals(2, listener.errors.size());
     assertEquals(
-        "this is log line #1 with arg={Cannot find symbol: typoArg1}", snapshot0.getMessage());
-    assertEquals(1, snapshot0.getEvaluationErrors().size());
-    assertEquals(
-        "Cannot find symbol: typoArg1", snapshot0.getEvaluationErrors().get(0).getMessage());
-    Snapshot snapshot1 = snapshots.get(1);
+        "Cannot find symbol: typoArg1", listener.errors.get(LOG_ID1.getId()).get(0).getMessage());
+    Snapshot snapshot1 = listener.snapshots.get(1);
     assertEquals(LOG_ID2.getId(), snapshot1.getProbe().getId());
     assertNotNull(snapshot1.getCaptures().getEntry());
     assertNotNull(snapshot1.getCaptures().getReturn());
+    assertEquals("this is log line #2 with arg=", snapshot1.getMessage());
     assertEquals(
-        "this is log line #2 with arg={Cannot find symbol: typoArg2}", snapshot1.getMessage());
-    assertEquals(1, snapshot1.getEvaluationErrors().size());
-    assertEquals(
-        "Cannot find symbol: typoArg2", snapshot1.getEvaluationErrors().get(0).getMessage());
+        "Cannot find symbol: typoArg2", listener.errors.get(LOG_ID2.getId()).get(0).getMessage());
   }
 
-  private List<Snapshot> doMergedMethodTemplateMixLogError(
+  private DebuggerTransformerTest.TestSnapshotListener doMergedMethodTemplateMixLogError(
       String mainTemplate, String additionalTemplate) throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     LogProbe logProbe1 =
@@ -436,8 +430,7 @@ public class LogProbesInstrumentationTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
-    Assertions.assertEquals(2, listener.snapshots.size());
-    return listener.snapshots;
+    return listener;
   }
 
   private DebuggerTransformerTest.TestSnapshotListener installSingleProbe(

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 public class CapturedSnapshot20 {
   private int intField = 42;
+  private List<String> nullListField = null;
   private final String strField = "hello";
   private final List<String> strList = Arrays.asList("foobar1", "foobar2", "foobar3");
   private final Map<String, String> map = new HashMap<>();


### PR DESCRIPTION
# What Does This Do
When conditions or value expressions contain permanent errors like referencing a variable not defined, we report the error through probe statuses instead of snapshot and evaluation errors. We keep evaluation errors for transient error like a null pointer.

# Motivation

# Additional Notes
