### PR TITLE
Fix sampling when log probe is evaluation at Exit

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1828,6 +1828,7 @@ public class CapturedSnapshotTest {
         .probeId(id)
         .captureSnapshot(true)
         .where(typeName, methodName, signature, lines)
+        // Increase sampling limit to avoid being sampled during tests
         .sampling(new LogProbe.Sampling(100));
   }
 


### PR DESCRIPTION
# What Does This Do
Change the instrumentation to call in any cases readyToCapture method that invoke sampling except for SpanDecorationProbe.

# Motivation
With evaluateAt == EXIT for a log probe, sampling was not invoked. 
# Additional Notes
