### PR TITLE
restore exception profiling instrumentation enablement

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -314,8 +314,9 @@ public interface Instrumenter {
 
     @Override
     public boolean isEnabled() {
-      return !ConfigProvider.getInstance()
-          .getBoolean(ProfilingConfig.PROFILING_ULTRA_MINIMAL, false);
+      return super.isEnabled()
+          && !ConfigProvider.getInstance()
+              .getBoolean(ProfilingConfig.PROFILING_ULTRA_MINIMAL, false);
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Fixes regression introduced in #5583 where `-Ddd.integrations.<name>.enabled` flag would no longer be checked. This does not affect other profiling instrumentations (direct allocation profiling, queue time) which have profiling scoped flags.

# Motivation

# Additional Notes
