### PR TITLE
Report dd-trace-java and its dependencies to telemetry

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -30,7 +30,10 @@ targetCompatibility = JavaVersion.VERSION_1_7
 ext.generalShadowJarConfig = {
   mergeServiceFiles()
 
-  exclude '**/META-INF/maven/'
+  // Remove some cruft from the final jar.
+  // These patterns should NOT include **/META-INF/maven/**/pom.properties, which is
+  // used to report our own dependencies.
+  exclude '**/META-INF/maven/**/pom.xml'
   exclude '**/META-INF/proguard/'
   exclude '**/META-INF/*.kotlin_module'
   exclude '**/module-info.class'

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -30,6 +30,8 @@ targetCompatibility = JavaVersion.VERSION_1_7
 ext.generalShadowJarConfig = {
   mergeServiceFiles()
 
+  duplicatesStrategy = DuplicatesStrategy.FAIL
+
   // Remove some cruft from the final jar.
   // These patterns should NOT include **/META-INF/maven/**/pom.properties, which is
   // used to report our own dependencies.

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -117,7 +117,11 @@ shadowJar {
     exclude('datadog.trace.api.sampling.*')
     exclude('datadog.trace.context.*')
   }
-  exclude('META-INF/maven/')
+
+  // Remove some cruft from the final jar.
+  // These patterns should NOT include **/META-INF/maven/**/pom.properties, which is
+  // used to report our own dependencies.
+  exclude '**/META-INF/maven/**/pom.xml'
   exclude('META-INF/proguard/')
   exclude('/META-INF/*.kotlin_module')
 }

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -118,6 +118,8 @@ shadowJar {
     exclude('datadog.trace.context.*')
   }
 
+  duplicatesStrategy = DuplicatesStrategy.FAIL
+
   // Remove some cruft from the final jar.
   // These patterns should NOT include **/META-INF/maven/**/pom.properties, which is
   // used to report our own dependencies.

--- a/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
@@ -17,9 +17,6 @@ class LocationsCollectingTransformer implements ClassFileTransformer {
   private final DDCache<ProtectionDomain, Boolean> seenDomains =
       DDCaches.newFixedSizeWeakKeyCache(MAX_CACHED_JARS);
 
-  private final ProtectionDomain tracerDomain =
-      LocationsCollectingTransformer.class.getProtectionDomain();
-
   public LocationsCollectingTransformer(DependencyService dependencyService) {
     this.dependencyService = dependencyService;
   }
@@ -31,7 +28,7 @@ class LocationsCollectingTransformer implements ClassFileTransformer {
       Class<?> classBeingRedefined,
       ProtectionDomain protectionDomain,
       byte[] classfileBuffer) {
-    if (protectionDomain != null && !protectionDomain.equals(tracerDomain)) {
+    if (protectionDomain != null) {
       seenDomains.computeIfAbsent(protectionDomain, this::addDependency);
     }
     // returning 'null' is the best way to indicate that no transformation has been done.

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/LocationsCollectingTransformerSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/LocationsCollectingTransformerSpecification.groovy
@@ -14,16 +14,6 @@ class LocationsCollectingTransformerSpecification extends DepSpecification {
 
   LocationsCollectingTransformer transformer = new LocationsCollectingTransformer(depService)
 
-  void 'no dependency for agent jar'() {
-    when:
-    transformer.transform(null, null, null, getClass().getProtectionDomain(), null)
-
-    then:
-    depService.resolveOneDependency()
-    def dependencies = depService.drainDeterminedDependencies()
-    dependencies.isEmpty()
-  }
-
   void 'no dependency if null protection domain'() {
     when:
     transformer.transform(null, null, null, null, null)


### PR DESCRIPTION
# What Does This Do

* Remove the telemetry check we previously added to avoid reporting dd-trace-java vendored dependencies to telemetry.
* Amend the exclusion of `META-INF/maven` to not include `pom.properties` (introduced in 5346d91d34c), which we use to report dependencies to telemetry.


# Motivation
While this might be sometimes confusing, we want to report the runtime dependencies as accurately as possible, include those that are introduced by the tracer.

# Additional Notes
* This leads to a ~0.5ms regression in telemetry startup, presumably because now loading classes from the tracer hits the regular codepath that hits `DDCache#computeIfAbsent` for `seenDomains`.