### PR TITLE
skip creating profiling context integration on windows

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -829,7 +829,7 @@ public class Agent {
    * on JFR.
    */
   private static ProfilingContextIntegration createProfilingContextIntegration() {
-    if (Config.get().isProfilingEnabled()) {
+    if (Config.get().isProfilingEnabled() && !Platform.isWindows()) {
       try {
         return (ProfilingContextIntegration)
             AGENT_CLASSLOADER


### PR DESCRIPTION
# What Does This Do

We don't have context support on windows so we shouldn't attempt to create the integration

# Motivation

# Additional Notes
