### PR TITLE
Skip attaching the tracer when we know the JVM is running a JDK tool such as `jstack`

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -55,10 +55,7 @@ public final class AgentBootstrap {
   }
 
   public static void agentmain(final String agentArgs, final Instrumentation inst) {
-    if (checkAndLogIfInitializedTwice(System.out)) {
-      return;
-    }
-    if (checkAndLogIfLessThanJava8()) {
+    if (alreadyInitialized() || lessThanJava8() || isJdkTool()) {
       return;
     }
 
@@ -95,12 +92,12 @@ public final class AgentBootstrap {
     return false;
   }
 
-  private static boolean checkAndLogIfLessThanJava8() {
-    return checkAndLogIfLessThanJava8(System.getProperty("java.version"), System.out);
+  private static boolean lessThanJava8() {
+    return lessThanJava8(System.getProperty("java.version"), System.out);
   }
 
   // Reachable for testing
-  static boolean checkAndLogIfLessThanJava8(String version, PrintStream output) {
+  static boolean lessThanJava8(String version, PrintStream output) {
     if (parseJavaMajorVersion(version) < 8) {
       String agentVersion = "This version"; // If we can't find the agent version
       try {
@@ -121,14 +118,18 @@ public final class AgentBootstrap {
     return false;
   }
 
-  static boolean checkAndLogIfInitializedTwice(final PrintStream output) {
+  private static boolean alreadyInitialized() {
     if (initialized) {
-      output.println(
+      System.out.println(
           "Warning: dd-java-agent is being initialized more than once. Please, check that you are defining -javaagent:dd-java-agent.jar only once.");
       return true;
     }
     initialized = true;
     return false;
+  }
+
+  private static boolean isJdkTool() {
+    return System.getProperty("jdk.module.main", "").startsWith("jdk.");
   }
 
   // Reachable for testing
@@ -158,7 +159,7 @@ public final class AgentBootstrap {
   }
 
   public static void main(final String[] args) {
-    if (checkAndLogIfLessThanJava8()) {
+    if (lessThanJava8()) {
       return;
     }
     AgentJar.main(args);

--- a/dd-java-agent/src/test/groovy/datadog/trace/bootstrap/AgentBootstrapTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/bootstrap/AgentBootstrapTest.groovy
@@ -52,7 +52,7 @@ class AgentBootstrapTest extends Specification {
     def logStream = new PrintStream(baos)
 
     when:
-    def isLowerThan8 = AgentBootstrap.checkAndLogIfLessThanJava8(version, logStream)
+    def isLowerThan8 = AgentBootstrap.lessThanJava8(version, logStream)
     logStream.flush()
     def logLines = Arrays.asList(baos.toString().split('\n'))
     // If the list only contains a single String and that is the empty String, then the set is empty

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -682,13 +682,15 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   protected void finalize() {
-    try {
-      shutdownCallback.run();
-      Runtime.getRuntime().removeShutdownHook(shutdownCallback);
-    } catch (final IllegalStateException e) {
-      // Do nothing.  Already shutting down
-    } catch (final Exception e) {
-      log.error("Error while finalizing DDTracer.", e);
+    if (null != shutdownCallback) {
+      try {
+        shutdownCallback.run();
+        Runtime.getRuntime().removeShutdownHook(shutdownCallback);
+      } catch (final IllegalStateException e) {
+        // Do nothing.  Already shutting down
+      } catch (final Exception e) {
+        log.error("Error while finalizing DDTracer.", e);
+      }
     }
   }
 


### PR DESCRIPTION
# Motivation

When a user adds the tracer with `-javaagent` to `JAVA_TOOL_OPTIONS` that option will be picked up not only by any `java` command launched from that environment, but also short-lived JDK tools such as `jstack`, `javac` or `jcmd`. 

This PR stops the Java tracer from activating when we know we're attaching to a JDK tool run on Java 9 or later. Specifically it checks the `jdk.module.main` system property for modules under the `jdk.` namespace, which covers the majority of JDK tools that we want to skip.

Skipping these tools avoids potential log-spam such as reported in #5838