### PR TITLE
Upgrade to ddprof 0.73.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.72.0",
+    ddprof        : "0.73.0",
     asm           : "9.5",
     cafe_crypto   : "0.1.0"
   ]


### PR DESCRIPTION
# What Does This Do

Upgrades to ddprof 0.73.0, which:
*  normalises metadata for classes and methods associated with reflection (`LambdaForm`, `GeneratedConstructorAccessor`, `GeneratedMethodAccessor` to use less memory and produce smaller recordings). 
* Removes potential memory leak when JVMTI fails to provide some but not all metadata attributes

# Motivation

# Additional Notes
