### PR TITLE
Improve performance while computing IAST metrics

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestStartedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestStartedHandler.java
@@ -23,6 +23,10 @@ public class TelemetryRequestStartedHandler extends RequestStartedHandler {
     final TaintedObjects taintedObjects =
         TaintedObjectsWithTelemetry.build(verbosity, TaintedObjects.acquire());
     final IastMetricCollector collector = new IastMetricCollector();
-    return new IastRequestContext(taintedObjects, collector);
+    final IastRequestContext ctx = new IastRequestContext(taintedObjects, collector);
+    if (taintedObjects instanceof TaintedObjectsWithTelemetry) {
+      ((TaintedObjectsWithTelemetry) taintedObjects).initContext(ctx);
+    }
+    return ctx;
   }
 }


### PR DESCRIPTION
# What Does This Do
Improve IAST metrics by:

- Removing the need to have extra accesses to the current context in the tainted 
- Removing `replaceAll` method call with a simpler `replace`

# Motivation

# Additional Notes
