### PR TITLE
Preserve tracer's default metrics namespace as "datadog.tracer" in dd-trace-ot

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1105,7 +1105,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
               host,
               port,
               config.getDogStatsDNamedPipe(),
-              "datadog.tracer",
+              // use replace to stop string being changed to 'ddtrot.dd.tracer' in dd-trace-ot
+              "datadog:tracer".replace(':', '.'),
               generateConstantTags(config));
     }
   }


### PR DESCRIPTION
# What Does This Do

Stops the `CoreTracer`'s default statsd namespace from being changed by `dd-trace-ot`'s relocation rules

# Motivation

Otherwise tracer metrics collected when using `dd-trace-ot` end up prefixed with `ddtrot.dd.tracer` as reported in https://github.com/DataDog/dd-trace-java/issues/5808