### PR TITLE
Capture more Spark parameters

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkConfAllowList.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkConfAllowList.java
@@ -17,6 +17,7 @@ class SparkConfAllowList {
   private static final Set<String> allowedApplicationParams =
       new HashSet<>(
           Arrays.asList(
+              "spark.default.parallelism",
               "spark.dynamicAllocation.enabled",
               "spark.dynamicAllocation.executorIdleTimeout",
               "spark.dynamicAllocation.initialExecutors",
@@ -30,10 +31,12 @@ class SparkConfAllowList {
               "spark.driver.memoryOverhead",
               "spark.driver.memoryOverheadFactor",
               "spark.executor.cores",
+              "spark.executor.instances",
               "spark.executor.memory",
               "spark.executor.pyspark.memory",
               "spark.executor.memoryOverhead",
               "spark.executor.memoryOverheadFactor",
+              "spark.files.maxPartitionBytes",
               "spark.master",
               "spark.memory.fraction",
               "spark.memory.storageFraction",
@@ -41,6 +44,7 @@ class SparkConfAllowList {
               "spark.memory.offHeap.size",
               "spark.submit.deployMode",
               "spark.sql.autoBroadcastJoinThreshold",
+              "spark.sql.files.maxPartitionBytes",
               "spark.sql.shuffle.partitions"));
 
   /**


### PR DESCRIPTION
# What Does This Do

Adding those 4 spark parameters to the list that are captured since they are quite important

|                                   |                                                                                                                               |
|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
| spark.default.parallelism         | Default number of partitions in RDDs returned by transformations like join, reduceByKey, and parallelize when not set by user |
| spark.executor.instances          | Number of executors when not using dynamic allocation                                                                         |
| spark.files.maxPartitionBytes     | The maximum number of bytes to pack into a single partition when reading files.                                               |
| spark.sql.files.maxPartitionBytes | Same as spark.files.maxPartitionBytes for SQL operations                                                                      |

