### PR TITLE
Add Reactor async result types support for OpenTelemetry annotations

### DIFF
--- a/dd-java-agent/instrumentation/reactor-core-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/build.gradle
@@ -16,8 +16,10 @@ dependencies {
   compileOnly group: 'io.projectreactor', name: 'reactor-core', version: '3.1.0.RELEASE'
 
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
+  testImplementation project(':dd-java-agent:instrumentation:opentelemetry:opentelemetry-annotations-1.20')
 
   testImplementation group: 'io.projectreactor', name: 'reactor-core', version: '3.1.0.RELEASE'
+  testImplementation group: 'io.opentelemetry.instrumentation', name: 'opentelemetry-instrumentation-annotations', version: '1.28.0'
 
   latestDepTestImplementation group: 'io.projectreactor', name: 'reactor-core', version: '3.4.+'
   // Looks like later versions on reactor need this dependency for some reason even though it is marked as optional.

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/MonoFluxInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/MonoFluxInstrumentation.java
@@ -1,0 +1,46 @@
+package datadog.trace.instrumentation.reactor.core;
+
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class MonoFluxInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForKnownTypes {
+  public MonoFluxInstrumentation() {
+    super("reactor-core");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    // Only used with OpenTelemetry @WithSpan annotations
+    return InstrumenterConfig.get().isTraceOtelEnabled();
+  }
+
+  @Override
+  public String[] knownMatchingTypes() {
+    return new String[] {"reactor.core.publisher.Flux", "reactor.core.publisher.Mono"};
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".ReactorAsyncResultSupportExtension",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(isConstructor(), this.getClass().getName() + "$AsyncTypeAdvice");
+  }
+
+  public static class AsyncTypeAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void init() {
+      ReactorAsyncResultSupportExtension.initialize();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/ReactorAsyncResultSupportExtension.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/ReactorAsyncResultSupportExtension.java
@@ -1,0 +1,43 @@
+package datadog.trace.instrumentation.reactor.core;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.decorator.AsyncResultDecorator;
+import datadog.trace.bootstrap.instrumentation.decorator.AsyncResultDecorator.AsyncResultSupportExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class ReactorAsyncResultSupportExtension implements AsyncResultSupportExtension {
+  static {
+    AsyncResultDecorator.registerExtension(new ReactorAsyncResultSupportExtension());
+  }
+
+  /**
+   * Register the extension as an {@link AsyncResultSupportExtension} using static class
+   * initialization.<br>
+   * It uses an empty static method call to ensure the class loading and the one-time-only static
+   * class initialization. This will ensure this extension will only be registered once to the
+   * {@link AsyncResultDecorator}.
+   */
+  public static void initialize() {}
+
+  @Override
+  public boolean supports(Class<?> result) {
+    return Flux.class.isAssignableFrom(result) || Mono.class.isAssignableFrom(result);
+  }
+
+  @Override
+  public Object apply(Object result, AgentSpan span) {
+    if (result instanceof Flux) {
+      return ((Flux<?>) result)
+          .doOnError(span::addThrowable)
+          .doOnTerminate(span::finish)
+          .doOnCancel(span::finish);
+    } else if (result instanceof Mono) {
+      return ((Mono<?>) result)
+          .doOnError(span::addThrowable)
+          .doOnTerminate(span::finish)
+          .doOnCancel(span::finish);
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorAsyncResultSupportExtensionTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorAsyncResultSupportExtensionTest.groovy
@@ -1,0 +1,200 @@
+import annotatedsample.ReactorTracedMethods
+import com.google.common.util.concurrent.ListeningExecutorService
+import com.google.common.util.concurrent.MoreExecutors
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import spock.lang.Shared
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+class ReactorAsyncResultSupportExtensionTest extends AgentTestRunner {
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig("dd.trace.otel.enabled", "true")
+    injectSysConfig("dd.integration.opentelemetry-annotations-1.20.enabled", "true")
+  }
+
+  @Shared
+  ListeningExecutorService executor
+
+  def setupSpec() {
+    this.executor = MoreExecutors.listeningDecorator(Executors.newSingleThreadExecutor())
+  }
+
+  def cleanupSpec() {
+    this.executor.shutdownNow()
+  }
+
+  def "test WithSpan annotated async method (Mono)"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def mono = ReactorTracedMethods.traceAsyncMono(latch)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    mono.block()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "ReactorTracedMethods.traceAsyncMono"
+          operationName "ReactorTracedMethods.traceAsyncMono"
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+          }
+        }
+      }
+    }
+  }
+
+  def "test WithSpan annotated async method (failing Mono)"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def expectedException = new IllegalStateException("Test exception")
+    def mono = ReactorTracedMethods.traceAsyncFailingMono(latch, expectedException)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    mono.block()
+
+    then:
+    thrown(IllegalStateException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "ReactorTracedMethods.traceAsyncFailingMono"
+          operationName "ReactorTracedMethods.traceAsyncFailingMono"
+          errored true
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+            errorTags(expectedException)
+          }
+        }
+      }
+    }
+  }
+
+  def "test WithSpan annotated async method (cancelled Mono)"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def mono = ReactorTracedMethods.traceAsyncMono(latch)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    mono.subscribe(new ReactorTracedMethods.CancelSubscriber<>())
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "ReactorTracedMethods.traceAsyncMono"
+          operationName "ReactorTracedMethods.traceAsyncMono"
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+          }
+        }
+      }
+    }
+  }
+
+  def "test WithSpan annotated async method (Flux)"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def flux = ReactorTracedMethods.traceAsyncFlux(latch)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    flux.blockLast()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "ReactorTracedMethods.traceAsyncFlux"
+          operationName "ReactorTracedMethods.traceAsyncFlux"
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+          }
+        }
+      }
+    }
+  }
+
+  def "test WithSpan annotated async method (failing Flux)"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def expectedException = new IllegalStateException("Test exception")
+    def flux = ReactorTracedMethods.traceAsyncFailingFlux(latch, expectedException)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    flux.blockLast()
+
+    then:
+    thrown(IllegalStateException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "ReactorTracedMethods.traceAsyncFailingFlux"
+          operationName "ReactorTracedMethods.traceAsyncFailingFlux"
+          errored true
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+            errorTags(expectedException)
+          }
+        }
+      }
+    }
+  }
+
+  def "test WithSpan annotated async method (cancelled Flux)"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def flux = ReactorTracedMethods.traceAsyncFlux(latch)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    flux.subscribe(new ReactorTracedMethods.CancelSubscriber<>())
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "ReactorTracedMethods.traceAsyncFlux"
+          operationName "ReactorTracedMethods.traceAsyncFlux"
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/java/annotatedsample/ReactorTracedMethods.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/java/annotatedsample/ReactorTracedMethods.java
@@ -1,0 +1,75 @@
+package annotatedsample;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.util.concurrent.CountDownLatch;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class ReactorTracedMethods {
+  @WithSpan
+  public static Mono<String> traceAsyncMono(CountDownLatch latch) {
+    return Mono.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Mono<String> traceAsyncFailingMono(CountDownLatch latch, Exception exception) {
+    return Mono.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Flux<String> traceAsyncFlux(CountDownLatch latch) {
+    return Flux.create(
+        emitter -> {
+          await(latch);
+          emitter.next("hello");
+          emitter.complete();
+        });
+  }
+
+  @WithSpan
+  public static Flux<String> traceAsyncFailingFlux(CountDownLatch latch, Exception exception) {
+    return Flux.create(
+        emitter -> {
+          await(latch);
+          emitter.error(exception);
+        });
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, SECONDS)) {
+        throw new IllegalStateException("Latch still locked");
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static class CancelSubscriber<T> implements Subscriber<T> {
+    @Override
+    public void onSubscribe(Subscription s) {
+      s.cancel();
+    }
+
+    @Override
+    public void onNext(T t) {}
+
+    @Override
+    public void onError(Throwable t) {}
+
+    @Override
+    public void onComplete() {}
+  }
+}


### PR DESCRIPTION
# What Does This Do

This features is a follow up of #5593 and #5737.
This brings the support for Reactor types: `Mono` and `Flux`.

# Motivation

Those are the third asynchronous types according the most used libraries.

# Additional Notes
