### PR TITLE
Weak cipher detection in javax.crypto.KeyGenerator

### DIFF
--- a/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakCipherInstrumentationCallSite.java
+++ b/dd-java-agent/instrumentation/java-security/src/main/java/datadog/trace/instrumentation/java/security/WeakCipherInstrumentationCallSite.java
@@ -6,28 +6,29 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.WeakCipherModule;
-import java.security.Provider;
 
 @Sink(VulnerabilityTypes.WEAK_CIPHER)
 @CallSite(spi = IastCallSites.class)
 public class WeakCipherInstrumentationCallSite {
 
   @CallSite.Before("javax.crypto.Cipher javax.crypto.Cipher.getInstance(java.lang.String)")
-  public static void beforeGetInstance(@CallSite.Argument final String algo) {
-    onCipherAlgorithm(algo);
-  }
-
   @CallSite.Before(
       "javax.crypto.Cipher javax.crypto.Cipher.getInstance(java.lang.String, java.lang.String)")
-  public static void beforeGetInstance(
-      @CallSite.Argument final String algo, @CallSite.Argument final String provider) {
-    onCipherAlgorithm(algo);
-  }
-
   @CallSite.Before(
       "javax.crypto.Cipher javax.crypto.Cipher.getInstance(java.lang.String, java.security.Provider)")
-  public static void beforeGetInstance(
-      @CallSite.Argument final String algo, @CallSite.Argument final Provider provider) {
+  @CallSite.Before(
+      "javax.crypto.KeyGenerator  javax.crypto.KeyGenerator.getInstance(java.lang.String)")
+  @CallSite.Before(
+      "javax.crypto.KeyGenerator  javax.crypto.KeyGenerator.getInstance(java.lang.String, java.lang.String)")
+  @CallSite.Before(
+      "javax.crypto.KeyGenerator javax.crypto.KeyGenerator.getInstance(java.lang.String, java.security.Provider)")
+  @CallSite.Before(
+      "javax.crypto.SecretKeyFactory  javax.crypto.SecretKeyFactory.getInstance(java.lang.String)")
+  @CallSite.Before(
+      "javax.crypto.SecretKeyFactory  javax.crypto.SecretKeyFactory.getInstance(java.lang.String, java.lang.String)")
+  @CallSite.Before(
+      "javax.crypto.SecretKeyFactory javax.crypto.SecretKeyFactory.getInstance(java.lang.String, java.security.Provider)")
+  public static void beforeGetInstance(@CallSite.Argument final String algo) {
     onCipherAlgorithm(algo);
   }
 

--- a/dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherTest.groovy
+++ b/dd-java-agent/instrumentation/java-security/src/test/groovy/test/WeakCipherTest.groovy
@@ -62,6 +62,45 @@ class WeakCipherTest extends AgentTestRunner {
     1 * module.onCipherAlgorithm(_)
   }
 
+  // Key Generator
+  def "test weak cipher instrumentation"() {
+    setup:
+    WeakCipherModule module = Mock(WeakCipherModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    new TestSuite().getKeyGeneratorInstance("DES")
+
+    then:
+    1 * module.onCipherAlgorithm(_)
+  }
+
+  def "test weak cipher instrumentation with provider"() {
+    setup:
+    WeakCipherModule module = Mock(WeakCipherModule)
+    InstrumentationBridge.registerIastModule(module)
+    final provider = providerFor('DES')
+
+    when:
+    new TestSuite().getKeyGeneratorInstance("DES", provider)
+
+    then:
+    1 * module.onCipherAlgorithm(_)
+  }
+
+  def "test weak cipher instrumentation with provider string"() {
+    setup:
+    WeakCipherModule module = Mock(WeakCipherModule)
+    InstrumentationBridge.registerIastModule(module)
+    final provider = providerFor('DES')
+
+    when:
+    new TestSuite().getKeyGeneratorInstance('DES', provider.getName())
+
+    then:
+    1 * module.onCipherAlgorithm(_)
+  }
+
   def "weak cipher instrumentation with null argument"() {
     setup:
     WeakCipherModule module = Mock(WeakCipherModule)

--- a/dd-java-agent/instrumentation/java-security/src/test/java/foo/bar/TestSuite.java
+++ b/dd-java-agent/instrumentation/java-security/src/test/java/foo/bar/TestSuite.java
@@ -5,7 +5,9 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Provider;
 import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKeyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +27,54 @@ public class TestSuite {
     log.debug("Before Cipher.getInstance");
     Cipher c = Cipher.getInstance(algo, provider);
     log.debug("after Cipher.getInstance");
+    return c;
+  }
+
+  public KeyGenerator getKeyGeneratorInstance(String algo, Provider provider)
+      throws NoSuchPaddingException, NoSuchAlgorithmException {
+    log.debug("Before KeyGenerator.getInstance");
+    KeyGenerator c = KeyGenerator.getInstance(algo, provider);
+    log.debug("after KeyGenerator.getInstance");
+    return c;
+  }
+
+  public KeyGenerator getKeyGeneratorInstance(String algo)
+      throws NoSuchPaddingException, NoSuchAlgorithmException {
+    log.debug("Before KeyGenerator.getInstance");
+    KeyGenerator c = KeyGenerator.getInstance(algo);
+    log.debug("after KeyGenerator.getInstance");
+    return c;
+  }
+
+  public KeyGenerator getKeyGeneratorInstance(String algo, String provider)
+      throws NoSuchPaddingException, NoSuchAlgorithmException, NoSuchProviderException {
+    log.debug("Before KeyGenerator.getInstance");
+    KeyGenerator c = KeyGenerator.getInstance(algo, provider);
+    log.debug("after KeyGenerator.getInstance");
+    return c;
+  }
+
+  public SecretKeyFactory getSecretKeyFactoryInstance(String algo, Provider provider)
+      throws NoSuchPaddingException, NoSuchAlgorithmException {
+    log.debug("Before SecretKeyFactory.getInstance");
+    SecretKeyFactory c = SecretKeyFactory.getInstance(algo, provider);
+    log.debug("after SecretKeyFactory.getInstance");
+    return c;
+  }
+
+  public SecretKeyFactory getSecretKeyFactoryInstance(String algo)
+      throws NoSuchPaddingException, NoSuchAlgorithmException {
+    log.debug("Before SecretKeyFactory.getInstance");
+    SecretKeyFactory c = SecretKeyFactory.getInstance(algo);
+    log.debug("after SecretKeyFactory.getInstance");
+    return c;
+  }
+
+  public SecretKeyFactory getSecretKeyFactoryInstance(String algo, String provider)
+      throws NoSuchPaddingException, NoSuchAlgorithmException, NoSuchProviderException {
+    log.debug("Before SecretKeyFactory.getInstance");
+    SecretKeyFactory c = SecretKeyFactory.getInstance(algo, provider);
+    log.debug("after SecretKeyFactory.getInstance");
     return c;
   }
 

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -70,6 +70,18 @@ public class IastWebController {
     return "Weak Hash page";
   }
 
+  @RequestMapping("/weak_key_generator")
+  public String weakKeyGenerator() {
+    hasher.generateKey();
+    return "Weak Key generator page";
+  }
+
+  @RequestMapping("/weak_key_generator_with_provider")
+  public String weakKeyGeneratorWithProvider() {
+    hasher.generateKeyWithProvider();
+    return "Weak Key generator page";
+  }
+
   @GetMapping("/insecure_cookie")
   public String insecureCookie(HttpServletResponse response) {
     Cookie cookie = new Cookie("user-id", "7");

--- a/dd-smoke-tests/iast-util/src/main/java/ddtest/client/sources/Hasher.java
+++ b/dd-smoke-tests/iast-util/src/main/java/ddtest/client/sources/Hasher.java
@@ -2,6 +2,9 @@ package ddtest.client.sources;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
 
 public class Hasher {
   public MessageDigest sha1() {
@@ -24,6 +27,22 @@ public class Hasher {
     try {
       return MessageDigest.getInstance("MD5");
     } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public SecretKey generateKey() {
+    try {
+      return KeyGenerator.getInstance("DES").generateKey();
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public SecretKey generateKeyWithProvider() {
+    try {
+      return KeyGenerator.getInstance("DES", "SUN").generateKey();
+    } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
       throw new RuntimeException(e);
     }
   }

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -110,6 +110,37 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     }
   }
 
+  void 'weak cipher vulnerability is present when calling key generator'() {
+    setup:
+    String url = "http://localhost:${httpPort}/weak_key_generator"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    hasVulnerability { vul ->
+      vul.type == 'WEAK_CIPHER' &&
+        vul.evidence.value == 'DES'
+    }
+  }
+
+  void 'weak cipher vulnerability is present when calling key generator with provider'() {
+    setup:
+    String url = "http://localhost:${httpPort}/weak_key_generator_with_provider"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    hasVulnerability { vul ->
+      vul.type == 'WEAK_CIPHER' &&
+        vul.evidence.value == 'DES'
+    }
+  }
+
+
   void 'insecure cookie vulnerability is present'() {
     setup:
     String url = "http://localhost:${httpPort}/insecure_cookie"


### PR DESCRIPTION
# What Does This Do
Instruments javax.crypto.KeyGenerator so we can detect weak cypher vulnerabilities

# Motivation
We need to cover all of the calls where the user can create a cypher with a weak algorithm including KeyGenerator and SecretKeyFactory

# Additional Notes
