### PR TITLE
Allow a single subscriber per AppSec event

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -156,7 +156,7 @@ public class AppSecSystem {
       }
 
       for (AppSecModule.EventSubscription sub : module.getEventSubscriptions()) {
-        eventSubscriptionSet.addSubscription(sub.eventType, sub);
+        eventSubscriptionSet.setSubscription(sub.eventType, sub);
       }
 
       for (AppSecModule.DataSubscription sub : module.getDataSubscriptions()) {
@@ -180,7 +180,7 @@ public class AppSecSystem {
     EventDispatcher newEd = new EventDispatcher();
     for (AppSecModule module : STARTED_MODULES_INFO.keySet()) {
       for (AppSecModule.EventSubscription sub : module.getEventSubscriptions()) {
-        eventSubscriptionSet.addSubscription(sub.eventType, sub);
+        eventSubscriptionSet.setSubscription(sub.eventType, sub);
       }
 
       for (AppSecModule.DataSubscription sub : module.getDataSubscriptions()) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/EventDispatcher.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/EventDispatcher.java
@@ -10,7 +10,6 @@ import datadog.trace.api.gateway.Flow;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -23,7 +22,8 @@ public class EventDispatcher implements EventProducerService {
   private static final Logger log = LoggerFactory.getLogger(EventDispatcher.class);
   private static final char[] EMPTY_CHAR_ARRAY = new char[0];
 
-  private List<List<EventListener>> eventListeners; // index: eventType.serial
+  private EventListener[] eventListeners =
+      new EventListener[NUM_EVENT_TYPES]; // index: eventType.serial
 
   // indexes are the ids we successively attribute to listeners
   // we support up to 2^16 listeners in total
@@ -36,12 +36,6 @@ public class EventDispatcher implements EventProducerService {
   public EventDispatcher() {
     KnownAddresses.HEADERS_NO_COOKIES.getKey(); // force class initialization
 
-    // empty subscriptions
-    eventListeners = new ArrayList<>(NUM_EVENT_TYPES);
-    for (int i = 0; i < NUM_EVENT_TYPES; i++) {
-      eventListeners.add(Collections.emptyList());
-    }
-
     final int addressCount = Address.instanceCount();
     dataListenerSubs = new ArrayList<>(addressCount);
     for (int i = 0; i < addressCount; i++) {
@@ -50,27 +44,19 @@ public class EventDispatcher implements EventProducerService {
   }
 
   public static class EventSubscriptionSet {
-    private final List<List<EventListener>> eventListeners; // index: eventType.serial
+    private final EventListener[] eventListeners =
+        new EventListener[NUM_EVENT_TYPES]; // index: eventType.serial
 
     public EventSubscriptionSet() {
       KnownAddresses.HEADERS_NO_COOKIES.getKey(); // force class initialization
-
-      eventListeners = new ArrayList<>(NUM_EVENT_TYPES);
-      for (int i = 0; i < NUM_EVENT_TYPES; i++) {
-        eventListeners.add(new ArrayList<>(2));
-      }
     }
 
-    public void addSubscription(EventType event, EventListener listener) {
-      List<EventListener> eventListeners = this.eventListeners.get(event.ordinal());
-      eventListeners.add(listener);
+    public void setSubscription(EventType event, EventListener listener) {
+      this.eventListeners[event.ordinal()] = listener;
     }
   }
 
   public void subscribeEvents(EventSubscriptionSet subscriptionSet) {
-    for (List<EventListener> eventListener : subscriptionSet.eventListeners) {
-      eventListener.sort(OrderedCallback.CallbackPriorityComparator.INSTANCE);
-    }
     this.eventListeners = subscriptionSet.eventListeners;
   }
 
@@ -136,13 +122,14 @@ public class EventDispatcher implements EventProducerService {
 
   @Override
   public void publishEvent(AppSecRequestContext ctx, EventType event) {
-    List<EventListener> eventListeners = this.eventListeners.get(event.ordinal());
-    for (EventListener listener : eventListeners) {
-      try {
-        listener.onEvent(ctx, event);
-      } catch (RuntimeException rte) {
-        log.warn("AppSec callback exception", rte);
-      }
+    final EventListener listener = this.eventListeners[event.ordinal()];
+    if (listener == null) {
+      return;
+    }
+    try {
+      listener.onEvent(ctx, event);
+    } catch (RuntimeException rte) {
+      log.warn("AppSec callback exception", rte);
     }
   }
 
@@ -209,7 +196,7 @@ public class EventDispatcher implements EventProducerService {
     EventType[] values = EventType.values();
     List<EventType> res = new ArrayList<>(values.length);
     for (int i = 0; i < values.length; i++) {
-      if (!eventListeners.get(i).isEmpty()) {
+      if (eventListeners[i] != null) {
         res.add(values[i]);
       }
     }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/EventDispatcherSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/EventDispatcherSpecification.groovy
@@ -16,28 +16,6 @@ class EventDispatcherSpecification extends DDSpecification {
   EventDispatcher dispatcher = new EventDispatcher()
   AppSecRequestContext ctx = Mock()
 
-  void 'notifies about events in order'() {
-    given:
-    EventListener eventListener1 = Mock()
-    EventListener eventListener2 = Mock()
-    eventListener1.priority >> OrderedCallback.Priority.DEFAULT
-    eventListener2.priority >> OrderedCallback.Priority.HIGH
-
-    def set = new EventDispatcher.EventSubscriptionSet()
-    set.addSubscription(EventType.REQUEST_END, eventListener1)
-    set.addSubscription(EventType.REQUEST_END, eventListener2)
-    dispatcher.subscribeEvents(set)
-
-    when:
-    dispatcher.publishEvent(ctx, EventType.REQUEST_END)
-
-    then:
-    1 * eventListener2.onEvent(ctx, EventType.REQUEST_END)
-
-    then:
-    1 * eventListener1.onEvent(ctx, EventType.REQUEST_END)
-  }
-
   void 'notifies about data in order with the same flow'() {
     Flow savedFlow1, savedFlow2, savedFlow3
 
@@ -167,7 +145,7 @@ class EventDispatcherSpecification extends DDSpecification {
     EventListener eventListener = Mock()
     eventListener.priority >> OrderedCallback.Priority.DEFAULT
     def set = new EventDispatcher.EventSubscriptionSet()
-    set.addSubscription(EventType.REQUEST_END, eventListener)
+    set.setSubscription(EventType.REQUEST_END, eventListener)
 
     DataListener dataListener = Mock()
     dataListener.priority >> OrderedCallback.Priority.DEFAULT


### PR DESCRIPTION
# What Does This Do

# Motivation
We only use one listener per event, so we don't need the logic for multiple events.

# Additional Notes
