### PR TITLE
Unify spark metrics naming

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -158,11 +158,10 @@ public class DatadogSparkListener extends SparkListener {
       applicationSpan.setTag(DDTags.ERROR_STACK, lastJobFailedStackTrace);
     }
 
-    applicationMetrics.setSpanMetrics(applicationSpan, "spark_application_metrics");
-    applicationSpan.setMetric("spark_application_metrics.max_executor_count", maxExecutorCount);
+    applicationMetrics.setSpanMetrics(applicationSpan);
+    applicationSpan.setMetric("spark.max_executor_count", maxExecutorCount);
     applicationSpan.setMetric(
-        "spark_application_metrics.available_executor_time",
-        computeCurrentAvailableExecutorTime(time));
+        "spark.available_executor_time", computeCurrentAvailableExecutorTime(time));
 
     applicationSpan.finish(time * 1000);
   }
@@ -278,7 +277,7 @@ public class DatadogSparkListener extends SparkListener {
 
     SparkAggregatedTaskMetrics metrics = jobMetrics.remove(jobEnd.jobId());
     if (metrics != null) {
-      metrics.setSpanMetrics(jobSpan, "spark_job_metrics");
+      metrics.setSpanMetrics(jobSpan);
     }
 
     jobSpan.finish(jobEnd.time() * 1000);
@@ -374,7 +373,7 @@ public class DatadogSparkListener extends SparkListener {
     SparkAggregatedTaskMetrics stageMetric = stageMetrics.remove(stageSpanKey);
     if (stageMetric != null) {
       stageMetric.computeSkew();
-      stageMetric.setSpanMetrics(span, "spark_stage_metrics");
+      stageMetric.setSpanMetrics(span);
       applicationMetrics.accumulateStageMetrics(stageMetric);
 
       jobMetrics
@@ -530,7 +529,7 @@ public class DatadogSparkListener extends SparkListener {
 
       if (batchSpan != null) {
         if (metrics != null) {
-          metrics.setSpanMetrics(batchSpan, "spark");
+          metrics.setSpanMetrics(batchSpan);
         }
 
         batchSpan.setTag("id", event.id());
@@ -565,7 +564,7 @@ public class DatadogSparkListener extends SparkListener {
     SparkAggregatedTaskMetrics metrics = streamingBatchMetrics.remove(batchKey);
     if (batchSpan != null) {
       if (metrics != null) {
-        metrics.setSpanMetrics(batchSpan, "spark");
+        metrics.setSpanMetrics(batchSpan);
       }
 
       batchSpan.setTag("id", progress.id());

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkAggregatedTaskMetrics.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkAggregatedTaskMetrics.java
@@ -197,41 +197,41 @@ class SparkAggregatedTaskMetrics {
     }
   }
 
-  public void setSpanMetrics(AgentSpan span, String prefix) {
-    span.setMetric(prefix + ".executor_deserialize_time", executorDeserializeTime);
-    span.setMetric(prefix + ".executor_deserialize_cpu_time", executorDeserializeCpuTime);
-    span.setMetric(prefix + ".executor_run_time", executorRunTime);
-    span.setMetric(prefix + ".executor_cpu_time", executorCpuTime);
-    span.setMetric(prefix + ".result_size", resultSize);
-    span.setMetric(prefix + ".jvm_gc_time", jvmGCTime);
-    span.setMetric(prefix + ".result_serialization_time", resultSerializationTime);
-    span.setMetric(prefix + ".memory_bytes_spilled", memoryBytesSpilled);
-    span.setMetric(prefix + ".disk_bytes_spilled", diskBytesSpilled);
-    span.setMetric(prefix + ".peak_execution_memory", peakExecutionMemory);
+  public void setSpanMetrics(AgentSpan span) {
+    span.setMetric("spark.executor_deserialize_time", executorDeserializeTime);
+    span.setMetric("spark.executor_deserialize_cpu_time", executorDeserializeCpuTime);
+    span.setMetric("spark.executor_run_time", executorRunTime);
+    span.setMetric("spark.executor_cpu_time", executorCpuTime);
+    span.setMetric("spark.result_size", resultSize);
+    span.setMetric("spark.jvm_gc_time", jvmGCTime);
+    span.setMetric("spark.result_serialization_time", resultSerializationTime);
+    span.setMetric("spark.memory_bytes_spilled", memoryBytesSpilled);
+    span.setMetric("spark.disk_bytes_spilled", diskBytesSpilled);
+    span.setMetric("spark.peak_execution_memory", peakExecutionMemory);
 
-    span.setMetric(prefix + ".input_bytes", inputBytesRead);
-    span.setMetric(prefix + ".input_records", inputRecordsRead);
-    span.setMetric(prefix + ".output_bytes", outputBytesWritten);
-    span.setMetric(prefix + ".output_records", outputRecordsWritten);
+    span.setMetric("spark.input_bytes", inputBytesRead);
+    span.setMetric("spark.input_records", inputRecordsRead);
+    span.setMetric("spark.output_bytes", outputBytesWritten);
+    span.setMetric("spark.output_records", outputRecordsWritten);
 
-    span.setMetric(prefix + ".shuffle_read_bytes", shuffleReadBytes);
-    span.setMetric(prefix + ".shuffle_read_bytes_local", shuffleReadBytesLocal);
-    span.setMetric(prefix + ".shuffle_read_bytes_remote", shuffleReadBytesRemote);
-    span.setMetric(prefix + ".shuffle_read_bytes_remote_to_disk", shuffleReadBytesRemoteToDisk);
-    span.setMetric(prefix + ".shuffle_read_fetch_wait_time", shuffleReadFetchWaitTime);
-    span.setMetric(prefix + ".shuffle_read_records", shuffleReadRecords);
+    span.setMetric("spark.shuffle_read_bytes", shuffleReadBytes);
+    span.setMetric("spark.shuffle_read_bytes_local", shuffleReadBytesLocal);
+    span.setMetric("spark.shuffle_read_bytes_remote", shuffleReadBytesRemote);
+    span.setMetric("spark.shuffle_read_bytes_remote_to_disk", shuffleReadBytesRemoteToDisk);
+    span.setMetric("spark.shuffle_read_fetch_wait_time", shuffleReadFetchWaitTime);
+    span.setMetric("spark.shuffle_read_records", shuffleReadRecords);
 
-    span.setMetric(prefix + ".shuffle_write_bytes", shuffleWriteBytes);
-    span.setMetric(prefix + ".shuffle_write_records", shuffleWriteRecords);
-    span.setMetric(prefix + ".shuffle_write_time", shuffleWriteTime);
+    span.setMetric("spark.shuffle_write_bytes", shuffleWriteBytes);
+    span.setMetric("spark.shuffle_write_records", shuffleWriteRecords);
+    span.setMetric("spark.shuffle_write_time", shuffleWriteTime);
 
-    span.setMetric(prefix + ".task_completed_count", taskCompletedCount);
-    span.setMetric(prefix + ".task_failed_count", taskFailedCount);
-    span.setMetric(prefix + ".task_retried_count", taskRetriedCount);
-    span.setMetric(prefix + ".task_with_output_count", taskWithOutputCount);
+    span.setMetric("spark.task_completed_count", taskCompletedCount);
+    span.setMetric("spark.task_failed_count", taskFailedCount);
+    span.setMetric("spark.task_retried_count", taskRetriedCount);
+    span.setMetric("spark.task_with_output_count", taskWithOutputCount);
 
-    span.setMetric(prefix + ".available_executor_time", attributedAvailableExecutorTime);
-    span.setMetric(prefix + ".skew_time", skewTime);
+    span.setMetric("spark.available_executor_time", attributedAvailableExecutorTime);
+    span.setMetric("spark.skew_time", skewTime);
 
     if (taskRunTimeHistogram != null && taskRunTimeHistogram.getCount() > 0) {
       span.setTag("_dd.spark.task_run_time", histogramToBase64(taskRunTimeHistogram));

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkListenerTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkListenerTest.groovy
@@ -199,7 +199,7 @@ class SparkListenerTest extends AgentTestRunner {
         span {
           operationName "spark.application"
           spanType "spark"
-          assert span.tags["spark_application_metrics.available_executor_time"] == expectedExecutorTime
+          assert span.tags["spark.available_executor_time"] == expectedExecutorTime
         }
       }
     }
@@ -248,48 +248,48 @@ class SparkListenerTest extends AgentTestRunner {
       trace(5) {
         span {
           operationName "spark.application"
-          assert span.tags["spark_application_metrics.available_executor_time"] == 8000L
-          assert span.tags["spark_application_metrics.executor_run_time"] == 2900L
-          assert span.tags["spark_application_metrics.executor_deserialize_time"] == 100L
-          assert span.tags["spark_application_metrics.result_serialization_time"] == 100L
+          assert span.tags["spark.available_executor_time"] == 8000L
+          assert span.tags["spark.executor_run_time"] == 2900L
+          assert span.tags["spark.executor_deserialize_time"] == 100L
+          assert span.tags["spark.result_serialization_time"] == 100L
           spanType "spark"
         }
         span {
           operationName "spark.job"
-          assert span.tags["spark_job_metrics.available_executor_time"] == 4800L
-          assert span.tags["spark_job_metrics.executor_run_time"] == 2900L
-          assert span.tags["spark_job_metrics.executor_deserialize_time"] == 100L
-          assert span.tags["spark_job_metrics.result_serialization_time"] == 100L
+          assert span.tags["spark.available_executor_time"] == 4800L
+          assert span.tags["spark.executor_run_time"] == 2900L
+          assert span.tags["spark.executor_deserialize_time"] == 100L
+          assert span.tags["spark.result_serialization_time"] == 100L
           spanType "spark"
           childOf(span(0))
         }
         span {
           operationName "spark.stage"
           assert span.tags["stage_id"] == 3
-          assert span.tags["spark_stage_metrics.available_executor_time"] == 3000L
-          assert span.tags["spark_stage_metrics.executor_run_time"] == 1900L
-          assert span.tags["spark_stage_metrics.executor_deserialize_time"] == 0L
-          assert span.tags["spark_stage_metrics.result_serialization_time"] == 0L
+          assert span.tags["spark.available_executor_time"] == 3000L
+          assert span.tags["spark.executor_run_time"] == 1900L
+          assert span.tags["spark.executor_deserialize_time"] == 0L
+          assert span.tags["spark.result_serialization_time"] == 0L
           spanType "spark"
           childOf(span(1))
         }
         span {
           operationName "spark.stage"
           assert span.tags["stage_id"] == 2
-          assert span.tags["spark_stage_metrics.available_executor_time"] == 1000L
-          assert span.tags["spark_stage_metrics.executor_run_time"] == 900L
-          assert span.tags["spark_stage_metrics.executor_deserialize_time"] == 0L
-          assert span.tags["spark_stage_metrics.result_serialization_time"] == 100L
+          assert span.tags["spark.available_executor_time"] == 1000L
+          assert span.tags["spark.executor_run_time"] == 900L
+          assert span.tags["spark.executor_deserialize_time"] == 0L
+          assert span.tags["spark.result_serialization_time"] == 100L
           spanType "spark"
           childOf(span(1))
         }
         span {
           operationName "spark.stage"
           assert span.tags["stage_id"] == 1
-          assert span.tags["spark_stage_metrics.available_executor_time"] == 800L
-          assert span.tags["spark_stage_metrics.executor_run_time"] == 100L
-          assert span.tags["spark_stage_metrics.executor_deserialize_time"] == 100L
-          assert span.tags["spark_stage_metrics.result_serialization_time"] == 0L
+          assert span.tags["spark.available_executor_time"] == 800L
+          assert span.tags["spark.executor_run_time"] == 100L
+          assert span.tags["spark.executor_deserialize_time"] == 100L
+          assert span.tags["spark.result_serialization_time"] == 0L
           spanType "spark"
           childOf(span(1))
         }
@@ -322,26 +322,26 @@ class SparkListenerTest extends AgentTestRunner {
       trace(4) {
         span {
           operationName "spark.application"
-          assert span.tags["spark_application_metrics.peak_execution_memory"] == 1400L
+          assert span.tags["spark.peak_execution_memory"] == 1400L
           spanType "spark"
         }
         span {
           operationName "spark.job"
-          assert span.tags["spark_job_metrics.peak_execution_memory"] == 1400L
+          assert span.tags["spark.peak_execution_memory"] == 1400L
           spanType "spark"
           childOf(span(0))
         }
         span {
           operationName "spark.stage"
           assert span.tags["stage_id"] == 2
-          assert span.tags["spark_stage_metrics.peak_execution_memory"] == 1400L
+          assert span.tags["spark.peak_execution_memory"] == 1400L
           spanType "spark"
           childOf(span(1))
         }
         span {
           operationName "spark.stage"
           assert span.tags["stage_id"] == 1
-          assert span.tags["spark_stage_metrics.peak_execution_memory"] == 1200L
+          assert span.tags["spark.peak_execution_memory"] == 1200L
           spanType "spark"
           childOf(span(1))
         }
@@ -414,19 +414,19 @@ class SparkListenerTest extends AgentTestRunner {
       trace(4) {
         span {
           operationName "spark.application"
-          validateRelativeError(span.tags["spark_application_metrics.skew_time"] as double, 7700, relativeAccuracy)
+          validateRelativeError(span.tags["spark.skew_time"] as double, 7700, relativeAccuracy)
           spanType "spark"
         }
         span {
           operationName "spark.job"
           spanType "spark"
-          validateRelativeError(span.tags["spark_job_metrics.skew_time"] as double, 7700, relativeAccuracy)
+          validateRelativeError(span.tags["spark.skew_time"] as double, 7700, relativeAccuracy)
           childOf(span(0))
         }
         span {
           operationName "spark.stage"
           assert span.tags["stage_id"] == 2
-          validateRelativeError(span.tags["spark_stage_metrics.skew_time"] as double, 7500, relativeAccuracy)
+          validateRelativeError(span.tags["spark.skew_time"] as double, 7500, relativeAccuracy)
           validateSerializedHistogram(span.tags["_dd.spark.task_run_time"] as String, 7500, 11250, 15000, relativeAccuracy)
           spanType "spark"
           childOf(span(1))
@@ -434,7 +434,7 @@ class SparkListenerTest extends AgentTestRunner {
         span {
           operationName "spark.stage"
           assert span.tags["stage_id"] == 1
-          validateRelativeError(span.tags["spark_stage_metrics.skew_time"] as double, 200, relativeAccuracy)
+          validateRelativeError(span.tags["spark.skew_time"] as double, 200, relativeAccuracy)
           validateSerializedHistogram(span.tags["_dd.spark.task_run_time"] as String, 100, 200, 300, relativeAccuracy)
           spanType "spark"
           childOf(span(1))


### PR DESCRIPTION
# What Does This Do

Spark metrics had a separate prefix for each operation (application, job, stage) which turned out to be complicated to use from the UI. This PR unifies the prefix to "spark" for all operations

There is already a processing in the backend to rename those prefix, so spans already appear with the name "spark" in datadog UI

# Motivation

# Additional Notes
