### PR TITLE
Enable user event tracking only when AppSec is enabled

### DIFF
--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/AbstractUserDetailsAuthenticationProviderAdvice.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/AbstractUserDetailsAuthenticationProviderAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.springsecurity5;
 
+import datadog.trace.bootstrap.ActiveSubsystems;
 import net.bytebuddy.asm.Advice;
 import org.springframework.security.core.AuthenticationException;
 
@@ -9,9 +10,11 @@ public class AbstractUserDetailsAuthenticationProviderAdvice {
   public static boolean onEnter(
       @Advice.FieldValue(value = "hideUserNotFoundExceptions", readOnly = false)
           boolean hideUserNotFoundExceptions) {
-    // Ensure we are not hiding exception
     boolean originalValue = hideUserNotFoundExceptions;
-    hideUserNotFoundExceptions = false;
+    if (ActiveSubsystems.APPSEC_ACTIVE) {
+      // Ensure we are not hiding exception
+      hideUserNotFoundExceptions = false;
+    }
     return originalValue;
   }
 

--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/AuthenticationProviderAdvice.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/AuthenticationProviderAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.springsecurity5;
 
+import datadog.trace.bootstrap.ActiveSubsystems;
 import net.bytebuddy.asm.Advice;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -11,6 +12,8 @@ public class AuthenticationProviderAdvice {
       @Advice.Argument(value = 0, readOnly = false) Authentication authentication,
       @Advice.Return final Authentication result,
       @Advice.Thrown final AuthenticationException throwable) {
-    SpringSecurityUserEventDecorator.DECORATE.onLogin(authentication, throwable, result);
+    if (ActiveSubsystems.APPSEC_ACTIVE) {
+      SpringSecurityUserEventDecorator.DECORATE.onLogin(authentication, throwable, result);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/UserDetailsManagerAdvice.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/UserDetailsManagerAdvice.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.springsecurity5;
 
+import datadog.trace.bootstrap.ActiveSubsystems;
 import net.bytebuddy.asm.Advice;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -7,6 +8,8 @@ public class UserDetailsManagerAdvice {
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void onExit(@Advice.Argument(value = 0, readOnly = false) UserDetails user) {
-    SpringSecurityUserEventDecorator.DECORATE.onSignup(user);
+    if (ActiveSubsystems.APPSEC_ACTIVE) {
+      SpringSecurityUserEventDecorator.DECORATE.onSignup(user);
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do
Fixed activation for User Event Tracking.
Active only if AppSec is active with `DD_APPSEC_ENABLED=true` or via remote config.

# Motivation
Customer reported an issue when User Event Tracking was working even with inactive AppSec.

# Additional Notes
