### PR TITLE
Fix missing HttpOnly cookie vulnerability detection (1.18.x backport)

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/CookieSecurityDetails.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/CookieSecurityDetails.java
@@ -20,7 +20,7 @@ public class CookieSecurityDetails {
     if ("SECURE".equalsIgnoreCase(name)) {
       isSecure = true;
     }
-    if ("HTTPONLY".equalsIgnoreCase(name) && "true".equalsIgnoreCase(value)) {
+    if ("HTTPONLY".equalsIgnoreCase(name)) {
       isHttpOnly = true;
     }
     if ("SAMESITE".equalsIgnoreCase(name) && "strict".equalsIgnoreCase(value)) {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/CookieSecurityParserTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/CookieSecurityParserTest.groovy
@@ -29,22 +29,22 @@ class CookieSecurityParserTest extends Specification {
     isSameSiteStrict == badCookie.isSameSiteStrict()
 
     where:
-    header                                                                                                                                              | cookieName      | isSecure | isHttpOnly | isSameSiteStrict
-    "user-id=7"                                                                                                                                         | "user-id"       | false    | false      | false
-    "user-id=7;Secure"                                                                                                                                  | "user-id"       | true     | false      | false
-    "user-id=7;Secure;HttpOnly=true"                                                                                                                    | "user-id"       | true     | true       | false
-    "CUSTOMER=WILE_E_COYOTE; version='1'"                                                                                                               | "CUSTOMER"      | false    | false      | false
-    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT"                                                                         | "CUSTOMER"      | false    | false      | false
-    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT;SameSite=Lax;HttpOnly=true"                                              | "CUSTOMER"      | false    | true       | false
-    "PREF=ID=1eda537de48ac25d:CR=1:TM=1112868587:LM=1112868587:S=t3FPA-mT9lTR3bxU;expires=Sun, 17-Jan-2038 19:14:07 GMT; path=/; domain=.google.com"    | "PREF"          | false    | false      | false
-    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; Secure"                                                                 | "CUSTOMER"      | true     | false      | false
-    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; path=\"/acme\";SameSite=Strict"                                         | "CUSTOMER"      | false    | false      | true
+    header                                                                                                                                           | cookieName | isSecure | isHttpOnly | isSameSiteStrict
+    "user-id=7"                                                                                                                                      | "user-id"  | false    | false      | false
+    "user-id=7;Secure"                                                                                                                               | "user-id"  | true     | false      | false
+    "user-id=7;Secure;HttpOnly"                                                                                                                      | "user-id"  | true     | true       | false
+    "CUSTOMER=WILE_E_COYOTE; version='1'"                                                                                                            | "CUSTOMER" | false    | false      | false
+    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT"                                                                      | "CUSTOMER" | false    | false      | false
+    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT;SameSite=Lax;HttpOnly"                                                | "CUSTOMER" | false    | true       | false
+    "PREF=ID=1eda537de48ac25d:CR=1:TM=1112868587:LM=1112868587:S=t3FPA-mT9lTR3bxU;expires=Sun, 17-Jan-2038 19:14:07 GMT; path=/; domain=.google.com" | "PREF"     | false    | false      | false
+    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; Secure"                                                              | "CUSTOMER" | true     | false      | false
+    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; path=\"/acme\";SameSite=Strict"                                      | "CUSTOMER" | false    | false      | true
   }
 
 
   void 'parsing multi cookie header'() {
     given:
-    String headerValue = "A=1;Secure;HttpOnly=true;SameSite=Strict;version='1',B=2;Secure;SameSite=Strict,C=3"
+    String headerValue = "A=1;Secure;HttpOnly;SameSite=Strict;version='1',B=2;Secure;SameSite=Strict,C=3"
     when:
     final badCookies = new CookieSecurityParser(headerValue).getCookies()
 
@@ -59,12 +59,12 @@ class CookieSecurityParserTest extends Specification {
 
     badCookies.get(1).getCookieName() == 'B'
     badCookies.get(1).isSecure()
-    ! badCookies.get(1).isHttpOnly()
+    !badCookies.get(1).isHttpOnly()
     badCookies.get(1).isSameSiteStrict()
 
     badCookies.get(2).getCookieName() == 'C'
-    ! badCookies.get(2).isSecure()
-    ! badCookies.get(2).isHttpOnly()
-    ! badCookies.get(2).isSameSiteStrict()
+    !badCookies.get(2).isSecure()
+    !badCookies.get(2).isHttpOnly()
+    !badCookies.get(2).isSameSiteStrict()
   }
 }


### PR DESCRIPTION
# What Does This Do
Backports the bugfix for the parsing of the HttpOnly for cookies

# Motivation

# Additional Notes
