### PR TITLE
Fix async propagation in some versions of undertow

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/WrapRunnableAsNewTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/WrapRunnableAsNewTaskInstrumentation.java
@@ -39,7 +39,8 @@ public final class WrapRunnableAsNewTaskInstrumentation extends Instrumenter.Tra
       "io.netty.util.concurrent.GlobalEventExecutor",
       "io.netty.util.concurrent.SingleThreadEventExecutor",
       "java.util.concurrent.AbstractExecutorService",
-      "org.glassfish.grizzly.threadpool.GrizzlyExecutorService"
+      "org.glassfish.grizzly.threadpool.GrizzlyExecutorService",
+      "org.jboss.threads.EnhancedQueueExecutor",
     };
   }
 

--- a/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSmokeTest.groovy
+++ b/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSmokeTest.groovy
@@ -34,8 +34,7 @@ abstract class QuarkusSmokeTest extends AbstractServerSmokeTest {
 
   @Override
   protected Set<String> expectedTraces() {
-    // TODO is this really how quarkus requests should look?
-    return ["[jax-rs.request]", "[netty.request[vertx.route-handler]]"].toSet()
+    ['[netty.request[vertx.route-handler[jax-rs.request]]]'] as Set
   }
 
   @Shared
@@ -56,8 +55,7 @@ abstract class QuarkusSmokeTest extends AbstractServerSmokeTest {
       def id = ThreadLocalRandom.current().nextInt(1, 4711)
       doAndValidateRequest(id)
     })
-    // TODO quarkus requests are split in two, so we need to wait for the double amount
-    waitForTraceCount(2 * totalInvocations) == 2 * totalInvocations
+    waitForTraceCount(totalInvocations) == totalInvocations
     validateLogInjection(resourceName()) == totalInvocations
     checkLogPostExit()
     !logHasErrors


### PR DESCRIPTION
The executor that netty uses in more recent versions is not instrumented.