### PR TITLE
Enable Trivy security scanning for published artifacts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -76,7 +76,7 @@ _Action:_
 
 _Recovery:_ Check at the milestone for the related issues and update them manually.
 
-## Code Quality
+## Code Quality and Security
 
 ### codeql-analysis [🔗](codeql-analysis.yml)
 
@@ -84,11 +84,19 @@ _Trigger:_ When pushing commits to `master` or any pull request to `master`
 
 _Action:_ Run GitHub CodeQL action and upload result to GitHub security tab.
 
+### trivy-analysis [🔗](trivy-analysis.yml)
+
+_Trigger:_ When pushing commits to `master` or any pull request to `master`
+
+_Action:_ Run Trivy security scanner on built artifacts and upload result to GitHub security tab.
+
 ### gradle-wrapper-validation [🔗](gradle-wrapper-validation.yaml.disabled)
 
 **DISABLED** - GitHub provides a way to disable actions rather than changing their extensions.
 
 _Comment:_ To delete?
+
+## Lib Injection
 
 ### lib-injection [🔗](lib-injection.yaml)
 

--- a/.github/workflows/trivy-analysis.yml
+++ b/.github/workflows/trivy-analysis.yml
@@ -1,0 +1,59 @@
+name: "Trivy Security Analysis"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # 3.6.0
+
+      - name: Remove old artifacts
+        run: |
+          MVN_LOCAL_REPO=$(./mvnw help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
+          echo "MVN_LOCAL_REPO=${MVN_LOCAL_REPO}" >> "$GITHUB_ENV"
+          rm -rf "${MVN_LOCAL_REPO}/com/datadoghq"
+
+      - name: Build and publish artifacts locally
+        run: |
+          GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G'" JAVA_HOME=$JAVA_HOME_8_X64 JAVA_8_HOME=$JAVA_HOME_8_X64 JAVA_11_HOME=$JAVA_HOME_11_X64 JAVA_17_HOME=$JAVA_HOME_17_X64 ./gradlew clean publishToMavenLocal --build-cache --parallel --stacktrace --no-daemon --max-workers=4
+
+      - name: Copy published artifacts
+        run: |
+          mkdir -p ./workspace/.trivy
+          cp -RP "${MVN_LOCAL_REPO}/com/datadoghq" ./workspace/.trivy/
+
+      - name: List copied artifacts
+        run: |
+          ls -laR "./workspace/.trivy"
+
+      - name: Run Trivy security scanner
+        uses: aquasecurity/trivy-action@41f05d9ecffa2ed3f1580af306000f734b733e54 # v0.11.2
+        with:
+          scan-type: rootfs
+          scan-ref: './workspace/.trivy/'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@00e563ead9f72a8461b24876bee2d0c2e8bd2ee8 # 2.15
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
# What Does This Do

Enables [Trivy](https://trivy.dev/) security scanning for the published artifacts.

# Motivation

Get notifications about potential security issues as soon as possible.

# Additional Notes
