### PR TITLE
rework Queue time tracking to avoid unwrapping the task type unless the event will be recorded

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/QueueTimerHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/QueueTimerHelper.java
@@ -1,7 +1,5 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
-import static datadog.trace.bootstrap.TaskWrapper.getUnwrappedType;
-
 import datadog.trace.api.profiling.QueueTiming;
 import datadog.trace.api.profiling.Timer;
 import datadog.trace.bootstrap.ContextStore;
@@ -12,25 +10,14 @@ public class QueueTimerHelper {
   public static <T> void startQueuingTimer(
       ContextStore<T, State> taskContextStore, Class<?> schedulerClass, T task) {
     State state = taskContextStore.get(task);
+    startQueuingTimer(state, schedulerClass, task);
+  }
+
+  public static void startQueuingTimer(State state, Class<?> schedulerClass, Object task) {
     if (task != null && state != null) {
       QueueTiming timing =
           (QueueTiming) AgentTracer.get().getTimer().start(Timer.TimerType.QUEUEING);
-      timing.setTask(getUnwrappedType(task));
-      timing.setScheduler(schedulerClass);
-      state.setTiming(timing);
-    }
-  }
-
-  public static <T> Class<?> unwrap(T task) {
-    return getUnwrappedType(task);
-  }
-
-  public static <T> void startQueuingTimer(
-      State state, Class<?> schedulerClass, Class<?> unwrappedTaskClass, T task) {
-    if (task != null) {
-      QueueTiming timing =
-          (QueueTiming) AgentTracer.get().getTimer().start(Timer.TimerType.QUEUEING);
-      timing.setTask(unwrappedTaskClass);
+      timing.setTask(task);
       timing.setScheduler(schedulerClass);
       state.setTiming(timing);
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/profiling/UnwrappingVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/profiling/UnwrappingVisitor.java
@@ -58,7 +58,8 @@ public class UnwrappingVisitor implements AsmVisitorWrapper {
 
   private static class ImplementTaskWrapperClassVisitor extends ClassVisitor {
 
-    private static final String TASK_WRAPPER = "datadog/trace/bootstrap/TaskWrapper";
+    private static final String TASK_WRAPPER =
+        "datadog/trace/bootstrap/instrumentation/api/TaskWrapper";
 
     private final String className;
     private final String fieldName;

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/TaskUnwrappingForkedTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/TaskUnwrappingForkedTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.bootstrap.TaskWrapper
+import datadog.trace.bootstrap.instrumentation.api.TaskWrapper
 
 import java.util.concurrent.Callable
 import java.util.concurrent.ForkJoinTask

--- a/dd-java-agent/instrumentation/netty-concurrent-4/src/main/java/datadog/trace/instrumentation/netty40/concurrent/SingleThreadEventExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-concurrent-4/src/main/java/datadog/trace/instrumentation/netty40/concurrent/SingleThreadEventExecutorInstrumentation.java
@@ -87,15 +87,7 @@ public class SingleThreadEventExecutorInstrumentation extends Instrumenter.Profi
         }
         EventExecutorGroup parent = executor.parent();
         Class<?> schedulerClass = parent == null ? executor.getClass() : parent.getClass();
-        Class<?> unwrappedTaskClass = QueueTimerHelper.unwrap(task);
-        // best effort attempt to filter out chore tasks
-        if (unwrappedTaskClass != null
-            && !unwrappedTaskClass.getName().endsWith(".AbstractScheduledEventExecutor$1")
-            && !unwrappedTaskClass.getName().endsWith(".SingleThreadEventExecutor$5")
-            && !unwrappedTaskClass.getName().endsWith(".SingleThreadEventExecutor$PurgeTask")) {
-          QueueTimerHelper.startQueuingTimer(
-              state, schedulerClass, unwrappedTaskClass, (RunnableFuture<?>) task);
-        }
+        QueueTimerHelper.startQueuingTimer(state, schedulerClass, task);
       }
     }
   }

--- a/dd-java-agent/instrumentation/netty-concurrent-4/src/test/groovy/TimingTest.groovy
+++ b/dd-java-agent/instrumentation/netty-concurrent-4/src/test/groovy/TimingTest.groovy
@@ -52,13 +52,20 @@ class TimingTest extends AgentTestRunner {
   void verify() {
     assert TEST_TIMER.isBalanced()
     assert !TEST_TIMER.closedTimings.isEmpty()
+    int numAsserts = 0
     while (!TEST_TIMER.closedTimings.isEmpty()) {
       def timing = TEST_TIMER.closedTimings.takeFirst() as TestTimer.TestQueueTiming
-      assert timing != null
-      assert timing.task == TestRunnable
-      assert timing.scheduler == DefaultEventExecutorGroup
-      assert timing.origin == Thread.currentThread()
+      // filter out any netty chores, filtering these out by class name in the instrumentation
+      // may be too expensive. They should get filtered out by duration anyway.
+      if (!(timing.task as Class).simpleName.isEmpty()) {
+        assert timing != null
+        assert timing.task == TestRunnable
+        assert timing.scheduler == DefaultEventExecutorGroup
+        assert timing.origin == Thread.currentThread()
+        numAsserts++
+      }
     }
+    assert numAsserts > 0
   }
 
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/timer/TestTimer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/timer/TestTimer.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.agent.test.timer
 
+import datadog.trace.bootstrap.instrumentation.api.TaskWrapper
 import datadog.trace.api.profiling.QueueTiming
 import datadog.trace.api.profiling.Timer
 import datadog.trace.api.profiling.Timing
@@ -47,8 +48,8 @@ class TestTimer implements Timer {
     }
 
     @Override
-    void setTask(Class<?> task) {
-      this.task = task
+    void setTask(Object task) {
+      this.task = TaskWrapper.getUnwrappedType(task)
     }
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/api/profiling/QueueTiming.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/QueueTiming.java
@@ -2,7 +2,7 @@ package datadog.trace.api.profiling;
 
 public interface QueueTiming extends Timing {
 
-  void setTask(Class<?> task);
+  void setTask(Object task);
 
   void setScheduler(Class<?> scheduler);
 }

--- a/internal-api/src/main/java/datadog/trace/api/profiling/Timing.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/Timing.java
@@ -11,7 +11,7 @@ public interface Timing extends AutoCloseable {
     public void close() {}
 
     @Override
-    public void setTask(Class<?> task) {}
+    public void setTask(Object task) {}
 
     @Override
     public void setScheduler(Class<?> scheduler) {}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TaskWrapper.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TaskWrapper.java
@@ -1,4 +1,4 @@
-package datadog.trace.bootstrap;
+package datadog.trace.bootstrap.instrumentation.api;
 
 public interface TaskWrapper {
   static Class<?> getUnwrappedType(Object task) {

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/TaskWrapperTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/TaskWrapperTest.groovy
@@ -1,4 +1,5 @@
-package datadog.trace.bootstrap
+package datadog.trace.bootstrap.instrumentation.api
+
 
 import datadog.trace.test.util.DDSpecification
 


### PR DESCRIPTION
# What Does This Do

* Move `TaskWrapper` from bootstrap to internal api so it can be used by the profiler
* Track a weak reference to the task rather than an eagerly unwrapped task, the unwrapping will take place if the queue time threshold is breached
* Stop filtering out Netty chores because filtering them out by unwrapped class name may be too expensive - they will probably be filtered out by the duration threshold anyway.

# Motivation

Interface `instanceof` checks are dangerous in instrumentation because they may lead to flip-flopping of `secondary_super_cache` which can be a scalability bottleneck. This change delays unwrapping the task type until we know we will record a queue time sample, and therefore there is already a bottleneck anyway.

# Additional Notes
