### PR TITLE
Elasticsearch and Opensearch should omit `params` by default

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -182,7 +182,7 @@ public final class ConfigDefaults {
 
   static final float DEFAULT_TRACE_FLUSH_INTERVAL = 1;
 
-  static final boolean DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED = true;
+  static final boolean DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED = false;
 
   static final boolean DEFAULT_SPARK_TASK_HISTOGRAM_ENABLED = true;
 


### PR DESCRIPTION
# What Does This Do
Makes it so that `elasticsearch.params` and `opensearch.params` are omitted by default

The original behavior can be maintained by setting `trace.elasticsearch.body-and-params.enabled` to `true

# Motivation
This is beneficial in the case that they contain sensitive information
Also closes #5718 

# Additional Notes
