### PR TITLE
Fix simultaneous jetty 10/11 instrumentation when jakarta/javax servlet are both present

### DIFF
--- a/dd-java-agent/instrumentation/jetty-11/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-11/build.gradle
@@ -57,6 +57,10 @@ dependencies {
   latestDepTestImplementation group: 'org.eclipse.jetty', name: 'jetty-servlet', version: '11.+',  {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
+
+  // just to mix things up, see if there's no conflict
+  latestDepTestRuntimeOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
+  latestDepTestRuntimeOnly project(':dd-java-agent:instrumentation:jetty-9')
 }
 
 idea {

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
@@ -43,6 +43,10 @@ public class JettyServerAdvice {
     public static void closeScope(@Advice.Enter final AgentScope scope) {
       scope.close();
     }
+
+    private void muzzleCheck(Request r) {
+      r.getAsyncContext(); // there must be a getAsyncContext returning a jakarta AsyncContext
+    }
   }
 
   /**

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
@@ -41,4 +41,8 @@ public class HandleAdvice {
   public static void closeScope(@Advice.Enter final AgentScope scope) {
     scope.close();
   }
+
+  private void muzzleCheck(Request r) {
+    r.getAsyncContext(); // there must be a getAsyncContext returning a javax AsyncContext
+  }
 }


### PR DESCRIPTION
See https://github.com/DataDog/dd-trace-java/issues/5782