### PR TITLE
Fix race condition in AppSec GatewayBridge

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -380,8 +380,7 @@ public class GatewayBridge {
             DataBundle bundle =
                 new SingletonDataBundle<>(KnownAddresses.GRPC_SERVER_REQUEST_MESSAGE, convObj);
             try {
-              return producerService.publishDataEvent(
-                  grpcServerRequestMsgSubInfo, ctx, bundle, true);
+              return producerService.publishDataEvent(subInfo, ctx, bundle, true);
             } catch (ExpiredSubscriberInfoException e) {
               grpcServerRequestMsgSubInfo = null;
             }
@@ -519,8 +518,9 @@ public class GatewayBridge {
             .build();
 
     while (true) {
-      if (initialReqDataSubInfo == null) {
-        initialReqDataSubInfo =
+      DataSubscriberInfo subInfo = this.initialReqDataSubInfo;
+      if (subInfo == null) {
+        subInfo =
             producerService.getDataSubscribers(
                 KnownAddresses.HEADERS_NO_COOKIES,
                 KnownAddresses.REQUEST_COOKIES,
@@ -531,12 +531,13 @@ public class GatewayBridge {
                 KnownAddresses.REQUEST_CLIENT_IP,
                 KnownAddresses.REQUEST_CLIENT_PORT,
                 KnownAddresses.REQUEST_INFERRED_CLIENT_IP);
+        initialReqDataSubInfo = subInfo;
       }
 
       try {
-        return producerService.publishDataEvent(initialReqDataSubInfo, ctx, bundle, false);
+        return producerService.publishDataEvent(subInfo, ctx, bundle, false);
       } catch (ExpiredSubscriberInfoException e) {
-        initialReqDataSubInfo = null;
+        this.initialReqDataSubInfo = null;
       }
     }
   }
@@ -557,14 +558,16 @@ public class GatewayBridge {
             KnownAddresses.RESPONSE_HEADERS_NO_COOKIES, ctx.getResponseHeaders());
 
     while (true) {
-      if (respDataSubInfo == null) {
-        respDataSubInfo =
+      DataSubscriberInfo subInfo = respDataSubInfo;
+      if (subInfo == null) {
+        subInfo =
             producerService.getDataSubscribers(
                 KnownAddresses.RESPONSE_STATUS, KnownAddresses.RESPONSE_HEADERS_NO_COOKIES);
+        respDataSubInfo = subInfo;
       }
 
       try {
-        return producerService.publishDataEvent(respDataSubInfo, ctx, bundle, false);
+        return producerService.publishDataEvent(subInfo, ctx, bundle, false);
       } catch (ExpiredSubscriberInfoException e) {
         respDataSubInfo = null;
       }


### PR DESCRIPTION
# What Does This Do
Prevent a logged NullPointerException (not propagated to the app) while GatewayBridge is being updated.

# Motivation
A few cases were not included in https://github.com/DataDog/dd-trace-java/pull/5383

# Additional Notes
Example exception:

```
Callback for EventType{name='http.server.client_socket_address'} threw. [exception:java.lang.NullPointerException: Cannot invoke "com.datadog.appsec.event.EventDispatcher$DataSubscriberInfoImpl.isEventDispatcher(com.datadog.appsec.event.EventDispatcher)" because "subscribers" is null.
    at com.datadog.appsec.event.EventDispatcher.publishDataEvent(EventDispatcher.java:185)
    at com.datadog.appsec.event.ReplaceableEventProducerService.publishDataEvent(ReplaceableEventProducerService.java:33)
    at com.datadog.appsec.gateway.GatewayBridge.maybePublishRequestData(GatewayBridge.java:537)
    at com.datadog.appsec.gateway.GatewayBridge.lambda$init$8(GatewayBridge.java:319)
    at com.datadog.appsec.gateway.GatewayBridge$$Lambda$427/0x000000b0013338e0.apply(Unknown Source)
    at datadog.trace.api.gateway.InstrumentationGateway$7.apply(InstrumentationGateway.java:274)
    at datadog.trace.api.gateway.InstrumentationGateway$7.apply(InstrumentationGateway.java:269)
    at datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.callIGCallbackAddressAndPort(HttpServerDecorator.java:522)
    at datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.onRequest(HttpServerDecorator.java:282)
    at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:313)
```
