### PR TITLE
Fix rate limiting for DI log probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -413,12 +413,9 @@ public class LogProbe extends ProbeDefinition {
     int maxDepth = capture != null ? capture.maxReferenceDepth : -1;
     Snapshot snapshot = new Snapshot(Thread.currentThread(), this, maxDepth);
     if (entryStatus.shouldSend() && exitStatus.shouldSend()) {
-      // only rate limit if a condition is defined
-      if (probeCondition != null) {
-        if (!ProbeRateLimiter.tryProbe(id)) {
-          sink.skipSnapshot(id, DebuggerContext.SkipCause.RATE);
-          return;
-        }
+      if (!ProbeRateLimiter.tryProbe(id)) {
+        sink.skipSnapshot(id, DebuggerContext.SkipCause.RATE);
+        return;
       }
       if (isCaptureSnapshot()) {
         snapshot.setEntry(entryContext);
@@ -487,12 +484,9 @@ public class LogProbe extends ProbeDefinition {
     Snapshot snapshot = new Snapshot(Thread.currentThread(), this, maxDepth);
     boolean shouldCommit = false;
     if (status.shouldSend()) {
-      // only rate limit if a condition is defined
-      if (probeCondition != null) {
-        if (!ProbeRateLimiter.tryProbe(id)) {
-          sink.skipSnapshot(id, DebuggerContext.SkipCause.RATE);
-          return;
-        }
+      if (!ProbeRateLimiter.tryProbe(id)) {
+        sink.skipSnapshot(id, DebuggerContext.SkipCause.RATE);
+        return;
       }
       if (isCaptureSnapshot()) {
         snapshot.addLine(lineContext, line);


### PR DESCRIPTION
# What Does This Do

Fixes a bug in DI where log probes would not be rate-limited when they should be.

# Motivation

The rate limit should apply no matter if the probe has a condition or not. The desired flow is:

1. Evaluate condition if there is one, else default to `true`
2. Apply rate-limit on the remaining probes

# Additional Notes
