### PR TITLE
Fix for Vert.x 4.0 instrumentation to close span on timeout

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
@@ -27,6 +27,8 @@ artifacts {
 }
 
 dependencies {
+  api project(':dd-java-agent:instrumentation:netty-4.1-shared')
+
   compileOnly group: 'io.vertx', name: 'vertx-web', version: '4.2.7'
 
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/client/HttpClientRequestBaseInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/client/HttpClientRequestBaseInstrumentation.java
@@ -1,0 +1,63 @@
+package datadog.trace.instrumentation.vertx_4_0.client;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
+import static datadog.trace.bootstrap.instrumentation.httpurlconnection.HttpUrlConnectionDecorator.DECORATE;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPackagePrivate;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.netty.util.AttributeKey;
+import io.vertx.core.http.impl.HttpClientStream;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class HttpClientRequestBaseInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForKnownTypes {
+  static final String[] CONCRETE_TYPES = {
+    "io.vertx.core.http.impl.HttpClientRequestImpl",
+    "io.vertx.core.http.impl.HttpClientRequestPushPromise"
+  };
+
+  public HttpClientRequestBaseInstrumentation() {
+    super("vertx", "vertx-4.0");
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(isPackagePrivate())
+            .and(named("reset"))
+            .and(takesArgument(0, named("java.lang.Throwable"))),
+        HttpClientRequestBaseInstrumentation.class.getName() + "$ResetAdvice");
+  }
+
+  @Override
+  public String[] knownMatchingTypes() {
+    return CONCRETE_TYPES;
+  }
+
+  public static class ResetAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.Argument(value = 0) Throwable cause,
+        @Advice.FieldValue("stream") final HttpClientStream stream,
+        @Advice.Return(readOnly = false) boolean result) {
+      if (result) {
+        AttributeKey<AgentSpan> spanAttr = AttributeKey.valueOf(DD_SPAN_ATTRIBUTE);
+        AgentSpan nettySpan = stream.connection().channel().attr(spanAttr).get();
+        if (nettySpan != null) {
+          try (final AgentScope scope = activateSpan(nettySpan)) {
+            DECORATE.onError(scope, cause);
+          }
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -8,6 +8,8 @@ import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpClientOptions
 import io.vertx.core.http.HttpClientResponse
 import io.vertx.core.http.HttpMethod
+import io.vertx.core.http.RequestOptions
+import io.vertx.core.http.impl.NoStackTraceTimeoutException
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
@@ -37,9 +39,20 @@ class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHt
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+    return doRequest(method, uri, headers, body, callback, -1)
+  }
+
+  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback, long timeout) {
     CompletableFuture<HttpClientResponse> future = new CompletableFuture<>()
 
-    httpClient.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri", { requestReadyToBeSend ->
+    RequestOptions requestOptions = new RequestOptions()
+      .setMethod(HttpMethod.valueOf(method))
+      .setHost(uri.host)
+      .setPort(uri.port)
+      .setURI(uri.toString())
+      .setTimeout(timeout)
+
+    httpClient.request(requestOptions, { requestReadyToBeSend ->
       def request = requestReadyToBeSend.result()
       headers.each { request.putHeader(it.key, it.value) }
       request.send(body, { response ->
@@ -52,7 +65,8 @@ class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHt
       })
     })
 
-    return future.get(10, TimeUnit.SECONDS).statusCode()
+    HttpClientResponse response = future.get(10, TimeUnit.SECONDS)
+    return response == null ? 0 : response.statusCode()
   }
 
   @Override
@@ -73,5 +87,24 @@ class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHt
   boolean testRemoteConnection() {
     // FIXME: figure out how to configure timeouts.
     false
+  }
+
+  def "handle timeout"() {
+    when:
+    def status = doRequest(method, url, [:], "", null, timeout)
+
+    then:
+    status == 0
+    assertTraces(1) {
+      trace(size(1)) {
+        clientSpan(it, null, method, false, false, url, null, true, ex)
+      }
+    }
+
+    where:
+    timeout = 1000
+    method = "GET"
+    url = server.address.resolve("/timeout")
+    ex = new NoStackTraceTimeoutException("The timeout period of ${timeout}ms has been exceeded while executing GET http://localhost:${url.port}/timeout for server localhost:${url.port}")
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -87,6 +87,10 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
           .addHeader('x-datadog-test-response-header', 'baz')
           .send(msg)
       }
+      prefix("/timeout") {
+        Thread.sleep(10_000)
+        throw new IllegalStateException("Should never happen")
+      }
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Fix for an issue with Vert.x HTTP timed out client requests. It was keeping a request span unfinished.

Vert.x uses Netty under the hood. Netty instrumentation already has timeout handling but turns out that Vert.x has its own timeout handling that have not been covered with instrumentation.

There are two main pieces. First, closing a span in Netty instrumentation in case of the `channelInactive` event. Second, decorating a span on Vert.x instrumentation side with the original exception, so it's clear that the request has been timed out.

# Motivation

A client reported issue about created but never finished client http spans in case of timeout.

# Additional Notes

Example of a timed out span:

```json
[
  {
    "service": "service-name",
    "name": "netty.client.request",
    "resource": "GET /?",
    "trace_id": "2178227018975193174",
    "span_id": "7989050593220702817",
    "parent_id": 0,
    "start": "1692834467128191917",
    "duration": 1017764708,
    "type": "http",
    "error": 1,
    "metrics": {
      "_sampling_priority_v1": 1,
      "_dd.measured": 1,
      "_dd.top_level": 1,
      "thread.id": 27,
      "process_id": 55085,
      "_dd.profiling.enabled": 0,
      "_dd.agent_psr": 1,
      "peer.port": 80,
      "_dd.trace_span_attribute_schema": 0
    },
    "meta": {
      "_dd.p.dm": "-1",
      "thread.name": "vert.x-eventloop-thread-0",
      "http.url": "http://httpstat.us/200",
      "language": "jvm",
      "env": "local-test",
      "version": "1",
      "peer.ipv4": "20.40.202.3",
      "component": "netty-client",
      "error.type": "io.vertx.core.http.impl.NoStackTraceTimeoutException",
      "span.kind": "client",
      "error.message": "The timeout period of 1000ms has been exceeded while executing GET /200?sleep=2000 for server httpstat.us:80",
      "error.stack": "io.vertx.core.http.impl.NoStackTraceTimeoutException: The timeout period of 1000ms has been exceeded while executing GET /200?sleep=2000 for server httpstat.us:80\n",
      "runtime-id": "aaf5dacb-af13-449d-a82d-9d7bd45422b8",
      "peer.hostname": "httpstat.us",
      "http.method": "GET"
    }
  }
]
```