### PR TITLE
add _dd.base_service to disambiguate service map

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -60,7 +60,7 @@ class TagsAssert {
     assertedTags.add(DDTags.PID_TAG)
     assertedTags.add(DDTags.SCHEMA_VERSION_TAG_KEY)
     assertedTags.add(DDTags.PROFILING_ENABLED)
-
+    assertedTags.add(DDTags.BASE_SERVICE)
 
     assert tags["thread.name"] != null
     assert tags["thread.id"] != null

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -52,4 +52,5 @@ public class DDTags {
   public static final String INTERNAL_GIT_COMMIT_SHA = "_dd.git.commit.sha";
 
   public static final String PROFILING_ENABLED = "_dd.profiling.enabled";
+  public static final String BASE_SERVICE = "_dd.base_service";
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
@@ -1,0 +1,30 @@
+package datadog.trace.core.tagprocessor;
+
+import datadog.trace.api.DDTags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.core.DDSpanContext;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class BaseServiceAdder implements TagsPostProcessor {
+  private final UTF8BytesString ddService;
+
+  public BaseServiceAdder(@Nullable final String ddService) {
+    this.ddService = ddService != null ? UTF8BytesString.create(ddService) : null;
+  }
+
+  @Override
+  public Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+    // we are only able to do something if the span service name is known
+    return unsafeTags;
+  }
+
+  @Override
+  public Map<String, Object> processTagsWithContext(
+      Map<String, Object> unsafeTags, DDSpanContext spanContext) {
+    if (ddService != null && !ddService.toString().equals(spanContext.getServiceName())) {
+      unsafeTags.put(DDTags.BASE_SERVICE, ddService);
+    }
+    return unsafeTags;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PostProcessorChain.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PostProcessorChain.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.tagprocessor;
 
+import datadog.trace.core.DDSpanContext;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
@@ -13,9 +14,15 @@ public class PostProcessorChain implements TagsPostProcessor {
 
   @Override
   public Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+    return processTagsWithContext(unsafeTags, null);
+  }
+
+  @Override
+  public Map<String, Object> processTagsWithContext(
+      Map<String, Object> unsafeTags, DDSpanContext spanContext) {
     Map<String, Object> currentTags = unsafeTags;
     for (final TagsPostProcessor tagsPostProcessor : chain) {
-      currentTags = tagsPostProcessor.processTags(currentTags);
+      currentTags = tagsPostProcessor.processTagsWithContext(currentTags, spanContext);
     }
     return currentTags;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessor.java
@@ -1,7 +1,13 @@
 package datadog.trace.core.tagprocessor;
 
+import datadog.trace.core.DDSpanContext;
 import java.util.Map;
 
 public interface TagsPostProcessor {
   Map<String, Object> processTags(Map<String, Object> unsafeTags);
+
+  default Map<String, Object> processTagsWithContext(
+      Map<String, Object> unsafeTags, DDSpanContext spanContext) {
+    return processTags(unsafeTags);
+  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessorFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessorFactory.java
@@ -1,0 +1,44 @@
+package datadog.trace.core.tagprocessor;
+
+import datadog.trace.api.Config;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class TagsPostProcessorFactory {
+  private static boolean addBaseService = true;
+
+  private static class Lazy {
+    private static TagsPostProcessor create() {
+      final List<TagsPostProcessor> processors = new ArrayList<>(addBaseService ? 3 : 2);
+      processors.add(new PeerServiceCalculator());
+      if (addBaseService) {
+        processors.add(new BaseServiceAdder(Config.get().getServiceName()));
+      }
+      processors.add(new QueryObfuscator(Config.get().getObfuscationQueryRegexp()));
+      return new PostProcessorChain(
+          processors.toArray(processors.toArray(new TagsPostProcessor[0])));
+    }
+
+    private static TagsPostProcessor instance = create();
+  }
+
+  public static TagsPostProcessor instance() {
+    return Lazy.instance;
+  }
+
+  /**
+   * Mostly used for test purposes.
+   *
+   * @param enabled if false, {@link BaseServiceAdder} is not put in the chain.
+   */
+  public static void withAddBaseService(boolean enabled) {
+    addBaseService = enabled;
+    Lazy.instance = Lazy.create();
+  }
+
+  /** Used for testing purposes. It reset the singleton and restore default options */
+  public static void reset() {
+    withAddBaseService(true);
+    Lazy.instance = Lazy.create();
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/BaseServiceAdderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/BaseServiceAdderTest.groovy
@@ -1,0 +1,28 @@
+package datadog.trace.core.tagprocessor
+
+
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString
+import datadog.trace.core.DDSpanContext
+import datadog.trace.test.util.DDSpecification
+
+class BaseServiceAdderTest extends DDSpecification {
+  def "should add _dd.base_service when service differs to ddService"() {
+    setup:
+    def calculator = new BaseServiceAdder("test")
+    def spanContext = Mock(DDSpanContext)
+
+    when:
+    def enrichedTags = calculator.processTagsWithContext([:], spanContext)
+
+    then:
+    1 * spanContext.getServiceName() >> serviceName
+
+    and:
+    assert enrichedTags == expectedTags
+
+    where:
+    serviceName     | expectedTags
+    "anotherOne"    | ["_dd.base_service": UTF8BytesString.create("test")]
+    "test"          | [:]
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
@@ -12,6 +12,7 @@ import datadog.trace.core.CoreTracer.CoreTracerBuilder
 import datadog.trace.core.DDSpan
 import datadog.trace.core.DDSpanContext
 import datadog.trace.core.propagation.PropagationTags
+import datadog.trace.core.tagprocessor.TagsPostProcessorFactory
 import datadog.trace.test.util.DDSpecification
 
 abstract class DDCoreSpecification extends DDSpecification {
@@ -22,6 +23,16 @@ abstract class DDCoreSpecification extends DDSpecification {
 
   protected boolean useStrictTraceWrites() {
     return true
+  }
+
+  @Override
+  void setupSpec() {
+    TagsPostProcessorFactory.withAddBaseService(false)
+  }
+
+  @Override
+  void cleanupSpec() {
+    TagsPostProcessorFactory.reset()
   }
 
   protected CoreTracerBuilder tracerBuilder() {


### PR DESCRIPTION
# What Does This Do

When the service name is different to the configured one (DD_SERVICE) we add a tag `_dd.base_service` that's used internally to improve the service map

# Motivation

# Additional Notes
