### PR TITLE
Fix IAST Akka tests for latest dependency versions

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/build.gradle
+++ b/dd-java-agent/instrumentation/akka-http-10.0/build.gradle
@@ -137,9 +137,10 @@ dependencies {
 
   // TODO: test with Scala 3
   latestDepIastTestImplementation deps.scala213
+  // Use akka-2.8.+ since latest akka-http release is still not compatible with akka-2.9.0-M1+.
   latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '10.+'
-  latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.+'
-  latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-actor_2.13', version: '2.+'
+  latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.8.+'
+  latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-actor_2.13', version: '2.8.+'
   latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-http-jackson_2.13', version: '10.+'
   latestDepIastTestImplementation(testFixtures(project(':dd-java-agent:agent-iast')))
 


### PR DESCRIPTION


# What Does This Do
Tests rely on Akka + Akka HTTP, but latest Akka HTTP does not support Akka 2.9.0-M1 yet. So limiting tests to Akka 2.8.x at the moment.
# Motivation

# Additional Notes
