### PR TITLE
Get databricks cluster name from spark conf, instead of job properties

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkConfAllowList.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkConfAllowList.java
@@ -74,7 +74,8 @@ class SparkConfAllowList {
               "user"));
 
   public static boolean canCaptureApplicationParameter(String parameterName) {
-    return allowedApplicationParams.contains(parameterName);
+    return allowedApplicationParams.contains(parameterName)
+        || allowedJobParams.contains(parameterName);
   }
 
   public static boolean canCaptureJobParameter(String parameterName) {

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -219,16 +219,15 @@ class SparkTest extends AgentTestRunner {
       .config("spark.default.parallelism", "2") // Small parallelism to speed up tests
       .config("spark.sql.shuffle.partitions", "2")
       .config("spark.databricks.sparkContextId", "some_id")
+      .config("spark.databricks.clusterUsageTags.clusterName", "job-1234-run-5678-Job_cluster")
       .getOrCreate()
 
     sparkSession.sparkContext().setLocalProperty("spark.databricks.job.id", "1234")
     sparkSession.sparkContext().setLocalProperty("spark.databricks.job.runId", "9012")
-    sparkSession.sparkContext().setLocalProperty("spark.databricks.clusterUsageTags.clusterName", "job-1234-run-5678-Job_cluster")
     TestSparkComputation.generateTestSparkComputation(sparkSession)
 
     sparkSession.sparkContext().setLocalProperty("spark.databricks.job.id", null)
     sparkSession.sparkContext().setLocalProperty("spark.databricks.job.runId", null)
-    sparkSession.sparkContext().setLocalProperty("spark.databricks.clusterUsageTags.clusterName", null)
     TestSparkComputation.generateTestSparkComputation(sparkSession)
 
     expect:


### PR DESCRIPTION
# What Does This Do

Rely on the `spark.databricks.clusterUsageTags.clusterName` present in the SparkConf instead of the one present in the jobProperties

After some trial and errors, it turned out that the value in jobProperties can sometimes be missing, while it is always present in the SparkConf

# Motivation

