### PR TITLE
Add configuration option to allow Jax-RS exceptions to not be handled as errors

### DIFF
--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/build.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/build.gradle
@@ -12,4 +12,8 @@ dependencies {
   compileOnly group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.0'
 
   compileOnly project(':dd-java-agent:instrumentation:jax-rs-client-2.0')
+
+  testImplementation group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.0'
+
+  testImplementation project(':dd-java-agent:instrumentation:jax-rs-client-2.0')
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/main/java/org/glassfish/jersey/client/WrappingResponseCallback.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/main/java/org/glassfish/jersey/client/WrappingResponseCallback.java
@@ -1,5 +1,6 @@
 package org.glassfish.jersey.client;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.jaxrs.ClientTracingFilter;
 import javax.ws.rs.ProcessingException;
@@ -30,8 +31,14 @@ public final class WrappingResponseCallback implements ResponseCallback {
     final Object prop = request.getProperty(ClientTracingFilter.SPAN_PROPERTY_NAME);
     if (prop instanceof AgentSpan) {
       final AgentSpan span = (AgentSpan) prop;
-      span.setError(true);
       span.addThrowable(error);
+
+      @SuppressWarnings("deprecation")
+      final boolean isJaxRsExceptionAsErrorEnabled = Config.get().isJaxRsExceptionAsErrorEnabled();
+      if (!isJaxRsExceptionAsErrorEnabled) {
+        span.setError(false);
+      }
+
       span.finish();
     }
   }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/main/java/org/glassfish/jersey/client/WrappingResponseCallback.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/main/java/org/glassfish/jersey/client/WrappingResponseCallback.java
@@ -35,9 +35,7 @@ public final class WrappingResponseCallback implements ResponseCallback {
 
       @SuppressWarnings("deprecation")
       final boolean isJaxRsExceptionAsErrorEnabled = Config.get().isJaxRsExceptionAsErrorEnabled();
-      if (!isJaxRsExceptionAsErrorEnabled) {
-        span.setError(false);
-      }
+      span.setError(isJaxRsExceptionAsErrorEnabled);
 
       span.finish();
     }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/test/groovy/WrappingResponseCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/test/groovy/WrappingResponseCallbackTest.groovy
@@ -16,7 +16,7 @@ class WrappingResponseCallbackTest extends AgentTestRunner {
       injectSysConfig(JAX_RS_EXCEPTION_AS_ERROR_ENABLED, "$jaxRsExceptionAsErrorEnabled")
     }
     def testSpan = TEST_TRACER.buildSpan("testInstrumentation", "testSpan").start()
-    def props = Map.of(ClientTracingFilter.SPAN_PROPERTY_NAME, testSpan)
+    def props = [(ClientTracingFilter.SPAN_PROPERTY_NAME): testSpan]
     def propertiesDelegate = new MapPropertiesDelegate(props)
     def clientConfig = new ClientConfig(new JerseyClient())
 

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/test/groovy/WrappingResponseCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-jersey/src/test/groovy/WrappingResponseCallbackTest.groovy
@@ -1,0 +1,46 @@
+import static datadog.trace.api.config.TraceInstrumentationConfig.JAX_RS_EXCEPTION_AS_ERROR_ENABLED
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.jaxrs.ClientTracingFilter
+import javax.ws.rs.ProcessingException
+import org.glassfish.jersey.client.ClientConfig
+import org.glassfish.jersey.client.ClientRequest
+import org.glassfish.jersey.client.JerseyClient
+import org.glassfish.jersey.client.WrappingResponseCallback
+import org.glassfish.jersey.internal.MapPropertiesDelegate
+
+class WrappingResponseCallbackTest extends AgentTestRunner {
+  def "handleProcessingException properly utilizes the config"() {
+    setup:
+    if (jaxRsExceptionAsErrorEnabled != null) {
+      injectSysConfig(JAX_RS_EXCEPTION_AS_ERROR_ENABLED, "$jaxRsExceptionAsErrorEnabled")
+    }
+    def testSpan = TEST_TRACER.buildSpan("testInstrumentation", "testSpan").start()
+    def props = Map.of(ClientTracingFilter.SPAN_PROPERTY_NAME, testSpan)
+    def propertiesDelegate = new MapPropertiesDelegate(props)
+    def clientConfig = new ClientConfig(new JerseyClient())
+
+    def clientRequest = new ClientRequest(new URI("https://www.google.com/"), clientConfig, propertiesDelegate)
+    def processingException = new ProcessingException("test")
+
+    when:
+    WrappingResponseCallback.handleProcessingException(clientRequest, processingException)
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "testSpan"
+          resourceName "testSpan"
+          errored isErrored
+        }
+      }
+    }
+
+    where:
+    jaxRsExceptionAsErrorEnabled | isErrored
+    true                         | true
+    false                        | false
+    null                         | true
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -186,5 +186,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_SPARK_TASK_HISTOGRAM_ENABLED = true;
 
