### PR TITLE
Jax-RS exception configuration option should apply to Resteasy

### DIFF
--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/build.gradle
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/build.gradle
@@ -12,4 +12,8 @@ dependencies {
   compileOnly group: 'org.jboss.resteasy', name: 'resteasy-client', version: '3.0.0.Final'
 
   compileOnly project(':dd-java-agent:instrumentation:jax-rs-client-2.0')
+
+  testImplementation group: 'org.jboss.resteasy', name: 'resteasy-client', version: '3.0.0.Final'
+
+  testImplementation project(':dd-java-agent:instrumentation:jax-rs-client-2.0')
 }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/main/java/datadog/trace/instrumentation/connection_error/resteasy/ResteasyClientConnectionErrorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/main/java/datadog/trace/instrumentation/connection_error/resteasy/ResteasyClientConnectionErrorInstrumentation.java
@@ -7,6 +7,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.instrumentation.jaxrs.ClientTracingFilter;
 import java.util.concurrent.Future;
@@ -58,8 +59,13 @@ public final class ResteasyClientConnectionErrorInstrumentation extends Instrume
         final Object prop = context.getProperty(ClientTracingFilter.SPAN_PROPERTY_NAME);
         if (prop instanceof AgentSpan) {
           final AgentSpan span = (AgentSpan) prop;
-          span.setError(true);
           span.addThrowable(throwable);
+
+          @SuppressWarnings("deprecation")
+          final boolean isJaxRsExceptionAsErrorEnabled =
+              Config.get().isJaxRsExceptionAsErrorEnabled();
+          span.setError(isJaxRsExceptionAsErrorEnabled);
+
           span.finish();
         }
       }

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/test/groovy/ResteasyClientConnectionErrorsInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/test/groovy/ResteasyClientConnectionErrorsInstrumentationTest.groovy
@@ -1,0 +1,65 @@
+import static datadog.trace.api.config.TraceInstrumentationConfig.JAX_RS_EXCEPTION_AS_ERROR_ENABLED
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.connection_error.resteasy.ResteasyClientConnectionErrorInstrumentation
+import datadog.trace.instrumentation.jaxrs.ClientTracingFilter
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration
+import org.jboss.resteasy.spi.ResteasyProviderFactory
+
+class ResteasyClientConnectionErrorsInstrumentationTest extends AgentTestRunner {
+  def "handleError does not generate traces for non-exceptions"() {
+    setup:
+    if (jaxRsExceptionAsErrorEnabled != null) {
+      injectSysConfig(JAX_RS_EXCEPTION_AS_ERROR_ENABLED, "$jaxRsExceptionAsErrorEnabled")
+    }
+    def testSpan = TEST_TRACER.buildSpan("testInstrumentation", "testSpan").start()
+    def props = Map.of(ClientTracingFilter.SPAN_PROPERTY_NAME, testSpan)
+
+    def clientConfig = new ClientConfiguration(new ResteasyProviderFactory())
+    clientConfig.setProperties(props)
+
+    when:
+    ResteasyClientConnectionErrorInstrumentation.InvokeAdvice.handleError(clientConfig, null)
+
+    then:
+    assertTraces(0) {}
+
+    where:
+    jaxRsExceptionAsErrorEnabled | isErrored
+    true                         | true
+    false                        | false
+    null                         | true
+  }
+
+  def "handleError properly utilizes the config"() {
+    setup:
+    if (jaxRsExceptionAsErrorEnabled != null) {
+      injectSysConfig(JAX_RS_EXCEPTION_AS_ERROR_ENABLED, "$jaxRsExceptionAsErrorEnabled")
+    }
+    def testSpan = TEST_TRACER.buildSpan("testInstrumentation", "testSpan").start()
+    def props = Map.of(ClientTracingFilter.SPAN_PROPERTY_NAME, testSpan)
+
+    def clientConfig = new ClientConfiguration(new ResteasyProviderFactory())
+    clientConfig.setProperties(props)
+
+    when:
+    ResteasyClientConnectionErrorInstrumentation.InvokeAdvice.handleError(clientConfig, new RuntimeException("failed"))
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "testSpan"
+          resourceName "testSpan"
+          errored isErrored
+        }
+      }
+    }
+
+    where:
+    jaxRsExceptionAsErrorEnabled | isErrored
+    true                         | true
+    false                        | false
+    null                         | true
+  }
+}

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/test/groovy/WrappedFutureTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/connection-error-handling-resteasy/src/test/groovy/WrappedFutureTest.groovy
@@ -1,0 +1,80 @@
+import static datadog.trace.api.config.TraceInstrumentationConfig.JAX_RS_EXCEPTION_AS_ERROR_ENABLED
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.instrumentation.connection_error.resteasy.WrappedFuture
+import datadog.trace.instrumentation.jaxrs.ClientTracingFilter
+import java.util.concurrent.CompletableFuture
+import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration
+import org.jboss.resteasy.spi.ResteasyProviderFactory
+
+class WrappedFutureTest extends AgentTestRunner {
+  def "wrappedFuture does not generate traces for non-exceptions"() {
+    setup:
+    if (jaxRsExceptionAsErrorEnabled != null) {
+      injectSysConfig(JAX_RS_EXCEPTION_AS_ERROR_ENABLED, "$jaxRsExceptionAsErrorEnabled")
+    }
+    def testSpan = TEST_TRACER.buildSpan("testInstrumentation", "testSpan").start()
+    def props = Map.of(ClientTracingFilter.SPAN_PROPERTY_NAME, testSpan)
+
+
+    def completedFuture = CompletableFuture.completedFuture("passed")
+
+    def clientConfig = new ClientConfiguration(new ResteasyProviderFactory())
+    clientConfig.setProperties(props)
+    def wrappedFuture = new WrappedFuture(completedFuture, clientConfig)
+
+    when:
+    try {
+      wrappedFuture.get()
+    } catch (ignored) {
+    }
+
+    then:
+    assertTraces(0) {}
+
+    where:
+    jaxRsExceptionAsErrorEnabled | isErrored
+    true                         | true
+    false                        | false
+    null                         | true
+  }
+
+  def "wrappedFuture handleProcessingException properly utilizes the config"() {
+    setup:
+    if (jaxRsExceptionAsErrorEnabled != null) {
+      injectSysConfig(JAX_RS_EXCEPTION_AS_ERROR_ENABLED, "$jaxRsExceptionAsErrorEnabled")
+    }
+    def testSpan = TEST_TRACER.buildSpan("testInstrumentation", "testSpan").start()
+    def props = Map.of(ClientTracingFilter.SPAN_PROPERTY_NAME, testSpan)
+
+
+    def completedFuture = CompletableFuture.failedFuture(new RuntimeException("failed"))
+
+    def clientConfig = new ClientConfiguration(new ResteasyProviderFactory())
+    clientConfig.setProperties(props)
+    def wrappedFuture = new WrappedFuture(completedFuture, clientConfig)
+
+    when:
+    try {
+      wrappedFuture.get()
+    } catch (ignored) {
+    }
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "testSpan"
+          resourceName "testSpan"
+          errored isErrored
+        }
+      }
+    }
+
+    where:
+    jaxRsExceptionAsErrorEnabled | isErrored
+    true                         | true
+    false                        | false
+    null                         | true
+  }
+}


### PR DESCRIPTION
# What Does This Do
Expands upon the initial implementation in #5691 to apply to `Resteasy` in addition to `Jersey` Jax-RS exceptions

The configuration option `DD_TRACE_JAX_RS_EXCEPTION_AS_ERROR_ENABLED` when set to `false` will now force exceptions from `RestEasy` to not be treated as errors. As was before, this does not drop the underlying exception if it exists

# Motivation
This is helpful for situations for situations where a 3xx level responses from `Resteasy` returned triggers a custom exception in the underlying code since the span should not be considered an error

# Additional Notes
