### PR TITLE
Add RxJava async result types support for OpenTelemetry annotations

### DIFF
--- a/dd-java-agent/instrumentation/rxjava-2/build.gradle
+++ b/dd-java-agent/instrumentation/rxjava-2/build.gradle
@@ -16,7 +16,9 @@ dependencies {
   compileOnly group: 'io.reactivex.rxjava2', name: 'rxjava', version: '2.0.0'
 
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
+  testImplementation project(':dd-java-agent:instrumentation:opentelemetry:opentelemetry-annotations-1.20')
 
   testImplementation group: 'io.reactivex.rxjava2', name: 'rxjava', version: '2.0.5'
+  testImplementation group: 'io.opentelemetry.instrumentation', name: 'opentelemetry-instrumentation-annotations', version: '1.28.0'
   latestDepTestImplementation group: 'io.reactivex.rxjava2', name: 'rxjava', version: '+'
 }

--- a/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/RxJavaAsyncResultSupportExtension.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/RxJavaAsyncResultSupportExtension.java
@@ -1,0 +1,67 @@
+package datadog.trace.instrumentation.rxjava2;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.decorator.AsyncResultDecorator;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+
+public class RxJavaAsyncResultSupportExtension
+    implements AsyncResultDecorator.AsyncResultSupportExtension {
+  static {
+    AsyncResultDecorator.registerExtension(new RxJavaAsyncResultSupportExtension());
+  }
+
+  /**
+   * Register the extension as an {@link AsyncResultDecorator.AsyncResultSupportExtension} using
+   * static class initialization.<br>
+   * It uses an empty static method call to ensure the class loading and the one-time-only static
+   * class initialization. This will ensure this extension will only be registered once to the
+   * {@link AsyncResultDecorator}.
+   */
+  public static void initialize() {}
+
+  @Override
+  public boolean supports(Class<?> result) {
+    return Completable.class.isAssignableFrom(result)
+        || Maybe.class.isAssignableFrom(result)
+        || Single.class.isAssignableFrom(result)
+        || Observable.class.isAssignableFrom(result)
+        || Flowable.class.isAssignableFrom(result);
+  }
+
+  @Override
+  public Object apply(Object result, AgentSpan span) {
+    if (result instanceof Completable) {
+      return ((Completable) result)
+          .doOnEvent(throwable -> onError(span, throwable))
+          .doOnDispose(span::finish);
+    } else if (result instanceof Maybe) {
+      return ((Maybe<?>) result)
+          .doOnEvent((o, throwable) -> onError(span, throwable))
+          .doOnDispose(span::finish);
+    } else if (result instanceof Single) {
+      return ((Single<?>) result)
+          .doOnEvent((o, throwable) -> onError(span, throwable))
+          .doOnDispose(span::finish);
+    } else if (result instanceof Observable) {
+      return ((Observable<?>) result)
+          .doOnComplete(span::finish)
+          .doOnError(throwable -> onError(span, throwable))
+          .doOnDispose(span::finish);
+    } else if (result instanceof Flowable) {
+      return ((Flowable<?>) result)
+          .doOnComplete(span::finish)
+          .doOnError(throwable -> onError(span, throwable))
+          .doOnCancel(span::finish);
+    }
+    return null;
+  }
+
+  private static void onError(AgentSpan span, Throwable throwable) {
+    span.addThrowable(throwable);
+    span.finish();
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/RxJavaPluginsInstrumentation.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/main/java/datadog/trace/instrumentation/rxjava2/RxJavaPluginsInstrumentation.java
@@ -1,0 +1,47 @@
+package datadog.trace.instrumentation.rxjava2;
+
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class RxJavaPluginsInstrumentation extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+
+  public RxJavaPluginsInstrumentation() {
+    super("rxjava");
+  }
+
+  @Override
+  protected boolean defaultEnabled() {
+    // Only used with OpenTelemetry @WithSpan annotations
+    return InstrumenterConfig.get().isTraceOtelEnabled();
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "io.reactivex.plugins.RxJavaPlugins";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".RxJavaAsyncResultSupportExtension",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(isMethod(), getClass().getName() + "$RxJavaPluginsAdvice");
+  }
+
+  public static class RxJavaPluginsAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void init() {
+      RxJavaAsyncResultSupportExtension.initialize();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2ResultSupportExtensionTest.groovy
+++ b/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2ResultSupportExtensionTest.groovy
@@ -1,0 +1,127 @@
+import annotatedsample.RxJava2TracedMethods
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.bootstrap.instrumentation.api.Tags
+
+import java.util.concurrent.CountDownLatch
+
+class RxJava2ResultSupportExtensionTest extends AgentTestRunner {
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig("dd.trace.otel.enabled", "true")
+    injectSysConfig("dd.integration.opentelemetry-annotations-1.20.enabled", "true")
+  }
+
+  def "test WithSpan annotated async method #type"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def asyncType = RxJava2TracedMethods."$method"(latch)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    asyncType."$operation"()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "RxJava2TracedMethods.$method"
+          operationName "RxJava2TracedMethods.traceAsync$type"
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+          }
+        }
+      }
+    }
+
+    where:
+    type          | operation
+    'Completable' | 'blockingGet'
+    'Maybe'       | 'blockingGet'
+    'Single'      | 'blockingGet'
+    'Observable'  | 'blockingLast'
+    'Flowable'    | 'blockingLast'
+    method = "traceAsync$type"
+  }
+
+  def "test WithSpan annotated async method failing #type"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def expectedException = new IllegalStateException("Test exception")
+    def asyncType = RxJava2TracedMethods."$method"(latch, expectedException)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    asyncType."$operation"()
+
+    then:
+    thrown(IllegalStateException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "RxJava2TracedMethods.$method"
+          operationName "RxJava2TracedMethods.$method"
+          errored true
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+            errorTags(expectedException)
+          }
+        }
+      }
+    }
+
+    where:
+    type          | operation
+    'Completable' | 'blockingAwait'
+    'Maybe'       | 'blockingGet'
+    'Single'      | 'blockingGet'
+    'Observable'  | 'blockingLast'
+    'Flowable'    | 'blockingLast'
+    method = "traceAsyncFailing$type"
+  }
+
+  def "test WithSpan annotated async method cancelled #type"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def asyncType = RxJava2TracedMethods."$method"(latch)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    asyncType.subscribe().dispose()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "RxJava2TracedMethods.$method"
+          operationName "RxJava2TracedMethods.traceAsync$type"
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "opentelemetry"
+          }
+        }
+      }
+    }
+
+    where:
+    type          | operation
+    'Completable' | 'blockingGet'
+    'Maybe'       | 'blockingGet'
+    'Single'      | 'blockingGet'
+    'Observable'  | 'blockingLast'
+    'Flowable'    | 'blockingLast'
+    method = "traceAsync$type"
+  }
+}