+  static final boolean DEFAULT_JAX_RS_EXCEPTION_AS_ERROR_ENABLED = true;
+
   private ConfigDefaults() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -29,6 +29,8 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_CLASSES_EXCLUDE_FILE = "trace.classes.exclude.file";
   public static final String TRACE_CLASSLOADERS_EXCLUDE = "trace.classloaders.exclude";
   public static final String TRACE_CODESOURCES_EXCLUDE = "trace.codesources.exclude";
+
+  @SuppressWarnings("unused")
   public static final String TRACE_TESTS_ENABLED = "trace.tests.enabled";
 
   public static final String TRACE_THREAD_POOL_EXECUTORS_EXCLUDE =
@@ -115,6 +117,9 @@ public final class TraceInstrumentationConfig {
       "trace.elasticsearch.body-and-params.enabled";
 
   public static final String SPARK_TASK_HISTOGRAM_ENABLED = "spark.task-histogram.enabled";
+
+  public static final String JAX_RS_EXCEPTION_AS_ERROR_ENABLED =
+      "trace.jax-rs.exception-as-error.enabled";
 
   private TraceInstrumentationConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -291,6 +291,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_MEASUR
 import static datadog.trace.api.config.TraceInstrumentationConfig.HYSTRIX_TAGS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.IGNITE_CACHE_INCLUDE_KEYS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JAX_RS_EXCEPTION_AS_ERROR_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_QUEUES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_PROPAGATION_DISABLED_TOPICS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JMS_UNACKNOWLEDGED_MAX_AGE;
@@ -769,6 +770,7 @@ public class Config {
   private final long longRunningTraceFlushInterval;
   private final boolean elasticsearchBodyAndParamsEnabled;
   private final boolean sparkTaskHistogramEnabled;
+  private final boolean jaxRsExceptionAsErrorsEnabled;
 
   private final float traceFlushIntervalSeconds;
 
@@ -1701,6 +1703,11 @@ public class Config {
     this.sparkTaskHistogramEnabled =
         configProvider.getBoolean(
             SPARK_TASK_HISTOGRAM_ENABLED, ConfigDefaults.DEFAULT_SPARK_TASK_HISTOGRAM_ENABLED);
+
+    this.jaxRsExceptionAsErrorsEnabled =
+        configProvider.getBoolean(
+            JAX_RS_EXCEPTION_AS_ERROR_ENABLED,
+            ConfigDefaults.DEFAULT_JAX_RS_EXCEPTION_AS_ERROR_ENABLED);
 
     this.traceFlushIntervalSeconds =
         configProvider.getFloat(
@@ -2791,6 +2798,10 @@ public class Config {
     return sparkTaskHistogramEnabled;
   }
 
+  public boolean isJaxRsExceptionAsErrorEnabled() {
+    return jaxRsExceptionAsErrorsEnabled;
+  }
+
   /** @return A map of tags to be applied only to the local application root span. */
   public Map<String, Object> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
@@ -3805,6 +3816,8 @@ public class Config {
         + logsInjectionEnabled
         + ", sparkTaskHistogramEnabled="
         + sparkTaskHistogramEnabled
+        + ", jaxRsExceptionAsErrorsEnabled="
+        + jaxRsExceptionAsErrorsEnabled
         + '}';
   }
 }

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/Flaky.java
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/Flaky.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Tag;
 
 /**
  * Use this annotation for suites or test cases that are flaky. When running in CI, these will be
- * seggregated to a separate job.
+ * segregated to a separate job.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})


### PR DESCRIPTION
# What Does This Do
Adds a new configuration option via `DD_TRACE_JAX_RS_EXCEPTION_AS_ERROR_ENABLED` which, when set to `false` forces exceptions from JAX-RS to not be treated as errors. This does not drop the underlying exception if it exists

# Motivation
This is helpful for situations for situations where a 3xx level response returned triggers a custom exception in the underlying code since the span should not be considered an error

# Additional Notes
