### PR TITLE
Exclude JMXFetch jackson dependencies...

### DIFF
--- a/dd-java-agent/agent-jmxfetch/build.gradle
+++ b/dd-java-agent/agent-jmxfetch/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.slf4j', module: 'slf4j-jdk14'
     exclude group: 'com.beust', module: 'jcommander'
+    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+    exclude group: 'com.fasterxml.jackson.jr', module: 'jackson-jr-objects'
   }
   api deps.slf4j
   api project(':internal-api')

--- a/dd-java-agent/agent-jmxfetch/src/main/java/com/fasterxml/jackson/core/JsonProcessingException.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/com/fasterxml/jackson/core/JsonProcessingException.java
@@ -1,0 +1,4 @@
+package com.fasterxml.jackson.core;
+
+// empty stub; here to satisfy a catch reference in org.datadog.jmxfetch.App
+public class JsonProcessingException extends java.io.IOException {}


### PR DESCRIPTION
... because we don't need them for our embedded usage

Note: currently `org.datadog.jmxfetch.App` does refer to `JsonProcessingException` in a catch block, but we can satisfy this with an empty stub class without needing the whole library. In practice this exception will not be thrown anywhere.

This also reduces the `dd-java-agent` jar size by ~400k
