### PR TITLE
Make Maven test module names unique

### DIFF
--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenExecutionListener.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenExecutionListener.java
@@ -15,12 +15,8 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class MavenExecutionListener extends AbstractExecutionListener {
-
-  private static final Logger log = LoggerFactory.getLogger(MavenExecutionListener.class);
 
   private static final String FORK_COUNT_CONFIG = "forkCount";
   private static final String SYSTEM_PROPERTY_VARIABLES_CONFIG = "systemPropertyVariables";
@@ -53,9 +49,7 @@ public class MavenExecutionListener extends AbstractExecutionListener {
       MavenSession session = event.getSession();
       MavenExecutionRequest request = session.getRequest();
       MavenProject project = event.getProject();
-      String projectName = project.getName();
-      String lifecyclePhase = mojoExecution.getLifecyclePhase();
-      String moduleName = projectName + " " + lifecyclePhase;
+      String moduleName = getUniqueModuleName(project, mojoExecution);
 
       mojoStarted(event);
       buildEventsHandler.onTestModuleSkip(request, moduleName, null);
@@ -70,9 +64,7 @@ public class MavenExecutionListener extends AbstractExecutionListener {
       MavenSession session = event.getSession();
       MavenExecutionRequest request = session.getRequest();
       MavenProject project = event.getProject();
-      String projectName = project.getName();
-      String lifecyclePhase = mojoExecution.getLifecyclePhase();
-      String moduleName = projectName + " " + lifecyclePhase;
+      String moduleName = getUniqueModuleName(project, mojoExecution);
       String startCommand = MavenUtils.getCommandLine(session);
 
       String executionId =
@@ -150,10 +142,7 @@ public class MavenExecutionListener extends AbstractExecutionListener {
       MavenSession session = event.getSession();
       MavenExecutionRequest request = session.getRequest();
       MavenProject project = event.getProject();
-
-      String projectName = project.getName();
-      String lifecyclePhase = mojoExecution.getLifecyclePhase();
-      String moduleName = projectName + " " + lifecyclePhase;
+      String moduleName = getUniqueModuleName(project, mojoExecution);
       buildEventsHandler.onTestModuleFinish(request, moduleName);
 
       System.clearProperty(
@@ -170,11 +159,7 @@ public class MavenExecutionListener extends AbstractExecutionListener {
       MavenSession session = event.getSession();
       MavenExecutionRequest request = session.getRequest();
       MavenProject project = event.getProject();
-
-      String projectName = project.getName();
-      String lifecyclePhase = mojoExecution.getLifecyclePhase();
-      String moduleName = projectName + " " + lifecyclePhase;
-
+      String moduleName = getUniqueModuleName(project, mojoExecution);
       Exception exception = event.getException();
       buildEventsHandler.onTestModuleFail(request, moduleName, exception);
       buildEventsHandler.onTestModuleFinish(request, moduleName);
@@ -184,5 +169,13 @@ public class MavenExecutionListener extends AbstractExecutionListener {
       System.clearProperty(
           Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_MODULE_ID));
     }
+  }
+
+  private static String getUniqueModuleName(MavenProject project, MojoExecution mojoExecution) {
+    return project.getName()
+        + " "
+        + mojoExecution.getArtifactId()
+        + " "
+        + mojoExecution.getExecutionId();
   }
 }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/MavenTest.groovy
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/MavenTest.groovy
@@ -102,7 +102,7 @@ class MavenTest extends CiVisibilityTest {
             (Tags.TEST_COMMAND)  : "mvn clean test",
             (Tags.TEST_EXECUTION): "maven-surefire-plugin:test:default-test",
           ],
-          null, "Maven Integration Tests Project test")
+          null, "Maven Integration Tests Project maven-surefire-plugin default-test")
       }
     }
   }
@@ -137,7 +137,7 @@ class MavenTest extends CiVisibilityTest {
             (Tags.TEST_EXECUTION): "maven-surefire-plugin:test:default-test",
           ],
           testsFailedException,
-          "Maven Integration Tests Project test")
+          "Maven Integration Tests Project maven-surefire-plugin default-test")
       }
     }
   }
