### PR TITLE
Updated config parsing for integer ranges

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigConverter.java
@@ -307,7 +307,7 @@ final class ConfigConverter {
   static BitSet parseIntegerRangeSet(@Nonnull String str, final String settingName)
       throws NumberFormatException {
     str = str.replaceAll("\\s", "");
-    if (!str.matches("\\d{3}(?:-\\d{3})?(?:,\\d{3}(?:-\\d{3})?)*")) {
+    if (!str.matches("\\d{1,3}(?:-\\d{1,3})?(?:,\\d{1,3}(?:-\\d{1,3})?)*")) {
       log.warn(
           "Invalid config for {}: '{}'. Must be formatted like '400-403,405,410-499'.",
           settingName,

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -1163,7 +1163,9 @@ class ConfigTest extends DDSpecification {
     where:
     value               | expected // null means default value
     // spotless:off
-    "1"                 | null
+    "1"                 | [1]
+    "3,13,400-403"      | [3,13,400,401,402,403]
+    "2,10,13-15"        | [2,10,13,14,15]
     "a"                 | null
     ""                  | null
     "1000"              | null


### PR DESCRIPTION
# What Does This Do
Updates the  config integer range parsing logic to handle single and double digit integers for handling grpc response codes.

# Motivation
https://github.com/DataDog/dd-trace-java/issues/5679 

# Additional Notes
