### PR TITLE
Avoid ServiceLoader in AppSec

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -21,9 +21,6 @@ dependencies {
   implementation group: 'io.sqreen', name: 'libsqreen', version: '7.1.0'
   implementation group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
 
-  annotationProcessor deps.autoserviceProcessor
-  compileOnly deps.autoserviceAnnotation
-
   testImplementation deps.bytebuddy
   testImplementation project(':utils:test-utils')
   testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -7,6 +7,7 @@ import com.datadog.appsec.event.EventDispatcher;
 import com.datadog.appsec.event.ReplaceableEventProducerService;
 import com.datadog.appsec.gateway.GatewayBridge;
 import com.datadog.appsec.gateway.RateLimiter;
+import com.datadog.appsec.powerwaf.PowerWAFModule;
 import com.datadog.appsec.util.AbortStartupException;
 import com.datadog.appsec.util.StandardizedLogging;
 import datadog.appsec.api.blocking.Blocking;
@@ -23,8 +24,8 @@ import datadog.trace.bootstrap.ActiveSubsystems;
 import datadog.trace.util.Strings;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -141,8 +142,7 @@ public class AppSecSystem {
     EventDispatcher.DataSubscriptionSet dataSubscriptionSet =
         new EventDispatcher.DataSubscriptionSet();
 
-    ServiceLoader<AppSecModule> modules =
-        ServiceLoader.load(AppSecModule.class, AppSecSystem.class.getClassLoader());
+    final List<AppSecModule> modules = Collections.singletonList(new PowerWAFModule());
     for (AppSecModule module : modules) {
       log.debug("Starting appsec module {}", module.getName());
       try {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -20,7 +20,6 @@ import com.datadog.appsec.report.raw.events.Rule;
 import com.datadog.appsec.report.raw.events.RuleMatch;
 import com.datadog.appsec.report.raw.events.Tags;
 import com.datadog.appsec.util.StandardizedLogging;
-import com.google.auto.service.AutoService;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
@@ -65,7 +64,6 @@ import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@AutoService(AppSecModule.class)
 public class PowerWAFModule implements AppSecModule {
   private static final Logger log = LoggerFactory.getLogger(PowerWAFModule.class);
 


### PR DESCRIPTION


# What Does This Do

# Motivation
There is a single implementation of AppSec module, and we do not expect more.

# Additional Notes
