### PR TITLE
Close outstanding APM spans before finishing test span

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
@@ -23,8 +23,12 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import javax.annotation.Nullable;
 import org.objectweb.asm.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DDTestImpl implements DDTest {
+
+  private static final Logger log = LoggerFactory.getLogger(DDTestImpl.class);
 
   private final AgentSpan span;
   private final TestContext suiteContext;
@@ -158,6 +162,8 @@ public class DDTestImpl implements DDTest {
 
   @Override
   public void end(@Nullable Long endTime) {
+    closeOutstandingSpans();
+
     final AgentScope scope = AgentTracer.activeScope();
     if (scope == null) {
       throw new IllegalStateException(
@@ -190,6 +196,36 @@ public class DDTestImpl implements DDTest {
     if (endTime != null) {
       span.finish(endTime);
     } else {
+      span.finish();
+    }
+  }
+
+  /**
+   * Tests often perform operations that involve APM instrumentations: sending an HTTP request,
+   * executing a database query, etc. APM instrumentations create spans that correspond to those
+   * operations. Ideally, the instrumentations close these spans once their corresponding operations
+   * are finished.
+   *
+   * <p>However, this is not always the case, especially with tests: developers sometimes feel like
+   * proper resources disposal, such as closing a connection, is not obligatory in tests code. Not
+   * finalizing an operation properly usually results in its span remaining open. This is something
+   * that we have no control over, since this happens in the clients' codebase.
+   *
+   * <p>This method attempts to finalize such "dangling" spans: it closes whatever is on top of the
+   * spans stack until it encounters a CI Visibility span or the stack is empty.
+   */
+  private void closeOutstandingSpans() {
+    AgentScope scope;
+    while ((scope = AgentTracer.activeScope()) != null) {
+      AgentSpan span = scope.span();
+
+      if (TestDecorator.TEST_TYPE.equals(span.getTag(Tags.TEST_TYPE))) {
+        // encountered a CI Visibility span (test, suite, module, session)
+        break;
+      }
+
+      log.debug("Closing outstanding span: {}", span);
+      scope.close();
       span.finish();
     }
   }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/DDTestImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/DDTestImplTest.groovy
@@ -1,0 +1,139 @@
+package datadog.trace.civisibility
+
+
+import datadog.trace.agent.test.asserts.ListWriterAssert
+import datadog.trace.agent.test.civisibility.coverage.NoopCoverageProbeStore
+import datadog.trace.agent.tooling.TracerInstaller
+import datadog.trace.api.Config
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.IdGenerationStrategy
+import datadog.trace.api.civisibility.InstrumentationBridge
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.civisibility.codeowners.CodeownersImpl
+import datadog.trace.civisibility.context.ParentProcessTestContext
+import datadog.trace.civisibility.decorator.TestDecoratorImpl
+import datadog.trace.civisibility.source.MethodLinesResolver
+import datadog.trace.common.writer.ListWriter
+import datadog.trace.core.CoreTracer
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Shared
+
+class DDTestImplTest extends DDSpecification {
+
+  @SuppressWarnings('PropertyName')
+  @Shared
+  ListWriter TEST_WRITER
+
+  @SuppressWarnings('PropertyName')
+  @Shared
+  AgentTracer.TracerAPI TEST_TRACER
+
+  void setupSpec() {
+    TEST_WRITER = new ListWriter()
+    TEST_TRACER =
+      Spy(
+      CoreTracer.builder()
+      .writer(TEST_WRITER)
+      .idGenerationStrategy(IdGenerationStrategy.fromName("SEQUENTIAL"))
+      .build())
+    TracerInstaller.forceInstallGlobalTracer(TEST_TRACER)
+
+    TEST_TRACER.startSpan(*_) >> {
+      def agentSpan = callRealMethod()
+      agentSpan
+    }
+
+    InstrumentationBridge.registerCoverageProbeStoreFactory(new NoopCoverageProbeStore.NoopCoverageProbeStoreFactory())
+  }
+
+  void cleanupSpec() {
+    TEST_TRACER?.close()
+  }
+
+  void setup() {
+    assert TEST_TRACER.activeSpan() == null: "Span is active before test has started: " + TEST_TRACER.activeSpan()
+    TEST_TRACER.flush()
+    TEST_WRITER.start()
+  }
+
+  void cleanup() {
+    TEST_TRACER.flush()
+  }
+
+  def "test span is generated"() {
+    setup:
+    def test = givenATest()
+
+    when:
+    test.end(null)
+
+    then:
+    ListWriterAssert.assertTraces(TEST_WRITER, 1, false, {
+      trace(1) {
+        span(0) {
+          parent()
+          spanType DDSpanTypes.TEST
+        }
+      }
+    })
+  }
+
+  def "test outstanding operation spans are closed"() {
+    setup:
+    def test = givenATest()
+
+    // given operation that is started, but not closed
+    AgentTracer.activateSpan(AgentTracer.get().startSpan("instrumentation", "span"))
+
+    when:
+    test.end(null)
+
+    then:
+    ListWriterAssert.assertTraces(TEST_WRITER, 1, false, ListWriterAssert.SORT_TRACES_BY_START, {
+      trace(2) {
+        long testId
+        span(0) {
+          parent()
+          spanType DDSpanTypes.TEST
+          testId = getSpan().getSpanId()
+        }
+        span(1) {
+          parentSpanId(BigInteger.valueOf(testId))
+        }
+      }
+    })
+  }
+
+  private DDTestImpl givenATest() {
+    def sessionId = 123
+    def moduleId = 456
+    def suiteId = 789
+
+    def moduleContext = new ParentProcessTestContext(sessionId, moduleId)
+    def suiteContext = new ParentProcessTestContext(moduleId, suiteId)
+
+    def config = Config.get()
+    def testDecorator = new TestDecoratorImpl("component", [:])
+    def sourcePathResolver = { it -> null }
+    def methodLinesResolver = { it -> MethodLinesResolver.MethodLines.EMPTY }
+    def codeowners = CodeownersImpl.EMPTY
+
+    new DDTestImpl(
+      suiteContext,
+      moduleContext,
+      "moduleName",
+      "suiteName",
+      "testName",
+      null,
+      null,
+      null,
+      null,
+      config,
+      testDecorator,
+      sourcePathResolver,
+      methodLinesResolver,
+      codeowners
+      )
+  }
+
+}


### PR DESCRIPTION
# What Does This Do
Updates CI Visibility logic to check if there are any active (unfinished) spans when a "test finished" event is received.
If any active spans are found that are children of the span corresponding to finished test, they are closed.

# Motivation
We cannot properly finish the test span if its scope is not on top of the scopes stack.

# Additional Notes
Tests often perform operations that trigger APM instrumentation code: sending an HTTP request, executing a database query, etc. APM instrumentations create spans that correspond to those operations. Ideally, the instrumentations close these spans once their corresponding operations are finished.

However, this is not always the case, especially with tests: sometimes developers do not perform proper resources disposal (such as closing a connection) in tests code. Not finalizing an operation properly results in its span remaining open. This is something that we have no control over, since this happens in the clients' codebase.
