### PR TITLE
Update ddprof-lib to 0.70.1 (#5752)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.70.0",
+    ddprof        : "0.70.1",
     asm           : "9.5"
   ]
 


### PR DESCRIPTION
# What Does This Do
Updates ddprof-lib to [0.70.1](https://github.com/DataDog/java-profiler/releases/tag/v_0.70.1)

# Motivation
The 0.70.0 seems to be containing a slow memory leak. The 0.70.1 patch rolls back the suspected functionality.

# Additional Notes
(cherry picked from commit d7ef89215f6065edf5618f0addfcdf284299cb79)
