### PR TITLE
Fix NullPointerException in unvalidated redirect detection

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
@@ -99,7 +99,7 @@ public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
   private boolean isRefererHeader(Range[] ranges) {
     for (Range range : ranges) {
       if (range.getSource().getOrigin() != SourceTypes.REQUEST_HEADER_VALUE
-          || !range.getSource().getName().equalsIgnoreCase(REFERER)) {
+          || !REFERER.equalsIgnoreCase(range.getSource().getName())) {
         return false;
       }
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
@@ -157,6 +157,10 @@ class UnvalidatedRedirectModuleTest extends IastModuleImplTestBase {
       new Range(0, 2, new Source(SourceTypes.REQUEST_HEADER_VALUE, 'referer', 'value'), NOT_MARKED),
       new Range(4, 1, new Source(SourceTypes.REQUEST_PARAMETER_NAME, 'referer', 'value'), NOT_MARKED)
     ]
+    'test03' | [
+      new Range(0, 2, new Source(SourceTypes.REQUEST_HEADER_VALUE, null, null), NOT_MARKED),
+      new Range(4, 1, new Source(SourceTypes.REQUEST_PARAMETER_NAME, 'referer', 'value'), NOT_MARKED)
+    ]
   }
 
   void 'If all ranges from tainted element have unvalidated redirect mark vulnerability is not reported'() {


### PR DESCRIPTION


# What Does This Do
Under some circumstances, the `name` field of an IAST source can be `null` (very rare, and generally an indicative of another issue, but it's currently legal). In this case, the unvalidated redirect detection can throw a NPE.

This NPE is caught in the instrumentation, so it will not break the app, but it will log to debug:

```
[dd.trace 2023-08-22 18:49:20:322 +0200] [http-nio-20002-exec-3] DEBUG datadog.trace.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for org.springframework.web.method.support.InvocableHandlerMethod
java.lang.NullPointerException
	at com.datadog.iast.sink.UnvalidatedRedirectModuleImpl.isRefererHeader(UnvalidatedRedirectModuleImpl.java:102)
	at com.datadog.iast.sink.UnvalidatedRedirectModuleImpl.checkUnvalidatedRedirect(UnvalidatedRedirectModuleImpl.java:74)
	at com.datadog.iast.sink.UnvalidatedRedirectModuleImpl.onRedirect(UnvalidatedRedirectModuleImpl.java:41)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1070)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:655)
```

# Motivation

# Additional Notes