@@ -170,7 +170,7 @@ class MavenTest extends CiVisibilityTest {
             (Tags.TEST_COMMAND)  : "mvn clean test",
             (Tags.TEST_EXECUTION): "maven-surefire-plugin:test:default-test",
           ],
-          null, "module-a test")
+          null, "module-a maven-surefire-plugin default-test")
         testModuleSpan(it, 1, testSessionId,
           CIConstants.TEST_FAIL,
           [
@@ -178,7 +178,7 @@ class MavenTest extends CiVisibilityTest {
             (Tags.TEST_EXECUTION): "maven-surefire-plugin:test:default-test",
           ],
           testsFailedException,
-          "module-b test")
+          "module-b maven-surefire-plugin default-test")
       }
     }
   }
@@ -207,14 +207,14 @@ class MavenTest extends CiVisibilityTest {
             (Tags.TEST_COMMAND)  : "mvn -T4 clean test",
             (Tags.TEST_EXECUTION): "maven-surefire-plugin:test:default-test",
           ],
-          null, "module-a test")
+          null, "module-a maven-surefire-plugin default-test")
         testModuleSpan(it, 1, testSessionId,
           CIConstants.TEST_PASS,
           [
             (Tags.TEST_COMMAND)  : "mvn -T4 clean test",
             (Tags.TEST_EXECUTION): "maven-surefire-plugin:test:default-test",
           ],
-          null, "module-b test")
+          null, "module-b maven-surefire-plugin default-test")
       }
     }
   }
@@ -243,14 +243,14 @@ class MavenTest extends CiVisibilityTest {
             (Tags.TEST_COMMAND)  : "mvn verify",
             (Tags.TEST_EXECUTION): "maven-surefire-plugin:test:default-test",
           ],
-          null, "Maven Integration Tests Project test")
+          null, "Maven Integration Tests Project maven-surefire-plugin default-test")
         testModuleSpan(it, 0, testSessionId,
           CIConstants.TEST_PASS,
           [
             (Tags.TEST_COMMAND)  : "mvn verify",
             (Tags.TEST_EXECUTION): "maven-failsafe-plugin:integration-test:default",
           ],
-          null, "Maven Integration Tests Project integration-test")
+          null, "Maven Integration Tests Project maven-failsafe-plugin default")
       }
     }
   }
@@ -280,7 +280,7 @@ class MavenTest extends CiVisibilityTest {
             (Tags.TEST_COMMAND)  : "mvn clean test",
             (Tags.TEST_EXECUTION): "maven-surefire-plugin:test:default-test",
           ],
-          null, "Maven Integration Tests Project test")
+          null, "Maven Integration Tests Project maven-surefire-plugin default-test")
       }
     }
   }

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -167,12 +167,12 @@ class MavenSmokeTest extends Specification {
     verifyAll(moduleEndEvent) {
       verifyAll(content) {
         name == "maven.test_module"
-        resource == "Maven Smoke Tests Project test" // project name + execution goal
+        resource == "Maven Smoke Tests Project maven-surefire-plugin default-test" // project name + plugin name + execution ID
         test_session_id == sessionEndEvent.content.test_session_id
         test_module_id > 0
         verifyAll(meta) {
           it["span.kind"] == "test_module_end"
-          it["test.module"] == "Maven Smoke Tests Project test" // project name + execution goal
+          it["test.module"] == "Maven Smoke Tests Project maven-surefire-plugin default-test" // project name + plugin name + execution ID
           it["test.status"] == "pass"
           it["test.code_coverage.enabled"] == "true"
           it["test.itr.tests_skipping.enabled"] == "true"


### PR DESCRIPTION
# What Does This Do
Changes the way CI Visibility test module names are calculated in instrumented Maven projects.
Previous module name used to include project name and lifecycle phase.
New module name includes project name, plugin name, and execution ID.

# Motivation
Project name and lifecycle phase combination gives a module name that is not necessarily unique: it is possible to have a project configuration that binds multiple test executions in the same module to the same phase.
Project name, plugin name and execution ID combination is unique, Maven itself enforces this.

# Additional Notes
Non-unique module names may cause the following issues:
- if two modules with the same name execute in parallel the build will fail (due to some internal details of the test module registry implementation that uses the module name to uniquely identify `DDTestModule` instance)
- it will be impossible to distinguish between different test executions in the UI

Backport of #5762