### PR TITLE
Redact empty sensitive ranges

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/EvidenceAdapter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/EvidenceAdapter.java
@@ -339,7 +339,7 @@ public class EvidenceAdapter extends FormattingAdapter<Evidence> {
 
     @Override
     public void write(final Context ctx, final JsonWriter writer) throws IOException {
-      if (value == null || value.isEmpty()) {
+      if (value == null) {
         return;
       }
       writer.beginObject();
@@ -470,7 +470,7 @@ public class EvidenceAdapter extends FormattingAdapter<Evidence> {
 
     @Override
     public void write(final Context ctx, final JsonWriter writer) throws IOException {
-      if (value == null || value.isEmpty()) {
+      if (value == null) {
         return;
       }
       writer.beginObject();

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/Ranged.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/Ranged.java
@@ -88,7 +88,11 @@ public interface Ranged {
     if (range == null) {
       return true;
     }
-    return getStart() <= range.getStart();
+    final int offset = getStart() - range.getStart();
+    if (offset == 0) {
+      return getLength() <= range.getLength(); // put smaller ranges first
+    }
+    return offset < 0;
   }
 
   static Ranged build(int start, int end) {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/EvidenceRedactionTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/EvidenceRedactionTest.groovy
@@ -70,11 +70,8 @@ class EvidenceRedactionTest extends DDSpecification {
     new StringValuePart(null)                                  | _
     new StringValuePart('')                                    | _
     new RedactedValuePart(null)                                | _
-    new RedactedValuePart('')                                  | _
     new TaintedValuePart(Mock(JsonAdapter), null, null, true)  | _
-    new TaintedValuePart(Mock(JsonAdapter), null, '', true)    | _
     new TaintedValuePart(Mock(JsonAdapter), null, null, false) | _
-    new TaintedValuePart(Mock(JsonAdapter), null, '', false)   | _
   }
 
   void 'test #suite'() {

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -1605,3 +1605,37 @@ suite:
           }
         ]
       }   
+
+  - type: 'VULNERABILITIES'
+    description: 'SQLi exploited'
+    input: >
+      [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "SELECT * FROM Users WHERE email = '' OR TRUE --' AND password = '81dc9bdb52d04dc20036dbd8313ed055' AND deletedAt IS NULL",
+            "ranges": [
+              { "start" : 35, "length" : 12, "source": { "origin": "http.request.parameter", "name": "email", "value": "' OR TRUE --" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "email", "value": "' OR TRUE --" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "SELECT * FROM Users WHERE email = '" },
+                { "redacted": true },
+                { "source": 0, "value": "' OR TRUE --" },
+                { "redacted": true }
+              ]
+            }
+          }
+        ]
+      }


### PR DESCRIPTION
# What Does This Do
When redacting SQL queries, an empty literal should be redacted as well or we would be leaking information.

# Motivation

# Additional Notes
