### PR TITLE
[Spark] Add support for spark structured streaming

### DIFF
--- a/dd-java-agent/instrumentation/spark/build.gradle
+++ b/dd-java-agent/instrumentation/spark/build.gradle
@@ -1,7 +1,7 @@
 muzzle {
   pass {
     group = "org.apache.spark"
-    module = "spark-core_2.12"
+    module = "spark-sql_2.12"
     versions = "[2.4.0,)"
   }
 }
@@ -20,6 +20,7 @@ ext {
 
 dependencies {
   compileOnly group: 'org.apache.spark', name: 'spark-core_2.12', version: '2.4.0'
+  compileOnly group: 'org.apache.spark', name: 'spark-sql_2.12', version: '2.4.0'
 
   testImplementation group: 'com.datadoghq', name: 'sketches-java', version: '0.8.2'
   testImplementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.14.0'

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -7,13 +7,23 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 import org.apache.spark.ExceptionFailure;
 import org.apache.spark.SparkConf;
 import org.apache.spark.TaskFailedReason;
 import org.apache.spark.scheduler.*;
+import org.apache.spark.sql.execution.streaming.MicroBatchExecution;
+import org.apache.spark.sql.execution.streaming.StreamExecution;
+import org.apache.spark.sql.streaming.SourceProgress;
+import org.apache.spark.sql.streaming.StateOperatorProgress;
+import org.apache.spark.sql.streaming.StreamingQueryListener;
+import org.apache.spark.sql.streaming.StreamingQueryProgress;
 import scala.Tuple2;
 
 /**
@@ -37,15 +47,20 @@ public class DatadogSparkListener extends SparkListener {
   private final AgentTracer.TracerAPI tracer;
 
   private AgentSpan applicationSpan;
+  private final HashMap<String, AgentSpan> streamingBatchSpans = new HashMap<>();
   private final HashMap<Integer, AgentSpan> jobSpans = new HashMap<>();
   private final HashMap<Long, AgentSpan> stageSpans = new HashMap<>();
 
   private final HashMap<Integer, Integer> stageToJob = new HashMap<>();
+  private final HashMap<Long, Properties> stageProperties = new HashMap<>();
 
   private final SparkAggregatedTaskMetrics applicationMetrics = new SparkAggregatedTaskMetrics();
+  private final HashMap<String, SparkAggregatedTaskMetrics> streamingBatchMetrics = new HashMap<>();
   private final HashMap<Integer, SparkAggregatedTaskMetrics> jobMetrics = new HashMap<>();
   private final HashMap<Long, SparkAggregatedTaskMetrics> stageMetrics = new HashMap<>();
 
+  private final HashMap<UUID, StreamingQueryListener.QueryStartedEvent> streamingQueries =
+      new HashMap<>();
   private final HashMap<String, SparkListenerExecutorAdded> liveExecutors = new HashMap<>();
 
   private final boolean isRunningOnDatabricks;
@@ -143,7 +158,21 @@ public class DatadogSparkListener extends SparkListener {
             .withTag("job_id", jobStart.jobId())
             .withTag("stage_count", jobStart.stageInfos().size());
 
-    if (isRunningOnDatabricks) {
+    String batchKey = getStreamingBatchKey(jobStart.properties());
+
+    if (batchKey != null) {
+      AgentSpan batchSpan = streamingBatchSpans.get(batchKey);
+
+      if (batchSpan == null) {
+        batchSpan =
+            buildSparkSpan("spark.batch").withStartTimestamp(jobStart.time() * 1000).start();
+
+        streamingBatchSpans.put(batchKey, batchSpan);
+      }
+
+      // In streaming mode, the batch spans are the local root spans
+      jobSpanBuilder.asChildOf(batchSpan.context());
+    } else if (isRunningOnDatabricks) {
       // In databricks, the spark jobs are the local root spans so adding the spark conf parameters
       // to the job spans
       for (Tuple2<String, String> conf : sparkConf.getAll()) {
@@ -173,7 +202,7 @@ public class DatadogSparkListener extends SparkListener {
         }
       }
     } else {
-      // In non-databricks env, the spark application is the local root spans
+      // In non-databricks, non-streaming env, the spark application is the local root span
       jobSpanBuilder.asChildOf(applicationSpan.context());
     }
 
@@ -262,6 +291,7 @@ public class DatadogSparkListener extends SparkListener {
     stageMetrics.put(
         stageSpanKey,
         new SparkAggregatedTaskMetrics(computeCurrentAvailableExecutorTime(submissionTimeMs)));
+    stageProperties.put(stageSpanKey, stageSubmitted.properties());
 
     AgentSpan stageSpan =
         buildSparkSpan("spark.stage")
@@ -327,6 +357,15 @@ public class DatadogSparkListener extends SparkListener {
       jobMetrics
           .computeIfAbsent(jobId, k -> new SparkAggregatedTaskMetrics())
           .accumulateStageMetrics(stageMetric);
+
+      Properties prop = stageProperties.remove(stageSpanKey);
+      String batchKey = getStreamingBatchKey(prop);
+
+      if (batchKey != null) {
+        streamingBatchMetrics
+            .computeIfAbsent(batchKey, k -> new SparkAggregatedTaskMetrics())
+            .accumulateStageMetrics(stageMetric);
+      }
     }
 
     span.finish(completionTimeMs * 1000);
@@ -430,6 +469,157 @@ public class DatadogSparkListener extends SparkListener {
     }
   }
 
+  @Override
+  public void onOtherEvent(SparkListenerEvent event) {
+    if (event instanceof StreamingQueryListener.QueryStartedEvent) {
+      onStreamingQueryStartedEvent((StreamingQueryListener.QueryStartedEvent) event);
+    } else if (event instanceof StreamingQueryListener.QueryProgressEvent) {
+      onStreamingQueryProgressEvent((StreamingQueryListener.QueryProgressEvent) event);
+    } else if (event instanceof StreamingQueryListener.QueryTerminatedEvent) {
+      onStreamingQueryTerminatedEvent((StreamingQueryListener.QueryTerminatedEvent) event);
+    }
+  }
+
+  private synchronized void onStreamingQueryStartedEvent(
+      StreamingQueryListener.QueryStartedEvent event) {
+    if (streamingQueries.size() > MAX_COLLECTION_SIZE) {
+      return;
+    }
+
+    streamingQueries.put(event.id(), event);
+  }
+
+  private synchronized void onStreamingQueryTerminatedEvent(
+      StreamingQueryListener.QueryTerminatedEvent event) {
+    StreamingQueryListener.QueryStartedEvent startedEvent = streamingQueries.remove(event.id());
+
+    ArrayList<String> batchesToFinish = new ArrayList<>();
+
+    for (String batchKey : streamingBatchSpans.keySet()) {
+      if (batchKey.startsWith(event.id().toString())) {
+        batchesToFinish.add(batchKey);
+      }
+    }
+
+    for (String batchKey : batchesToFinish) {
+      AgentSpan batchSpan = streamingBatchSpans.remove(batchKey);
+      SparkAggregatedTaskMetrics metrics = streamingBatchMetrics.remove(batchKey);
+
+      if (batchSpan != null) {
+        if (metrics != null) {
+          metrics.setSpanMetrics(batchSpan, "spark");
+        }
+
+        batchSpan.setTag("id", event.id());
+        batchSpan.setTag("run_id", event.runId());
+        batchSpan.setTag("batch_id", getBatchIdFromBatchKey(batchKey));
+        if (startedEvent != null) {
+          batchSpan.setTag("name", startedEvent.name());
+          batchSpan.setTag(DDTags.RESOURCE_NAME, startedEvent.name());
+        }
+
+        if (event.exception().isDefined()) {
+          String exceptionString = event.exception().get();
+
+          batchSpan.setError(true);
+          batchSpan.setErrorMessage(getErrorMessageWithoutStackTrace(exceptionString));
+          batchSpan.setTag(DDTags.ERROR_STACK, exceptionString);
+        }
+
+        batchSpan.finish();
+      }
+    }
+  }
+
+  private synchronized void onStreamingQueryProgressEvent(
+      StreamingQueryListener.QueryProgressEvent event) {
+    StreamingQueryProgress progress = event.progress();
+
+    String batchKey =
+        getStreamingBatchKey(progress.id().toString(), String.valueOf(progress.batchId()));
+
+    AgentSpan batchSpan = streamingBatchSpans.remove(batchKey);
+    SparkAggregatedTaskMetrics metrics = streamingBatchMetrics.remove(batchKey);
+    if (batchSpan != null) {
+      if (metrics != null) {
+        metrics.setSpanMetrics(batchSpan, "spark");
+      }
+
+      batchSpan.setTag("id", progress.id());
+      batchSpan.setTag("run_id", progress.runId());
+      batchSpan.setTag("batch_id", progress.batchId());
+      batchSpan.setTag("name", progress.name());
+      batchSpan.setTag(DDTags.RESOURCE_NAME, progress.name());
+
+      batchSpan.setMetric("spark.num_input_rows", progress.numInputRows());
+      batchSpan.setMetric("spark.input_rows_per_second", progress.inputRowsPerSecond());
+      batchSpan.setMetric("spark.processed_rows_per_second", progress.processedRowsPerSecond());
+
+      Long watermark = convertStringDateToMillis(progress.eventTime().get("watermark"));
+      if (watermark != null) {
+        batchSpan.setMetric("spark.event_time.watermark", watermark);
+      }
+      Long maxEventTime = convertStringDateToMillis(progress.eventTime().get("max"));
+      if (maxEventTime != null) {
+        batchSpan.setMetric("spark.event_time.max", maxEventTime);
+      }
+      Long minEventTime = convertStringDateToMillis(progress.eventTime().get("min"));
+      if (minEventTime != null) {
+        batchSpan.setMetric("spark.event_time.min", minEventTime);
+      }
+
+      Long addBatch = progress.durationMs().get("addBatch");
+      if (addBatch != null) {
+        batchSpan.setMetric("spark.add_batch_duration", addBatch);
+      }
+      Long getBatch = progress.durationMs().get("getBatch");
+      if (getBatch != null) {
+        batchSpan.setMetric("spark.get_batch_duration", getBatch);
+      }
+      Long latestOffset = progress.durationMs().get("latestOffset");
+      if (latestOffset != null) {
+        batchSpan.setMetric("spark.latest_offset_duration", latestOffset);
+      }
+      Long queryPlanning = progress.durationMs().get("queryPlanning");
+      if (queryPlanning != null) {
+        batchSpan.setMetric("spark.query_planing_duration", queryPlanning);
+      }
+      Long triggerExecution = progress.durationMs().get("triggerExecution");
+      if (triggerExecution != null) {
+        batchSpan.setMetric("spark.trigger_execution_duration", triggerExecution);
+      }
+      Long walCommit = progress.durationMs().get("walCommit");
+      if (walCommit != null) {
+        batchSpan.setMetric("spark.wal_commit_duration", walCommit);
+      }
+
+      for (int i = 0; i < progress.sources().length; i++) {
+        SourceProgress source = progress.sources()[i];
+        String prefix = "spark.source." + i + ".";
+
+        batchSpan.setTag(prefix + "description", source.description());
+        batchSpan.setTag(prefix + "start_offset", source.startOffset());
+        batchSpan.setTag(prefix + "end_offset", source.endOffset());
+        batchSpan.setTag(prefix + "num_input_rows", source.numInputRows());
+        batchSpan.setTag(prefix + "input_rows_per_second", source.inputRowsPerSecond());
+        batchSpan.setTag(prefix + "processed_rows_per_second", source.processedRowsPerSecond());
+      }
+
+      for (int i = 0; i < progress.stateOperators().length; i++) {
+        StateOperatorProgress state = progress.stateOperators()[i];
+        String prefix = "spark.state." + i + ".";
+
+        batchSpan.setTag(prefix + "num_rows_total", state.numRowsTotal());
+        batchSpan.setTag(prefix + "num_rows_updated", state.numRowsUpdated());
+        batchSpan.setTag(prefix + "memory_used_bytes", state.memoryUsedBytes());
+      }
+
+      batchSpan.setTag("spark.sink.description", progress.sink().description());
+
+      batchSpan.finish();
+    }
+  }
+
   private AgentTracer.SpanBuilder buildSparkSpan(String spanName) {
     return tracer.buildSpan(spanName).withSpanType("spark").withTag("app_id", appId);
   }
@@ -483,5 +673,40 @@ public class DatadogSparkListener extends SparkListener {
     }
 
     return currentAvailableExecutorTime;
+  }
+
+  private static Long convertStringDateToMillis(String isoUtcDateStr) {
+    if (isoUtcDateStr == null) {
+      return null;
+    }
+
+    try {
+      return OffsetDateTime.parse(isoUtcDateStr).toInstant().toEpochMilli();
+    } catch (DateTimeParseException e) {
+      return null;
+    }
+  }
+
+  private static String getStreamingBatchKey(Properties properties) {
+    if (properties == null) {
+      return null;
+    }
+
+    Object queryId = properties.get(StreamExecution.QUERY_ID_KEY());
+    Object batchId = properties.get(MicroBatchExecution.BATCH_ID_KEY());
+
+    if (queryId == null || batchId == null) {
+      return null;
+    }
+
+    return getStreamingBatchKey(queryId.toString(), batchId.toString());
+  }
+
+  private static String getStreamingBatchKey(String queryId, String batchId) {
+    return queryId + "." + batchId;
+  }
+
+  private static String getBatchIdFromBatchKey(String batchKey) {
+    return batchKey.substring(batchKey.lastIndexOf(".") + 1);
   }
 }

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
@@ -50,6 +50,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
     query.processAllAvailable()
 
     query.stop()
+    sparkSession.stop()
 
     expect:
     assertTraces(2) {
@@ -163,9 +164,6 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
         }
       }
     }
-
-    cleanup:
-    sparkSession.stop()
   }
 
   def "handle failure during streaming processing"() {
@@ -185,6 +183,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
       query.processAllAvailable()
     }
     catch (Exception ignored) {}
+    sparkSession.stop()
 
     assertTraces(1) {
       trace(4) {
@@ -217,8 +216,5 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
         }
       }
     }
-
-    cleanup:
-    sparkSession.stop()
   }
 }

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
@@ -1,0 +1,224 @@
+import datadog.trace.agent.test.AgentTestRunner
+import org.apache.spark.sql.Encoders
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.SparkSession
+import scala.Option
+import scala.collection.JavaConverters
+import scala.collection.immutable.Seq
+
+class SparkStructuredStreamingTest extends AgentTestRunner {
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.integration.spark.enabled", "true")
+  }
+
+  private memoryStream(SparkSession sparkSession) {
+    if (TestSparkComputation.sparkVersion >= '3') {
+      return new MemoryStream<String>(1, sparkSession.sqlContext(), Option.empty(), Encoders.STRING())
+    }
+
+    return new MemoryStream<String>(1, sparkSession.sqlContext(), Encoders.STRING())
+  }
+
+  def "generate spark structured streaming batches"() {
+    setup:
+    def sparkSession = SparkSession.builder()
+      .config("spark.master", "local[2]")
+      .config("spark.sql.shuffle.partitions", "2") // Small parallelism to speed up tests
+      .appName("Sample Streaming Application")
+      .getOrCreate()
+
+    def inputStream = memoryStream(sparkSession)
+
+    def query = inputStream
+      .toDS()
+      .selectExpr("value", "current_timestamp() as event_time")
+      .withWatermark("event_time", "0 seconds")
+      .groupBy("value")
+      .count()
+      .writeStream()
+      .queryName("test-query")
+      .outputMode("complete")
+      .format("console")
+      .start()
+
+    inputStream.addData(JavaConverters.asScalaBuffer(["foo", "foo", "bar"]).toSeq() as Seq<String>)
+    query.processAllAvailable()
+    inputStream.addData(JavaConverters.asScalaBuffer(["foo", "bar"]).toSeq() as Seq<String>)
+    query.processAllAvailable()
+
+    query.stop()
+
+    expect:
+    assertTraces(2) {
+      trace(4) {
+        span {
+          operationName "spark.batch"
+          resourceName "test-query"
+          spanType "spark"
+          parent()
+          tags {
+            defaultTags()
+            // Streaming tags
+            "batch_id" 0
+            "name" "test-query"
+            "app_id" String
+            "id" UUID
+            "run_id" UUID
+            "spark.num_input_rows" 3
+            "spark.add_batch_duration" Long
+            "spark.get_batch_duration" Long
+            "spark.query_planing_duration" Long
+            "spark.trigger_execution_duration" Long
+            "spark.wal_commit_duration" Long
+            "spark.input_rows_per_second" Double
+            "spark.processed_rows_per_second" Double
+            "spark.sink.description" ~"org.apache.spark.sql.execution.streaming.Console.*"
+            "spark.source.0.description" "MemoryStream[value#1]"
+            "spark.source.0.end_offset" String
+            "spark.source.0.input_rows_per_second" Double
+            "spark.source.0.num_input_rows" 3
+            "spark.source.0.processed_rows_per_second" Double
+            "spark.state.0.memory_used_bytes" Long
+            "spark.state.0.num_rows_total" 2
+            "spark.state.0.num_rows_updated" 2
+            "spark.event_time.watermark" Long
+            "spark.event_time.max" Long
+            "spark.event_time.min" Long
+            if (TestSparkComputation.sparkVersion >= '3') {
+              "spark.latest_offset_duration" Long
+            }
+
+            // Regular spark tags
+            "spark.available_executor_time" Long
+            "spark.disk_bytes_spilled" Long
+            "spark.executor_cpu_time" Long
+            "spark.executor_deserialize_cpu_time" Long
+            "spark.executor_deserialize_time" Long
+            "spark.executor_run_time" Long
+            "spark.input_bytes" Long
+            "spark.input_records" Long
+            "spark.jvm_gc_time" Long
+            "spark.memory_bytes_spilled" Long
+            "spark.output_bytes" Long
+            "spark.output_records" Long
+            "spark.peak_execution_memory" Long
+            "spark.result_serialization_time" Long
+            "spark.result_size" Long
+            "spark.skew_time" Long
+            "spark.shuffle_read_bytes" Long
+            "spark.shuffle_read_bytes_local" Long
+            "spark.shuffle_read_bytes_remote" Long
+            "spark.shuffle_read_bytes_remote_to_disk" Long
+            "spark.shuffle_read_fetch_wait_time" Long
+            "spark.shuffle_read_records" Long
+            "spark.shuffle_write_bytes" Long
+            "spark.shuffle_write_records" Long
+            "spark.shuffle_write_time" Long
+            "spark.task_completed_count" Long
+            "spark.task_failed_count" Long
+            "spark.task_retried_count" Long
+            "spark.task_with_output_count" Long
+          }
+        }
+        span {
+          operationName "spark.job"
+          spanType "spark"
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          childOf(span(1))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          childOf(span(1))
+        }
+      }
+      trace(4) {
+        span {
+          operationName "spark.batch"
+          spanType "spark"
+          assert span.tags["batch_id"] == 1
+          parent()
+        }
+        span {
+          operationName "spark.job"
+          spanType "spark"
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          childOf(span(1))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          childOf(span(1))
+        }
+      }
+    }
+
+    cleanup:
+    sparkSession.stop()
+  }
+
+  def "handle failure during streaming processing"() {
+    setup:
+    def sparkSession = SparkSession.builder()
+      .config("spark.master", "local[2]")
+      .config("spark.sql.shuffle.partitions", "2") // Small parallelism to speed up tests
+      .appName("Failing Streaming Application")
+      .getOrCreate()
+
+    def inputStream = memoryStream(sparkSession)
+
+    def query = TestSparkComputation.generateTestFailingStreamingComputation(inputStream.toDS())
+
+    try {
+      inputStream.addData(JavaConverters.asScalaBuffer(["foo", "bar"]).toSeq() as Seq<String>)
+      query.processAllAvailable()
+    }
+    catch (Exception ignored) {}
+
+    assertTraces(1) {
+      trace(4) {
+        span {
+          operationName "spark.batch"
+          resourceName "failing-query"
+          spanType "spark"
+          errored true
+          assert span.tags["error.message"] =~ /org.apache.spark.SparkException: .*\n/
+          assert span.tags["error.stack"] =~ /(?s).*Job aborted due to stage failure.*Caused by: java.lang.NullPointerException.*/
+          parent()
+        }
+        span {
+          operationName "spark.job"
+          spanType "spark"
+          errored true
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          errored true
+          childOf(span(1))
+        }
+        span {
+          operationName "spark.task"
+          spanType "spark"
+          errored true
+          childOf(span(2))
+        }
+      }
+    }
+
+    cleanup:
+    sparkSession.stop()
+  }
+}

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -45,21 +45,21 @@ class SparkTest extends AgentTestRunner {
         }
         span {
           operationName "spark.job"
-          resourceName "count at TestSparkComputation.java:12"
+          resourceName "count at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           childOf(span(0))
         }
         span {
           operationName "spark.stage"
-          resourceName "count at TestSparkComputation.java:12"
+          resourceName "count at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           childOf(span(1))
         }
         span {
           operationName "spark.stage"
-          resourceName "distinct at TestSparkComputation.java:12"
+          resourceName "distinct at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           childOf(span(1))
@@ -142,7 +142,7 @@ class SparkTest extends AgentTestRunner {
         }
         span {
           operationName "spark.job"
-          resourceName "collect at TestSparkComputation.java:21"
+          resourceName "collect at TestSparkComputation.java:26"
           spanType "spark"
           errored true
           childOf(span(0))
@@ -152,7 +152,7 @@ class SparkTest extends AgentTestRunner {
         }
         span {
           operationName "spark.stage"
-          resourceName "collect at TestSparkComputation.java:21"
+          resourceName "collect at TestSparkComputation.java:26"
           spanType "spark"
           errored true
           childOf(span(1))
@@ -204,6 +204,7 @@ class SparkTest extends AgentTestRunner {
 
     cleanup:
     sparkSession.stop()
+    DatadogSparkListener.finishTraceOnApplicationEnd = true
   }
 
   def "generate databricks spans"() {
@@ -230,7 +231,7 @@ class SparkTest extends AgentTestRunner {
       trace(3) {
         span {
           operationName "spark.job"
-          resourceName "count at TestSparkComputation.java:12"
+          resourceName "count at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           traceId 8944764253919609482G
@@ -238,14 +239,14 @@ class SparkTest extends AgentTestRunner {
         }
         span {
           operationName "spark.stage"
-          resourceName "count at TestSparkComputation.java:12"
+          resourceName "count at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           childOf(span(0))
         }
         span {
           operationName "spark.stage"
-          resourceName "distinct at TestSparkComputation.java:12"
+          resourceName "distinct at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           childOf(span(0))
@@ -254,21 +255,21 @@ class SparkTest extends AgentTestRunner {
       trace(3) {
         span {
           operationName "spark.job"
-          resourceName "count at TestSparkComputation.java:12"
+          resourceName "count at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           parent()
         }
         span {
           operationName "spark.stage"
-          resourceName "count at TestSparkComputation.java:12"
+          resourceName "count at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           childOf(span(0))
         }
         span {
           operationName "spark.stage"
-          resourceName "distinct at TestSparkComputation.java:12"
+          resourceName "distinct at TestSparkComputation.java:17"
           spanType "spark"
           errored false
           childOf(span(0))

--- a/dd-java-agent/instrumentation/spark/src/test/java/TestSparkComputation.java
+++ b/dd-java-agent/instrumentation/spark/src/test/java/TestSparkComputation.java
@@ -1,4 +1,9 @@
+import java.util.concurrent.TimeoutException;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.streaming.StreamingQuery;
 
 /**
  * Helper class to generate the spark computation for test. Doing it in java because spark does not
@@ -19,6 +24,16 @@ public class TestSparkComputation {
         .toJavaRDD()
         .map(x -> ((Long) null).toString())
         .collect();
+  }
+
+  public static StreamingQuery generateTestFailingStreamingComputation(Dataset<String> ds)
+      throws TimeoutException {
+    return ds.map((MapFunction<String, String>) x -> ((Long) null).toString(), Encoders.STRING())
+        .writeStream()
+        .queryName("failing-query")
+        .outputMode("append")
+        .format("console")
+        .start();
   }
 
   public static String getSparkVersion() {


### PR DESCRIPTION
# What Does This Do

[Spark structured streaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html) is a stream processing engine built on the Spark SQL. It process data streams as a series of small batch jobs, where each batch jobs is composed of the regular spark operations (job / stage / task)

A streaming applications is composed of 
- one or more long running queries, identified a `queryId`
- each query continuously executes batches identified by a incrementing `batchId`

Spark is emitting 3 type of events in structured streaming:
- `QueryStartedEvent` 
- `QueryTerminatedEvent` 
- `QueryProgressEvent`

`QueryProgressEvent` is emitted at the end of each micro-batch in the [finishTrigger](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MicroBatchExecution.scala#L293) method and has a lot of metrics about the executed batch

There is no event emitted at the start of a micro batch (QueryStartedEvent is emitted at the start of the long running query, not for every micro-batch). To circumvent that, the batch span is started at the start of its first job, the caveat is that the first job is started after the `getBatch` and `queryPlanning` computations, leading to the batch span being shorter that the real batch duration

Spark structured streaming is part of the `spark-sql` module, meaning that the muzzle directive has to be changed. This is acceptable as Spark SQL is the recommended way to use spark and vendors like EMR or databricks always provide `spark-sql` in their managed versions