--- a/dd-java-agent/instrumentation/rxjava-2/src/test/java/annotatedsample/RxJava2TracedMethods.java
+++ b/dd-java-agent/instrumentation/rxjava-2/src/test/java/annotatedsample/RxJava2TracedMethods.java
@@ -1,0 +1,112 @@
+package annotatedsample;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import java.util.concurrent.CountDownLatch;
+
+public class RxJava2TracedMethods {
+  @WithSpan
+  public static Completable traceAsyncCompletable(CountDownLatch latch) {
+    return Completable.fromRunnable(() -> await(latch));
+  }
+
+  @WithSpan
+  public static Completable traceAsyncFailingCompletable(
+      CountDownLatch latch, Exception exception) {
+    return Completable.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Maybe<String> traceAsyncMaybe(CountDownLatch latch) {
+    return Maybe.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Maybe<String> traceAsyncFailingMaybe(CountDownLatch latch, Exception exception) {
+    return Maybe.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Single<String> traceAsyncSingle(CountDownLatch latch) {
+    return Single.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Single<String> traceAsyncFailingSingle(CountDownLatch latch, Exception exception) {
+    return Single.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Observable<String> traceAsyncObservable(CountDownLatch latch) {
+    return Observable.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Observable<String> traceAsyncFailingObservable(
+      CountDownLatch latch, Exception exception) {
+    return Observable.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  @WithSpan
+  public static Flowable<String> traceAsyncFlowable(CountDownLatch latch) {
+    return Flowable.fromCallable(
+        () -> {
+          await(latch);
+          return "hello";
+        });
+  }
+
+  @WithSpan
+  public static Flowable<String> traceAsyncFailingFlowable(
+      CountDownLatch latch, Exception exception) {
+    return Flowable.fromCallable(
+        () -> {
+          await(latch);
+          throw exception;
+        });
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, SECONDS)) {
+        throw new IllegalStateException("Latch still locked");
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

This features is a follow up of #5593 and #5737.
This brings the support for RxJava types: `Completable`, `Maybe`, `Single`, `Observable`, and `Flowable`.
 
# Motivation

Those are the fourth asynchronous type according the most used libraries.

# Additional Notes
