### PR TITLE
Automatically configure list of packages for Jacoco instrumentation

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -68,6 +68,7 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.ipc.SkippableTestsResponse",
   "datadog.trace.civisibility.ipc.TestFramework",
   "datadog.trace.civisibility.source.MethodLinesResolver.MethodLines",
+  "datadog.trace.civisibility.source.index.PackageTree.Node",
   "datadog.trace.civisibility.source.index.RepoIndexBuilder.RepoIndexingFileVisitor",
   "datadog.trace.civisibility.source.index.RepoIndexFetcher",
   "datadog.trace.civisibility.source.index.RepoIndexSourcePathResolver",

--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -69,6 +69,7 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.ipc.TestFramework",
   "datadog.trace.civisibility.source.MethodLinesResolver.MethodLines",
   "datadog.trace.civisibility.source.index.PackageTree.Node",
+  "datadog.trace.civisibility.source.index.RepoIndex",
   "datadog.trace.civisibility.source.index.RepoIndexBuilder.RepoIndexingFileVisitor",
   "datadog.trace.civisibility.source.index.RepoIndexFetcher",
   "datadog.trace.civisibility.source.index.RepoIndexSourcePathResolver",

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -165,7 +165,8 @@ public class CiVisibilitySystem {
       GitDataUploader gitDataUploader =
           buildGitDataUploader(config, gitInfoProvider, gitClientFactory, backendApi, repoRoot);
       ModuleExecutionSettingsFactory moduleExecutionSettingsFactory =
-          buildModuleExecutionSettingsFactory(config, backendApi, gitDataUploader, repoRoot);
+          buildModuleExecutionSettingsFactory(
+              config, backendApi, gitDataUploader, indexProvider, repoRoot);
 
       String signalServerHost = config.getCiVisibilitySignalServerHost();
       int signalServerPort = config.getCiVisibilitySignalServerPort();
@@ -273,9 +274,10 @@ public class CiVisibilitySystem {
       if (parentProcessSessionId == null || parentProcessModuleId == null) {
         GitDataUploader gitDataUploader =
             buildGitDataUploader(config, gitInfoProvider, gitClientFactory, backendApi, repoRoot);
-        ModuleExecutionSettingsFactory moduleExecutionSettingsFactory =
-            buildModuleExecutionSettingsFactory(config, backendApi, gitDataUploader, repoRoot);
         RepoIndexProvider indexProvider = new RepoIndexBuilder(repoRoot, FileSystems.getDefault());
+        ModuleExecutionSettingsFactory moduleExecutionSettingsFactory =
+            buildModuleExecutionSettingsFactory(
+                config, backendApi, gitDataUploader, indexProvider, repoRoot);
         SourcePathResolver sourcePathResolver = getSourcePathResolver(repoRoot, indexProvider);
 
         // only start Git data upload in parent process
@@ -391,6 +393,7 @@ public class CiVisibilitySystem {
       Config config,
       BackendApi backendApi,
       GitDataUploader gitDataUploader,
+      RepoIndexProvider repoIndexProvider,
       String repositoryRoot) {
     ConfigurationApi configurationApi;
     if (backendApi == null) {
@@ -403,7 +406,7 @@ public class CiVisibilitySystem {
     return new CachingModuleExecutionSettingsFactory(
         config,
         new ModuleExecutionSettingsFactoryImpl(
-            config, configurationApi, gitDataUploader, repositoryRoot));
+            config, configurationApi, gitDataUploader, repoIndexProvider, repositoryRoot));
   }
 
   private static SourcePathResolver getSourcePathResolver(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -150,7 +150,8 @@ public class CiVisibilitySystem {
       CIInfo ciInfo = ciProviderInfo.buildCIInfo();
       String repoRoot = ciInfo.getCiWorkspace();
 
-      RepoIndexProvider indexProvider = new RepoIndexBuilder(repoRoot, FileSystems.getDefault());
+      RepoIndexProvider indexProvider =
+          new RepoIndexBuilder(projectRoot.toString(), FileSystems.getDefault());
       SourcePathResolver sourcePathResolver = getSourcePathResolver(repoRoot, indexProvider);
       Codeowners codeowners = getCodeowners(repoRoot);
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemModuleImpl.java
@@ -196,7 +196,9 @@ public class DDBuildSystemModuleImpl extends DDTestModuleImpl implements DDBuild
   private File getCoverageReportFolder() {
     String coverageReportDumpDir = config.getCiVisibilityCodeCoverageReportDumpDir();
     if (coverageReportDumpDir != null) {
-      return Paths.get(coverageReportDumpDir, "session-" + sessionId, moduleName).toFile();
+      return Paths.get(coverageReportDumpDir, "session-" + sessionId, moduleName)
+          .toAbsolutePath()
+          .toFile();
     } else {
       return null;
     }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemSessionImpl.java
@@ -196,7 +196,9 @@ public class DDBuildSystemSessionImpl extends DDTestSessionImpl implements DDBui
   private File getCoverageReportFolder() {
     String coverageReportDumpDir = config.getCiVisibilityCodeCoverageReportDumpDir();
     if (coverageReportDumpDir != null) {
-      return Paths.get(coverageReportDumpDir, "session-" + span.getSpanId(), "aggregated").toFile();
+      return Paths.get(coverageReportDumpDir, "session-" + span.getSpanId(), "aggregated")
+          .toAbsolutePath()
+          .toFile();
     } else {
       return null;
     }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestFrameworkModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestFrameworkModuleImpl.java
@@ -4,7 +4,6 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.civisibility.config.ModuleExecutionSettings;
 import datadog.trace.api.civisibility.config.SkippableTest;
-import datadog.trace.api.config.CiVisibilityConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.codeowners.Codeowners;
@@ -88,10 +87,8 @@ public class DDTestFrameworkModuleImpl extends DDTestModuleImpl implements DDTes
   private Collection<SkippableTest> fetchSkippableTests() {
     ModuleExecutionSettings moduleExecutionSettings =
         moduleExecutionSettingsFactory.create(JvmInfo.CURRENT_JVM, moduleName);
-    Map<String, String> systemProperties = moduleExecutionSettings.getSystemProperties();
-    codeCoverageEnabled =
-        propertyEnabled(systemProperties, CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_ENABLED);
-    itrEnabled = propertyEnabled(systemProperties, CiVisibilityConfig.CIVISIBILITY_ITR_ENABLED);
+    codeCoverageEnabled = moduleExecutionSettings.isCodeCoverageEnabled();
+    itrEnabled = moduleExecutionSettings.isItrEnabled();
     return new HashSet<>(moduleExecutionSettings.getSkippableTests(moduleName));
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
@@ -8,12 +8,16 @@ import datadog.trace.api.config.CiVisibilityConfig;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.civisibility.git.tree.GitDataUploader;
+import datadog.trace.civisibility.source.index.RepoIndex;
+import datadog.trace.civisibility.source.index.RepoIndexProvider;
 import datadog.trace.util.Strings;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -31,16 +35,19 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
   private final Config config;
   private final ConfigurationApi configurationApi;
   private final GitDataUploader gitDataUploader;
+  private final RepoIndexProvider repoIndexProvider;
   private final String repositoryRoot;
 
   public ModuleExecutionSettingsFactoryImpl(
       Config config,
       ConfigurationApi configurationApi,
       GitDataUploader gitDataUploader,
+      RepoIndexProvider repoIndexProvider,
       String repositoryRoot) {
     this.config = config;
     this.configurationApi = configurationApi;
     this.gitDataUploader = gitDataUploader;
+    this.repoIndexProvider = repoIndexProvider;
     this.repositoryRoot = repositoryRoot;
   }
 
@@ -67,7 +74,13 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
             ? getSkippableTestsByModulePath(Paths.get(repositoryRoot), tracerEnvironment)
             : Collections.emptyMap();
 
-    return new ModuleExecutionSettings(systemProperties, skippableTestsByModulePath);
+    List<String> coverageEnabledPackages = getCoverageEnabledPackages(codeCoverageEnabled);
+    return new ModuleExecutionSettings(
+        codeCoverageEnabled,
+        itrEnabled,
+        systemProperties,
+        skippableTestsByModulePath,
+        coverageEnabledPackages);
   }
 
   private TracerEnvironment buildTracerEnvironment(
@@ -179,5 +192,47 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
       LOGGER.error("Could not obtain list of skippable tests, will proceed without skipping", e);
       return Collections.emptyMap();
     }
+  }
+
+  private List<String> getCoverageEnabledPackages(boolean codeCoverageEnabled) {
+    if (!codeCoverageEnabled) {
+      return Collections.emptyList();
+    }
+
+    List<String> includedPackages = config.getCiVisibilityJacocoPluginIncludes();
+    if (includedPackages != null && !includedPackages.isEmpty()) {
+      return includedPackages;
+    }
+
+    RepoIndex repoIndex = repoIndexProvider.getIndex();
+    List<String> packages = new ArrayList<>(repoIndex.getRootPackages());
+    List<String> excludedPackages = config.getCiVisibilityJacocoPluginExcludes();
+    if (excludedPackages != null && !excludedPackages.isEmpty()) {
+      removeMatchingPackages(packages, excludedPackages);
+    }
+    return packages;
+  }
+
+  private static void removeMatchingPackages(List<String> packages, List<String> excludedPackages) {
+    List<String> excludedPrefixes =
+        excludedPackages.stream()
+            .map(ModuleExecutionSettingsFactoryImpl::trimTrailingAsterisk)
+            .collect(Collectors.toList());
+
+    Iterator<String> packagesIterator = packages.iterator();
+    while (packagesIterator.hasNext()) {
+      String p = packagesIterator.next();
+
+      for (String excludedPrefix : excludedPrefixes) {
+        if (p.startsWith(excludedPrefix)) {
+          packagesIterator.remove();
+          break;
+        }
+      }
+    }
+  }
+
+  private static String trimTrailingAsterisk(String s) {
+    return s.endsWith("*") ? s.substring(0, s.length() - 1) : s;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageResolver.java
@@ -3,6 +3,6 @@ package datadog.trace.civisibility.source.index;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public interface SourceRootResolver {
-  Path getSourceRoot(Path sourceFile) throws IOException;
+public interface PackageResolver {
+  Path getPackage(Path sourceFile) throws IOException;
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageResolverImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageResolverImpl.java
@@ -8,34 +8,28 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
-class SourceRootResolverImpl implements SourceRootResolver {
+class PackageResolverImpl implements PackageResolver {
 
   private static final String PACKAGE_KEYWORD = "package";
   private final FileSystem fileSystem;
 
-  SourceRootResolverImpl(FileSystem fileSystem) {
+  PackageResolverImpl(FileSystem fileSystem) {
     this.fileSystem = fileSystem;
   }
 
   /**
-   * Given a path to a Java source file, returns its source root (i.e. path without the filename and
-   * package folders).
-   *
-   * <p>For example, a class <code>foo.bar.MyClass</code> located at <code>
-   * /repo/src/foo/bar/MyClass.java</code> will have the source root <code>/repo/src</code>
+   * Given a path to a source file, returns its package path.
    *
    * <p>The implementation of this method is rather naive: it does not actually parse the file, nor
    * does it build an AST.
    *
-   * <p>It simply looks for a line, that contains the <code>package</code> keyword, extracts the
+   * <p>It simply looks for a line, that contains the <code>package</code> keyword and extracts the
    * part that goes after it and until the nearest <code>;</code> character, then verifies that the
-   * extracted part looks plausible by checking the actual file path (package path is the suffix
-   * that is stripped from the full path in order to get the source root).
+   * extracted part looks plausible by checking the actual file path.
    */
   @Override
-  public Path getSourceRoot(Path sourceFile) throws IOException {
+  public Path getPackage(Path sourceFile) throws IOException {
     Path folder = sourceFile.getParent();
-
     try (BufferedReader br = Files.newBufferedReader(sourceFile)) {
       String line;
       while ((line = br.readLine()) != null) {
@@ -53,7 +47,7 @@ class SourceRootResolverImpl implements SourceRootResolver {
 
         int packageNameEnd = line.indexOf(';', packageNameStart);
         if (packageNameEnd == -1) {
-          packageNameEnd = lineLength; // no ';' is possible if this is a groovy file
+          packageNameEnd = lineLength; // no ';' is possible if this is a Groovy file
         }
 
         String packageName = line.substring(packageNameStart, packageNameEnd);
@@ -64,18 +58,13 @@ class SourceRootResolverImpl implements SourceRootResolver {
           continue;
         }
 
-        if (!folder.endsWith(packagePath)) {
-          continue;
+        if (folder.endsWith(packagePath)) {
+          return packagePath;
         }
-
-        // remove package path suffix from folder path to get source root
-        return folder
-            .getRoot()
-            .resolve(folder.subpath(0, folder.getNameCount() - packagePath.getNameCount()));
       }
     }
 
     // apparently there is no package declaration - class is located in the default package
-    return folder;
+    return fileSystem.getPath("");
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageTree.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageTree.java
@@ -1,0 +1,148 @@
+package datadog.trace.civisibility.source.index;
+
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class maintains the list of packages present in a repository.
+ *
+ * <p>If a package includes classes, all of its children packages are ignored (that is, if there are
+ * packages a/b, a/b/c, a/b/d, all of which contain classes, only a/b will be retained - a/b/c and
+ * a/b/d will be discarded as redundant).
+ *
+ * <p>The length of the list is limited by {@link #MAX_CHILDREN_LEAVES}. If there are more packages
+ * present than the limit, coarsening will happen (for instance, if there are packages a/b/c, a/b/d,
+ * b/c/d, b/c/e/f and the limit is 2, the packages will be coarsened and a/b, b/c will be retained
+ * as the result).
+ *
+ * <p>The intent is to be as specific as possible without exceeding the limit, so coarsening applies
+ * first to the "longest" package names (not in terms of the actual string length, but in terms of
+ * the number of segments separated by "."). If there are multiple packages with the same length,
+ * those that have more children will be coarsened first.
+ */
+public class PackageTree {
+
+  private static final int MAX_CHILDREN_LEAVES = 25;
+
+  private final Node root = new Node(null, "");
+
+  void add(Path packagePath) {
+    if (packagePath.toString().isEmpty()) {
+      return;
+    }
+    root.add(packagePath.iterator());
+  }
+
+  List<String> asList() {
+    truncateIfNeeded(root);
+
+    List<String> childrenPackages = new ArrayList<>(MAX_CHILDREN_LEAVES);
+    for (Node child : root.children.values()) {
+      child.stringify(childrenPackages, "");
+    }
+    return childrenPackages;
+  }
+
+  private static void truncateIfNeeded(Node root) {
+    Deque<List<Node>> nodesByDepth = new ArrayDeque<>();
+
+    List<Node> current = Collections.singletonList(root);
+    while (!current.isEmpty()) {
+      List<Node> next = new ArrayList<>();
+      for (Node treeNode : current) {
+        next.addAll(treeNode.children.values());
+      }
+      nodesByDepth.push(current);
+      current = next;
+    }
+
+    // start truncating with the deepest nodes
+    // (i.e. most specific packages names)
+    while (!nodesByDepth.isEmpty()) {
+      List<Node> nodes = nodesByDepth.pop();
+      // sorting the nodes now as leafChildren counts might have changed
+      // if their children were truncated
+      nodes.sort(Comparator.comparingInt(node -> -node.leafChildren));
+
+      for (Node node : nodes) {
+        if (root.leafChildren <= MAX_CHILDREN_LEAVES) {
+          // stop as soon as we have truncated enough, even if it's mid-level
+          return;
+        } else {
+          node.truncate();
+        }
+      }
+    }
+  }
+
+  private static final class Node {
+    private final Node parent;
+    private final String name;
+    private Map<String, Node> children = new HashMap<>();
+    private int leafChildren;
+    private boolean leaf;
+
+    private Node(Node parent, String name) {
+      this.parent = parent;
+      this.name = name;
+    }
+
+    private int add(Iterator<Path> iterator) {
+      if (leaf) {
+        return 0;
+
+      } else if (!iterator.hasNext()) {
+        leaf = true;
+        if (leafChildren == 0) {
+          return ++leafChildren;
+        } else {
+          // what used to be a non-leaf is now a leaf,
+          // truncating children
+          int delta = 1 - leafChildren;
+          children = Collections.emptyMap();
+          leafChildren = 1;
+          return delta;
+        }
+
+      } else {
+        Path element = iterator.next();
+        Node child =
+            children.computeIfAbsent(element.toString(), nodeName -> new Node(this, nodeName));
+        int delta = child.add(iterator);
+        leafChildren += delta;
+        return delta;
+      }
+    }
+
+    private void truncate() {
+      children = Collections.emptyMap();
+      leaf = true;
+
+      int delta = leafChildren - 1;
+      Node current = this;
+      while (current != null) {
+        current.leafChildren -= delta;
+        current = current.parent;
+      }
+    }
+
+    private void stringify(List<String> childrenPackages, String currentPath) {
+      currentPath += name + ".";
+      if (leaf) {
+        childrenPackages.add(currentPath + "*");
+      } else {
+        for (Node child : children.values()) {
+          child.stringify(childrenPackages, currentPath);
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndex.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndex.java
@@ -27,7 +27,8 @@ import org.slf4j.LoggerFactory;
 public class RepoIndex {
 
   static final RepoIndex EMPTY =
-      new RepoIndex(ClassNameTrie.Builder.EMPTY_TRIE, Collections.emptyList());
+      new RepoIndex(
+          ClassNameTrie.Builder.EMPTY_TRIE, Collections.emptyList(), Collections.emptyList());
 
   private static final Logger log = LoggerFactory.getLogger(RepoIndex.class);
   private static final int ACCESS_MODIFIERS =
@@ -35,10 +36,16 @@ public class RepoIndex {
 
   private final ClassNameTrie trie;
   private final List<String> sourceRoots;
+  private final List<String> rootPackages;
 
-  RepoIndex(ClassNameTrie trie, List<String> sourceRoots) {
+  RepoIndex(ClassNameTrie trie, List<String> sourceRoots, List<String> rootPackages) {
     this.trie = trie;
     this.sourceRoots = sourceRoots;
+    this.rootPackages = rootPackages;
+  }
+
+  public List<String> getRootPackages() {
+    return rootPackages;
   }
 
   @Nullable
@@ -182,15 +189,26 @@ public class RepoIndex {
     byte[] serializedTrie = byteArrayOutputStream.toByteArray();
     totalLength = Integer.BYTES + serializedTrie.length;
 
-    int idx = 0;
+    int sourceRootIdx = 0;
     byte[][] sourceRootBytes = new byte[sourceRoots.size()][];
     for (String sourceRoot : sourceRoots) {
-      sourceRootBytes[idx++] = sourceRoot.getBytes(StandardCharsets.UTF_8);
+      sourceRootBytes[sourceRootIdx++] = sourceRoot.getBytes(StandardCharsets.UTF_8);
     }
 
     totalLength += Integer.BYTES;
     for (byte[] sourceRoot : sourceRootBytes) {
       totalLength += Integer.BYTES + sourceRoot.length;
+    }
+
+    int rootPackageIds = 0;
+    byte[][] rootPackageBytes = new byte[rootPackages.size()][];
+    for (String rootPackage : rootPackages) {
+      rootPackageBytes[rootPackageIds++] = rootPackage.getBytes(StandardCharsets.UTF_8);
+    }
+
+    totalLength += Integer.BYTES;
+    for (byte[] rootPackage : rootPackageBytes) {
+      totalLength += Integer.BYTES + rootPackage.length;
     }
 
     ByteBuffer buffer = ByteBuffer.allocate(totalLength);
@@ -201,6 +219,12 @@ public class RepoIndex {
     for (byte[] sourceRoot : sourceRootBytes) {
       buffer.putInt(sourceRoot.length);
       buffer.put(sourceRoot);
+    }
+
+    buffer.putInt(rootPackageBytes.length);
+    for (byte[] rootPackage : rootPackageBytes) {
+      buffer.putInt(rootPackage.length);
+      buffer.put(rootPackage);
     }
 
     buffer.flip();
@@ -229,6 +253,16 @@ public class RepoIndex {
       buffer.get(sourceRootBytes);
       sourceRoots.add(new String(sourceRootBytes, StandardCharsets.UTF_8));
     }
-    return new RepoIndex(trie, sourceRoots);
+
+    int rootPackagesCount = buffer.getInt();
+    List<String> rootPackages = new ArrayList<>(rootPackagesCount);
+    while (rootPackagesCount-- > 0) {
+      int rootPackageLength = buffer.getInt();
+      byte[] rootPackageBytes = new byte[rootPackageLength];
+      buffer.get(rootPackageBytes);
+      rootPackages.add(new String(rootPackageBytes, StandardCharsets.UTF_8));
+    }
+
+    return new RepoIndex(trie, sourceRoots, rootPackages);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -75,14 +75,15 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
     long duration = System.currentTimeMillis() - startTime;
     RepoIndexingStats stats = repoIndexingFileVisitor.indexingStats;
+    RepoIndex index = repoIndexingFileVisitor.getIndex();
     log.info(
-        "Indexing took {} ms. Files visited: {}, source files visited: {}, source roots found: {}",
+        "Indexing took {} ms. Files visited: {}, source files visited: {}, source roots found: {}, root packages found: {}",
         duration,
         stats.filesVisited,
         stats.sourceFilesVisited,
-        repoIndexingFileVisitor.sourceRoots.size());
-
-    return repoIndexingFileVisitor.getIndex();
+        repoIndexingFileVisitor.sourceRoots.size(),
+        index.getRootPackages());
+    return index;
   }
 
   private static final class RepoIndexingFileVisitor implements FileVisitor<Path> {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -21,7 +21,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
   private static final Logger log = LoggerFactory.getLogger(RepoIndexBuilder.class);
 
   private final String repoRoot;
-  private final SourceRootResolver sourceRootResolver;
+  private final PackageResolver packageResolver;
   private final FileSystem fileSystem;
 
   private final Object indexInitializationLock = new Object();
@@ -29,13 +29,13 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
   public RepoIndexBuilder(String repoRoot, FileSystem fileSystem) {
     this.repoRoot = repoRoot;
-    this.sourceRootResolver = new SourceRootResolverImpl(fileSystem);
+    this.packageResolver = new PackageResolverImpl(fileSystem);
     this.fileSystem = fileSystem;
   }
 
-  RepoIndexBuilder(String repoRoot, SourceRootResolver sourceRootResolver, FileSystem fileSystem) {
+  RepoIndexBuilder(String repoRoot, PackageResolver packageResolver, FileSystem fileSystem) {
     this.repoRoot = repoRoot;
-    this.sourceRootResolver = sourceRootResolver;
+    this.packageResolver = packageResolver;
     this.fileSystem = fileSystem;
   }
 
@@ -60,7 +60,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
     Path repoRootPath = fileSystem.getPath(repoRoot);
     RepoIndexingFileVisitor repoIndexingFileVisitor =
-        new RepoIndexingFileVisitor(sourceRootResolver, repoRootPath);
+        new RepoIndexingFileVisitor(packageResolver, repoRootPath);
 
     long startTime = System.currentTimeMillis();
     try {
@@ -80,7 +80,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
         duration,
         stats.filesVisited,
         stats.sourceFilesVisited,
-        stats.sourceRoots);
+        repoIndexingFileVisitor.sourceRoots.size());
 
     return repoIndexingFileVisitor.getIndex();
   }
@@ -89,17 +89,19 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
     private static final Logger log = LoggerFactory.getLogger(RepoIndexingFileVisitor.class);
 
-    private final SourceRootResolver sourceRootResolver;
+    private final PackageResolver packageResolver;
     private final ClassNameTrie.Builder trieBuilder;
     private final LinkedHashSet<String> sourceRoots;
+    private final PackageTree packageTree;
     private final RepoIndexingStats indexingStats;
     private final Path repoRoot;
 
-    private RepoIndexingFileVisitor(SourceRootResolver sourceRootResolver, Path repoRoot) {
-      this.sourceRootResolver = sourceRootResolver;
+    private RepoIndexingFileVisitor(PackageResolver packageResolver, Path repoRoot) {
+      this.packageResolver = packageResolver;
       this.repoRoot = repoRoot;
       trieBuilder = new ClassNameTrie.Builder();
       sourceRoots = new LinkedHashSet<>();
+      packageTree = new PackageTree();
       indexingStats = new RepoIndexingStats();
     }
 
@@ -118,9 +120,11 @@ public class RepoIndexBuilder implements RepoIndexProvider {
         if (sourceType != null) {
           indexingStats.sourceFilesVisited++;
 
-          Path currentSourceRoot = sourceRootResolver.getSourceRoot(file);
+          Path packagePath = packageResolver.getPackage(file);
+          packageTree.add(packagePath);
+
+          Path currentSourceRoot = getSourceRoot(file, packagePath);
           sourceRoots.add(repoRoot.relativize(currentSourceRoot).toString());
-          indexingStats.sourceRoots++;
 
           Path relativePath = currentSourceRoot.relativize(file);
           String classNameWithExtension = relativePath.toString().replace(File.separatorChar, '.');
@@ -132,6 +136,14 @@ public class RepoIndexBuilder implements RepoIndexProvider {
         log.error("Failed to index file {}", file, e);
       }
       return FileVisitResult.CONTINUE;
+    }
+
+    private Path getSourceRoot(Path file, Path packagePath) {
+      Path folder = file.getParent();
+      // remove package path suffix from folder path to get source root
+      return folder
+          .getRoot()
+          .resolve(folder.subpath(0, folder.getNameCount() - packagePath.getNameCount()));
     }
 
     @Override
@@ -151,13 +163,13 @@ public class RepoIndexBuilder implements RepoIndexProvider {
     }
 
     public RepoIndex getIndex() {
-      return new RepoIndex(trieBuilder.buildTrie(), new ArrayList<>(sourceRoots));
+      return new RepoIndex(
+          trieBuilder.buildTrie(), new ArrayList<>(sourceRoots), packageTree.asList());
     }
   }
 
   private static final class RepoIndexingStats {
     int filesVisited;
     int sourceFilesVisited;
-    int sourceRoots;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolver.java
@@ -20,9 +20,9 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
   }
 
   RepoIndexSourcePathResolver(
-      String repoRoot, SourceRootResolver sourceRootResolver, FileSystem fileSystem) {
+      String repoRoot, PackageResolver packageResolver, FileSystem fileSystem) {
     this.repoRoot = repoRoot;
-    this.indexProvider = new RepoIndexBuilder(repoRoot, sourceRootResolver, fileSystem);
+    this.indexProvider = new RepoIndexBuilder(repoRoot, packageResolver, fileSystem);
   }
 
   @Nullable

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/PackageResolverImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/PackageResolverImplTest.groovy
@@ -6,9 +6,9 @@ import spock.lang.Specification
 
 import java.nio.file.Files
 
-class SourceRootResolverImplTest extends Specification {
+class PackageResolverImplTest extends Specification {
 
-  def "test source root resolution"() {
+  def "test source root resolution: #path"() {
     setup:
     def fileSystem = Jimfs.newFileSystem(Configuration.unix())
     def javaFilePath = fileSystem.getPath(path)
@@ -17,22 +17,22 @@ class SourceRootResolverImplTest extends Specification {
     Files.write(javaFilePath, contents.getBytes())
 
     when:
-    def sourceRootResolver = new SourceRootResolverImpl(fileSystem)
-    def sourceRoot = sourceRootResolver.getSourceRoot(javaFilePath)
+    def packageResolver = new PackageResolverImpl(fileSystem)
+    def packagePath = packageResolver.getPackage(javaFilePath)
 
     then:
-    sourceRoot == fileSystem.getPath(expectedSourceRoot)
+    packagePath == fileSystem.getPath(expectedPackageName)
 
     where:
-    path                             | contents                                      | expectedSourceRoot
-    "/root/src/MyClass.java"         | CLASS_IN_DEFAULT_PACKAGE                      | "/root/src"
-    "/root/src/foo/bar/MyClass.java" | CLASS_IN_FOO_BAR_PACKAGE                      | "/root/src"
-    "/root/src/foo/bar/MyClass.java" | BLANK_LINES_BEFORE_PACKAGE                    | "/root/src"
-    "/root/src/foo/bar/MyClass.java" | SPACES_BEFORE_PACKAGE                         | "/root/src"
-    "/root/src/foo/bar/MyClass.java" | COMMENT_BEFORE_PACKAGE                        | "/root/src"
-    "/root/src/foo/bar/MyClass.java" | COMMENT_WITH_KEYWORD_BEFORE_PACKAGE           | "/root/src"
-    "/root/src/foo/bar/MyClass.java" | MULTILINE_COMMENT_BEFORE_PACKAGE              | "/root/src"
-    "/root/src/foo/bar/MyClass.java" | MULTILINE_COMMENT_WITH_KEYWORD_BEFORE_PACKAGE | "/root/src"
+    path                             | contents                                      | expectedPackageName
+    "/root/src/MyClass.java"         | CLASS_IN_DEFAULT_PACKAGE                      | ""
+    "/root/src/foo/bar/MyClass.java" | CLASS_IN_FOO_BAR_PACKAGE                      | "foo/bar"
+    "/root/src/foo/bar/MyClass.java" | BLANK_LINES_BEFORE_PACKAGE                    | "foo/bar"
+    "/root/src/foo/bar/MyClass.java" | SPACES_BEFORE_PACKAGE                         | "foo/bar"
+    "/root/src/foo/bar/MyClass.java" | COMMENT_BEFORE_PACKAGE                        | "foo/bar"
+    "/root/src/foo/bar/MyClass.java" | COMMENT_WITH_KEYWORD_BEFORE_PACKAGE           | "foo/bar"
+    "/root/src/foo/bar/MyClass.java" | MULTILINE_COMMENT_BEFORE_PACKAGE              | "foo/bar"
+    "/root/src/foo/bar/MyClass.java" | MULTILINE_COMMENT_WITH_KEYWORD_BEFORE_PACKAGE | "foo/bar"
   }
 
   private static final String CLASS_IN_DEFAULT_PACKAGE =

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/RepoIndexTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/RepoIndexTest.groovy
@@ -12,7 +12,7 @@ class RepoIndexTest extends Specification {
     trieBuilder.put(RepoIndexSourcePathResolverTest.name + SourceType.GROOVY.extension, 1)
 
     def sourceRoots = Arrays.asList("myClassSourceRoot", "myOtherClassSourceRoot")
-    def repoIndex = new RepoIndex(trieBuilder.buildTrie(), sourceRoots)
+    def repoIndex = new RepoIndex(trieBuilder.buildTrie(), sourceRoots, Collections.emptyList())
 
     when:
     def serialized = repoIndex.serialize()

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
@@ -64,10 +64,12 @@ abstract class CiVisibilityTest extends AgentTestRunner {
 
     def moduleExecutionSettingsFactory = Stub(ModuleExecutionSettingsFactory)
     moduleExecutionSettingsFactory.create(_, _) >> {
+      def codeCoverageEnabled = false
+      def itrEnabled = !skippableTests.isEmpty()
       Map<String, String> properties = [
-        (CiVisibilityConfig.CIVISIBILITY_ITR_ENABLED) : String.valueOf(!skippableTests.isEmpty())
+        (CiVisibilityConfig.CIVISIBILITY_ITR_ENABLED) : String.valueOf(itrEnabled)
       ]
-      return new ModuleExecutionSettings(properties, Collections.singletonMap(dummyModule, skippableTests))
+      return new ModuleExecutionSettings(codeCoverageEnabled, itrEnabled, properties, Collections.singletonMap(dummyModule, skippableTests), Collections.emptyList())
     }
 
     def coverageProbeStoreFactory = new NoopCoverageProbeStore.NoopCoverageProbeStoreFactory()

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListener.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildListener.java
@@ -106,6 +106,8 @@ public class GradleBuildListener extends BuildAdapter {
     for (Task testExecution : testExecutions) {
       GradleProjectConfigurator.INSTANCE.configureTracer(
           testExecution, moduleExecutionSettings.getSystemProperties());
+      GradleProjectConfigurator.INSTANCE.configureJacoco(
+          testExecution.getProject(), moduleExecutionSettings);
     }
   }
 

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenInstrumentation.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenInstrumentation.java
@@ -35,6 +35,7 @@ public class MavenInstrumentation extends Instrumenter.CiVisibility
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      packageName + ".MavenTestExecution",
       packageName + ".MavenUtils",
       packageName + ".MavenExecutionListener",
       packageName + ".MavenProjectConfigurator",

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenTestExecution.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenTestExecution.java
@@ -1,0 +1,36 @@
+package datadog.trace.instrumentation.maven3;
+
+import java.nio.file.Path;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+
+public final class MavenTestExecution {
+  private final MavenProject project;
+  private final MojoExecution execution;
+  private final Path forkedJvmPath;
+  private final boolean runsWithJacoco;
+
+  public MavenTestExecution(
+      MavenProject project, MojoExecution execution, Path forkedJvmPath, boolean runsWithJacoco) {
+    this.project = project;
+    this.execution = execution;
+    this.forkedJvmPath = forkedJvmPath;
+    this.runsWithJacoco = runsWithJacoco;
+  }
+
+  public MavenProject getProject() {
+    return project;
+  }
+
+  public MojoExecution getExecution() {
+    return execution;
+  }
+
+  public Path getForkedJvmPath() {
+    return forkedJvmPath;
+  }
+
+  public boolean isRunsWithJacoco() {
+    return runsWithJacoco;
+  }
+}

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
@@ -227,6 +227,16 @@ public abstract class MavenUtils {
             && ("test".equals(goal) || "plugin-test".equals(goal) || "bnd-test".equals(goal));
   }
 
+  public static boolean isJacocoInstrumentationExecution(MojoExecution mojoExecution) {
+    Plugin plugin = mojoExecution.getPlugin();
+    String artifactId = plugin.getArtifactId();
+    String groupId = plugin.getGroupId();
+    String goal = mojoExecution.getGoal();
+    return "jacoco-maven-plugin".equals(artifactId)
+        && "org.jacoco".equals(groupId)
+        && "prepare-agent".equals(goal);
+  }
+
   public static String getConfigurationValue(Xpp3Dom configuration, String... path) {
     if (configuration == null) {
       return null;

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -1016,12 +1016,9 @@ class GradleDaemonSmokeTest extends Specification {
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.APPLICATION_KEY_FILE)}=${ddApplicationKeyPath.toAbsolutePath().toString()}," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_ENABLED)}=true," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED)}=true," +
-      "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_ENABLED)}=true," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_GIT_UPLOAD_ENABLED)}=false," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED)}=false," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_COVERAGE_SEGMENTS_ENABLED)}=true," +
-      "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_JACOCO_PLUGIN_VERSION)}=0.8.10," +
-      "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_JACOCO_PLUGIN_INCLUDES)}=datadog.smoke.*," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL)}=${intakeServer.address.toString()}"
 
     Files.write(testKitFolder.resolve("gradle.properties"), gradleProperties.getBytes())

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -2,6 +2,7 @@ package datadog.smoketest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.trace.agent.test.server.http.TestHttpServer
+import datadog.trace.api.Config
 import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.test.util.MultipartRequestParser
@@ -32,8 +33,8 @@ class MavenSmokeTest extends Specification {
 
   private static final String TEST_SERVICE_NAME = "test-maven-service"
   private static final String TEST_ENVIRONMENT_NAME = "integration-test"
-  private static final String JAVAC_PLUGIN_VERSION = "0.1.6"
-  private static final String JACOCO_PLUGIN_VERSION = "0.8.10"
+  private static final String JAVAC_PLUGIN_VERSION = Config.get().ciVisibilityCompilerPluginVersion
+  private static final String JACOCO_PLUGIN_VERSION = Config.get().ciVisibilityJacocoPluginVersion
 
   private static final int PROCESS_TIMEOUT_SECS = 60
 
@@ -410,8 +411,6 @@ class MavenSmokeTest extends Specification {
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_GIT_UPLOAD_ENABLED)}=false," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_COVERAGE_SEGMENTS_ENABLED)}=true," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_COMPILER_PLUGIN_VERSION)}=${JAVAC_PLUGIN_VERSION}," +
-        "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_JACOCO_PLUGIN_VERSION)}=${JACOCO_PLUGIN_VERSION}," +
-        "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_JACOCO_PLUGIN_INCLUDES)}=datadog.smoke.*," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL)}=${intakeServer.address.toString()}"
       arguments += agentArgument.toString()
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -114,6 +114,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_CIVISIBILITY_AUTO_CONFIGURATION_ENABLED = true;
   static final boolean DEFAULT_CIVISIBILITY_COMPILER_PLUGIN_AUTO_CONFIGURATION_ENABLED = true;
   static final String DEFAULT_CIVISIBILITY_COMPILER_PLUGIN_VERSION = "0.1.7";
+  static final String DEFAULT_CIVISIBILITY_JACOCO_PLUGIN_VERSION = "0.8.10";
   static final String DEFAULT_CIVISIBILITY_JACOCO_PLUGIN_EXCLUDES =
       "datadog.trace.*:org.apache.commons.*:org.mockito.*";
   static final boolean DEFAULT_CIVISIBILITY_GIT_UPLOAD_ENABLED = true;

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -20,6 +20,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_GIT_UNSHALLO
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_GIT_UPLOAD_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_GIT_UPLOAD_TIMEOUT_MILLIS;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_JACOCO_PLUGIN_EXCLUDES;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_JACOCO_PLUGIN_VERSION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_SIGNAL_SERVER_HOST;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_SIGNAL_SERVER_PORT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_CIVISIBILITY_SOURCE_DATA_ENABLED;
@@ -1522,7 +1523,9 @@ public class Config {
     ciVisibilityCompilerPluginVersion =
         configProvider.getString(
             CIVISIBILITY_COMPILER_PLUGIN_VERSION, DEFAULT_CIVISIBILITY_COMPILER_PLUGIN_VERSION);
-    ciVisibilityJacocoPluginVersion = configProvider.getString(CIVISIBILITY_JACOCO_PLUGIN_VERSION);
+    ciVisibilityJacocoPluginVersion =
+        configProvider.getString(
+            CIVISIBILITY_JACOCO_PLUGIN_VERSION, DEFAULT_CIVISIBILITY_JACOCO_PLUGIN_VERSION);
     ciVisibilityJacocoPluginIncludes =
         Arrays.asList(
             COLON.split(configProvider.getString(CIVISIBILITY_JACOCO_PLUGIN_INCLUDES, ":")));

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/config/ModuleExecutionSettings.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/config/ModuleExecutionSettings.java
@@ -7,14 +7,31 @@ import java.util.Map;
 
 public class ModuleExecutionSettings {
 
+  private final boolean codeCoverageEnabled;
+  private final boolean itrEnabled;
   private final Map<String, String> systemProperties;
   private final Map<String, List<SkippableTest>> skippableTestsByModule;
+  private final List<String> coverageEnabledPackages;
 
   public ModuleExecutionSettings(
+      boolean codeCoverageEnabled,
+      boolean itrEnabled,
       Map<String, String> systemProperties,
-      Map<String, List<SkippableTest>> skippableTestsByModule) {
+      Map<String, List<SkippableTest>> skippableTestsByModule,
+      List<String> coverageEnabledPackages) {
+    this.codeCoverageEnabled = codeCoverageEnabled;
+    this.itrEnabled = itrEnabled;
     this.systemProperties = systemProperties;
     this.skippableTestsByModule = skippableTestsByModule;
+    this.coverageEnabledPackages = coverageEnabledPackages;
+  }
+
+  public boolean isCodeCoverageEnabled() {
+    return codeCoverageEnabled;
+  }
+
+  public boolean isItrEnabled() {
+    return itrEnabled;
   }
 
   public Map<String, String> getSystemProperties() {
@@ -23,5 +40,9 @@ public class ModuleExecutionSettings {
 
   public Collection<SkippableTest> getSkippableTests(String relativeModulePath) {
     return skippableTestsByModule.getOrDefault(relativeModulePath, Collections.emptyList());
+  }
+
+  public List<String> getCoverageEnabledPackages() {
+    return coverageEnabledPackages;
   }
 }


### PR DESCRIPTION
# What Does This Do
Automatically computes the list of packages that should be instrumented with Jacoco when automatic Jacoco plugin injection is used (whenever build system instrumentation detects that code coverage is enabled).

# Motivation
Previously the customers were required to configure the list of packages by hand (which might not be trivial, depending on the project) or allow Jacoco to instrument all the packages (which can lead to significant performance overhead).

# Additional Notes
The data about which packages to instrument is retrieved from repository index.