### PR TITLE
Inject WAF custom rules for testing in smoke tests

### DIFF
--- a/dd-java-agent/appsec/src/main/resources/default_config.json
+++ b/dd-java-agent/appsec/src/main/resources/default_config.json
@@ -7074,32 +7074,6 @@
         }
       ],
       "transformers": []
-    },
-    {
-      "id": "__troubleshooting_rule",
-      "name": "troubleshooting rule for block on request body",
-      "tags": {
-        "type": "troubleshooting",
-        "category": "troubleshooting",
-        "confidence": "1"
-      },
-      "conditions": [
-        {
-          "parameters": {
-            "inputs": [
-              {
-                "address": "server.request.body"
-              }
-            ],
-            "regex": "ADKMFFpndcwHNnr2MW9W"
-          },
-          "operator": "match_regex"
-        }
-      ],
-      "transformers": [],
-      "on_match": [
-        "block"
-      ]
     }
   ]
 }

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -1,19 +1,68 @@
 package datadog.smoketest.appsec
 
 import datadog.trace.agent.test.utils.ThreadUtils
+import groovy.json.JsonGenerator
+import groovy.json.JsonSlurper
 import okhttp3.MediaType
 import okhttp3.Request
 import okhttp3.RequestBody
+import org.apache.commons.io.IOUtils
+import spock.lang.Shared
+
+import java.nio.charset.StandardCharsets
+import java.util.jar.JarFile
 
 class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
+
+  @Shared
+  String buildDir = new File(System.getProperty("datadog.smoketest.builddir")).absolutePath
+  @Shared
+  String customRulesPath = "${buildDir}/appsec_custom_rules.json"
+
+  def prepareCustomRules() {
+    // Prepare ruleset with additional test rules
+    final jarFile = new JarFile(shadowJarPath)
+    final zipEntry = jarFile.getEntry("appsec/default_config.json")
+    final content = IOUtils.toString(jarFile.getInputStream(zipEntry), StandardCharsets.UTF_8)
+    final json = new JsonSlurper().parseText(content) as Map<String, Object>
+    final rules = json.rules as List<Map<String, Object>>
+    rules.add([
+      id: '__test_request_body_block',
+      name: 'test rule to block on request body',
+      tags: [
+        type: 'test',
+        category: 'test',
+        confidence: 1,
+      ],
+      conditions: [
+        [
+          parameters: [
+            inputs: [ [ address: 'server.request.body' ] ],
+            regex: 'dd-test-request-body-block',
+          ],
+          operator: 'match_regex',
+        ]
+      ],
+      transformers: [],
+      on_match: [ 'block' ]
+    ])
+    final gen = new JsonGenerator.Options().build()
+    IOUtils.write(gen.toJson(json), new FileOutputStream(customRulesPath, false), StandardCharsets.UTF_8)
+  }
+
   @Override
   ProcessBuilder createProcessBuilder() {
+    // We run this here to ensure it runs before starting the process. Child setupSpec runs after parent setupSpec,
+    // so it is not a valid location.
+    prepareCustomRules()
+
     String springBootShadowJar = System.getProperty("datadog.smoketest.appsec.springboot.shadowJar.path")
 
     List<String> command = new ArrayList<>()
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
     command.addAll(defaultAppSecProperties)
+    command.add("-Ddd.appsec.rules=${customRulesPath}" as String)
     command.addAll((String[]) ["-jar", springBootShadowJar, "--server.port=${httpPort}"])
 
     ProcessBuilder processBuilder = new ProcessBuilder(command)
@@ -137,7 +186,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     String url = "http://localhost:${httpPort}/greeting"
     def request = new Request.Builder()
       .url(url)
-      .post(RequestBody.create(MediaType.parse('application/x-www-form-urlencoded'), 'k=ADKMFFpndcwHNnr2MW9W'))
+      .post(RequestBody.create(MediaType.parse('application/x-www-form-urlencoded'), 'd=dd-test-request-body-block'))
       .build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()
@@ -152,7 +201,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     then:
     rootSpans.size() == 1
     forEachRootSpanTrigger {
-      assert it['rule']['id'] == '__troubleshooting_rule'
+      assert it['rule']['id'] == '__test_request_body_block'
     }
     rootSpans.each {
       assert it.meta.get('appsec.blocked') != null, 'appsec.blocked is not set'


### PR DESCRIPTION
# What Does This Do
* Inject test rules that we need for tests at test time.

# Motivation
* Avoid polluting the production ruleset.

# Additional Notes
* Follow up to https://github.com/DataDog/dd-trace-java/pull/5594
* Spotted while working on https://github.com/DataDog/dd-trace-java/pull/5815
