### PR TITLE
Fix request body tainting in spring boot 2.7.5

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -288,6 +288,8 @@
 0 org.springframework.core.io.buffer.DataBuffer
 0 org.springframework.core.io.buffer.DefaultDataBuffer
 0 org.springframework.core.io.buffer.NettyDataBuffer
+# Need for IAST so propagation of tainted objects is complete in spring 2.7.5
+0 org.springframework.util.StreamUtils$NonClosingInputStream
 # There are some Mono implementation that get instrumented
 0 org.springframework.http.server.reactive.*
 2 org.springframework.instrument.*


### PR DESCRIPTION
# What Does This Do
Fixes instrumentation for spring boot 2.7.5 

# Motivation
Maintenance bug fix for the new version of spring boot using a new class NonClosingStream that was in the instrumentation exclussion list.

# Additional Notes
