### PR TITLE
Reduce the amount of benchmarks run in the benchmarking platform

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -32,30 +32,6 @@ RUN cd insecure-bank \
   && cp build/libs/*.war /insecure-bank.war
 
 
-# K6 distribution
-FROM grafana/xk6 as k6
-
-USER 0:0
-RUN xk6 build \
-    --with github.com/szkiba/xk6-faker@latest \
-    --output /k6
-
-
-# sirun distribution
-FROM debian:bookworm-slim as sirun
-
-RUN apt-get update \
-  && apt-get -y install wget \
-  && apt-get -y clean \
-  && rm -rf /var/lib/apt/lists/*
-
-USER 0:0
-ARG SIRUN_VERSION=0.1.11
-RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v$SIRUN_VERSION/sirun-v$SIRUN_VERSION-x86_64-unknown-linux-musl.tar.gz \
-	&& tar -xzf sirun.tar.gz \
-	&& rm sirun.tar.gz
-
-
 FROM debian:bookworm-slim
 
 RUN apt-get update \
@@ -80,8 +56,17 @@ ENV JAVA_17_HOME=/usr/lib/jvm/17
 ENV JAVA_HOME=${JAVA_8_HOME}
 ENV PATH=${PATH}:${JAVA_HOME}/bin
 
-COPY --from=k6 /k6 /usr/bin/k6
-COPY --from=sirun /sirun /usr/bin/sirun
+ARG SIRUN_VERSION=0.1.11
+RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v$SIRUN_VERSION/sirun-v$SIRUN_VERSION-x86_64-unknown-linux-musl.tar.gz \
+	&& tar -xzf sirun.tar.gz \
+	&& rm sirun.tar.gz \
+  && mv sirun /usr/bin/sirun
+
+ARG K6_VERSION=0.45.1
+RUN wget -O k6.tar.gz https://github.com/grafana/k6/releases/download/v$K6_VERSION/k6-v$K6_VERSION-linux-amd64.tar.gz \
+	&& tar --strip-components=1 -xzf k6.tar.gz \
+	&& rm k6.tar.gz \
+  && mv k6 /usr/bin/k6
 
 RUN mkdir -p /app
 

--- a/benchmark/load/insecure-bank/k6.js
+++ b/benchmark/load/insecure-bank/k6.js
@@ -6,7 +6,7 @@ const baseUrl = 'http://localhost:8080';
 export const options = {
   discardResponseBodies: true,
   vus: 5,
-  iterations: 90000
+  iterations: 40000
 };
 
 export default function () {

--- a/benchmark/load/petclinic/benchmark.json
+++ b/benchmark/load/petclinic/benchmark.json
@@ -35,18 +35,6 @@
         "VARIANT": "iast",
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.iast.enabled=true"
       }
-    },
-    "iast_FULL": {
-      "env": {
-        "VARIANT": "iast_FULL",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.iast.enabled=true -Ddd.iast.detection.mode=FULL"
-      }
-    },
-    "iast_INACTIVE": {
-      "env": {
-        "VARIANT": "iast_INACTIVE",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.iast.enabled=inactive"
-      }
     }
   }
 }

--- a/benchmark/startup/insecure-bank/benchmark.json
+++ b/benchmark/startup/insecure-bank/benchmark.json
@@ -27,7 +27,7 @@
     "iast": {
       "env": {
         "VARIANT": "iast",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast -Ddd.iast.enabled=true -Ddd.iast.detection.mode=FULL"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast -Ddd.iast.enabled=true"
       }
     }
   }

--- a/benchmark/startup/petclinic/benchmark.json
+++ b/benchmark/startup/petclinic/benchmark.json
@@ -27,7 +27,7 @@
     "iast": {
       "env": {
         "VARIANT": "iast",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast -Ddd.iast.enabled=true -Ddd.iast.detection.mode=FULL"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast -Ddd.iast.enabled=true"
       }
     }
   }

--- a/benchmark/utils/k6.js
+++ b/benchmark/utils/k6.js
@@ -1,5 +1,4 @@
 import {check} from 'k6';
-import {Faker} from "k6/x/faker";
 
 export function checkResponse(response) {
   const checks = Array.prototype.slice.call(arguments, 1);
@@ -20,5 +19,3 @@ export function bodyContains(text) {
     'body contains': r => r.body.includes(text)
   }
 }
-
-export const faker = new Faker(123456789)

--- a/benchmark/utils/run-sirun-benchmarks.sh
+++ b/benchmark/utils/run-sirun-benchmarks.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 set -eu
 
+function message() {
+  echo "$(date +"%T"): $1"
+}
+
 run_benchmark() {
   local type=$1
   local app=$2
   if [[ -d "${app}" ]] && [[ -f "${app}/benchmark.json" ]]; then
 
-    echo "Running ${type} benchmark: ${app}"
+    message "${type} benchmark: ${app} started"
     cd "${app}"
 
     # create output folder for the test
@@ -21,6 +25,8 @@ run_benchmark() {
 
     # run the sirun test
     sirun "${benchmark}" &>"${OUTPUT_DIR}/${app}.json"
+
+    message "${type} benchmark: ${app} finished"
 
     cd ..
   fi


### PR DESCRIPTION
# What Does This Do
Reduces the number of benchmarks run in the bench-marking platform and moves towards the parallel version

# Motivation

# Additional Notes
Now the time taken by the benchmark task should be around 40min.
