### PR TITLE
Update ddprof to 0.71.0

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -14,7 +14,6 @@ import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallContextF
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.getWallInterval;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isAllocationProfilingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isCpuProfilerEnabled;
-import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isJmethodIdCacheEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isLiveHeapSizeTrackingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isMemoryLeakProfilingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isSpanNameContextAttributeEnabled;
@@ -144,6 +143,7 @@ public final class DatadogProfiler {
     try {
       profiler =
           JavaProfiler.getInstance(
+              configProvider.getString(ProfilingConfig.PROFILING_DATADOG_PROFILER_LIBPATH),
               configProvider.getString(
                   ProfilingConfig.PROFILING_DATADOG_PROFILER_SCRATCH,
                   ProfilingConfig.PROFILING_DATADOG_PROFILER_SCRATCH_DEFAULT));
@@ -342,10 +342,6 @@ public final class DatadogProfiler {
       if (profilingModes.contains(MEMLEAK)) {
         cmd.append(isLiveHeapSizeTrackingEnabled(configProvider) ? 'L' : 'l');
       }
-    }
-    if (isJmethodIdCacheEnabled()) {
-      // element retention is 30 chunk rotations, will be checked only if >10000 elements in cache
-      cmd.append(",minfocache=30:1000");
     }
     String cmdString = cmd.toString();
     log.debug("Datadog profiler command line: {}", cmdString);

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -40,8 +40,6 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_WALL_INTERVAL_DEFAULT;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_JMETHODID_CACHE_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_JMETHODID_CACHE_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ULTRA_MINIMAL;
@@ -280,15 +278,6 @@ public class DatadogProfilerConfig {
 
   public static boolean isSpanNameContextAttributeEnabled(ConfigProvider configProvider) {
     return configProvider.getBoolean(PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED, true);
-  }
-
-  public static boolean isJmethodIdCacheEnabled() {
-    return isJmethodIdCacheEnabled(ConfigProvider.getInstance());
-  }
-
-  public static boolean isJmethodIdCacheEnabled(ConfigProvider configProvider) {
-    return configProvider.getBoolean(
-        PROFILING_JMETHODID_CACHE_ENABLED, PROFILING_JMETHODID_CACHE_ENABLED_DEFAULT);
   }
 
   public static String getString(ConfigProvider configProvider, String key, String defaultValue) {

--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/SmokeTestUtils.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/SmokeTestUtils.java
@@ -35,10 +35,6 @@ final class SmokeTestUtils {
                 "-Ddd.profiling.ddprof.enabled=true",
                 "-Ddd." + ProfilingConfig.PROFILING_AUXILIARY_TYPE + "=async",
                 "-Ddd."
-                    + ProfilingConfig.PROFILING_DATADOG_PROFILER_LIBPATH
-                    + "="
-                    + System.getenv("TEST_LIBASYNC"),
-                "-Ddd."
                     + ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_INTERVAL
                     + "="
                     + cpuSamplerIntervalMs
@@ -67,6 +63,13 @@ final class SmokeTestUtils {
                 "-cp",
                 profilingShadowJar(),
                 targetClass));
+    if (System.getenv("TEST_LIBASYNC") != null) {
+      command.add(
+          "-Ddd."
+              + ProfilingConfig.PROFILING_DATADOG_PROFILER_LIBPATH
+              + "="
+              + System.getenv("TEST_LIBASYNC"));
+    }
     command.addAll(Arrays.asList(args));
     final ProcessBuilder processBuilder = new ProcessBuilder(command);
     processBuilder.directory(new File(buildDirectory()));

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -176,10 +176,6 @@ public final class ProfilingConfig {
 
   public static final long PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS_DEFAULT = 50;
 
-  public static final String PROFILING_JMETHODID_CACHE_ENABLED =
-      "profiling.experimental.jmethodid_cache.enabled";
-  public static final boolean PROFILING_JMETHODID_CACHE_ENABLED_DEFAULT = false;
-
   public static final String PROFILING_ULTRA_MINIMAL = "profiling.ultra.minimal";
 
   private ProfilingConfig() {}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.70.1",
+    ddprof        : "0.71.0",
     asm           : "9.5",
     cafe_crypto   : "0.1.0"
   ]


### PR DESCRIPTION
# What Does This Do
Updates the ddprof dependendcy.
The new version dropped the jmethodid cache because it is not really possible to implement it in a performant way.
Instead of cache a 'deep' jmethodId check function was added which seems to be preventing all the (so far) observed crashes related to jmethodIDs.

# Motivation
See https://github.com/DataDog/java-profiler/releases/tag/v_0.71.0

# Additional Notes
