### PR TITLE
[data streams] Tag with version

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter {
   private static final byte[] ENV = "Env".getBytes(ISO_8859_1);
+  private static final byte[] VERSION = "Version".getBytes(ISO_8859_1);
   private static final byte[] PRIMARY_TAG = "PrimaryTag".getBytes(ISO_8859_1);
   private static final byte[] LANG = "Lang".getBytes(ISO_8859_1);
   private static final byte[] TRACER_VERSION = "TracerVersion".getBytes(ISO_8859_1);
@@ -55,7 +56,7 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
 
   @Override
   public void writePayload(Collection<StatsBucket> data) {
-    writer.startMap(6);
+    writer.startMap(7);
     /* 1 */
     writer.writeUTF8(ENV);
     writer.writeUTF8(wellKnownTags.getEnv());
@@ -77,8 +78,13 @@ public class MsgPackDatastreamsPayloadWriter implements DatastreamsPayloadWriter
     writer.writeUTF8(tracerVersionValue);
 
     /* 6 */
+    writer.writeUTF8(VERSION);
+    writer.writeUTF8(wellKnownTags.getVersion());
+
+    /* 7 */
     writer.writeUTF8(STATS);
     writer.startArray(data.size());
+
     for (StatsBucket bucket : data) {
       boolean hasBacklogs = !bucket.getBacklogs().isEmpty();
       writer.startMap(3 + (hasBacklogs ? 1 : 0));

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DataStreamsWritingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DataStreamsWritingTest.groovy
@@ -107,7 +107,7 @@ class DataStreamsWritingTest extends DDCoreSpecification {
     BufferedSource bufferedSource = Okio.buffer(gzipSource)
     MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bufferedSource.inputStream())
 
-    assert unpacker.unpackMapHeader() == 6
+    assert unpacker.unpackMapHeader() == 7
     assert unpacker.unpackString() == "Env"
     assert unpacker.unpackString() == "test"
     assert unpacker.unpackString() == "Service"
@@ -118,6 +118,8 @@ class DataStreamsWritingTest extends DDCoreSpecification {
     assert unpacker.unpackString() == "region-1"
     assert unpacker.unpackString() == "TracerVersion"
     assert unpacker.unpackString() == DDTraceCoreInfo.VERSION
+    assert unpacker.unpackString() == "Version"
+    assert unpacker.unpackString() == "version"
     assert unpacker.unpackString() == "Stats"
     assert unpacker.unpackArrayHeader() == 2  // 2 time buckets
 


### PR DESCRIPTION
# What Does This Do

Add version tag to data stream stats. This will help us track changes in throughput / latency during deployments.

# Motivation

# Additional Notes
