### PR TITLE
Upgrade to ddprof 0.67.0

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -241,7 +241,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 27 : 26
+    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 28 : 27
     assert shadowJar.archiveFile.get().getAsFile().length() <= megs * 1024 * 1024
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0-SNAPSHOT",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.65.0",
+    ddprof        : "0.67.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do

The profiler now statically links libstdc++ so can be loaded on more platforms.

# Motivation

# Additional Notes
