### PR TITLE
Use JMC 8.1.0 release from Maven Central (1.18.x backport)

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation
 
-  testImplementation group: 'org.openjdk.jmc', name: 'flightrecorder.writer', version: '8.1.0-SNAPSHOT'
+  testImplementation group: 'org.openjdk.jmc', name: 'flightrecorder.writer', version: '8.1.0'
   testImplementation deps.mockito
   testImplementation deps.junit5
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -31,7 +31,7 @@ final class CachedData {
     jctools       : '3.3.0',
     moshi         : '1.11.0',
     testcontainers: '1.17.3',
-    jmc           : "8.1.0-SNAPSHOT",
+    jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
     ddprof        : "0.63.0",
     asm           : "9.5"

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -1,15 +1,6 @@
 repositories {
   mavenLocal()
   mavenCentral()
-  maven {
-    url "https://adoptopenjdk.jfrog.io/adoptopenjdk/jmc-libs-snapshots"
-    content {
-      includeGroup "org.openjdk.jmc"
-    }
-    mavenContent {
-      snapshotsOnly()
-    }
-  }
   // add sonatype repository for snapshot dependencies
   maven {
     content {


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes
https://github.com/DataDog/dd-trace-java/pull/5661