### PR TITLE
Mark ci-visibility test as flaky

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ChannelContextTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ChannelContextTest.groovy
@@ -1,11 +1,15 @@
 package datadog.trace.civisibility.ipc
 
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 
 import java.nio.ByteBuffer
 import java.nio.channels.ByteChannel
 import java.util.concurrent.ThreadLocalRandom
 
+@IgnoreIf(reason = "JVM crash with IBM JDK", value = {
+  System.getProperty("java.vendor").contains("IBM") && System.getProperty("java.version").contains("1.8.")
+})
 class ChannelContextTest extends Specification {
 
   def "test message is read"() {


### PR DESCRIPTION
# What Does This Do

This PR marks a ci-visibility test as flaky.

# Motivation

This should improve CI stability.

# Additional Notes

I opened an issue related to this PR: #5618
