### PR TITLE
Use DD Javac Plugin metadata to resolve method lines

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -40,10 +40,12 @@ import datadog.trace.civisibility.git.tree.GitDataUploader;
 import datadog.trace.civisibility.git.tree.GitDataUploaderImpl;
 import datadog.trace.civisibility.ipc.SignalClient;
 import datadog.trace.civisibility.ipc.SignalServer;
-import datadog.trace.civisibility.source.BestEfforSourcePathResolver;
+import datadog.trace.civisibility.source.BestEffortMethodLinesResolver;
+import datadog.trace.civisibility.source.BestEffortSourcePathResolver;
+import datadog.trace.civisibility.source.ByteCodeMethodLinesResolver;
+import datadog.trace.civisibility.source.CompilerAidedMethodLinesResolver;
 import datadog.trace.civisibility.source.CompilerAidedSourcePathResolver;
 import datadog.trace.civisibility.source.MethodLinesResolver;
-import datadog.trace.civisibility.source.MethodLinesResolverImpl;
 import datadog.trace.civisibility.source.index.RepoIndexBuilder;
 import datadog.trace.civisibility.source.index.RepoIndexFetcher;
 import datadog.trace.civisibility.source.index.RepoIndexProvider;
@@ -133,7 +135,11 @@ public class CiVisibilitySystem {
       RepoIndexProvider indexProvider = getRepoIndexProvider(config, repoRoot);
       SourcePathResolver sourcePathResolver = getSourcePathResolver(repoRoot, indexProvider);
       Codeowners codeowners = getCodeowners(repoRoot);
-      MethodLinesResolver methodLinesResolver = new MethodLinesResolverImpl();
+
+      MethodLinesResolver methodLinesResolver =
+          new BestEffortMethodLinesResolver(
+              new CompilerAidedMethodLinesResolver(), new ByteCodeMethodLinesResolver());
+
       Map<String, String> ciTags = new CITagsProvider().getCiTags(ciInfo);
       TestDecorator testDecorator = new TestDecoratorImpl(component, ciTags);
       TestModuleRegistry testModuleRegistry = new TestModuleRegistry();
@@ -294,7 +300,7 @@ public class CiVisibilitySystem {
     if (repoRoot != null) {
       RepoIndexSourcePathResolver indexSourcePathResolver =
           new RepoIndexSourcePathResolver(repoRoot, indexProvider);
-      return new BestEfforSourcePathResolver(
+      return new BestEffortSourcePathResolver(
           new CompilerAidedSourcePathResolver(repoRoot), indexSourcePathResolver);
     } else {
       return clazz -> null;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/BestEffortMethodLinesResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/BestEffortMethodLinesResolver.java
@@ -1,0 +1,25 @@
+package datadog.trace.civisibility.source;
+
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+
+public class BestEffortMethodLinesResolver implements MethodLinesResolver {
+
+  private final MethodLinesResolver[] delegates;
+
+  public BestEffortMethodLinesResolver(MethodLinesResolver... delegates) {
+    this.delegates = delegates;
+  }
+
+  @Nonnull
+  @Override
+  public MethodLines getLines(@Nonnull Method method) {
+    for (MethodLinesResolver delegate : delegates) {
+      MethodLines lines = delegate.getLines(method);
+      if (lines.isValid()) {
+        return lines;
+      }
+    }
+    return MethodLines.EMPTY;
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/BestEffortSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/BestEffortSourcePathResolver.java
@@ -4,11 +4,11 @@ import datadog.trace.api.civisibility.source.SourcePathResolver;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class BestEfforSourcePathResolver implements SourcePathResolver {
+public class BestEffortSourcePathResolver implements SourcePathResolver {
 
   private final SourcePathResolver[] delegates;
 
-  public BestEfforSourcePathResolver(SourcePathResolver... delegates) {
+  public BestEffortSourcePathResolver(SourcePathResolver... delegates) {
     this.delegates = delegates;
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/ByteCodeMethodLinesResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/ByteCodeMethodLinesResolver.java
@@ -16,9 +16,9 @@ import org.objectweb.asm.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MethodLinesResolverImpl implements MethodLinesResolver {
+public class ByteCodeMethodLinesResolver implements MethodLinesResolver {
 
-  private static final Logger log = LoggerFactory.getLogger(MethodLinesResolverImpl.class);
+  private static final Logger log = LoggerFactory.getLogger(ByteCodeMethodLinesResolver.class);
 
   private final DDCache<Class<?>, ClassMethodLines> methodLinesCache =
       DDCaches.newFixedSizeIdentityCache(16);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/CompilerAidedMethodLinesResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/CompilerAidedMethodLinesResolver.java
@@ -1,0 +1,21 @@
+package datadog.trace.civisibility.source;
+
+import datadog.compiler.utils.CompilerUtils;
+import java.lang.reflect.Method;
+import javax.annotation.Nonnull;
+
+public class CompilerAidedMethodLinesResolver implements MethodLinesResolver {
+  @Nonnull
+  @Override
+  public MethodLines getLines(@Nonnull Method method) {
+    int startLine = CompilerUtils.getStartLine(method);
+    if (startLine <= 0) {
+      return MethodLines.EMPTY;
+    }
+    int endLine = CompilerUtils.getEndLine(method);
+    if (endLine <= 0) {
+      return MethodLines.EMPTY;
+    }
+    return new MethodLines(startLine, endLine);
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/MethodLinesResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/MethodLinesResolver.java
@@ -1,6 +1,7 @@
 package datadog.trace.civisibility.source;
 
 import java.lang.reflect.Method;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 
 public interface MethodLinesResolver {
@@ -29,6 +30,23 @@ public interface MethodLinesResolver {
 
     public boolean isValid() {
       return startLineNumber <= finishLineNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      MethodLines that = (MethodLines) o;
+      return startLineNumber == that.startLineNumber && finishLineNumber == that.finishLineNumber;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(startLineNumber, finishLineNumber);
     }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/BestEffortMethodLinesResolverTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/BestEffortMethodLinesResolverTest.groovy
@@ -1,0 +1,67 @@
+package datadog.trace.civisibility.source
+
+
+import spock.lang.Specification
+
+class BestEffortMethodLinesResolverTest extends Specification {
+
+  def "test get source info from delegate"() {
+    setup:
+    def testMethod = TestClass.getDeclaredMethod("testMethod")
+    def expectedLines = new MethodLinesResolver.MethodLines(42, 43)
+
+    def delegate = Stub(MethodLinesResolver)
+    def secondDelegate = Stub(MethodLinesResolver)
+    def resolver = new BestEffortMethodLinesResolver(delegate, secondDelegate)
+
+    delegate.getLines(testMethod) >> expectedLines
+    secondDelegate.getLines(testMethod) >> MethodLinesResolver.MethodLines.EMPTY
+
+    when:
+    def lines = resolver.getLines(testMethod)
+
+    then:
+    lines == expectedLines
+  }
+
+  def "test get source info from second delegate"() {
+    setup:
+    def testMethod = TestClass.getDeclaredMethod("testMethod")
+    def expectedLines = new MethodLinesResolver.MethodLines(42, 43)
+
+    def delegate = Stub(MethodLinesResolver)
+    def secondDelegate = Stub(MethodLinesResolver)
+    def resolver = new BestEffortMethodLinesResolver(delegate, secondDelegate)
+
+    delegate.getLines(testMethod) >> MethodLinesResolver.MethodLines.EMPTY
+    secondDelegate.getLines(testMethod) >> expectedLines
+
+    when:
+    def lines = resolver.getLines(testMethod)
+
+    then:
+    lines == expectedLines
+  }
+
+  def "test failed to get info from both delegates"() {
+    setup:
+    def testMethod = TestClass.getDeclaredMethod("testMethod")
+
+    def delegate = Stub(MethodLinesResolver)
+    def secondDelegate = Stub(MethodLinesResolver)
+    def resolver = new BestEffortMethodLinesResolver(delegate, secondDelegate)
+
+    delegate.getLines(testMethod) >> MethodLinesResolver.MethodLines.EMPTY
+    secondDelegate.getLines(testMethod) >> MethodLinesResolver.MethodLines.EMPTY
+
+    when:
+    def lines = resolver.getLines(testMethod)
+
+    then:
+    lines == MethodLinesResolver.MethodLines.EMPTY
+  }
+
+  private static final class TestClass {
+    void testMethod() {}
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/BestEffortSourcePathResolverTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/BestEffortSourcePathResolverTest.groovy
@@ -10,7 +10,7 @@ class BestEffortSourcePathResolverTest extends Specification {
     def expectedPath = "source/path/TestClass.java"
     def delegate = Stub(SourcePathResolver)
     def secondDelegate = Stub(SourcePathResolver)
-    def resolver = new BestEfforSourcePathResolver(delegate, secondDelegate)
+    def resolver = new BestEffortSourcePathResolver(delegate, secondDelegate)
 
     delegate.getSourcePath(TestClass) >> expectedPath
     secondDelegate.getSourcePath(TestClass) >> null
@@ -27,7 +27,7 @@ class BestEffortSourcePathResolverTest extends Specification {
     def expectedPath = "source/path/TestClass.java"
     def delegate = Stub(SourcePathResolver)
     def secondDelegate = Stub(SourcePathResolver)
-    def resolver = new BestEfforSourcePathResolver(delegate, secondDelegate)
+    def resolver = new BestEffortSourcePathResolver(delegate, secondDelegate)
 
     delegate.getSourcePath(TestClass) >> null
     secondDelegate.getSourcePath(TestClass) >> expectedPath
@@ -43,7 +43,7 @@ class BestEffortSourcePathResolverTest extends Specification {
     setup:
     def delegate = Stub(SourcePathResolver)
     def secondDelegate = Stub(SourcePathResolver)
-    def resolver = new BestEfforSourcePathResolver(delegate, secondDelegate)
+    def resolver = new BestEffortSourcePathResolver(delegate, secondDelegate)
 
     delegate.getSourcePath(TestClass) >> null
     secondDelegate.getSourcePath(TestClass) >> null

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/ByteCodeMethodLinesResolverTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/ByteCodeMethodLinesResolverTest.groovy
@@ -4,14 +4,14 @@ package datadog.trace.civisibility.source
 import org.spockframework.util.IoUtil
 import spock.lang.Specification
 
-class MethodLinesResolverImplTest extends Specification {
+class ByteCodeMethodLinesResolverTest extends Specification {
 
   def "test method lines resolution"() {
     setup:
     def aTestMethod = NestedClass.getDeclaredMethod("aTestMethod")
 
     when:
-    def methodLinesResolver = new MethodLinesResolverImpl()
+    def methodLinesResolver = new ByteCodeMethodLinesResolver()
     def methodLines = methodLinesResolver.getLines(aTestMethod)
 
     then:
@@ -25,7 +25,7 @@ class MethodLinesResolverImplTest extends Specification {
     def aTestMethod = NestedClass.getDeclaredMethod("abstractMethod")
 
     when:
-    def methodLinesResolver = new MethodLinesResolverImpl()
+    def methodLinesResolver = new ByteCodeMethodLinesResolver()
     def methodLines = methodLinesResolver.getLines(aTestMethod)
 
     then:
@@ -46,7 +46,7 @@ class MethodLinesResolverImplTest extends Specification {
     def misbehavingMethod = misbehavingClass.getDeclaredMethod("aTestMethod")
 
     when:
-    def methodLinesResolver = new MethodLinesResolverImpl()
+    def methodLinesResolver = new ByteCodeMethodLinesResolver()
     def methodLines = methodLinesResolver.getLines(misbehavingMethod)
 
     then:
@@ -56,7 +56,7 @@ class MethodLinesResolverImplTest extends Specification {
   def "test returns empty method lines when unknown method is attempted to be resolved"() {
     setup:
     def aTestMethod = NestedClass.getDeclaredMethod("abstractMethod")
-    def classMethodLines = new MethodLinesResolverImpl.ClassMethodLines()
+    def classMethodLines = new ByteCodeMethodLinesResolver.ClassMethodLines()
 
     when:
     def methodLines = classMethodLines.get(aTestMethod)

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/CompilerAidedMethodLinesResolverTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/CompilerAidedMethodLinesResolverTest.groovy
@@ -1,0 +1,40 @@
+package datadog.trace.civisibility.source
+
+import datadog.compiler.annotations.MethodLines
+import spock.lang.Specification
+
+class CompilerAidedMethodLinesResolverTest extends Specification {
+
+  def "test source info retrieval for #methodName"() {
+    setup:
+    def resolver = new CompilerAidedMethodLinesResolver()
+    def method = TestClass.getDeclaredMethod(methodName)
+
+    when:
+    def lines = resolver.getLines(method)
+
+    then:
+    lines.valid == expectedValid
+
+    if (lines.valid) {
+      lines.startLineNumber == expectedStart
+      lines.finishLineNumber == expectedFinish
+    }
+
+    where:
+    methodName                                | expectedValid | expectedStart | expectedFinish
+    "methodWithNoLinesInfoInjected"      | false         | -1            | -1
+    "methodWithLinesInfoInjected"        | true          | 10            | 20
+    "methodWithUnknownLinesInfoInjected" | false         | -1            | -1
+  }
+
+  private static final class TestClass {
+    void methodWithNoLinesInfoInjected() {}
+
+    @MethodLines(start = 10, end = 20)
+    void methodWithLinesInfoInjected() {}
+
+    @MethodLines(start = -1, end = -1)
+    void methodWithUnknownLinesInfoInjected() {}
+  }
+}

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -281,8 +281,8 @@ class GradleDaemonSmokeTest extends Specification {
     "7.6.1" | "success"
     "8.0.2" | "success"
     "8.1.1" | "success"
-    "8.2.1" | "success"
-    "8.2.1" | "successJunit5"
+    "8.3" | "success"
+    "8.3" | "successJunit5"
   }
 
   // this is a separate test case since older Gradle versions need to declare dependencies differently
@@ -591,7 +591,7 @@ class GradleDaemonSmokeTest extends Specification {
 
     where:
     //
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.3"]
   }
 
   def "Failed build emits session and module spans: Gradle v#gradleVersion"() {
@@ -695,7 +695,7 @@ class GradleDaemonSmokeTest extends Specification {
     }
 
     where:
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.3"]
   }
 
   def "Build without tests emits session and module spans: Gradle v#gradleVersion"() {
@@ -748,7 +748,7 @@ class GradleDaemonSmokeTest extends Specification {
     }
 
     where:
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.3"]
   }
 
   def "Corrupted build emits session span: Gradle v#gradleVersion"() {
@@ -785,7 +785,7 @@ class GradleDaemonSmokeTest extends Specification {
     }
 
     where:
-    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.2.1"]
+    gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.3"]
   }
 
   private void givenGradleProperties() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -113,7 +113,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_CIVISIBILITY_BUILD_INSTRUMENTATION_ENABLED = true;
   static final boolean DEFAULT_CIVISIBILITY_AUTO_CONFIGURATION_ENABLED = true;
   static final boolean DEFAULT_CIVISIBILITY_COMPILER_PLUGIN_AUTO_CONFIGURATION_ENABLED = true;
-  static final String DEFAULT_CIVISIBILITY_COMPILER_PLUGIN_VERSION = "0.1.6";
+  static final String DEFAULT_CIVISIBILITY_COMPILER_PLUGIN_VERSION = "0.1.7";
   static final String DEFAULT_CIVISIBILITY_JACOCO_PLUGIN_EXCLUDES =
       "datadog.trace.*:org.apache.commons.*:org.mockito.*";
   static final boolean DEFAULT_CIVISIBILITY_GIT_UPLOAD_ENABLED = true;

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -154,8 +154,8 @@ dependencies {
   api project(":utils:time-utils")
 
   // has to be loaded by system classloader:
-  // it contains annotation that is also present in the instrumented application classes
-  api "com.datadoghq:dd-javac-plugin-client:0.1.6"
+  // it contains annotations that are also present in the instrumented application classes
+  api "com.datadoghq:dd-javac-plugin-client:0.1.7"
 
   testImplementation project(":utils:test-utils")
   testImplementation("org.assertj:assertj-core:3.20.2")


### PR DESCRIPTION
# What Does This Do
Updates CI Visibility logic that extracts lines metadata for test methods.
The update is to use `@MethodLines` annotation injected by [dd-javac-plugin](https://github.com/DataDog/dd-javac-plugin/tree/master) if available, and fall back to the previously used method (class bytecode traversing) if not.

# Motivation
Data injected by the compiler plugin is more accurate (as it includes method declaration lines - method name, modifiers, annotations) and can be retrieved with less overhead (as getting a runtime annotation does not required reading class data from disk, which is needed for bytecode traversing).
