### PR TITLE
Correctly handle cases when there are multiple JVM forks per single test module

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -66,6 +66,7 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.ipc.SignalClient",
   "datadog.trace.civisibility.ipc.SignalClient.Factory",
   "datadog.trace.civisibility.ipc.SkippableTestsResponse",
+  "datadog.trace.civisibility.ipc.TestFramework",
   "datadog.trace.civisibility.source.MethodLinesResolver.MethodLines",
   "datadog.trace.civisibility.source.index.RepoIndexBuilder.RepoIndexingFileVisitor",
   "datadog.trace.civisibility.source.index.RepoIndexFetcher",

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemSessionImpl.java
@@ -104,14 +104,6 @@ public class DDBuildSystemSessionImpl extends DDTestSessionImpl implements DDBui
     if (result.isItrEnabled()) {
       itrEnabled = true;
     }
-    String testFramework = result.getTestFramework();
-    if (testFramework != null) {
-      setTag(Tags.TEST_FRAMEWORK, testFramework);
-    }
-    String testFrameworkVersion = result.getTestFrameworkVersion();
-    if (testFrameworkVersion != null) {
-      setTag(Tags.TEST_FRAMEWORK_VERSION, testFrameworkVersion);
-    }
 
     testsSkipped.add(result.getTestsSkippedTotal());
 
@@ -239,6 +231,7 @@ public class DDBuildSystemSessionImpl extends DDTestSessionImpl implements DDBui
             methodLinesResolver,
             coverageProbeStoreFactory,
             repoIndexBuilder,
+            testModuleRegistry,
             SpanUtils.propagateCiVisibilityTagsTo(span));
     testModuleRegistry.addModule(module);
     return module;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
@@ -24,10 +24,14 @@ public class TestModuleRegistry {
     testModuleById.put(module.getId(), module);
   }
 
