### PR TITLE
Use bytes instead of strings in IAST metrics tags

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/ext/IastExtensionTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/ext/IastExtensionTest.groovy
@@ -13,6 +13,7 @@ import datadog.trace.plugin.csi.impl.assertion.AdviceAssert
 import datadog.trace.plugin.csi.impl.assertion.AssertBuilder
 import datadog.trace.plugin.csi.impl.assertion.CallSiteAssert
 import datadog.trace.plugin.csi.impl.ext.tests.IastExtensionCallSite
+import datadog.trace.plugin.csi.impl.ext.tests.SourceTypes
 import groovy.transform.CompileDynamic
 import spock.lang.TempDir
 
@@ -85,18 +86,32 @@ class IastExtensionTest extends BaseCsiPluginTest {
       advices(0) {
         pointcut('javax/servlet/http/HttpServletRequest', 'getHeader', '(Ljava/lang/String;)Ljava/lang/String;')
         instrumentedMetric('IastMetric.INSTRUMENTED_SOURCE') {
-          metricStatements('IastMetricCollector.add(IastMetric.INSTRUMENTED_SOURCE, "http.request.header.name", 1);')
+          metricStatements('IastMetricCollector.add(IastMetric.INSTRUMENTED_SOURCE, (byte) 3, 1);')
         }
         executedMetric('IastMetric.EXECUTED_SOURCE') {
           metricStatements(
             'handler.field(net.bytebuddy.jar.asm.Opcodes.GETSTATIC, "datadog/trace/api/iast/telemetry/IastMetric", "EXECUTED_SOURCE", "Ldatadog/trace/api/iast/telemetry/IastMetric;");',
-            'handler.loadConstant("http.request.header.name");',
+            'handler.instruction(net.bytebuddy.jar.asm.Opcodes.ICONST_3);',
             'handler.instruction(net.bytebuddy.jar.asm.Opcodes.ICONST_1);',
-            'handler.method(net.bytebuddy.jar.asm.Opcodes.INVOKESTATIC, "datadog/trace/api/iast/telemetry/IastMetricCollector", "add", "(Ldatadog/trace/api/iast/telemetry/IastMetric;Ljava/lang/String;I)V", false);'
+            'handler.method(net.bytebuddy.jar.asm.Opcodes.INVOKESTATIC, "datadog/trace/api/iast/telemetry/IastMetricCollector", "add", "(Ldatadog/trace/api/iast/telemetry/IastMetric;BI)V", false);'
           )
         }
       }
       advices(1) {
+        pointcut('javax/servlet/http/HttpServletRequest', 'getInputStream', '()Ljavax/servlet/ServletInputStream;')
+        instrumentedMetric('IastMetric.INSTRUMENTED_SOURCE') {
+          metricStatements('IastMetricCollector.add(IastMetric.INSTRUMENTED_SOURCE, (byte) 127, 1);')
+        }
+        executedMetric('IastMetric.EXECUTED_SOURCE') {
+          metricStatements(
+            'handler.field(net.bytebuddy.jar.asm.Opcodes.GETSTATIC, "datadog/trace/api/iast/telemetry/IastMetric", "EXECUTED_SOURCE", "Ldatadog/trace/api/iast/telemetry/IastMetric;");',
+            'handler.instruction(net.bytebuddy.jar.asm.Opcodes.BIPUSH, 127);',
+            'handler.instruction(net.bytebuddy.jar.asm.Opcodes.ICONST_1);',
+            'handler.method(net.bytebuddy.jar.asm.Opcodes.INVOKESTATIC, "datadog/trace/api/iast/telemetry/IastMetricCollector", "add", "(Ldatadog/trace/api/iast/telemetry/IastMetric;BI)V", false);'
+          )
+        }
+      }
+      advices(2) {
         pointcut('javax/servlet/ServletRequest', 'getReader', '()Ljava/io/BufferedReader;')
         instrumentedMetric('IastMetric.INSTRUMENTED_PROPAGATION') {
           metricStatements('IastMetricCollector.add(IastMetric.INSTRUMENTED_PROPAGATION, 1);')

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/IastExtensionCallSite.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/IastExtensionCallSite.java
@@ -2,13 +2,14 @@ package datadog.trace.plugin.csi.impl.ext.tests;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import java.io.BufferedReader;
+import javax.servlet.ServletInputStream;
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 
 @CallSite(spi = IastCallSites.class)
 public class IastExtensionCallSite {
 
-  @Source(SourceTypes.REQUEST_HEADER_NAME_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_NAME)
   @CallSite.After(
       "java.lang.String javax.servlet.http.HttpServletRequest.getHeader(java.lang.String)")
   public static String afterGetHeader(
@@ -16,6 +17,15 @@ public class IastExtensionCallSite {
       @CallSite.Argument final String headerName,
       @CallSite.Return final String headerValue) {
     return headerValue;
+  }
+
+  @Source(SourceTypes.REQUEST_BODY)
+  @CallSite.After(
+      "javax.servlet.ServletInputStream javax.servlet.http.HttpServletRequest.getInputStream()")
+  public static ServletInputStream afterGetInputStream(
+      @CallSite.This final HttpServletRequest self,
+      @CallSite.Return final ServletInputStream stream) {
+    return stream;
   }
 
   @Propagation

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/Source.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/Source.java
@@ -9,5 +9,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Source {
   /** Source type */
-  String value();
+  byte value();
 }

--- a/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/SourceTypes.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/ext/tests/SourceTypes.java
@@ -2,5 +2,7 @@ package datadog.trace.plugin.csi.impl.ext.tests;
 
 public class SourceTypes {
 
-  public static final String REQUEST_HEADER_NAME_STRING = "http.request.header.name";
+  public static final byte REQUEST_HEADER_NAME = 3;
+
+  public static final byte REQUEST_BODY = 127;
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -10,55 +10,58 @@ import javax.annotation.Nonnull;
 
 public interface VulnerabilityType {
   VulnerabilityType WEAK_CIPHER =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_CIPHER, NOT_MARKED);
-  VulnerabilityType WEAK_HASH = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_HASH, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_CIPHER_STRING, NOT_MARKED);
+  VulnerabilityType WEAK_HASH =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_HASH_STRING, NOT_MARKED);
   VulnerabilityType INSECURE_COOKIE =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_COOKIE, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_COOKIE_STRING, NOT_MARKED);
   VulnerabilityType NO_HTTPONLY_COOKIE =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.NO_HTTPONLY_COOKIE, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.NO_HTTPONLY_COOKIE_STRING, NOT_MARKED);
   VulnerabilityType HSTS_HEADER_MISSING =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.HSTS_HEADER_MISSING, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.HSTS_HEADER_MISSING_STRING, NOT_MARKED);
   VulnerabilityType XCONTENTTYPE_HEADER_MISSING =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING_STRING, NOT_MARKED);
   VulnerabilityType NO_SAMESITE_COOKIE =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.NO_SAMESITE_COOKIE, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.NO_SAMESITE_COOKIE_STRING, NOT_MARKED);
 
   InjectionType SQL_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.SQL_INJECTION, VulnerabilityMarks.SQL_INJECTION_MARK, ' ');
+          VulnerabilityTypes.SQL_INJECTION_STRING, VulnerabilityMarks.SQL_INJECTION_MARK, ' ');
   InjectionType COMMAND_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.COMMAND_INJECTION, VulnerabilityMarks.COMMAND_INJECTION_MARK, ' ');
+          VulnerabilityTypes.COMMAND_INJECTION_STRING,
+          VulnerabilityMarks.COMMAND_INJECTION_MARK,
+          ' ');
   InjectionType PATH_TRAVERSAL =
       new InjectionTypeImpl(
-          VulnerabilityTypes.PATH_TRAVERSAL,
+          VulnerabilityTypes.PATH_TRAVERSAL_STRING,
           VulnerabilityMarks.PATH_TRAVERSAL_MARK,
           File.separatorChar);
   InjectionType LDAP_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.LDAP_INJECTION, VulnerabilityMarks.LDAP_INJECTION_MARK, ' ');
+          VulnerabilityTypes.LDAP_INJECTION_STRING, VulnerabilityMarks.LDAP_INJECTION_MARK, ' ');
   InjectionType SSRF =
-      new InjectionTypeImpl(VulnerabilityTypes.SSRF, VulnerabilityMarks.SSRF_MARK, ' ');
+      new InjectionTypeImpl(VulnerabilityTypes.SSRF_STRING, VulnerabilityMarks.SSRF_MARK, ' ');
   InjectionType UNVALIDATED_REDIRECT =
       new InjectionTypeImpl(
-          VulnerabilityTypes.UNVALIDATED_REDIRECT,
+          VulnerabilityTypes.UNVALIDATED_REDIRECT_STRING,
           VulnerabilityMarks.UNVALIDATED_REDIRECT_MARK,
           ' ');
   VulnerabilityType WEAK_RANDOMNESS =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_RANDOMNESS, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_RANDOMNESS_STRING, NOT_MARKED);
 
   InjectionType XPATH_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.XPATH_INJECTION, VulnerabilityMarks.XPATH_INJECTION_MARK, ' ');
+          VulnerabilityTypes.XPATH_INJECTION_STRING, VulnerabilityMarks.XPATH_INJECTION_MARK, ' ');
 
   InjectionType TRUST_BOUNDARY_VIOLATION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION,
