### PR TITLE
Type resolver's use of URL caches should be configurable

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ClassFileLocators.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ClassFileLocators.java
@@ -101,6 +101,8 @@ public final class ClassFileLocators {
   private ClassFileLocators() {}
 
   public static final class LazyResolution implements Resolution {
+    private static final Boolean USE_URL_CACHES = InstrumenterConfig.get().isResolverUseUrlCaches();
+
     private final URL url;
     private byte[] bytecode;
 
@@ -122,7 +124,9 @@ public final class ClassFileLocators {
       if (null == bytecode) {
         try {
           URLConnection uc = url.openConnection();
-          uc.setUseCaches(false);
+          if (null != USE_URL_CACHES) {
+            uc.setUseCaches(USE_URL_CACHES);
+          }
           try (InputStream in = uc.getInputStream()) {
             bytecode = StreamDrainer.DEFAULT.drain(in);
           }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -111,8 +111,10 @@ public final class TraceInstrumentationConfig {
   public static final String RESOLVER_CACHE_CONFIG = "resolver.cache.config";
   public static final String RESOLVER_CACHE_DIR = "resolver.cache.dir";
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
+  public static final String RESOLVER_USE_URL_CACHES = "resolver.use.url.caches";
   public static final String RESOLVER_RESET_INTERVAL = "resolver.reset.interval";
   public static final String RESOLVER_NAMES_ARE_UNIQUE = "resolver.names.are.unique";
+
   public static final String ELASTICSEARCH_BODY_ENABLED = "trace.elasticsearch.body.enabled";
   public static final String ELASTICSEARCH_PARAMS_ENABLED = "trace.elasticsearch.params.enabled";
   public static final String ELASTICSEARCH_BODY_AND_PARAMS_ENABLED =

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -35,6 +35,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_NAMES_ARE_UNIQUE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_RESET_INTERVAL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_URL_CACHES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_128_BIT_TRACEID_LOGGING_ENABLED;
@@ -94,6 +95,7 @@ public class InstrumenterConfig {
   private final String resolverCacheDir;
   private final boolean resolverNamesAreUnique;
   private final boolean resolverUseLoadClass;
+  private final Boolean resolverUseUrlCaches;
   private final int resolverResetInterval;
 
   private final boolean runtimeContextFieldInjection;
@@ -169,6 +171,7 @@ public class InstrumenterConfig {
     resolverCacheDir = configProvider.getString(RESOLVER_CACHE_DIR);
     resolverNamesAreUnique = configProvider.getBoolean(RESOLVER_NAMES_ARE_UNIQUE, false);
     resolverUseLoadClass = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
+    resolverUseUrlCaches = configProvider.getBoolean(RESOLVER_USE_URL_CACHES);
     resolverResetInterval =
         Platform.isNativeImageBuilder()
             ? 0
@@ -320,6 +323,10 @@ public class InstrumenterConfig {
     return resolverUseLoadClass;
   }
 
+  public Boolean isResolverUseUrlCaches() {
+    return resolverUseUrlCaches;
+  }
+
   public int getResolverResetInterval() {
     return resolverResetInterval;
   }
@@ -424,6 +431,8 @@ public class InstrumenterConfig {
         + resolverNamesAreUnique
         + ", resolverUseLoadClass="
         + resolverUseLoadClass
+        + ", resolverUseUrlCaches="
+        + resolverUseUrlCaches
         + ", resolverResetInterval="
         + resolverResetInterval
         + ", runtimeContextFieldInjection="


### PR DESCRIPTION
Some deployments will want to use URL caches for performance reasons. Others may want to skip URL caches as they can lead to JarFiles being pinned in memory (or keeping files locked in Windows)

The Java tracer will now use the default URLConnection 'UseCaches' setting, but this can be overriden (to false or true) by adding this JVM option:
```
-Ddd.resolver.use.url.caches=false
```
or by setting this environment variable:
```
DD_RESOLVER_USE_URL_CACHES=false
```