### PR TITLE
Add git command line client builder to GitInfoProvider

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -7,8 +7,6 @@ apply from: "$rootDir/gradle/java.gradle"
 apply from: "$rootDir/gradle/version.gradle"
 
 minimumBranchCoverage = 0.7
-minimumInstructionCoverage = 0.8
-
 excludedClassesCoverage += [
   "datadog.trace.civisibility.CiVisibilitySystem",
   "datadog.trace.civisibility.CiVisibilitySystem.1",
@@ -52,6 +50,8 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.events.TestDescriptor",
   "datadog.trace.civisibility.events.TestModuleDescriptor",
   "datadog.trace.civisibility.events.TestSuiteDescriptor",
+  "datadog.trace.civisibility.git.CILocalGitInfoBuilder",
+  "datadog.trace.civisibility.git.GitClientGitInfoBuilder",
   "datadog.trace.civisibility.git.GitObject",
   "datadog.trace.civisibility.git.tree.*",
   "datadog.trace.civisibility.ipc.ModuleExecutionResult",
@@ -68,6 +68,8 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.utils.ShellCommandExecutor",
   "datadog.trace.civisibility.utils.ShellCommandExecutor.OutputParser",
 ]
+minimumInstructionCoverage = 0.8
+
 
 dependencies {
   api deps.slf4j

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -219,7 +219,8 @@ public class CiVisibilitySystem {
 
     GitDataApi gitDataApi = new GitDataApi(backendApi);
     GitClient gitClient = new GitClient(repoRoot, "1 month ago", 1000, commandTimeoutMillis);
-    return new GitDataUploaderImpl(config, gitDataApi, gitClient, remoteName);
+    return new GitDataUploaderImpl(
+        config, gitDataApi, gitClient, GitInfoProvider.INSTANCE, repoRoot, remoteName);
   }
 
   private static ModuleExecutionSettingsFactory buildModuleExecutionSettingsFactory(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/CILocalGitInfoBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/CILocalGitInfoBuilder.java
@@ -2,14 +2,25 @@ package datadog.trace.civisibility.git;
 
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoBuilder;
+import datadog.trace.civisibility.git.tree.GitClient;
+import datadog.trace.util.Strings;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.Function;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CILocalGitInfoBuilder implements GitInfoBuilder {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(CILocalGitInfoBuilder.class);
+
+  private final Function<String, GitClient> gitClientFactory;
   private final String gitFolderName;
 
-  public CILocalGitInfoBuilder(String gitFolderName) {
+  public CILocalGitInfoBuilder(Function<String, GitClient> gitClientFactory, String gitFolderName) {
+    this.gitClientFactory = gitClientFactory;
     this.gitFolderName = gitFolderName;
   }
 
@@ -18,8 +29,25 @@ public class CILocalGitInfoBuilder implements GitInfoBuilder {
     if (repositoryPath == null) {
       return GitInfo.NOOP;
     }
-    return new LocalFSGitInfoExtractor()
-        .headCommit(Paths.get(repositoryPath, gitFolderName).toFile().getAbsolutePath());
+
+    Path gitPath = getGitPath(repositoryPath);
+    return new LocalFSGitInfoExtractor().headCommit(gitPath.toFile().getAbsolutePath());
+  }
+
+  private Path getGitPath(String repositoryPath) {
+    try {
+      GitClient gitClient = gitClientFactory.apply(repositoryPath);
+      String gitFolder = gitClient.getGitFolder();
+      if (Strings.isNotBlank(gitFolder)) {
+        Path gitFolderPath = Paths.get(gitFolder);
+        if (Files.exists(gitFolderPath)) {
+          return gitFolderPath;
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.debug("Error while getting Git folder in " + repositoryPath, e);
+    }
+    return Paths.get(repositoryPath, gitFolderName);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/GitClientGitInfoBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/GitClientGitInfoBuilder.java
@@ -1,0 +1,63 @@
+package datadog.trace.civisibility.git;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.git.CommitInfo;
+import datadog.trace.api.git.GitInfo;
+import datadog.trace.api.git.GitInfoBuilder;
+import datadog.trace.api.git.PersonInfo;
+import datadog.trace.civisibility.git.tree.GitClient;
+import java.util.List;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GitClientGitInfoBuilder implements GitInfoBuilder {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GitClientGitInfoBuilder.class);
+
+  private final Config config;
+  private final Function<String, GitClient> gitClientFactory;
+
+  public GitClientGitInfoBuilder(Config config, Function<String, GitClient> gitClientFactory) {
+    this.config = config;
+    this.gitClientFactory = gitClientFactory;
+  }
+
+  @Override
+  public GitInfo build(@Nullable String repositoryPath) {
+    GitClient gitClient = gitClientFactory.apply(repositoryPath);
+    try {
+      String remoteName = config.getCiVisibilityGitRemoteName();
+      String remoteUrl = gitClient.getRemoteUrl(remoteName);
+      String branch = gitClient.getCurrentBranch();
+      List<String> tags = gitClient.getTags(GitClient.HEAD);
+      String tag = !tags.isEmpty() ? tags.iterator().next() : null;
+
+      String currentCommitSha = gitClient.getSha(GitClient.HEAD);
+      String fullMessage = gitClient.getFullMessage(GitClient.HEAD);
+
+      String authorName = gitClient.getAuthorName(GitClient.HEAD);
+      String authorEmail = gitClient.getAuthorEmail(GitClient.HEAD);
+      String authorDate = gitClient.getAuthorDate(GitClient.HEAD);
+      PersonInfo author = new PersonInfo(authorName, authorEmail, authorDate);
+
+      String committerName = gitClient.getCommitterName(GitClient.HEAD);
+      String committerEmail = gitClient.getCommitterEmail(GitClient.HEAD);
+      String committerDate = gitClient.getCommitterDate(GitClient.HEAD);
+      PersonInfo committer = new PersonInfo(committerName, committerEmail, committerDate);
+
+      CommitInfo commitInfo = new CommitInfo(currentCommitSha, author, committer, fullMessage);
+      return new GitInfo(remoteUrl, branch, tag, commitInfo);
+
+    } catch (Exception e) {
+      LOGGER.debug("Error while getting Git data from " + repositoryPath, e);
+      return GitInfo.NOOP;
+    }
+  }
+
+  @Override
+  public int order() {
+    return 3;
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
@@ -3,6 +3,7 @@ package datadog.trace.civisibility.git.tree;
 import datadog.trace.civisibility.utils.IOUtils;
 import datadog.trace.civisibility.utils.ShellCommandExecutor;
 import datadog.trace.util.Strings;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -11,12 +12,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
 /** Client for fetching data and performing operations on a local Git repository. */
 public class GitClient {
+
+  public static final String HEAD = "HEAD";
 
   private static final String DD_TEMP_DIRECTORY_PREFIX = "dd-ci-vis-";
 
@@ -70,8 +74,7 @@ public class GitClient {
    *     finish
    */
   public void unshallow() throws IOException, TimeoutException, InterruptedException {
-    String headSha =
-        commandExecutor.executeCommand(IOUtils::readFully, "git", "rev-parse", "HEAD").trim();
+    String headSha = getSha(HEAD);
     String remote =
         commandExecutor
             .executeCommand(
@@ -98,6 +101,21 @@ public class GitClient {
   }
 
   /**
+   * Returns the absolute path of the .git directory.
+   *
+   * @return absolute path
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getGitFolder() throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "rev-parse", "--absolute-git-dir")
+        .trim();
+  }
+
+  /**
    * Returns URL of the remote with the given name
    *
    * @param remoteName Name of the remote
@@ -112,6 +130,178 @@ public class GitClient {
     return commandExecutor
         .executeCommand(
             IOUtils::readFully, "git", "config", "--get", "remote." + remoteName + ".url")
+        .trim();
+  }
+
+  /**
+   * Returns current branch, or an empty string if HEAD is not pointing to a branch
+   *
+   * @return current branch, or an empty string if HEAD is not pointing to a branch
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getCurrentBranch()
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "branch", "--show-current")
+        .trim();
+  }
+
+  /**
+   * Returns list of tags that provided commit points to
+   *
+   * @param commit Commit SHA or reference (HEAD, branch name, etc) to check
+   * @return list of tags that the commit is pointing to, or empty list if there are no such tags
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull List<String> getTags(String commit)
+      throws IOException, TimeoutException, InterruptedException {
+    try {
+      return commandExecutor.executeCommand(
+          IOUtils::readLines, "git", "describe", "--tags", "--exact-match", commit);
+    } catch (ShellCommandExecutor.ShellCommandFailedException e) {
+      // if provided commit is not tagged,
+      // command will fail because "--exact-match" is specified
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Returns SHA of the provided reference
+   *
+   * @param reference Reference (HEAD, branch name, etc) to check
+   * @return full SHA of the provided reference
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getSha(String reference)
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor.executeCommand(IOUtils::readFully, "git", "rev-parse", reference).trim();
+  }
+
+  /**
+   * Returns full message of the provided commit
+   *
+   * @param commit Commit SHA or reference (HEAD, branch name, etc) to check
+   * @return full message of the provided commit
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getFullMessage(String commit)
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "log", "-n", "1", "--format=%B", commit)
+        .trim();
+  }
+
+  /**
+   * Returns author name for the provided commit
+   *
+   * @param commit Commit SHA or reference (HEAD, branch name, etc) to check
+   * @return author name for the provided commit
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getAuthorName(String commit)
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "log", "-n", "1", "--format=%an", commit)
+        .trim();
+  }
+
+  /**
+   * Returns author email for the provided commit
+   *
+   * @param commit Commit SHA or reference (HEAD, branch name, etc) to check
+   * @return author email for the provided commit
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getAuthorEmail(String commit)
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "log", "-n", "1", "--format=%ae", commit)
+        .trim();
+  }
+
+  /**
+   * Returns author date in strict ISO 8601 format for the provided commit
+   *
+   * @param commit Commit SHA or reference (HEAD, branch name, etc) to check
+   * @return author date in strict ISO 8601 format
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getAuthorDate(String commit)
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "log", "-n", "1", "--format=%aI", commit)
+        .trim();
+  }
+
+  /**
+   * Returns committer name for the provided commit
+   *
+   * @param commit Commit SHA or reference (HEAD, branch name, etc) to check
+   * @return committer name for the provided commit
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getCommitterName(String commit)
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "log", "-n", "1", "--format=%cn", commit)
+        .trim();
+  }
+
+  /**
+   * Returns committer email for the provided commit
+   *
+   * @param commit Commit SHA or reference (HEAD, branch name, etc) to check
+   * @return committer email for the provided commit
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getCommitterEmail(String commit)
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "log", "-n", "1", "--format=%ce", commit)
+        .trim();
+  }
+
+  /**
+   * Returns committer date in strict ISO 8601 format for the provided commit
+   *
+   * @param commit Commit SHA or reference (HEAD, branch name, etc) to check
+   * @return committer date in strict ISO 8601 format
+   * @throws IOException If an error was encountered while writing command input or reading output
+   * @throws TimeoutException If timeout was reached while waiting for Git command to finish
+   * @throws InterruptedException If current thread was interrupted while waiting for Git command to
+   *     finish
+   */
+  public @NonNull String getCommitterDate(String commit)
+      throws IOException, TimeoutException, InterruptedException {
+    return commandExecutor
+        .executeCommand(IOUtils::readFully, "git", "log", "-n", "1", "--format=%cI", commit)
         .trim();
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
@@ -5,8 +5,6 @@ import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.civisibility.utils.FileUtils;
 import datadog.trace.util.AgentThreadFactory;
-import datadog.trace.util.Strings;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -85,7 +83,8 @@ public class GitDataUploaderImpl implements GitDataUploader {
         gitClient.unshallow();
       }
 
-      String remoteUrl = getRemoteUrl();
+      GitInfo gitInfo = gitInfoProvider.getGitInfo(repoRoot);
+      String remoteUrl = gitInfo.getRepositoryURL();
       List<String> latestCommits = gitClient.getLatestCommits();
       if (latestCommits.isEmpty()) {
         LOGGER.debug("No commits in the last month");
@@ -135,16 +134,6 @@ public class GitDataUploaderImpl implements GitDataUploader {
       callback.completeExceptionally(e);
     } finally {
       Runtime.getRuntime().removeShutdownHook(uploadFinishedShutdownHook);
-    }
-  }
-
-  private String getRemoteUrl() throws IOException, TimeoutException, InterruptedException {
-    GitInfo gitInfo = gitInfoProvider.getGitInfo(repoRoot);
-    String repositoryURL = gitInfo.getRepositoryURL();
-    if (Strings.isNotBlank(repositoryURL)) {
-      return repositoryURL;
-    } else {
-      return gitClient.getRemoteUrl(remoteName);
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/IOUtils.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/IOUtils.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.utils;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -22,11 +23,11 @@ public abstract class IOUtils {
 
   private IOUtils() {}
 
-  public static String readFully(InputStream input) throws IOException {
+  public static @NonNull String readFully(InputStream input) throws IOException {
     return readFully(input, Charset.defaultCharset());
   }
 
-  public static String readFully(InputStream input, Charset charset) throws IOException {
+  public static @NonNull String readFully(InputStream input, Charset charset) throws IOException {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     readFully(input, output);
     return new String(output.toByteArray(), charset);
@@ -40,17 +41,17 @@ public abstract class IOUtils {
     }
   }
 
-  public static List<String> readLines(final InputStream input) throws IOException {
+  public static @NonNull List<String> readLines(final InputStream input) throws IOException {
     return readLines(input, Charset.defaultCharset());
   }
 
-  public static List<String> readLines(final InputStream input, final Charset charset)
+  public static @NonNull List<String> readLines(final InputStream input, final Charset charset)
       throws IOException {
     final InputStreamReader reader = new InputStreamReader(input, charset);
     return readLines(reader);
   }
 
-  public static List<String> readLines(final Reader input) throws IOException {
+  public static @NonNull List<String> readLines(final Reader input) throws IOException {
     final BufferedReader reader = new BufferedReader(input, DEFAULT_BUFFER_SIZE);
     final List<String> list = new ArrayList<>();
     String line = reader.readLine();

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/ShellCommandExecutor.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/ShellCommandExecutor.java
@@ -115,7 +115,7 @@ public class ShellCommandExecutor {
       if (p.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)) {
         int exitValue = p.exitValue();
         if (exitValue != 0) {
-          throw new IOException(
+          throw new ShellCommandFailedException(
               "Command '"
                   + Strings.join(" ", command)
                   + "' failed with exit code "
@@ -192,5 +192,11 @@ public class ShellCommandExecutor {
     OutputParser<Void> IGNORE = is -> null;
 
     T parse(InputStream inputStream) throws IOException;
+  }
+
+  public static final class ShellCommandFailedException extends IOException {
+    public ShellCommandFailedException(String message) {
+      super(message);
+    }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/CITagsProviderTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/CITagsProviderTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.api.git.UserSuppliedGitInfoBuilder
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.civisibility.git.CILocalGitInfoBuilder
 import datadog.trace.civisibility.git.CIProviderGitInfoBuilder
+import datadog.trace.civisibility.git.tree.GitClient
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
@@ -170,7 +171,7 @@ abstract class CITagsProviderTest extends Specification {
     GitInfoProvider gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(new UserSuppliedGitInfoBuilder())
     gitInfoProvider.registerGitInfoBuilder(new CIProviderGitInfoBuilder())
-    gitInfoProvider.registerGitInfoBuilder(new CILocalGitInfoBuilder(GIT_FOLDER_FOR_TESTS))
+    gitInfoProvider.registerGitInfoBuilder(new CILocalGitInfoBuilder({ Stub(GitClient) }, GIT_FOLDER_FOR_TESTS))
     return new CITagsProvider(gitInfoProvider)
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/UnknownCIInfoTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/UnknownCIInfoTest.groovy
@@ -6,12 +6,13 @@ import datadog.trace.api.git.UserSuppliedGitInfoBuilder
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.civisibility.git.CILocalGitInfoBuilder
 import datadog.trace.civisibility.git.CIProviderGitInfoBuilder
+import datadog.trace.civisibility.git.tree.GitClient
 
 import java.nio.file.Paths
 
 class UnknownCIInfoTest extends CITagsProviderTest {
 
-  def workspaceForTests = Paths.get(getClass().getClassLoader().getResource(CITagsProviderTest.CI_WORKSPACE_PATH_FOR_TESTS).toURI())
+  def workspaceForTests = Paths.get(getClass().getClassLoader().getResource(CI_WORKSPACE_PATH_FOR_TESTS).toURI())
 
   @Override
   String getProviderName() {
@@ -58,7 +59,7 @@ class UnknownCIInfoTest extends CITagsProviderTest {
     GitInfoProvider gitInfoProvider = new GitInfoProvider()
     gitInfoProvider.registerGitInfoBuilder(new UserSuppliedGitInfoBuilder())
     gitInfoProvider.registerGitInfoBuilder(new CIProviderGitInfoBuilder())
-    gitInfoProvider.registerGitInfoBuilder(new CILocalGitInfoBuilder("this-target-folder-does-not-exist"))
+    gitInfoProvider.registerGitInfoBuilder(new CILocalGitInfoBuilder({ Stub(GitClient) }, "this-target-folder-does-not-exist"))
     CIProviderInfoFactory ciProviderInfoFactory = new CIProviderInfoFactory(Config.get(), "this-target-folder-does-not-exist")
 
     def ciProviderInfo = ciProviderInfoFactory.createCIProviderInfo(workspaceForTests)

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/CILocalGitInfoBuilderTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/CILocalGitInfoBuilderTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.civisibility.git
 
-
+import datadog.trace.civisibility.git.tree.GitClient
 import spock.lang.Specification
 
 import java.nio.file.Paths
@@ -9,7 +9,8 @@ class CILocalGitInfoBuilderTest extends Specification {
 
   def "returns empty git info when repository path is not specified"() {
     setup:
-    def builder = new CILocalGitInfoBuilder(".git")
+    def gitClientFactory = { Stub(GitClient) }
+    def builder = new CILocalGitInfoBuilder(gitClientFactory,".git")
 
     when:
     def gitInfo = builder.build(null)
@@ -21,7 +22,8 @@ class CILocalGitInfoBuilderTest extends Specification {
 
   def "parses git info"() {
     setup:
-    def builder = new CILocalGitInfoBuilder("git_folder_for_tests")
+    def gitClientFactory = { Stub(GitClient) }
+    def builder = new CILocalGitInfoBuilder(gitClientFactory, "git_folder_for_tests")
     def workspace = resolve("ci/ci_workspace_for_tests")
 
     when:

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/GitClientGitInfoBuilderTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/GitClientGitInfoBuilderTest.groovy
@@ -1,0 +1,66 @@
+package datadog.trace.civisibility.git
+
+import datadog.trace.api.Config
+import datadog.trace.civisibility.git.tree.GitClient
+import datadog.trace.civisibility.utils.IOUtils
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.function.Function
+
+class GitClientGitInfoBuilderTest extends Specification {
+
+  private static final int GIT_COMMAND_TIMEOUT_MILLIS = 10_000
+
+  private static final String GIT_FOLDER = ".git"
+
+  @TempDir
+  private Path tempDir
+
+  def "test git client info builder"() {
+    given:
+    givenGitRepo()
+
+    def config = Stub(Config)
+    config.getCiVisibilityGitRemoteName() >> "origin"
+
+    Function<String, GitClient> gitClientFactory = {
+      new GitClient(it, "25 years ago", 10, GIT_COMMAND_TIMEOUT_MILLIS)
+    }
+
+    def infoBuilder = new GitClientGitInfoBuilder(config, gitClientFactory)
+
+    when:
+    def gitInfo = infoBuilder.build(tempDir.toAbsolutePath().toString())
+
+    then:
+    gitInfo.repositoryURL == "git@github.com:DataDog/dd-trace-dotnet.git"
+    gitInfo.branch == "master"
+    gitInfo.tag == null
+    gitInfo.commit.sha == "5b6f3a6dab5972d73a56dff737bd08d995255c08"
+    gitInfo.commit.author.name == "Tony Redondo"
+    gitInfo.commit.author.email == "tony.redondo@datadoghq.com"
+    gitInfo.commit.author.iso8601Date == "2021-02-26T19:32:13+01:00"
+    gitInfo.commit.committer.name == "GitHub"
+    gitInfo.commit.committer.email == "noreply@github.com"
+    gitInfo.commit.committer.iso8601Date == "2021-02-26T19:32:13+01:00"
+    gitInfo.commit.fullMessage == "Adding Git information to test spans (#1242)\n\n" +
+      "* Initial basic GitInfo implementation.\r\n\r\n" +
+      "* Adds Author, Committer and Message git parser.\r\n\r\n" +
+      "* Changes based on the review."
+  }
+
+  private void givenGitRepo() {
+    givenGitRepo("ci/git/with_pack/git")
+  }
+
+  private void givenGitRepo(String resourceName) {
+    def gitFolder = Paths.get(getClass().getClassLoader().getResource(resourceName).toURI())
+    def tempGitFolder = tempDir.resolve(GIT_FOLDER)
+    Files.createDirectories(tempGitFolder)
+    IOUtils.copyFolder(gitFolder, tempGitFolder)
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
@@ -14,6 +14,8 @@ class GitClientTest extends Specification {
 
   private static final int GIT_COMMAND_TIMEOUT_MILLIS = 10_000
 
+  private static final String GIT_FOLDER = ".git"
+
   @TempDir
   private Path tempDir
 
@@ -64,6 +66,18 @@ class GitClientTest extends Specification {
     commits.size() == 10
   }
 
+  def "test get git folder"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def folder = gitClient.getGitFolder()
+
+    then:
+    folder == tempDir.resolve(GIT_FOLDER).toRealPath().toString()
+  }
+
   def "test get remote url"() {
     given:
     givenGitRepo()
@@ -74,6 +88,129 @@ class GitClientTest extends Specification {
 
     then:
     remoteUrl == "git@github.com:DataDog/dd-trace-dotnet.git"
+  }
+
+  def "test get current branch"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def branch = gitClient.getCurrentBranch()
+
+    then:
+    branch == "master"
+  }
+
+  def "test get tags"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def tags = gitClient.getTags(GitClient.HEAD)
+
+    then:
+    tags.empty
+  }
+
+  def "test get sha"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def sha = gitClient.getSha(GitClient.HEAD)
+
+    then:
+    sha == "5b6f3a6dab5972d73a56dff737bd08d995255c08"
+  }
+
+  def "test get full message"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def message = gitClient.getFullMessage(GitClient.HEAD)
+
+    then:
+    message == "Adding Git information to test spans (#1242)\n\n" +
+      "* Initial basic GitInfo implementation.\r\n\r\n" +
+      "* Adds Author, Committer and Message git parser.\r\n\r\n" +
+      "* Changes based on the review."
+  }
+
+  def "test get author name"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def authorName = gitClient.getAuthorName(GitClient.HEAD)
+
+    then:
+    authorName == "Tony Redondo"
+  }
+
+  def "test get author email"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def authorEmail = gitClient.getAuthorEmail(GitClient.HEAD)
+
+    then:
+    authorEmail == "tony.redondo@datadoghq.com"
+  }
+
+  def "test get author date"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def authorDate = gitClient.getAuthorDate(GitClient.HEAD)
+
+    then:
+    authorDate == "2021-02-26T19:32:13+01:00"
+  }
+
+  def "test get committer name"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def authorName = gitClient.getCommitterName(GitClient.HEAD)
+
+    then:
+    authorName == "GitHub"
+  }
+
+  def "test get committer email"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def authorEmail = gitClient.getCommitterEmail(GitClient.HEAD)
+
+    then:
+    authorEmail == "noreply@github.com"
+  }
+
+  def "test get committer date"() {
+    given:
+    givenGitRepo()
+
+    when:
+    def gitClient = givenGitClient()
+    def authorDate = gitClient.getCommitterDate(GitClient.HEAD)
+
+    then:
+    authorDate == "2021-02-26T19:32:13+01:00"
   }
 
   def "test get latest commits"() {
@@ -154,7 +291,7 @@ class GitClientTest extends Specification {
 
   private void givenGitRepo(String resourceName) {
     def gitFolder = Paths.get(getClass().getClassLoader().getResource(resourceName).toURI())
-    def tempGitFolder = tempDir.resolve(".git")
+    def tempGitFolder = tempDir.resolve(GIT_FOLDER)
     Files.createDirectories(tempGitFolder)
     IOUtils.copyFolder(gitFolder, tempGitFolder)
   }

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -81,6 +81,7 @@ excludedClassesCoverage += [
   "datadog.trace.api.civisibility.events.BuildEventsHandler.ModuleInfo",
   // POJO
   "datadog.trace.api.git.GitInfo",
+  "datadog.trace.api.git.GitInfoProvider",
   // POJO
   "datadog.trace.api.git.PersonInfo",
   // POJO

--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
@@ -8,9 +8,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 public class GitInfoProvider {
@@ -46,59 +47,95 @@ public class GitInfoProvider {
   }
 
   private GitInfo buildGitInfo(String repositoryPath) {
-    List<GitInfo> infos =
-        builders.stream()
-            .map(builder -> builder.build(repositoryPath))
-            .collect(Collectors.toList());
-
-    String commitSha = firstNonBlank(infos, gi -> gi.getCommit().getSha());
+    Evaluator evaluator = new Evaluator(repositoryPath, builders);
     return new GitInfo(
-        firstNonBlank(infos, gi -> GitUtils.filterSensitiveInfo(gi.getRepositoryURL())),
-        firstNonBlank(infos, GitInfo::getBranch),
-        firstNonBlank(infos, GitInfo::getTag),
+        evaluator.firstNonBlank(gi -> GitUtils.filterSensitiveInfo(gi.getRepositoryURL())),
+        evaluator.firstNonBlank(GitInfo::getBranch),
+        evaluator.firstNonBlank(GitInfo::getTag),
         new CommitInfo(
-            commitSha,
+            evaluator.firstNonBlank(gi1 -> gi1.getCommit().getSha()),
             new PersonInfo(
-                firstNonBlankWithMatchingCommit(
-                    infos, commitSha, gi -> gi.getCommit().getAuthor().getName()),
-                firstNonBlankWithMatchingCommit(
-                    infos, commitSha, gi -> gi.getCommit().getAuthor().getEmail()),
-                firstNonBlankWithMatchingCommit(
-                    infos, commitSha, gi -> gi.getCommit().getAuthor().getIso8601Date())),
+                evaluator.firstNonBlankWithMatchingCommit(
+                    gi -> gi.getCommit().getAuthor().getName()),
+                evaluator.firstNonBlankWithMatchingCommit(
+                    gi -> gi.getCommit().getAuthor().getEmail()),
+                evaluator.firstNonBlankWithMatchingCommit(
+                    gi -> gi.getCommit().getAuthor().getIso8601Date())),
             new PersonInfo(
-                firstNonBlankWithMatchingCommit(
-                    infos, commitSha, gi -> gi.getCommit().getCommitter().getName()),
-                firstNonBlankWithMatchingCommit(
-                    infos, commitSha, gi -> gi.getCommit().getCommitter().getEmail()),
-                firstNonBlankWithMatchingCommit(
-                    infos, commitSha, gi -> gi.getCommit().getCommitter().getIso8601Date())),
-            firstNonBlankWithMatchingCommit(
-                infos, commitSha, gi -> gi.getCommit().getFullMessage())));
+                evaluator.firstNonBlankWithMatchingCommit(
+                    gi -> gi.getCommit().getCommitter().getName()),
+                evaluator.firstNonBlankWithMatchingCommit(
+                    gi -> gi.getCommit().getCommitter().getEmail()),
+                evaluator.firstNonBlankWithMatchingCommit(
+                    gi -> gi.getCommit().getCommitter().getIso8601Date())),
+            evaluator.firstNonBlankWithMatchingCommit(gi -> gi.getCommit().getFullMessage())));
   }
 
-  private static String firstNonBlank(
-      Iterable<GitInfo> gitInfos, Function<GitInfo, String> function) {
-    for (GitInfo gitInfo : gitInfos) {
-      String result = function.apply(gitInfo);
-      if (Strings.isNotBlank(result)) {
-        return result;
-      }
-    }
-    return null;
-  }
+  /**
+   * Uses provided GitInfoBuilder instances to get GitInfo data.
+   *
+   * <p>Provided builders are sorted according to priority: those builders that are first in the
+   * list have higher priority.
+   *
+   * <p>GitInfo is evaluated at most once for each builder, and the evaluation is lazy: if all
+   * required info can be retrieved from a higher-priority builder, those with lower priority will
+   * not be evaluated.
+   */
+  private static final class Evaluator {
+    private final String repositoryPath;
+    private final Map<GitInfoBuilder, GitInfo> infos;
 
-  private static String firstNonBlankWithMatchingCommit(
-      Iterable<GitInfo> gitInfos, String commitSha, Function<GitInfo, String> function) {
-    for (GitInfo gitInfo : gitInfos) {
-      if (commitSha != null && !commitSha.equalsIgnoreCase(gitInfo.getCommit().getSha())) {
-        continue;
-      }
-      String result = function.apply(gitInfo);
-      if (Strings.isNotBlank(result)) {
-        return result;
+    private Evaluator(String repositoryPath, Collection<GitInfoBuilder> builders) {
+      this.repositoryPath = repositoryPath;
+      this.infos = new LinkedHashMap<>();
+      for (GitInfoBuilder builder : builders) {
+        infos.put(builder, null);
       }
     }
-    return null;
+
+    private String firstNonBlank(Function<GitInfo, String> function) {
+      return firstNonBlank(function, false);
+    }
+
+    /**
+     * If a builder with a higher priority has commit SHA that differs from that of a builder with
+     * lower priority, lower-priority info will be ignored.
+     */
+    private String firstNonBlankWithMatchingCommit(Function<GitInfo, String> function) {
+      return firstNonBlank(function, true);
+    }
+
+    private String firstNonBlank(Function<GitInfo, String> function, boolean checkShaIntegrity) {
+      String commitSha = null;
+      for (Map.Entry<GitInfoBuilder, GitInfo> e : infos.entrySet()) {
+        GitInfo info = e.getValue();
+        if (info == null) {
+          GitInfoBuilder builder = e.getKey();
+          info = builder.build(repositoryPath);
+          e.setValue(info);
+        }
+
+        if (checkShaIntegrity) {
+          CommitInfo currentCommit = info.getCommit();
+          String currentCommitSha = currentCommit != null ? currentCommit.getSha() : null;
+          if (Strings.isNotBlank(currentCommitSha)) {
+            if (commitSha == null) {
+              commitSha = currentCommitSha;
+            } else if (!commitSha.equals(currentCommitSha)) {
+              // We already have a commit SHA from source that has higher priority.
+              // Commit SHA from current source is different, so we have to skip it
+              continue;
+            }
+          }
+        }
+
+        String result = function.apply(info);
+        if (Strings.isNotBlank(result)) {
+          return result;
+        }
+      }
+      return null;
+    }
   }
 
   public synchronized void registerGitInfoBuilder(GitInfoBuilder builder) {
@@ -106,6 +143,10 @@ public class GitInfoProvider {
     updatedBuilders.add(builder);
     updatedBuilders.sort(Comparator.comparingInt(GitInfoBuilder::order));
     builders = updatedBuilders;
+    gitInfoCache.clear();
+  }
+
+  public synchronized void invalidateCache() {
     gitInfoCache.clear();
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/git/GitInfoProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/git/GitInfoProviderTest.groovy
@@ -238,6 +238,27 @@ class GitInfoProviderTest extends Specification {
     actualGitInfo.commit.committer.iso8601Date == null
   }
 
+  def "test ignores remote URLs starting with file protocol"() {
+    setup:
+    def gitInfoBuilderA = givenABuilderReturning(
+      new GitInfo("file://uselessUrl", null, null, new CommitInfo(null)), 1
+      )
+
+    def gitInfoBuilderB = givenABuilderReturning(
+      new GitInfo("http://usefulUrl", null, null, new CommitInfo(null)), 2
+      )
+
+    def gitInfoProvider = new GitInfoProvider()
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderA)
+    gitInfoProvider.registerGitInfoBuilder(gitInfoBuilderB)
+
+    when:
+    def actualGitInfo = gitInfoProvider.getGitInfo(REPO_PATH)
+
+    then:
+    actualGitInfo.repositoryURL == "http://usefulUrl"
+  }
+
   private GitInfoBuilder givenABuilderReturning(GitInfo gitInfo) {
     givenABuilderReturning(gitInfo, 1)
   }


### PR DESCRIPTION
# What Does This Do
Adds a new `GitInfoBuilder` instance to `GitInfoProvider`.
The new instance fetches git data using shell commands.

Also repository URL in Git data upload now uses `GitInfoProvider` instead of directly invoking the shell command.

# Motivation
Previously Git data upload relied solely on executing a shell command to obtain Git remote URL, while the other logic that used Git remote URL extracted it from a variety of sources: CI provider or user-supplied environment variables, locally available `.git` folder, etc.
This change makes Git data upload consistent with the other places in the code that use Git info.

In addition to that, the other places can now benefit from info fetched with shell commands, in case it cannot be obtained from other sources.

# Additional notes
The new shell-command-based `GitInfoBuilder` has lower priority than the other existing sources.