### PR TITLE
re-enable muzzle for spring 6

### DIFF
--- a/dd-java-agent/instrumentation/spring-webflux-6/build.gradle
+++ b/dd-java-agent/instrumentation/spring-webflux-6/build.gradle
@@ -2,6 +2,15 @@ ext {
   minJavaVersionForTests = JavaVersion.VERSION_17
 }
 
+muzzle {
+  pass {
+    group = 'org.springframework'
+    module = 'spring-webflux'
+    versions = "[6,)"
+    javaVersion = "17"
+  }
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 [compileMain_java17Java, compileTestJava].each {
@@ -14,10 +23,6 @@ apply from: "$rootDir/gradle/java.gradle"
 
 // test that webflux5 instrumentation works for webflux6 too
 addTestSuite('iastTest')
-
-tasks.named('muzzle').configure {
-  enabled = false
-}
 
 [compileTestGroovy, compileIastTestGroovy].each {
   it.javaLauncher = getJavaLauncherFor(17)

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/build.gradle
@@ -2,6 +2,16 @@ ext {
   minJavaVersionForTests = JavaVersion.VERSION_17
 }
 
+muzzle {
+  pass {
+    group = 'org.springframework'
+    module = 'spring-webmvc'
+    versions = "[6,)"
+    javaVersion = "17"
+    extraDependency "jakarta.servlet:jakarta.servlet-api:5.0.0"
+  }
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 [compileMain_java17Java, compileTestJava].each {
@@ -12,10 +22,6 @@ apply from: "$rootDir/gradle/java.gradle"
   }
 }
 
-tasks.named('muzzle').configure {
-  enabled = false
-}
-
 compileTestGroovy {
   javaLauncher = getJavaLauncherFor(17)
 }
@@ -23,9 +29,6 @@ compileTestGroovy {
 dependencies {
   main_java17CompileOnly(group: 'org.springframework', name: 'spring-webmvc', version: '6.0.0')
   main_java17CompileOnly group: 'jakarta.servlet', name: 'jakarta.servlet-api', version: '5.0.0'
-
-  main_java17CompileOnly project(':dd-java-agent:instrumentation:spring-webmvc-3.1')
-  main_java17CompileOnly project(':dd-java-agent:instrumentation:spring-webmvc-5.3')
 
   testImplementation(project(':dd-java-agent:testing')) {
     exclude(module: 'jetty-server') // incompatible servlet api

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/TemplateAndMatrixVariablesInstrumentation.java
@@ -55,7 +55,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends Instrumenter.Defa
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "datadog.trace.instrumentation.springweb.PairList",
+      packageName + ".PairList",
     };
   }
 }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
@@ -14,7 +14,6 @@ import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.instrumentation.springweb.PairList;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/PairList.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/PairList.java
@@ -1,0 +1,29 @@
+package datadog.trace.instrumentation.springweb6;
+
+import java.util.AbstractList;
+
+public class PairList extends AbstractList<Object> {
+  private final Object obj1;
+  private final Object obj2;
+
+  public PairList(Object obj1, Object obj2) {
+    this.obj1 = obj1;
+    this.obj2 = obj2;
+  }
+
+  @Override
+  public Object get(int index) {
+    if (index == 0) {
+      return obj1;
+    } else if (index == 1) {
+      return obj2;
+    } else {
+      throw new IndexOutOfBoundsException("Valid indices are 0 and 1");
+    }
+  }
+
+  @Override
+  public int size() {
+    return 2;
+  }
+}


### PR DESCRIPTION
# What Does This Do

Re-enable muzzle for spring 6

I had to duplicate PairList class because otherwise muzzle classpath would need stuff like `javax.servlet` (brung from spring web 5 and 3) while spring 6 is purely relying on jakarta

# Motivation


At time spring 6 instrumentation has been implemented, muzzle did not support a JDK17. Now it does

# Additional Notes
