### PR TITLE
Fix possible invalid parent span using OpenTelemetry API

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanBuilder.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpanBuilder.java
@@ -26,7 +26,10 @@ public class OtelSpanBuilder implements SpanBuilder {
 
   @Override
   public SpanBuilder setParent(Context context) {
-    this.delegate.asChildOf(extract(context));
+    AgentSpan.Context extractedContext = extract(context);
+    if (extractedContext != null) {
+      this.delegate.asChildOf(extractedContext);
+    }
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelTracerProvider.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelTracerProvider.java
@@ -5,12 +5,13 @@ import io.opentelemetry.api.trace.TracerBuilder;
 import io.opentelemetry.api.trace.TracerProvider;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ParametersAreNonnullByDefault
 public class OtelTracerProvider implements TracerProvider {
-  private static final Logger logger = Logger.getLogger(OtelTracerProvider.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(OtelTracerProvider.class);
   private static final String DEFAULT_TRACER_NAME = "";
   public static final OtelTracerProvider INSTANCE = new OtelTracerProvider();
 
@@ -47,7 +48,7 @@ public class OtelTracerProvider implements TracerProvider {
   @Override
   public TracerBuilder tracerBuilder(String instrumentationScopeName) {
     if (instrumentationScopeName.trim().isEmpty()) {
-      logger.fine("Tracer requested without instrumentation scope name.");
+      LOGGER.debug("Tracer requested without instrumentation scope name.");
       instrumentationScopeName = DEFAULT_TRACER_NAME;
     }
     return new OtelTracerBuilder(instrumentationScopeName);

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -101,6 +101,23 @@ class OpenTelemetry14Test extends AgentTestRunner {
     }
   }
 
+  def "test parent span using invalid reference"() {
+    when:
+    def invalidCurrentSpanContext = Context.root() // Contains a SpanContext with TID/SID to 0 as current span
+    def childSpan = tracer.spanBuilder("some-name")
+      .setParent(invalidCurrentSpanContext)
+      .startSpan()
+    childSpan.end()
+
+    TEST_WRITER.waitForTraces(1)
+    def trace = TEST_WRITER.firstTrace()
+
+
+    then:
+    trace.size() == 1
+    trace[0].spanId != 0
+  }
+
   def "test no parent to create new root span"() {
     setup:
     def parentSpan = tracer.spanBuilder("some-name").startSpan()


### PR DESCRIPTION
# What Does This Do

This PR fixes an issue with the OpenTelemetry instrumentation.
When setting a parent context to a `SpanBuilder`, it might not have a current span within.
If not, the tracer will reuse this invalid span context and generate a new (OTel) span with a Trace ID to 0.
Instead, if the span context is not valid, we want to generate a new trace.

# Motivation

This issue was encounter using [the Clojure `clj-otel` library](https://github.com/steffan-westcott/clj-otel) that always set parent context (even empty ones) when creating spans.

# Additional Notes
