### PR TITLE
Add Spark SQL spans

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
@@ -59,7 +59,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
 
     expect:
     assertTraces(2) {
-      trace(4) {
+      trace(5) {
         span {
           operationName "spark.batch"
           resourceName "test-query"
@@ -129,6 +129,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
             "spark.task_with_output_count" Long
 
             // Config tags
+            "config.spark_version" String
             "config.spark_app_id" String
             "config.spark_app_name" String
             "config.spark_jobGroup_id" String
@@ -144,22 +145,27 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
           }
         }
         span {
-          operationName "spark.job"
+          operationName "spark.sql"
           spanType "spark"
           childOf(span(0))
         }
         span {
-          operationName "spark.stage"
+          operationName "spark.job"
           spanType "spark"
           childOf(span(1))
         }
         span {
           operationName "spark.stage"
           spanType "spark"
-          childOf(span(1))
+          childOf(span(2))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          childOf(span(2))
         }
       }
-      trace(4) {
+      trace(5) {
         span {
           operationName "spark.batch"
           spanType "spark"
@@ -167,19 +173,24 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
           parent()
         }
         span {
-          operationName "spark.job"
+          operationName "spark.sql"
           spanType "spark"
           childOf(span(0))
         }
         span {
-          operationName "spark.stage"
+          operationName "spark.job"
           spanType "spark"
           childOf(span(1))
         }
         span {
           operationName "spark.stage"
           spanType "spark"
-          childOf(span(1))
+          childOf(span(2))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          childOf(span(2))
         }
       }
     }
@@ -205,7 +216,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
     sparkSession.stop()
 
     assertTraces(1) {
-      trace(4) {
+      trace(5) {
         span {
           operationName "spark.batch"
           resourceName "failing-query"
@@ -216,22 +227,27 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
           parent()
         }
         span {
-          operationName "spark.job"
+          operationName "spark.sql"
           spanType "spark"
-          errored true
           childOf(span(0))
         }
         span {
-          operationName "spark.stage"
+          operationName "spark.job"
           spanType "spark"
           errored true
           childOf(span(1))
         }
         span {
-          operationName "spark.task"
+          operationName "spark.stage"
           spanType "spark"
           errored true
           childOf(span(2))
+        }
+        span {
+          operationName "spark.task"
+          spanType "spark"
+          errored true
+          childOf(span(3))
         }
       }
     }

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkTest.groovy
@@ -10,7 +10,11 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.spark.deploy.SparkSubmit
 import org.apache.spark.deploy.yarn.ApplicationMaster
 import org.apache.spark.deploy.yarn.ApplicationMasterArguments
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.RowFactory
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types.StructType
 import scala.reflect.ClassTag$
 import spock.lang.IgnoreIf
 
@@ -304,5 +308,91 @@ class SparkTest extends AgentTestRunner {
 
     contextWithoutTaskRunId.getTraceId() == DDTraceId.ZERO
     contextWithoutTaskRunId.getSpanId() == DDSpanId.ZERO
+  }
+
+  private Dataset<Row> generateSampleDataframe(SparkSession spark) {
+    def structType = new StructType()
+    structType = structType.add("col", "String", false)
+
+    def rows = new ArrayList<Row>()
+    rows.add(RowFactory.create("value"))
+    spark.createDataFrame(rows, structType)
+  }
+
+  def "generate spark sql spans"() {
+    setup:
+    def sparkSession = SparkSession.builder()
+      .config("spark.master", "local[2]")
+      .config("spark.sql.shuffle.partitions", "2")
+      .getOrCreate()
+
+    def df = generateSampleDataframe(sparkSession)
+    df.coalesce(1).count()
+    sparkSession.stop()
+
+    expect:
+    assertTraces(1) {
+      trace(4) {
+        span {
+          operationName "spark.application"
+          spanType "spark"
+          parent()
+        }
+        span {
+          operationName "spark.sql"
+          spanType "spark"
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.job"
+          spanType "spark"
+          childOf(span(1))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          childOf(span(2))
+        }
+      }
+    }
+  }
+
+  def "generate spark sql spans on databricks"() {
+    setup:
+    def sparkSession = SparkSession.builder()
+      .config("spark.master", "local[2]")
+      .config("spark.sql.shuffle.partitions", "2")
+      .config("spark.databricks.sparkContextId", "some_id")
+      .config("spark.databricks.clusterUsageTags.clusterName", "job-1234-run-5678-Job_cluster")
+      .getOrCreate()
+
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.job.id", "1234")
+    sparkSession.sparkContext().setLocalProperty("spark.databricks.job.runId", "9012")
+
+    def df = generateSampleDataframe(sparkSession)
+    df.coalesce(1).count()
+    sparkSession.stop()
+
+    expect:
+    assertTraces(1) {
+      trace(3) {
+        span {
+          operationName "spark.sql"
+          spanType "spark"
+          traceId 8944764253919609482G
+          parentSpanId 15104224823446433673G
+        }
+        span {
+          operationName "spark.job"
+          spanType "spark"
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          childOf(span(1))
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR introduce the `spark.sql` spans which are created whenever the SQL API is used

[Spark SQL](https://spark.apache.org/docs/latest/sql-programming-guide.html) is the higher level API to perform spark computation following the SQL standard. A Spark SQL query is then broken down by spark into multiple `spark.job` and `spark.stage`

The hierarchy of a spark.job span is now

```
spark.application | spark.batch | databricks.task depending on the environment where spark is running
               \          |         /
                     [spark.sql] optional, only present if using spark-sql
                          |
                      spark.job
```
