### PR TITLE
Fix blocking for jetty 10.0.16 and 11.0.16

### DIFF
--- a/dd-java-agent/instrumentation/jetty-9/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-9/build.gradle
@@ -43,6 +43,14 @@ muzzle {
     javaVersion = 11
   }
   pass {
+    name = 'named_dispatches'
+    group = 'org.eclipse.jetty'
+    module = 'jetty-server'
+    versions = "[10.0.16,11),[11.0.16,12)"
+    assertInverse = true
+    javaVersion = 11
+  }
+  pass {
     name = 'between_10_and_12'
     group = "org.eclipse.jetty"
     module = 'jetty-server'

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/DispatchableInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/DispatchableInstrumentation.java
@@ -1,0 +1,65 @@
+package datadog.trace.instrumentation.jetty10;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.muzzle.Reference;
+
+@AutoService(Instrumenter.class)
+public class DispatchableInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForKnownTypes {
+  public DispatchableInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "named_dispatches";
+  }
+
+  @Override
+  public Reference[] additionalMuzzleReferences() {
+    return new Reference[] {
+      new Reference.Builder("org.eclipse.jetty.server.HttpChannel$RequestDispatchable")
+          .withField(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "this$0",
+              "Lorg/eclipse/jetty/server/HttpChannel;")
+          .build(),
+      new Reference.Builder("org.eclipse.jetty.server.HttpChannel$AsyncDispatchable")
+          .withField(
+              new String[0],
+              Reference.EXPECTS_NON_STATIC,
+              "this$0",
+              "Lorg/eclipse/jetty/server/HttpChannel;")
+          .build(),
+    };
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      "datadog.trace.instrumentation.jetty.JettyBlockingHelper",
+    };
+  }
+
+  @Override
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "org.eclipse.jetty.server.HttpChannel$RequestDispatchable",
+      "org.eclipse.jetty.server.HttpChannel$RequestAsyncDispatchable",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(named("dispatch")).and(isPublic()).and(takesArguments(0)),
+        packageName + ".DispatchableAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/DispatchableAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/DispatchableAdvice.java
@@ -1,0 +1,26 @@
+package datadog.trace.instrumentation.jetty10;
+
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
+import net.bytebuddy.asm.Advice;
+import org.eclipse.jetty.server.HttpChannel;
+
+public class DispatchableAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+  public static boolean /* skip */ before(@Advice.FieldValue("this$0") HttpChannel channel) {
+    AgentSpan span = AgentTracer.activeSpan();
+    if (span == null) {
+      return false;
+    }
+    Flow.Action.RequestBlockingAction rba = span.getRequestBlockingAction();
+    if (rba == null) {
+      return false;
+    }
+
+    boolean blocked =
+        JettyBlockingHelper.block(channel.getRequest(), channel.getResponse(), rba, span);
+    return blocked;
+  }
+}


### PR DESCRIPTION
The change in jetty was also applied on jetty 12.0.1, but we don't support AppSec on jetty-12 yet.

