### PR TITLE
Separate config for Elasticsearch body and params

### DIFF
--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -97,7 +97,9 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
       final Map<String, String> parameters) {
     span.setTag(Tags.HTTP_METHOD, method);
     span.setTag(Tags.HTTP_URL, endpoint);
-    if (Config.get().isElasticsearchBodyAndParamsEnabled()) {
+
+    final Config config = Config.get();
+    if (config.isElasticsearchBodyEnabled() || config.isElasticsearchBodyAndParamsEnabled()) {
       if (entity != null) {
         long contentLength = entity.getContentLength();
         if (contentLength <= MAX_ELASTICSEARCH_BODY_CONTENT_LENGTH) {
@@ -112,6 +114,9 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
                   + ">");
         }
       }
+    }
+
+    if (config.isElasticsearchParamsEnabled() || config.isElasticsearchBodyAndParamsEnabled()) {
       if (parameters != null) {
         StringBuilder queryParametersStringBuilder = new StringBuilder();
         for (Map.Entry<String, String> parameter : parameters.entrySet()) {

--- a/dd-java-agent/instrumentation/opensearch/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/opensearch/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientDecorator.java
@@ -95,8 +95,10 @@ public class OpensearchRestClientDecorator extends DBTypeProcessingDatabaseClien
       final Map<String, String> parameters) {
     span.setTag(Tags.HTTP_METHOD, method);
     span.setTag(Tags.HTTP_URL, endpoint);
-    if (Config.get()
-        .isElasticsearchBodyAndParamsEnabled()) { // Elasticsearch also controls Opensearch
+
+    final Config config = Config.get();
+    // Elasticsearch also controls OpenSearch
+    if (config.isElasticsearchBodyEnabled() || config.isElasticsearchBodyAndParamsEnabled()) {
       if (entity != null) {
         long contentLength = entity.getContentLength();
         if (contentLength <= MAX_OPENSEARCH_BODY_CONTENT_LENGTH) {
@@ -111,6 +113,9 @@ public class OpensearchRestClientDecorator extends DBTypeProcessingDatabaseClien
                   + ">");
         }
       }
+    }
+
+    if (config.isElasticsearchParamsEnabled() || config.isElasticsearchBodyAndParamsEnabled()) {
       if (parameters != null) {
         StringBuilder queryParametersStringBuilder = new StringBuilder();
         for (Map.Entry<String, String> parameter : parameters.entrySet()) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -182,6 +182,8 @@ public final class ConfigDefaults {
 
   static final float DEFAULT_TRACE_FLUSH_INTERVAL = 1;
 
+  static final boolean DEFAULT_ELASTICSEARCH_BODY_ENABLED = false;
+  static final boolean DEFAULT_ELASTICSEARCH_PARAMS_ENABLED = true;
   static final boolean DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED = false;
 
   static final boolean DEFAULT_SPARK_TASK_HISTOGRAM_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -113,6 +113,8 @@ public final class TraceInstrumentationConfig {
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
   public static final String RESOLVER_RESET_INTERVAL = "resolver.reset.interval";
   public static final String RESOLVER_NAMES_ARE_UNIQUE = "resolver.names.are.unique";
+  public static final String ELASTICSEARCH_BODY_ENABLED = "trace.elasticsearch.body.enabled";
+  public static final String ELASTICSEARCH_PARAMS_ENABLED = "trace.elasticsearch.params.enabled";
   public static final String ELASTICSEARCH_BODY_AND_PARAMS_ENABLED =
       "trace.elasticsearch.body-and-params.enabled";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -46,6 +46,8 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_VERIFY_BYTECODE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DOGSTATSD_START_DELAY;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_ELASTICSEARCH_BODY_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_ELASTICSEARCH_PARAMS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_GRPC_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_GRPC_SERVER_ERROR_STATUSES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_HEALTH_METRICS_ENABLED;
@@ -275,6 +277,8 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX;
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_DBM_PROPAGATION_MODE_MODE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.ELASTICSEARCH_BODY_AND_PARAMS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.ELASTICSEARCH_BODY_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.ELASTICSEARCH_PARAMS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_CLIENT_ERROR_STATUSES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_INBOUND_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_IGNORED_OUTBOUND_METHODS;
@@ -768,6 +772,8 @@ public class Config {
 
   private final boolean longRunningTraceEnabled;
   private final long longRunningTraceFlushInterval;
+  private final boolean elasticsearchBodyEnabled;
+  private final boolean elasticsearchParamsEnabled;
   private final boolean elasticsearchBodyAndParamsEnabled;
   private final boolean sparkTaskHistogramEnabled;
   private final boolean jaxRsExceptionAsErrorsEnabled;
@@ -849,6 +855,11 @@ public class Config {
     } else {
       secureRandom = configProvider.getBoolean(SECURE_RANDOM, DEFAULT_SECURE_RANDOM);
     }
+    elasticsearchBodyEnabled =
+        configProvider.getBoolean(ELASTICSEARCH_BODY_ENABLED, DEFAULT_ELASTICSEARCH_BODY_ENABLED);
+    elasticsearchParamsEnabled =
+        configProvider.getBoolean(
+            ELASTICSEARCH_PARAMS_ENABLED, DEFAULT_ELASTICSEARCH_PARAMS_ENABLED);
     elasticsearchBodyAndParamsEnabled =
         configProvider.getBoolean(
             ELASTICSEARCH_BODY_AND_PARAMS_ENABLED, DEFAULT_ELASTICSEARCH_BODY_AND_PARAMS_ENABLED);
@@ -2791,6 +2802,14 @@ public class Config {
     return grpcClientErrorStatuses;
   }
 
+  public boolean isElasticsearchBodyEnabled() {
+    return elasticsearchBodyEnabled;
+  }
+
+  public boolean isElasticsearchParamsEnabled() {
+    return elasticsearchParamsEnabled;
+  }
+
   public boolean isElasticsearchBodyAndParamsEnabled() {
     return elasticsearchBodyAndParamsEnabled;
   }
@@ -3807,6 +3826,10 @@ public class Config {
         + longRunningTraceEnabled
         + ", longRunningTraceFlushInterval="
         + longRunningTraceFlushInterval
+        + ", elasticsearchBodyEnabled="
+        + elasticsearchBodyEnabled
+        + ", elasticsearchParamsEnabled="
+        + elasticsearchParamsEnabled
         + ", elasticsearchBodyAndParamsEnabled="
         + elasticsearchBodyAndParamsEnabled
         + ", traceFlushInterval="


### PR DESCRIPTION
# What Does This Do
Expands upon #5749 to separate the configuration options for `body` and `params` so that they can be individually selected

After this, the usage of `dd.trace.elasticsearch.body-and-params.enabled` will be discouraged in favor of the individual options, `dd.trace.elasticsearch.body.enabled` and `dd.trace.elasticsearch.params.enabled`

# Motivation
Gives users of the library increased flexibility when it comes to configuring their elasticsearch instrumentation

# Additional Notes
