### PR TITLE
Exclude org.mockito package from CI Visibility code coverage by default

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -115,7 +115,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_CIVISIBILITY_COMPILER_PLUGIN_AUTO_CONFIGURATION_ENABLED = true;
   static final String DEFAULT_CIVISIBILITY_COMPILER_PLUGIN_VERSION = "0.1.6";
   static final String DEFAULT_CIVISIBILITY_JACOCO_PLUGIN_EXCLUDES =
-      "datadog.trace.*:org.apache.commons.*";
+      "datadog.trace.*:org.apache.commons.*:org.mockito.*";
   static final boolean DEFAULT_CIVISIBILITY_GIT_UPLOAD_ENABLED = true;
   static final boolean DEFAULT_CIVISIBILITY_GIT_UNSHALLOW_ENABLED = true;
   static final long DEFAULT_CIVISIBILITY_GIT_COMMAND_TIMEOUT_MILLIS = 30_000;


### PR DESCRIPTION
# What Does This Do
Excludes `org.mockito` package from CI Visibility code coverage. 
When customer uses Jacoco injected by tracer, there is a list of packages that are by default excluded from Jacoco instrumentation.
This change extends this list with `org.mockito`.

# Motivation
Instrumenting classes in `org.mockito` may cause `StackOverflowError` - some of the tracer code that handles coverage probe activations uses certain classes (`ConcurrentHashMap` in particular) that are transformed by Mockito.
As the result, activating a coverage probe in a Mockito class leads to invoking a Mockito class which leads to activating a coverage probe.
This continues until method execution stack is overflown.
