### PR TITLE
Support servlet getRequestURI/getPathTranslated/getPathInfo as IAST sources

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -8,6 +8,7 @@ import com.datadog.iast.taint.TaintedObjects;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.source.WebModule;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -61,6 +62,16 @@ public class WebModuleImpl implements WebModule {
   @Override
   public void onCookieNames(@Nullable Iterable<String> cookieNames) {
     onNamed(cookieNames, SourceTypes.REQUEST_COOKIE_NAME);
+  }
+
+  @Override
+  public void onGetPathInfo(@Nullable String s) {
+    onNamed(Collections.singleton(s), SourceTypes.REQUEST_PATH);
+  }
+
+  @Override
+  public void onGetRequestURI(@Nullable String s) {
+    onNamed(Collections.singleton(s), SourceTypes.REQUEST_URI);
   }
 
   private static void onNamed(@Nullable final Iterable<String> names, final byte source) {

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -294,8 +294,6 @@
 0 org.springframework.core.io.buffer.DataBuffer
 0 org.springframework.core.io.buffer.DefaultDataBuffer
 0 org.springframework.core.io.buffer.NettyDataBuffer
-# Need for IAST so propagation of tainted objects is complete in spring 2.7.5
-0 org.springframework.util.StreamUtils$NonClosingInputStream
 # There are some Mono implementation that get instrumented
 0 org.springframework.http.server.reactive.*
 2 org.springframework.instrument.*
@@ -331,6 +329,8 @@
 0 org.springframework.web.servlet.*
 # Included for IAST
 0 org.springframework.web.util.WebUtils
+# Need for IAST so propagation of tainted objects is complete in spring 2.7.5
+0 org.springframework.util.StreamUtils$NonClosingInputStream
 # Included for IAST Spring mvc unvalidated redirect and xss vulnerability
 0 org.springframework.web.method.support.HandlerMethodReturnValueHandlerComposite
 2 org.xml.*

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -250,4 +250,39 @@ public class HttpServletRequestCallSite {
       }
     }
   }
+
+  @Source(SourceTypes.REQUEST_URI)
+  @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getRequestURI()")
+  public static String afterGetRequestURI(
+      @CallSite.This final HttpServletRequest self, @CallSite.Return final String retValue) {
+    if (null != retValue && !retValue.isEmpty()) {
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        try {
+          module.onGetRequestURI(retValue);
+        } catch (final Throwable e) {
+          module.onUnexpectedException("afterGetRequestURI threw", e);
+        }
+      }
+    }
+    return retValue;
+  }
+
+  @Source(SourceTypes.REQUEST_PATH)
+  @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getPathInfo()")
+  @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getPathTranslated()")
+  public static String afterGetPathInfo(
+      @CallSite.This final HttpServletRequest self, @CallSite.Return final String retValue) {
+    if (null != retValue && !retValue.isEmpty()) {
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        try {
+          module.onGetPathInfo(retValue);
+        } catch (final Throwable e) {
+          module.onUnexpectedException("afterGetPathInfo threw", e);
+        }
+      }
+    }
+    return retValue;
+  }
 }

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
@@ -178,6 +178,70 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
     HttpServletRequestWrapper | _
   }
 
