### PR TITLE
Ensure OpenTelemetry spans are not modifiable when finished

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
@@ -39,7 +39,9 @@ public class OtelSpan implements Span {
 
   @Override
   public <T> Span setAttribute(AttributeKey<T> key, T value) {
-    this.delegate.setTag(key.getKey(), value);
+    if (this.recording) {
+      this.delegate.setTag(key.getKey(), value);
+    }
     return this;
   }
 
@@ -57,13 +59,15 @@ public class OtelSpan implements Span {
 
   @Override
   public Span setStatus(StatusCode statusCode, String description) {
-    if (this.statusCode == UNSET) {
-      this.statusCode = statusCode;
-      this.delegate.setError(statusCode == ERROR);
-      this.delegate.setErrorMessage(statusCode == ERROR ? description : null);
-    } else if (this.statusCode == ERROR && statusCode == OK) {
-      this.delegate.setError(false);
-      this.delegate.setErrorMessage(null);
+    if (this.recording) {
+      if (this.statusCode == UNSET) {
+        this.statusCode = statusCode;
+        this.delegate.setError(statusCode == ERROR);
+        this.delegate.setErrorMessage(statusCode == ERROR ? description : null);
+      } else if (this.statusCode == ERROR && statusCode == OK) {
+        this.delegate.setError(false);
+        this.delegate.setErrorMessage(null);
+      }
     }
     return this;
   }
@@ -76,7 +80,9 @@ public class OtelSpan implements Span {
 
   @Override
   public Span updateName(String name) {
-    this.delegate.setOperationName(name);
+    if (this.recording) {
+      this.delegate.setOperationName(name);
+    }
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -341,4 +341,33 @@ class OpenTelemetry14Test extends AgentTestRunner {
       }
     }
   }
+
+  def "test span update after end"() {
+    setup:
+    def builder = tracer.spanBuilder("some-name")
+    def result = builder.startSpan()
+
+    when:
+    result.setAttribute("string", "value")
+    result.setStatus(ERROR)
+    result.end()
+    result.updateName("other-name")
+    result.setAttribute("string", "other-value")
+    result.setStatus(OK)
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          parent()
+          operationName "some-name"
+          errored true
+          tags {
+            defaultTags()
+            "string" "value"
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
# What Does This Do

The OpenTelemetry spans should not be modifiable when finished.

# Motivation

[Specification reference](https://opentelemetry.io/docs/specs/otel/trace/api/#isrecording)

# Additional Notes
