### PR TITLE
Update system-tests to 9659a5e409cf8bacabd739b6af07c5f03c9bcbd6

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -29,7 +29,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 68da674b83d7a1a1730387a3b27a1d4328392f3c
+default_system_tests_commit: &default_system_tests_commit 9659a5e409cf8bacabd739b6af07c5f03c9bcbd6
 
 parameters:
   gradle_flags:

--- a/.circleci/update_pinned_system_tests.sh
+++ b/.circleci/update_pinned_system_tests.sh
@@ -8,7 +8,7 @@ if [[ -n $(git diff --stat) ]]; then
     exit 1
 fi
 
-current_commit="$(grep ^default_system_tests_commit: config.yml | sed -e 's~^.* ~~g')"
+current_commit="$(grep ^default_system_tests_commit: config.continue.yml.j2 | sed -e 's~^.* ~~g')"
 latest_commit="$(git ls-remote git@github.com:DataDog/system-tests.git refs/heads/main | cut -f 1)"
 
 echo "Current commit: $current_commit"
@@ -19,6 +19,6 @@ if [[ "$current_commit" = "$latest_commit" ]]; then
 fi
 
 echo "Updating config.yml"
-sed -i -e "s~${current_commit?}~${latest_commit?}~g" config.yml
-git diff config.yml | cat
-git commit -m "Update system-tests to $latest_commit" config.yml
+sed -i -e "s~${current_commit?}~${latest_commit?}~g" config.continue.yml.j2
+git diff config.continue.yml.j2 | cat
+git commit -m "Update system-tests to $latest_commit" config.continue.yml.j2


### PR DESCRIPTION
# What Does This Do

* Fix the update script for the new dynamic config.
* Comparison:
https://github.com/datadog/system-tests/compare/68da674b83d7a1a1730387a3b27a1d4328392f3c..9659a5e409cf8bacabd739b6af07c5f03c9bcbd6

# Motivation

# Additional Notes
Previous update: https://github.com/DataDog/dd-trace-java/pull/5703

Relevant changes:
* https://github.com/DataDog/system-tests/pull/1480
* https://github.com/DataDog/system-tests/pull/1482
* https://github.com/DataDog/system-tests/pull/1344
* https://github.com/DataDog/system-tests/pull/1481
* https://github.com/DataDog/system-tests/pull/1494
* https://github.com/DataDog/system-tests/pull/1431
