### PR TITLE
Avoid sending trace context twice when using JMS-over-SQS

### DIFF
--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -147,6 +147,12 @@ public final class JMSDecorator extends MessagingClientDecorator {
     }
   }
 
+  public static boolean canInject(Message message) {
+    // JMS->SQS already stores the trace context in 'X-Amzn-Trace-Id' / 'AWSTraceHeader',
+    // so skip storing same context again to avoid SQS limit of 10 attributes per message.
+    return !message.getClass().getName().startsWith("com.amazon.sqs.javamessaging");
+  }
+
   public void onTimeInQueue(AgentSpan span, CharSequence resourceName, String serviceName) {
     if (null != resourceName) {
       span.setResourceName(resourceName);

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -103,13 +103,15 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
       final AgentSpan span = startSpan(JMS_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, resourceName);
-      if (Config.get().isJmsPropagationEnabled()
-          && (null == producerState || !producerState.isPropagationDisabled())) {
-        propagate().inject(span, message, SETTER);
-      }
-      if (TIME_IN_QUEUE_ENABLED) {
-        if (null != producerState) {
-          SETTER.injectTimeInQueue(message, producerState);
+      if (JMSDecorator.canInject(message)) {
+        if (Config.get().isJmsPropagationEnabled()
+            && (null == producerState || !producerState.isPropagationDisabled())) {
+          propagate().inject(span, message, SETTER);
+        }
+        if (TIME_IN_QUEUE_ENABLED) {
+          if (null != producerState) {
+            SETTER.injectTimeInQueue(message, producerState);
+          }
         }
       }
       return activateSpan(span);
@@ -148,16 +150,18 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Tracin
       final AgentSpan span = startSpan(JMS_PRODUCE);
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, resourceName);
-      if (Config.get().isJmsPropagationEnabled()
-          && !Config.get().isJmsPropagationDisabledForDestination(destinationName)) {
-        propagate().inject(span, message, SETTER);
-      }
-      if (TIME_IN_QUEUE_ENABLED) {
-        MessageProducerState producerState =
-            InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)
-                .get(producer);
-        if (null != producerState) {
-          SETTER.injectTimeInQueue(message, producerState);
+      if (JMSDecorator.canInject(message)) {
+        if (Config.get().isJmsPropagationEnabled()
+            && !Config.get().isJmsPropagationDisabledForDestination(destinationName)) {
+          propagate().inject(span, message, SETTER);
+        }
+        if (TIME_IN_QUEUE_ENABLED) {
+          MessageProducerState producerState =
+              InstrumentationContext.get(MessageProducer.class, MessageProducerState.class)
+                  .get(producer);
+          if (null != producerState) {
+            SETTER.injectTimeInQueue(message, producerState);
+          }
         }
       }
       return activateSpan(span);


### PR DESCRIPTION
# What Does This Do

When sending JMS messages over SQS we already store the trace context in 'X-Amzn-Trace-Id' / 'AWSTraceHeader',
so we can skip storing the same context as JMS message properties.

# Motivation

Avoids a potential issue where adding JMS message properties might exceed the SQS limit of 10 attributes per message.

# Additional Notes

One alternative approach would be to instrument `SQSMessage` (which implements the JMS message API) and filter out setting of any trace context related properties.

Alternatively we could instrument the `propertyToMessageAttribute` method in `SQSMessageProducer` which copies the JMS message properties into SQS message attributes and filter out any trace context related properties there instead.

Both of these alternatives involve generating and injecting the distributed trace context via the JMS API, but filtering it out before it reaches SQS. I decided to go with a simpler approach of not injecting it to begin with when we know that the JMS message is a wrapper around SQS.

Luckily we can rely on the package name, as the [Amazon SQS Java Messaging Library](https://github.com/awslabs/amazon-sqs-java-messaging-lib/) uses the same package-prefix for all its message types.