### PR TITLE
Fix instrumentation when bytecode generation fails

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -329,6 +329,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
       classNode.accept(writer);
     } catch (Throwable t) {
       log.error("Cannot write classfile for class: {} Exception: ", classFilePath, t);
+      return null;
     }
     byte[] data = writer.toByteArray();
     dumpInstrumentedClassFile(classFilePath, data);


### PR DESCRIPTION
If bytecode generation fails for any reason we should returns null for cancelling the current class transformation

# What Does This Do

# Motivation

# Additional Notes
