### PR TITLE
Fixed NPE in User Events Tracking

### DIFF
--- a/dd-smoke-tests/appsec/springboot-security/src/main/java/datadog/smoketest/appsec/springbootsecurity/WebSecurityConfig.java
+++ b/dd-smoke-tests/appsec/springboot-security/src/main/java/datadog/smoketest/appsec/springbootsecurity/WebSecurityConfig.java
@@ -3,9 +3,14 @@ package datadog.smoketest.appsec.springbootsecurity;
 import javax.sql.DataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.datasource.init.DataSourceInitializer;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
@@ -36,7 +41,26 @@ public class WebSecurityConfig {
   }
 
   @Bean
+  @DependsOn("dataSource")
+  public DataSourceInitializer dataSourceInitializer() {
+    ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+    populator.addScript(new ClassPathResource("schema.sql"));
+
+    DataSourceInitializer initializer = new DataSourceInitializer();
+    initializer.setDataSource(dataSource);
+    initializer.setDatabasePopulator(populator);
+
+    return initializer;
+  }
+
+  @Bean
+  @DependsOn("dataSourceInitializer")
   public UserDetailsManager userDetailsService() {
-    return new JdbcUserDetailsManager(dataSource);
+    UserDetailsManager userDetailsManager = new JdbcUserDetailsManager(dataSource);
+
+    // Create some default for case when user creation happens outside request
+    userDetailsManager.createUser(User.withUsername("default_user").password("{noop}").roles("USER").build());
+
+    return userDetailsManager;
   }
 }

--- a/dd-smoke-tests/appsec/springboot-security/src/main/java/datadog/smoketest/appsec/springbootsecurity/WebSecurityConfig.java
+++ b/dd-smoke-tests/appsec/springboot-security/src/main/java/datadog/smoketest/appsec/springbootsecurity/WebSecurityConfig.java
@@ -59,7 +59,8 @@ public class WebSecurityConfig {
     UserDetailsManager userDetailsManager = new JdbcUserDetailsManager(dataSource);
 
     // Create some default for case when user creation happens outside request
-    userDetailsManager.createUser(User.withUsername("default_user").password("{noop}").roles("USER").build());
+    userDetailsManager.createUser(
+        User.withUsername("default_user").password("{noop}").roles("USER").build());
 
     return userDetailsManager;
   }

--- a/dd-smoke-tests/appsec/springboot-security/src/main/resources/application.properties
+++ b/dd-smoke-tests/appsec/springboot-security/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 spring.datasource.url=jdbc:h2:mem:authDB;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
 spring.datasource.password=
+# DB Initialization happens in WebSecurityConfig.dataSourceInitializer()
+spring.sql.init.enabled=false
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1229,7 +1229,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public TraceSegment getTraceSegment() {
-    AgentSpan.Context ctx = activeSpan().context();
+    AgentSpan activeSpan = activeSpan();
+    if (activeSpan == null) {
+      return null;
+    }
+    AgentSpan.Context ctx = activeSpan.context();
     if (ctx instanceof DDSpanContext) {
       return ((DDSpanContext) ctx).getTraceSegment();
     }


### PR DESCRIPTION
# What Does This Do
Fixed SpringSecurity NullPointerException when user creation happens outside request context.

# Motivation
Reported exception message in debug log:
```
[dd.trace 2023-08-16 12:27:42:204 +0000] [main] DEBUG datadog.trace.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for org.springframework.security.provisioning.InMemoryUserDetailsManager
java.lang.NullPointerException
        at datadog.trace.agent.core.CoreTracer.getTraceSegment(CoreTracer.java:1232)
        at datadog.trace.bootstrap.instrumentation.decorator.AppSecUserEventDecorator.getSegment(AppSecUserEventDecorator.java:68)
        at datadog.trace.bootstrap.instrumentation.decorator.AppSecUserEventDecorator.onSignup(AppSecUserEventDecorator.java:41)
        at datadog.trace.instrumentation.springsecurity5.SpringSecurityUserEventDecorator.onSignup(SpringSecurityUserEventDecorator.java:38)
        at org.springframework.security.provisioning.InMemoryUserDetailsManager.createUser(InMemoryUserDetailsManager.java:96)
        at org.springframework.security.provisioning.InMemoryUserDetailsManager.<init>(InMemoryUserDetailsManager.java:71)
        at org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration.inMemoryUserDetailsManager(UserDetailsServiceAutoConfiguration.java:81)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)
        at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:154)
```