### PR TITLE
Use a NoOp tainted objects for vulnerabilities without context

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -4,6 +4,7 @@ import static com.datadog.iast.IastTag.ANALYZED;
 
 import com.datadog.iast.model.Vulnerability;
 import com.datadog.iast.model.VulnerabilityBatch;
+import com.datadog.iast.taint.TaintedObjects;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.gateway.RequestContext;
@@ -81,7 +82,8 @@ public class Reporter {
 
   private AgentSpan startNewSpan() {
     final AgentSpan.Context tagContext =
-        new TagContext().withRequestContextDataIast(new IastRequestContext());
+        new TagContext()
+            .withRequestContextDataIast(new IastRequestContext(TaintedObjects.NoOp.INSTANCE));
     final AgentSpan span =
         tracer()
             .startSpan("iast", VULNERABILITY_SPAN_NAME, tagContext)

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
@@ -300,4 +300,54 @@ public interface TaintedObjects extends Iterable<TaintedObject> {
       return taintedObjects;
     }
   }
+
+  enum NoOp implements TaintedObjects {
+    INSTANCE;
+
+    @Override
+    public TaintedObject taintInputString(
+        @Nonnull final String obj, @Nonnull final Source source, final int mark) {
+      return null;
+    }
+
+    @Override
+    public TaintedObject taintInputObject(
+        @Nonnull final Object obj, @Nonnull final Source source, final int mark) {
+      return null;
+    }
+
+    @Override
+    public TaintedObject taint(@Nonnull final Object obj, @Nonnull final Range[] ranges) {
+      return null;
+    }
+
+    @Override
+    public TaintedObject get(@Nonnull final Object obj) {
+      return null;
+    }
+
+    @Override
+    public void release() {}
+
+    @Override
+    public boolean isFlat() {
+      return false;
+    }
+
+    @Override
+    public int count() {
+      return 0;
+    }
+
+    @Override
+    public int getEstimatedSize() {
+      return 0;
+    }
+
+    @Override
+    @Nonnull
+    public Iterator<TaintedObject> iterator() {
+      return emptyIterator();
+    }
+  }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsNoOpTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsNoOpTest.groovy
@@ -1,0 +1,33 @@
+package com.datadog.iast.taint
+
+import com.datadog.iast.model.Source
+import spock.lang.Specification
+
+class TaintedObjectsNoOpTest extends Specification {
+
+
+  void 'test no op implementation'() {
+    setup:
+    final instance = TaintedObjects.NoOp.INSTANCE
+    final toTaint = 'test'
+
+    when:
+    final taintedString = instance.taintInputString(toTaint, new Source(0 as byte, 'test', 'test'))
+    final taintedObject = instance.taintInputObject(toTaint, new Source(0 as byte, 'test', 'test'))
+
+    then:
+    taintedString == null
+    taintedObject == null
+    instance.get(toTaint) == null
+    instance.estimatedSize == 0
+    instance.size() == 0
+    !instance.flat
+    !instance.iterator().hasNext()
+
+    when:
+    instance.release()
+
+    then:
+    noExceptionThrown()
+  }
+}


### PR DESCRIPTION
# What Does This Do
Remove the need to acquire a full tainted objects instance when reporting with a custom span

# Motivation

# Additional Notes
