### PR TITLE
Telemetry v2 and message-batching

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -30,7 +30,7 @@ debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
 # TODO do not merge this line to master
-default_system_tests_commit: &default_system_tests_commit 7655009d9d26d28ff387f009d20c0d41154bde40
+default_system_tests_commit: &default_system_tests_commit ef1b79ee4ee84bb7efb650139157f0dfbf4aa476
 
 parameters:
   nightly:

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -29,6 +29,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
+# TODO do not merge this line to master
 default_system_tests_commit: &default_system_tests_commit 7655009d9d26d28ff387f009d20c0d41154bde40
 
 parameters:

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -29,7 +29,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 3598f2583cd5c25326cd7a5c01097374d94c1993
+default_system_tests_commit: &default_system_tests_commit 7655009d9d26d28ff387f009d20c0d41154bde40
 
 parameters:
   nightly:

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -188,8 +188,8 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED = false;
 
   static final boolean DEFAULT_SPARK_TASK_HISTOGRAM_ENABLED = true;
-
   static final boolean DEFAULT_JAX_RS_EXCEPTION_AS_ERROR_ENABLED = true;
+  static final boolean DEFAULT_TELEMETRY_DEBUG_REQUESTS_ENABLED = false;
 
   private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -66,5 +66,7 @@ public final class GeneralConfig {
   public static final String TELEMETRY_DEPENDENCY_COLLECTION_ENABLED =
       "telemetry.dependency-collection.enabled";
 
+  public static final String TELEMETRY_DEBUG_REQUESTS_ENABLED = "telemetry.debug.requests.enabled";
+
   private GeneralConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -790,6 +790,8 @@ public class Config {
 
   private final float traceFlushIntervalSeconds;
 
+  private final boolean telemetryDebugRequestsEnabled;
+
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
     this(ConfigProvider.createDefault());
@@ -1757,6 +1759,11 @@ public class Config {
           "Attempt to start in Agentless mode without API key. "
               + "Please ensure that either an API key is configured, or the tracer is set up to work with the Agent");
     }
+
+    this.telemetryDebugRequestsEnabled =
+        configProvider.getBoolean(
+            GeneralConfig.TELEMETRY_DEBUG_REQUESTS_ENABLED,
+            ConfigDefaults.DEFAULT_TELEMETRY_DEBUG_REQUESTS_ENABLED);
 
     log.debug("New instance: {}", this);
   }
@@ -3304,6 +3311,10 @@ public class Config {
     return Config.get().isTraceAnalyticsIntegrationEnabled(integrationNames, defaultEnabled);
   }
 
