### PR TITLE
Fix NullPointerException when calculating ITR skippable tests in TestNG

### DIFF
--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
@@ -154,7 +154,8 @@ public abstract class TestNGUtils {
   }
 
   public static SkippableTest toSkippableTest(Method method, Object instance, Object[] parameters) {
-    String testSuiteName = instance.getClass().getName();
+    Class<?> testClass = instance != null ? instance.getClass() : method.getDeclaringClass();
+    String testSuiteName = testClass.getName();
     String testName = method.getName();
     String testParameters = TestNGUtils.getParameters(parameters);
     return new SkippableTest(testSuiteName, testName, testParameters, null);

--- a/dd-java-agent/instrumentation/testng/src/testFixtures/java/org/example/TestSucceedDataProvider.java
+++ b/dd-java-agent/instrumentation/testng/src/testFixtures/java/org/example/TestSucceedDataProvider.java
@@ -1,0 +1,27 @@
+package org.example;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class TestSucceedDataProvider {
+
+  private final int param;
+
+  @Factory(dataProvider = "dataMethod")
+  public TestSucceedDataProvider(int param) {
+    this.param = param;
+  }
+
+  @DataProvider
+  public static Object[][] dataMethod() {
+    return new Object[][] {{0}};
+  }
+
+  @Test
+  public void testMethod() {
+    assertEquals(param, 0);
+  }
+}


### PR DESCRIPTION
# What Does This Do
Fixes `NullPointerException` that occurs when checking if a TestNG `@Factory` test with `@DataProvider` is skippable.

# Motivation
There is a Github [issue](https://github.com/DataDog/dd-trace-java/issues/5268) reported by a CI Visibility user.

# Additional Notes
In legacy instrumentation mode (when only JVMs running the tests are instrumented, and the build system is not), ITR instrumentations are applied even if ITR is not enabled (since it is impossible to make a request for remote config before applying instrumentations - when the latter is done, CI Visibility is not initialised yet).
So even though ITR will not skip tests when it is disabled, some ITR-related code will still execute.
Therefore this issue may impact even customers that do not use ITR.