### PR TITLE
Filter out alpha and beta versions of dependencies

### DIFF
--- a/dd-java-agent/instrumentation/netty-concurrent-4/build.gradle
+++ b/dd-java-agent/instrumentation/netty-concurrent-4/build.gradle
@@ -24,3 +24,12 @@ dependencies {
 tasks.named("latestDepTest").configure {
   dependsOn "latestDep4Test"
 }
+
+configurations.configureEach {
+  resolutionStrategy.componentSelection.all { ComponentSelection selection ->
+    def version = selection.candidate.version.toLowerCase()
+    if (version.contains('alpha') || version.contains('beta')) {
+      reject("Early Access Version: ${selection.candidate.version}")
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

Filters out versions of dependencies containing `alpha` or `beta`

# Motivation

The dependency `io.netty:netty-common:5.0.0.Alpha2` failed the `latestDepTest`

# Additional Notes
