### PR TITLE
Add asynchronous type support for trace annotation instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceAdvice.java
@@ -6,6 +6,7 @@ import static datadog.trace.instrumentation.trace_annotation.TraceDecorator.DECO
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import java.lang.reflect.Method;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 
 public class TraceAdvice {
 
@@ -16,10 +17,12 @@ public class TraceAdvice {
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
   public static void stopSpan(
-      @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+      @Advice.Enter final AgentScope scope,
+      @Advice.Return(typing = Assigner.Typing.DYNAMIC, readOnly = false) Object result,
+      @Advice.Thrown final Throwable throwable) {
     DECORATE.onError(scope, throwable);
     DECORATE.beforeFinish(scope);
     scope.close();
-    scope.span().finish();
+    result = DECORATE.wrapAsyncResultOrFinishSpan(result, scope.span());
   }
 }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsAsyncTest.groovy
@@ -1,0 +1,41 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import dd.test.trace.annotation.SayTracedHello
+
+import java.util.concurrent.CountDownLatch
+
+class TraceAnnotationsAsyncTest extends AgentTestRunner {
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.trace.annotation.async", "true")
+  }
+
+  def "test span finish with async type support"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def completableFuture = SayTracedHello.sayHelloFuture(latch)
+
+    expect:
+    TEST_WRITER.size() == 0
+
+    when:
+    latch.countDown()
+    completableFuture.join()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          serviceName "test"
+          resourceName "SayTracedHello.sayHelloFuture"
+          operationName "trace.annotation"
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "trace"
+          }
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
@@ -5,6 +5,8 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import datadog.trace.api.DDTags;
 import datadog.trace.api.Trace;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 
 public class SayTracedHello {
 
@@ -60,6 +62,20 @@ public class SayTracedHello {
   @Trace(operationName = "ERROR", resourceName = "WORLD")
   public static String sayERRORWithResource() {
     throw new RuntimeException();
+  }
+
+  @Trace
+  public static CompletableFuture<String> sayHelloFuture(CountDownLatch latch) {
+    activeSpan().setTag(DDTags.SERVICE_NAME, "test");
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            latch.await();
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+          return "hello!";
+        });
   }
 
   public static String fromCallable() throws Exception {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -149,6 +149,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   static final String DEFAULT_TRACE_ANNOTATIONS = null;
+  static final boolean DEFAULT_TRACE_ANNOTATION_ASYNC = false;
   static final boolean DEFAULT_TRACE_EXECUTORS_ALL = false;
   static final String DEFAULT_TRACE_METHODS = null;
   static final String DEFAULT_MEASURE_METHODS = "";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -17,6 +17,7 @@ public final class TraceInstrumentationConfig {
   public static final String INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME =
       "integration.synapse.legacy-operation-name";
   public static final String TRACE_ANNOTATIONS = "trace.annotations";
+  public static final String TRACE_ANNOTATION_ASYNC = "trace.annotation.async";
   public static final String TRACE_EXECUTORS_ALL = "trace.executors.all";
   public static final String TRACE_EXECUTORS = "trace.executors";
   public static final String TRACE_METHODS = "trace.methods";

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -11,6 +11,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_IN
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATIONS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATION_ASYNC;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXECUTORS_ALL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_METHODS;
@@ -39,6 +40,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEX
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_128_BIT_TRACEID_LOGGING_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATION_ASYNC;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSES_EXCLUDE_FILE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CLASSLOADERS_EXCLUDE;
@@ -100,6 +102,7 @@ public class InstrumenterConfig {
   private final boolean serialVersionUIDFieldInjection;
 
   private final String traceAnnotations;
+  private final boolean traceAnnotationAsync;
   private final Map<String, Set<String>> traceMethods;
   private final Map<String, Set<String>> measureMethods;
 
@@ -182,6 +185,8 @@ public class InstrumenterConfig {
             SERIALVERSIONUID_FIELD_INJECTION, DEFAULT_SERIALVERSIONUID_FIELD_INJECTION);
 
     traceAnnotations = configProvider.getString(TRACE_ANNOTATIONS, DEFAULT_TRACE_ANNOTATIONS);
+    traceAnnotationAsync =
+        configProvider.getBoolean(TRACE_ANNOTATION_ASYNC, DEFAULT_TRACE_ANNOTATION_ASYNC);
     traceMethods =
         MethodFilterConfigParser.parse(
             configProvider.getString(TRACE_METHODS, DEFAULT_TRACE_METHODS));
@@ -336,6 +341,15 @@ public class InstrumenterConfig {
     return traceAnnotations;
   }
 
+  /**
+   * Check whether asynchronous result types are supported with @Trace annotation.
+   *
+   * @return {@code true} if supported, {@code false} otherwise.
+   */
+  public boolean isTraceAnnotationAsync() {
+    return traceAnnotationAsync;
+  }
+
   public Map<String, Set<String>> getTraceMethods() {
     return traceMethods;
   }
@@ -433,6 +447,8 @@ public class InstrumenterConfig {
         + ", traceAnnotations='"
         + traceAnnotations
         + '\''
+        + ", traceAnnotationAsync="
+        + traceAnnotationAsync
         + ", traceMethods='"
         + traceMethods
         + '\''


### PR DESCRIPTION
# What Does This Do

This PR brings the asynchronous result type support from OpenTelemetry annotations (see #5593) to the original `@Trace` annotation.  

# Motivation

This should improve the generated span by having more precise span duration (span end will be at the end of the async operation).

# Additional Notes

As a behavior change, this is not the default behavior despite it should be closer of the expected behavior.
The feature must be enabled by setting `dd.trace.annotation.async` to `true`.
