### PR TITLE
Add support for the profiler jmethodid cache

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -14,6 +14,7 @@ import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallContextF
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallInterval;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isAllocationProfilingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isCpuProfilerEnabled;
+import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isJmethodIdCacheEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isLiveHeapSizeTrackingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isMemoryLeakProfilingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isSpanNameContextAttributeEnabled;
@@ -341,6 +342,10 @@ public final class DatadogProfiler {
       if (profilingModes.contains(MEMLEAK)) {
         cmd.append(isLiveHeapSizeTrackingEnabled(configProvider) ? 'L' : 'l');
       }
+    }
+    if (isJmethodIdCacheEnabled()) {
+      // element retention is 30 chunk rotations, will be checked only if >10000 elements in cache
+      cmd.append(",minfocache=30:1000");
     }
     String cmdString = cmd.toString();
     log.debug("Datadog profiler command line: {}", cmdString);

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -40,6 +40,8 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_INTERVAL_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_JMETHODID_CACHE_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_JMETHODID_CACHE_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ULTRA_MINIMAL;
@@ -278,6 +280,15 @@ public class DatadogProfilerConfig {
 
   public static boolean isSpanNameContextAttributeEnabled(ConfigProvider configProvider) {
     return configProvider.getBoolean(PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED, true);
+  }
+
+  public static boolean isJmethodIdCacheEnabled() {
+    return isJmethodIdCacheEnabled(ConfigProvider.getInstance());
+  }
+
+  public static boolean isJmethodIdCacheEnabled(ConfigProvider configProvider) {
+    return configProvider.getBoolean(
+        PROFILING_JMETHODID_CACHE_ENABLED, PROFILING_JMETHODID_CACHE_ENABLED_DEFAULT);
   }
 
   public static String getString(ConfigProvider configProvider, String key, String defaultValue) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -176,6 +176,10 @@ public final class ProfilingConfig {
 
   public static final long PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS_DEFAULT = 50;
 
+  public static final String PROFILING_JMETHODID_CACHE_ENABLED =
+      "profiling.experimental.jmethodid_cache.enabled";
+  public static final boolean PROFILING_JMETHODID_CACHE_ENABLED_DEFAULT = false;
+
   public static final String PROFILING_ULTRA_MINIMAL = "profiling.ultra.minimal";
 
   private ProfilingConfig() {}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.67.0",
+    ddprof        : "0.68.0",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do
Bumps the ddprof dependency to 0.68.0 and adds a new experimental config flag to enable the jmethodid cache in the profiler.

# Motivation
The JVMTI jmethodids are used to identify frames returned from the JVMTI functions like `GetStackTrace`.
The problem is that those ids are guaranteed to be valid only while the class defining the method that is pointed to by the particular jmethodid is still loaded. And, with concurrent class unloading, this assumption may be broken immediately after the stacktrace has been obtained, unless the caller of the `GetStackTrace` manages to create strong references to all classes referenced from the stack trace, which is utterly impossible.

While the invalid jmethodid will manifest as a NULL pointer and that will be treated correctly by the JVMTI there are situations where the jmethodid points to a deallocated memory but is still not set to NULL (or the value change hasn't been propagated yet because of concurrent updates) - and this leads to spurious crashes while using only legitimate JVMTI calls.

The jmethodid cache is designed to work-around the problem by caching the required method metadata at class load, instead of relying on the lazy evaluation by JVMTI. Since there is no reliable way to get notified when a class is going to be unloaded, the cache is relying on 'retention' - when a particular jmethodid hasn't been used for long enough time it is considered to be 'dead' and all further attempts to get metadata for such jmethodid will be resolved as 'unknown frame'. This is not perfect, but much better than crashing randomly.

The cache is disable by default and the flag is marked as experimental as it is to be used for stability testing only as of now.

# Additional Notes
