### PR TITLE
Replace okio dependency…

### DIFF
--- a/communication/build.gradle
+++ b/communication/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation project(':utils:socket-utils')
   implementation project(':utils:version-utils')
 
+  api deps.okio
   api deps.okhttp
   api group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
   implementation group: 'com.datadoghq', name: 'java-dogstatsd-client', version: "${versions.dogstatsd}"

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -174,6 +174,12 @@ tasks.withType(GenerateMavenPom).configureEach { task ->
 }
 
 dependencies {
+  modules {
+    module("com.squareup.okio:okio") {
+      replacedBy("com.datadoghq.okio:okio") // embed our patched fork
+    }
+  }
+
   testImplementation(project(':dd-java-agent:agent-bootstrap')) {
     exclude group: 'com.datadoghq', module: 'agent-logging'
   }

--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -29,6 +29,12 @@ dependencies {
   annotationProcessor deps.autoserviceProcessor
   compileOnly deps.autoserviceAnnotation
 
+  modules {
+    module("com.squareup.okio:okio") {
+      replacedBy("com.datadoghq.okio:okio") // embed our patched fork
+    }
+  }
+
   api project(':dd-trace-api')
   implementation (project(':dd-trace-core')) {
     // why all communication pulls in remote config is beyond me...

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ final class CachedData {
     guava         : "[16.0,20.0]", // Last version to support Java 7
     okhttp        : "3.12.15", // Datadog fork to support Java 7
     okhttp_legacy : "[3.0,3.12.12]", // 3.12.x is last version to support Java7)
-    okio          : "1.16.0",
+    okio          : "1.17.6", // Datadog fork
 
     spock         : "2.1-groovy-$spockGroovyVer",
     groovy        : groovyVer,
@@ -46,7 +46,7 @@ final class CachedData {
     jctools              : "org.jctools:jctools-core:${versions.jctools}",
     okhttp               : "com.datadoghq.okhttp3:okhttp:${versions.okhttp}",
     okhttp_legacy        : "com.squareup.okhttp3:okhttp:${versions.okhttp_legacy}",
-    okio                 : "com.squareup.okio:okio:${versions.okio}",
+    okio                 : "com.datadoghq.okio:okio:${versions.okio}",
     bytebuddy            : "net.bytebuddy:byte-buddy:${versions.bytebuddy}",
     bytebuddyagent       : "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}",
     autoserviceProcessor : "com.google.auto.service:auto-service:${versions.autoservice}",
@@ -101,11 +101,11 @@ final class CachedData {
 
     // Shared between appsec, agent tooling, iast, instrumentation, JMXFetch, profiling, and ci-visibility
     shared               : [
-      "com.datadoghq.okhttp3:okhttp:${versions.okhttp}",
       // Force specific version of okio required by com.squareup.moshi:moshi
       // When all of the dependencies are declared in dd-trace-core, moshi overrides the okhttp's
       // transitive dependency.  Since okhttp is declared here and moshi is not, this lead to an incompatible version
-      "com.squareup.okio:okio:${versions.okio}",
+      "com.datadoghq.okio:okio:${versions.okio}",
+      "com.datadoghq.okhttp3:okhttp:${versions.okhttp}",
       "com.datadoghq:java-dogstatsd-client:${versions.dogstatsd}",
       "com.github.jnr:jnr-unixsocket:${versions.jnr_unixsocket}",
       "com.squareup.moshi:moshi:${versions.moshi}",
@@ -131,8 +131,10 @@ final class CachedData {
       exclude(project(':utils:version-utils'))
       exclude(dependency('org.slf4j::'))
 
-      // okhttp and its transitives
+      // okhttp and its transitives (both fork and non-fork)
       exclude(dependency('com.datadoghq.okhttp3:okhttp'))
+      exclude(dependency('com.squareup.okhttp3:okhttp'))
+      exclude(dependency('com.datadoghq.okio:okio'))
       exclude(dependency('com.squareup.okio:okio'))
 
       // dogstatsd and its transitives


### PR DESCRIPTION
…with fork that backports the fix for [CVE-2023-3635](https://nvd.nist.gov/vuln/detail/CVE-2023-3635)