### PR TITLE
Add manual Gitlab job for running CI Visibility test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 # Intellij Idea #
 #################
 /.idea
+/.run
 *.iml
 *.ipr
 *.iws

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ include:
   - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
   - local: ".gitlab/benchmarks.yml"
   - local: ".gitlab/exploration-tests.yml"
+  - local: ".gitlab/ci-visibility-tests.yml"
 
 stages:
   - build
@@ -10,6 +11,7 @@ stages:
   - deploy
   - benchmarks
   - exploration-tests
+  - ci-visibility-tests
   - generate-signing-key
 
 variables:

--- a/.gitlab/ci-visibility-tests.yml
+++ b/.gitlab/ci-visibility-tests.yml
@@ -1,0 +1,19 @@
+run-ci-visibility-test-environment:
+  stage: ci-visibility-tests
+  when: manual
+  needs: []
+  trigger:
+    project: DataDog/apm-reliability/test-environment
+    branch: main
+    strategy: depend
+  variables:
+    UPSTREAM_PACKAGE_JOB: build
+    UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID
+    UPSTREAM_BRANCH: $CI_COMMIT_BRANCH
+    UPSTREAM_TAG: $CI_COMMIT_TAG
+    UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
+    UPSTREAM_COMMIT_SHORT_SHA: $CI_COMMIT_SHORT_SHA
+    TRACER_LANG: java
+    JAVA_TRACER_REF_TO_TEST: $CI_COMMIT_BRANCH


### PR DESCRIPTION
# What Does This Do
Adds a manual Gitlab job that triggers CI Visibility [test-environment](https://github.com/DataDog/test-environment) run with the tracer built in the current branch.

# Motivation
Make it easier to run these external tests before tracer changes are merged.

# Additional Notes
The job is only triggered manually, so it will not interfere with the other products.