### PR TITLE
Skip collection of config during native-image build…

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3491,7 +3491,11 @@ public class Config {
   // This has to be placed after all other static fields to give them a chance to initialize
   @SuppressFBWarnings("SI_INSTANCE_BEFORE_FINALS_ASSIGNED")
   private static final Config INSTANCE =
-      new Config(ConfigProvider.getInstance(), InstrumenterConfig.get());
+      new Config(
+          Platform.isNativeImageBuilder()
+              ? ConfigProvider.withoutCollector()
+              : ConfigProvider.getInstance(),
+          InstrumenterConfig.get());
 
   public static Config get() {
     return INSTANCE;


### PR DESCRIPTION
… since telemetry is off

We already do this for `InstrumenterConfig.SINGLETON` which is used directly during instrumentation.

While we avoid touching `Config` during the build, we mark it as "rerun" in  our patched `native-image` config. The `native-image` generator will analyze it indirectly to check what's needed to "rerun" class initialization, so we should therefore have the same check to turn off collection in `Config.SINGLETON`.
