### PR TITLE
Fix automatic tracer configuration for Maven projects that use Jacoco

### DIFF
--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenProjectConfigurator.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenProjectConfigurator.java
@@ -17,12 +17,8 @@ import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class MavenProjectConfigurator {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(MavenProjectConfigurator.class);
 
   static final MavenProjectConfigurator INSTANCE = new MavenProjectConfigurator();
 

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -108,6 +108,31 @@ class MavenSmokeTest extends Specification {
     then:
     exitCode == 0
 
+    verifyEventsAndCoverages(mavenVersion)
+
+    where:
+    mavenVersion << ["3.2.1", "3.2.5", "3.3.9", "3.5.4", "3.6.3", "3.8.8", "3.9.4", "4.0.0-alpha-7"]
+  }
+
+  def "test maven run with jacoco and argLine, v#mavenVersion"() {
+    given:
+    givenWrapperPropertiesFile(mavenVersion)
+    givenMavenProjectFiles("test_successful_maven_run_with_jacoco_and_argline")
+    givenMavenDependenciesAreLoaded()
+
+    when:
+    def exitCode = whenRunningMavenBuild()
+
+    then:
+    exitCode == 0
+
+    verifyEventsAndCoverages(mavenVersion)
+
+    where:
+    mavenVersion << ["3.9.4"]
+  }
+
+  private verifyEventsAndCoverages(String mavenVersion) {
     def events = waitForEvents(5)
     assert events.size() == 5
 
@@ -249,9 +274,6 @@ class MavenSmokeTest extends Specification {
         ]
       ]
     ]
-
-    where:
-    mavenVersion << ["3.2.1", "3.2.5", "3.3.9", "3.5.4", "3.6.3", "3.8.8", "3.9.3", "4.0.0-alpha-7"]
   }
 
   private void givenWrapperPropertiesFile(String mavenVersion) {

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_jacoco_and_argline/pom.xml
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_jacoco_and_argline/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.datadog.ci.test</groupId>
+  <artifactId>maven-smoke-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Maven Smoke Tests Project</name>
+
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <!-- Older Maven versions (e.g. 3.2.1) use http protocol instead of https for repositories by default.
+    Nowadays Maven Central does not work over unencrypted http -->
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <updatePolicy>never</updatePolicy>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <argLine>@{argLine}</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.10</version>
+        <executions>
+          <execution>
+            <id>default-prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_jacoco_and_argline/src/test/java/datadog/smoke/TestSucceed.java
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_jacoco_and_argline/src/test/java/datadog/smoke/TestSucceed.java
@@ -1,0 +1,18 @@
+package datadog.smoke;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TestSucceed {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  @Test
+  public void test_to_skip_with_itr() {
+    assertTrue(true);
+  }
+}


### PR DESCRIPTION
# What Does This Do
Fixes automatic tracer configuration for Maven projects that use Jacoco.

Jacoco Maven plugin modifies the project's `<argLine>` property, adding Jacoco agent argument.
In order for things to work, Surefire plugin's `<argLine>` has to contain a reference to the project's arg line: `@{argLine}` (this form is "late-substitution", meaning value is substituted after Jacoco plugin has run).

The logic that does automatic tracer configuration adds this reference when changing Surefire plugin's arg line.
The reference is added unconditionally.
The problem is that if Surefire's original arg line (as specified in `pom.xml`) already contains the `@{argLine}` bit, the one we're adding is a duplicate, and this breaks the build.

The fix is to check whether the original configuration already has the reference, and only add it if it's missing.

# Motivation
Fixing a bug in automatic configuration logic.
