### PR TITLE
Exclude net.jpountz.xxhash in IAST

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -161,6 +161,8 @@
 1 nano.xml.*
 1 net.bytebuddy.*
 1 net.jcip.*
+# Amusing weak randomness false positive in XXHashFactory
+1 net.jpountz.xxhash.*
 1 net.logstash.*
 1 net.nicholaswilliams.*
 1 net.sf.beanlib.*


### PR DESCRIPTION
# What Does This Do
Exclude `net.jpountz.xxhash.*` from IAST instrumentation.

# Motivation
There is currently a weak randomness false positive in net.jpountz.xxhash.XXHashFactory.

# Additional Notes
See https://github.com/lz4/lz4-java/blob/7c931bef32d179ec3d3286ee71638b23ebde3459/src/java/net/jpountz/xxhash/XXHashFactory.java#L184-L188