+  public void removeModule(DDBuildSystemModule module) {
+    testModuleById.remove(module.getId());
+  }
+
   public SignalResponse onModuleExecutionResultReceived(
       ModuleExecutionResult result, ExecutionDataStore coverageData) {
     long moduleId = result.getModuleId();
-    DDBuildSystemModule module = testModuleById.remove(moduleId);
+    DDBuildSystemModule module = testModuleById.get(moduleId);
     if (module == null) {
       String message =
           String.format(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/ModuleExecutionResult.java
@@ -1,7 +1,11 @@
 package datadog.trace.civisibility.ipc;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -16,8 +20,7 @@ public class ModuleExecutionResult implements Signal {
   private final boolean coverageEnabled;
   private final boolean itrEnabled;
   private final long testsSkippedTotal;
-  @Nullable private final String testFramework;
-  @Nullable private final String testFrameworkVersion;
+  private final Collection<TestFramework> testFrameworks;
   @Nullable private final byte[] coverageData;
 
   public ModuleExecutionResult(
@@ -26,16 +29,14 @@ public class ModuleExecutionResult implements Signal {
       boolean coverageEnabled,
       boolean itrEnabled,
       long testsSkippedTotal,
-      @Nullable String testFramework,
-      @Nullable String testFrameworkVersion,
+      Collection<TestFramework> testFrameworks,
       @Nullable byte[] coverageData) {
     this.sessionId = sessionId;
     this.moduleId = moduleId;
     this.coverageEnabled = coverageEnabled;
     this.itrEnabled = itrEnabled;
     this.testsSkippedTotal = testsSkippedTotal;
-    this.testFramework = testFramework;
-    this.testFrameworkVersion = testFrameworkVersion;
+    this.testFrameworks = testFrameworks;
     this.coverageData = coverageData;
   }
 
@@ -59,14 +60,8 @@ public class ModuleExecutionResult implements Signal {
     return testsSkippedTotal;
   }
 
-  @Nullable
-  public String getTestFramework() {
-    return testFramework;
-  }
-
-  @Nullable
-  public String getTestFrameworkVersion() {
-    return testFrameworkVersion;
+  public Collection<TestFramework> getTestFrameworks() {
+    return testFrameworks;
   }
 
   @Nullable
@@ -88,8 +83,7 @@ public class ModuleExecutionResult implements Signal {
         && coverageEnabled == that.coverageEnabled
         && itrEnabled == that.itrEnabled
         && testsSkippedTotal == that.testsSkippedTotal
-        && Objects.equals(testFramework, that.testFramework)
-        && Objects.equals(testFrameworkVersion, that.testFrameworkVersion)
+        && Objects.equals(testFrameworks, that.testFrameworks)
         && Arrays.equals(coverageData, that.coverageData);
   }
 
@@ -101,8 +95,7 @@ public class ModuleExecutionResult implements Signal {
         coverageEnabled,
         itrEnabled,
         testsSkippedTotal,
-        testFramework,
-        testFrameworkVersion,
+        testFrameworks,
         Arrays.hashCode(coverageData));
   }
 
@@ -129,16 +122,20 @@ public class ModuleExecutionResult implements Signal {
 
   @Override
   public ByteBuffer serialize() {
-    byte[] testFrameworkBytes = testFramework != null ? testFramework.getBytes() : null;
-    byte[] testFrameworkVersionBytes =
-        testFrameworkVersion != null ? testFrameworkVersion.getBytes() : null;
-
-    int testFrameworkLength = testFrameworkBytes != null ? testFrameworkBytes.length : 0;
-    int testFrameworkVersionLength =
-        testFrameworkVersionBytes != null ? testFrameworkVersionBytes.length : 0;
     int coverageDataLength = coverageData != null ? coverageData.length : 0;
-    int variableLength =
-        Integer.BYTES * 3 + testFrameworkLength + testFrameworkVersionLength + coverageDataLength;
+    int variableLength = Integer.BYTES * 2 + coverageDataLength;
+
+    for (TestFramework testFramework : testFrameworks) {
+      String testFrameworkName = testFramework.getName();
+      String testFrameworkVersion = testFramework.getVersion();
+      int testFrameworkNameBytes =
+          testFrameworkName != null ? testFrameworkName.getBytes(StandardCharsets.UTF_8).length : 0;
+      int testFrameworkVersionBytes =
+          testFrameworkVersion != null
+              ? testFrameworkVersion.getBytes(StandardCharsets.UTF_8).length
+              : 0;
+      variableLength += Integer.BYTES * 2 + testFrameworkNameBytes + testFrameworkVersionBytes;
+    }
 
     ByteBuffer buffer = ByteBuffer.allocate(FIXED_LENGTH + variableLength);
     buffer.putLong(sessionId);
@@ -154,14 +151,25 @@ public class ModuleExecutionResult implements Signal {
     }
     buffer.put(flags);
 
-    buffer.putInt(testFrameworkLength);
-    if (testFrameworkLength != 0) {
-      buffer.put(testFrameworkBytes);
-    }
+    buffer.putInt(testFrameworks.size());
+    for (TestFramework testFramework : testFrameworks) {
+      String testFrameworkName = testFramework.getName();
+      if (testFrameworkName != null) {
+        byte[] testFrameworkNameBytes = testFrameworkName.getBytes(StandardCharsets.UTF_8);
+        buffer.putInt(testFrameworkNameBytes.length);
+        buffer.put(testFrameworkNameBytes);
+      } else {
+        buffer.putInt(0);
+      }
 
-    buffer.putInt(testFrameworkVersionLength);
-    if (testFrameworkVersionLength != 0) {
-      buffer.put(testFrameworkVersionBytes);
+      String testFrameworkVersion = testFramework.getVersion();
+      if (testFrameworkVersion != null) {
+        byte[] testFrameworkVersionBytes = testFrameworkVersion.getBytes(StandardCharsets.UTF_8);
+        buffer.putInt(testFrameworkVersionBytes.length);
+        buffer.put(testFrameworkVersionBytes);
+      } else {
+        buffer.putInt(0);
+      }
     }
 
     buffer.putInt(coverageDataLength);
@@ -190,24 +198,30 @@ public class ModuleExecutionResult implements Signal {
     boolean coverageEnabled = (flags & COVERAGE_ENABLED_FLAG) != 0;
     boolean itrEnabled = (flags & ITR_ENABLED_FLAG) != 0;
 
-    String testFramework;
-    int testFrameworkLength = buffer.getInt();
-    if (testFrameworkLength != 0) {
-      byte[] testFrameworkBytes = new byte[testFrameworkLength];
-      buffer.get(testFrameworkBytes);
-      testFramework = new String(testFrameworkBytes);
-    } else {
-      testFramework = null;
-    }
+    int testFrameworksSize = buffer.getInt();
+    List<TestFramework> testFrameworks = new ArrayList<>(testFrameworksSize);
+    for (int i = 0; i < testFrameworksSize; i++) {
+      int testFrameworkNameLength = buffer.getInt();
+      String testFrameworkName;
+      if (testFrameworkNameLength != 0) {
+        byte[] testFrameworkNameBytes = new byte[testFrameworkNameLength];
+        buffer.get(testFrameworkNameBytes);
+        testFrameworkName = new String(testFrameworkNameBytes, StandardCharsets.UTF_8);
+      } else {
+        testFrameworkName = null;
+      }
 
-    String testFrameworkVersion;
-    int testFrameworkVersionLength = buffer.getInt();
-    if (testFrameworkVersionLength != 0) {
-      byte[] testFrameworkVersionBytes = new byte[testFrameworkVersionLength];
-      buffer.get(testFrameworkVersionBytes);
-      testFrameworkVersion = new String(testFrameworkVersionBytes);
-    } else {
-      testFrameworkVersion = null;
+      int testFrameworkVersionLength = buffer.getInt();
+      String testFrameworkVersion;
+      if (testFrameworkVersionLength != 0) {
+        byte[] testFrameworkVersionBytes = new byte[testFrameworkVersionLength];
+        buffer.get(testFrameworkVersionBytes);
+        testFrameworkVersion = new String(testFrameworkVersionBytes, StandardCharsets.UTF_8);
+      } else {
+        testFrameworkVersion = null;
+      }
+
+      testFrameworks.add(new TestFramework(testFrameworkName, testFrameworkVersion));
     }
 
     byte[] coverageData;
@@ -225,8 +239,7 @@ public class ModuleExecutionResult implements Signal {
         coverageEnabled,
         itrEnabled,
         testsSkippedTotal,
-        testFramework,
-        testFrameworkVersion,
+        testFrameworks,
         coverageData);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/TestFramework.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/TestFramework.java
@@ -1,0 +1,38 @@
+package datadog.trace.civisibility.ipc;
+
+import java.util.Objects;
+
+public final class TestFramework {
+  private final String name;
+  private final String version;
+
+  public TestFramework(String name, String version) {
+    this.name = name;
+    this.version = version;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TestFramework that = (TestFramework) o;
+    return Objects.equals(name, that.name) && Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, version);
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/ModuleExecutionResultTest.groovy
@@ -14,19 +14,21 @@ class ModuleExecutionResultTest extends Specification {
     then:
     deserialized == signal
 
+
+
     where:
     signal << [
-      new ModuleExecutionResult(12345, 67890, false, false, 0, null, null, null),
-      new ModuleExecutionResult(12345, 67890, true, false, 1, "junit", "4.13.2", new byte[] {
+      new ModuleExecutionResult(12345, 67890, false, false, 0, Collections.emptyList(), null),
+      new ModuleExecutionResult(12345, 67890, true, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")), new byte[] {
         1, 2, 3
       }),
-      new ModuleExecutionResult(12345, 67890, false, true, 2, null, "4.13.2", new byte[] {
+      new ModuleExecutionResult(12345, 67890, false, true, 2, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework("junit", "5.9.2")), new byte[] {
         1, 2, 3
       }),
-      new ModuleExecutionResult(12345, 67890, false, false, 3, "junit", null, new byte[] {
+      new ModuleExecutionResult(12345, 67890, false, false, 3, Arrays.asList(new TestFramework("junit", null), new TestFramework("junit", "5.9.2")), new byte[] {
         1, 2, 3
       }),
-      new ModuleExecutionResult(12345, 67890, true, true, Integer.MAX_VALUE, "junit", "4.13.2", new byte[] {
+      new ModuleExecutionResult(12345, 67890, true, true, Integer.MAX_VALUE, Arrays.asList(new TestFramework("junit", "4.13.2"), new TestFramework(null, "5.9.2")), new byte[] {
         1, 2, 3
       })
     ]

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
@@ -9,7 +9,7 @@ class SignalServerTest extends Specification {
   def "test message send and receive"() {
     given:
     def signalProcessed = new AtomicBoolean(false)
-    def signal = new ModuleExecutionResult(123, 456, true, true, 1, "junit", "4.13.2", new byte[] {
+    def signal = new ModuleExecutionResult(123, 456, true, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")), new byte[] {
       1, 2, 3
     })
     def server = new SignalServer()
@@ -40,10 +40,10 @@ class SignalServerTest extends Specification {
 
   def "test multiple messages send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(123, 456, false, false, 0, "junit", "4.13.2", new byte[] {
+    def signalA = new ModuleExecutionResult(123, 456, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")), new byte[] {
       1, 2, 3
     })
-    def signalB = new ModuleExecutionResult(234, 567, true, true, 1, "junit", "4.13.2", null)
+    def signalB = new ModuleExecutionResult(234, 567, true, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")), null)
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -71,10 +71,10 @@ class SignalServerTest extends Specification {
 
   def "test multiple clients send and receive"() {
     given:
-    def signalA = new ModuleExecutionResult(123, 456, true, false, 1, "junit", "4.13.2", new byte[] {
+    def signalA = new ModuleExecutionResult(123, 456, true, false, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")), new byte[] {
       1, 2, 3
     })
-    def signalB = new ModuleExecutionResult(234, 567, false, true, 0, "junit", "4.13.2", null)
+    def signalB = new ModuleExecutionResult(234, 567, false, true, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")), null)
     def server = new SignalServer()
     def received = new ArrayList()
 
@@ -121,7 +121,7 @@ class SignalServerTest extends Specification {
     when:
     def address = server.getAddress()
     try (def client = new SignalClient(address, clientTimeoutMillis)) {
-      client.send(new ModuleExecutionResult(123, 456, false, false, 0, "junit", "4.13.2", new byte[] {
+      client.send(new ModuleExecutionResult(123, 456, false, false, 0, Collections.singletonList(new TestFramework("junit", "4.13.2")), new byte[] {
         1, 2, 3
       }))
     }
@@ -135,7 +135,7 @@ class SignalServerTest extends Specification {
 
   def "test error response receipt"() {
     given:
-    def signal = new ModuleExecutionResult(123, 456, true, true, 1, "junit", "4.13.2", new byte[] {
+    def signal = new ModuleExecutionResult(123, 456, true, true, 1, Collections.singletonList(new TestFramework("junit", "4.13.2")), new byte[] {
       1, 2, 3
     })
     def server = new SignalServer()

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -792,6 +792,211 @@ class GradleDaemonSmokeTest extends Specification {
     gradleVersion << ["4.0", "5.0", "6.0", "7.0", "7.6.1", "8.0.2", "8.1.1", "8.3"]
   }
 
+  def "Successful build with module that has multiple forks: Gradle v#gradleVersion"() {
+    given:
+    givenGradleVersionIsCompatibleWithCurrentJvm(gradleVersion)
+    givenGradleProjectFiles("datadog/smoketest/successMultiForks/")
+    ensureDependenciesDownloaded(gradleVersion)
+
+    when:
+    BuildResult buildResult = runGradleTests(gradleVersion)
+
+    then:
+    assertBuildSuccessful(buildResult)
+
+    def events = waitForEvents(6)
+    assert events.size() == 6
+
+    def sessionEndEvent = events.find { it.type == "test_session_end" }
+    assert sessionEndEvent != null
+    verifyCommonTags(sessionEndEvent)
+    verifyAll(sessionEndEvent) {
+      verifyAll(content) {
+        name == "gradle.test_session"
+        resource == "gradle-instrumentation-test-project" // project name
+        verifyAll(metrics) {
+          process_id > 0 // only applied to root spans
+          it["test.itr.tests_skipping.count"] == 0
+          it["test.code_coverage.lines_pct"] == 73
+        }
+        verifyAll(meta) {
+          it["span.kind"] == "test_session_end"
+          it["language"] == "jvm" // only applied to root spans
+          it["test.toolchain"] == "gradle:${gradleVersion}" // only applied to session events
+          it["test.code_coverage.enabled"] == "true"
+          it["test.itr.tests_skipping.enabled"] == "true"
+          it["test.itr.tests_skipping.type"] == "test"
+          it["_dd.ci.itr.tests_skipped"] == null
+          verifyTestFrameworks(it)
+        }
+      }
+    }
+
+    def moduleEndEvent = events.find { it.type == "test_module_end" }
+    assert moduleEndEvent != null
+    verifyCommonTags(moduleEndEvent)
+    verifyAll(moduleEndEvent) {
+      verifyAll(content) {
+        name == "gradle.test_module"
+        resource == ":test" // task path
+        test_module_id > 0
+        verifyAll(metrics) {
+          it["test.itr.tests_skipping.count"] == 0
+          it["test.code_coverage.lines_pct"] == 73
+        }
+        verifyAll(meta) {
+          it["span.kind"] == "test_module_end"
+          it["test.module"] == ":test" // task path
+          it["test.code_coverage.enabled"] == "true"
+          it["test.itr.tests_skipping.enabled"] == "true"
+          it["test.itr.tests_skipping.type"] == "test"
+          it["_dd.ci.itr.tests_skipped"] == null
+          verifyTestFrameworks(it)
+        }
+      }
+    }
+
+    def suiteAEndEvent = events.find { it.type == "test_suite_end" && it.content.resource == "datadog.smoke.TestSucceed" }
+    assert suiteAEndEvent != null
+    verifyCommonTags(suiteAEndEvent, "pass", false)
+    verifyAll(suiteAEndEvent) {
+      verifyAll(content) {
+        name == "junit.test_suite"
+        resource == "datadog.smoke.TestSucceed"
+        test_module_id > 0
+        test_suite_id > 0
+        verifyAll(metrics) {
+          process_id > 0
+        }
+        verifyAll(meta) {
+          it["span.kind"] == "test_suite_end"
+          it["test.suite"] == "datadog.smoke.TestSucceed"
+          it["test.source.file"] == "src/test/java/datadog/smoke/TestSucceed.java"
+          it["test.framework"] == "junit4"
+          it["test.framework_version"] == "4.13.2"
+        }
+      }
+    }
+
+    def testAEvent = events.find { it.type == "test" && it.content.resource == "datadog.smoke.TestSucceed.test_succeed" }
+    assert testAEvent != null
+    verifyCommonTags(testAEvent, "pass", false)
+    verifyAll(testAEvent) {
+      verifyAll(content) {
+        name == "junit.test"
+        resource == "datadog.smoke.TestSucceed.test_succeed"
+        test_module_id > 0
+        test_suite_id > 0
+        trace_id > 0
+        span_id > 0
+        parent_id == 0
+        verifyAll(metrics) {
+          process_id > 0
+        }
+        verifyAll(meta) {
+          it["span.kind"] == "test"
+          it["test.suite"] == "datadog.smoke.TestSucceed"
+          it["test.name"] == "test_succeed"
+          it["test.source.file"] == "src/test/java/datadog/smoke/TestSucceed.java"
+          it["test.framework"] == "junit4"
+          it["test.framework_version"] == "4.13.2"
+        }
+      }
+    }
+
+    def suiteBEndEvent = events.find { it.type == "test_suite_end" && it.content.resource == "datadog.smoke.TestSucceedJunit5" }
+    assert suiteBEndEvent != null
+    verifyCommonTags(suiteBEndEvent, "pass", false)
+    verifyAll(suiteBEndEvent) {
+      verifyAll(content) {
+        name == "junit.test_suite"
+        resource == "datadog.smoke.TestSucceedJunit5"
+        test_module_id > 0
+        test_suite_id > 0
+        verifyAll(metrics) {
+          process_id > 0
+        }
+        verifyAll(meta) {
+          it["span.kind"] == "test_suite_end"
+          it["test.suite"] == "datadog.smoke.TestSucceedJunit5"
+          it["test.source.file"] == "src/test/java/datadog/smoke/TestSucceedJunit5.java"
+          it["test.framework"] == "junit5"
+          it["test.framework_version"] == "5.9.3"
+        }
+      }
+    }
+
+    def testBEvent = events.find { it.type == "test" && it.content.resource == "datadog.smoke.TestSucceedJunit5.test_succeed" }
+    assert testBEvent != null
+    verifyCommonTags(testBEvent, "pass", false)
+    verifyAll(testBEvent) {
+      verifyAll(content) {
+        name == "junit.test"
+        resource == "datadog.smoke.TestSucceedJunit5.test_succeed"
+        test_module_id > 0
+        test_suite_id > 0
+        trace_id > 0
+        span_id > 0
+        parent_id == 0
+        verifyAll(metrics) {
+          process_id > 0
+        }
+        verifyAll(meta) {
+          it["span.kind"] == "test"
+          it["test.suite"] == "datadog.smoke.TestSucceedJunit5"
+          it["test.name"] == "test_succeed"
+          it["test.source.file"] == "src/test/java/datadog/smoke/TestSucceedJunit5.java"
+          it["test.framework"] == "junit5"
+          it["test.framework_version"] == "5.9.3"
+        }
+      }
+    }
+
+    def coverages = waitForCoverages(2)
+    assert coverages.size() == 2
+
+    coverages.contains([
+      test_session_id: testAEvent.content.test_session_id,
+      test_suite_id  : testAEvent.content.test_suite_id,
+      span_id        : testAEvent.content.span_id,
+      files          : [
+        [
+          filename: "src/test/java/datadog/smoke/TestSucceed.java",
+          segments: [[7, -1, 7, -1, -1], [10, -1, 11, -1, -1]]
+        ],
+        [
+          filename: "src/main/java/datadog/smoke/Calculator.java",
+          segments: [[5, -1, 5, -1, -1]]
+        ]
+      ]
+    ])
+    coverages.contains([
+      test_session_id: testBEvent.content.test_session_id,
+      test_suite_id  : testBEvent.content.test_suite_id,
+      span_id        : testBEvent.content.span_id,
+      files          : [
+        [
+          filename: "src/main/java/datadog/smoke/Calculator.java",
+          segments: [[8, -1, 8, -1, -1]]
+        ],
+        [
+          filename: "src/test/java/datadog/smoke/TestSucceedJunit5.java",
+          segments: [[10, -1, 11, -1, -1]]
+        ]
+      ]
+    ])
+
+    where:
+    gradleVersion << ["8.3"]
+  }
+
+  private static boolean verifyTestFrameworks(it) {
+    // test frameworks may be reported by the forked JVMs in any order
+    // (depending on which JVM finishes executing its tests first)
+    it["test.framework"] == "[\"junit4\",\"junit5\"]" && it["test.framework_version"] == "[\"4.13.2\",\"5.9.3\"]"
+    || it["test.framework"] == "[\"junit5\",\"junit4\"]" && it["test.framework_version"] == "[\"5.9.3\",\"4.13.2\"]"
+  }
+
   private void givenGradleProperties() {
     String agentShadowJar = System.getProperty("datadog.smoketest.agent.shadowJar.path")
     assert new File(agentShadowJar).isFile()

--- a/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/build.gradleTest
@@ -1,0 +1,21 @@
+apply plugin: 'java'
+
+repositories {
+  mavenLocal()
+  mavenCentral()
+}
+
+dependencies {
+  testImplementation 'junit:junit:4.10'
+  testImplementation 'org.junit.platform:junit-platform-launcher:1.9.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+  testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.2'
+}
+
+test {
+  maxParallelForks = 2
+  forkEvery = 1
+
+  useJUnitPlatform()
+}

--- a/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/settings.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/settings.gradleTest
@@ -1,0 +1,1 @@
+rootProject.name = 'gradle-instrumentation-test-project'

--- a/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/src/main/java/datadog/smoke/Calculator.java
+++ b/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/src/main/java/datadog/smoke/Calculator.java
@@ -1,0 +1,10 @@
+package datadog.smoke;
+
+public class Calculator {
+  public static int add(int a, int b) {
+    return a + b;
+  }
+  public static int subtract(int a, int b) {
+    return a - b;
+  }
+}

--- a/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/src/test/java/datadog/smoke/TestSucceed.java
+++ b/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/src/test/java/datadog/smoke/TestSucceed.java
@@ -1,0 +1,12 @@
+package datadog.smoke;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TestSucceed {
+  @Test
+  public void test_succeed() {
+    assertTrue(Calculator.add(2, 2) == 4);
+  }
+}

--- a/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/src/test/java/datadog/smoke/TestSucceedJunit5.java
+++ b/dd-smoke-tests/gradle/src/test/resources/datadog/smoketest/successMultiForks/src/test/java/datadog/smoke/TestSucceedJunit5.java
@@ -1,0 +1,12 @@
+package datadog.smoke;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class TestSucceedJunit5 {
+  @Test
+  public void test_succeed() {
+    assertTrue(Calculator.subtract(2, 2) == 0);
+  }
+}

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -410,7 +410,6 @@ class MavenSmokeTest extends Specification {
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_GIT_UPLOAD_ENABLED)}=false," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_COVERAGE_SEGMENTS_ENABLED)}=true," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_COMPILER_PLUGIN_VERSION)}=${JAVAC_PLUGIN_VERSION}," +
-        "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_REPORT_DUMP_DIR)}=/tmp/covtest," + // FIXME nikita: remove
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_JACOCO_PLUGIN_VERSION)}=${JACOCO_PLUGIN_VERSION}," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_JACOCO_PLUGIN_INCLUDES)}=datadog.smoke.*," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL)}=${intakeServer.address.toString()}"

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1.java
@@ -14,6 +14,7 @@ import datadog.trace.common.writer.RemoteMapper;
 import datadog.trace.core.CoreSpan;
 import datadog.trace.core.Metadata;
 import datadog.trace.core.MetadataConsumer;
+import datadog.trace.util.Strings;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
@@ -284,9 +285,15 @@ public class CiTestCycleMapperV1 implements RemoteMapper {
         writable.writeUTF8(metadata.getHttpStatusCode());
       }
       for (Map.Entry<String, Object> entry : metadata.getTags().entrySet()) {
-        if (!(entry.getValue() instanceof Number)) {
+        Object value = entry.getValue();
+        if (!(value instanceof Number)) {
           writable.writeString(entry.getKey(), null);
-          writable.writeObjectString(entry.getValue(), null);
+          if (!(value instanceof Iterable)) {
+            writable.writeObjectString(value, null);
+          } else {
+            String serializedValue = Strings.toJson((Iterable<String>) value);
+            writable.writeString(serializedValue, null);
+          }
         }
       }
     }


### PR DESCRIPTION
# What Does This Do
Updates build system instrumentations to correctly handle cases when tests for a specific module are executed in multiple JVMs.
Also handles cases when tests for a specific module use different testing frameworks (this is orthogonal to multiple forks, can happen even if there is only one fork per module).

# Motivation
When tests for one module run in multiple forked JVMs, we want the reported module span to contain the aggregated data (that is, all the test frameworks used in all the forks, combined code coverage data from all the forks, the total number of tests skipped by ITR for all the forks, etc).

# Additional Notes
Depending on the build configuration it is possible to have multiple JVM forks started for the one module: in Gradle this is achieved with `maxParallelForks` or `forkEvery` properties of the `Test` task, in Maven - with `forkCount` property of the Surefire plugin. The forks can execute either concurrently or sequentially.
