### PR TITLE
Update build to reflect refactoring in grpc-java 1.58

### DIFF
--- a/dd-java-agent/instrumentation/grpc-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/grpc-1.5/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   testImplementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 
   latestDepTestImplementation sourceSets.test.output // include the protobuf generated classes
+  latestDepTestImplementation group: 'io.grpc', name: 'grpc-inprocess', version: '1.+'
   latestDepTestImplementation group: 'io.grpc', name: 'grpc-netty', version: '1.+'
   latestDepTestImplementation group: 'io.grpc', name: 'grpc-protobuf', version: '1.+'
   latestDepTestImplementation group: 'io.grpc', name: 'grpc-stub', version: '1.+'


### PR DESCRIPTION
`InProcessChannelBuilder` used in the tests was moved to `grpc-inprocess`