### PR TITLE
Check for overhead constraints in weak randomness module

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/WeakRandomnessModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/WeakRandomnessModuleImpl.java
@@ -2,6 +2,7 @@ package com.datadog.iast.sink;
 
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.VulnerabilityType;
+import com.datadog.iast.overhead.Operations;
 import datadog.trace.api.iast.sink.WeakRandomnessModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -16,6 +17,9 @@ public class WeakRandomnessModuleImpl extends SinkModuleBase implements WeakRand
       return;
     }
     final AgentSpan span = AgentTracer.activeSpan();
+    if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
+      return;
+    }
     report(span, VulnerabilityType.WEAK_RANDOMNESS, new Evidence(instance.getName()));
   }
 


### PR DESCRIPTION
# What Does This Do
Check for overhead limits before reporting weak randomness vulnerability

# Motivation

# Additional Notes
