### PR TITLE
Prevent IAST from creating empty spans for duplicated vulnerabilities

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -41,6 +41,9 @@ public class Reporter {
   }
 
   public void report(@Nullable final AgentSpan span, @Nonnull final Vulnerability vulnerability) {
+    if (duplicated.test(vulnerability)) {
+      return;
+    }
     if (span == null) {
       final AgentSpan newSpan = startNewSpan();
       try (final AgentScope autoClosed = tracer().activateSpan(newSpan, ScopeSource.MANUAL)) {
@@ -62,9 +65,6 @@ public class Reporter {
     }
     final IastRequestContext ctx = reqCtx.getData(RequestContextSlot.IAST);
     if (ctx == null) {
-      return;
-    }
-    if (duplicated.test(vulnerability)) {
       return;
     }
     final VulnerabilityBatch batch = ctx.getVulnerabilityBatch();

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -52,10 +52,10 @@ class ReporterTest extends DDSpecification {
     span.getSpanId() >> spanId
 
     final v = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(spanId, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("MD5")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(spanId, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("MD5")
+    )
 
     when:
     reporter.report(span, v)
@@ -97,15 +97,15 @@ class ReporterTest extends DDSpecification {
     span.getSpanId() >> spanId
 
     final v1 = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(spanId, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("MD5")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(spanId, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("MD5")
+    )
     final v2 = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(spanId, new StackTraceElement("foo", "foo", "foo", 2)),
-      new Evidence("MD4")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(spanId, new StackTraceElement("foo", "foo", "foo", 2)),
+    new Evidence("MD4")
+    )
 
     when:
     reporter.report(span, v1)
@@ -155,10 +155,10 @@ class ReporterTest extends DDSpecification {
     reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final reporter = new Reporter()
     final v = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(0, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("MD5")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(0, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("MD5")
+    )
 
     when:
     reporter.report(null, v)
@@ -177,6 +177,28 @@ class ReporterTest extends DDSpecification {
     0 * _
   }
 
+  void 'no spans are create if duplicates are reported'() {
+    given:
+    final tracerAPI = Mock(TracerAPI)
+    AgentTracer.forceRegister(tracerAPI)
+    final ctx = new IastRequestContext()
+    final reqCtx = Stub(RequestContext)
+    reqCtx.getData(RequestContextSlot.IAST) >> ctx
+    final reporter = new Reporter((vul) -> true)
+    final v = new Vulnerability(
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(0, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("MD5")
+    )
+
+    when:
+    reporter.report(null, v)
+
+    then:
+    noExceptionThrown()
+    0 * _
+  }
+
   void 'null RequestContext does not throw'() {
     given:
     final Reporter reporter = new Reporter()
@@ -184,10 +206,10 @@ class ReporterTest extends DDSpecification {
     span.getRequestContext() >> null
     span.getSpanId() >> 12345L
     final v = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(0, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("MD5")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(0, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("MD5")
+    )
 
     when:
     reporter.report(span, v)
@@ -208,10 +230,10 @@ class ReporterTest extends DDSpecification {
     span.getRequestContext() >> reqCtx
     span.getSpanId() >> spanId
     final v = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(spanId, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("MD5")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(spanId, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("MD5")
+    )
 
     when:
     reporter.report(span, v)
@@ -226,15 +248,15 @@ class ReporterTest extends DDSpecification {
   void 'Vulnerabilities with same type and location are equals'() {
     given:
     final vulnerability1 = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(123456, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("GOOD")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(123456, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("GOOD")
+    )
     final vulnerability2 = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(7890, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("BAD")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(7890, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("BAD")
+    )
 
     expect:
     vulnerability1 == vulnerability2
@@ -243,15 +265,15 @@ class ReporterTest extends DDSpecification {
   void 'Vulnerabilities with same type and different location are not equals'() {
     given:
     final vulnerability1 = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(123456, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("GOOD")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(123456, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("GOOD")
+    )
     final vulnerability2 = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(7890, new StackTraceElement("foo", "foo", "foo", 2)),
-      new Evidence("BAD")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(7890, new StackTraceElement("foo", "foo", "foo", 2)),
+    new Evidence("BAD")
+    )
 
     expect:
     vulnerability1 != vulnerability2
@@ -264,10 +286,10 @@ class ReporterTest extends DDSpecification {
     final batch = new VulnerabilityBatch()
     final span = spanWithBatch(batch)
     final vulnerability = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(span.spanId, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("GOOD")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(span.spanId, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("GOOD")
+    )
 
     when: 'first time a vulnerability is reported'
     reporter.report(span, vulnerability)
@@ -289,10 +311,10 @@ class ReporterTest extends DDSpecification {
     final batch = new VulnerabilityBatch()
     final span = spanWithBatch(batch)
     final vulnerability = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(span.spanId, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("GOOD")
-      )
+    VulnerabilityType.WEAK_HASH,
+    Location.forSpanAndStack(span.spanId, new StackTraceElement("foo", "foo", "foo", 1)),
+    new Evidence("GOOD")
+    )
 
     when: 'first time a vulnerability is reported'
     reporter.report(span, vulnerability)
@@ -316,10 +338,10 @@ class ReporterTest extends DDSpecification {
     final span = spanWithBatch(batch)
     final vulnerabilityBuilder = { int index ->
       new Vulnerability(
-        VulnerabilityType.WEAK_HASH,
-        Location.forSpanAndStack(span.spanId, new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
-        new Evidence("GOOD")
-        )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span.spanId, new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
+      new Evidence("GOOD")
+      )
     }
 
     when: 'the deduplication cache is filled for the first time'
@@ -356,10 +378,10 @@ class ReporterTest extends DDSpecification {
     final span = spanWithBatch(batch)
     final vulnerabilityBuilder = { int index ->
       new Vulnerability(
-        VulnerabilityType.WEAK_HASH,
-        Location.forSpanAndStack(span.spanId, new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
-        new Evidence("GOOD")
-        )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span.spanId, new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
+      new Evidence("GOOD")
+      )
     }
 
     when: 'a few duplicates are reported in a concurrent scenario'


### PR DESCRIPTION
# What Does This Do
Skips span creation when a duplicate vulnerability is detected and there is no active span.

# Motivation
We have detected excessive span creation by IAST due to duplicated vulnerabilities creating span that latter were not used.

# Additional Notes
