### PR TITLE
Make partial flushing settings consistent with other tracer libraries

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -71,6 +71,7 @@ public final class TracerConfig {
   public static final String SCOPE_INHERIT_ASYNC_PROPAGATION =
       "trace.scope.inherit.async.propagation";
   public static final String SCOPE_ITERATION_KEEP_ALIVE = "trace.scope.iteration.keep.alive";
+  public static final String PARTIAL_FLUSH_ENABLED = "trace.partial.flush.enabled";
   public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";
   public static final String TRACE_STRICT_WRITES_ENABLED = "trace.strict.writes.enabled";
   public static final String PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED =

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -312,7 +312,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
       // Finished root with pending work ... delay write
       pendingTraceBuffer.enqueue(this);
       return PublishState.ROOT_BUFFERED;
-    } else if (0 < partialFlushMinSpans && partialFlushMinSpans < size()) {
+    } else if (partialFlushMinSpans > 0 && size() >= partialFlushMinSpans) {
       // Trace is getting too big, write anything completed.
       partialFlush();
       return PublishState.PARTIAL_FLUSH;
@@ -361,7 +361,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
           // the completedSpanCount has not yet been incremented. This means that eventually the
           // count(s) will be incremented, and any new spans added during the period that the count
           // was negative will be written by someone even if we don't write them right now.
-          if (size > 0 && (!isPartial || size > tracer.getPartialFlushMinSpans())) {
+          if (size > 0 && (!isPartial || size >= tracer.getPartialFlushMinSpans())) {
             trace = new ArrayList<>(size);
             completedSpans = enqueueSpansToWrite(trace, writeRunningSpans);
           } else {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTestBase.groovy
@@ -116,7 +116,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
 
   def "partial flush"() {
     when:
-    injectSysConfig(PARTIAL_FLUSH_MIN_SPANS, "1")
+    injectSysConfig(PARTIAL_FLUSH_MIN_SPANS, "2")
     def quickTracer = tracerBuilder().writer(writer).build()
     def rootSpan = quickTracer.buildSpan("root").start()
     def trace = rootSpan.context().trace
@@ -161,7 +161,7 @@ abstract class PendingTraceTestBase extends DDCoreSpecification {
 
   def "partial flush with root span closed last"() {
     when:
-    injectSysConfig(PARTIAL_FLUSH_MIN_SPANS, "1")
+    injectSysConfig(PARTIAL_FLUSH_MIN_SPANS, "2")
     def quickTracer = tracerBuilder().writer(writer).build()
     def rootSpan = quickTracer.buildSpan("root").start()
     def trace = rootSpan.context().trace

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -319,6 +319,7 @@ import static datadog.trace.api.config.TracerConfig.HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.config.TracerConfig.ID_GENERATION_STRATEGY;
+import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_ENABLED;
 import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS;
 import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING;
 import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING_FORCE;
@@ -1062,8 +1063,11 @@ public class Config {
     scopeIterationKeepAlive =
         configProvider.getInteger(SCOPE_ITERATION_KEEP_ALIVE, DEFAULT_SCOPE_ITERATION_KEEP_ALIVE);
 
+    boolean partialFlushEnabled = configProvider.getBoolean(PARTIAL_FLUSH_ENABLED, true);
     partialFlushMinSpans =
-        configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
+        !partialFlushEnabled
+            ? 0
+            : configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
 
     traceStrictWritesEnabled = configProvider.getBoolean(TRACE_STRICT_WRITES_ENABLED, false);
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -11,6 +11,7 @@ import spock.lang.Unroll
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_CLIENT_ERROR_STATUSES
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSES
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL
 import static datadog.trace.api.DDTags.HOST_TAG
@@ -96,6 +97,7 @@ import static datadog.trace.api.config.TracerConfig.HEADER_TAGS
 import static datadog.trace.api.config.TracerConfig.HTTP_CLIENT_ERROR_STATUSES
 import static datadog.trace.api.config.TracerConfig.HTTP_SERVER_ERROR_STATUSES
 import static datadog.trace.api.config.TracerConfig.ID_GENERATION_STRATEGY
+import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_ENABLED
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_ENABLED
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_FLUSH_INTERVAL
 import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS
@@ -2332,5 +2334,29 @@ class ConfigTest extends DDSpecification {
     "451"         | DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL
     "20"          | 20
     "450"         | 450
+  }
+
+  def "partial flush and min spans interaction #"() {
+    when:
+    def prop = new Properties()
+    if (configuredPartialEnabled != null) {
+      prop.setProperty(PARTIAL_FLUSH_ENABLED, configuredPartialEnabled.toString())
+    }
+    if (configuredPartialMinSpans != null) {
+      prop.setProperty(PARTIAL_FLUSH_MIN_SPANS, configuredPartialMinSpans.toString())
+    }
+    Config config = Config.get(prop)
+
+    then:
+    config.partialFlushMinSpans == partialMinSpans
+
+    where:
+    configuredPartialEnabled | configuredPartialMinSpans | partialMinSpans
+    null                     | null                      | DEFAULT_PARTIAL_FLUSH_MIN_SPANS
+    true                     | null                      | DEFAULT_PARTIAL_FLUSH_MIN_SPANS
+    false                    | null                      | 0
+    null                     | 47                        | 47
+    true                     | 11                        | 11
+    false                    | 17                        | 0
   }
 }


### PR DESCRIPTION
# What Does This Do

Adds a setting for disabling partial flushing `DD_TRACE_PARTIAL_FLUSH_ENABLED` and aligns the use of `DD_TRACE_PARTIAL_FLUSH_MIN_SPANS` with other tracer implementations.

# Motivation

# Additional Notes
