### PR TITLE
Set concrete types for the response instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/servlet-common/src/test/groovy/HttpServletResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet-common/src/test/groovy/HttpServletResponseInstrumentationTest.groovy
@@ -75,7 +75,7 @@ class HttpServletResponseInstrumentationTest extends AgentTestRunner {
     final response = new DummyResponse()
 
     when:
-    response.addCookie(null)
+    response.addCookie((Cookie) null)
 
     then:
     0 * _
@@ -196,6 +196,31 @@ class HttpServletResponseInstrumentationTest extends AgentTestRunner {
     then:
     noExceptionThrown()
     1 * module.taintIfInputIsTainted(_, "http://dummy.url.com")
+    0 * _
+  }
+
+  void 'test instrumentation with unknown types'() {
+    setup:
+    final module = Mock(HttpResponseHeaderModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addCookie(new DummyResponse.CustomCookie())
+
+    then:
+    0 * _
+
+    when:
+    response.addHeader(new DummyResponse.CustomHeaderName(), "value")
+
+    then:
+    0 * _
+
+    when:
+    response.setHeader(new DummyResponse.CustomHeaderName(), "value")
+
+    then:
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/servlet-common/src/test/java/foo/bar/DummyResponse.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/test/java/foo/bar/DummyResponse.java
@@ -11,6 +11,8 @@ public class DummyResponse implements HttpServletResponse {
   @Override
   public void addCookie(Cookie cookie) {}
 
+  public void addCookie(CustomCookie cookie) {}
+
   @Override
   public boolean containsHeader(String name) {
     return false;
@@ -54,8 +56,12 @@ public class DummyResponse implements HttpServletResponse {
   @Override
   public void setHeader(String name, String value) {}
 
+  public void setHeader(CustomHeaderName name, String value) {}
+
   @Override
   public void addHeader(String name, String value) {}
+
+  public void addHeader(CustomHeaderName name, String value) {}
 
   @Override
   public void setIntHeader(String name, int value) {}
@@ -119,4 +125,8 @@ public class DummyResponse implements HttpServletResponse {
   public Locale getLocale() {
     return null;
   }
+
+  public static class CustomCookie {}
+
+  public static class CustomHeaderName {}
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
@@ -7,6 +7,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
@@ -41,9 +42,14 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
-    transformation.applyAdvice(named("addCookie"), getClass().getName() + "$AddCookieAdvice");
     transformation.applyAdvice(
-        namedOneOf("setHeader", "addHeader"), getClass().getName() + "$AddHeaderAdvice");
+        named("addCookie")
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("jakarta.servlet.http.Cookie"))),
+        getClass().getName() + "$AddCookieAdvice");
+    transformation.applyAdvice(
+        namedOneOf("setHeader", "addHeader").and(takesArguments(String.class, String.class)),
+        getClass().getName() + "$AddHeaderAdvice");
     transformation.applyAdvice(
         namedOneOf("encodeRedirectURL", "encodeURL")
             .and(takesArgument(0, String.class))

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletResponseInstrumentationTest.groovy
@@ -82,7 +82,7 @@ class JakartaHttpServletResponseInstrumentationTest extends AgentTestRunner {
     final response = new DummyResponse()
 
     when:
-    response.addCookie(null)
+    response.addCookie((Cookie) null)
 
     then:
     0 * _
@@ -108,7 +108,7 @@ class JakartaHttpServletResponseInstrumentationTest extends AgentTestRunner {
     final response = new DummyResponse()
 
     when:
-    response.addHeader(null, null)
+    response.addHeader((String) null, null)
 
     then:
     noExceptionThrown()
@@ -135,7 +135,7 @@ class JakartaHttpServletResponseInstrumentationTest extends AgentTestRunner {
     final response = new DummyResponse()
 
     when:
-    response.setHeader(null, null)
+    response.setHeader((String) null, null)
 
     then:
     noExceptionThrown()
@@ -228,6 +228,31 @@ class JakartaHttpServletResponseInstrumentationTest extends AgentTestRunner {
     then:
     noExceptionThrown()
     1 * module.taintIfInputIsTainted(_, "http://dummy.url.com")
+    0 * _
+  }
+
+  void 'test instrumentation with unknown types'() {
+    setup:
+    final module = Mock(HttpResponseHeaderModule)
+    InstrumentationBridge.registerIastModule(module)
+    final response = new DummyResponse()
+
+    when:
+    response.addCookie(new DummyResponse.CustomCookie())
+
+    then:
+    0 * _
+
+    when:
+    response.addHeader(new DummyResponse.CustomHeaderName(), "value")
+
+    then:
+    0 * _
+
+    when:
+    response.setHeader(new DummyResponse.CustomHeaderName(), "value")
+
+    then:
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/DummyResponse.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/DummyResponse.java
@@ -12,6 +12,8 @@ public class DummyResponse implements HttpServletResponse {
   @Override
   public void addCookie(Cookie cookie) {}
 
+  public void addCookie(CustomCookie cookie) {}
+
   @Override
   public boolean containsHeader(String name) {
     return false;
@@ -55,8 +57,12 @@ public class DummyResponse implements HttpServletResponse {
   @Override
   public void setHeader(String name, String value) {}
 
+  public void setHeader(CustomHeaderName name, String value) {}
+
   @Override
   public void addHeader(String name, String value) {}
+
+  public void addHeader(CustomHeaderName name, String value) {}
 
   @Override
   public void setIntHeader(String name, int value) {}
@@ -151,4 +157,8 @@ public class DummyResponse implements HttpServletResponse {
   public Locale getLocale() {
     return null;
   }
+
+  public static class CustomCookie {}
+
+  public static class CustomHeaderName {}
 }


### PR DESCRIPTION
# What Does This Do
Adds concrete types for the response instrumentation methods

# Motivation
Instrumentation errors lead to logged exceptions in Undertow and Jetty.

# Additional Notes
