### PR TITLE
Fix span metrics tag

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/telemetry/CoreMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/CoreMetricCollector.java
@@ -14,6 +14,7 @@ import java.util.concurrent.BlockingQueue;
 /** This class is in charge of draining core metrics for telemetry. */
 public class CoreMetricCollector implements MetricCollector<CoreMetricCollector.CoreMetric> {
   private static final String METRIC_NAMESPACE = "tracers";
+  private static final String INTEGRATION_NAME_TAG = "integration_name:";
   private static final CoreMetricCollector INSTANCE = new CoreMetricCollector();
   private final SpanMetricRegistryImpl spanMetricRegistry = SpanMetricRegistryImpl.getInstance();
 
@@ -31,7 +32,7 @@ public class CoreMetricCollector implements MetricCollector<CoreMetricCollector.
   public void prepareMetrics() {
     for (SpanMetrics spanMetric : this.spanMetricRegistry.getSpanMetrics()) {
       SpanMetricsImpl spanMetricsImpl = (SpanMetricsImpl) spanMetric;
-      String tag = spanMetricsImpl.getInstrumentationName();
+      String tag = INTEGRATION_NAME_TAG + spanMetricsImpl.getInstrumentationName();
       for (CoreCounter counter : spanMetricsImpl.getCounters()) {
         long value = counter.getValueAndReset();
         if (value == 0) {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -29,12 +29,13 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 public class AgentTracer {
+  private static final String DEFAULT_INSTRUMENTATION_NAME = "datadog";
 
   // Implicit parent
   /** Deprecated. Use {@link #startSpan(String, CharSequence)} instead. */
   @Deprecated
   public static AgentSpan startSpan(final CharSequence spanName) {
-    return startSpan("default", spanName);
+    return startSpan(DEFAULT_INSTRUMENTATION_NAME, spanName);
   }
 
   /** @see TracerAPI#startSpan(String, CharSequence) */
@@ -46,7 +47,7 @@ public class AgentTracer {
   /** Deprecated. Use {@link #startSpan(String, CharSequence, long)} instead. */
   @Deprecated
   public static AgentSpan startSpan(final CharSequence spanName, final long startTimeMicros) {
-    return startSpan("default", spanName, startTimeMicros);
+    return startSpan(DEFAULT_INSTRUMENTATION_NAME, spanName, startTimeMicros);
   }
 
   /** @see TracerAPI#startSpan(String, CharSequence, long) */
@@ -59,7 +60,7 @@ public class AgentTracer {
   /** Deprecated. Use {@link #startSpan(String, CharSequence, AgentSpan.Context)} instead. */
   @Deprecated
   public static AgentSpan startSpan(final CharSequence spanName, final AgentSpan.Context parent) {
-    return startSpan("default", spanName, parent);
+    return startSpan(DEFAULT_INSTRUMENTATION_NAME, spanName, parent);
   }
 
   /** @see TracerAPI#startSpan(String, CharSequence, AgentSpan.Context) */
@@ -75,7 +76,7 @@ public class AgentTracer {
   @Deprecated
   public static AgentSpan startSpan(
       final CharSequence spanName, final AgentSpan.Context parent, final long startTimeMicros) {
-    return startSpan("default", spanName, parent, startTimeMicros);
+    return startSpan(DEFAULT_INSTRUMENTATION_NAME, spanName, parent, startTimeMicros);
   }
 
   /** @see TracerAPI#startSpan(String, CharSequence, AgentSpan.Context, long) */
@@ -239,7 +240,7 @@ public class AgentTracer {
     /** Deprecated. Use {@link #buildSpan(String, CharSequence)} instead. */
     @Deprecated
     default SpanBuilder buildSpan(CharSequence spanName) {
-      return buildSpan("default", spanName);
+      return buildSpan(DEFAULT_INSTRUMENTATION_NAME, spanName);
     }
 
     SpanBuilder buildSpan(String instrumentationName, CharSequence spanName);

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/TelemetryCollectorsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/TelemetryCollectorsTest.groovy
@@ -191,7 +191,7 @@ class TelemetryCollectorsTest extends DDSpecification {
 
   def "update-drain span core metrics"() {
     setup:
-    def spanMetrics = SpanMetricRegistryImpl.getInstance().get('test-update-drain')
+    def spanMetrics = SpanMetricRegistryImpl.getInstance().get('datadog')
     spanMetrics.onSpanCreated()
     spanMetrics.onSpanCreated()
     spanMetrics.onSpanFinished()
@@ -209,14 +209,14 @@ class TelemetryCollectorsTest extends DDSpecification {
     spanCreatedMetric.value == 2
     spanCreatedMetric.namespace == 'tracers'
     spanCreatedMetric.metricName == 'spans_created'
-    spanCreatedMetric.tags == ['test-update-drain']
+    spanCreatedMetric.tags == ['integration_name:datadog']
 
     def spanFinishedMetric = metrics[1]
     spanFinishedMetric.type == 'count'
     spanFinishedMetric.value == 1
     spanFinishedMetric.namespace == 'tracers'
     spanFinishedMetric.metricName == 'spans_finished'
-    spanFinishedMetric.tags == ['test-update-drain']
+    spanFinishedMetric.tags == ['integration_name:datadog']
   }
 
   def "overflowing core metrics"() {

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/CoreMetricsPeriodActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/CoreMetricsPeriodActionTest.groovy
@@ -170,7 +170,7 @@ class CoreMetricsPeriodActionTest extends Specification {
     assert metric.points.size() == 1
     assert metric.points[0].size() == 2
     assert metric.points[0][1] == count
-    assert metric.tags == [instrumentationName]
+    assert metric.tags == ['integration_name:' + instrumentationName]
     assert metric.type == Metric.TypeEnum.COUNT
   }
 }


### PR DESCRIPTION

# What Does This Do

This PR fixes the span metrics `spans_created` and `spans_finished`  `integration_name` tag.
It also updates the default name (when no integration name is provided) to `datadog` which seems more inline with other tracers behavior.

# Motivation

Integration names are missing from metrics.

# Additional Notes
