### PR TITLE
Add span smoke tests

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -182,6 +182,9 @@ public class ConfigurationUpdater
 
   private void recordInstrumentationProgress(
       ProbeDefinition definition, InstrumentationResult instrumentationResult) {
+    if (instrumentationResult.isError()) {
+      return;
+    }
     instrumentationResults.put(definition.getId(), instrumentationResult);
     if (instrumentationResult.isInstalled()) {
       sink.addInstalled(definition.getProbeId());

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.agent;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.NOOP_TRACER;
+
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.DebuggerSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -8,12 +10,12 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 
 public class DebuggerTracer implements DebuggerContext.Tracer {
-  private static final String OPERATION_NAME = "dd.dynamic.span";
+  public static final String OPERATION_NAME = "dd.dynamic.span";
 
   @Override
   public DebuggerSpan createSpan(String resourceName, String[] tags) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
-    if (tracerAPI == null) {
+    if (tracerAPI == null || tracerAPI == NOOP_TRACER) {
       return DebuggerSpan.NOOP_SPAN;
     }
     AgentSpan dynamicSpan =

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -486,7 +486,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
             capturedContextProbes.add(definition);
           } else {
             List<DiagnosticMessage> probeDiagnostics = diagnostics.get(definition.getProbeId());
-            definition.instrument(classLoader, classNode, methodNode, probeDiagnostics);
+            status = definition.instrument(classLoader, classNode, methodNode, probeDiagnostics);
           }
         }
         if (capturedContextProbes.size() > 0) {
@@ -495,8 +495,9 @@ public class DebuggerTransformer implements ClassFileTransformer {
           ProbeDefinition referenceDefinition = selectReferenceDefinition(capturedContextProbes);
           List<DiagnosticMessage> probeDiagnostics =
               diagnostics.get(referenceDefinition.getProbeId());
-          referenceDefinition.instrument(
-              classLoader, classNode, methodNode, probeDiagnostics, probesIds);
+          status =
+              referenceDefinition.instrument(
+                  classLoader, classNode, methodNode, probeDiagnostics, probesIds);
         }
       } catch (Throwable t) {
         log.warn("Exception during instrumentation: ", t);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/InstrumentationResult.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/InstrumentationResult.java
@@ -56,6 +56,10 @@ public class InstrumentationResult {
     this.methodName = methodName;
   }
 
+  public boolean isError() {
+    return status == Status.ERROR;
+  }
+
   public boolean isBlocked() {
     return status == Status.BLOCKED;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -69,7 +69,7 @@ public abstract class Instrumentor {
     localVarsBySlot = extractLocalVariables(argTypes);
   }
 
-  public abstract void instrument();
+  public abstract InstrumentationResult.Status instrument();
 
   private LocalVariableNode[] extractLocalVariables(Type[] argTypes) {
     if (methodNode.localVariables == null || methodNode.localVariables.isEmpty()) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -10,6 +10,7 @@ import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.instrumentation.CapturedContextInstrumentor;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
+import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.sink.Sink;
 import com.datadog.debugger.sink.Snapshot;
 import com.squareup.moshi.Json;
@@ -343,13 +344,13 @@ public class LogProbe extends ProbeDefinition {
   }
 
   @Override
-  public void instrument(
+  public InstrumentationResult.Status instrument(
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
       List<String> probeIds) {
-    new CapturedContextInstrumentor(
+    return new CapturedContextInstrumentor(
             this,
             classLoader,
             classNode,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.probe;
 import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
+import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MetricInstrumentor;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
@@ -135,13 +136,13 @@ public class MetricProbe extends ProbeDefinition {
   }
 
   @Override
-  public void instrument(
+  public InstrumentationResult.Status instrument(
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
       List<String> probeIds) {
-    new MetricInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
+    return new MetricInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
         .instrument();
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -122,15 +122,15 @@ public abstract class ProbeDefinition implements ProbeImplementation {
     }
   }
 
-  public void instrument(
+  public InstrumentationResult.Status instrument(
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics) {
-    instrument(classLoader, classNode, methodNode, diagnostics, singletonList(getId()));
+    return instrument(classLoader, classNode, methodNode, diagnostics, singletonList(getId()));
   }
 
-  public abstract void instrument(
+  public abstract InstrumentationResult.Status instrument(
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -7,6 +7,7 @@ import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.instrumentation.CapturedContextInstrumentor;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
+import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.sink.Snapshot;
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.debugger.CapturedContext;
@@ -132,13 +133,13 @@ public class SpanDecorationProbe extends ProbeDefinition {
   }
 
   @Override
-  public void instrument(
+  public InstrumentationResult.Status instrument(
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
       List<String> probeIds) {
-    new CapturedContextInstrumentor(
+    return new CapturedContextInstrumentor(
             this, classLoader, classNode, methodNode, diagnostics, probeIds, false, Limits.DEFAULT)
         .instrument();
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.probe;
 
 import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
+import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.SpanInstrumentor;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
@@ -23,13 +24,13 @@ public class SpanProbe extends ProbeDefinition {
   }
 
   @Override
-  public void instrument(
+  public InstrumentationResult.Status instrument(
       ClassLoader classLoader,
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
       List<String> probeIds) {
-    new SpanInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
+    return new SpanInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
         .instrument();
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -345,7 +345,7 @@ public class DebuggerTransformerTest {
     }
 
     @Override
-    public void instrument(
+    public InstrumentationResult.Status instrument(
         ClassLoader classLoader,
         ClassNode classNode,
         MethodNode methodNode,
@@ -353,6 +353,7 @@ public class DebuggerTransformerTest {
         List<String> probeIds) {
       methodNode.instructions.insert(
           new VarInsnNode(Opcodes.ASTORE, methodNode.localVariables.size()));
+      return InstrumentationResult.Status.INSTALLED;
     }
 
     public static MockProbe.Builder builder(ProbeId probeId) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
@@ -1,0 +1,75 @@
+package datadog.smoketest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.datadog.debugger.agent.DebuggerTracer;
+import com.datadog.debugger.agent.ProbeStatus;
+import com.datadog.debugger.probe.SpanProbe;
+import datadog.trace.test.agent.decoder.DecodedMessage;
+import datadog.trace.test.agent.decoder.DecodedSpan;
+import datadog.trace.test.agent.decoder.Decoder;
+import java.nio.file.Path;
+import java.util.List;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
+
+  @Override
+  protected ProcessBuilder createProcessBuilder(Path logFilePath, String... params) {
+    List<String> commandParams = getDebuggerCommandParams();
+    commandParams.add("-Ddd.trace.enabled=true"); // explicitly enable tracer
+    return ProcessBuilderHelper.createProcessBuilder(
+        commandParams, logFilePath, getAppClass(), params);
+  }
+
+  @Test
+  @DisplayName("testMethodSpan")
+  void testMethodSpan() throws Exception {
+    final String METHOD_NAME = "fullMethod";
+    final String EXPECTED_UPLOADS = "3"; // 2 + 1 for letting the trace being sent (async)
+    SpanProbe spanProbe =
+        SpanProbe.builder().probeId(PROBE_ID).where(MAIN_CLASS_NAME, METHOD_NAME).build();
+    setCurrentConfiguration(createSpanConfig(spanProbe));
+    targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
+    RecordedRequest spanRequest = retrieveSpanRequest();
+    DecodedMessage decodedMessage = Decoder.decodeV04(spanRequest.getBody().readByteArray());
+    DecodedSpan decodedSpan = decodedMessage.getTraces().get(0).getSpans().get(0);
+    assertEquals(DebuggerTracer.OPERATION_NAME, decodedSpan.getName());
+    assertEquals("Main.fullMethod", decodedSpan.getResource());
+  }
+
+  @Test
+  @DisplayName("testLineRangeSpan")
+  void testLineRangeSpan() throws Exception {
+    final String METHOD_NAME = "fullMethod";
+    final String EXPECTED_UPLOADS = "3"; // 2 + 1 for letting the trace being sent (async)
+    SpanProbe spanProbe =
+        SpanProbe.builder().probeId(PROBE_ID).where(MAIN_CLASS_NAME, 68, 77).build();
+    setCurrentConfiguration(createSpanConfig(spanProbe));
+    targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
+    RecordedRequest spanRequest = retrieveSpanRequest();
+    DecodedMessage decodedMessage = Decoder.decodeV04(spanRequest.getBody().readByteArray());
+    DecodedSpan decodedSpan = decodedMessage.getTraces().get(0).getSpans().get(0);
+    assertEquals(DebuggerTracer.OPERATION_NAME, decodedSpan.getName());
+    assertEquals("Main.fullMethod:L68-77", decodedSpan.getResource());
+  }
+
+  @Test
+  @DisplayName("testSingleLineSpan")
+  void testSingleLineSpan() throws Exception {
+    final String METHOD_NAME = "fullMethod";
+    final String EXPECTED_UPLOADS = "2"; // 2 probe statuses: RECEIVED + ERROR
+    SpanProbe spanProbe = SpanProbe.builder().probeId(PROBE_ID).where(MAIN_CLASS_NAME, 68).build();
+    setCurrentConfiguration(createSpanConfig(spanProbe));
+    targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
+    ProbeStatus status = retrieveProbeStatusRequest();
+    assertEquals(ProbeStatus.Status.RECEIVED, status.getDiagnostics().getStatus());
+    status = retrieveProbeStatusRequest();
+    assertEquals(ProbeStatus.Status.ERROR, status.getDiagnostics().getStatus());
+    assertEquals(
+        "Single line span is not supported, you need to provide a range.",
+        status.getDiagnostics().getException().getMessage());
+  }
+}

--- a/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v04/raw/SpanV04.java
+++ b/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v04/raw/SpanV04.java
@@ -98,6 +98,9 @@ public class SpanV04 implements DecodedSpan {
   private static String unpackString(String expectedKey, MessageUnpacker unpacker)
       throws IOException {
     unpackKey(expectedKey, unpacker);
+    if (unpacker.tryUnpackNil()) {
+      return null;
+    }
     return unpacker.unpackString();
   }
 


### PR DESCRIPTION
# What Does This Do
Also refactor the status of the instrumentation to be returned by instrument method. It avoids to send a probe status INSTALLED first then received later the ERROR one.
Report a probe status error when trying to instrument a single line span probe.

# Motivation

# Additional Notes
