### PR TITLE
Update ddprof-lib to 0.70.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.70.0",
+    ddprof        : "0.70.1",
     asm           : "9.5",
     cafe_crypto   : "0.1.0"
   ]


### PR DESCRIPTION
# What Does This Do
Updates ddprof-lib to [0.70.1](https://github.com/DataDog/java-profiler/releases/tag/v_0.70.1)

# Motivation
The 0.70.0 seems to be containing a slow memory leak. The 0.70.1 patch rolls back the suspected functionality.

# Additional Notes