+  public boolean isTelemetryDebugRequestsEnabled() {
+    return telemetryDebugRequestsEnabled;
+  }
+
   private <T> Set<T> getSettingsSetFromEnvironment(
       String name, Function<String, T> mapper, boolean splitOnWS) {
     final String value = configProvider.getString(name, "");
@@ -3897,6 +3908,8 @@ public class Config {
         + removeIntegrationServiceNamesEnabled
         + ", spanAttributeSchemaVersion="
         + spanAttributeSchemaVersion
+        + ", telemetryDebugRequestsEnabled="
+        + telemetryDebugRequestsEnabled
         + '}';
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/BatchRequestBuilder.java
+++ b/telemetry/src/main/java/datadog/telemetry/BatchRequestBuilder.java
@@ -38,10 +38,7 @@ public class BatchRequestBuilder {
     if (requestBuilder == null) {
       throw new IllegalStateException("Request not started!");
     }
-    requestBuilder.endRequest();
-    Request request = requestBuilder.request();
-    requestBuilder = null;
-    return request;
+    return requestBuilder.endRequest();
   }
 
   public void writeConfigurationMessage() {
@@ -216,21 +213,5 @@ public class BatchRequestBuilder {
 
   public void writeHeartbeatEvent() {
     requestBuilder.writeHeartbeatEvent();
-  }
-
-  public void beginSinglePayload() {
-    requestBuilder.beginSinglePayload();
-  }
-
-  public void endSinglePayload() {
-    requestBuilder.endSinglePayload();
-  }
-
-  public void beginMultiplePayloads() {
-    requestBuilder.beginMultiplePayload();
-  }
-
-  public void endMultiplePayloads() {
-    requestBuilder.endMultiplePayload();
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/BatchRequestBuilder.java
+++ b/telemetry/src/main/java/datadog/telemetry/BatchRequestBuilder.java
@@ -1,0 +1,179 @@
+package datadog.telemetry;
+
+import datadog.telemetry.api.ConfigChange;
+import datadog.telemetry.api.DistributionSeries;
+import datadog.telemetry.api.Integration;
+import datadog.telemetry.api.LogMessage;
+import datadog.telemetry.api.Metric;
+import datadog.telemetry.api.RequestType;
+import datadog.telemetry.dependency.Dependency;
+import java.io.IOException;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+
+public class BatchRequestBuilder {
+  private final EventSource eventSource;
+  private final EventSink eventSink;
+  private RequestBuilder requestBuilder;
+
+  public BatchRequestBuilder(EventSource eventSource, EventSink eventSink) {
+    this.eventSource = eventSource;
+    this.eventSink = eventSink;
+  }
+
+  public void beginRequest(RequestType requestType, HttpUrl httpUrl) {
+    if (requestBuilder != null) {
+      throw new IllegalStateException("Request already started!");
+    }
+    requestBuilder = new RequestBuilder(requestType, httpUrl);
+    requestBuilder.beginRequest();
+  }
+
+  public Request endRequest() {
+    if (requestBuilder == null) {
+      throw new IllegalStateException("Request not started!");
+    }
+    requestBuilder.endRequest();
+    Request request = requestBuilder.request();
+    requestBuilder = null;
+    return request;
+  }
+
+  public void writeConfigurationMessage() {
+    ConfigChange event = eventSource.nextConfigChangeEvent();
+    if (event == null) {
+      return;
+    }
+    try {
+      requestBuilder.beginMessage(RequestType.APP_CLIENT_CONFIGURATION_CHANGE);
+      requestBuilder.beginPayload();
+      requestBuilder.beginConfiguration();
+      while (event != null) {
+        requestBuilder.writeConfiguration(event);
+        eventSink.addConfigChangeEvent(event);
+        if (!checkSize()) {
+          break;
+        }
+        event = eventSource.nextConfigChangeEvent();
+      }
+      requestBuilder.endConfiguration();
+      requestBuilder.endPayload();
+      requestBuilder.endMessage();
+    } catch (IOException e) {
+      throw new RequestBuilder.SerializationException("configuration-message", e);
+    }
+  }
+
+  public void writeIntegrationsMessage() {
+    Integration event = eventSource.nextIntegrationEvent();
+    if (event == null) {
+      return;
+    }
+    try {
+      requestBuilder.beginIntegrations();
+      while (event != null) {
+        requestBuilder.writeIntegration(event);
+        eventSink.addIntegrationEvent(event);
+        if (!checkSize()) {
+          break;
+        }
+        event = eventSource.nextIntegrationEvent();
+      }
+      requestBuilder.endIntegrations();
+    } catch (IOException e) {
+      throw new RequestBuilder.SerializationException("integrations-message", e);
+    }
+  }
+
+  public void writeDependenciesMessage() {
+    Dependency event = eventSource.nextDependencyEvent();
+    if (event == null) {
+      return;
+    }
+    try {
+      requestBuilder.beginDependencies();
+      while (event != null) {
+        requestBuilder.writeDependency(event);
+        eventSink.addDependencyEvent(event);
+        if (!checkSize()) {
+          break;
+        }
+        event = eventSource.nextDependencyEvent();
+      }
+      requestBuilder.endDependencies();
+    } catch (IOException e) {
+      throw new RequestBuilder.SerializationException("dependencies-message", e);
+    }
+  }
+
+  public void writeMetricsMessage() {
+    Metric event = eventSource.nextMetricEvent();
+    if (event == null) {
+      return;
+    }
+    try {
+      requestBuilder.beginMetrics();
+      while (event != null) {
+        requestBuilder.writeMetric(event);
+        eventSink.addMetricEvent(event);
+        if (!checkSize()) {
+          break;
+        }
+        event = eventSource.nextMetricEvent();
+      }
+      requestBuilder.endMetrics();
+    } catch (IOException e) {
+      throw new RequestBuilder.SerializationException("metrics-message", e);
+    }
+  }
+
+  public void writeDistributionsMessage() {
+    DistributionSeries event = eventSource.nextDistributionSeriesEvent();
+    if (event == null) {
+      return;
+    }
+    try {
+      requestBuilder.beginDistributions();
+      while (event != null) {
+        requestBuilder.writeDistribution(event);
+        eventSink.addDistributionSeriesEvent(event);
+        if (!checkSize()) {
+          break;
+        }
+        event = eventSource.nextDistributionSeriesEvent();
+      }
+      requestBuilder.endDistributions();
+    } catch (IOException e) {
+      throw new RequestBuilder.SerializationException("distributions-message", e);
+    }
+  }
+
+  public void writeLogsMessage() {
+    LogMessage event = eventSource.nextLogMessageEvent();
+    if (event == null) {
+      return;
+    }
+    try {
+      requestBuilder.beginLogs();
+      while (event != null) {
+        requestBuilder.writeLog(event);
+        eventSink.addLogMessageEvent(event);
+        if (!checkSize()) {
+          break;
+        }
+        event = eventSource.nextLogMessageEvent();
+      }
+      requestBuilder.endLogs();
+    } catch (IOException e) {
+      throw new RequestBuilder.SerializationException("logs-message", e);
+    }
+  }
+
+  private boolean checkSize() {
+    return requestBuilder.size() < 3_000_000;
+  }
+
+  public void writeHeartbeatEvent() {
+    requestBuilder.writeHeartbeatEvent();
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
+++ b/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
@@ -92,6 +92,11 @@ public final class BufferedEvents implements EventSource, EventSink {
     return configChangeEvents.get(configChangeIndex++);
   }
 
+  @Override
+  public boolean hasConfigChangeEvent() {
+    return !isConfigEventsEmpty();
+  }
+
   private boolean isConfigEventsEmpty() {
     return configChangeEvents == null || configChangeIndex == configChangeEvents.size();
   }

--- a/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
+++ b/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
@@ -29,12 +29,12 @@ public final class BufferedEvents implements EventSource, EventSink {
 
   @Override
   public boolean isEmpty() {
-    return (configChangeEvents == null || configChangeEvents.isEmpty())
-        && (integrationEvents == null || integrationEvents.isEmpty())
-        && (dependencyEvents == null || dependencyEvents.isEmpty())
-        && (metricEvents == null || metricEvents.isEmpty())
-        && (distributionSeriesEvents == null || distributionSeriesEvents.isEmpty())
-        && (logMessageEvents == null || logMessageEvents.isEmpty());
+    return isConfigEventsEmpty()
+        && isIntegrationEventsEmpty()
+        && isDependencyEventsEmpty()
+        && isMetricEventsEmpty()
+        && isDistributionSeriesEmpty()
+        && isLogMessageEventsEmpty();
   }
 
   public void addConfigChangeEvent(ConfigChange event) {
@@ -86,50 +86,74 @@ public final class BufferedEvents implements EventSource, EventSink {
 
   @Override
   public ConfigChange nextConfigChangeEvent() {
-    if (configChangeEvents == null || configChangeIndex == configChangeEvents.size()) {
+    if (isConfigEventsEmpty()) {
       return null;
     }
     return configChangeEvents.get(configChangeIndex++);
   }
 
+  private boolean isConfigEventsEmpty() {
+    return configChangeEvents == null || configChangeIndex == configChangeEvents.size();
+  }
+
   @Override
   public Integration nextIntegrationEvent() {
-    if (integrationEvents == null || integrationIndex == integrationEvents.size()) {
+    if (isIntegrationEventsEmpty()) {
       return null;
     }
     return integrationEvents.get(integrationIndex++);
   }
 
+  private boolean isIntegrationEventsEmpty() {
+    return integrationEvents == null || integrationIndex == integrationEvents.size();
+  }
+
   @Override
   public Dependency nextDependencyEvent() {
-    if (dependencyEvents == null || dependencyIndex == dependencyEvents.size()) {
+    if (isDependencyEventsEmpty()) {
       return null;
     }
     return dependencyEvents.get(dependencyIndex++);
   }
 
+  private boolean isDependencyEventsEmpty() {
+    return dependencyEvents == null || dependencyIndex == dependencyEvents.size();
+  }
+
   @Override
   public Metric nextMetricEvent() {
-    if (metricEvents == null || metricIndex == metricEvents.size()) {
+    if (isMetricEventsEmpty()) {
       return null;
     }
     return metricEvents.get(metricIndex++);
   }
 
+  private boolean isMetricEventsEmpty() {
+    return metricEvents == null || metricIndex == metricEvents.size();
+  }
+
   @Override
   public DistributionSeries nextDistributionSeriesEvent() {
-    if (distributionSeriesEvents == null
-        || distributionSeriesIndex == distributionSeriesEvents.size()) {
+    if (isDistributionSeriesEmpty()) {
       return null;
     }
     return distributionSeriesEvents.get(distributionSeriesIndex++);
   }
 
+  private boolean isDistributionSeriesEmpty() {
+    return distributionSeriesEvents == null
+        || distributionSeriesIndex == distributionSeriesEvents.size();
+  }
+
   @Override
   public LogMessage nextLogMessageEvent() {
-    if (logMessageEvents == null || logMessageIndex == logMessageEvents.size()) {
+    if (isLogMessageEventsEmpty()) {
       return null;
     }
     return logMessageEvents.get(logMessageIndex++);
+  }
+
+  private boolean isLogMessageEventsEmpty() {
+    return logMessageEvents == null || logMessageIndex == logMessageEvents.size();
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
+++ b/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
@@ -27,16 +27,6 @@ public final class BufferedEvents implements EventSource, EventSink {
   private ArrayList<LogMessage> logMessageEvents;
   private int logMessageIndex;
 
-  @Override
-  public boolean isEmpty() {
-    return !hasConfigChangeEvent()
-        && !hasIntegrationEvent()
-        && !hasDependencyEvent()
-        && !hasMetricEvent()
-        && !hasDistributionSeriesEvent()
-        && !hasLogMessageEvent();
-  }
-
   public void addConfigChangeEvent(ConfigChange event) {
     if (configChangeEvents == null) {
       configChangeEvents = new ArrayList<>(INITIAL_CAPACITY);

--- a/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
+++ b/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 
 /**
  * Keeps track of attempted to send telemetry events that can be used as a source for the next
- * telemetry request attempt.
+ * telemetry request attempt or telemetry metric calculation.
  */
 public final class BufferedEvents implements EventSource, EventSink {
   private static final int INITIAL_CAPACITY = 32;
@@ -29,12 +29,12 @@ public final class BufferedEvents implements EventSource, EventSink {
 
   @Override
   public boolean isEmpty() {
-    return isConfigEventsEmpty()
-        && isIntegrationEventsEmpty()
-        && isDependencyEventsEmpty()
-        && isMetricEventsEmpty()
-        && isDistributionSeriesEmpty()
-        && isLogMessageEventsEmpty();
+    return !hasConfigChangeEvent()
+        && !hasIntegrationEvent()
+        && !hasDependencyEvent()
+        && !hasMetricEvent()
+        && !hasDistributionSeriesEvent()
+        && !hasLogMessageEvent();
   }
 
   public void addConfigChangeEvent(ConfigChange event) {
@@ -85,80 +85,63 @@ public final class BufferedEvents implements EventSource, EventSink {
   }
 
   @Override
+  public boolean hasConfigChangeEvent() {
+    return configChangeEvents != null && configChangeIndex < configChangeEvents.size();
+  }
+
+  @Override
   public ConfigChange nextConfigChangeEvent() {
-    if (isConfigEventsEmpty()) {
-      throw new IllegalStateException("No config-change event available");
-    }
     return configChangeEvents.get(configChangeIndex++);
   }
 
   @Override
-  public boolean hasConfigChangeEvent() {
-    return !isConfigEventsEmpty();
-  }
-
-  private boolean isConfigEventsEmpty() {
-    return configChangeEvents == null || configChangeIndex == configChangeEvents.size();
+  public boolean hasIntegrationEvent() {
+    return integrationEvents != null && integrationIndex < integrationEvents.size();
   }
 
   @Override
   public Integration nextIntegrationEvent() {
-    if (isIntegrationEventsEmpty()) {
-      return null;
-    }
     return integrationEvents.get(integrationIndex++);
   }
 
-  private boolean isIntegrationEventsEmpty() {
-    return integrationEvents == null || integrationIndex == integrationEvents.size();
+  @Override
+  public boolean hasDependencyEvent() {
+    return dependencyEvents != null && dependencyIndex < dependencyEvents.size();
   }
 
   @Override
   public Dependency nextDependencyEvent() {
-    if (isDependencyEventsEmpty()) {
-      return null;
-    }
     return dependencyEvents.get(dependencyIndex++);
   }
 
-  private boolean isDependencyEventsEmpty() {
-    return dependencyEvents == null || dependencyIndex == dependencyEvents.size();
+  @Override
+  public boolean hasMetricEvent() {
+    return dependencyEvents != null && metricIndex < dependencyEvents.size();
   }
 
   @Override
   public Metric nextMetricEvent() {
-    if (isMetricEventsEmpty()) {
-      return null;
-    }
     return metricEvents.get(metricIndex++);
   }
 
-  private boolean isMetricEventsEmpty() {
-    return metricEvents == null || metricIndex == metricEvents.size();
+  @Override
+  public boolean hasDistributionSeriesEvent() {
+    return distributionSeriesEvents != null
+        && distributionSeriesIndex < distributionSeriesEvents.size();
   }
 
   @Override
   public DistributionSeries nextDistributionSeriesEvent() {
-    if (isDistributionSeriesEmpty()) {
-      return null;
-    }
     return distributionSeriesEvents.get(distributionSeriesIndex++);
   }
 
-  private boolean isDistributionSeriesEmpty() {
-    return distributionSeriesEvents == null
-        || distributionSeriesIndex == distributionSeriesEvents.size();
+  @Override
+  public boolean hasLogMessageEvent() {
+    return logMessageEvents != null && logMessageIndex < logMessageEvents.size();
   }
 
   @Override
   public LogMessage nextLogMessageEvent() {
-    if (isLogMessageEventsEmpty()) {
-      return null;
-    }
     return logMessageEvents.get(logMessageIndex++);
-  }
-
-  private boolean isLogMessageEventsEmpty() {
-    return logMessageEvents == null || logMessageIndex == logMessageEvents.size();
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
+++ b/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
@@ -1,0 +1,135 @@
+package datadog.telemetry;
+
+import datadog.telemetry.api.ConfigChange;
+import datadog.telemetry.api.DistributionSeries;
+import datadog.telemetry.api.Integration;
+import datadog.telemetry.api.LogMessage;
+import datadog.telemetry.api.Metric;
+import datadog.telemetry.dependency.Dependency;
+import java.util.ArrayList;
+
+/**
+ * Keeps track of attempted to send telemetry events that can be used as a source for the next
+ * telemetry request attempt.
+ */
+public final class BufferedEvents implements EventSource, EventSink {
+  private static final int INITIAL_CAPACITY = 36;
+  private ArrayList<ConfigChange> configChangeEvents;
+  private int configChangeIndex;
+  private ArrayList<Integration> integrationEvents;
+  private int integrationIndex;
+  private ArrayList<Dependency> dependencyEvents;
+  private int dependencyIndex;
+  private ArrayList<Metric> metricEvents;
+  private int metricIndex;
+  private ArrayList<DistributionSeries> distributionSeriesEvents;
+  private int distributionSeriesIndex;
+  private ArrayList<LogMessage> logMessageEvents;
+  private int logMessageIndex;
+
+  @Override
+  public boolean isEmpty() {
+    return (configChangeEvents == null || configChangeEvents.isEmpty())
+        && (integrationEvents == null || integrationEvents.isEmpty())
+        && (dependencyEvents == null || dependencyEvents.isEmpty())
+        && (metricEvents == null || metricEvents.isEmpty())
+        && (distributionSeriesEvents == null || distributionSeriesEvents.isEmpty())
+        && (logMessageEvents == null || logMessageEvents.isEmpty());
+  }
+
+  public void addConfigChangeEvent(ConfigChange event) {
+    if (configChangeEvents == null) {
+      configChangeEvents = new ArrayList<>(INITIAL_CAPACITY);
+    }
+    configChangeEvents.add(event);
+  }
+
+  @Override
+  public void addIntegrationEvent(Integration event) {
+    if (integrationEvents == null) {
+      integrationEvents = new ArrayList<>(INITIAL_CAPACITY);
+    }
+    integrationEvents.add(event);
+  }
+
+  @Override
+  public void addDependencyEvent(Dependency event) {
+    if (dependencyEvents == null) {
+      dependencyEvents = new ArrayList<>(INITIAL_CAPACITY);
+    }
+    dependencyEvents.add(event);
+  }
+
+  @Override
+  public void addMetricEvent(Metric event) {
+    if (metricEvents == null) {
+      metricEvents = new ArrayList<>(INITIAL_CAPACITY);
+    }
+    metricEvents.add(event);
+  }
+
+  @Override
+  public void addDistributionSeriesEvent(DistributionSeries event) {
+    if (distributionSeriesEvents == null) {
+      distributionSeriesEvents = new ArrayList<>(INITIAL_CAPACITY);
+    }
+    distributionSeriesEvents.add(event);
+  }
+
+  @Override
+  public void addLogMessageEvent(LogMessage event) {
+    if (logMessageEvents == null) {
+      logMessageEvents = new ArrayList<>(INITIAL_CAPACITY);
+    }
+    logMessageEvents.add(event);
+  }
+
+  @Override
+  public ConfigChange nextConfigChangeEvent() {
+    if (configChangeEvents == null || configChangeIndex == configChangeEvents.size()) {
+      return null;
+    }
+    return configChangeEvents.get(configChangeIndex++);
+  }
+
+  @Override
+  public Integration nextIntegrationEvent() {
+    if (integrationEvents == null || integrationIndex == integrationEvents.size()) {
+      return null;
+    }
+    return integrationEvents.get(integrationIndex++);
+  }
+
+  @Override
+  public Dependency nextDependencyEvent() {
+    if (dependencyEvents == null || dependencyIndex == dependencyEvents.size()) {
+      return null;
+    }
+    return dependencyEvents.get(dependencyIndex++);
+  }
+
+  @Override
+  public Metric nextMetricEvent() {
+    if (metricEvents == null || metricIndex == metricEvents.size()) {
+      return null;
+    }
+    return metricEvents.get(metricIndex++);
+  }
+
+  @Override
+  public DistributionSeries nextDistributionSeriesEvent() {
+    if (distributionSeriesEvents == null
+        || distributionSeriesIndex == distributionSeriesEvents.size()) {
+      return null;
+    }
+    return distributionSeriesEvents.get(distributionSeriesIndex++);
+  }
+
+  @Override
+  public LogMessage nextLogMessageEvent() {
+    if (logMessageEvents == null || logMessageIndex == logMessageEvents.size()) {
+      return null;
+    }
+    return logMessageEvents.get(logMessageIndex++);
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
+++ b/telemetry/src/main/java/datadog/telemetry/BufferedEvents.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
  * telemetry request attempt.
  */
 public final class BufferedEvents implements EventSource, EventSink {
-  private static final int INITIAL_CAPACITY = 36;
+  private static final int INITIAL_CAPACITY = 32;
   private ArrayList<ConfigChange> configChangeEvents;
   private int configChangeIndex;
   private ArrayList<Integration> integrationEvents;
@@ -87,7 +87,7 @@ public final class BufferedEvents implements EventSource, EventSink {
   @Override
   public ConfigChange nextConfigChangeEvent() {
     if (isConfigEventsEmpty()) {
-      return null;
+      throw new IllegalStateException("No config-change event available");
     }
     return configChangeEvents.get(configChangeIndex++);
   }

--- a/telemetry/src/main/java/datadog/telemetry/EventSink.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSink.java
@@ -7,6 +7,11 @@ import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.dependency.Dependency;
 
+/**
+ * A unified interface for telemetry event sink. It is used to buffer events polled from the queues
+ * to reattempt next sending attempt. A NOOP implementation is used to discard event on the next
+ * failing attempt.
+ */
 interface EventSink {
   void addConfigChangeEvent(ConfigChange event);
 
@@ -20,12 +25,10 @@ interface EventSink {
 
   void addLogMessageEvent(LogMessage event);
 
-  static EventSink noop() {
-    return Noop.INSTANCE;
-  }
+  EventSink NOOP = new Noop();
 
-  enum Noop implements EventSink {
-    INSTANCE;
+  class Noop implements EventSink {
+    private Noop() {}
 
     @Override
     public void addConfigChangeEvent(ConfigChange event) {}

--- a/telemetry/src/main/java/datadog/telemetry/EventSink.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSink.java
@@ -1,0 +1,48 @@
+package datadog.telemetry;
+
+import datadog.telemetry.api.ConfigChange;
+import datadog.telemetry.api.DistributionSeries;
+import datadog.telemetry.api.Integration;
+import datadog.telemetry.api.LogMessage;
+import datadog.telemetry.api.Metric;
+import datadog.telemetry.dependency.Dependency;
+
+interface EventSink {
+  void addConfigChangeEvent(ConfigChange event);
+
+  void addIntegrationEvent(Integration event);
+
+  void addDependencyEvent(Dependency event);
+
+  void addMetricEvent(Metric event);
+
+  void addDistributionSeriesEvent(DistributionSeries event);
+
+  void addLogMessageEvent(LogMessage event);
+
+  static EventSink noop() {
+    return Noop.INSTANCE;
+  }
+
+  enum Noop implements EventSink {
+    INSTANCE;
+
+    @Override
+    public void addConfigChangeEvent(ConfigChange event) {}
+
+    @Override
+    public void addIntegrationEvent(Integration event) {}
+
+    @Override
+    public void addDependencyEvent(Dependency event) {}
+
+    @Override
+    public void addMetricEvent(Metric event) {}
+
+    @Override
+    public void addDistributionSeriesEvent(DistributionSeries event) {}
+
+    @Override
+    public void addLogMessageEvent(LogMessage event) {}
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/EventSource.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSource.java
@@ -8,6 +8,11 @@ import datadog.telemetry.api.Metric;
 import datadog.telemetry.dependency.Dependency;
 import java.util.Queue;
 
+/**
+ * A unified interface for telemetry event source. There are two types of event sources: - Queued -
+ * a primary telemetry event source - BufferedEvents - events taken from the primary source and
+ * buffered for a retry
+ */
 interface EventSource {
   boolean isEmpty();
 

--- a/telemetry/src/main/java/datadog/telemetry/EventSource.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSource.java
@@ -14,8 +14,6 @@ import java.util.Queue;
  * buffered for a retry
  */
 interface EventSource {
-  boolean isEmpty();
-
   boolean hasConfigChangeEvent();
 
   ConfigChange nextConfigChangeEvent();
@@ -40,6 +38,15 @@ interface EventSource {
 
   LogMessage nextLogMessageEvent();
 
+  default boolean isEmpty() {
+    return !hasConfigChangeEvent()
+        && !hasIntegrationEvent()
+        && !hasDependencyEvent()
+        && !hasMetricEvent()
+        && !hasDistributionSeriesEvent()
+        && !hasLogMessageEvent();
+  }
+
   final class Queued implements EventSource {
     private final Queue<ConfigChange> configChangeQueue;
     private final Queue<Integration> integrationQueue;
@@ -61,16 +68,6 @@ interface EventSource {
       this.metricQueue = metricQueue;
       this.distributionSeriesQueue = distributionSeriesQueue;
       this.logMessageQueue = logMessageQueue;
-    }
-
-    @Override
-    public boolean isEmpty() {
-      return !hasConfigChangeEvent()
-          && integrationQueue.isEmpty()
-          && dependencyQueue.isEmpty()
-          && metricQueue.isEmpty()
-          && distributionSeriesQueue.isEmpty()
-          && logMessageQueue.isEmpty();
     }
 
     @Override

--- a/telemetry/src/main/java/datadog/telemetry/EventSource.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSource.java
@@ -13,6 +13,8 @@ interface EventSource {
 
   ConfigChange nextConfigChangeEvent();
 
+  boolean hasConfigChangeEvent();
+
   Integration nextIntegrationEvent();
 
   Dependency nextDependencyEvent();
@@ -38,6 +40,11 @@ interface EventSource {
     @Override
     public ConfigChange nextConfigChangeEvent() {
       return null;
+    }
+
+    @Override
+    public boolean hasConfigChangeEvent() {
+      return false;
     }
 
     @Override
@@ -91,7 +98,7 @@ interface EventSource {
 
     @Override
     public boolean isEmpty() {
-      return configChangeQueue.isEmpty()
+      return !hasConfigChangeEvent()
           && integrationQueue.isEmpty()
           && dependencyQueue.isEmpty()
           && metricQueue.isEmpty()
@@ -102,6 +109,11 @@ interface EventSource {
     @Override
     public ConfigChange nextConfigChangeEvent() {
       return configChangeQueue.poll();
+    }
+
+    @Override
+    public boolean hasConfigChangeEvent() {
+      return !configChangeQueue.isEmpty();
     }
 
     @Override

--- a/telemetry/src/main/java/datadog/telemetry/EventSource.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSource.java
@@ -11,67 +11,29 @@ import java.util.Queue;
 interface EventSource {
   boolean isEmpty();
 
+  boolean hasConfigChangeEvent();
+
   ConfigChange nextConfigChangeEvent();
 
-  boolean hasConfigChangeEvent();
+  boolean hasIntegrationEvent();
 
   Integration nextIntegrationEvent();
 
+  boolean hasDependencyEvent();
+
   Dependency nextDependencyEvent();
+
+  boolean hasMetricEvent();
 
   Metric nextMetricEvent();
 
+  boolean hasDistributionSeriesEvent();
+
   DistributionSeries nextDistributionSeriesEvent();
 
+  boolean hasLogMessageEvent();
+
   LogMessage nextLogMessageEvent();
-
-  static EventSource noop() {
-    return EventSource.Noop.INSTANCE;
-  }
-
-  enum Noop implements EventSource {
-    INSTANCE;
-
-    @Override
-    public boolean isEmpty() {
-      return true;
-    }
-
-    @Override
-    public ConfigChange nextConfigChangeEvent() {
-      return null;
-    }
-
-    @Override
-    public boolean hasConfigChangeEvent() {
-      return false;
-    }
-
-    @Override
-    public Integration nextIntegrationEvent() {
-      return null;
-    }
-
-    @Override
-    public Dependency nextDependencyEvent() {
-      return null;
-    }
-
-    @Override
-    public Metric nextMetricEvent() {
-      return null;
-    }
-
-    @Override
-    public DistributionSeries nextDistributionSeriesEvent() {
-      return null;
-    }
-
-    @Override
-    public LogMessage nextLogMessageEvent() {
-      return null;
-    }
-  }
 
   final class Queued implements EventSource {
     private final Queue<ConfigChange> configChangeQueue;
@@ -107,13 +69,18 @@ interface EventSource {
     }
 
     @Override
+    public boolean hasConfigChangeEvent() {
+      return !configChangeQueue.isEmpty();
+    }
+
+    @Override
     public ConfigChange nextConfigChangeEvent() {
       return configChangeQueue.poll();
     }
 
     @Override
-    public boolean hasConfigChangeEvent() {
-      return !configChangeQueue.isEmpty();
+    public boolean hasIntegrationEvent() {
+      return !integrationQueue.isEmpty();
     }
 
     @Override
@@ -122,8 +89,18 @@ interface EventSource {
     }
 
     @Override
+    public boolean hasDependencyEvent() {
+      return !dependencyQueue.isEmpty();
+    }
+
+    @Override
     public Dependency nextDependencyEvent() {
       return dependencyQueue.poll();
+    }
+
+    @Override
+    public boolean hasMetricEvent() {
+      return !metricQueue.isEmpty();
     }
 
     @Override
@@ -132,8 +109,18 @@ interface EventSource {
     }
 
     @Override
+    public boolean hasDistributionSeriesEvent() {
+      return !distributionSeriesQueue.isEmpty();
+    }
+
+    @Override
     public DistributionSeries nextDistributionSeriesEvent() {
       return distributionSeriesQueue.poll();
+    }
+
+    @Override
+    public boolean hasLogMessageEvent() {
+      return !logMessageQueue.isEmpty();
     }
 
     @Override

--- a/telemetry/src/main/java/datadog/telemetry/EventSource.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSource.java
@@ -23,6 +23,49 @@ interface EventSource {
 
   LogMessage nextLogMessageEvent();
 
+  static EventSource noop() {
+    return EventSource.Noop.INSTANCE;
+  }
+
+  enum Noop implements EventSource {
+    INSTANCE;
+
+    @Override
+    public boolean isEmpty() {
+      return true;
+    }
+
+    @Override
+    public ConfigChange nextConfigChangeEvent() {
+      return null;
+    }
+
+    @Override
+    public Integration nextIntegrationEvent() {
+      return null;
+    }
+
+    @Override
+    public Dependency nextDependencyEvent() {
+      return null;
+    }
+
+    @Override
+    public Metric nextMetricEvent() {
+      return null;
+    }
+
+    @Override
+    public DistributionSeries nextDistributionSeriesEvent() {
+      return null;
+    }
+
+    @Override
+    public LogMessage nextLogMessageEvent() {
+      return null;
+    }
+  }
+
   final class Queued implements EventSource {
     private final Queue<ConfigChange> configChangeQueue;
     private final Queue<Integration> integrationQueue;

--- a/telemetry/src/main/java/datadog/telemetry/EventSource.java
+++ b/telemetry/src/main/java/datadog/telemetry/EventSource.java
@@ -1,0 +1,89 @@
+package datadog.telemetry;
+
+import datadog.telemetry.api.ConfigChange;
+import datadog.telemetry.api.DistributionSeries;
+import datadog.telemetry.api.Integration;
+import datadog.telemetry.api.LogMessage;
+import datadog.telemetry.api.Metric;
+import datadog.telemetry.dependency.Dependency;
+import java.util.Queue;
+
+interface EventSource {
+  boolean isEmpty();
+
+  ConfigChange nextConfigChangeEvent();
+
+  Integration nextIntegrationEvent();
+
+  Dependency nextDependencyEvent();
+
+  Metric nextMetricEvent();
+
+  DistributionSeries nextDistributionSeriesEvent();
+
+  LogMessage nextLogMessageEvent();
+
+  final class Queued implements EventSource {
+    private final Queue<ConfigChange> configChangeQueue;
+    private final Queue<Integration> integrationQueue;
+    private final Queue<Dependency> dependencyQueue;
+    private final Queue<Metric> metricQueue;
+    private final Queue<DistributionSeries> distributionSeriesQueue;
+    private final Queue<LogMessage> logMessageQueue;
+
+    Queued(
+        Queue<ConfigChange> configChangeQueue,
+        Queue<Integration> integrationQueue,
+        Queue<Dependency> dependencyQueue,
+        Queue<Metric> metricQueue,
+        Queue<DistributionSeries> distributionSeriesQueue,
+        Queue<LogMessage> logMessageQueue) {
+      this.configChangeQueue = configChangeQueue;
+      this.integrationQueue = integrationQueue;
+      this.dependencyQueue = dependencyQueue;
+      this.metricQueue = metricQueue;
+      this.distributionSeriesQueue = distributionSeriesQueue;
+      this.logMessageQueue = logMessageQueue;
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return configChangeQueue.isEmpty()
+          && integrationQueue.isEmpty()
+          && dependencyQueue.isEmpty()
+          && metricQueue.isEmpty()
+          && distributionSeriesQueue.isEmpty()
+          && logMessageQueue.isEmpty();
+    }
+
+    @Override
+    public ConfigChange nextConfigChangeEvent() {
+      return configChangeQueue.poll();
+    }
+
+    @Override
+    public Integration nextIntegrationEvent() {
+      return integrationQueue.poll();
+    }
+
+    @Override
+    public Dependency nextDependencyEvent() {
+      return dependencyQueue.poll();
+    }
+
+    @Override
+    public Metric nextMetricEvent() {
+      return metricQueue.poll();
+    }
+
+    @Override
+    public DistributionSeries nextDistributionSeriesEvent() {
+      return distributionSeriesQueue.poll();
+    }
+
+    @Override
+    public LogMessage nextLogMessageEvent() {
+      return logMessageQueue.poll();
+    }
+  }
+}

--- a/telemetry/src/main/java/datadog/telemetry/HostInfo.java
+++ b/telemetry/src/main/java/datadog/telemetry/HostInfo.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 
 public class HostInfo {
   private static final Path PROC_VERSION = FileSystems.getDefault().getPath("/proc/version");
-  private static final Logger log = LoggerFactory.getLogger(RequestBuilder.class);
+  private static final Logger log = LoggerFactory.getLogger(TelemetryRequestState.class);
 
   private static String hostname;
   private static String osName;

--- a/telemetry/src/main/java/datadog/telemetry/RequestBuilder.java
+++ b/telemetry/src/main/java/datadog/telemetry/RequestBuilder.java
@@ -308,7 +308,8 @@ public class RequestBuilder extends RequestBody {
         bodyWriter.beginObject();
         bodyWriter.name("name").value(cc.name);
         bodyWriter.name("value").jsonValue(cc.value);
-        // TODO origin - mandatory
+        // TODO provide a real origin when it's implemented
+        bodyWriter.name("origin").jsonValue("unknown");
         // error - optional
         // seq_id - optional
         bodyWriter.endObject();

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
@@ -54,13 +54,10 @@ public class TelemetryRequest {
     }
     try {
       telemetryRequestState.beginConfiguration();
-      while (eventSource.hasConfigChangeEvent()) {
+      while (eventSource.hasConfigChangeEvent() && isWithinSizeLimits()) {
         ConfigChange event = eventSource.nextConfigChangeEvent();
         telemetryRequestState.writeConfiguration(event);
         eventSink.addConfigChangeEvent(event);
-        if (!isWithinSizeLimits()) {
-          break;
-        }
       }
       telemetryRequestState.endConfiguration();
     } catch (IOException e) {
@@ -81,22 +78,15 @@ public class TelemetryRequest {
   }
 
   public void writeIntegrationsMessage() {
-    if (!isWithinSizeLimits()) {
-      return;
-    }
-    Integration event = eventSource.nextIntegrationEvent();
-    if (event == null) {
+    if (!isWithinSizeLimits() || !eventSource.hasIntegrationEvent()) {
       return;
     }
     try {
       telemetryRequestState.beginIntegrations();
-      while (event != null) {
+      while (eventSource.hasIntegrationEvent() && isWithinSizeLimits()) {
+        Integration event = eventSource.nextIntegrationEvent();
         telemetryRequestState.writeIntegration(event);
         eventSink.addIntegrationEvent(event);
-        if (!isWithinSizeLimits()) {
-          break;
-        }
-        event = eventSource.nextIntegrationEvent();
       }
       telemetryRequestState.endIntegrations();
     } catch (IOException e) {
@@ -105,22 +95,15 @@ public class TelemetryRequest {
   }
 
   public void writeDependenciesMessage() {
-    if (!isWithinSizeLimits()) {
-      return;
-    }
-    Dependency event = eventSource.nextDependencyEvent();
-    if (event == null) {
+    if (!isWithinSizeLimits() || !eventSource.hasDependencyEvent()) {
       return;
     }
     try {
       telemetryRequestState.beginDependencies();
-      while (event != null) {
+      while (eventSource.hasDependencyEvent() && isWithinSizeLimits()) {
+        Dependency event = eventSource.nextDependencyEvent();
         telemetryRequestState.writeDependency(event);
         eventSink.addDependencyEvent(event);
-        if (!isWithinSizeLimits()) {
-          break;
-        }
-        event = eventSource.nextDependencyEvent();
       }
       telemetryRequestState.endDependencies();
     } catch (IOException e) {
@@ -129,22 +112,15 @@ public class TelemetryRequest {
   }
 
   public void writeMetricsMessage() {
-    if (!isWithinSizeLimits()) {
-      return;
-    }
-    Metric event = eventSource.nextMetricEvent();
-    if (event == null) {
+    if (!isWithinSizeLimits() || !eventSource.hasMetricEvent()) {
       return;
     }
     try {
       telemetryRequestState.beginMetrics();
-      while (event != null) {
+      while (eventSource.hasMetricEvent() && isWithinSizeLimits()) {
+        Metric event = eventSource.nextMetricEvent();
         telemetryRequestState.writeMetric(event);
         eventSink.addMetricEvent(event);
-        if (!isWithinSizeLimits()) {
-          break;
-        }
-        event = eventSource.nextMetricEvent();
       }
       telemetryRequestState.endMetrics();
     } catch (IOException e) {
@@ -153,22 +129,15 @@ public class TelemetryRequest {
   }
 
   public void writeDistributionsMessage() {
-    if (!isWithinSizeLimits()) {
-      return;
-    }
-    DistributionSeries event = eventSource.nextDistributionSeriesEvent();
-    if (event == null) {
+    if (!isWithinSizeLimits() || !eventSource.hasDistributionSeriesEvent()) {
       return;
     }
     try {
       telemetryRequestState.beginDistributions();
-      while (event != null) {
+      while (eventSource.hasDistributionSeriesEvent() && isWithinSizeLimits()) {
+        DistributionSeries event = eventSource.nextDistributionSeriesEvent();
         telemetryRequestState.writeDistribution(event);
         eventSink.addDistributionSeriesEvent(event);
-        if (!isWithinSizeLimits()) {
-          break;
-        }
-        event = eventSource.nextDistributionSeriesEvent();
       }
       telemetryRequestState.endDistributions();
     } catch (IOException e) {
@@ -177,22 +146,15 @@ public class TelemetryRequest {
   }
 
   public void writeLogsMessage() {
-    if (!isWithinSizeLimits()) {
-      return;
-    }
-    LogMessage event = eventSource.nextLogMessageEvent();
-    if (event == null) {
+    if (!isWithinSizeLimits() || !eventSource.hasLogMessageEvent()) {
       return;
     }
     try {
       telemetryRequestState.beginLogs();
-      while (event != null) {
+      while (eventSource.hasLogMessageEvent() && isWithinSizeLimits()) {
+        LogMessage event = eventSource.nextLogMessageEvent();
         telemetryRequestState.writeLog(event);
         eventSink.addLogMessageEvent(event);
-        if (!isWithinSizeLimits()) {
-          break;
-        }
-        event = eventSource.nextLogMessageEvent();
       }
       telemetryRequestState.endLogs();
     } catch (IOException e) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequestState.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequestState.java
@@ -22,7 +22,7 @@ import okhttp3.RequestBody;
 import okio.Buffer;
 import okio.BufferedSink;
 
-public class RequestBuilder extends RequestBody {
+public class TelemetryRequestState extends RequestBody {
 
   public static class SerializationException extends RuntimeException {
 
@@ -64,11 +64,11 @@ public class RequestBuilder extends RequestBody {
     final String osVersion = HostInfo.getOsVersion();
   }
 
-  RequestBuilder(RequestType requestType, HttpUrl httpUrl) {
+  TelemetryRequestState(RequestType requestType, HttpUrl httpUrl) {
     this(requestType, httpUrl, false);
   }
 
-  RequestBuilder(RequestType requestType, HttpUrl httpUrl, boolean debug) {
+  TelemetryRequestState(RequestType requestType, HttpUrl httpUrl, boolean debug) {
     this.requestType = requestType;
     this.requestBuilder =
         new Request.Builder()
@@ -141,7 +141,7 @@ public class RequestBuilder extends RequestBody {
       }
       bodyWriter.endObject(); // request
       requestBuilder.addHeader("Content-Length", String.valueOf(body.size()));
-      return buildRequest();
+      return request();
     } catch (Exception ex) {
       throw new SerializationException("end-request", ex);
     }
@@ -389,7 +389,7 @@ public class RequestBuilder extends RequestBody {
     // integrations - optional
   }
 
-  Request buildRequest() {
+  Request request() {
     return requestBuilder.build();
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequestState.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequestState.java
@@ -43,9 +43,8 @@ public class TelemetryRequestState extends RequestBody {
   private final Request.Builder requestBuilder;
   private final boolean debug;
 
-  private enum CommonData {
-    INSTANCE;
-
+  /** Exists in a separate class to avoid startup toll */
+  private static class CommonData {
     final Config config = Config.get();
     final String env = config.getEnv();
     final String langVersion = Platform.getLangVersion();
@@ -63,6 +62,8 @@ public class TelemetryRequestState extends RequestBody {
     final String osName = HostInfo.getOsName();
     final String osVersion = HostInfo.getOsVersion();
   }
+
+  private static final CommonData commonData = new CommonData();
 
   TelemetryRequestState(RequestType requestType, HttpUrl httpUrl) {
     this(requestType, httpUrl, false);
@@ -84,7 +85,6 @@ public class TelemetryRequestState extends RequestBody {
 
   public void beginRequest() {
     try {
-      CommonData commonData = CommonData.INSTANCE;
       bodyWriter.beginObject();
       bodyWriter.name("api_version").value(API_VERSION);
       // naming_schema_version - optional

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -68,6 +68,9 @@ public class TelemetryRunnable implements Runnable {
         }
         if (startupEventSent) {
           mainLoopIteration();
+        } else {
+          // force waiting until next heartbeat interval
+          scheduler.shouldRunHeartbeat();
         }
         scheduler.sleepUntilNextIteration();
       } catch (InterruptedException e) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -56,7 +56,7 @@ public class TelemetryRunnable implements Runnable {
     // Ensure that Config has been initialized, so ConfigCollector can collect all settings first.
     Config.get();
 
-    scheduler.init();
+    collectConfigChanges();
 
     int attempt = 0;
     while (!Thread.interrupted()
@@ -71,6 +71,8 @@ public class TelemetryRunnable implements Runnable {
     if (attempt == MAX_APP_STARTED_RETRIES) {
       log.error("Couldn't send an app-started event!");
     }
+
+    scheduler.init();
 
     while (!Thread.interrupted()) {
       try {
@@ -87,10 +89,7 @@ public class TelemetryRunnable implements Runnable {
   }
 
   private void mainLoopIteration() throws InterruptedException {
-    Map<String, Object> collectedConfig = ConfigCollector.get().collect();
-    if (!collectedConfig.isEmpty()) {
-      telemetryService.addConfiguration(collectedConfig);
-    }
+    collectConfigChanges();
 
     // Collect request metrics every N seconds (default 10s)
     if (scheduler.shouldRunMetrics()) {
@@ -109,6 +108,13 @@ public class TelemetryRunnable implements Runnable {
           break;
         }
       }
+    }
+  }
+
+  private void collectConfigChanges() {
+    Map<String, Object> collectedConfig = ConfigCollector.get().collect();
+    if (!collectedConfig.isEmpty()) {
+      telemetryService.addConfiguration(collectedConfig);
     }
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -66,7 +66,7 @@ public class TelemetryRunnable implements Runnable {
       }
     }
 
-    telemetryService.sendAppClosingRequest();
+    telemetryService.sendAppClosingEvent();
     log.debug("Telemetry thread finished");
   }
 
@@ -87,7 +87,7 @@ public class TelemetryRunnable implements Runnable {
       for (final TelemetryPeriodicAction action : this.actions) {
         action.doIteration(this.telemetryService);
       }
-      telemetryService.sendIntervalRequests();
+      telemetryService.sendTelemetryEvents();
     }
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -58,14 +58,18 @@ public class TelemetryRunnable implements Runnable {
 
     scheduler.init();
 
-    for (int attempt = 1; attempt <= MAX_APP_STARTED_RETRIES; attempt++) {
-      if (Thread.interrupted() || telemetryService.sendAppStartedEvent()) {
-        break;
-      }
+    int attempt = 0;
+    while (!Thread.interrupted()
+        && !telemetryService.sendAppStartedEvent()
+        && attempt < MAX_APP_STARTED_RETRIES) {
+      attempt += 1;
       log.debug(
           "Couldn't send an app-started event on {} attempt out of {}.",
           attempt,
           MAX_APP_STARTED_RETRIES);
+    }
+    if (attempt == MAX_APP_STARTED_RETRIES) {
+      log.error("Couldn't send an app-started event!");
     }
 
     while (!Thread.interrupted()) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRunnable.java
@@ -69,7 +69,7 @@ public class TelemetryRunnable implements Runnable {
           MAX_APP_STARTED_RETRIES);
     }
     if (attempt == MAX_APP_STARTED_RETRIES) {
-      log.error("Couldn't send an app-started event!");
+      log.warn("Couldn't send an app-started event!");
     }
 
     scheduler.init();

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -7,13 +7,9 @@ import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.api.RequestType;
 import datadog.telemetry.dependency.Dependency;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import javax.annotation.Nullable;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -26,14 +22,7 @@ public class TelemetryService {
 
   private static final String API_ENDPOINT = "telemetry/proxy/api/v2/apmtelemetry";
 
-  private static final int MAX_ELEMENTS_PER_REQUEST = 100;
-
-  // https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/producing-telemetry.md#when-to-use-it-1
-  private static final int MAX_DEPENDENCIES_PER_REQUEST = 2000;
-
   private final HttpClient httpClient;
-  private final int maxElementsPerReq;
-  private final int maxDepsPerReq;
   private final BlockingQueue<ConfigChange> configurations = new LinkedBlockingQueue<>();
   private final BlockingQueue<Integration> integrations = new LinkedBlockingQueue<>();
   private final BlockingQueue<Dependency> dependencies = new LinkedBlockingQueue<>();
@@ -44,6 +33,10 @@ public class TelemetryService {
 
   private final BlockingQueue<DistributionSeries> distributionSeries =
       new LinkedBlockingQueue<>(1024);
+
+  private final EventSource.Queued eventSource =
+      new EventSource.Queued(
+          configurations, integrations, dependencies, metrics, distributionSeries, logMessages);
 
   private final HttpUrl httpUrl;
 
@@ -59,22 +52,12 @@ public class TelemetryService {
     this(new HttpClient(okHttpClient), httpUrl);
   }
 
-  public TelemetryService(final HttpClient httpClient, final HttpUrl httpUrl) {
-    this(httpClient, MAX_ELEMENTS_PER_REQUEST, MAX_DEPENDENCIES_PER_REQUEST, httpUrl);
-  }
-
   // For testing purposes
-  TelemetryService(
-      final HttpClient httpClient,
-      final int maxElementsPerReq,
-      final int maxDepsPerReq,
-      final HttpUrl agentUrl) {
+  TelemetryService(final HttpClient httpClient, final HttpUrl agentUrl) {
     this.httpClient = httpClient;
     this.sentAppStarted = false;
     this.openTracingIntegrationEnabled = false;
     this.openTelemetryIntegrationEnabled = false;
-    this.maxElementsPerReq = maxElementsPerReq;
-    this.maxDepsPerReq = maxDepsPerReq;
     this.httpUrl = agentUrl.newBuilder().addPathSegments(API_ENDPOINT).build();
   }
 
@@ -119,176 +102,76 @@ public class TelemetryService {
   }
 
   public void sendAppClosingEvent() {
-    RequestBuilder rb = new RequestBuilder(RequestType.APP_CLOSING, httpUrl);
-    rb.beginRequest();
+    EventSource eventSource = new BufferedEvents(); // TODO empty source
+    BatchRequestBuilder batchRequestBuilder =
+        new BatchRequestBuilder(eventSource, EventSink.noop());
+    batchRequestBuilder.beginRequest(RequestType.APP_CLOSING, httpUrl);
+    Request request = batchRequestBuilder.endRequest();
     // TODO include metrics and other payloads
-    rb.endRequest();
-    Request request = rb.request();
-    httpClient.sendRequest(request);
+    if (httpClient.sendRequest(request) != HttpClient.Result.SUCCESS) {
+      // TODO log error
+    }
   }
 
+  // keeps track of unsent events from the previous attempt
+  private BufferedEvents bufferedEvents;
+
   public void sendTelemetryEvents() {
-    final State state =
-        new State(
-            configurations, integrations, dependencies, metrics, distributionSeries, logMessages);
-    if (!sentAppStarted) {
-      RequestBuilder rb = new RequestBuilder(RequestType.APP_STARTED, httpUrl);
-      rb.beginRequest();
-      rb.writeAppStartedEvent(state.configurations.getOrNull());
-      rb.endRequest();
-      HttpClient.Result result = httpClient.sendRequest(rb.request());
-
-      if (result != HttpClient.Result.SUCCESS) {
-        // Do not send other telemetry messages unless app-started has been sent successfully.
-        state.rollback();
-        return;
-      }
-      sentAppStarted = true;
-      state.commit();
-      state.rollback();
-      // When app-started is sent, we do not send more messages until the next interval.
-      return;
-    }
-
-    RequestBuilder requestBuilder;
-    if (state.isEmpty()) {
-      requestBuilder = new RequestBuilder(RequestType.APP_HEARTBEAT, httpUrl);
-      requestBuilder.beginRequest();
-      requestBuilder.endRequest();
+    EventSource eventSource;
+    EventSink eventSink;
+    if (bufferedEvents == null) {
+      // build a telemetry request from the event queues
+      eventSource = this.eventSource;
+      // use a buffer, so we can retry on the next attempt in case of a request failure
+      bufferedEvents = new BufferedEvents();
+      eventSink = bufferedEvents;
     } else {
-      requestBuilder = new RequestBuilder(RequestType.MESSAGE_BATCH, httpUrl);
-      requestBuilder.beginRequest();
-      requestBuilder.writeHeartbeatEvent();
-      requestBuilder.writeConfigChangeEvent(state.configurations.get(maxElementsPerReq));
-      requestBuilder.writeIntegrationsEvent(state.integrations.get(maxElementsPerReq));
-      requestBuilder.writeDependenciesLoadedEvent(state.dependencies.get(maxDepsPerReq));
-      requestBuilder.writeGenerateMetricsEvent(state.metrics.get());
-      requestBuilder.writeDistributionsEvent(state.distributionSeries.get());
-      requestBuilder.writeLogsEvent(state.logMessages.get());
-      requestBuilder.endRequest();
+      // retry sending unsent buffered events from the last attempt
+      eventSource = bufferedEvents;
+      eventSink = EventSink.noop(); // TODO add metrics for unsent events
+    }
+    BatchRequestBuilder batchRequestBuilder = new BatchRequestBuilder(eventSource, eventSink);
+
+    Request request;
+    if (!sentAppStarted) {
+      batchRequestBuilder.beginRequest(RequestType.APP_STARTED, httpUrl);
+      batchRequestBuilder.writeConfigurationMessage();
+      request = batchRequestBuilder.endRequest();
+    } else if (eventSource.isEmpty()) {
+      batchRequestBuilder.beginRequest(RequestType.APP_HEARTBEAT, httpUrl);
+      request = batchRequestBuilder.endRequest();
+    } else {
+      batchRequestBuilder.beginRequest(RequestType.MESSAGE_BATCH, httpUrl);
+      batchRequestBuilder.writeHeartbeatEvent();
+      batchRequestBuilder.writeConfigurationMessage();
+      batchRequestBuilder.writeIntegrationsMessage();
+      batchRequestBuilder.writeDependenciesMessage();
+      batchRequestBuilder.writeMetricsMessage();
+      batchRequestBuilder.writeDistributionsMessage();
+      batchRequestBuilder.writeLogsMessage();
+      request = batchRequestBuilder.endRequest();
     }
 
-    HttpClient.Result result = httpClient.sendRequest(requestBuilder.request());
+    HttpClient.Result result = httpClient.sendRequest(request);
     if (result == HttpClient.Result.SUCCESS) {
-      state.commit();
+      sentAppStarted = true;
+      // TODO send the other batch if not all data fit the request limit
+      if (eventSource == bufferedEvents) {
+        // if the buffered events have been successfully sent then do another request immediately
+        // with events if any
+        bufferedEvents = null;
+        if (!eventSource.isEmpty()) {
+          sendTelemetryEvents();
+        }
+      } else {
+        // discard buffered events when they have been successfully sent
+        bufferedEvents = null;
+      }
     }
-    // rollback everything that hasn't been sent
-    state.rollback();
   }
 
   void warnAboutExclusiveIntegrations() {
     log.warn(
         "Both OpenTracing and OpenTelemetry integrations are enabled but mutually exclusive. Tracing performance can be degraded.");
-  }
-
-  private static class StateList<T> {
-    private final BlockingQueue<T> queue;
-    private List<T> batch;
-    private int consumed;
-
-    public StateList(final BlockingQueue<T> queue) {
-      this.queue = queue;
-      final int size = queue.size();
-      this.batch = new ArrayList<>(size);
-      queue.drainTo(this.batch);
-      this.consumed = 0;
-    }
-
-    public boolean isEmpty() {
-      return consumed >= batch.size();
-    }
-
-    @Nullable
-    public List<T> getOrNull() {
-      final List<T> result = get();
-      if (result.isEmpty()) {
-        return null;
-      }
-      return result;
-    }
-
-    public List<T> get() {
-      return get(batch.size());
-    }
-
-    public List<T> get(final int maxSize) {
-      if (consumed >= batch.size()) {
-        return Collections.emptyList();
-      }
-      final int toIndex = Math.min(batch.size(), consumed + maxSize);
-      final List<T> result = batch.subList(consumed, toIndex);
-      consumed += result.size();
-      return result;
-    }
-
-    public void commit() {
-      if (consumed >= batch.size()) {
-        batch = Collections.emptyList();
-      } else {
-        batch = batch.subList(consumed, batch.size());
-      }
-      consumed = 0;
-    }
-
-    public void rollback() {
-      for (final T element : batch) {
-        // Ignore result, if the queue is full, we'll just lose data.
-        // TODO: Emit a metric when data is lost.
-        queue.offer(element);
-      }
-      batch = Collections.emptyList();
-      consumed = 0;
-    }
-  }
-
-  private static class State {
-    private final StateList<ConfigChange> configurations;
-    private final StateList<Integration> integrations;
-    private final StateList<Dependency> dependencies;
-    private final StateList<Metric> metrics;
-    private final StateList<DistributionSeries> distributionSeries;
-    private final StateList<LogMessage> logMessages;
-
-    public State(
-        BlockingQueue<ConfigChange> configurations,
-        BlockingQueue<Integration> integrations,
-        BlockingQueue<Dependency> dependencies,
-        BlockingQueue<Metric> metrics,
-        BlockingQueue<DistributionSeries> distributionSeries,
-        BlockingQueue<LogMessage> logMessages) {
-      this.configurations = new StateList<>(configurations);
-      this.integrations = new StateList<>(integrations);
-      this.dependencies = new StateList<>(dependencies);
-      this.metrics = new StateList<>(metrics);
-      this.distributionSeries = new StateList<>(distributionSeries);
-      this.logMessages = new StateList<>(logMessages);
-    }
-
-    public void rollback() {
-      this.configurations.rollback();
-      this.integrations.rollback();
-      this.dependencies.rollback();
-      this.metrics.rollback();
-      this.distributionSeries.rollback();
-      this.logMessages.rollback();
-    }
-
-    public void commit() {
-      this.configurations.commit();
-      this.integrations.commit();
-      this.dependencies.commit();
-      this.metrics.commit();
-      this.distributionSeries.commit();
-      this.logMessages.commit();
-    }
-
-    public boolean isEmpty() {
-      return configurations.isEmpty()
-          && integrations.isEmpty()
-          && dependencies.isEmpty()
-          && metrics.isEmpty()
-          && distributionSeries.isEmpty()
-          && logMessages.isEmpty();
-    }
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -159,8 +159,8 @@ public class TelemetryService {
   }
 
   /**
-   * @return true - only part of data has been sent because of the message limitation per request
-   *     false - all data has been sent, or it has failed to send a request
+   * @return true - only part of data has been sent because of the request size limit false - all
+   *     data has been sent, or it has failed sending a request
    */
   public boolean sendTelemetryEvents() {
     EventSource eventSource;
@@ -214,9 +214,7 @@ public class TelemetryService {
     if (result == HttpClient.Result.SUCCESS) {
       log.debug("Telemetry request has been sent successfully.");
       bufferedEvents = null;
-      if (isMoreDataAvailable) {
-        return true;
-      }
+      return isMoreDataAvailable;
     } else {
       log.debug("Telemetry request has failed: {}", result);
       if (eventSource == bufferedEvents) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -92,11 +92,13 @@ public class TelemetryService {
   }
 
   public boolean addIntegration(Integration integration) {
-    if ("opentelemetry-1".equals(integration.name) && integration.enabled) {
-      this.openTelemetryIntegrationEnabled = true;
-      warnAboutExclusiveIntegrations();
-    } else if ("opentracing".equals(integration.name) && integration.enabled) {
-      this.openTracingIntegrationEnabled = true;
+    if ("opentelemetry-1".equals(integration.name)) {
+      openTelemetryIntegrationEnabled = integration.enabled;
+    }
+    if ("opentracing".equals(integration.name)) {
+      openTracingIntegrationEnabled = integration.enabled;
+    }
+    if (openTelemetryIntegrationEnabled && openTracingIntegrationEnabled) {
       warnAboutExclusiveIntegrations();
     }
     return this.integrations.offer(integration);
@@ -170,15 +172,13 @@ public class TelemetryService {
     if (result == HttpClient.Result.SUCCESS) {
       state.commit();
     }
-    // rollback everything that hasn't been sent, e.g. app-started only includes configuration
+    // rollback everything that hasn't been sent
     state.rollback();
   }
 
-  private void warnAboutExclusiveIntegrations() {
-    if (this.openTelemetryIntegrationEnabled && this.openTracingIntegrationEnabled) {
-      log.warn(
-          "Both Open Tracing and Open Telemetry integrations are enabled but mutually exclusive. Tracing performance can be degraded.");
-    }
+  void warnAboutExclusiveIntegrations() {
+    log.warn(
+        "Both OpenTracing and OpenTelemetry integrations are enabled but mutually exclusive. Tracing performance can be degraded.");
   }
 
   private static class StateList<T> {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -50,6 +50,12 @@ public class TelemetryService {
   private boolean openTracingIntegrationEnabled;
   private boolean openTelemetryIntegrationEnabled;
 
+  /**
+   * @param okHttpClient - an instance to do http calls
+   * @param httpUrl - telemetry endpoint URL
+   * @param debug - when `true` it adds a debug flag to a telemetry request to handle it on the
+   *     backend with verbose logging
+   */
   public TelemetryService(
       final OkHttpClient okHttpClient, final HttpUrl httpUrl, final boolean debug) {
     this(new HttpClient(okHttpClient), httpUrl, DEFAULT_MESSAGE_BYTES_SOFT_LIMIT, debug);

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -189,7 +189,7 @@ public class TelemetryService {
       batchRequestBuilder.writeDistributionsMessage();
       batchRequestBuilder.writeLogsMessage();
       batchRequestBuilder.endMultiplePayloads();
-      isMoreDataAvailable = !eventSource.isEmpty();
+      isMoreDataAvailable = !this.eventSource.isEmpty();
     }
     request = batchRequestBuilder.endRequest();
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -102,9 +102,8 @@ public class TelemetryService {
   }
 
   public void sendAppClosingEvent() {
-    EventSource eventSource = new BufferedEvents(); // TODO empty source
     BatchRequestBuilder batchRequestBuilder =
-        new BatchRequestBuilder(eventSource, EventSink.noop());
+        new BatchRequestBuilder(EventSource.noop(), EventSink.noop());
     batchRequestBuilder.beginRequest(RequestType.APP_CLOSING, httpUrl);
     Request request = batchRequestBuilder.endRequest();
     // TODO include metrics and other payloads
@@ -155,17 +154,12 @@ public class TelemetryService {
     HttpClient.Result result = httpClient.sendRequest(request);
     if (result == HttpClient.Result.SUCCESS) {
       sentAppStarted = true;
-      // TODO send the other batch if not all data fit the request limit
-      if (eventSource == bufferedEvents) {
-        // if the buffered events have been successfully sent then do another request immediately
-        // with events if any
-        bufferedEvents = null;
-        if (!eventSource.isEmpty()) {
-          sendTelemetryEvents();
-        }
-      } else {
-        // discard buffered events when they have been successfully sent
-        bufferedEvents = null;
+      bufferedEvents = null;
+      if (!this.eventSource.isEmpty()) {
+        // if the events have been successfully sent then do another request immediately with new
+        // events if any
+        // TODO maybe limit number of requests
+        sendTelemetryEvents();
       }
     }
   }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -113,7 +113,7 @@ public class TelemetryService {
     TelemetryRequest telemetryRequest =
         new TelemetryRequest(
             this.eventSource,
-            EventSink.noop(),
+            EventSink.NOOP,
             messageBytesSoftLimit,
             RequestType.APP_CLOSING,
             httpUrl,
@@ -175,7 +175,7 @@ public class TelemetryService {
       log.debug(
           "Sending buffered telemetry events that couldn't have been sent on previous attempt");
       eventSource = bufferedEvents;
-      eventSink = EventSink.noop(); // TODO collect metrics for unsent events
+      eventSink = EventSink.NOOP; // TODO collect metrics for unsent events
     }
     TelemetryRequest telemetryRequest;
     boolean isMoreDataAvailable = false;

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -136,10 +136,8 @@ public class TelemetryService {
 
     log.debug("Preparing app-started request");
     batchRequestBuilder.beginRequest(RequestType.APP_STARTED, httpUrl);
-    batchRequestBuilder.beginSinglePayload();
     batchRequestBuilder.writeProducts();
     batchRequestBuilder.writeConfigurations();
-    batchRequestBuilder.endSinglePayload();
     Request request = batchRequestBuilder.endRequest();
 
     if (httpClient.sendRequest(request) == HttpClient.Result.SUCCESS) {
@@ -180,7 +178,6 @@ public class TelemetryService {
     } else {
       log.debug("Preparing message-batch request");
       batchRequestBuilder.beginRequest(RequestType.MESSAGE_BATCH, httpUrl);
-      batchRequestBuilder.beginMultiplePayloads();
       batchRequestBuilder.writeHeartbeatEvent();
       batchRequestBuilder.writeConfigurationMessage();
       batchRequestBuilder.writeIntegrationsMessage();
@@ -188,7 +185,6 @@ public class TelemetryService {
       batchRequestBuilder.writeMetricsMessage();
       batchRequestBuilder.writeDistributionsMessage();
       batchRequestBuilder.writeLogsMessage();
-      batchRequestBuilder.endMultiplePayloads();
       isMoreDataAvailable = !this.eventSource.isEmpty();
     }
     request = batchRequestBuilder.endRequest();

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -129,9 +129,10 @@ public class TelemetryService {
     if (!sentAppStarted) {
       RequestBuilder rb = new RequestBuilder(RequestType.APP_STARTED, httpUrl);
       rb.writeHeader();
+      // products - optional
       rb.writeConfigChangeEvent(state.configurations.getOrNull());
-      rb.writeIntegrationsEvent(state.integrations.get(maxElementsPerReq));
-      rb.writeDependenciesLoadedEvent(state.dependencies.get(maxElementsPerReq));
+      // error - optional
+      // additional_payload - optional
       rb.writeFooter();
       HttpClient.Result result = httpClient.sendRequest(rb.request());
 
@@ -211,7 +212,7 @@ public class TelemetryService {
     while (!state.metrics.isEmpty()) {
       RequestBuilder rb = new RequestBuilder(RequestType.GENERATE_METRICS, httpUrl);
       rb.writeHeader();
-      rb.writeMetrics(state.metrics.get(maxElementsPerReq));
+      rb.writeGenerateMetricsEvent(state.metrics.get(maxElementsPerReq));
       rb.writeFooter();
       HttpClient.Result result = httpClient.sendRequest(rb.request());
       if (result == HttpClient.Result.SUCCESS) {

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -141,7 +141,10 @@ public class TelemetryService {
     if (!sentAppStarted) {
       log.debug("Preparing app-started request");
       batchRequestBuilder.beginRequest(RequestType.APP_STARTED, httpUrl);
-      batchRequestBuilder.writeConfigurationMessage();
+      batchRequestBuilder.beginSinglePayload();
+      batchRequestBuilder.writeProducts();
+      batchRequestBuilder.writeConfigurations();
+      batchRequestBuilder.endSinglePayload();
       request = batchRequestBuilder.endRequest();
     } else if (eventSource.isEmpty()) {
       log.debug("Preparing app-heartbeat request");
@@ -150,6 +153,7 @@ public class TelemetryService {
     } else {
       log.debug("Preparing message-batch request");
       batchRequestBuilder.beginRequest(RequestType.MESSAGE_BATCH, httpUrl);
+      batchRequestBuilder.beginMultiplePayloads();
       batchRequestBuilder.writeHeartbeatEvent();
       batchRequestBuilder.writeConfigurationMessage();
       batchRequestBuilder.writeIntegrationsMessage();
@@ -157,6 +161,7 @@ public class TelemetryService {
       batchRequestBuilder.writeMetricsMessage();
       batchRequestBuilder.writeDistributionsMessage();
       batchRequestBuilder.writeLogsMessage();
+      batchRequestBuilder.endMultiplePayloads();
       request = batchRequestBuilder.endRequest();
     }
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -112,7 +112,7 @@ public class TelemetryService {
   public void sendAppClosingEvent() {
     TelemetryRequest telemetryRequest =
         new TelemetryRequest(
-            EventSource.noop(),
+            this.eventSource,
             EventSink.noop(),
             messageBytesSoftLimit,
             RequestType.APP_CLOSING,

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -60,7 +60,8 @@ public class TelemetrySystem {
       Instrumentation instrumentation, SharedCommunicationObjects sco) {
     sco.createRemaining(Config.get());
     DependencyService dependencyService = createDependencyService(instrumentation);
-    TelemetryService telemetryService = new TelemetryService(sco.okHttpClient, sco.agentUrl, false);
+    boolean debug = Config.get().isTelemetryDebugRequestsEnabled();
+    TelemetryService telemetryService = new TelemetryService(sco.okHttpClient, sco.agentUrl, debug);
     TELEMETRY_THREAD = createTelemetryRunnable(telemetryService, dependencyService);
     TELEMETRY_THREAD.start();
   }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -60,7 +60,7 @@ public class TelemetrySystem {
       Instrumentation instrumentation, SharedCommunicationObjects sco) {
     sco.createRemaining(Config.get());
     DependencyService dependencyService = createDependencyService(instrumentation);
-    TelemetryService telemetryService = new TelemetryService(sco.okHttpClient, sco.agentUrl);
+    TelemetryService telemetryService = new TelemetryService(sco.okHttpClient, sco.agentUrl, false);
     TELEMETRY_THREAD = createTelemetryRunnable(telemetryService, dependencyService);
     TELEMETRY_THREAD.start();
   }

--- a/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
@@ -12,11 +12,12 @@ public enum RequestType {
   APP_CLOSING("app-closing"),
   GENERATE_METRICS("generate-metrics"),
   LOGS("logs"),
-  DISTRIBUTIONS("distributions");
+  DISTRIBUTIONS("distributions"),
   // apm-onboarding-event -
   // https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/payload.md#if-request_type--apm-onboarding-event-we-add-the-following-to-payload
   // apm-remote-config-event -
   // https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/payload.md#if-request_type--apm-remote-config-event-we-add-the-following-to-payload
+  MESSAGE_BATCH("message-batch");
 
   private final String value;
 

--- a/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
@@ -8,7 +8,6 @@ public enum RequestType {
   // app-product-change
   APP_HEARTBEAT("app-heartbeat"),
   // app-extended-heartbeat
-  // message-batch
   APP_CLOSING("app-closing"),
   GENERATE_METRICS("generate-metrics"),
   LOGS("logs"),

--- a/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/RequestType.java
@@ -2,14 +2,21 @@ package datadog.telemetry.api;
 
 public enum RequestType {
   APP_STARTED("app-started"),
-  APP_CLIENT_CONFIGURATION_CHANGE("app-client-configuration-change"),
   APP_DEPENDENCIES_LOADED("app-dependencies-loaded"),
   APP_INTEGRATIONS_CHANGE("app-integrations-change"),
+  APP_CLIENT_CONFIGURATION_CHANGE("app-client-configuration-change"),
+  // app-product-change
   APP_HEARTBEAT("app-heartbeat"),
+  // app-extended-heartbeat
+  // message-batch
   APP_CLOSING("app-closing"),
   GENERATE_METRICS("generate-metrics"),
   LOGS("logs"),
   DISTRIBUTIONS("distributions");
+  // apm-onboarding-event -
+  // https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/payload.md#if-request_type--apm-onboarding-event-we-add-the-following-to-payload
+  // apm-remote-config-event -
+  // https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/payload.md#if-request_type--apm-remote-config-event-we-add-the-following-to-payload
 
   private final String value;
 

--- a/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
@@ -16,11 +16,11 @@ class BufferedEventsSpecification extends DDSpecification {
     expect:
     events.isEmpty()
     !events.hasConfigChangeEvent()
-    events.nextDependencyEvent() == null
-    events.nextDistributionSeriesEvent() == null
-    events.nextIntegrationEvent() == null
-    events.nextLogMessageEvent() == null
-    events.nextMetricEvent() == null
+    !events.hasDependencyEvent()
+    !events.hasDistributionSeriesEvent()
+    !events.hasIntegrationEvent()
+    !events.hasLogMessageEvent()
+    !events.hasMetricEvent()
   }
 
   def 'return added events'() {
@@ -42,38 +42,42 @@ class BufferedEventsSpecification extends DDSpecification {
 
     then:
     !events.isEmpty()
+
     events.hasConfigChangeEvent()
     events.nextConfigChangeEvent() == configChangeEvent
     !events.hasConfigChangeEvent()
+
     !events.isEmpty()
+
+    events.hasDependencyEvent()
     events.nextDependencyEvent() == dependency
-    events.nextDependencyEvent() == null
+    !events.hasDependencyEvent()
+
     !events.isEmpty()
+
+    events.hasDistributionSeriesEvent()
     events.nextDistributionSeriesEvent() == series
-    events.nextDistributionSeriesEvent() == null
+    !events.hasDistributionSeriesEvent()
+
     !events.isEmpty()
+
+    events.hasIntegrationEvent()
     events.nextIntegrationEvent() == integration
-    events.nextIntegrationEvent() == null
+    !events.hasIntegrationEvent()
+
     !events.isEmpty()
+
+    events.hasLogMessageEvent()
     events.nextLogMessageEvent() == logMessage
-    events.nextLogMessageEvent() == null
+    !events.hasLogMessageEvent()
+
     !events.isEmpty()
+
+    events.hasMetricEvent()
     events.nextMetricEvent() == metric
-    events.nextMetricEvent() == null
+    !events.hasMetricEvent()
+
     events.isEmpty()
-  }
-
-  def 'noop source'() {
-    def src = EventSource.noop()
-
-    expect:
-    src.isEmpty()
-    src.nextMetricEvent() == null
-    src.nextLogMessageEvent() == null
-    src.nextIntegrationEvent() == null
-    src.nextDistributionSeriesEvent() == null
-    src.nextDependencyEvent() == null
-    src.nextConfigChangeEvent() == null
   }
 
   def 'noop sink'() {

--- a/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
@@ -15,7 +15,7 @@ class BufferedEventsSpecification extends DDSpecification {
 
     expect:
     events.isEmpty()
-    events.nextConfigChangeEvent() == null
+    !events.hasConfigChangeEvent()
     events.nextDependencyEvent() == null
     events.nextDistributionSeriesEvent() == null
     events.nextIntegrationEvent() == null
@@ -42,8 +42,9 @@ class BufferedEventsSpecification extends DDSpecification {
 
     then:
     !events.isEmpty()
+    events.hasConfigChangeEvent()
     events.nextConfigChangeEvent() == configChangeEvent
-    events.nextConfigChangeEvent() == null
+    !events.hasConfigChangeEvent()
     !events.isEmpty()
     events.nextDependencyEvent() == dependency
     events.nextDependencyEvent() == null

--- a/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
@@ -81,7 +81,7 @@ class BufferedEventsSpecification extends DDSpecification {
   }
 
   def 'noop sink'() {
-    def sink = EventSink.noop()
+    def sink = EventSink.NOOP
 
     expect:
     sink.addMetricEvent(null)

--- a/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/BufferedEventsSpecification.groovy
@@ -1,0 +1,89 @@
+package datadog.telemetry
+
+import datadog.telemetry.api.ConfigChange
+import datadog.telemetry.api.DistributionSeries
+import datadog.telemetry.api.Integration
+import datadog.telemetry.api.LogMessage
+import datadog.telemetry.api.Metric
+import datadog.telemetry.dependency.Dependency
+import datadog.trace.test.util.DDSpecification
+
+class BufferedEventsSpecification extends DDSpecification {
+
+  def 'empty events'() {
+    def events = new BufferedEvents()
+
+    expect:
+    events.isEmpty()
+    events.nextConfigChangeEvent() == null
+    events.nextDependencyEvent() == null
+    events.nextDistributionSeriesEvent() == null
+    events.nextIntegrationEvent() == null
+    events.nextLogMessageEvent() == null
+    events.nextMetricEvent() == null
+  }
+
+  def 'return added events'() {
+    def events = new BufferedEvents()
+    def configChangeEvent = new ConfigChange("key", "value")
+    def dependency = new Dependency("name", "version", "source", "hash")
+    def series = new DistributionSeries()
+    def integration = new Integration("integration-name", true)
+    def logMessage = new LogMessage()
+    def metric = new Metric()
+
+    when:
+    events.addConfigChangeEvent(configChangeEvent)
+    events.addDependencyEvent(dependency)
+    events.addDistributionSeriesEvent(series)
+    events.addIntegrationEvent(integration)
+    events.addLogMessageEvent(logMessage)
+    events.addMetricEvent(metric)
+
+    then:
+    !events.isEmpty()
+    events.nextConfigChangeEvent() == configChangeEvent
+    events.nextConfigChangeEvent() == null
+    !events.isEmpty()
+    events.nextDependencyEvent() == dependency
+    events.nextDependencyEvent() == null
+    !events.isEmpty()
+    events.nextDistributionSeriesEvent() == series
+    events.nextDistributionSeriesEvent() == null
+    !events.isEmpty()
+    events.nextIntegrationEvent() == integration
+    events.nextIntegrationEvent() == null
+    !events.isEmpty()
+    events.nextLogMessageEvent() == logMessage
+    events.nextLogMessageEvent() == null
+    !events.isEmpty()
+    events.nextMetricEvent() == metric
+    events.nextMetricEvent() == null
+    events.isEmpty()
+  }
+
+  def 'noop source'() {
+    def src = EventSource.noop()
+
+    expect:
+    src.isEmpty()
+    src.nextMetricEvent() == null
+    src.nextLogMessageEvent() == null
+    src.nextIntegrationEvent() == null
+    src.nextDistributionSeriesEvent() == null
+    src.nextDependencyEvent() == null
+    src.nextConfigChangeEvent() == null
+  }
+
+  def 'noop sink'() {
+    def sink = EventSink.noop()
+
+    expect:
+    sink.addMetricEvent(null)
+    sink.addLogMessageEvent(null)
+    sink.addIntegrationEvent(null)
+    sink.addDistributionSeriesEvent(null)
+    sink.addDependencyEvent(null)
+    sink.addConfigChangeEvent(null)
+  }
+}

--- a/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
@@ -65,7 +65,7 @@ class RequestBuilderSpecification extends Specification {
     ])
 
     then:
-    drainToString(rb.request()) == ',"payload":{"configuration":[{"name":"string","value":"bar"},{"name":"int","value":2342},{"name":"double","value":123.456},{"name":"map","value":{"key1":"value1","key2":432.32,"key3":324}}]}'
+    drainToString(rb.request()) == ',"payload":{"configuration":[{"name":"string","value":"bar","origin":"unknown"},{"name":"int","value":2342,"origin":"unknown"},{"name":"double","value":123.456,"origin":"unknown"},{"name":"map","value":{"key1":"value1","key2":432.32,"key3":324},"origin":"unknown"}]}'
   }
 
   String drainToString(Request req) {

--- a/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
@@ -18,8 +18,8 @@ class RequestBuilderSpecification extends Specification {
     def b = new RequestBuilder(RequestType.APP_STARTED, httpUrl)
 
     when:
-    b.writeHeader()
-    b.writeHeader()
+    b.beginRequest()
+    b.beginRequest()
 
     then:
     RequestBuilder.SerializationException ex = thrown()
@@ -32,9 +32,9 @@ class RequestBuilderSpecification extends Specification {
     def b = new RequestBuilder(RequestType.APP_STARTED, httpUrl)
 
     when:
-    b.writeHeader()
-    b.writeFooter()
-    b.writeHeader()
+    b.beginRequest()
+    b.endRequest()
+    b.beginRequest()
 
     then:
     RequestBuilder.SerializationException ex = thrown()
@@ -52,7 +52,7 @@ class RequestBuilderSpecification extends Specification {
 
     when:
     // header needed for a proper JSON
-    rb.writeHeader()
+    rb.beginRequest()
     // but not needed for verification
     drainToString(rb.request())
 
@@ -65,7 +65,7 @@ class RequestBuilderSpecification extends Specification {
     ])
 
     then:
-    drainToString(rb.request()) == '"configuration":[{"name":"string","value":"bar"},{"name":"int","value":2342},{"name":"double","value":123.456},{"name":"map","value":{"key1":"value1","key2":432.32,"key3":324}}]'
+    drainToString(rb.request()) == ',"payload":{"configuration":[{"name":"string","value":"bar"},{"name":"int","value":2342},{"name":"double","value":123.456},{"name":"map","value":{"key1":"value1","key2":432.32,"key3":324}}]}'
   }
 
   String drainToString(Request req) {

--- a/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
@@ -23,7 +23,7 @@ class RequestBuilderSpecification extends Specification {
 
     then:
     RequestBuilder.SerializationException ex = thrown()
-    ex.message == "Failed serializing Telemetry request header part!"
+    ex.message == "Failed serializing Telemetry begin-request part!"
     ex.cause != null
   }
 
@@ -38,7 +38,7 @@ class RequestBuilderSpecification extends Specification {
 
     then:
     RequestBuilder.SerializationException ex = thrown()
-    ex.message == "Failed serializing Telemetry request header part!"
+    ex.message == "Failed serializing Telemetry begin-request part!"
     ex.cause != null
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
@@ -57,15 +57,17 @@ class RequestBuilderSpecification extends Specification {
     drainToString(rb.request())
 
     then:
-    rb.writeConfigChangeEvent([
+    rb.beginConfiguration()
+    [
       new ConfigChange("string", "bar"),
       new ConfigChange("int", 2342),
       new ConfigChange("double", Double.valueOf("123.456")),
       new ConfigChange("map", map)
-    ])
+    ].forEach { cc -> rb.writeConfiguration(cc) }
+    rb.endConfiguration()
 
     then:
-    drainToString(rb.request()) == ',"payload":{"configuration":[{"name":"string","value":"bar","origin":"unknown"},{"name":"int","value":2342,"origin":"unknown"},{"name":"double","value":123.456,"origin":"unknown"},{"name":"map","value":{"key1":"value1","key2":432.32,"key3":324},"origin":"unknown"}]}'
+    drainToString(rb.request()) == ',"configuration":[{"name":"string","value":"bar","origin":"unknown"},{"name":"int","value":2342,"origin":"unknown"},{"name":"double","value":123.456,"origin":"unknown"},{"name":"map","value":{"key1":"value1","key2":432.32,"key3":324},"origin":"unknown"}]'
   }
 
   String drainToString(Request req) {

--- a/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/RequestBuilderSpecification.groovy
@@ -51,10 +51,9 @@ class RequestBuilderSpecification extends Specification {
     map.put("key3", 324)
 
     when:
-    // header needed for a proper JSON
     rb.beginRequest()
-    // but not needed for verification
-    drainToString(rb.request())
+    // exclude request header to simplify assertion
+    drainToString(rb.buildRequest())
 
     then:
     rb.beginConfiguration()
@@ -67,7 +66,19 @@ class RequestBuilderSpecification extends Specification {
     rb.endConfiguration()
 
     then:
-    drainToString(rb.request()) == ',"configuration":[{"name":"string","value":"bar","origin":"unknown"},{"name":"int","value":2342,"origin":"unknown"},{"name":"double","value":123.456,"origin":"unknown"},{"name":"map","value":{"key1":"value1","key2":432.32,"key3":324},"origin":"unknown"}]'
+    drainToString(rb.endRequest()) == ',"configuration":[{"name":"string","value":"bar","origin":"unknown"},{"name":"int","value":2342,"origin":"unknown"},{"name":"double","value":123.456,"origin":"unknown"},{"name":"map","value":{"key1":"value1","key2":432.32,"key3":324},"origin":"unknown"}]}'
+  }
+
+  def 'add debug flag'() {
+    setup:
+    RequestBuilder rb = new RequestBuilder(RequestType.APP_STARTED, httpUrl, true)
+
+    when:
+    rb.beginRequest()
+    def request = rb.endRequest()
+
+    then:
+    drainToString(request).contains("\"debug\":true")
   }
 
   String drainToString(Request req) {

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRequestStateSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRequestStateSpecification.groovy
@@ -10,26 +10,26 @@ import spock.lang.Specification
 /**
  * This test only verifies non-functional specifics that are not covered in TelemetryServiceSpecification
  */
-class RequestBuilderSpecification extends Specification {
+class TelemetryRequestStateSpecification extends Specification {
   final HttpUrl httpUrl = HttpUrl.get("https://example.com")
 
   def 'throw SerializationException in case of JSON nesting problem'() {
     setup:
-    def b = new RequestBuilder(RequestType.APP_STARTED, httpUrl)
+    def b = new TelemetryRequestState(RequestType.APP_STARTED, httpUrl)
 
     when:
     b.beginRequest()
     b.beginRequest()
 
     then:
-    RequestBuilder.SerializationException ex = thrown()
+    TelemetryRequestState.SerializationException ex = thrown()
     ex.message == "Failed serializing Telemetry begin-request part!"
     ex.cause != null
   }
 
   def 'throw SerializationException in case of more than one top-level JSON value'() {
     setup:
-    def b = new RequestBuilder(RequestType.APP_STARTED, httpUrl)
+    def b = new TelemetryRequestState(RequestType.APP_STARTED, httpUrl)
 
     when:
     b.beginRequest()
@@ -37,14 +37,14 @@ class RequestBuilderSpecification extends Specification {
     b.beginRequest()
 
     then:
-    RequestBuilder.SerializationException ex = thrown()
+    TelemetryRequestState.SerializationException ex = thrown()
     ex.message == "Failed serializing Telemetry begin-request part!"
     ex.cause != null
   }
 
   def 'writeConfig must support values of Boolean, String, Integer, Double, Map<String, Object>'() {
     setup:
-    RequestBuilder rb = new RequestBuilder(RequestType.APP_CLIENT_CONFIGURATION_CHANGE, httpUrl)
+    TelemetryRequestState rb = new TelemetryRequestState(RequestType.APP_CLIENT_CONFIGURATION_CHANGE, httpUrl)
     Map<String, Object> map = new HashMap<>()
     map.put("key1", "value1")
     map.put("key2", Double.parseDouble("432.32"))
@@ -53,7 +53,7 @@ class RequestBuilderSpecification extends Specification {
     when:
     rb.beginRequest()
     // exclude request header to simplify assertion
-    drainToString(rb.buildRequest())
+    drainToString(rb.request())
 
     then:
     rb.beginConfiguration()
@@ -71,7 +71,7 @@ class RequestBuilderSpecification extends Specification {
 
   def 'add debug flag'() {
     setup:
-    RequestBuilder rb = new RequestBuilder(RequestType.APP_STARTED, httpUrl, true)
+    TelemetryRequestState rb = new TelemetryRequestState(RequestType.APP_STARTED, httpUrl, true)
 
     when:
     rb.beginRequest()

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -62,7 +62,7 @@ class TelemetryRunnableSpecification extends Specification {
     1 * periodicAction.doIteration(telemetryService)
 
     then:
-    1 * telemetryService.sendIntervalRequests()
+    1 * telemetryService.sendTelemetryEvents()
     1 * timeSource.getCurrentTimeMillis() >> 60 * 1000 + 1
     1 * sleeperMock.sleep(9999)
     0 * _
@@ -157,7 +157,7 @@ class TelemetryRunnableSpecification extends Specification {
     1 * periodicAction.doIteration(telemetryService)
 
     then:
-    1 * telemetryService.sendIntervalRequests()
+    1 * telemetryService.sendTelemetryEvents()
     1 * timeSource.getCurrentTimeMillis() >> 120 * 1000 + 7
     1 * sleeperMock.sleep(9993)
     0 * _
@@ -167,7 +167,7 @@ class TelemetryRunnableSpecification extends Specification {
     t.join()
 
     then:
-    1 * telemetryService.sendAppClosingRequest()
+    1 * telemetryService.sendAppClosingEvent()
     0 * _
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -51,7 +51,7 @@ class TelemetryRunnableSpecification extends Specification {
     sleeper.sleeped.await(10, TimeUnit.SECONDS)
 
     then: 'three unsuccessful attempts to send app-started with the following successful attempt'
-    4 * telemetryService.sendAppStartedEvent() >>> [false, false, false, true]
+    3 * telemetryService.sendAppStartedEvent() >>> [false, false, true]
     1 * timeSource.getCurrentTimeMillis() >> 60 * 1000
     _ * telemetryService.addConfiguration(_)
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -50,7 +50,8 @@ class TelemetryRunnableSpecification extends Specification {
     t.start()
     sleeper.sleeped.await(10, TimeUnit.SECONDS)
 
-    then:
+    then: 'three unsuccessful attempts to send app-started with the following successful attempt'
+    4 * telemetryService.sendAppStartedEvent() >>> [false, false, false, true]
     1 * timeSource.getCurrentTimeMillis() >> 60 * 1000
     _ * telemetryService.addConfiguration(_)
 
@@ -61,8 +62,8 @@ class TelemetryRunnableSpecification extends Specification {
     1 * metricCollector.drain() >> []
     1 * periodicAction.doIteration(telemetryService)
 
-    then:
-    1 * telemetryService.sendTelemetryEvents()
+    then: 'two partial and one final telemetry data requests'
+    3 * telemetryService.sendTelemetryEvents() >>> [true, true, false]
     1 * timeSource.getCurrentTimeMillis() >> 60 * 1000 + 1
     1 * sleeperMock.sleep(9999)
     0 * _

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -172,7 +172,7 @@ class TelemetryRunnableSpecification extends Specification {
     0 * _
   }
 
-  void 'reattempt app-started event next cycle'() {
+  void 'do not reattempt app-started event until next cycle'() {
     setup:
     TelemetryRunnable.ThreadSleeper sleeperMock = Mock()
     TickSleeper sleeper = new TickSleeper(delegate: sleeperMock)
@@ -191,12 +191,9 @@ class TelemetryRunnableSpecification extends Specification {
     sleeper.sleeped.await(10, TimeUnit.SECONDS)
 
     then: 'three unsuccessful attempts to send app-started (TelemetryRunnable.MAX_APP_STARTED_RETRIES) with following successful attempt'
-    4 * telemetryService.sendAppStartedEvent() >>> [false, false, false, true]
-    3 * timeSource.getCurrentTimeMillis() >> 60 * 1000
-    _ * telemetryService.addConfiguration(_)
-    1 * metricCollector.prepareMetrics()
-    1 * metricCollector.drain() >> []
-    1 * periodicAction.doIteration(telemetryService)
+    3 * telemetryService.sendAppStartedEvent() >>> [false, false, false]
+    2 * timeSource.getCurrentTimeMillis() >> 60 * 1000
+    1 * sleeperMock.sleep(10000)
   }
 
   void 'scheduler skips metrics intervals'() {

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -245,4 +245,30 @@ class TelemetryServiceSpecification extends Specification {
     then:
     testHttpClient.assertRequestBody(RequestType.APP_CLOSING)
   }
+
+  void 'report when both OTel and OT are enabled'() {
+    setup:
+    TelemetryService telemetryService = Spy(new TelemetryService(testHttpClient, HttpUrl.get("https://example.com")))
+    def otel = new Integration("opentelemetry-1", otelEnabled)
+    def ot = new Integration("opentracing", otEnabled)
+
+    when:
+    telemetryService.addIntegration(otel)
+
+    then:
+    0 * telemetryService.warnAboutExclusiveIntegrations()
+
+    when:
+    telemetryService.addIntegration(ot)
+
+    then:
+    warnining * telemetryService.warnAboutExclusiveIntegrations()
+
+    where:
+    otelEnabled | otEnabled | warnining
+    true        | true      | 1
+    true        | false     | 0
+    false       | true      | 0
+    false       | false     | 0
+  }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -32,8 +32,7 @@ class TelemetryServiceSpecification extends Specification {
 
     then: 'app-started'
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
-      .assertPayload()
-      .configuration(null)
+      .assertNoPayload()
     testHttpClient.assertNoMoreRequests()
 
     when: 'second iteration'
@@ -97,8 +96,7 @@ class TelemetryServiceSpecification extends Specification {
 
     then:
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
-      .assertPayload()
-      .configuration(null)
+      .assertNoPayload()
     testHttpClient.assertNoMoreRequests()
 
     when: 'add data after first iteration'
@@ -143,8 +141,7 @@ class TelemetryServiceSpecification extends Specification {
 
     then: 'app-started is attempted'
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
-      .assertPayload()
-      .configuration(null)
+      .assertNoPayload()
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with 500 error'
@@ -153,8 +150,7 @@ class TelemetryServiceSpecification extends Specification {
 
     then: 'app-started is attempted'
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
-      .assertPayload()
-      .configuration(null)
+      .assertNoPayload()
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with unexpected FAILURE (e.g. 100 http status code) (not valid)'
@@ -163,8 +159,7 @@ class TelemetryServiceSpecification extends Specification {
 
     then: 'app-started is attempted'
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
-      .assertPayload()
-      .configuration(null)
+      .assertNoPayload()
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with success'
@@ -173,8 +168,7 @@ class TelemetryServiceSpecification extends Specification {
 
     then:
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
-      .assertPayload()
-      .configuration(null)
+      .assertNoPayload()
     testHttpClient.assertNoMoreRequests()
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -62,18 +62,11 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.addLogMessage(logMessage)
 
     and: 'send messages'
-    testHttpClient.expectRequest(HttpClient.Result.SUCCESS)
+    testHttpClient.expectRequests(2, HttpClient.Result.SUCCESS)
     telemetryService.sendTelemetryEvents()
 
     then:
     testHttpClient.assertRequestBody(RequestType.APP_STARTED).hasPayload().configuration([confKeyValue])
-    testHttpClient.assertNoMoreRequests()
-
-    when: 'second iteration'
-    testHttpClient.expectRequest(HttpClient.Result.SUCCESS)
-    telemetryService.sendTelemetryEvents()
-
-    then:
     testHttpClient.assertRequestBody(RequestType.MESSAGE_BATCH)
       .assertBatch(6)
       .assertFirstMessage(RequestType.APP_HEARTBEAT).hasNoPayload()
@@ -86,7 +79,7 @@ class TelemetryServiceSpecification extends Specification {
       .assertNoMoreMessages()
     testHttpClient.assertNoMoreRequests()
 
-    when: 'third iteration heartbeat only'
+    when: 'second iteration heartbeat only'
     testHttpClient.expectRequest(HttpClient.Result.SUCCESS)
     telemetryService.sendTelemetryEvents()
 
@@ -94,7 +87,7 @@ class TelemetryServiceSpecification extends Specification {
     testHttpClient.assertRequestBody(RequestType.APP_HEARTBEAT).assertNoPayload()
     testHttpClient.assertNoMoreRequests()
 
-    when: 'forth iteration metrics data'
+    when: 'third iteration metrics data'
     telemetryService.addMetric(metric)
     testHttpClient.expectRequest(HttpClient.Result.SUCCESS)
     telemetryService.sendTelemetryEvents()

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -34,8 +34,6 @@ class TelemetryServiceSpecification extends Specification {
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
       .assertPayload()
       .configuration(null)
-      .dependencies([])
-      .integrations([])
     testHttpClient.assertNoMoreRequests()
 
     when: 'second iteration'
@@ -64,16 +62,20 @@ class TelemetryServiceSpecification extends Specification {
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
       .assertPayload()
       .configuration([confKeyValue])
-      .dependencies([dependency])
-      .integrations([integration])
     testHttpClient.assertNoMoreRequests()
 
     when: 'second iteration'
-    testHttpClient.expectRequests(4, HttpClient.Result.SUCCESS)
+    testHttpClient.expectRequests(6, HttpClient.Result.SUCCESS)
     telemetryService.sendIntervalRequests()
 
     then:
     testHttpClient.assertRequestBody(RequestType.APP_HEARTBEAT)
+    testHttpClient.assertRequestBody(RequestType.APP_INTEGRATIONS_CHANGE)
+      .assertPayload()
+      .integrations([integration])
+    testHttpClient.assertRequestBody(RequestType.APP_DEPENDENCIES_LOADED)
+      .assertPayload()
+      .dependencies([dependency])
     testHttpClient.assertRequestBody(RequestType.GENERATE_METRICS)
       .assertPayload()
       .namespace("tracers")
@@ -97,8 +99,6 @@ class TelemetryServiceSpecification extends Specification {
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
       .assertPayload()
       .configuration(null)
-      .dependencies([])
-      .integrations([])
     testHttpClient.assertNoMoreRequests()
 
     when: 'add data after first iteration'
@@ -145,8 +145,6 @@ class TelemetryServiceSpecification extends Specification {
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
       .assertPayload()
       .configuration(null)
-      .dependencies([])
-      .integrations([])
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with 500 error'
@@ -157,8 +155,6 @@ class TelemetryServiceSpecification extends Specification {
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
       .assertPayload()
       .configuration(null)
-      .dependencies([])
-      .integrations([])
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with unexpected FAILURE (e.g. 100 http status code) (not valid)'
@@ -169,8 +165,6 @@ class TelemetryServiceSpecification extends Specification {
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
       .assertPayload()
       .configuration(null)
-      .dependencies([])
-      .integrations([])
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with success'
@@ -181,8 +175,6 @@ class TelemetryServiceSpecification extends Specification {
     testHttpClient.assertRequestBody(RequestType.APP_STARTED)
       .assertPayload()
       .configuration(null)
-      .dependencies([])
-      .integrations([])
     testHttpClient.assertNoMoreRequests()
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -32,8 +32,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then: 'app-started'
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED)
-      .assertNoPayload()
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().products()
     testHttpClient.assertNoMoreRequests()
 
     when: 'second iteration'
@@ -71,7 +70,9 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then:
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).hasPayload().configuration([confKeyValue])
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload()
+      .products()
+      .configuration([confKeyValue])
     testHttpClient.assertRequestBody(RequestType.MESSAGE_BATCH)
       .assertBatch(6)
       .assertFirstMessage(RequestType.APP_HEARTBEAT).hasNoPayload()
@@ -116,7 +117,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then:
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertNoPayload()
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().products()
     testHttpClient.assertNoMoreRequests()
 
     when: 'add data after first iteration'
@@ -155,7 +156,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then: 'app-started is attempted'
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertNoPayload()
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().products()
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with 500 error'
@@ -163,7 +164,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then: 'app-started is attempted'
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertNoPayload()
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().products()
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with unexpected FAILURE (not valid)'
@@ -171,7 +172,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then: 'app-started is attempted'
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertNoPayload()
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().products()
     testHttpClient.assertNoMoreRequests()
 
     when: 'attempt with success'
@@ -179,7 +180,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then: 'app-started is attempted'
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertNoPayload()
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().products()
     testHttpClient.assertNoMoreRequests()
   }
 
@@ -200,7 +201,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then: 'app-started attempted with config'
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).hasPayload().configuration([confKeyValue])
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().configuration([confKeyValue])
     testHttpClient.assertNoMoreRequests()
 
     when: 'successful attempt'
@@ -208,7 +209,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then: 'attempt with SUCCESS'
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).hasPayload().configuration([confKeyValue])
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().configuration([confKeyValue])
     testHttpClient.assertRequestBody(RequestType.MESSAGE_BATCH)
       .assertBatch(6)
       .assertFirstMessage(RequestType.APP_HEARTBEAT).hasNoPayload()
@@ -288,7 +289,7 @@ class TelemetryServiceSpecification extends Specification {
     telemetryService.sendTelemetryEvents()
 
     then: 'attempt with SUCCESS'
-    testHttpClient.assertRequestBody(RequestType.APP_STARTED).hasPayload().configuration([confKeyValue])
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().configuration([confKeyValue])
     testHttpClient.assertRequestBody(RequestType.MESSAGE_BATCH)
       .assertBatch(4)
       //TODO should a heartbeat be included in the batch request?

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -25,7 +25,7 @@ class TelemetryServiceSpecification extends Specification {
   void 'happy path without data'() {
     setup:
     TestHttpClient testHttpClient = new TestHttpClient()
-    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000)
+    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000, false)
 
     when: 'first iteration'
     testHttpClient.expectRequest(HttpClient.Result.SUCCESS)
@@ -55,7 +55,7 @@ class TelemetryServiceSpecification extends Specification {
   void 'happy path with data'() {
     setup:
     TestHttpClient testHttpClient = new TestHttpClient()
-    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000)
+    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000, false)
 
     when: 'add data before first iteration'
     telemetryService.addConfiguration(configuration)
@@ -116,7 +116,7 @@ class TelemetryServiceSpecification extends Specification {
   void 'happy path with data after app-started'() {
     setup:
     TestHttpClient testHttpClient = new TestHttpClient()
-    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000)
+    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000, false)
 
     when: 'send messages'
     testHttpClient.expectRequest(HttpClient.Result.SUCCESS)
@@ -155,7 +155,7 @@ class TelemetryServiceSpecification extends Specification {
   void 'do not discard data for app-started event until it has been successfully sent'() {
     setup:
     TestHttpClient testHttpClient = new TestHttpClient()
-    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000)
+    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000, false)
     telemetryService.addConfiguration(configuration)
 
     when: 'attempt with 404 error'
@@ -194,7 +194,7 @@ class TelemetryServiceSpecification extends Specification {
   def 'resend data on successful attempt after a failure'() {
     setup:
     TestHttpClient testHttpClient = new TestHttpClient()
-    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000)
+    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000, false)
 
     telemetryService.addConfiguration(configuration)
     telemetryService.addIntegration(integration)
@@ -247,7 +247,7 @@ class TelemetryServiceSpecification extends Specification {
   void 'send closing event request'() {
     setup:
     TestHttpClient testHttpClient = new TestHttpClient()
-    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000)
+    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 10000, false)
 
     when:
     testHttpClient.expectRequest(HttpClient.Result.SUCCESS)
@@ -261,7 +261,7 @@ class TelemetryServiceSpecification extends Specification {
   void 'report when both OTel and OT are enabled'() {
     setup:
     TestHttpClient testHttpClient = new TestHttpClient()
-    TelemetryService telemetryService = Spy(new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 1000))
+    TelemetryService telemetryService = Spy(new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 1000, false))
     def otel = new Integration("opentelemetry-1", otelEnabled)
     def ot = new Integration("opentracing", otEnabled)
 
@@ -288,7 +288,7 @@ class TelemetryServiceSpecification extends Specification {
   void 'split telemetry requests if the size above the limit'() {
     setup:
     TestHttpClient testHttpClient = new TestHttpClient()
-    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 5000)
+    TelemetryService telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), 5000, false)
 
     when: 'send a heartbeat request without telemetry data to measure body size to set stable request size limit'
     testHttpClient.expectRequest(HttpClient.Result.SUCCESS)
@@ -299,7 +299,7 @@ class TelemetryServiceSpecification extends Specification {
     bodySize > 0
 
     when: 'sending first part of data'
-    telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), bodySize + 500)
+    telemetryService = new TelemetryService(testHttpClient, HttpUrl.get("https://example.com"), bodySize + 500, false)
 
     telemetryService.addConfiguration(configuration)
     telemetryService.addIntegration(integration)

--- a/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
@@ -141,8 +141,7 @@ class TestHttpClient extends HttpClient {
 
     BatchAssertions assertBatch(int expectedNumberOfPayloads) {
       def payloads = body['payload'] as List<Map<String, Object>>
-      assert payloads != null
-      assert payloads.size() == expectedNumberOfPayloads
+      assert payloads != null && payloads.size() == expectedNumberOfPayloads
       return new BatchAssertions(payloads)
     }
 
@@ -224,7 +223,7 @@ class TestHttpClient extends HttpClient {
       def expected = configuration == null ? null : []
       if (configuration != null) {
         for (ConfigChange kv : configuration) {
-          expected.add([name: kv.name, value: kv.value])
+          expected.add([name: kv.name, value: kv.value, origin: 'unknown'])
         }
       }
       assert this.payload['configuration'] == expected

--- a/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
@@ -136,7 +136,13 @@ class TestHttpClient extends HttpClient {
     }
 
     PayloadAssertions assertPayload() {
-      return new PayloadAssertions(body['payload'] as Map<String, Object>)
+      def payload = body['payload'] as Map<String, Object>
+      assert payload != null
+      return new PayloadAssertions(payload)
+    }
+
+    void assertNoPayload() {
+      assert body['payload'] == null
     }
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
@@ -73,25 +73,27 @@ class TestHttpClient extends HttpClient {
     }
 
     RequestAssertions headers(RequestType requestType) {
-      assert request.method() == 'POST'
-      assert request.headers().names() == [
+      assert this.request.method() == 'POST'
+      assert this.request.headers().names() == [
         'Content-Type',
         'DD-Client-Library-Language',
         'DD-Client-Library-Version',
         'DD-Telemetry-API-Version',
-        'DD-Telemetry-Request-Type'
+        'DD-Telemetry-Request-Type',
+        'Content-Length'
       ] as Set
-      assert request.header('Content-Type') == 'application/json; charset=utf-8'
-      assert request.header('DD-Client-Library-Language') == 'jvm'
-      assert request.header('DD-Client-Library-Version') == TracerVersion.TRACER_VERSION
-      assert request.header('DD-Telemetry-API-Version') == 'v2'
-      assert request.header('DD-Telemetry-Request-Type') == requestType.toString()
+      assert this.request.header('Content-Type') == 'application/json; charset=utf-8'
+      assert this.request.header('DD-Client-Library-Language') == 'jvm'
+      assert this.request.header('DD-Client-Library-Version') == TracerVersion.TRACER_VERSION
+      assert this.request.header('DD-Telemetry-API-Version') == 'v2'
+      assert this.request.header('DD-Telemetry-Request-Type') == requestType.toString()
+      //      assert this.request.header('Content-Length') ==
       return this
     }
 
     BodyAssertions assertBody() {
       Buffer buf = new Buffer()
-      request.body().writeTo(buf)
+      this.request.body().writeTo(buf)
       byte[] bytes = new byte[buf.size()]
       buf.read(bytes)
       return new BodyAssertions(SLURPER.parse(bytes) as Map<String, Object>)

--- a/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
@@ -87,7 +87,7 @@ class TestHttpClient extends HttpClient {
       assert request.header('Content-Type') == 'application/json; charset=utf-8'
       assert request.header('DD-Client-Library-Language') == 'jvm'
       assert request.header('DD-Client-Library-Version') == TracerVersion.TRACER_VERSION
-      assert request.header('DD-Telemetry-API-Version') == 'v1'
+      assert request.header('DD-Telemetry-API-Version') == 'v2'
       assert request.header('DD-Telemetry-Request-Type') == requestType.toString()
       return this
     }
@@ -109,7 +109,7 @@ class TestHttpClient extends HttpClient {
     }
 
     BodyAssertions commonParts(RequestType requestType) {
-      assert body['api_version'] == 'v1'
+      assert body['api_version'] == 'v2'
 
       def app = body['application']
       assert app['env'] != null
@@ -161,7 +161,7 @@ class TestHttpClient extends HttpClient {
     PayloadAssertions dependencies(List<Dependency> dependencies) {
       def expected = []
       for (Dependency d : dependencies) {
-        expected.add([hash: d.hash, name: d.name, type: "PlatformStandard", version: d.version])
+        expected.add([hash: d.hash, name: d.name, version: d.version])
       }
       assert payload['dependencies'] == expected
       return this

--- a/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
@@ -87,7 +87,7 @@ class TestHttpClient extends HttpClient {
       assert this.request.header('DD-Client-Library-Version') == TracerVersion.TRACER_VERSION
       assert this.request.header('DD-Telemetry-API-Version') == 'v2'
       assert this.request.header('DD-Telemetry-Request-Type') == requestType.toString()
-      //      assert this.request.header('Content-Length') ==
+      assert this.request.header('Content-Length').toInteger() > 0
       return this
     }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
@@ -134,7 +134,7 @@ class TestHttpClient extends HttpClient {
       return this
     }
 
-    PayloadAssertions hasPayload() {
+    PayloadAssertions assertPayload() {
       def payload = body['payload'] as Map<String, Object>
       assert payload != null
       return new PayloadAssertions(payload)
@@ -228,6 +228,12 @@ class TestHttpClient extends HttpClient {
         }
       }
       assert this.payload['configuration'] == expected
+      return this
+    }
+
+    PayloadAssertions products(boolean appsecEnabled = true, boolean profilerEnabled = false) {
+      def expected = [appsec: [enabled: appsecEnabled], profiler: [enabled: profilerEnabled]]
+      assert this.payload['products'] == expected
       return this
     }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
@@ -51,8 +51,7 @@ class TestHttpClient extends HttpClient {
   }
 
   BodyAssertions assertRequestBody(RequestType rt) {
-    return assertRequest().headers(rt)
-    .assertBody().commonParts(rt)
+    return assertRequest().headers(rt).assertBody().commonParts(rt)
   }
 
   void assertNoMoreRequests() {
@@ -73,7 +72,7 @@ class TestHttpClient extends HttpClient {
       this.request = request
     }
 
-    private RequestAssertions headers(RequestType requestType) {
+    RequestAssertions headers(RequestType requestType) {
       assert request.method() == 'POST'
       assert request.headers().names() == [
         'Content-Type',
@@ -106,7 +105,7 @@ class TestHttpClient extends HttpClient {
       this.body = body
     }
 
-    private BodyAssertions commonParts(RequestType requestType) {
+    BodyAssertions commonParts(RequestType requestType) {
       assert body['api_version'] == 'v2'
 
       def app = body['application']
@@ -140,7 +139,7 @@ class TestHttpClient extends HttpClient {
     }
 
     BatchAssertions assertBatch(int expectedNumberOfPayloads) {
-      def payloads = body['payload'] as List<Map<String, Object>>
+      List<Map<String, Object>> payloads = body['payload']
       assert payloads != null && payloads.size() == expectedNumberOfPayloads
       return new BatchAssertions(payloads)
     }

--- a/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestHttpClient.groovy
@@ -96,15 +96,22 @@ class TestHttpClient extends HttpClient {
       this.request.body().writeTo(buf)
       byte[] bytes = new byte[buf.size()]
       buf.read(bytes)
-      return new BodyAssertions(SLURPER.parse(bytes) as Map<String, Object>)
+      def parsed = SLURPER.parse(bytes) as Map<String, Object>
+      return new BodyAssertions(parsed, bytes)
     }
   }
 
   static class BodyAssertions {
-    private Map<String, Object> body
+    private final Map<String, Object> body
+    private final byte[] bodyBytes
 
-    BodyAssertions(Map<String, Object> body) {
+    BodyAssertions(Map<String, Object> body, byte[] bodyBytes) {
       this.body = body
+      this.bodyBytes = bodyBytes
+    }
+
+    int bodySize() {
+      return this.bodyBytes.length
     }
 
     BodyAssertions commonParts(RequestType requestType) {


### PR DESCRIPTION
# What Does This Do

Adjustments for Telemetry V2 protocol.
Add app-started product info (appsec, profiler).
Retry app-started for limited number of times (3), and every heartbeat interval until it's been successfully sent.
Message-batching and message buffering for retries on next heartbeat interval as required by RFC. When sending a request fails it keeps unsent data till the next heartbeat interval for a retry. If it fails again we discard data.

# Motivation

Telemetry V2 implementation.

# Additional Notes

System-tests use this version: https://github.com/DataDog/system-tests/pull/1551
