### PR TITLE
Add UDS support for the debugger by using `OkHttpUtils.buildHttpClient`

### DIFF
--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -15,6 +15,7 @@ excludedClassesCoverage += [
   'com.datadog.debugger.agent.DebuggerProbe.When.Threshold',
   'com.datadog.debugger.agent.DebuggerAgent.ShutdownHook',
   'com.datadog.debugger.agent.DebuggerAgent',
+  'com.datadog.debugger.uploader.BatchUploader',
   // too old for this coverage (JDK 1.2)
   'antlr.*',
   'com.datadog.debugger.util.MoshiSnapshotHelper' // only static classes

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -94,12 +94,12 @@ public class BatchUploader {
             config,
             new Dispatcher(okHttpExecutorService),
             urlBase,
-            true,
+            true, /* retryOnConnectionFailure */
             MAX_RUNNING_REQUESTS,
-            null,
-            null,
-            null,
-            null,
+            null, /* proxyHost */
+            null, /* proxyPort */
+            null, /* proxyUsername */
+            null, /* proxyPassword */
             requestTimeout.toMillis());
 
     debuggerMetrics = DebuggerMetrics.getInstance(config);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -10,7 +10,6 @@ import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentThreadFactory;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.SynchronousQueue;
@@ -20,7 +19,6 @@ import java.util.concurrent.TimeoutException;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.ConnectionPool;
-import okhttp3.ConnectionSpec;
 import okhttp3.Dispatcher;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -91,17 +89,18 @@ public class BatchUploader {
     ConnectionPool connectionPool = new ConnectionPool(MAX_RUNNING_REQUESTS, 1, TimeUnit.SECONDS);
 
     Duration requestTimeout = Duration.ofSeconds(config.getDebuggerUploadTimeout());
-    client = OkHttpUtils.buildHttpClient(
-        config,
-        new Dispatcher(okHttpExecutorService),
-        urlBase,
-        true,
-        MAX_RUNNING_REQUESTS,
-        null,
-        null,
-        null,
-        null,
-        requestTimeout.toMillis());
+    client =
+        OkHttpUtils.buildHttpClient(
+            config,
+            new Dispatcher(okHttpExecutorService),
+            urlBase,
+            true,
+            MAX_RUNNING_REQUESTS,
+            null,
+            null,
+            null,
+            null,
+            requestTimeout.toMillis());
 
     debuggerMetrics = DebuggerMetrics.getInstance(config);
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -4,6 +4,7 @@ import static datadog.trace.util.AgentThreadFactory.AgentThread.DEBUGGER_HTTP_DI
 
 import com.datadog.debugger.util.DebuggerMetrics;
 import datadog.common.container.ContainerInfo;
+import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
 import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentThreadFactory;
@@ -88,26 +89,20 @@ public class BatchUploader {
     // Reusing connections causes non daemon threads to be created which causes agent to prevent app
     // from exiting. See https://github.com/square/okhttp/issues/4029 for some details.
     ConnectionPool connectionPool = new ConnectionPool(MAX_RUNNING_REQUESTS, 1, TimeUnit.SECONDS);
-    // Use same timeout everywhere for simplicity
-    Duration requestTimeout = Duration.ofSeconds(config.getDebuggerUploadTimeout());
-    OkHttpClient.Builder clientBuilder =
-        new OkHttpClient.Builder()
-            .connectTimeout(requestTimeout)
-            .writeTimeout(requestTimeout)
-            .readTimeout(requestTimeout)
-            .callTimeout(requestTimeout)
-            .dispatcher(new Dispatcher(okHttpExecutorService))
-            .connectionPool(connectionPool);
 
-    if ("http".equals(urlBase.scheme())) {
-      // force clear text when using http to avoid failures for JVMs without TLS
-      // see: https://github.com/DataDog/dd-trace-java/pull/1582
-      clientBuilder.connectionSpecs(Collections.singletonList(ConnectionSpec.CLEARTEXT));
-    }
-    client = clientBuilder.build();
-    client.dispatcher().setMaxRequests(MAX_RUNNING_REQUESTS);
-    // We are mainly talking to the same(ish) host so we need to raise this limit
-    client.dispatcher().setMaxRequestsPerHost(MAX_RUNNING_REQUESTS);
+    Duration requestTimeout = Duration.ofSeconds(config.getDebuggerUploadTimeout());
+    client = OkHttpUtils.buildHttpClient(
+        config,
+        new Dispatcher(okHttpExecutorService),
+        urlBase,
+        true,
+        MAX_RUNNING_REQUESTS,
+        null,
+        null,
+        null,
+        null,
+        requestTimeout.toMillis());
+
     debuggerMetrics = DebuggerMetrics.getInstance(config);
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -94,7 +94,7 @@ public class BatchUploader {
             config,
             new Dispatcher(okHttpExecutorService),
             urlBase,
-            true, /* retryOnConnectionFailure */
+            true, /* retry */
             MAX_RUNNING_REQUESTS,
             null, /* proxyHost */
             null, /* proxyPort */


### PR DESCRIPTION
# What Does This Do
Change the way we construct our `OkHttpClient` in Dynamic Instrumentation to match the way it is constructed in Profiling.

# Motivation
At the moment, Dynamic Instrumentation does not work in environment where the tracer is configured to use UDS (e.g. k8s with the Admissions Controller where [the configuration](https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator#configure-apm-and-dogstatsd-communication-mode) for `admission_controller.inject_config.mode` or `admission.datadoghq.com/config.mode` is set to `socket`).

# Additional Notes
System tests will be added in a separate PR.
