### PR TITLE
Fix log template issue for duplicated line probes

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -269,6 +270,7 @@ public class DebuggerContext {
   public static void evalContextAndCommit(
       CapturedContext context, Class<?> callingClass, int line, String... probeIds) {
     try {
+      List<ProbeImplementation> probeImplementations = new ArrayList<>();
       for (String probeId : probeIds) {
         ProbeImplementation probeImplementation = resolveProbe(probeId, callingClass);
         if (probeImplementation == null) {
@@ -276,6 +278,9 @@ public class DebuggerContext {
         }
         context.evaluate(
             probeId, probeImplementation, callingClass.getTypeName(), -1, MethodLocation.DEFAULT);
+        probeImplementations.add(probeImplementation);
+      }
+      for (ProbeImplementation probeImplementation : probeImplementations) {
         probeImplementation.commit(context, line);
       }
     } catch (Exception ex) {


### PR DESCRIPTION
# What Does This Do
With line probe, the freeze/commit of the data is done just after the evaluation per probe id.
The fix is to perform 2 loops on the probe ids, first only evaluation and then commit.

# Motivation
Having 2 line probes on the same location with same template or accessing the same field, arg or var result in an error evaluating the template.

# Additional Notes
