### PR TITLE
Fix multi-buffers response case

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/usm/Payload.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/usm/Payload.java
@@ -12,7 +12,7 @@ public final class Payload implements Encodable {
   // HTTPS request
   // should be equal to:
   // https://github.com/DataDog/datadog-agent/blob/main/pkg/network/ebpf/c/protocols/http-types.h#L7
-  static final int MAX_HTTPS_BUFFER_SIZE = 8 * 20;
+  public static final int MAX_HTTPS_BUFFER_SIZE = 8 * 20;
   private final byte[] payload;
   private final int offset;
   private final int length;

--- a/dd-java-agent/instrumentation/sslengine/src/main/java/datadog/trace/instrumentation/sslengine/SslEngineInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslengine/src/main/java/datadog/trace/instrumentation/sslengine/SslEngineInstrumentation.java
@@ -121,7 +121,7 @@ public final class SslEngineInstrumentation extends Instrumenter.Usm
         return;
       }
       if (result.bytesProduced() > 0 && dst.limit() >= result.bytesProduced()) {
-        int bufferSize = Math.min(result.bytesProduced(),MAX_HTTPS_BUFFER_SIZE);
+        int bufferSize = Math.min(result.bytesProduced(), MAX_HTTPS_BUFFER_SIZE);
         byte[] b = new byte[bufferSize];
         int oldPos = dst.position();
         dst.position(dst.arrayOffset());

--- a/dd-java-agent/instrumentation/sslengine/src/main/java/datadog/trace/instrumentation/sslengine/SslEngineInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslengine/src/main/java/datadog/trace/instrumentation/sslengine/SslEngineInstrumentation.java
@@ -98,7 +98,7 @@ public final class SslEngineInstrumentation extends Instrumenter.Usm
           // update number of total copied bytes so far
           consumed += oldPos;
         }
-        dstBuffer.flip();
+
         Peer peer = new Peer(thiz.getPeerHost(), thiz.getPeerPort());
         Payload payload = new Payload(dstBuffer.array(), 0, dstBuffer.limit());
         Buffer message = MessageEncoder.encode(MessageEncoder.ASYNC_PAYLOAD, peer, payload);

--- a/dd-java-agent/instrumentation/sslengine/src/main/java/datadog/trace/instrumentation/sslengine/SslEngineInstrumentation.java
+++ b/dd-java-agent/instrumentation/sslengine/src/main/java/datadog/trace/instrumentation/sslengine/SslEngineInstrumentation.java
@@ -121,7 +121,7 @@ public final class SslEngineInstrumentation extends Instrumenter.Usm
         return;
       }
       if (result.bytesProduced() > 0 && dst.limit() >= result.bytesProduced()) {
-        int bufferSize = Math.min(result.bytesProduced(),MAX_HTTPS_BUFFER_SIZE)
+        int bufferSize = Math.min(result.bytesProduced(),MAX_HTTPS_BUFFER_SIZE);
         byte[] b = new byte[bufferSize];
         int oldPos = dst.position();
         dst.position(dst.arrayOffset());


### PR DESCRIPTION
# What Does This Do

- Support response that is split into multiple buffers
- limited the Payload buffer to 160 bytes (max buffer size supported by USM on a kernel side)

# Motivation

# Additional Notes
