### PR TITLE
Scale down CircleCI runner resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ jobs:
 
   spotless:
     <<: *defaults
-    resource_class: large
+    resource_class: medium+
 
     steps:
       - setup_code
@@ -380,7 +380,7 @@ jobs:
       cacheType:
         type: string
 
-    resource_class: large
+    resource_class: medium+
 
     parallelism: << parameters.parallelism >>
 
@@ -470,6 +470,7 @@ jobs:
 
   tests: &tests
     <<: *defaults
+    # since tests use test containers, they will use a Linux VM / Remote Docker executor, so there is no medium+ size
     resource_class: large
 
     docker:
@@ -639,10 +640,6 @@ jobs:
     resource_class: xlarge
 
 
-  huge_tests:
-    <<: *tests
-    resource_class: 2xlarge
-
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
   # doesn't consume so many resources. The execution time for this including spin up seems to
   # be around 6 seconds.
@@ -679,8 +676,7 @@ jobs:
 
   test_published_artifacts:
     <<: *defaults
-    resource_class: large
-
+    resource_class: medium
     docker:
       - image: << pipeline.parameters.docker_image >>:7
 
@@ -770,7 +766,7 @@ jobs:
     machine:
       # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
       image: ubuntu-2004:current
-    resource_class: large
+    resource_class: medium
     parameters:
       weblog-variant:
         type: string
@@ -842,7 +838,7 @@ jobs:
     machine:
       # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
       image: ubuntu-2004:current
-    resource_class: large
+    resource_class: medium
     steps:
       - setup_system_tests
 
@@ -877,7 +873,7 @@ jobs:
     machine:
       # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
       image: ubuntu-2004:current
-    resource_class: xlarge
+    resource_class: large
     steps:
       - setup_system_tests
 


### PR DESCRIPTION
# What Does This Do

Moves a few CircleCI jobs to smaller resource classes.

# Motivation

Smaller is smaller.

# Additional Notes
