### PR TITLE
use case insensitive comparison for _dd.base_service

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
@@ -22,7 +22,7 @@ public class BaseServiceAdder implements TagsPostProcessor {
   @Override
   public Map<String, Object> processTagsWithContext(
       Map<String, Object> unsafeTags, DDSpanContext spanContext) {
-    if (ddService != null && !ddService.toString().equals(spanContext.getServiceName())) {
+    if (ddService != null && !ddService.toString().equalsIgnoreCase(spanContext.getServiceName())) {
       unsafeTags.put(DDTags.BASE_SERVICE, ddService);
     }
     return unsafeTags;

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/BaseServiceAdderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/BaseServiceAdderTest.groovy
@@ -24,5 +24,6 @@ class BaseServiceAdderTest extends DDSpecification {
     serviceName     | expectedTags
     "anotherOne"    | ["_dd.base_service": UTF8BytesString.create("test")]
     "test"          | [:]
+    "TeSt"          | [:]
   }
 }


### PR DESCRIPTION
# What Does This Do

Use case insensitive comparison when deciding if adding `_dd.base_service` tag

# Motivation


# Additional Notes