+          VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION_STRING,
           VulnerabilityMarks.TRUST_BOUNDARY_VIOLATION,
           ' ');
 
   InjectionType XSS =
-      new InjectionTypeImpl(VulnerabilityTypes.XSS, VulnerabilityMarks.XSS_MARK, ' ');
+      new InjectionTypeImpl(VulnerabilityTypes.XSS_STRING, VulnerabilityMarks.XSS_MARK, ' ');
 
   String name();
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/TelemetryRequestEndedHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/TelemetryRequestEndedHandlerTest.groovy
@@ -63,15 +63,14 @@ class TelemetryRequestEndedHandlerTest extends AbstractTelemetryCallbackTest {
     given:
     final handler = new TelemetryRequestEndedHandler(delegate)
     final metric = TAINTED_FLAT_MODE
-    final tagValue = null
 
     when:
-    iastCtx.metricCollector.addMetric(metric, tagValue, 1)
+    iastCtx.metricCollector.addMetric(metric, (byte) -1, 1)
     handler.apply(reqCtx, span)
 
     then:
     1 * delegate.apply(reqCtx, span)
-    1 * traceSegment.setTagTop(String.format(TRACE_METRIC_PATTERN, getSpanTagValue(metric, tagValue)), 1)
+    1 * traceSegment.setTagTop(String.format(TRACE_METRIC_PATTERN, getSpanTagValue(metric)), 1)
 
     when:
     globalCollector.prepareMetrics()
@@ -111,32 +110,36 @@ class TelemetryRequestEndedHandlerTest extends AbstractTelemetryCallbackTest {
     where:
     metrics                                                                       | description
     [
-      metric(REQUEST_TAINTED, null, 123),
-      metric(EXECUTED_SOURCE, SourceTypes.REQUEST_PARAMETER_VALUE_STRING, 2),
-      metric(EXECUTED_SOURCE, SourceTypes.REQUEST_HEADER_VALUE_STRING, 4),
+      metric(REQUEST_TAINTED, 123),
+      metric(EXECUTED_SOURCE, SourceTypes.REQUEST_PARAMETER_VALUE, 2),
+      metric(EXECUTED_SOURCE, SourceTypes.REQUEST_HEADER_VALUE, 4),
       metric(EXECUTED_SINK, VulnerabilityTypes.SQL_INJECTION, 1),
       metric(EXECUTED_SINK, VulnerabilityTypes.COMMAND_INJECTION, 2),
     ]                                                                             | 'List of only request scoped metrics'
     [
-      metric(REQUEST_TAINTED, null, 123),
-      metric(INSTRUMENTED_SOURCE, SourceTypes.REQUEST_PARAMETER_VALUE_STRING, 2),
+      metric(REQUEST_TAINTED, 123),
+      metric(INSTRUMENTED_SOURCE, SourceTypes.REQUEST_PARAMETER_VALUE, 2),
     ]                                                                             | 'Mix between global and request scoped metrics'
   }
 
-  private static String getSpanTagValue(final IastMetric metric, final String tagValue) {
+  private static String getSpanTagValue(final IastMetric metric, final Byte tagValue = null) {
     return metric.getTag() == null
       ? metric.getName()
-      : String.format("%s.%s", metric.getName(), tagValue.toLowerCase().replaceAll("\\.", "_"))
+      : String.format("%s.%s", metric.getName(), metric.tag.toString(tagValue).toLowerCase().replaceAll("\\.", "_"))
   }
 
-  private static Data metric(final IastMetric metric, final String tagValue, final int value) {
+  private static Data metric(final IastMetric metric, final byte tagValue, final int value) {
     return new Data(metric: metric, tagValue: tagValue, value: value)
+  }
+
+  private static Data metric(final IastMetric metric, final int value) {
+    return new Data(metric: metric, tagValue: (byte) -1, value: value)
   }
 
   @ToString
   private static class Data {
     IastMetric metric
-    String tagValue
+    byte tagValue
     int value
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/taint/TaintedObjectsWithTelemetryTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/taint/TaintedObjectsWithTelemetryTest.groovy
@@ -60,7 +60,7 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
     then:
     if (IastMetric.REQUEST_TAINTED.isEnabled(verbosity)) {
-      1 * mockCollector.addMetric(IastMetric.REQUEST_TAINTED, null, tainteds.size())
+      1 * mockCollector.addMetric(IastMetric.REQUEST_TAINTED, _, tainteds.size())
     } else {
       0 * mockCollector.addMetric
     }
@@ -80,7 +80,7 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
     then:
     if (IastMetric.EXECUTED_TAINTED.isEnabled(verbosity)) {
-      3 * mockCollector.addMetric(IastMetric.EXECUTED_TAINTED, null, 1) // two calls with one element
+      3 * mockCollector.addMetric(IastMetric.EXECUTED_TAINTED, _, 1) // two calls with one element
     } else {
       0 * mockCollector.addMetric
     }
@@ -100,7 +100,7 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
     then:
     if (IastMetric.TAINTED_FLAT_MODE.isEnabled(verbosity) && taintedObjects.isFlat()) {
-      1 * mockCollector.addMetric(IastMetric.TAINTED_FLAT_MODE, null, _)
+      1 * mockCollector.addMetric(IastMetric.TAINTED_FLAT_MODE, _, _)
     } else {
       0 * mockCollector.addMetric
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
@@ -162,6 +162,11 @@ public class CallSiteTransformer implements Instrumenter.AdviceTransformer {
     }
 
     @Override
+    public void instruction(final int opcode, final int parameter) {
+      mv.visitIntInsn(opcode, parameter);
+    }
+
+    @Override
     public void instruction(final int opcode, final String type) {
       mv.visitTypeInsn(opcode, type);
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
@@ -9,6 +9,9 @@ public interface CallSiteAdvice {
     /** Executes an instruction without parameters */
     void instruction(int opcode);
 
+    /** Executes an instruction with an int parameter */
+    void instruction(final int opcode, final int parameter);
+
     /** Executes an instruction with a type parameter */
     void instruction(int opcode, String type);
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieDirectivesInstrumentation.java
@@ -55,7 +55,7 @@ public class CookieDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintCookieAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintCookieFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -63,7 +63,7 @@ public class CookieDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintOptionalCookieAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive =
           directive.tmap(TaintOptionalCookieFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
@@ -53,7 +53,7 @@ public class CookieHeaderInstrumentation extends Instrumenter.Iast
 
   static class TaintAllCookiesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     static void after(
         @Advice.This HttpHeader cookie, @Advice.Return Seq<HttpCookiePair> cookiePairs) {
       WebModule mod = InstrumentationBridge.WEB;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/ExtractDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/ExtractDirectivesInstrumentation.java
@@ -72,7 +72,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUriDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_QUERY_STRING)
+    @Source(SourceTypes.REQUEST_QUERY)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintUriFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -80,7 +80,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintRequestDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintRequestFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -88,7 +88,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintRequestContextDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive =
           directive.tmap(TaintRequestContextFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/FormFieldDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/FormFieldDirectivesInstrumentation.java
@@ -101,7 +101,7 @@ public class FormFieldDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleFormFieldDirectiveOldScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Directive retval,
         @Advice.Argument(1) FormFieldDirectives.FieldMagnet fmag) {
@@ -116,7 +116,7 @@ public class FormFieldDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleFormFieldDirectiveNewScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Directive retval,
         @Advice.Argument(0) FormFieldDirectives.FieldMagnet fmag) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
@@ -15,7 +15,7 @@ import java.util.Collections;
  * because there are many calls to {@link HttpHeader#name()} inside akka-http code that we don't
  * care about.
  */
-@Source(value = SourceTypes.REQUEST_HEADER_NAME_STRING)
+@Source(value = SourceTypes.REQUEST_HEADER_NAME)
 @CallSite(spi = IastCallSites.class)
 public class HeaderNameCallSite {
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
@@ -59,7 +59,7 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
   @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
   static class RequestHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     static void onExit(
         @Advice.This HttpRequest thiz, @Advice.Return(readOnly = false) Seq<HttpHeader> headers) {
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/MarshallingDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/MarshallingDirectivesInstrumentation.java
@@ -76,7 +76,7 @@ public class MarshallingDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUnmarshallerInputOldScalaAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     static void before(@Advice.Argument(readOnly = false, value = 1) Unmarshaller unmarshaller) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod != null) {
@@ -87,7 +87,7 @@ public class MarshallingDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUnmarshallerInputNewScalaAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     static void before(@Advice.Argument(readOnly = false, value = 0) Unmarshaller unmarshaller) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod != null) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/ParameterDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/ParameterDirectivesInstrumentation.java
@@ -100,7 +100,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintMultiMapDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintMultiMapFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -108,7 +108,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintMapDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintMapFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -116,7 +116,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSeqDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintSeqFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -124,7 +124,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleParameterDirectiveOldScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Return(readOnly = false) Object retval,
         @Advice.Argument(1) ParameterDirectives.ParamMagnet pmag) {
@@ -144,7 +144,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleParameterDirectiveNewScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Return(readOnly = false) Object retval,
         @Advice.Argument(0) ParameterDirectives.ParamMagnet pmag) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
@@ -47,7 +47,7 @@ public class PathMatcherInstrumentation extends Instrumenter.Iast
   @RequiresRequestContext(RequestContextSlot.IAST)
   static class PathMatcherAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER)
     static void onExit(
         @Advice.Argument(1) Object extractions, @ActiveRequestContext RequestContext reqCtx) {
       if (!(extractions instanceof scala.Tuple1)) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
@@ -78,7 +78,7 @@ public class UriInstrumentation extends Instrumenter.Iast implements Instrumente
     // bind uri to a variable of type Object so that this advice can also
     // be used from FromDataInstrumentaton
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(@Advice.This /*Uri*/ Object uri, @Advice.Return Uri.Query ret) {
       WebModule web = InstrumentationBridge.WEB;
       PropagationModule prop = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/ParameterDirectivesImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/ParameterDirectivesImplInstrumentation.java
@@ -69,7 +69,7 @@ public class ParameterDirectivesImplInstrumentation extends Instrumenter.Iast
 
   static class FilterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Argument(0) String paramName,
         @Advice.Return(readOnly = false) Directive /*<Tuple1<?>>*/ retval) {
@@ -84,7 +84,7 @@ public class ParameterDirectivesImplInstrumentation extends Instrumenter.Iast
 
   static class RepeatedFilterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Argument(0) String paramName,
         @Advice.Return(readOnly = false) Directive /*<Tuple1<Iterable<?>>>*/ retval) {

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
@@ -37,7 +37,7 @@ public class AbstractFormProviderInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(@Advice.Return Map<String, List<String>> result) {
       final WebModule module = InstrumentationBridge.WEB;
       final PropagationModule prop = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
@@ -8,7 +8,7 @@ import net.bytebuddy.asm.Advice;
 
 public class AbstractStringReaderAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   public static void onExit(@Advice.Return(readOnly = true) Object result) {
     if (result instanceof String) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieInstrumentation.java
@@ -37,7 +37,7 @@ public class CookieInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class InstrumenterAdviceGetName {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_NAME_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_NAME)
     public static void onExit(@Advice.Return String cookieName, @Advice.This Object self) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -48,7 +48,7 @@ public class CookieInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class GetValueAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void onExit(
         @Advice.Return String cookieValue,
         @Advice.FieldValue("name") String name,

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieParamValueFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieParamValueFactoryInstrumentation.java
@@ -37,7 +37,7 @@ public class CookieParamValueFactoryInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void onExit() {
       ThreadLocalSourceType.set(SourceTypes.REQUEST_COOKIE_VALUE);
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/HeaderParamValueFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/HeaderParamValueFactoryInstrumentation.java
@@ -37,7 +37,7 @@ public class HeaderParamValueFactoryInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit() {
       ThreadLocalSourceType.set(SourceTypes.REQUEST_HEADER_VALUE);
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
@@ -42,7 +42,7 @@ public class InboundMessageContextInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdviceGetHeaders {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(@Advice.Return Map<String, List<String>> headers) {
       final PropagationModule prop = InstrumentationBridge.PROPAGATION;
       final WebModule web = InstrumentationBridge.WEB;
@@ -59,7 +59,7 @@ public class InboundMessageContextInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdviceGetRequestCookies {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void onExit(@Advice.Return Map<String, Object> cookies) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/PathParamValueFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/PathParamValueFactoryInstrumentation.java
@@ -36,7 +36,7 @@ public class PathParamValueFactoryInstrumentation extends Instrumenter.Iast
 
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER)
     public static void onExit() {
       ThreadLocalSourceType.set(SourceTypes.REQUEST_PATH_PARAMETER);
     }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
@@ -36,7 +36,7 @@ public class JSONObjectUtilsInstrumentation extends Instrumenter.Iast
   public static class InstrumenterAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onEnter(@Advice.Return Map<String, Object> map) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
 

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
@@ -35,7 +35,7 @@ public class JWTParserInstrumentation extends Instrumenter.Iast
   public static class InstrumenterAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onEnter(@Advice.Argument(0) String json) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
 

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/CookieDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/CookieDirectivesInstrumentation.java
@@ -56,7 +56,7 @@ public class CookieDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintCookieAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintCookieFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -64,7 +64,7 @@ public class CookieDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintOptionalCookieAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive =
           directive.tmap(TaintOptionalCookieFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/CookieHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/CookieHeaderInstrumentation.java
@@ -53,7 +53,7 @@ public class CookieHeaderInstrumentation extends Instrumenter.Iast
 
   static class TaintAllCookiesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     static void after(
         @Advice.This HttpHeader cookie, @Advice.Return Seq<HttpCookiePair> cookiePairs) {
       WebModule mod = InstrumentationBridge.WEB;

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/ExtractDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/ExtractDirectivesInstrumentation.java
@@ -73,7 +73,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUriDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_QUERY_STRING)
+    @Source(SourceTypes.REQUEST_QUERY)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintUriFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -81,7 +81,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintRequestDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintRequestFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -89,7 +89,7 @@ public class ExtractDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintRequestContextDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive =
           directive.tmap(TaintRequestContextFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/FormFieldDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/FormFieldDirectivesInstrumentation.java
@@ -107,7 +107,7 @@ public class FormFieldDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleFormFieldDirectiveOldScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Directive retval,
         @Advice.Argument(1) FormFieldDirectives.FieldMagnet fmag) {
@@ -122,7 +122,7 @@ public class FormFieldDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleFormFieldDirectiveNewScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Return(readOnly = false, typing = Assigner.Typing.DYNAMIC) Directive retval,
         @Advice.Argument(0) FormFieldDirectives.FieldMagnet fmag) {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HeaderNameCallSite.java
@@ -15,7 +15,7 @@ import org.apache.pekko.http.javadsl.model.HttpHeader;
  * because there are many calls to {@link HttpHeader#name()} inside pekko-http code that we don't
  * care about.
  */
-@Source(value = SourceTypes.REQUEST_HEADER_NAME_STRING)
+@Source(value = SourceTypes.REQUEST_HEADER_NAME)
 @CallSite(spi = IastCallSites.class)
 public class HeaderNameCallSite {
 

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpRequestInstrumentation.java
@@ -59,7 +59,7 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
   @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
   static class RequestHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     static void onExit(
         @Advice.This HttpRequest thiz, @Advice.Return(readOnly = false) Seq<HttpHeader> headers) {
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/MarshallingDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/MarshallingDirectivesInstrumentation.java
@@ -82,7 +82,7 @@ public class MarshallingDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUnmarshallerInputOldScalaAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     static void before(@Advice.Argument(readOnly = false, value = 1) Unmarshaller unmarshaller) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod != null) {
@@ -93,7 +93,7 @@ public class MarshallingDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintUnmarshallerInputNewScalaAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     static void before(@Advice.Argument(readOnly = false, value = 0) Unmarshaller unmarshaller) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod != null) {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/ParameterDirectivesImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/ParameterDirectivesImplInstrumentation.java
@@ -73,7 +73,7 @@ public class ParameterDirectivesImplInstrumentation extends Instrumenter.Iast
 
   static class FilterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Argument(0) String paramName,
         @Advice.Return(readOnly = false) Directive /*<Tuple1<?>>*/ retval) {
@@ -88,7 +88,7 @@ public class ParameterDirectivesImplInstrumentation extends Instrumenter.Iast
 
   static class RepeatedFilterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Argument(0) String paramName,
         @Advice.Return(readOnly = false) Directive /*<Tuple1<Iterable<?>>>*/ retval) {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/ParameterDirectivesInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/ParameterDirectivesInstrumentation.java
@@ -106,7 +106,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintMultiMapDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintMultiMapFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -114,7 +114,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintMapDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintMapFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -122,7 +122,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSeqDirectiveAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(@Advice.Return(readOnly = false) Directive directive) {
       directive = directive.tmap(TaintSeqFunction.INSTANCE, Tupler$.MODULE$.forTuple(null));
     }
@@ -130,7 +130,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleParameterDirectiveOldScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Return(readOnly = false) Object retval,
         @Advice.Argument(1) ParameterDirectives.ParamMagnet pmag) {
@@ -150,7 +150,7 @@ public class ParameterDirectivesInstrumentation extends Instrumenter.Iast
 
   static class TaintSingleParameterDirectiveNewScalaAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Return(readOnly = false) Object retval,
         @Advice.Argument(0) ParameterDirectives.ParamMagnet pmag) {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/PathMatcherInstrumentation.java
@@ -47,7 +47,7 @@ public class PathMatcherInstrumentation extends Instrumenter.Iast
   @RequiresRequestContext(RequestContextSlot.IAST)
   static class PathMatcherAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER)
     static void onExit(
         @Advice.Argument(1) Object extractions, @ActiveRequestContext RequestContext reqCtx) {
       if (!(extractions instanceof scala.Tuple1)) {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/UriInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/UriInstrumentation.java
@@ -78,7 +78,7 @@ public class UriInstrumentation extends Instrumenter.Iast implements Instrumente
     // bind uri to a variable of type Object so that this advice can also
     // be used from FromDataInstrumentaton
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(@Advice.This /*Uri*/ Object uri, @Advice.Return Uri.Query ret) {
       WebModule web = InstrumentationBridge.WEB;
       PropagationModule prop = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
@@ -9,7 +9,7 @@ import net.bytebuddy.asm.Advice;
 
 public class CookieParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_COOKIE_VALUE)
   public static void onExit(
       @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
     if (result instanceof String || result instanceof Collection) {

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
@@ -9,7 +9,7 @@ import net.bytebuddy.asm.Advice;
 
 public class FormParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   public static void onExit(
       @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
     if (result instanceof String || result instanceof Collection) {

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
@@ -9,7 +9,7 @@ import net.bytebuddy.asm.Advice;
 
 public class HeaderParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE)
   public static void onExit(
       @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
     if (result instanceof String || result instanceof Collection) {

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
@@ -9,7 +9,7 @@ import net.bytebuddy.asm.Advice;
 
 public class PathParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   public static void onExit(
       @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
     if (result instanceof String || result instanceof Collection) {

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
@@ -9,7 +9,7 @@ import net.bytebuddy.asm.Advice;
 
 public class QueryParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   public static void onExit(
       @Advice.Return Object result, @Advice.FieldValue("encodedName") String paramName) {
     if (result instanceof String || result instanceof Collection) {

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/HttpServlet3RequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/HttpServlet3RequestCallSite.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class HttpServlet3RequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After("java.util.Map javax.servlet.http.HttpServletRequest.getParameterMap()")
   @CallSite.After("java.util.Map javax.servlet.http.HttpServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/Servlet3RequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/callsite/Servlet3RequestCallSite.java
@@ -12,7 +12,7 @@ import javax.servlet.ServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class Servlet3RequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After("java.util.Map javax.servlet.ServletRequest.getParameterMap()")
   @CallSite.After("java.util.Map javax.servlet.ServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @CallSite(spi = IastCallSites.class)
 public class JakartaHttpServletRequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After(
       "java.lang.String jakarta.servlet.http.HttpServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
@@ -41,7 +41,7 @@ public class JakartaHttpServletRequestCallSite {
     return value;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
   @CallSite.After(
       "java.util.Enumeration jakarta.servlet.http.HttpServletRequest.getParameterNames()")
   @CallSite.After(
@@ -73,7 +73,7 @@ public class JakartaHttpServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After(
       "java.lang.String[] jakarta.servlet.http.HttpServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
@@ -95,7 +95,7 @@ public class JakartaHttpServletRequestCallSite {
     return parameterValues;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After("java.util.Map jakarta.servlet.http.HttpServletRequest.getParameterMap()")
   @CallSite.After("java.util.Map jakarta.servlet.http.HttpServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInputStreamCallSite.java
@@ -12,7 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class JakartaHttpServletRequestInputStreamCallSite {
 
-  @Source(SourceTypes.REQUEST_BODY_STRING)
+  @Source(SourceTypes.REQUEST_BODY)
   @CallSite.After(
       "jakarta.servlet.ServletInputStream jakarta.servlet.http.HttpServletRequest.getInputStream()")
   @CallSite.After(

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaServletRequestCallSite.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @CallSite(spi = IastCallSites.class)
 public class JakartaServletRequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After("java.lang.String jakarta.servlet.ServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
       "java.lang.String jakarta.servlet.ServletRequestWrapper.getParameter(java.lang.String)")
@@ -41,7 +41,7 @@ public class JakartaServletRequestCallSite {
     return value;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
   @CallSite.After("java.util.Enumeration jakarta.servlet.ServletRequest.getParameterNames()")
   @CallSite.After("java.util.Enumeration jakarta.servlet.ServletRequestWrapper.getParameterNames()")
   public static Enumeration<String> afterGetParameterNames(
@@ -71,7 +71,7 @@ public class JakartaServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After(
       "java.lang.String[] jakarta.servlet.ServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
@@ -93,7 +93,7 @@ public class JakartaServletRequestCallSite {
     return parameterValues;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After("java.util.Map jakarta.servlet.ServletRequest.getParameterMap()")
   @CallSite.After("java.util.Map jakarta.servlet.ServletRequestWrapper.getParameterMap()")
   public static java.util.Map<java.lang.String, java.lang.String[]> afterGetParameterMap(
@@ -125,7 +125,7 @@ public class JakartaServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_BODY_STRING)
+  @Source(SourceTypes.REQUEST_BODY)
   @CallSite.After(
       "jakarta.servlet.ServletInputStream jakarta.servlet.ServletRequest.getInputStream()")
   @CallSite.After(

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/CookieInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/CookieInstrumentation.java
@@ -42,7 +42,7 @@ public class CookieInstrumentation extends Instrumenter.Iast implements Instrume
 
   public static class GetNameAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_COOKIE_NAME_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_NAME)
     public static void afterGetName(
         @Advice.This final Object self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
@@ -59,7 +59,7 @@ public class CookieInstrumentation extends Instrumenter.Iast implements Instrume
   public static class GetValueAdvice {
 
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void afterGetValue(
         @Advice.This final Object self,
         @Advice.FieldValue("name") final String name,

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class HttpServletRequestCallSite {
 
-  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE)
   @CallSite.After(
       "java.lang.String javax.servlet.http.HttpServletRequest.getHeader(java.lang.String)")
   @CallSite.After(
@@ -42,7 +42,7 @@ public class HttpServletRequestCallSite {
     return value;
   }
 
-  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE)
   @CallSite.After(
       "java.util.Enumeration javax.servlet.http.HttpServletRequest.getHeaders(java.lang.String)")
   @CallSite.After(
@@ -77,7 +77,7 @@ public class HttpServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_HEADER_NAME_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_NAME)
   @CallSite.After("java.util.Enumeration javax.servlet.http.HttpServletRequest.getHeaderNames()")
   @CallSite.After(
       "java.util.Enumeration javax.servlet.http.HttpServletRequestWrapper.getHeaderNames()")
@@ -110,7 +110,7 @@ public class HttpServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_COOKIE_VALUE)
   @CallSite.After("javax.servlet.http.Cookie[] javax.servlet.http.HttpServletRequest.getCookies()")
   @CallSite.After(
       "javax.servlet.http.Cookie[] javax.servlet.http.HttpServletRequestWrapper.getCookies()")
@@ -129,7 +129,7 @@ public class HttpServletRequestCallSite {
     return cookies;
   }
 
-  @Source(SourceTypes.REQUEST_QUERY_STRING)
+  @Source(SourceTypes.REQUEST_QUERY)
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getQueryString()")
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequestWrapper.getQueryString()")
   public static String afterGetQueryString(
@@ -145,7 +145,7 @@ public class HttpServletRequestCallSite {
     return queryString;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After(
       "java.lang.String javax.servlet.http.HttpServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
@@ -165,7 +165,7 @@ public class HttpServletRequestCallSite {
     return value;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
   @CallSite.After("java.util.Enumeration javax.servlet.http.HttpServletRequest.getParameterNames()")
   @CallSite.After(
       "java.util.Enumeration javax.servlet.http.HttpServletRequestWrapper.getParameterNames()")
@@ -196,7 +196,7 @@ public class HttpServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After(
       "java.lang.String[] javax.servlet.http.HttpServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
@@ -218,7 +218,7 @@ public class HttpServletRequestCallSite {
     return parameterValues;
   }
 
-  @Source(SourceTypes.REQUEST_BODY_STRING)
+  @Source(SourceTypes.REQUEST_BODY)
   @CallSite.After("java.io.BufferedReader javax.servlet.http.HttpServletRequest.getReader()")
   @CallSite.After("java.io.BufferedReader javax.servlet.http.HttpServletRequestWrapper.getReader()")
   public static BufferedReader afterGetReader(

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestInputStreamCallSite.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class HttpServletRequestInputStreamCallSite {
 
-  @Source(SourceTypes.REQUEST_BODY_STRING)
+  @Source(SourceTypes.REQUEST_BODY)
   @CallSite.After(
       "javax.servlet.ServletInputStream javax.servlet.http.HttpServletRequest.getInputStream()")
   @CallSite.After(

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/ServletRequestCallSite.java
@@ -22,7 +22,7 @@ import javax.servlet.ServletRequest;
 @CallSite(spi = IastCallSites.class)
 public class ServletRequestCallSite {
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After("java.lang.String javax.servlet.ServletRequest.getParameter(java.lang.String)")
   @CallSite.After(
       "java.lang.String javax.servlet.ServletRequestWrapper.getParameter(java.lang.String)")
@@ -41,7 +41,7 @@ public class ServletRequestCallSite {
     return value;
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_NAME)
   @CallSite.After("java.util.Enumeration javax.servlet.ServletRequest.getParameterNames()")
   @CallSite.After("java.util.Enumeration javax.servlet.ServletRequestWrapper.getParameterNames()")
   public static Enumeration<String> afterGetParameterNames(
@@ -71,7 +71,7 @@ public class ServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   @CallSite.After(
       "java.lang.String[] javax.servlet.ServletRequest.getParameterValues(java.lang.String)")
   @CallSite.After(
@@ -93,7 +93,7 @@ public class ServletRequestCallSite {
     return parameterValues;
   }
 
-  @Source(SourceTypes.REQUEST_BODY_STRING)
+  @Source(SourceTypes.REQUEST_BODY)
   @CallSite.After("javax.servlet.ServletInputStream javax.servlet.ServletRequest.getInputStream()")
   @CallSite.After(
       "javax.servlet.ServletInputStream javax.servlet.ServletRequestWrapper.getInputStream()")
@@ -111,7 +111,7 @@ public class ServletRequestCallSite {
     return inputStream;
   }
 
-  @Source(SourceTypes.REQUEST_BODY_STRING)
+  @Source(SourceTypes.REQUEST_BODY)
   @CallSite.After("java.io.BufferedReader javax.servlet.ServletRequest.getReader()")
   @CallSite.After("java.io.BufferedReader javax.servlet.ServletRequestWrapper.getReader()")
   public static BufferedReader afterGetReader(

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HandleMatchAdvice.java
@@ -18,7 +18,7 @@ public class HandleMatchAdvice {
 
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER)
   public static void after(
       @Advice.Argument(2) ServerWebExchange xchg, @ActiveRequestContext RequestContext reqCtx) {
 

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/Jackson2TokenizerApplyAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/Jackson2TokenizerApplyAdvice.java
@@ -14,7 +14,7 @@ import reactor.core.publisher.Flux;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class Jackson2TokenizerApplyAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_BODY_STRING)
+  @Source(SourceTypes.REQUEST_BODY)
   public static void after(
       @Advice.Argument(0) DataBuffer dataBuffer,
       @Advice.Return(readOnly = false) Flux<TokenBuffer> flux) {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/RequestHeaderMapResolveAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/RequestHeaderMapResolveAdvice.java
@@ -16,7 +16,7 @@ import org.springframework.util.MultiValueMap;
 @RequiresRequestContext(RequestContextSlot.IAST)
 public class RequestHeaderMapResolveAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE)
   public static void after(@Advice.Return(typing = Assigner.Typing.DYNAMIC) Map<String, ?> values) {
     WebModule module = InstrumentationBridge.WEB;
     PropagationModule prop = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
@@ -14,7 +14,7 @@ import net.bytebuddy.asm.Advice;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class TaintHttpHeadersGetAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE)
   public static void after(@Advice.Argument(0) Object arg, @Advice.Return List<String> values) {
     PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || values == null) {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
@@ -12,7 +12,7 @@ import net.bytebuddy.asm.Advice;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class TaintHttpHeadersGetFirstAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE)
   public static void after(@Advice.Argument(0) String arg, @Advice.Return String value) {
     PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || arg == null || value == null) {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
@@ -15,7 +15,7 @@ import org.springframework.http.HttpHeaders;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class TaintHttpHeadersToSingleValueMapAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_HEADER_VALUE)
   public static void after(@Advice.Return Map<String, String> values) {
     PropagationModule propModule = InstrumentationBridge.PROPAGATION;
     WebModule module = InstrumentationBridge.WEB;

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintQueryParamsAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintQueryParamsAdvice.java
@@ -17,7 +17,7 @@ class TaintQueryParamsAdvice {
 
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class)
-  @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+  @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   public static void after(@Advice.Return MultiValueMap<String, String> queryParams) {
     final WebModule web = InstrumentationBridge.WEB;
     final PropagationModule prop = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
@@ -85,7 +85,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends Instrumenter.Defa
 
     @SuppressWarnings("Duplicates")
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    @Source(SourceTypes.REQUEST_MATRIX_PARAMETER_STRING)
+    @Source(SourceTypes.REQUEST_MATRIX_PARAMETER)
     public static void after(
         @Advice.Argument(2) final HttpServletRequest req,
         @Advice.Thrown(readOnly = false) Throwable t) {

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -74,7 +74,7 @@ public class TemplateVariablesUrlHandlerInstrumentation extends Instrumenter.Def
 
     @SuppressWarnings("Duplicates")
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER)
     public static void after(
         @Advice.Argument(0) final HttpServletRequest req,
         @Advice.Thrown(readOnly = false) Throwable t) {

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
@@ -28,7 +28,7 @@ public class HandleMatchAdvice {
 
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER)
   public static void after(
       @Advice.Argument(2) final HttpServletRequest req,
       @Advice.Thrown(readOnly = false) Throwable t) {

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
@@ -25,7 +25,7 @@ public class InterceptorPreHandleAdvice {
 
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER)
   public static void after(
       @Advice.Argument(0) final HttpServletRequest req,
       @Advice.Thrown(readOnly = false) Throwable t) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
@@ -60,7 +60,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
 
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
         @Advice.Local("beforeParams") final Object beforeParams,
         @Advice.Return final Object multiMap) {
@@ -88,7 +88,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
 
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
         @Advice.Local("beforeAttributes") final Object beforeAttributes,
         @Advice.Return final Object multiMap) {
@@ -109,7 +109,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class DataAdvice {
 
     @Advice.OnMethodEnter
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     public static void onExit(@Advice.Argument(0) final Object data) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/CaseInsensitiveHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/CaseInsensitiveHeadersInstrumentation.java
@@ -74,7 +74,7 @@ public class CaseInsensitiveHeadersInstrumentation extends Instrumenter.Iast
 
   public static class GetAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final String name,
@@ -93,7 +93,7 @@ public class CaseInsensitiveHeadersInstrumentation extends Instrumenter.Iast
 
   public static class GetAllAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final String name,
@@ -112,7 +112,7 @@ public class CaseInsensitiveHeadersInstrumentation extends Instrumenter.Iast
 
   public static class EntriesAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void afterEntries(
         @Advice.This final Object self,
         @Advice.Return final List<Map.Entry<String, String>> result) {
@@ -129,7 +129,7 @@ public class CaseInsensitiveHeadersInstrumentation extends Instrumenter.Iast
 
   public static class NamesAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_PARAMETER_NAME_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_NAME)
     public static void afterNames(
         @Advice.This final Object self, @Advice.Return final Set<String> result) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HeadersAdaptorInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HeadersAdaptorInstrumentation.java
@@ -66,7 +66,7 @@ public class HeadersAdaptorInstrumentation extends Instrumenter.Iast
 
   public static class GetAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -88,7 +88,7 @@ public class HeadersAdaptorInstrumentation extends Instrumenter.Iast
 
   public static class GetAllAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -110,7 +110,7 @@ public class HeadersAdaptorInstrumentation extends Instrumenter.Iast
 
   public static class EntriesAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterEntries(
         @Advice.This final Object self,
         @Advice.Return final List<Map.Entry<String, String>> result) {
@@ -127,7 +127,7 @@ public class HeadersAdaptorInstrumentation extends Instrumenter.Iast
 
   public static class NamesAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_NAME_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_NAME)
     public static void afterNames(
         @Advice.This final Object self, @Advice.Return final Set<String> result) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
@@ -46,7 +46,7 @@ public class Http2ServerRequestInstrumentation extends AbstractHttpServerRequest
     }
 
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(
         @Advice.Local("beforeHeaders") final Object beforeHeaders,
         @Advice.Return final Object multiMap) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
@@ -47,7 +47,7 @@ public class HttpServerRequestInstrumentation extends AbstractHttpServerRequestI
     }
 
     @Advice.OnMethodExit()
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(
         @Advice.Local("beforeHeaders") final Object beforeHeaders,
         @Advice.Return final Object multiMap) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/CookieImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/CookieImplInstrumentation.java
@@ -52,7 +52,7 @@ public class CookieImplInstrumentation extends Instrumenter.Iast
 
   public static class GetNameAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_COOKIE_NAME_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_NAME)
     public static void afterGetName(
         @Advice.This final Cookie self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
@@ -69,7 +69,7 @@ public class CookieImplInstrumentation extends Instrumenter.Iast
   public static class GetValueAdvice {
 
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void afterGetValue(
         @Advice.This final Cookie self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
@@ -53,7 +53,7 @@ public class IastRoutingContextImplInstrumentation extends Instrumenter.Iast
 
   public static class CookiesAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void onCookies(@Advice.Return final Set<Object> cookies) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       try {
@@ -66,7 +66,7 @@ public class IastRoutingContextImplInstrumentation extends Instrumenter.Iast
 
   public static class GetCookieAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void onGetCookie(@Advice.Return final Object cookie) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteMatchesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteMatchesAdvice.java
@@ -8,7 +8,7 @@ import net.bytebuddy.asm.Advice;
 
 class RouteMatchesAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER)
   static void after(
       @Advice.Return int ret,
       @Advice.Argument(0) final RoutingContext ctx,
@@ -27,7 +27,7 @@ class RouteMatchesAdvice {
 
   static class BooleanReturnVariant {
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER)
     static void after(
         @Advice.Return boolean ret,
         @Advice.Argument(0) final RoutingContext ctx,

--- a/dd-java-agent/instrumentation/vertx-web-3.5/src/main/java/datadog/trace/instrumentation/vertx_3_5/core/VertxHttpHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.5/src/main/java/datadog/trace/instrumentation/vertx_3_5/core/VertxHttpHeadersInstrumentation.java
@@ -72,7 +72,7 @@ public class VertxHttpHeadersInstrumentation extends Instrumenter.Iast
 
   public static class GetAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -94,7 +94,7 @@ public class VertxHttpHeadersInstrumentation extends Instrumenter.Iast
 
   public static class GetAllAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
@@ -116,7 +116,7 @@ public class VertxHttpHeadersInstrumentation extends Instrumenter.Iast
 
   public static class EntriesAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterEntries(
         @Advice.This final Object self,
         @Advice.Return final List<Map.Entry<String, String>> result) {
@@ -133,7 +133,7 @@ public class VertxHttpHeadersInstrumentation extends Instrumenter.Iast
 
   public static class NamesAdvice {
     @Advice.OnMethodExit
-    @Source(SourceTypes.REQUEST_HEADER_NAME_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_NAME)
     public static void afterNames(
         @Advice.This final Object self, @Advice.Return final Set<String> result) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
@@ -69,7 +69,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
         @Advice.Local("beforeParams") final Object beforeParams,
         @Advice.Return final Object multiMap) {
@@ -93,7 +93,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_PARAMETER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
         @Advice.Local("beforeAttributes") final Object beforeAttributes,
         @Advice.Return final Object multiMap) {
@@ -110,7 +110,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class HeadersAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(@Advice.Return final Object multiMap) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -122,7 +122,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class DataAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_BODY_STRING)
+    @Source(SourceTypes.REQUEST_BODY)
     public static void onExit(@Advice.Argument(0) final Object data) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -134,7 +134,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class CookiesAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void onExit(@Advice.Return final Set<Object> cookies) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
@@ -146,7 +146,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
   public static class GetCookieAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void onExit(@Advice.Return final Object cookie) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/CookieImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/CookieImplInstrumentation.java
@@ -50,7 +50,7 @@ public class CookieImplInstrumentation extends Instrumenter.Iast
 
   public static class GetNameAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_NAME_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_NAME)
     public static void afterGetName(
         @Advice.This final Cookie self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
@@ -63,7 +63,7 @@ public class CookieImplInstrumentation extends Instrumenter.Iast
   public static class GetValueAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_COOKIE_VALUE_STRING)
+    @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void afterGetValue(
         @Advice.This final Cookie self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteMatchesAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteMatchesAdvice.java
@@ -8,7 +8,7 @@ import net.bytebuddy.asm.Advice;
 
 class RouteMatchesAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-  @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+  @Source(SourceTypes.REQUEST_PATH_PARAMETER)
   static void after(
       @Advice.Return int ret,
       @Advice.Argument(0) final RoutingContext ctx,
@@ -27,7 +27,7 @@ class RouteMatchesAdvice {
 
   static class BooleanReturnVariant {
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    @Source(SourceTypes.REQUEST_PATH_PARAMETER_STRING)
+    @Source(SourceTypes.REQUEST_PATH_PARAMETER)
     static void after(
         @Advice.Return boolean ret,
         @Advice.Argument(0) final RoutingContext ctx,

--- a/internal-api/src/main/java/datadog/trace/api/iast/Sink.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/Sink.java
@@ -9,5 +9,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Sink {
   /** Vulnerability type */
-  String value();
+  byte value();
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/Source.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/Source.java
@@ -9,5 +9,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Source {
   /** Source type */
-  String value();
+  byte value();
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
@@ -4,44 +4,44 @@ public abstract class SourceTypes {
 
   private SourceTypes() {}
 
-  public static final byte NONE = 0;
+  public static final byte NONE = -1;
 
-  public static final byte REQUEST_PARAMETER_NAME = 1;
+  public static final byte REQUEST_PARAMETER_NAME = 0;
   public static final String REQUEST_PARAMETER_NAME_STRING = "http.request.parameter.name";
-  public static final byte REQUEST_PARAMETER_VALUE = 2;
+  public static final byte REQUEST_PARAMETER_VALUE = 1;
   public static final String REQUEST_PARAMETER_VALUE_STRING = "http.request.parameter";
-  public static final byte REQUEST_HEADER_NAME = 3;
+  public static final byte REQUEST_HEADER_NAME = 2;
   public static final String REQUEST_HEADER_NAME_STRING = "http.request.header.name";
-  public static final byte REQUEST_HEADER_VALUE = 4;
+  public static final byte REQUEST_HEADER_VALUE = 3;
   public static final String REQUEST_HEADER_VALUE_STRING = "http.request.header";
-  public static final byte REQUEST_COOKIE_NAME = 5;
+  public static final byte REQUEST_COOKIE_NAME = 4;
   public static final String REQUEST_COOKIE_NAME_STRING = "http.request.cookie.name";
-  public static final byte REQUEST_COOKIE_VALUE = 6;
+  public static final byte REQUEST_COOKIE_VALUE = 5;
   public static final String REQUEST_COOKIE_VALUE_STRING = "http.request.cookie.value";
-  public static final byte REQUEST_BODY = 7;
+  public static final byte REQUEST_BODY = 6;
   public static final String REQUEST_BODY_STRING = "http.request.body";
-  public static final byte REQUEST_QUERY = 8;
+  public static final byte REQUEST_QUERY = 7;
   public static final String REQUEST_QUERY_STRING = "http.request.query";
-  public static final byte REQUEST_PATH_PARAMETER = 9;
+  public static final byte REQUEST_PATH_PARAMETER = 8;
   public static final String REQUEST_PATH_PARAMETER_STRING = "http.request.path.parameter";
-  public static final byte REQUEST_MATRIX_PARAMETER = 10;
+  public static final byte REQUEST_MATRIX_PARAMETER = 9;
   public static final String REQUEST_MATRIX_PARAMETER_STRING = "http.request.matrix.parameter";
 
-  private static final String[] values = {
-    REQUEST_PARAMETER_NAME_STRING,
-    REQUEST_PARAMETER_VALUE_STRING,
-    REQUEST_HEADER_NAME_STRING,
-    REQUEST_HEADER_VALUE_STRING,
-    REQUEST_COOKIE_NAME_STRING,
-    REQUEST_COOKIE_VALUE_STRING,
-    REQUEST_BODY_STRING,
-    REQUEST_QUERY_STRING,
-    REQUEST_PATH_PARAMETER_STRING,
-    REQUEST_MATRIX_PARAMETER_STRING
+  private static final byte[] VALUES = {
+    REQUEST_PARAMETER_NAME,
+    REQUEST_PARAMETER_VALUE,
+    REQUEST_HEADER_NAME,
+    REQUEST_HEADER_VALUE,
+    REQUEST_COOKIE_NAME,
+    REQUEST_COOKIE_VALUE,
+    REQUEST_BODY,
+    REQUEST_QUERY,
+    REQUEST_PATH_PARAMETER,
+    REQUEST_MATRIX_PARAMETER
   };
 
-  public static String[] values() {
-    return values;
+  public static byte[] values() {
+    return VALUES;
   }
 
   public static String toString(final byte sourceType) {

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -4,42 +4,64 @@ public abstract class VulnerabilityTypes {
 
   private VulnerabilityTypes() {}
 
-  public static final String WEAK_CIPHER = "WEAK_CIPHER";
-  public static final String WEAK_HASH = "WEAK_HASH";
-  public static final String SQL_INJECTION = "SQL_INJECTION";
-  public static final String COMMAND_INJECTION = "COMMAND_INJECTION";
-  public static final String PATH_TRAVERSAL = "PATH_TRAVERSAL";
-  public static final String LDAP_INJECTION = "LDAP_INJECTION";
-  public static final String SSRF = "SSRF";
-  public static final String INSECURE_COOKIE = "INSECURE_COOKIE";
-  public static final String NO_HTTPONLY_COOKIE = "NO_HTTPONLY_COOKIE";
-  public static final String HSTS_HEADER_MISSING = "HSTS_HEADER_MISSING";
-  public static final String XCONTENTTYPE_HEADER_MISSING = "XCONTENTTYPE_HEADER_MISSING";
-  public static final String NO_SAMESITE_COOKIE = "NO_SAMESITE_COOKIE";
-  public static final String UNVALIDATED_REDIRECT = "UNVALIDATED_REDIRECT";
-  public static final String WEAK_RANDOMNESS = "WEAK_RANDOMNESS";
-  public static final String XPATH_INJECTION = "XPATH_INJECTION";
+  public static final byte WEAK_CIPHER = 0;
+  public static final String WEAK_CIPHER_STRING = "WEAK_CIPHER";
+  public static final byte WEAK_HASH = 1;
+  public static final String WEAK_HASH_STRING = "WEAK_HASH";
+  public static final byte SQL_INJECTION = 2;
+  public static final String SQL_INJECTION_STRING = "SQL_INJECTION";
+  public static final byte COMMAND_INJECTION = 3;
+  public static final String COMMAND_INJECTION_STRING = "COMMAND_INJECTION";
+  public static final byte PATH_TRAVERSAL = 4;
+  public static final String PATH_TRAVERSAL_STRING = "PATH_TRAVERSAL";
+  public static final byte LDAP_INJECTION = 5;
+  public static final String LDAP_INJECTION_STRING = "LDAP_INJECTION";
+  public static final byte SSRF = 6;
+  public static final String SSRF_STRING = "SSRF";
+  public static final byte INSECURE_COOKIE = 7;
+  public static final String INSECURE_COOKIE_STRING = "INSECURE_COOKIE";
+  public static final byte NO_HTTPONLY_COOKIE = 8;
+  public static final String NO_HTTPONLY_COOKIE_STRING = "NO_HTTPONLY_COOKIE";
+  public static final byte HSTS_HEADER_MISSING = 9;
+  public static final String HSTS_HEADER_MISSING_STRING = "HSTS_HEADER_MISSING";
+  public static final byte XCONTENTTYPE_HEADER_MISSING = 10;
+  public static final String XCONTENTTYPE_HEADER_MISSING_STRING = "XCONTENTTYPE_HEADER_MISSING";
+  public static final byte NO_SAMESITE_COOKIE = 11;
+  public static final String NO_SAMESITE_COOKIE_STRING = "NO_SAMESITE_COOKIE";
+  public static final byte UNVALIDATED_REDIRECT = 12;
+  public static final String UNVALIDATED_REDIRECT_STRING = "UNVALIDATED_REDIRECT";
+  public static final byte WEAK_RANDOMNESS = 13;
+  public static final String WEAK_RANDOMNESS_STRING = "WEAK_RANDOMNESS";
+  public static final byte XPATH_INJECTION = 14;
+  public static final String XPATH_INJECTION_STRING = "XPATH_INJECTION";
+  public static final byte TRUST_BOUNDARY_VIOLATION = 15;
+  public static final String TRUST_BOUNDARY_VIOLATION_STRING = "TRUST_BOUNDARY_VIOLATION";
+  public static final byte XSS = 16;
+  public static final String XSS_STRING = "XSS";
 
-  public static final String TRUST_BOUNDARY_VIOLATION = "TRUST_BOUNDARY_VIOLATION";
-
-  public static final String XSS = "XSS";
   /**
    * Use for telemetry only, this is a special vulnerability type that is not reported, reported
    * values will be {@link #RESPONSE_HEADER_TYPES}
    */
-  public static final String RESPONSE_HEADER = "RESPONSE_HEADER";
+  public static final byte RESPONSE_HEADER = -1;
 
-  public static final String[] RESPONSE_HEADER_TYPES = {UNVALIDATED_REDIRECT, INSECURE_COOKIE};
+  public static final byte[] RESPONSE_HEADER_TYPES = {
+    UNVALIDATED_REDIRECT,
+    INSECURE_COOKIE,
+    NO_SAMESITE_COOKIE,
+    XCONTENTTYPE_HEADER_MISSING,
+    HSTS_HEADER_MISSING
+  };
 
   /**
    * Use for telemetry only, this is a special vulnerability type that is not reported, reported
    * values will be {@link #SPRING_RESPONSE_TYPES}
    */
-  public static final String SPRING_RESPONSE = "SPRING_RESPONSE";
+  public static final byte SPRING_RESPONSE = -2;
   /** Use for spring unvalidated redirect and xss */
-  public static final String[] SPRING_RESPONSE_TYPES = {UNVALIDATED_REDIRECT, XSS};
+  public static final byte[] SPRING_RESPONSE_TYPES = {UNVALIDATED_REDIRECT, XSS};
 
-  private static final String[] values = {
+  private static final byte[] VALUES = {
     WEAK_CIPHER,
     WEAK_HASH,
     SQL_INJECTION,
@@ -55,10 +77,52 @@ public abstract class VulnerabilityTypes {
     TRUST_BOUNDARY_VIOLATION,
     HSTS_HEADER_MISSING,
     XCONTENTTYPE_HEADER_MISSING,
+    NO_SAMESITE_COOKIE,
     XSS
   };
 
-  public static String[] values() {
-    return values;
+  public static byte[] values() {
+    return VALUES;
+  }
+
+  public static String toString(final byte sourceType) {
+    switch (sourceType) {
+      case VulnerabilityTypes.WEAK_CIPHER:
+        return VulnerabilityTypes.WEAK_CIPHER_STRING;
+      case VulnerabilityTypes.WEAK_HASH:
+        return VulnerabilityTypes.WEAK_HASH_STRING;
+      case VulnerabilityTypes.SQL_INJECTION:
+        return VulnerabilityTypes.SQL_INJECTION_STRING;
+      case VulnerabilityTypes.COMMAND_INJECTION:
+        return VulnerabilityTypes.COMMAND_INJECTION_STRING;
+      case VulnerabilityTypes.PATH_TRAVERSAL:
+        return VulnerabilityTypes.PATH_TRAVERSAL_STRING;
+      case VulnerabilityTypes.LDAP_INJECTION:
+        return VulnerabilityTypes.LDAP_INJECTION_STRING;
+      case VulnerabilityTypes.SSRF:
+        return VulnerabilityTypes.SSRF_STRING;
+      case VulnerabilityTypes.INSECURE_COOKIE:
+        return VulnerabilityTypes.INSECURE_COOKIE_STRING;
+      case VulnerabilityTypes.NO_HTTPONLY_COOKIE:
+        return VulnerabilityTypes.NO_HTTPONLY_COOKIE_STRING;
+      case VulnerabilityTypes.UNVALIDATED_REDIRECT:
+        return VulnerabilityTypes.UNVALIDATED_REDIRECT_STRING;
+      case VulnerabilityTypes.WEAK_RANDOMNESS:
+        return VulnerabilityTypes.WEAK_RANDOMNESS_STRING;
+      case VulnerabilityTypes.XPATH_INJECTION:
+        return VulnerabilityTypes.XPATH_INJECTION_STRING;
+      case VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION:
+        return VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION_STRING;
+      case VulnerabilityTypes.HSTS_HEADER_MISSING:
+        return VulnerabilityTypes.HSTS_HEADER_MISSING_STRING;
+      case VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING:
+        return VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING_STRING;
+      case VulnerabilityTypes.NO_SAMESITE_COOKIE:
+        return VulnerabilityTypes.NO_SAMESITE_COOKIE_STRING;
+      case VulnerabilityTypes.XSS:
+        return VulnerabilityTypes.XSS_STRING;
+      default:
+        return null;
+    }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.iast.telemetry.IastMetric.Scope.REQUEST;
 import datadog.trace.api.Config;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.telemetry.IastMetric.Tag;
 import datadog.trace.api.telemetry.MetricCollector;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -76,19 +77,19 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
     add(metric, value, null);
   }
 
-  /** Prefer using {@link #add(IastMetric, String, int, Object)} if possible */
-  public static void add(@Nonnull final IastMetric metric, final String tagValue, final int value) {
+  public static void add(
+      @Nonnull final IastMetric metric, final int value, @Nullable final Object ctx) {
+    add(metric, (byte) -1, value, null);
+  }
+
+  /** Prefer using {@link #add(IastMetric, byte, int, Object)} if possible */
+  public static void add(@Nonnull final IastMetric metric, final byte tagValue, final int value) {
     add(metric, tagValue, value, null);
   }
 
   public static void add(
-      @Nonnull final IastMetric metric, final int value, @Nullable final Object ctx) {
-    add(metric, null, value, ctx);
-  }
-
-  public static void add(
       @Nonnull final IastMetric metric,
-      @Nullable final String tagValue,
+      final byte tagValue,
       final int value,
       @Nullable final Object ctx) {
     try {
@@ -99,14 +100,20 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
     }
   }
 
-  public void addMetric(final IastMetric metric, final String tagValue, final int value) {
-    final int index = metric.getIndex(tagValue);
-    if (index < 0) {
+  public void addMetric(final IastMetric metric, final byte tagValue, final int value) {
+    final Tag tag = metric.getTag();
+    if (tag != null && tag.isWrapped(tagValue)) {
       // e.g.: VulnerabilityTypes.RESPONSE_HEADER
-      for (final String tag : metric.getTag().parse(tagValue)) {
-        counters.getAndAdd(metric.getIndex(tag), value);
+      for (final byte unwrapped : metric.getTag().unwrap(tagValue)) {
+        increment(metric.getIndex(unwrapped), value);
       }
     } else {
+      increment(metric.getIndex(tagValue), value);
+    }
+  }
+
+  private void increment(final int index, final int value) {
+    if (index >= 0) {
       counters.getAndAdd(index, value);
     }
   }
@@ -114,7 +121,7 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
   public void merge(final Collection<IastMetricData> metrics) {
     for (final IastMetricData data : metrics) {
       final IastMetric metric = data.metric;
-      final String tagValue = data.tagValue;
+      final byte tagValue = data.tagValue;
       final long value = data.value.longValue();
       counters.getAndAdd(metric.getIndex(tagValue), value);
     }
@@ -124,16 +131,16 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
   public void prepareMetrics() {
     for (final IastMetric metric : IastMetric.values()) {
       if (metric.getTag() == null) {
-        prepareMetric(metric, null);
+        prepareMetric(metric, (byte) -1);
       } else {
-        for (final String tagValue : metric.getTag().getValues()) {
+        for (final byte tagValue : metric.getTag().getValues()) {
           prepareMetric(metric, tagValue);
         }
       }
     }
   }
 
-  private void prepareMetric(final IastMetric metric, final String tagValue) {
+  private void prepareMetric(final IastMetric metric, final byte tagValue) {
     final int index = metric.getIndex(tagValue);
     final long value = counters.getAndSet(index, 0);
     if (value > 0) {
@@ -156,9 +163,9 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
   public static class IastMetricData extends MetricCollector.Metric {
 
     private final IastMetric metric;
-    private final String tagValue;
+    private final byte tagValue;
 
-    public IastMetricData(final IastMetric metric, final String tagValue, final long value) {
+    public IastMetricData(final IastMetric metric, final byte tagValue, final long value) {
       super(
           NAMESPACE,
           metric.isCommon(),
@@ -174,25 +181,24 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
       return metric;
     }
 
-    public String getTagValue() {
+    public byte getTagValue() {
       return tagValue;
     }
 
     public String getSpanTag() {
-      return metric.getTag() == null
-          ? metric.getName()
-          : String.format("%s.%s", metric.getName(), processSpanTagValue(tagValue));
+      if (metric.getTag() == null) {
+        return metric.getName();
+      }
+      final String tag = metric.getTag().toString(tagValue);
+      final String spanTag = tag.toLowerCase(Locale.ROOT).replace('.', '_');
+      return String.format("%s.%s", metric.getName(), spanTag);
     }
 
-    private static String processSpanTagValue(final String tagValue) {
-      return tagValue.toLowerCase(Locale.ROOT).replace('.', '_');
-    }
-
-    public static String computeTag(final IastMetric metric, final String tagValue) {
+    public static String computeTag(final IastMetric metric, final byte tagValue) {
       if (metric.getTag() == null) {
         return null;
       }
-      return String.format("%s:%s", metric.getTag().getName(), tagValue);
+      return String.format("%s:%s", metric.getTag().getName(), metric.getTag().toString(tagValue));
     }
   }
 
@@ -208,7 +214,7 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
     }
 
     @Override
-    public void addMetric(final IastMetric metric, final String tagValue, final int value) {}
+    public void addMetric(final IastMetric metric, final byte tagValue, final int value) {}
 
     @Override
     public void merge(final Collection<IastMetricData> metrics) {}

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.api.iast.telemetry
 
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.VulnerabilityTypes
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
@@ -61,7 +62,7 @@ class IastMetricCollectorTest extends DDSpecification {
     result.empty
   }
 
-  void 'test collectors'() {
+  void 'test collector in heavy concurrency'() {
     given:
     final times = 1000
     final value = 5
@@ -76,9 +77,13 @@ class IastMetricCollectorTest extends DDSpecification {
     final futures = (1..times).collect { i ->
       executor.submit {
         final metric = metrics[random.nextInt(metrics.length)]
-        final tag = metric.tag == null ? null : metric.tag.values[random.nextInt(metric.tag.values.length)]
         latch.await()
-        IastMetricCollector.add(metric, tag, value)
+        if (metric.tag == null) {
+          IastMetricCollector.add(metric, value)
+        } else {
+          final tag = metric.tag.values[random.nextInt(metric.tag.values.length)]
+          IastMetricCollector.add(metric, tag, value)
+        }
       }
     }
     latch.countDown()
@@ -96,13 +101,11 @@ class IastMetricCollectorTest extends DDSpecification {
   void 'test no op collector does nothing'() {
     setup:
     final collector = new NoOpInstance()
-    final metric = IastMetric.EXECUTED_PROPAGATION
-    final tag = null
-
-    when:
+    final metric = IastMetric.EXECUTED_SINK
+    final tag = VulnerabilityTypes.SQL_INJECTION
 
     when: 'adding a metric'
-    collector.addMetric(metric, tag, 23)
+    collector.addMetric(metric, tag, 1)
     collector.prepareMetrics()
     final collectorMetrics = collector.drain()
 
@@ -110,7 +113,7 @@ class IastMetricCollectorTest extends DDSpecification {
     collectorMetrics.empty
 
     when: 'merging metrics'
-    collector.merge([new IastMetricCollector.IastMetricData(metric, tag, 23)])
+    collector.merge([new IastMetricCollector.IastMetricData(metric, tag, 100)])
     collector.prepareMetrics()
     final mergedMetrics = collector.drain()
 
@@ -153,41 +156,71 @@ class IastMetricCollectorTest extends DDSpecification {
     0 * _
   }
 
-  void 'test metric tags/span tags'() {
-    given:
-    final metric = IastMetric.INSTRUMENTED_SINK
-    final tag = VulnerabilityTypes.SQL_INJECTION
-
+  void 'test metric tags/span tags: #metric'() {
     when:
-    final withTag = new IastMetricCollector.IastMetricData(metric, tag, 1)
+    final data = new IastMetricCollector.IastMetricData(metric, tag, 1)
 
     then:
-    withTag.tags == ["${metric.tag.name}:${tag}"]
-    withTag.spanTag == "${metric.name}.${tag.toLowerCase().replaceAll('\\.', '_')}"
+    if (metric.tag) {
+      final tagString = metric.tag.toString(tag)
+      data.tags.size() == 1
+      data.tags.first() == "${metric.tag.name}:${tagString}"
+      data.spanTag == "${metric.name}.${tagString.toLowerCase().replaceAll('\\.', '_')}"
+    } else {
+      data.tags.empty
+      data.spanTag == metric.name
+    }
+
+    where:
+    metric                         | tag
+    IastMetric.INSTRUMENTED_SINK   | VulnerabilityTypes.SQL_INJECTION
+    IastMetric.INSTRUMENTED_SOURCE | SourceTypes.REQUEST_HEADER_NAME
+    IastMetric.EXECUTED_TAINTED    | (byte) -1
   }
 
-  void 'test metrics with multiple tags'() {
+  void 'test metric: #metric'() {
     given:
     final collector = new IastMetricCollector()
-    final metric = IastMetric.INSTRUMENTED_SINK
-    final tag = VulnerabilityTypes.RESPONSE_HEADER
-    final value = 1
+    final value = 125
 
     when:
-    collector.addMetric(metric, tag, value)
+    collector.addMetric(metric, metric.tag == null ? (byte) -1 : tag, value)
     collector.prepareMetrics()
     final result = collector.drain()
 
-    then: 'multiple data points are added'
-
-    result.size() == 2
-    final grouped = result.groupBy { it.tags.first() }
-    VulnerabilityTypes.RESPONSE_HEADER_TYPES.each {
-      final tagValue = "${metric.tag.name}:${it}"
-      final data = grouped[tagValue].first()
-      assert data.metric == metric
-      assert data.value.toLong() == value
-      assert data.tags == [tagValue]
+    then:
+    if (metric.tag) {
+      final assertedTags = metric.tag.isWrapped(tag) ? metric.tag.unwrap(tag) : [tag]
+      result.size() == assertedTags
+      final grouped = result.groupBy { it.tags.first() }
+      assertedTags.each {
+        final tagValue = "${metric.tag.name}:${metric.tag.toString(it as byte)}"
+        final data = grouped[tagValue].first()
+        assert data.metric == metric
+        assert data.value.toLong() == value
+        assert data.tags.size() == 1
+        assert data.tags.first() == tagValue
+      }
+    } else {
+      result.size() == 1
+      final data = result.first()
+      data.metric == metric
+      data.value.toLong() == value
+      data.tags.empty
     }
+
+    where:
+    metric                         | tag
+    IastMetric.INSTRUMENTED_SINK   | VulnerabilityTypes.SQL_INJECTION
+    IastMetric.EXECUTED_SINK       | VulnerabilityTypes.SQL_INJECTION
+
+    IastMetric.INSTRUMENTED_SINK   | VulnerabilityTypes.RESPONSE_HEADER // wrapped one
+    IastMetric.EXECUTED_SINK       | VulnerabilityTypes.RESPONSE_HEADER
+
+    IastMetric.INSTRUMENTED_SOURCE | SourceTypes.REQUEST_HEADER_NAME
+    IastMetric.EXECUTED_SOURCE     | SourceTypes.REQUEST_HEADER_NAME
+
+    IastMetric.EXECUTED_TAINTED    | null
+    IastMetric.TAINTED_FLAT_MODE   | null
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricTest.groovy
@@ -30,15 +30,15 @@ class IastMetricTest extends Specification {
 
   void 'test parsing of tags'() {
     when:
-    final result = metricTag.parse(tag)
+    final result = metricTag.unwrap(tag)
 
     then:
     result == expected
 
     where:
-    metricTag                         | tag                                        | expected
-    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.RESPONSE_HEADER         | VulnerabilityTypes.RESPONSE_HEADER_TYPES
-    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.SQL_INJECTION           | new String[0]
-    IastMetric.Tag.SOURCE_TYPE        | SourceTypes.REQUEST_PARAMETER_VALUE_STRING | new String[0]
+    metricTag                         | tag                                 | expected
+    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.RESPONSE_HEADER  | VulnerabilityTypes.RESPONSE_HEADER_TYPES
+    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.SQL_INJECTION    | new byte[0]
+    IastMetric.Tag.SOURCE_TYPE        | SourceTypes.REQUEST_PARAMETER_VALUE | new byte[0]
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/IastMetricPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/IastMetricPeriodicActionTest.groovy
@@ -33,7 +33,8 @@ class IastMetricPeriodicActionTest extends Specification {
     final action = new IastMetricPeriodicAction()
     final service = Mock(TelemetryService)
     final iastMetric = IastMetric.INSTRUMENTED_SOURCE
-    final tag = SourceTypes.REQUEST_PARAMETER_VALUE_STRING
+    final tag = SourceTypes.REQUEST_PARAMETER_VALUE
+    final tagString = SourceTypes.REQUEST_PARAMETER_VALUE_STRING
     final value = 23
 
     when:
@@ -42,7 +43,7 @@ class IastMetricPeriodicActionTest extends Specification {
     action.doIteration(service)
 
     then:
-    1 * service.addMetric({ matches(it, iastMetric, value, ["${iastMetric.tag.name}:${tag}"]) })
+    1 * service.addMetric({ matches(it, iastMetric, value, ["${iastMetric.tag.name}:${tagString}"]) })
     0 * _
   }
 


### PR DESCRIPTION
# What Does This Do
Uses bytes instead of strings for the tags values in IAST metrics, it's not until building the final metric that the byte value is converted to its string representation.

# Motivation
We detected a performance bottleneck due to IAST tag computation due to the heavy usage of metrics.

# Additional Notes