+  void 'test getRequestURI'() {
+    setup:
+    final iastModule = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final mock = Mock(HttpServletRequest){
+      getRequestURI() >> 'retValue'
+    }
+    final testSuite = new TestHttpServletRequestCallSiteSuite(mock)
+
+    when:
+    testSuite.getRequestURI()
+
+    then:
+    1 * iastModule.onGetRequestURI('retValue')
+
+    where:
+    clazz                     | _
+    HttpServletRequest        | _
+    HttpServletRequestWrapper | _
+  }
+
+  void 'test getPathInfo'() {
+    setup:
+    final iastModule = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final mock = Mock(HttpServletRequest){
+      getPathInfo() >> 'retValue'
+    }
+    final testSuite = new TestHttpServletRequestCallSiteSuite(mock)
+
+    when:
+    testSuite.getPathInfo()
+
+    then:
+    1 * iastModule.onGetPathInfo('retValue')
+
+    where:
+    clazz                     | _
+    HttpServletRequest        | _
+    HttpServletRequestWrapper | _
+  }
+
+  void 'test getPathTranslated'() {
+    setup:
+    final iastModule = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final mock = Mock(HttpServletRequest){
+      getPathTranslated() >> 'retValue'
+    }
+    final testSuite = new TestHttpServletRequestCallSiteSuite(mock)
+
+    when:
+    testSuite.getPathTranslated()
+
+    then:
+    1 * iastModule.onGetPathInfo('retValue')
+
+    where:
+    clazz                     | _
+    HttpServletRequest        | _
+    HttpServletRequestWrapper | _
+  }
+
+
   private static class NuclearBomb extends RuntimeException {
     NuclearBomb(final String message) {
       super(message)

--- a/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/TestHttpServletRequestCallSiteSuite.java
+++ b/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/TestHttpServletRequestCallSiteSuite.java
@@ -31,4 +31,16 @@ public class TestHttpServletRequestCallSiteSuite {
   public String getQueryString() {
     return request.getQueryString();
   }
+
+  public String getRequestURI() {
+    return request.getRequestURI();
+  }
+
+  public String getPathInfo() {
+    return request.getPathInfo();
+  }
+
+  public String getPathTranslated() {
+    return request.getPathTranslated();
+  }
 }

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -337,6 +337,12 @@ public class IastWebController {
     return "ok";
   }
 
+  @GetMapping("/getrequesturi")
+  String pathInfo(HttpServletRequest request) {
+    String pathInfo = request.getRequestURI();
+    return String.format("Request.getRequestURI returns %s", pathInfo);
+  }
+
   private void withProcess(final Operation<Process> op) {
     Process process = null;
     try {

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -794,4 +794,19 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     hasVulnerabilityInLogs { vul -> vul.type == 'UNVALIDATED_REDIRECT' && vul.location.method == 'getViewfromTaintedString' }
   }
 
+  void 'getRequestURI taints its output'() {
+    setup:
+    final url = "http://localhost:${httpPort}/getrequesturi"
+    final request = new Request.Builder().url(url).get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    hasTainted { tainted ->
+      tainted.value == '/getrequesturi' &&
+        tainted.ranges[0].source.origin == 'http.request.uri'
+    }
+  }
+
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
@@ -29,6 +29,10 @@ public abstract class SourceTypes {
   public static final byte REQUEST_MULTIPART_PARAMETER = 10;
   public static final String REQUEST_MULTIPART_PARAMETER_STRING =
       "http.request.multipart.parameter";
+  public static final byte REQUEST_URI = 11;
+  public static final String REQUEST_URI_STRING = "http.request.uri";
+  public static final byte REQUEST_PATH = 12;
+  public static final String REQUEST_PATH_STRING = "http.request.path";
 
   private static final byte[] VALUES = {
     REQUEST_PARAMETER_NAME,
@@ -41,7 +45,9 @@ public abstract class SourceTypes {
     REQUEST_QUERY,
     REQUEST_PATH_PARAMETER,
     REQUEST_MATRIX_PARAMETER,
-    REQUEST_MULTIPART_PARAMETER
+    REQUEST_MULTIPART_PARAMETER,
+    REQUEST_PATH,
+    REQUEST_URI
   };
 
   public static byte[] values() {
@@ -72,6 +78,10 @@ public abstract class SourceTypes {
         return SourceTypes.REQUEST_MATRIX_PARAMETER_STRING;
       case SourceTypes.REQUEST_MULTIPART_PARAMETER:
         return SourceTypes.REQUEST_MULTIPART_PARAMETER_STRING;
+      case SourceTypes.REQUEST_PATH:
+        return SourceTypes.REQUEST_PATH_STRING;
+      case SourceTypes.REQUEST_URI:
+        return SourceTypes.REQUEST_URI_STRING;
       default:
         return null;
     }

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -29,4 +29,8 @@ public interface WebModule extends IastModule {
 
   void onMultipartValues(
       @Nullable String headerName, @Nullable final Collection<String> headerValues);
+
+  void onGetPathInfo(@Nullable String s);
+
+  void onGetRequestURI(@Nullable String s);
 }


### PR DESCRIPTION

# What Does This Do
Added instrumentation for getRequestURI, getPathTranslated and getPathInfo in ServletRequest 

# Motivation
To cover all of the cases where intput needs to be tainted in order to detect vulnerabilities.

# Additional Notes
