### PR TITLE
Add basic Scala MUnit support

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndex.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndex.java
@@ -81,6 +81,9 @@ public class RepoIndex {
       if ("kotlin.Metadata".equals(annotationType.getName())) {
         return SourceType.KOTLIN;
       }
+      if ("scala.reflect.ScalaSignature".equals(annotationType.getName())) {
+        return SourceType.SCALA;
+      }
     }
 
     // assuming Java

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/SourceType.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/SourceType.java
@@ -3,7 +3,10 @@ package datadog.trace.civisibility.source.index;
 enum SourceType {
   JAVA(".java"),
   GROOVY(".groovy"),
-  KOTLIN(".kt");
+  KOTLIN(".kt"),
+  SCALA(".scala");
+
+  private static final SourceType[] UNIVERSE = SourceType.values();
 
   private final String extension;
 
@@ -16,7 +19,7 @@ enum SourceType {
   }
 
   static SourceType getByFileName(String fileName) {
-    for (SourceType sourceType : values()) {
+    for (SourceType sourceType : UNIVERSE) {
       if (fileName.endsWith(sourceType.extension)) {
         return sourceType;
       }

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
@@ -342,7 +342,8 @@ abstract class CiVisibilityTest extends AgentTestRunner {
   final Throwable exception = null,
   final boolean emptyDuration = false,
   final Collection<String> categories = null,
-  final boolean sourceFilePresent = true) {
+  final boolean sourceFilePresent = true,
+  final boolean sourceMethodPresent = true) {
     def testFramework = expectedTestFramework()
     def testFrameworkVersion = expectedTestFrameworkVersion()
 
@@ -376,10 +377,13 @@ abstract class CiVisibilityTest extends AgentTestRunner {
 
         if (sourceFilePresent) {
           "$Tags.TEST_SOURCE_FILE" DUMMY_SOURCE_PATH
+          "$Tags.TEST_CODEOWNERS" Strings.toJson(DUMMY_CODE_OWNERS)
+        }
+
+        if (sourceMethodPresent) {
           "$Tags.TEST_SOURCE_METHOD" testMethod
           "$Tags.TEST_SOURCE_START" DUMMY_TEST_METHOD_START
           "$Tags.TEST_SOURCE_END" DUMMY_TEST_METHOD_END
-          "$Tags.TEST_CODEOWNERS" Strings.toJson(DUMMY_CODE_OWNERS)
         }
 
         if (exception) {

--- a/dd-java-agent/instrumentation/junit-4.10/build.gradle
+++ b/dd-java-agent/instrumentation/junit-4.10/build.gradle
@@ -1,4 +1,5 @@
 apply from: "$rootDir/gradle/java.gradle"
+apply plugin: 'scala'
 
 muzzle {
   pass {
@@ -25,4 +26,12 @@ dependencies {
   testImplementation group: 'io.cucumber', name: 'cucumber-java', version: '5.4.0'
   testImplementation group: 'io.cucumber', name: 'cucumber-junit', version: '5.4.0'
   testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.1'
+
+  testImplementation group: 'org.scala-lang', name: 'scala-library', version: '2.13.10'
+  testImplementation group: 'org.scalameta', name: 'munit_2.13', version: '0.7.28'
+}
+
+compileTestGroovy {
+  dependsOn compileTestScala
+  classpath += files(sourceSets.test.scala.destinationDirectory)
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -37,6 +37,8 @@ public class JUnit4Instrumentation extends Instrumenter.CiVisibility
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SkippedByItr",
+      packageName + ".JUnit4Utils$Cucumber",
+      packageName + ".JUnit4Utils$Munit",
       packageName + ".JUnit4Utils",
       packageName + ".TestEventsHandlerHolder",
       packageName + ".TracingListener",

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4ItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4ItrInstrumentation.java
@@ -47,6 +47,8 @@ public class JUnit4ItrInstrumentation extends Instrumenter.CiVisibility
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SkippedByItr",
+      packageName + ".JUnit4Utils$Cucumber",
+      packageName + ".JUnit4Utils$Munit",
       packageName + ".JUnit4Utils",
       packageName + ".TestEventsHandlerHolder",
       packageName + ".TracingListener",

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4SuiteEventsInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4SuiteEventsInstrumentation.java
@@ -1,9 +1,7 @@
 package datadog.trace.instrumentation.junit4;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
@@ -36,13 +34,6 @@ public class JUnit4SuiteEventsInstrumentation extends Instrumenter.CiVisibility
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
-    // Avoid matching versions >= 4.13
-    // where proper support for suite events was added
-    return not(hasClassNamed("org.junit.runner.OrderWith"));
-  }
-
-  @Override
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SkippedByItr",
@@ -64,6 +55,10 @@ public class JUnit4SuiteEventsInstrumentation extends Instrumenter.CiVisibility
     public static void fireSuiteStartedEvent(
         @Advice.Argument(0) final RunNotifier runNotifier,
         @Advice.This final ParentRunner<?> runner) {
+      if (JUnit4Utils.NATIVE_SUITE_EVENTS_SUPPORTED) {
+        return;
+      }
+
       final List<RunListener> runListeners = JUnit4Utils.runListenersFromRunNotifier(runNotifier);
       if (runListeners == null) {
         return;
@@ -81,6 +76,10 @@ public class JUnit4SuiteEventsInstrumentation extends Instrumenter.CiVisibility
     public static void fireSuiteFinishedEvent(
         @Advice.Argument(0) final RunNotifier runNotifier,
         @Advice.This final ParentRunner<?> runner) {
+      if (JUnit4Utils.NATIVE_SUITE_EVENTS_SUPPORTED) {
+        return;
+      }
+
       final List<RunListener> runListeners = JUnit4Utils.runListenersFromRunNotifier(runNotifier);
       if (runListeners == null) {
         return;

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4SuiteEventsInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4SuiteEventsInstrumentation.java
@@ -37,6 +37,8 @@ public class JUnit4SuiteEventsInstrumentation extends Instrumenter.CiVisibility
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".SkippedByItr",
+      packageName + ".JUnit4Utils$Cucumber",
+      packageName + ".JUnit4Utils$Munit",
       packageName + ".JUnit4Utils",
       packageName + ".TestEventsHandlerHolder",
       packageName + ".TracingListener",

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -46,6 +46,7 @@ public abstract class JUnit4Utils {
   public static final String JUNIT_4_FRAMEWORK = "junit4";
   public static final String CUCUMBER_FRAMEWORK = "cucumber";
   public static final String MUNIT_FRAMEWORK = "munit";
+  public static final boolean NATIVE_SUITE_EVENTS_SUPPORTED;
 
   static {
     MethodHandles.Lookup lookup = MethodHandles.lookup();
@@ -54,6 +55,17 @@ public abstract class JUnit4Utils {
     INNER_SYNCHRONIZED_LISTENER = accessListenerFieldInSynchronizedListener(lookup);
     DESCRIPTION_UNIQUE_ID = accessUniqueIdInDescription(lookup);
     CREATE_DESCRIPTION_WITH_UNIQUE_ID = accessCreateDescriptionWithUniqueId(lookup);
+    NATIVE_SUITE_EVENTS_SUPPORTED = nativeSuiteEventsSupported();
+  }
+
+  /** JUnit 4 support test suite started/finished events in versions 4.13 and later */
+  private static boolean nativeSuiteEventsSupported() {
+    try {
+      RunListener.class.getDeclaredMethod("testSuiteStarted", Description.class);
+      return true;
+    } catch (NoSuchMethodException e) {
+      return false;
+    }
   }
 
   private static MethodHandle accessDescribeChildMethodInParentRunner(MethodHandles.Lookup lookup) {

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TracingListener.java
@@ -2,21 +2,13 @@ package datadog.trace.instrumentation.junit4;
 
 import java.lang.reflect.Method;
 import java.util.List;
-import junit.runner.Version;
 import org.junit.Ignore;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
-import org.junit.runners.model.TestClass;
 
 public class TracingListener extends RunListener {
-
-  private final String version;
-
-  public TracingListener() {
-    version = Version.id();
-  }
 
   @Override
   public void testRunStarted(Description description) {
@@ -28,37 +20,34 @@ public class TracingListener extends RunListener {
     // on op
   }
 
-  public void testSuiteStarted(final TestClass junitTestClass, final Description description) {
-    if (!JUnit4Utils.isSuiteContainingChildren(junitTestClass, description)) {
+  public void testSuiteStarted(final Description description) {
+    if (!JUnit4Utils.isSuiteContainingChildren(description)) {
       // Not all test suites contain tests.
       // Given that test suites can be nested in other test suites,
       // we are only interested in the innermost ones where the actual test cases reside
       return;
     }
 
-    Class<?> testClass = junitTestClass.getJavaClass();
+    Class<?> testClass = description.getTestClass();
     String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
 
     String testFramework = JUnit4Utils.getTestFramework(description);
-    String testFrameworkVersion =
-        !JUnit4Utils.CUCUMBER_FRAMEWORK.equals(testFramework)
-            ? version
-            : JUnit4Utils.getCucumberVersion(description);
+    String testFrameworkVersion = JUnit4Utils.getTestFrameworkVersion(testFramework, description);
 
     List<String> categories = JUnit4Utils.getCategories(testClass, null);
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteStart(
         testSuiteName, testFramework, testFrameworkVersion, testClass, categories, false);
   }
 
-  public void testSuiteFinished(final TestClass junitTestClass, final Description description) {
-    if (!JUnit4Utils.isSuiteContainingChildren(junitTestClass, description)) {
+  public void testSuiteFinished(final Description description) {
+    if (!JUnit4Utils.isSuiteContainingChildren(description)) {
       // Not all test suites contain tests.
       // Given that test suites can be nested in other test suites,
       // we are only interested in the innermost ones where the actual test cases reside
       return;
     }
 
-    Class<?> testClass = junitTestClass.getJavaClass();
+    Class<?> testClass = description.getTestClass();
     String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(testSuiteName, testClass);
   }
@@ -73,10 +62,7 @@ public class TracingListener extends RunListener {
     String testName = JUnit4Utils.getTestName(description, testMethod);
 
     String testFramework = JUnit4Utils.getTestFramework(description);
-    String testFrameworkVersion =
-        !JUnit4Utils.CUCUMBER_FRAMEWORK.equals(testFramework)
-            ? version
-            : JUnit4Utils.getCucumberVersion(description);
+    String testFrameworkVersion = JUnit4Utils.getTestFrameworkVersion(testFramework, description);
 
     String testParameters = JUnit4Utils.getParameters(description);
     List<String> categories = JUnit4Utils.getCategories(testClass, testMethod);
@@ -171,10 +157,7 @@ public class TracingListener extends RunListener {
       String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
 
       String testFramework = JUnit4Utils.getTestFramework(description);
-      String testFrameworkVersion =
-          !JUnit4Utils.CUCUMBER_FRAMEWORK.equals(testFramework)
-              ? version
-              : JUnit4Utils.getCucumberVersion(description);
+      String testFrameworkVersion = JUnit4Utils.getTestFrameworkVersion(testFramework, description);
 
       List<String> categories = JUnit4Utils.getCategories(testClass, null);
 
@@ -199,10 +182,7 @@ public class TracingListener extends RunListener {
     String testName = JUnit4Utils.getTestName(description, testMethod);
 
     String testFramework = JUnit4Utils.getTestFramework(description);
-    String testFrameworkVersion =
-        !JUnit4Utils.CUCUMBER_FRAMEWORK.equals(testFramework)
-            ? version
-            : JUnit4Utils.getCucumberVersion(description);
+    String testFrameworkVersion = JUnit4Utils.getTestFrameworkVersion(testFramework, description);
 
     String testParameters = JUnit4Utils.getParameters(description);
     List<String> categories = JUnit4Utils.getCategories(testClass, testMethod);

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/CucumberTest.groovy
@@ -124,7 +124,7 @@ class CucumberTest extends CiVisibilityTest {
     final Throwable exception = null,
     final boolean emptyDuration = false,
     final Collection<String> categories = null) {
-    testSpan(trace, index, testSessionId, testModuleId, testSuiteId, testSuite, testName, null, testStatus, testTags, exception, emptyDuration, categories, false)
+    testSpan(trace, index, testSessionId, testModuleId, testSuiteId, testSuite, testName, null, testStatus, testTags, exception, emptyDuration, categories, false, false)
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -21,8 +21,8 @@ import org.example.TestSkippedClass
 import org.example.TestSucceed
 import org.example.TestSucceedAndSkipped
 import org.example.TestSucceedWithCategories
-import org.example.TestSuite
-import org.example.TestSuiteSetUpAssumption
+import org.example.TestSucceedSuite
+import org.example.TestFailedSuiteSetUpAssumption
 import org.junit.runner.JUnitCore
 
 @DisableTestTrace(reason = "avoid self-tracing")
@@ -320,7 +320,7 @@ class JUnit4Test extends CiVisibilityTest {
 
   def "test assumption failure during suite setup"() {
     setup:
-    runTests(TestSuiteSetUpAssumption)
+    runTests(TestFailedSuiteSetUpAssumption)
 
     expect:
     ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
@@ -330,10 +330,10 @@ class JUnit4Test extends CiVisibilityTest {
       trace(3, true) {
         testSessionId = testSessionSpan(it, 1, CIConstants.TEST_SKIP)
         testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_SKIP)
-        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSuiteSetUpAssumption", CIConstants.TEST_SKIP, testTags)
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestFailedSuiteSetUpAssumption", CIConstants.TEST_SKIP, testTags)
       }
       trace(1) {
-        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSuiteSetUpAssumption", "test_succeed", "test_succeed()V", CIConstants.TEST_SKIP, testTags, null)
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestFailedSuiteSetUpAssumption", "test_succeed", "test_succeed()V", CIConstants.TEST_SKIP, testTags, null)
       }
     })
 
@@ -536,7 +536,7 @@ class JUnit4Test extends CiVisibilityTest {
 
   def "test suite runner"() {
     setup:
-    runTests(TestSuite)
+    runTests(TestSucceedSuite)
 
     expect:
     ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
@@ -547,14 +547,14 @@ class JUnit4Test extends CiVisibilityTest {
       trace(4, true) {
         testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
         testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
-        firstSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSuite\$FirstTest", CIConstants.TEST_PASS)
-        secondSuiteId = testSuiteSpan(it, 3, testSessionId, testModuleId, "org.example.TestSuite\$SecondTest", CIConstants.TEST_PASS)
+        firstSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedSuite\$FirstTest", CIConstants.TEST_PASS)
+        secondSuiteId = testSuiteSpan(it, 3, testSessionId, testModuleId, "org.example.TestSucceedSuite\$SecondTest", CIConstants.TEST_PASS)
       }
       trace(1) {
-        testSpan(it, 0, testSessionId, testModuleId, firstSuiteId, "org.example.TestSuite\$FirstTest", "testAddition", "testAddition()V", CIConstants.TEST_PASS)
+        testSpan(it, 0, testSessionId, testModuleId, firstSuiteId, "org.example.TestSucceedSuite\$FirstTest", "testAddition", "testAddition()V", CIConstants.TEST_PASS)
       }
       trace(1) {
-        testSpan(it, 0, testSessionId, testModuleId, secondSuiteId, "org.example.TestSuite\$SecondTest", "testSubtraction", "testSubtraction()V", CIConstants.TEST_PASS)
+        testSpan(it, 0, testSessionId, testModuleId, secondSuiteId, "org.example.TestSucceedSuite\$SecondTest", "testSubtraction", "testSubtraction()V", CIConstants.TEST_PASS)
       }
     })
   }

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/MUnitTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/MUnitTest.groovy
@@ -1,0 +1,59 @@
+import datadog.trace.agent.test.asserts.ListWriterAssert
+import datadog.trace.api.DisableTestTrace
+import datadog.trace.api.civisibility.CIConstants
+import datadog.trace.civisibility.CiVisibilityTest
+import datadog.trace.instrumentation.junit4.TestEventsHandlerHolder
+import org.example.TestSucceedMUnit
+import org.junit.runner.JUnitCore
+
+@DisableTestTrace(reason = "avoid self-tracing")
+class MUnitTest extends CiVisibilityTest {
+
+  def runner = new JUnitCore()
+
+  def "test success generates spans"() {
+    setup:
+    runTests(TestSucceedMUnit)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedMUnit", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedMUnit", "Calculator.add", null, CIConstants.TEST_PASS, null, null, false, null, true, false)
+      }
+    })
+  }
+
+  private void runTests(Class<?>... tests) {
+    TestEventsHandlerHolder.start()
+    runner.run(tests)
+    TestEventsHandlerHolder.stop()
+  }
+
+  @Override
+  String expectedOperationPrefix() {
+    return "junit"
+  }
+
+  @Override
+  String expectedTestFramework() {
+    return "munit"
+  }
+
+  @Override
+  String expectedTestFrameworkVersion() {
+    return "0.7.28"
+  }
+
+  @Override
+  String component() {
+    return "junit"
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/MUnitTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/MUnitTest.groovy
@@ -3,6 +3,9 @@ import datadog.trace.api.DisableTestTrace
 import datadog.trace.api.civisibility.CIConstants
 import datadog.trace.civisibility.CiVisibilityTest
 import datadog.trace.instrumentation.junit4.TestEventsHandlerHolder
+import org.example.TestFailedAssumptionMUnit
+import org.example.TestSkippedMUnit
+import org.example.TestSkippedSuiteMUnit
 import org.example.TestSucceedMUnit
 import org.junit.runner.JUnitCore
 
@@ -26,7 +29,70 @@ class MUnitTest extends CiVisibilityTest {
         testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedMUnit", CIConstants.TEST_PASS)
       }
       trace(1) {
-        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedMUnit", "Calculator.add", null, CIConstants.TEST_PASS, null, null, false, null, true, false)
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedMUnit", "Calculator.add", null, CIConstants.TEST_PASS, null, null, false, ["myTag"], true, false)
+      }
+    })
+  }
+
+  def "test skipped generates spans"() {
+    setup:
+    runTests(TestSkippedMUnit)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_SKIP)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSkippedMUnit", CIConstants.TEST_SKIP)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSkippedMUnit", "Calculator.add", null, CIConstants.TEST_SKIP, null, null, false, ["Ignore"], true, false)
+      }
+    })
+  }
+
+  def "test skipped suite generates spans"() {
+    setup:
+    runTests(TestSkippedSuiteMUnit)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 3, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_SKIP)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_SKIP)
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSkippedSuiteMUnit", CIConstants.TEST_SKIP)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSkippedSuiteMUnit", "Calculator.add", null, CIConstants.TEST_SKIP, null, null, false, ["Ignore"], true, false)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSkippedSuiteMUnit", "Calculator.subtract", null, CIConstants.TEST_SKIP, null, null, false, ["Ignore"], true, false)
+      }
+    })
+  }
+
+  def "test failed assumption generates spans"() {
+    setup:
+    runTests(TestFailedAssumptionMUnit)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestFailedAssumptionMUnit", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestFailedAssumptionMUnit", "Calculator.add", null, CIConstants.TEST_PASS, null, null, false, null, true, false)
       }
     })
   }

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedSuiteSetUpAssumption.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestFailedSuiteSetUpAssumption.java
@@ -6,7 +6,7 @@ import static org.junit.Assume.assumeTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestSuiteSetUpAssumption {
+public class TestFailedSuiteSetUpAssumption {
 
   @BeforeClass
   public static void suiteSetup() {

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedSuite.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedSuite.java
@@ -8,8 +8,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({TestSuite.FirstTest.class, TestSuite.SecondTest.class})
-public class TestSuite {
+@Suite.SuiteClasses({TestSucceedSuite.FirstTest.class, TestSucceedSuite.SecondTest.class})
+public class TestSucceedSuite {
   public static class FirstTest {
     @Test
     public void testAddition() {

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSuite.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSuite.java
@@ -1,0 +1,26 @@
+package org.example;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({TestSuite.FirstTest.class, TestSuite.SecondTest.class})
+public class TestSuite {
+  public static class FirstTest {
+    @Test
+    public void testAddition() {
+      assertEquals(5, 2 + 3);
+    }
+  }
+
+  public static class SecondTest {
+    @Test
+    public void testSubtraction() {
+      assertNotEquals(1, 5 - 3);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestFailedAssumptionMUnit.scala
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestFailedAssumptionMUnit.scala
@@ -1,0 +1,10 @@
+package org.example
+
+import munit.FunSuite
+
+class TestFailedAssumptionMUnit extends FunSuite {
+  test("Calculator.add") {
+    assume(2 + 2 == 5, "this test always assumes the wrong thing")
+    assertEquals(1 + 2, 3)
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestSkippedMUnit.scala
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestSkippedMUnit.scala
@@ -1,0 +1,9 @@
+package org.example
+
+import munit.FunSuite
+
+class TestSkippedMUnit extends FunSuite {
+  test("Calculator.add".ignore) {
+    assertEquals(1 + 2, 3)
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestSkippedSuiteMUnit.scala
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestSkippedSuiteMUnit.scala
@@ -1,0 +1,14 @@
+package org.example
+
+import munit.FunSuite
+
+@munit.IgnoreSuite
+class TestSkippedSuiteMUnit extends FunSuite {
+  test("Calculator.add".ignore) {
+    assertEquals(1 + 2, 3)
+  }
+
+  test("Calculator.subtract".ignore) {
+    assertEquals(5 - 3, 18)
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestSucceedMUnit.scala
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestSucceedMUnit.scala
@@ -1,0 +1,9 @@
+package org.example
+
+import munit.FunSuite
+
+class TestSucceedMUnit extends FunSuite {
+  test("Calculator.add") {
+    assertEquals(1 + 2, 3)
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestSucceedMUnit.scala
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/scala/org/example/TestSucceedMUnit.scala
@@ -3,7 +3,7 @@ package org.example
 import munit.FunSuite
 
 class TestSucceedMUnit extends FunSuite {
-  test("Calculator.add") {
+  test("Calculator.add".tag(new munit.Tag("myTag"))) {
     assertEquals(1 + 2, 3)
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/CucumberTest.groovy
@@ -225,7 +225,7 @@ class CucumberTest extends CiVisibilityTest {
     final Throwable exception = null,
     final boolean emptyDuration = false,
     final Collection<String> categories = null) {
-    testSpan(trace, index, testSessionId, testModuleId, testSuiteId, testSuite, testName, null, testStatus, testTags, exception, emptyDuration, categories, false)
+    testSpan(trace, index, testSessionId, testModuleId, testSuiteId, testSuite, testName, null, testStatus, testTags, exception, emptyDuration, categories, false, false)
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Adds support for Scala [MUnit](https://scalameta.org/munit/) testing framework to CI Visibility.

# Motivation
There is a [feature request](https://github.com/DataDog/dd-trace-java/issues/5760).

# Additional Notes
MUnit is built on top of JUnit 4.

In order to support it, the following things were done:
- reworked test suite events mechanism: "custom" suite events implemented via bytecode instrumentation are now used only for JUnit < 4.13. Versions 4.13 and above now use "native" suite events that are available as part of the framework. The reason to change this was that the custom events were not working properly with custom runner implementations
- reworked logic that detects if a `Description` contains direct children that are atomic test cases: it was not working properly with `MUnit`, causing all suites to be ignored
- added a separate method to handle `MUnit` tests skipping, since there are some differences compared to the other frameworks (when skipping a test case, separate test start event is received; when skipping a suite, suite start and finished events are received)
- updated logic that detects test framework name and version: it now takes `MUnit` into account
- updated repository indexing logic to handle Scala classes
