### PR TITLE
Clean up DSM API from Core Tracer and introduce a new dedicate Propagation implementation 

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -143,9 +143,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     }
     AgentPropagation.ContextVisitor<REQUEST_CARRIER> getter = getter();
     if (null != carrier && null != getter) {
-      tracer()
-          .getDataStreamsMonitoring()
-          .setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
+      tracer().getDataStreamsMonitoring().setCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
     }
     return span;
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -143,7 +143,9 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     }
     AgentPropagation.ContextVisitor<REQUEST_CARRIER> getter = getter();
     if (null != carrier && null != getter) {
-      tracer().setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
+      tracer()
+          .getDataStreamsMonitoring()
+          .setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
     }
     return span;
   }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -18,6 +18,7 @@ import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter
 import datadog.trace.bootstrap.instrumentation.api.URIDefaultDataAdapter
+import datadog.trace.core.datastreams.NoopDataStreamsMonitoring
 
 import java.util.function.Function
 import java.util.function.Supplier
@@ -422,6 +423,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       startSpan(_, _, _) >> mSpan
       getCallbackProvider(RequestContextSlot.APPSEC) >> cbpAppSec
       getCallbackProvider(RequestContextSlot.IAST) >> CallbackProvider.CallbackProviderNoop.INSTANCE
+      getDataStreamsMonitoring() >> new NoopDataStreamsMonitoring()
     }
     def decorator = newDecorator(mTracer)
 

--- a/dd-java-agent/appsec/src/testFixtures/groovy/com/datadog/appsec/AppSecHttpServerTest.groovy
+++ b/dd-java-agent/appsec/src/testFixtures/groovy/com/datadog/appsec/AppSecHttpServerTest.groovy
@@ -18,7 +18,7 @@ abstract class AppSecHttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   }
 
   def setupSpec() {
-    SubscriptionService ss = AgentTracer.TracerAPI.get().getSubscriptionService(RequestContextSlot.APPSEC)
+    SubscriptionService ss = AgentTracer.get().getSubscriptionService(RequestContextSlot.APPSEC)
     def sco = new SharedCommunicationObjects()
     def config = Config.get()
     sco.createRemaining(config)

--- a/dd-java-agent/appsec/src/testFixtures/groovy/com/datadog/appsec/AppSecInactiveHttpServerTest.groovy
+++ b/dd-java-agent/appsec/src/testFixtures/groovy/com/datadog/appsec/AppSecInactiveHttpServerTest.groovy
@@ -7,7 +7,7 @@ import datadog.trace.agent.test.base.WithHttpServer
 import datadog.trace.api.Config
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.gateway.SubscriptionService
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.core.DDSpan
 import okhttp3.FormBody
 import okhttp3.HttpUrl
@@ -31,7 +31,7 @@ abstract class AppSecInactiveHttpServerTest extends WithHttpServer {
   }
 
   void setupSpec() {
-    SubscriptionService ss = TracerAPI.get().getSubscriptionService(RequestContextSlot.APPSEC)
+    SubscriptionService ss = AgentTracer.get().getSubscriptionService(RequestContextSlot.APPSEC)
     def sco = new SharedCommunicationObjects()
     def config = Config.get()
     sco.createRemaining(config)

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -91,7 +91,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
         sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
         sortedTags.put(TOPIC_TAG, urlFileName(queueUrl));
         sortedTags.put(TYPE_TAG, "sqs");
-        AgentTracer.get().setDataStreamCheckpoint(span, sortedTags, 0);
+        AgentTracer.get().getDataStreamsMonitoring().setDataStreamCheckpoint(span, sortedTags, 0);
 
         CONSUMER_DECORATE.afterStart(span);
         CONSUMER_DECORATE.onConsume(span, queueUrl, requestId);

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -91,7 +91,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
         sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
         sortedTags.put(TOPIC_TAG, urlFileName(queueUrl));
         sortedTags.put(TYPE_TAG, "sqs");
-        AgentTracer.get().getDataStreamsMonitoring().setDataStreamCheckpoint(span, sortedTags, 0);
+        AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, sortedTags, 0);
 
         CONSUMER_DECORATE.afterStart(span);
         CONSUMER_DECORATE.onConsume(span, queueUrl, requestId);

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -67,9 +67,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     CallbackProvider cbp = tracer.getCallbackProvider(RequestContextSlot.APPSEC);
     final AgentSpan span = startSpan(GRPC_SERVER, spanContext).setMeasured(true);
 
-    AgentTracer.get()
-        .getDataStreamsMonitoring()
-        .setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
+    AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
 
     RequestContext reqContext = span.getRequestContext();
     if (reqContext != null) {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -67,7 +67,9 @@ public class TracingServerInterceptor implements ServerInterceptor {
     CallbackProvider cbp = tracer.getCallbackProvider(RequestContextSlot.APPSEC);
     final AgentSpan span = startSpan(GRPC_SERVER, spanContext).setMeasured(true);
 
-    AgentTracer.get().setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
+    AgentTracer.get()
+        .getDataStreamsMonitoring()
+        .setDataStreamCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0);
 
     RequestContext reqContext = span.getRequestContext();
     if (reqContext != null) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -99,7 +99,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
         sortedTags.put(TYPE_TAG, "kafka");
         try {
           propagate().inject(span, record.headers(), SETTER);
-          propagate().injectBinaryPathwayContext(span, record.headers(), SETTER, sortedTags);
+          propagate().injectPathwayContext(span, record.headers(), SETTER, sortedTags);
         } catch (final IllegalStateException e) {
           // headers must be read-only from reused record. try again with new one.
           record =
@@ -112,7 +112,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
                   record.headers());
 
           propagate().inject(span, record.headers(), SETTER);
-          propagate().injectBinaryPathwayContext(span, record.headers(), SETTER, sortedTags);
+          propagate().injectPathwayContext(span, record.headers(), SETTER, sortedTags);
         }
         if (TIME_IN_QUEUE_ENABLED) {
           SETTER.injectTimeInQueue(record.headers());

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
@@ -7,8 +7,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.header.Headers;
 
-public class TextMapInjectAdapter
-    implements AgentPropagation.Setter<Headers>, AgentPropagation.BinarySetter<Headers> {
+public class TextMapInjectAdapter implements AgentPropagation.BinarySetter<Headers> {
 
   public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -90,7 +90,9 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           sortedTags.put(TOPIC_TAG, val.topic());
           sortedTags.put(TYPE_TAG, "kafka");
 
-          AgentTracer.get().setDataStreamCheckpoint(span, sortedTags, val.timestamp());
+          AgentTracer.get()
+              .getDataStreamsMonitoring()
+              .setDataStreamCheckpoint(span, sortedTags, val.timestamp());
         } else {
           span = startSpan(operationName, null);
         }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -92,7 +92,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
 
           AgentTracer.get()
               .getDataStreamsMonitoring()
-              .setDataStreamCheckpoint(span, sortedTags, val.timestamp());
+              .setCheckpoint(span, sortedTags, val.timestamp());
         } else {
           span = startSpan(operationName, null);
         }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -242,7 +242,9 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         }
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
-        AgentTracer.get().setDataStreamCheckpoint(span, sortedTags, record.timestamp);
+        AgentTracer.get()
+            .getDataStreamsMonitoring()
+            .setDataStreamCheckpoint(span, sortedTags, record.timestamp);
       } else {
         span = startSpan(KAFKA_CONSUME, null);
       }
