### PR TITLE
Fix OpenTelemetry Context instrumentation activation

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryContextInstrumentation.java
@@ -8,6 +8,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
@@ -27,7 +28,7 @@ public class OpenTelemetryContextInstrumentation extends Instrumenter.Tracing
 
   @Override
   protected boolean defaultEnabled() {
-    return false;
+    return InstrumenterConfig.get().isTraceOtelEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ActivationTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ActivationTest.groovy
@@ -1,0 +1,64 @@
+import datadog.trace.agent.test.AgentTestRunner
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.context.Context
+
+abstract class OpenTelemetry14ActivationTest extends AgentTestRunner {
+  abstract boolean shouldBeInjected()
+
+  def "test instrumentation injection"() {
+    setup:
+    def tracer = GlobalOpenTelemetry.get().tracerProvider.get("some-instrumentation")
+    def builder = tracer.spanBuilder("some-name")
+    def result = builder.startSpan()
+    def context = Context.current()
+
+    expect:
+    if (shouldBeInjected()) {
+      tracer.class.name.endsWith(".OtelTracer")
+      builder.class.name.endsWith(".OtelSpanBuilder")
+      result.class.name.endsWith(".OtelSpan")
+      context.class.name.endsWith(".OtelContext")
+    } else {
+      tracer.class.name.endsWith(".DefaultTracer")
+      context.class.name.endsWith(".ArrayBasedContext")
+    }
+  }
+}
+
+//
+// Below test variants are forked to allow GlobalOpenTelemetry static state to reset
+//
+
+class OpenTelemetry14ActivationByInstrumentationNameForkedTest extends OpenTelemetry14ActivationTest {
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("integration.opentelemetry.experimental.enabled", "true")
+  }
+
+  @Override
+  boolean shouldBeInjected() {
+    return true
+  }
+}
+
+class OpenTelemetry14ActivationByOtelRfcNameForkedTest extends OpenTelemetry14ActivationTest {
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("trace.otel.enabled", "true")
+  }
+
+  @Override
+  boolean shouldBeInjected() {
+    return true
+  }
+}
+
+class OpenTelemetry14DisableByDefaultForkedTest extends OpenTelemetry14ActivationTest {
+  @Override
+  boolean shouldBeInjected() {
+    return false
+  }
+}
+

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -4,13 +4,9 @@ import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.opentelemetry14.OtelContext
-import datadog.trace.instrumentation.opentelemetry14.OtelSpan
-import datadog.trace.instrumentation.opentelemetry14.OtelSpanBuilder
-import datadog.trace.instrumentation.opentelemetry14.OtelTracer
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
-import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
@@ -34,17 +30,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
     super.configurePreAgent()
 
     injectSysConfig("dd.integration.opentelemetry.experimental.enabled", "true")
-  }
-
-  def "test injection"() {
-    setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
-
-    expect:
-    tracer instanceof OtelTracer
-    builder instanceof OtelSpanBuilder
-    result instanceof OtelSpan
   }
 
   def "test parent span using active span"() {
@@ -300,7 +285,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     result.delegate.getTag(DDTags.ERROR_MSG) == null
 
     when:
-    result.setStatus(StatusCode.ERROR, "some error")
+    result.setStatus(ERROR, "some error")
 
     then:
     result.delegate.isError()


### PR DESCRIPTION
# What Does This Do

This PR fixes OTel activation requirement to be enabled when `trace.otel.enabled` is set to `true`.

# Motivation

Disabling context instrumentation cause issues when trying to retrieve the current active span.

# Additional Notes

Only OTel API instrumentation was enabled, Context API instrumentation wasn't.
