### PR TITLE
Do not attempt to use ddprof library on windows

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2249,7 +2249,9 @@ public class Config {
 
   public static boolean isDatadogProfilerEnablementOverridden() {
     // old non-LTS versions without important backports
-    return Platform.isJavaVersion(18)
+    // also, we have no windows binaries
+    return Platform.isWindows()
+        || Platform.isJavaVersion(18)
         || Platform.isJavaVersion(16)
         || Platform.isJavaVersion(15)
         || Platform.isJavaVersion(14)


### PR DESCRIPTION
# What Does This Do
Explicitly disables ddprof on windows.

# Motivation
The current enablement logic is a bit confusing for Windows - basically, we are pretending we are able to use ddprof but we, in fact, don't have the binaries for that platform.
The change will explicitly disable the ddprof library on Windows, improving the consistency.

# Additional Notes