@@ -305,7 +307,9 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         }
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
-        AgentTracer.get().setDataStreamCheckpoint(span, sortedTags, record.timestamp());
+        AgentTracer.get()
+            .getDataStreamsMonitoring()
+            .setDataStreamCheckpoint(span, sortedTags, record.timestamp());
       } else {
         span = startSpan(KAFKA_CONSUME, null);
       }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -244,7 +244,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         sortedTags.put(TYPE_TAG, "kafka");
         AgentTracer.get()
             .getDataStreamsMonitoring()
-            .setDataStreamCheckpoint(span, sortedTags, record.timestamp);
+            .setCheckpoint(span, sortedTags, record.timestamp);
       } else {
         span = startSpan(KAFKA_CONSUME, null);
       }
@@ -309,7 +309,7 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         sortedTags.put(TYPE_TAG, "kafka");
         AgentTracer.get()
             .getDataStreamsMonitoring()
-            .setDataStreamCheckpoint(span, sortedTags, record.timestamp());
+            .setCheckpoint(span, sortedTags, record.timestamp());
       } else {
         span = startSpan(KAFKA_CONSUME, null);
       }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelContextPropagators.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelContextPropagators.java
@@ -39,12 +39,13 @@ public class OtelContextPropagators implements ContextPropagators {
       if (span == null || !span.getContext().isValid()) {
         return;
       }
-      tracer.inject(converter.toAgentSpan(span), carrier, new OtelSetter<>(setter));
+      tracer.propagate().inject(converter.toAgentSpan(span), carrier, new OtelSetter<>(setter));
     }
 
     @Override
     public <C> Context extract(final Context context, final C carrier, final Getter<C> getter) {
-      final AgentSpan.Context agentContext = tracer.extract(carrier, new OtelGetter<>(getter));
+      final AgentSpan.Context agentContext =
+          tracer.propagate().extract(carrier, new OtelGetter<>(getter));
       return TracingContextUtils.withSpan(
           DefaultSpan.create(converter.toSpanContext(agentContext)), context);
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTTracer.java
@@ -49,7 +49,7 @@ public class OTTracer implements Tracer {
     if (carrier instanceof TextMap) {
       final AgentSpan.Context context = converter.toContext(spanContext);
 
-      tracer.inject(context, (TextMap) carrier, OTTextMapSetter.INSTANCE);
+      tracer.propagate().inject(context, (TextMap) carrier, OTTextMapSetter.INSTANCE);
     } else {
       log.debug("Unsupported format for propagation - {}", format.getClass().getName());
     }
@@ -59,7 +59,9 @@ public class OTTracer implements Tracer {
   public <C> SpanContext extract(final Format<C> format, final C carrier) {
     if (carrier instanceof TextMap) {
       final AgentSpan.Context tagContext =
-          tracer.extract((TextMap) carrier, ContextVisitors.<TextMap>stringValuesEntrySet());
+          tracer
+              .propagate()
+              .extract((TextMap) carrier, ContextVisitors.<TextMap>stringValuesEntrySet());
 
       return converter.toSpanContext(tagContext);
     } else {

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTTracer.java
@@ -61,7 +61,7 @@ public class OTTracer implements Tracer {
     if (carrier instanceof TextMapInject) {
       final AgentSpan.Context context = converter.toContext(spanContext);
 
-      tracer.inject(context, (TextMapInject) carrier, OTTextMapInjectSetter.INSTANCE);
+      tracer.propagate().inject(context, (TextMapInject) carrier, OTTextMapInjectSetter.INSTANCE);
     } else {
       log.debug("Unsupported format for propagation - {}", format.getClass().getName());
     }
@@ -71,7 +71,9 @@ public class OTTracer implements Tracer {
   public <C> SpanContext extract(final Format<C> format, final C carrier) {
     if (carrier instanceof TextMapExtract) {
       final AgentSpan.Context tagContext =
-          tracer.extract((TextMapExtract) carrier, ContextVisitors.stringValuesEntrySet());
+          tracer
+              .propagate()
+              .extract((TextMapExtract) carrier, ContextVisitors.stringValuesEntrySet());
 
       return converter.toSpanContext(tagContext);
     } else {

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.playws1;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -21,7 +21,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
   public AsyncHandlerWrapper(final AsyncHandler delegate, final AgentSpan span) {
     this.delegate = delegate;
     this.span = span;
-    continuation = propagate().capture();
+    continuation = capture();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.playws21;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -26,7 +26,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
   public AsyncHandlerWrapper(final AsyncHandler delegate, final AgentSpan span) {
     this.delegate = delegate;
     this.span = span;
-    continuation = propagate().capture();
+    continuation = capture();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.playws2;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -25,7 +25,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
   public AsyncHandlerWrapper(final AsyncHandler delegate, final AgentSpan span) {
     this.delegate = delegate;
     this.span = span;
-    continuation = propagate().capture();
+    continuation = capture();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -234,9 +234,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
       sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
       sortedTags.put(TOPIC_TAG, queue);
       sortedTags.put(TYPE_TAG, "rabbitmq");
-      AgentTracer.get()
-          .getDataStreamsMonitoring()
-          .setDataStreamCheckpoint(span, sortedTags, produceMillis);
+      AgentTracer.get().getDataStreamsMonitoring().setCheckpoint(span, sortedTags, produceMillis);
     }
 
     CONSUMER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -234,7 +234,9 @@ public class RabbitDecorator extends MessagingClientDecorator {
       sortedTags.put(DIRECTION_TAG, DIRECTION_IN);
       sortedTags.put(TOPIC_TAG, queue);
       sortedTags.put(TYPE_TAG, "rabbitmq");
-      AgentTracer.get().setDataStreamCheckpoint(span, sortedTags, produceMillis);
+      AgentTracer.get()
+          .getDataStreamsMonitoring()
+          .setDataStreamCheckpoint(span, sortedTags, produceMillis);
     }
 
     CONSUMER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
+++ b/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedOnSubscribe.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.rxjava;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -26,7 +26,7 @@ public class TracedOnSubscribe<T> implements Observable.OnSubscribe<T> {
     this.operationName = operationName;
     this.decorator = decorator;
 
-    continuation = propagate().capture();
+    continuation = capture();
   }
 
   @Override

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -30,7 +30,10 @@ excludedClassesCoverage += [
   'datadog.trace.core.CoreTracer.1',
   'datadog.trace.core.DDSpan.1',
   'datadog.trace.core.tagprocessor.QueryObfuscator.1',
-  'datadog.trace.common.writer.TraceProcessingWorker.NonDaemonTraceSerializingHandler'
+  'datadog.trace.common.writer.TraceProcessingWorker.NonDaemonTraceSerializingHandler',
+  // FIXME(DSM): test coverage needed
+  'datadog.trace.core.datastreams.DefaultDataStreamsMonitoring',
+  'datadog.trace.core.datastreams.DataStreamContextInjector'
 ]
 
 addTestSuite('traceAgentTest')

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -232,12 +232,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     return propagationTagsFactory;
   }
 
-  @Override
-  public AgentScope.Continuation capture() {
-    final AgentScope activeScope = activeScope();
 
-    return activeScope == null ? null : activeScope.capture();
-  }
 
   @Override
   public void onRootSpanFinished(AgentSpan root, EndpointTracker tracker) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamContextExtractor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamContextExtractor.java
@@ -12,8 +12,8 @@ public class DataStreamContextExtractor implements HttpCodec.Extractor {
   private final WellKnownTags wellKnownTags;
 
   public DataStreamContextExtractor(
-      HttpCodec.Extractor extractor, TimeSource timeSource, WellKnownTags wellKnownTags) {
-    this.delegate = extractor;
+      HttpCodec.Extractor delegate, TimeSource timeSource, WellKnownTags wellKnownTags) {
+    this.delegate = delegate;
     this.timeSource = timeSource;
     this.wellKnownTags = wellKnownTags;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamContextInjector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamContextInjector.java
@@ -30,7 +30,6 @@ public class DataStreamContextInjector {
     }
     pathwayContext.setCheckpoint(sortedTags, dataStreamsMonitoring::add);
 
-    @SuppressWarnings("unchecked")
     boolean injected =
         setter instanceof AgentPropagation.BinarySetter
             ? injectBinaryPathwayContext(

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamContextInjector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamContextInjector.java
@@ -1,0 +1,74 @@
+package datadog.trace.core.datastreams;
+
+import static datadog.trace.api.DDTags.PATHWAY_HASH;
+import static datadog.trace.bootstrap.instrumentation.api.PathwayContext.PROPAGATION_KEY_BASE64;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataStreamContextInjector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataStreamContextInjector.class);
+  private final DataStreamsMonitoring dataStreamsMonitoring;
+
+  public DataStreamContextInjector(DataStreamsMonitoring dataStreamsMonitoring) {
+    this.dataStreamsMonitoring = dataStreamsMonitoring;
+  }
+
+  public <C> void injectPathwayContext(
+      AgentSpan span,
+      C carrier,
+      AgentPropagation.Setter<C> setter,
+      LinkedHashMap<String, String> sortedTags) {
+    PathwayContext pathwayContext = span.context().getPathwayContext();
+    if (pathwayContext == null) {
+      return;
+    }
+    pathwayContext.setCheckpoint(sortedTags, dataStreamsMonitoring::add);
+
+    @SuppressWarnings("unchecked")
+    boolean injected =
+        setter instanceof AgentPropagation.BinarySetter
+            ? injectBinaryPathwayContext(
+                pathwayContext, carrier, (AgentPropagation.BinarySetter<C>) setter)
+            : injectPathwayContext(pathwayContext, carrier, setter);
+
+    if (injected && pathwayContext.getHash() != 0) {
+      span.setTag(PATHWAY_HASH, Long.toUnsignedString(pathwayContext.getHash()));
+    }
+  }
+
+  private static <C> boolean injectBinaryPathwayContext(
+      PathwayContext pathwayContext, C carrier, AgentPropagation.BinarySetter<C> setter) {
+    try {
+      byte[] encodedContext = pathwayContext.encode();
+      if (encodedContext != null) {
+        LOGGER.debug("Injecting binary pathway context {}", pathwayContext);
+        setter.set(carrier, PROPAGATION_KEY_BASE64, encodedContext);
+        return true;
+      }
+    } catch (IOException e) {
+      LOGGER.debug("Unable to set encode pathway context", e);
+    }
+    return false;
+  }
+
+  private static <C> boolean injectPathwayContext(
+      PathwayContext pathwayContext, C carrier, AgentPropagation.Setter<C> setter) {
+    try {
+      String encodedContext = pathwayContext.strEncode();
+      if (encodedContext != null) {
+        LOGGER.debug("Injecting pathway context {}", pathwayContext);
+        setter.set(carrier, PROPAGATION_KEY_BASE64, encodedContext);
+        return true;
+      }
+    } catch (IOException e) {
+      LOGGER.debug("Unable to set encode pathway context", e);
+    }
+    return false;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsMonitoring.java
@@ -14,12 +14,19 @@ public interface DataStreamsMonitoring extends AgentDataStreamsMonitoring, AutoC
   PathwayContext newPathwayContext();
 
   /**
-   * Adds DSM context extractor behavior.
+   * Get a context extractor that support {@link PathwayContext} extraction.
    *
-   * @param extractor The extractor to decorate with DSM extraction.
+   * @param delegate The extractor to delegate the common trace context extraction.
    * @return An extractor with DSM context extraction.
    */
-  HttpCodec.Extractor decorate(HttpCodec.Extractor extractor);
+  HttpCodec.Extractor extractor(HttpCodec.Extractor delegate);
+
+  /**
+   * Gets a context injector to propagate {@link PathwayContext}.
+   *
+   * @return A context injector if supported, {@code null} otherwise.
+   */
+  DataStreamContextInjector injector();
 
   /**
    * Injects DSM {@link PathwayContext} into a span {@link Context}.

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -180,7 +180,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
   }
 
   @Override
-  public void setDataStreamCheckpoint(
+  public void setCheckpoint(
       AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {
     PathwayContext pathwayContext = span.context().getPathwayContext();
     if (pathwayContext != null) {
@@ -210,7 +210,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
     sortedTags.put(TOPIC_TAG, source);
     sortedTags.put(TYPE_TAG, type);
 
-    setDataStreamCheckpoint(span, sortedTags, 0);
+    setCheckpoint(span, sortedTags, 0);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/NoopDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/NoopDataStreamsMonitoring.java
@@ -21,8 +21,13 @@ public class NoopDataStreamsMonitoring implements DataStreamsMonitoring {
   }
 
   @Override
-  public HttpCodec.Extractor decorate(HttpCodec.Extractor extractor) {
-    return extractor;
+  public HttpCodec.Extractor extractor(HttpCodec.Extractor delegate) {
+    return delegate;
+  }
+
+  @Override
+  public DataStreamContextInjector injector() {
+    return new DataStreamContextInjector(this);
   }
 
   @Override
@@ -30,6 +35,16 @@ public class NoopDataStreamsMonitoring implements DataStreamsMonitoring {
 
   @Override
   public void trackBacklog(LinkedHashMap<String, String> sortedTags, long value) {}
+
+  @Override
+  public void setDataStreamCheckpoint(
+      AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
+
+  @Override
+  public void setConsumeCheckpoint(String type, String source, DataStreamsContextCarrier carrier) {}
+
+  @Override
+  public void setProduceCheckpoint(String type, String target, DataStreamsContextCarrier carrier) {}
 
   @Override
   public void close() {}

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/NoopDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/NoopDataStreamsMonitoring.java
@@ -37,7 +37,7 @@ public class NoopDataStreamsMonitoring implements DataStreamsMonitoring {
   public void trackBacklog(LinkedHashMap<String, String> sortedTags, long value) {}
 
   @Override
-  public void setDataStreamCheckpoint(
+  public void setCheckpoint(
       AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/CorePropagation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/CorePropagation.java
@@ -1,0 +1,78 @@
+package datadog.trace.core.propagation;
+
+import datadog.trace.api.TracePropagationStyle;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.datastreams.DataStreamContextInjector;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class CorePropagation implements AgentPropagation {
+  private final HttpCodec.Injector injector;
+  private final Map<TracePropagationStyle, HttpCodec.Injector> injectors;
+  private final DataStreamContextInjector dataStreamContextInjector;
+  private final HttpCodec.Extractor extractor;
+
+  /**
+   * Constructor
+   *
+   * @param extractor The context extractor.
+   * @param defaultInjector The default injector when no {@link TracePropagationStyle} given.
+   * @param injectors All the other injectors available for context injection.
+   * @param dataStreamContextInjector The DSM context injector, as a specific object until generic
+   *     context injection is available.
+   */
+  public CorePropagation(
+      HttpCodec.Extractor extractor,
+      HttpCodec.Injector defaultInjector,
+      Map<TracePropagationStyle, HttpCodec.Injector> injectors,
+      DataStreamContextInjector dataStreamContextInjector) {
+    this.extractor = extractor;
+    this.injector = defaultInjector;
+    this.injectors = injectors;
+    this.dataStreamContextInjector = dataStreamContextInjector;
+  }
+
+  @Override
+  public <C> void inject(final AgentSpan span, final C carrier, final Setter<C> setter) {
+    inject(span.context(), carrier, setter, null);
+  }
+
+  @Override
+  public <C> void inject(AgentSpan.Context context, C carrier, Setter<C> setter) {
+    inject(context, carrier, setter, null);
+  }
+
+  @Override
+  public <C> void inject(AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style) {
+    inject(span.context(), carrier, setter, style);
+  }
+
+  private <C> void inject(
+      AgentSpan.Context context, C carrier, Setter<C> setter, TracePropagationStyle style) {
+    if (!(context instanceof DDSpanContext)) {
+      return;
+    }
+
+    final DDSpanContext ddSpanContext = (DDSpanContext) context;
+    ddSpanContext.getTrace().setSamplingPriorityIfNecessary();
+
+    if (null == style) {
+      injector.inject(ddSpanContext, carrier, setter);
+    } else {
+      injectors.get(style).inject(ddSpanContext, carrier, setter);
+    }
+  }
+
+  @Override
+  public <C> void injectPathwayContext(
+      AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags) {
+    this.dataStreamContextInjector.injectPathwayContext(span, carrier, setter, sortedTags);
+  }
+
+  @Override
+  public <C> AgentSpan.Context.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
+    return extractor.extract(carrier, getter);
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
@@ -550,7 +550,7 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
     Map<String, String> carrier = [(PathwayContext.PROPAGATION_KEY_BASE64): encoded, "someotherkey": "someothervalue"]
     def contextVisitor = new Base64MapContextVisitor()
     def extractor = new FakeExtractor()
-    def decorated = dataStreams.decorate(extractor)
+    def decorated = dataStreams.extractor(extractor)
 
     when:
     def extracted = decorated.extract(carrier, contextVisitor)
@@ -578,7 +578,7 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
     Map<String, String> carrier = [(PathwayContext.PROPAGATION_KEY_BASE64): encoded, "someotherkey": "someothervalue"]
     def contextVisitor = new Base64MapContextVisitor()
     def extractor = new NullExtractor()
-    def decorated = dataStreams.decorate(extractor)
+    def decorated = dataStreams.extractor(extractor)
 
     when:
     def extracted = decorated.extract(carrier, contextVisitor)
@@ -602,7 +602,7 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
     Map<String, String> carrier = ["someotherkey": "someothervalue"]
     def contextVisitor = new Base64MapContextVisitor()
     def extractor = new NullExtractor()
-    def decorated = dataStreams.decorate(extractor)
+    def decorated = dataStreams.extractor(extractor)
 
     when:
     def extracted = decorated.extract(carrier, contextVisitor)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/NoopDataStreamsMonitoringTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/NoopDataStreamsMonitoringTest.groovy
@@ -10,6 +10,6 @@ class NoopDataStreamsMonitoringTest extends DDCoreSpecification {
     def extractor = Mock(HttpCodec.Extractor)
 
     then:
-    checkpointer.decorate(extractor) == extractor
+    checkpointer.extractor(extractor) == extractor
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/CorePropagationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/CorePropagationTest.groovy
@@ -1,0 +1,207 @@
+package datadog.trace.core.propagation
+
+import datadog.trace.api.TracePropagationStyle
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation
+import datadog.trace.common.writer.LoggingWriter
+import datadog.trace.core.ControllableSampler
+import datadog.trace.core.datastreams.DataStreamContextInjector
+import datadog.trace.core.test.DDCoreSpecification
+
+import static datadog.trace.api.TracePropagationStyle.B3MULTI
+import static datadog.trace.api.TracePropagationStyle.DATADOG
+import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+
+class CorePropagationTest extends DDCoreSpecification {
+  HttpCodec.Extractor extractor
+  HttpCodec.Injector datadogInjector
+  HttpCodec.Injector b3Injector
+  HttpCodec.Injector traceContextInjector
+  Map<TracePropagationStyle, HttpCodec.Injector> allInjectors
+  DataStreamContextInjector dataStreamContextInjector
+  AgentPropagation propagation
+
+  def setup() {
+    extractor = Mock(HttpCodec.Extractor)
+    datadogInjector = Mock(HttpCodec.Injector)
+    b3Injector = Mock(HttpCodec.Injector)
+    traceContextInjector = Mock(HttpCodec.Injector)
+    allInjectors = [
+      (DATADOG)     : datadogInjector,
+      (B3MULTI)     : b3Injector,
+      (TRACECONTEXT): traceContextInjector,
+    ]
+    dataStreamContextInjector = Mock(DataStreamContextInjector)
+    propagation = new CorePropagation(extractor, datadogInjector, allInjectors, dataStreamContextInjector)
+  }
+
+  def 'test default injector for span'() {
+    setup:
+    def tracer = tracerBuilder().build()
+    def span = tracer.buildSpan('test', 'operation').start()
+    def setter = Mock(AgentPropagation.Setter)
+    def carrier = new Object()
+
+    when:
+    propagation.inject(span, carrier, setter)
+
+    then:
+    1 * datadogInjector.inject(_, carrier, setter)
+    0 * b3Injector.inject(_, carrier, setter)
+    0 * traceContextInjector.inject(_, carrier, setter)
+    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
+
+    cleanup:
+    span.finish()
+    tracer.close()
+  }
+
+  def 'test default injector for span context'() {
+    setup:
+    def tracer = tracerBuilder().build()
+    def span = tracer.buildSpan("test", "operation").start()
+    def setter = Mock(AgentPropagation.Setter)
+    def carrier = new Object()
+
+    when:
+    def spanContext = span.context()
+    propagation.inject(spanContext, carrier, setter)
+
+    then:
+    1 * datadogInjector.inject(_, carrier, setter)
+    0 * b3Injector.inject(_, carrier, setter)
+    0 * traceContextInjector.inject(_, carrier, setter)
+    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
+
+    cleanup:
+    span.finish()
+    tracer.close()
+  }
+
+  def 'test injector style selection'() {
+    setup:
+    def injector = allInjectors.get(style, datadogInjector)
+    def tracer = tracerBuilder().build()
+    def span = tracer.buildSpan('test', 'operation').start()
+    def setter = Mock(AgentPropagation.Setter)
+    def carrier = new Object()
+
+    when:
+    propagation.inject(span, carrier, setter, style)
+
+    then:
+    1 * injector.inject(_, carrier, setter)
+    if (injector != datadogInjector) {
+      0 * datadogInjector.inject(_, carrier, setter)
+    }
+    if (injector != b3Injector) {
+      0 * b3Injector.inject(_, carrier, setter)
+    }
+    if (injector != traceContextInjector) {
+      0 * traceContextInjector.inject(_, carrier, setter)
+    }
+    0 * dataStreamContextInjector.injectPathwayContext(_, carrier, setter, _)
+
+    cleanup:
+    span.finish()
+    tracer.close()
+
+    where:
+    style << [DATADOG, B3MULTI, TRACECONTEXT, null]
+  }
+
+  def 'test context extractor'() {
+    setup:
+    def getter = Mock(AgentPropagation.ContextVisitor)
+    def carrier = new Object()
+
+    when:
+    propagation.extract(carrier, getter)
+
+    then:
+    1 * extractor.extract(carrier, getter)
+  }
+
+  def 'span priority set when injecting'() {
+    given:
+    injectSysConfig('writer.type', 'LoggingWriter')
+    def tracer = tracerBuilder().build()
+    def setter = Mock(AgentPropagation.Setter)
+    def carrier = new Object()
+
+    when:
+    def root = tracer.buildSpan('test', 'operation').start()
+    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
+    tracer.propagate().inject(child, carrier, setter)
+
+    then:
+    root.getSamplingPriority() == SAMPLER_KEEP as int
+    child.getSamplingPriority() == root.getSamplingPriority()
+    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
+
+    cleanup:
+    child.finish()
+    root.finish()
+    tracer.close()
+  }
+
+  def 'span priority only set after first injection'() {
+    given:
+    def sampler = new ControllableSampler()
+    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
+    def setter = Mock(AgentPropagation.Setter)
+    def carrier = new Object()
+
+    when:
+    def root = tracer.buildSpan('test', 'operation').start()
+    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
+    tracer.propagate().inject(child, carrier, setter)
+
+    then:
+    root.getSamplingPriority() == SAMPLER_KEEP as int
+    child.getSamplingPriority() == root.getSamplingPriority()
+    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
+
+    when:
+    sampler.nextSamplingPriority = PrioritySampling.SAMPLER_DROP as int
+    def child2 = tracer.buildSpan('test', 'my_child2').asChildOf(root).start()
+    tracer.propagate().inject(child2, carrier, setter)
+
+    then:
+    root.getSamplingPriority() == SAMPLER_KEEP as int
+    child.getSamplingPriority() == root.getSamplingPriority()
+    child2.getSamplingPriority() == root.getSamplingPriority()
+    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(SAMPLER_KEEP))
+
+    cleanup:
+    child.finish()
+    child2.finish()
+    root.finish()
+    tracer.close()
+  }
+
+  def "injection doesn't override set priority"() {
+    given:
+    def sampler = new ControllableSampler()
+    def tracer = tracerBuilder().writer(new LoggingWriter()).sampler(sampler).build()
+    def setter = Mock(AgentPropagation.Setter)
+    def carrier = new Object()
+
+    when:
+    def root = tracer.buildSpan('test', 'operation').start()
+    def child = tracer.buildSpan('test', 'my_child').asChildOf(root).start()
+    child.setSamplingPriority(PrioritySampling.USER_DROP)
+    tracer.propagate().inject(child, carrier, setter)
+
+    then:
+    root.getSamplingPriority() == PrioritySampling.USER_DROP as int
+    child.getSamplingPriority() == root.getSamplingPriority()
+    1 * setter.set(carrier, DatadogHttpCodec.SAMPLING_PRIORITY_KEY, String.valueOf(PrioritySampling.USER_DROP))
+
+    cleanup:
+    child.finish()
+    root.finish()
+    tracer.close()
+  }
+}

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -468,7 +468,7 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
     if (carrier instanceof TextMap) {
       final AgentSpan.Context context = converter.toContext(spanContext);
 
-      tracer.inject(context, (TextMap) carrier, TextMapSetter.INSTANCE);
+      tracer.propagate().inject(context, (TextMap) carrier, TextMapSetter.INSTANCE);
     } else {
       log.debug("Unsupported format for propagation - {}", format.getClass().getName());
     }
@@ -478,7 +478,7 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
   public <C> SpanContext extract(final Format<C> format, final C carrier) {
     if (carrier instanceof TextMap) {
       final AgentSpan.Context tagContext =
-          tracer.extract((TextMap) carrier, new TextMapGetter((TextMap) carrier));
+          tracer.propagate().extract((TextMap) carrier, new TextMapGetter((TextMap) carrier));
 
       return converter.toSpanContext(tagContext);
     } else {

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -47,7 +47,6 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.Tags",
   "datadog.trace.bootstrap.instrumentation.api.CommonTagValues",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentPropagation",
-  "datadog.trace.bootstrap.instrumentation.api.AgentPropagation",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopContext",
   "datadog.trace.bootstrap.instrumentation.api.InstrumentationTags",

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -47,6 +47,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.Tags",
   "datadog.trace.bootstrap.instrumentation.api.CommonTagValues",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentPropagation",
+  "datadog.trace.bootstrap.instrumentation.api.AgentPropagation",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopContext",
   "datadog.trace.bootstrap.instrumentation.api.InstrumentationTags",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
@@ -16,6 +16,6 @@ public interface AgentDataStreamsMonitoring extends DataStreamsCheckpointer {
    *     message / payload itself (for instance: produce operations; http produce / consume etc).
    *     Value will be ignored for checkpoints happening not at the start of the pipeline.
    */
-  void setDataStreamCheckpoint(
+  void setCheckpoint(
       AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
@@ -1,7 +1,21 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
+import datadog.trace.api.experimental.DataStreamsCheckpointer;
 import java.util.LinkedHashMap;
 
-public interface AgentDataStreamsMonitoring {
+public interface AgentDataStreamsMonitoring extends DataStreamsCheckpointer {
   void trackBacklog(LinkedHashMap<String, String> sortedTags, long value);
+
+  /**
+   * Sets data streams checkpoint, used for both produce and consume operations.
+   *
+   * @param span active span
+   * @param sortedTags alphabetically sorted tags for the checkpoint (direction, queue type etc)
+   * @param defaultTimestamp unix timestamp to use as a start of the pathway if this is the first
+   *     checkpoint in the chain. Zero should be passed if we can't extract the timestamp from the
+   *     message / payload itself (for instance: produce operations; http produce / consume etc).
+   *     Value will be ignored for checkpoints happening not at the start of the pipeline.
+   */
+  void setDataStreamCheckpoint(
+      AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -11,8 +11,11 @@ public interface AgentPropagation {
   <C> void inject(AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style);
 
   // The input tags should be sorted.
-  <C> void injectBinaryPathwayContext(
-      AgentSpan span, C carrier, BinarySetter<C> setter, LinkedHashMap<String, String> sortedTags);
+  default <C> void injectBinaryPathwayContext(
+      AgentSpan span, C carrier, BinarySetter<C> setter, LinkedHashMap<String, String> sortedTags) {
+    //noinspection unchecked
+    injectPathwayContext(span, carrier, (Setter<C>) setter, sortedTags);
+  }
 
   // The input tags should be sorted.
   <C> void injectPathwayContext(

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -11,13 +11,6 @@ public interface AgentPropagation {
   <C> void inject(AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style);
 
   // The input tags should be sorted.
-  default <C> void injectBinaryPathwayContext(
-      AgentSpan span, C carrier, BinarySetter<C> setter, LinkedHashMap<String, String> sortedTags) {
-    //noinspection unchecked
-    injectPathwayContext(span, carrier, (Setter<C>) setter, sortedTags);
-  }
-
-  // The input tags should be sorted.
   <C> void injectPathwayContext(
       AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags);
 
@@ -25,7 +18,7 @@ public interface AgentPropagation {
     void set(C carrier, String key, String value);
   }
 
-  interface BinarySetter<C> {
+  interface BinarySetter<C> extends Setter<C> {
     void set(C carrier, String key, byte[] value);
   }
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -4,9 +4,6 @@ import datadog.trace.api.TracePropagationStyle;
 import java.util.LinkedHashMap;
 
 public interface AgentPropagation {
-
-  AgentScope.Continuation capture();
-
   <C> void inject(AgentSpan span, C carrier, Setter<C> setter);
 
   <C> void inject(AgentSpan.Context context, C carrier, Setter<C> setter);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -516,7 +516,7 @@ public class AgentTracer {
     }
   }
 
-  public static class NoopAgentSpan implements AgentSpan {
+  public static final class NoopAgentSpan implements AgentSpan {
     public static final NoopAgentSpan INSTANCE = new NoopAgentSpan();
 
     protected NoopAgentSpan() {}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1019,7 +1019,7 @@ public class AgentTracer {
     public void trackBacklog(LinkedHashMap<String, String> sortedTags, long value) {}
 
     @Override
-    public void setDataStreamCheckpoint(
+    public void setCheckpoint(
         AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -172,12 +172,7 @@ public class AgentTracer {
   private AgentTracer() {}
 
   public interface TracerAPI
-      extends datadog.trace.api.Tracer,
-          InternalTracer,
-          AgentPropagation,
-          EndpointCheckpointer,
-          DataStreamsCheckpointer,
-          ScopeStateAware {
+      extends datadog.trace.api.Tracer, InternalTracer, EndpointCheckpointer, ScopeStateAware {
 
     /**
      * Create and start a new span.
@@ -273,19 +268,6 @@ public class AgentTracer {
     CallbackProvider getCallbackProvider(RequestContextSlot slot);
 
     CallbackProvider getUniversalCallbackProvider();
-
-    /**
-     * Sets data streams checkpoint, used for both produce and consume operations.
-     *
-     * @param span active span
-     * @param sortedTags alphabetically sorted tags for the checkpoint (direction, queue type etc)
-     * @param defaultTimestamp unix timestamp to use as a start of the pathway if this is the first
-     *     checkpoint in the chain. Zero should be passed if we can't extract the timestamp from the
-     *     message / payload itself (for instance: produce operations; http produce / consume etc).
-     *     Value will be ignored for checkpoints happening not at the start of the pipeline.
-     */
-    void setDataStreamCheckpoint(
-        AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
 
     AgentSpan.Context notifyExtensionStart(Object event);
 
@@ -465,7 +447,7 @@ public class AgentTracer {
 
     @Override
     public DataStreamsCheckpointer getDataStreamsCheckpointer() {
-      return this;
+      return getDataStreamsMonitoring();
     }
 
     @Override
@@ -493,42 +475,12 @@ public class AgentTracer {
     }
 
     @Override
-    public <C> void inject(final AgentSpan span, final C carrier, final Setter<C> setter) {}
-
-    @Override
-    public <C> void inject(final Context context, final C carrier, final Setter<C> setter) {}
-
-    @Override
-    public <C> void inject(
-        AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style) {}
-
-    @Override
-    public <C> void injectBinaryPathwayContext(
-        AgentSpan span,
-        C carrier,
-        BinarySetter<C> setter,
-        LinkedHashMap<String, String> sortedTags) {}
-
-    @Override
-    public <C> void injectPathwayContext(
-        AgentSpan span, C carrier, Setter<C> setter, LinkedHashMap<String, String> sortedTags) {}
-
-    @Override
-    public <C> Context.Extracted extract(final C carrier, final ContextVisitor<C> getter) {
-      return null;
-    }
-
-    @Override
     public void onRootSpanFinished(AgentSpan root, EndpointTracker tracker) {}
 
     @Override
     public EndpointTracker onRootSpanStarted(AgentSpan root) {
       return EndpointTracker.NO_OP;
     }
-
-    @Override
-    public void setDataStreamCheckpoint(
-        AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
 
     @Override
     public AgentSpan.Context notifyExtensionStart(Object event) {
@@ -549,14 +501,6 @@ public class AgentTracer {
     }
 
     @Override
-    public void setConsumeCheckpoint(
-        String type, String source, DataStreamsContextCarrier carrier) {}
-
-    @Override
-    public void setProduceCheckpoint(
-        String type, String target, DataStreamsContextCarrier carrier) {}
-
-    @Override
     public Timer getTimer() {
       return Timer.NoOp.INSTANCE;
     }
@@ -572,10 +516,10 @@ public class AgentTracer {
     }
   }
 
-  public static final class NoopAgentSpan implements AgentSpan {
+  public static class NoopAgentSpan implements AgentSpan {
     public static final NoopAgentSpan INSTANCE = new NoopAgentSpan();
 
-    private NoopAgentSpan() {}
+    protected NoopAgentSpan() {}
 
     @Override
     public DDTraceId getTraceId() {
@@ -905,11 +849,6 @@ public class AgentTracer {
     static final NoopAgentPropagation INSTANCE = new NoopAgentPropagation();
 
     @Override
-    public AgentScope.Continuation capture() {
-      return NoopContinuation.INSTANCE;
-    }
-
-    @Override
     public <C> void inject(final AgentSpan span, final C carrier, final Setter<C> setter) {}
 
     @Override
@@ -918,13 +857,6 @@ public class AgentTracer {
     @Override
     public <C> void inject(
         AgentSpan span, C carrier, Setter<C> setter, TracePropagationStyle style) {}
-
-    @Override
-    public <C> void injectBinaryPathwayContext(
-        AgentSpan span,
-        C carrier,
-        BinarySetter<C> setter,
-        LinkedHashMap<String, String> sortedTags) {}
 
     @Override
     public <C> void injectPathwayContext(
@@ -1085,6 +1017,18 @@ public class AgentTracer {
 
     @Override
     public void trackBacklog(LinkedHashMap<String, String> sortedTags, long value) {}
+
+    @Override
+    public void setDataStreamCheckpoint(
+        AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
+
+    @Override
+    public void setConsumeCheckpoint(
+        String type, String source, DataStreamsContextCarrier carrier) {}
+
+    @Override
+    public void setProduceCheckpoint(
+        String type, String target, DataStreamsContextCarrier carrier) {}
   }
 
   public static class NoopPathwayContext implements PathwayContext {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -133,6 +133,11 @@ public class AgentTracer {
     return get().activeScope();
   }
 
+  public static AgentScope.Continuation capture() {
+    final AgentScope activeScope = activeScope();
+    return activeScope == null ? null : activeScope.capture();
+  }
+
   public static AgentPropagation propagate() {
     return get().propagate();
   }
@@ -485,11 +490,6 @@ public class AgentTracer {
     @Override
     public CallbackProvider getUniversalCallbackProvider() {
       return CallbackProvider.CallbackProviderNoop.INSTANCE;
-    }
-
-    @Override
-    public AgentScope.Continuation capture() {
-      return null;
     }
 
     @Override


### PR DESCRIPTION
# What Does This Do

This PR tries to separate both DataStreamMonitoring (DSM) concerns and context propagation capabilities from the core tracer.

# Motivation

Other than providing a better design and separation, this change is a preparation work to [a better context tracking API for the core module](https://github.com/DataDog/dd-trace-java/pull/5686). As DSM heavily interacts with context (through its pathway context and tags), putting it aside with clear separation makes easier to introduce a proper context API.
Similarly, creating a proper propagation implementation, that is responsible of all extractors and injectors, makes easier to refactor and generify them later.

Here are the high-level changes the PR introduce:

* Move `Continuation capture()` from `AgentPropagation` API to an helper method in `AgentTracer`.

* `TracerAPI` no more extends `AgentPropagation` API:
  TracerAPI and Propagation implementations were merged while TracerAPI offered a `AgentPropagation propagate()` getter. 
  `CoreTracer` will now return a (new) `CorePropagation` instance when calling `propagate()` 
* `TracerAPI` no more extends `DataStreamCheckpointer`:
  CoreTracer and DataStreamCheckpointer implementations were merged while DataStreamCheckpointer only relies on DSM implementation.
  `DataStreamMonitoring` will now inherits from `DataStreamCheckpointer`, moving the implementation of checkpointer into DSM implementation rather than Tracer implementation.
* Move `void setDataStreamCheckpoint(span, sortedTags, defaultTimestamp)` from to `TracerAPI` to `DataStreamMonitoring` API.

* Introduce `CorePropagation` as the `AgentPropagation` implementation.
  Its long term goal is to be able to manage the generic context propagation using generic injectors / extractors.
  For now, it gathers all the existing propagators even if they don't have the same interface yet.
* Introduce `DataStreamContextInjector` to inject DSM specific context

The whole PR is mainly moving code parts. Only DSM received implementation improvement for its injector (as I did for extractor during the last R&D week).


To help visualize, here are two class diagrams about the changes: the first as before changes, the last as after changes.

##### Before
![before](https://github.com/DataDog/dd-trace-java/assets/1766222/4cb2b81e-28ed-423f-8955-b3350ddadd9d)

##### After
![after](https://github.com/DataDog/dd-trace-java/assets/1766222/6057bbc8-2c1b-486e-84be-ed9c9b260d23)

# Additional Notes

Moving out context propagation and DSM implementation from core tracer also points out that those core parts were not tested as `CoreTracer` is excluded from code coverage check.
I added tests for the new context propagation implementation but will leave the DSM tests to its team.

![image](https://github.com/DataDog/dd-trace-java/assets/1766222/cfc92ec9-8489-4106-b841-7a3895d0c9ab)
