### PR TITLE
Fix NullPointerException in unvalidated redirect detection (#5755)

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UnvalidatedRedirectModuleImpl.java
@@ -99,7 +99,7 @@ public class UnvalidatedRedirectModuleImpl extends SinkModuleBase
   private boolean isRefererHeader(Range[] ranges) {
     for (Range range : ranges) {
       if (range.getSource().getOrigin() != SourceTypes.REQUEST_HEADER_VALUE
-          || !range.getSource().getName().equalsIgnoreCase(REFERER)) {
+          || !REFERER.equalsIgnoreCase(range.getSource().getName())) {
         return false;
       }
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
@@ -157,6 +157,10 @@ class UnvalidatedRedirectModuleTest extends IastModuleImplTestBase {
       new Range(0, 2, new Source(SourceTypes.REQUEST_HEADER_VALUE, 'referer', 'value'), NOT_MARKED),
       new Range(4, 1, new Source(SourceTypes.REQUEST_PARAMETER_NAME, 'referer', 'value'), NOT_MARKED)
     ]
+    'test03' | [
+      new Range(0, 2, new Source(SourceTypes.REQUEST_HEADER_VALUE, null, null), NOT_MARKED),
+      new Range(4, 1, new Source(SourceTypes.REQUEST_PARAMETER_NAME, 'referer', 'value'), NOT_MARKED)
+    ]
   }
 
   void 'If all ranges from tainted element have unvalidated redirect mark vulnerability is not reported'() {


### PR DESCRIPTION


# What Does This Do
Under some circumstances, the `name` field of an IAST source can be `null` (very rare, and generally an indicative of another issue, but it's currently legal). In this case, the unvalidated redirect detection can throw a NPE.

This NPE is caught in the instrumentation, so it will not break the app, but it will log to debug
# Motivation

# Additional Notes
Backport of #5755