### PR TITLE
Update system-tests to 3749ab47dba7ceb1ac48bc9de6c89cb6427b0daa

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -29,7 +29,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 9659a5e409cf8bacabd739b6af07c5f03c9bcbd6
+default_system_tests_commit: &default_system_tests_commit 3749ab47dba7ceb1ac48bc9de6c89cb6427b0daa
 
 parameters:
   nightly:


### PR DESCRIPTION
# What Does This Do
Comparison:
https://github.com/datadog/system-tests/compare/9659a5e409cf8bacabd739b6af07c5f03c9bcbd6..3749ab47dba7ceb1ac48bc9de6c89cb6427b0daa

# Motivation

# Additional Notes
Previous update: https://github.com/DataDog/dd-trace-java/pull/5738

Relevant changes:
* https://github.com/DataDog/system-tests/pull/1461
* https://github.com/DataDog/system-tests/pull/1487
* https://github.com/DataDog/system-tests/pull/1516
* https://github.com/DataDog/system-tests/pull/1476
