### PR TITLE
Imlpement ITR unskippable tests for JUnit 5

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestFrameworkModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestFrameworkModule.java
@@ -17,6 +17,15 @@ public interface DDTestFrameworkModule {
    * @param test Test to be checked
    * @return {@code true} if the test can be skipped, {@code false} otherwise
    */
+  boolean isSkippable(SkippableTest test);
+
+  /**
+   * Checks if a given test can be skipped with Intelligent Test Runner or not. It the test is
+   * considered skippable, the count of skippable tests is incremented.
+   *
+   * @param test Test to be checked
+   * @return {@code true} if the test can be skipped, {@code false} otherwise
+   */
   boolean skip(SkippableTest test);
 
   void end(Long startTime);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestFrameworkModuleProxy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestFrameworkModuleProxy.java
@@ -17,8 +17,10 @@ import datadog.trace.civisibility.ipc.TestFramework;
 import datadog.trace.civisibility.source.MethodLinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 import javax.annotation.Nullable;
@@ -46,8 +48,7 @@ public class DDTestFrameworkModuleProxy implements DDTestFrameworkModule {
   private final MethodLinesResolver methodLinesResolver;
   private final CoverageProbeStoreFactory coverageProbeStoreFactory;
   private final LongAdder testsSkipped = new LongAdder();
-  private final Object skippableTestsInitLock = new Object();
-  private volatile Collection<SkippableTest> skippableTests;
+  private final Collection<SkippableTest> skippableTests;
   private final Collection<TestFramework> testFrameworks = ConcurrentHashMap.newKeySet();
 
   public DDTestFrameworkModuleProxy(
@@ -73,40 +74,41 @@ public class DDTestFrameworkModuleProxy implements DDTestFrameworkModule {
     this.codeowners = codeowners;
     this.methodLinesResolver = methodLinesResolver;
     this.coverageProbeStoreFactory = coverageProbeStoreFactory;
+    this.skippableTests = fetchSkippableTests(moduleName, signalServerAddress);
+  }
+
+  private Collection<SkippableTest> fetchSkippableTests(
+      String moduleName, InetSocketAddress signalServerAddress) {
+    if (!config.isCiVisibilityItrEnabled()) {
+      return Collections.emptyList();
+    }
+
+    SkippableTestsRequest request = new SkippableTestsRequest(moduleName, JvmInfo.CURRENT_JVM);
+    try (SignalClient signalClient = new SignalClient(signalServerAddress)) {
+      SkippableTestsResponse response = (SkippableTestsResponse) signalClient.send(request);
+      Collection<SkippableTest> moduleSkippableTests = response.getTests();
+      log.debug("Received {} skippable tests", moduleSkippableTests.size());
+      return moduleSkippableTests.size() > 100
+          ? new HashSet<>(moduleSkippableTests)
+          : new ArrayList<>(moduleSkippableTests);
+    } catch (Exception e) {
+      log.error("Error while requesting skippable tests", e);
+      return Collections.emptySet();
+    }
+  }
+
+  @Override
+  public boolean isSkippable(SkippableTest test) {
+    return test != null && skippableTests.contains(test);
   }
 
   @Override
   public boolean skip(SkippableTest test) {
-    if (test == null) {
-      return false;
-    }
-
-    if (skippableTests == null) {
-      synchronized (skippableTestsInitLock) {
-        if (skippableTests == null) {
-          skippableTests = fetchSkippableTests();
-        }
-      }
-    }
-
-    if (skippableTests.contains(test)) {
+    if (isSkippable(test)) {
       testsSkipped.increment();
       return true;
     } else {
       return false;
-    }
-  }
-
-  private Collection<SkippableTest> fetchSkippableTests() {
-    SkippableTestsRequest request = new SkippableTestsRequest(moduleName, JvmInfo.CURRENT_JVM);
-    try (SignalClient signalClient = new SignalClient(signalServerAddress)) {
-      SkippableTestsResponse response = (SkippableTestsResponse) signalClient.send(request);
-      Collection<SkippableTest> tests = response.getTests();
-      log.debug("Received {} skippable tests", tests.size());
-      return tests;
-    } catch (Exception e) {
-      log.error("Error while requesting skippable tests", e);
-      return Collections.emptySet();
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestImpl.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
-import org.objectweb.asm.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +44,6 @@ public class DDTestImpl implements DDTest {
       String testName,
       @Nullable Long startTime,
       @Nullable Class<?> testClass,
-      @Nullable String testMethodName,
       @Nullable Method testMethod,
       Config config,
       TestDecorator testDecorator,
@@ -92,9 +90,6 @@ public class DDTestImpl implements DDTest {
 
     if (testClass != null && !testClass.getName().equals(testSuiteName)) {
       span.setTag(Tags.TEST_SOURCE_CLASS, testClass.getName());
-    }
-    if (testMethodName != null && testMethod != null) {
-      span.setTag(Tags.TEST_SOURCE_METHOD, testMethodName + Type.getMethodDescriptor(testMethod));
     }
 
     if (config.isCiVisibilitySourceDataEnabled()) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSuiteImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSuiteImpl.java
@@ -160,15 +160,6 @@ public class DDTestSuiteImpl implements DDTestSuite {
   @Override
   public DDTestImpl testStart(
       String testName, @Nullable Method testMethod, @Nullable Long startTime) {
-    return testStart(
-        testName, testMethod != null ? testMethod.getName() : null, testMethod, startTime);
-  }
-
-  public DDTestImpl testStart(
-      String testName,
-      @Nullable String methodName,
-      @Nullable Method testMethod,
-      @Nullable Long startTime) {
     return new DDTestImpl(
         sessionId,
         moduleId,
@@ -178,7 +169,6 @@ public class DDTestSuiteImpl implements DDTestSuite {
         testName,
         startTime,
         testClass,
-        methodName,
         testMethod,
         config,
         testDecorator,

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/DDTestImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/DDTestImplTest.groovy
@@ -121,7 +121,6 @@ class DDTestImplTest extends DDSpecification {
       null,
       null,
       null,
-      null,
       config,
       testDecorator,
       sourcePathResolver,

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
@@ -47,6 +47,7 @@ abstract class CiVisibilityTest extends AgentTestRunner {
   private static Path agentKeyFile
 
   private static final List<SkippableTest> skippableTests = new ArrayList<>()
+  private static volatile boolean itrEnabled = false
 
   def setupSpec() {
     def currentPath = Paths.get("").toAbsolutePath()
@@ -64,12 +65,10 @@ abstract class CiVisibilityTest extends AgentTestRunner {
 
     def moduleExecutionSettingsFactory = Stub(ModuleExecutionSettingsFactory)
     moduleExecutionSettingsFactory.create(_, _) >> {
-      def codeCoverageEnabled = false
-      def itrEnabled = !skippableTests.isEmpty()
       Map<String, String> properties = [
         (CiVisibilityConfig.CIVISIBILITY_ITR_ENABLED) : String.valueOf(itrEnabled)
       ]
-      return new ModuleExecutionSettings(codeCoverageEnabled, itrEnabled, properties, Collections.singletonMap(dummyModule, skippableTests), Collections.emptyList())
+      return new ModuleExecutionSettings(false, itrEnabled, properties, Collections.singletonMap(dummyModule, skippableTests), Collections.emptyList())
     }
 
     def coverageProbeStoreFactory = new NoopCoverageProbeStore.NoopCoverageProbeStoreFactory()
@@ -130,10 +129,12 @@ abstract class CiVisibilityTest extends AgentTestRunner {
   @Override
   void setup() {
     skippableTests.clear()
+    itrEnabled = false
   }
 
   def givenSkippableTests(List<SkippableTest> tests) {
     skippableTests.addAll(tests)
+    itrEnabled = true
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5ItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5ItrInstrumentation.java
@@ -10,11 +10,13 @@ import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.config.SkippableTest;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collection;
 import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.support.hierarchical.Node;
 import org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService;
 
@@ -82,6 +84,13 @@ public class JUnit5ItrInstrumentation extends Instrumenter.CiVisibility
         // should only happen in integration tests
         // because we cannot avoid instrumenting ourselves
         return;
+      }
+
+      Collection<TestTag> tags = JUnitPlatformUtils.getTags(testDescriptor);
+      for (TestTag tag : tags) {
+        if (InstrumentationBridge.ITR_UNSKIPPABLE_TAG.equals(tag.getName())) {
+          return;
+        }
       }
 
       SkippableTest test = JUnitPlatformUtils.toSkippableTest(testDescriptor);

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformLauncherUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformLauncherUtils.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.ServiceLoader;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -82,21 +81,7 @@ public abstract class JUnitPlatformLauncherUtils {
 
   public static @Nullable String getTestEngineId(final TestIdentifier testIdentifier) {
     UniqueId uniqueId = getUniqueId(testIdentifier);
-    List<UniqueId.Segment> segments = uniqueId.getSegments();
-    ListIterator<UniqueId.Segment> iterator = segments.listIterator(segments.size());
-    // Iterating from the end of the list,
-    // since we want the last segment with type "engine".
-    // In case junit-platform-suite engine is used,
-    // its segment will be the first,
-    // and the actual engine that runs the test
-    // will be in some later segment
-    while (iterator.hasPrevious()) {
-      UniqueId.Segment segment = iterator.previous();
-      if ("engine".equals(segment.getType())) {
-        return segment.getValue();
-      }
-    }
-    return null;
+    return JUnitPlatformUtils.getTestEngineId(uniqueId);
   }
 
   public static UniqueId getUniqueId(TestIdentifier testIdentifier) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/CucumberTest.groovy
@@ -12,6 +12,8 @@ import org.example.TestSkippedCucumber
 import org.example.TestSkippedExamplesCucumber
 import org.example.TestSkippedFeatureCucumber
 import org.example.TestSucceedCucumber
+import org.example.TestSucceedCucumberUnskippable
+import org.example.TestSucceedCucumberUnskippableSuite
 import org.example.TestSucceedExamplesCucumber
 import org.junit.platform.engine.DiscoverySelector
 import org.junit.platform.launcher.core.LauncherConfig
@@ -174,6 +176,46 @@ class CucumberTest extends CiVisibilityTest {
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner", (Tags.TEST_SKIPPED_BY_ITR): true]
+  }
+
+  def "test ITR test unskippable"() {
+    setup:
+    givenSkippableTests([new SkippableTest("Basic Arithmetic", "Addition", null, null),])
+    runTestClasses(TestSucceedCucumberUnskippable)
+
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testSuiteId = testFeatureSpan(it, 2, testSessionId, testModuleId, "Basic Arithmetic", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testScenarioSpan(it, 0, testSessionId, testModuleId, testSuiteId, "Basic Arithmetic", "Addition", CIConstants.TEST_PASS, null, null, false, ["datadog_itr_unskippable"])
+      }
+    })
+  }
+
+  def "test ITR test unskippable suite"() {
+    setup:
+    givenSkippableTests([new SkippableTest("Basic Arithmetic", "Addition", null, null),])
+    runTestClasses(TestSucceedCucumberUnskippableSuite)
+
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testSuiteId = testFeatureSpan(it, 2, testSessionId, testModuleId, "Basic Arithmetic", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testScenarioSpan(it, 0, testSessionId, testModuleId, testSuiteId, "Basic Arithmetic", "Addition", CIConstants.TEST_PASS, null, null, false, ["datadog_itr_unskippable"])
+      }
+    })
   }
 
   private static void runTestClasses(Class<?>... classes) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/CucumberTest.groovy
@@ -189,13 +189,20 @@ class CucumberTest extends CiVisibilityTest {
       long testSuiteId
       trace(3, true) {
         testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
-        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
         testSuiteId = testFeatureSpan(it, 2, testSessionId, testModuleId, "Basic Arithmetic", CIConstants.TEST_PASS)
       }
       trace(1) {
-        testScenarioSpan(it, 0, testSessionId, testModuleId, testSuiteId, "Basic Arithmetic", "Addition", CIConstants.TEST_PASS, null, null, false, ["datadog_itr_unskippable"])
+        testScenarioSpan(it, 0, testSessionId, testModuleId, testSuiteId, "Basic Arithmetic", "Addition", CIConstants.TEST_PASS, testTags, null, false, ["datadog_itr_unskippable"])
       }
     })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true, (Tags.TEST_ITR_FORCED_RUN): true]
   }
 
   def "test ITR test unskippable suite"() {
@@ -209,13 +216,20 @@ class CucumberTest extends CiVisibilityTest {
       long testSuiteId
       trace(3, true) {
         testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
-        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
         testSuiteId = testFeatureSpan(it, 2, testSessionId, testModuleId, "Basic Arithmetic", CIConstants.TEST_PASS)
       }
       trace(1) {
-        testScenarioSpan(it, 0, testSessionId, testModuleId, testSuiteId, "Basic Arithmetic", "Addition", CIConstants.TEST_PASS, null, null, false, ["datadog_itr_unskippable"])
+        testScenarioSpan(it, 0, testSessionId, testModuleId, testSuiteId, "Basic Arithmetic", "Addition", CIConstants.TEST_PASS, testTags, null, false, ["datadog_itr_unskippable"])
       }
     })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true, (Tags.TEST_ITR_FORCED_RUN): true]
   }
 
   private static void runTestClasses(Class<?>... classes) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
@@ -149,14 +149,21 @@ class SpockTest extends CiVisibilityTest {
       long testSuiteId
       trace(3, true) {
         testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
-        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
         testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedSpockUnskippable", CIConstants.TEST_PASS)
       }
       trace(1) {
         testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedSpockUnskippable", "test success", "test success()V", CIConstants.TEST_PASS,
-          null, null, false, [InstrumentationBridge.ITR_UNSKIPPABLE_TAG])
+          testTags, null, false, [InstrumentationBridge.ITR_UNSKIPPABLE_TAG])
       }
     })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true, (Tags.TEST_ITR_FORCED_RUN): true]
   }
 
   def "test ITR unskippable suite"() {
@@ -171,14 +178,21 @@ class SpockTest extends CiVisibilityTest {
       long testSuiteId
       trace(3, true) {
         testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
-        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
         testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedSpockUnskippableSuite", CIConstants.TEST_PASS)
       }
       trace(1) {
         testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedSpockUnskippableSuite", "test success", "test success()V", CIConstants.TEST_PASS,
-          null, null, false, [InstrumentationBridge.ITR_UNSKIPPABLE_TAG])
+          testTags, null, false, [InstrumentationBridge.ITR_UNSKIPPABLE_TAG])
       }
     })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true, (Tags.TEST_ITR_FORCED_RUN): true]
   }
 
   private static void runTestClasses(Class<?>... classes) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/SpockTest.groovy
@@ -2,12 +2,15 @@ import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.api.DDTags
 import datadog.trace.api.DisableTestTrace
 import datadog.trace.api.civisibility.CIConstants
+import datadog.trace.api.civisibility.InstrumentationBridge
 import datadog.trace.api.civisibility.config.SkippableTest
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.civisibility.CiVisibilityTest
 import datadog.trace.instrumentation.junit5.TestEventsHandlerHolder
 import org.example.TestParameterizedSpock
 import org.example.TestSucceedSpock
+import org.example.TestSucceedSpockUnskippable
+import org.example.TestSucceedSpockUnskippableSuite
 import org.junit.platform.engine.DiscoverySelector
 import org.junit.platform.launcher.core.LauncherConfig
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder
@@ -132,6 +135,50 @@ class SpockTest extends CiVisibilityTest {
       (Tags.TEST_SKIPPED_BY_ITR): true
     ]
     testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"test add 4 and 4"}}']
+  }
+
+  def "test ITR unskippable"() {
+    setup:
+    givenSkippableTests([new SkippableTest("org.example.TestSucceedSpockUnskippable", "test success", null, null),])
+    runTestClasses(TestSucceedSpockUnskippable)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedSpockUnskippable", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedSpockUnskippable", "test success", "test success()V", CIConstants.TEST_PASS,
+          null, null, false, [InstrumentationBridge.ITR_UNSKIPPABLE_TAG])
+      }
+    })
+  }
+
+  def "test ITR unskippable suite"() {
+    setup:
+    givenSkippableTests([new SkippableTest("org.example.TestSucceedSpockUnskippableSuite", "test success", null, null),])
+    runTestClasses(TestSucceedSpockUnskippableSuite)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS)
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedSpockUnskippableSuite", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedSpockUnskippableSuite", "test success", "test success()V", CIConstants.TEST_PASS,
+          null, null, false, [InstrumentationBridge.ITR_UNSKIPPABLE_TAG])
+      }
+    })
   }
 
   private static void runTestClasses(Class<?>... classes) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/org/example/TestSucceedSpockUnskippable.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/org/example/TestSucceedSpockUnskippable.groovy
@@ -1,0 +1,14 @@
+package org.example
+
+import datadog.trace.api.civisibility.InstrumentationBridge
+import spock.lang.Specification
+import spock.lang.Tag
+
+class TestSucceedSpockUnskippable extends Specification {
+
+  @Tag(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)
+  def "test success"() {
+    expect:
+    1 == 1
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/org/example/TestSucceedSpockUnskippableSuite.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/org/example/TestSucceedSpockUnskippableSuite.groovy
@@ -1,0 +1,14 @@
+package org.example
+
+import datadog.trace.api.civisibility.InstrumentationBridge
+import spock.lang.Specification
+import spock.lang.Tag
+
+@Tag(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)
+class TestSucceedSpockUnskippableSuite extends Specification {
+
+  def "test success"() {
+    expect:
+    1 == 1
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedCucumberUnskippable.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedCucumberUnskippable.java
@@ -1,0 +1,15 @@
+package org.example;
+
+import io.cucumber.core.options.Constants;
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("org/example/cucumber/calculator/basic_arithmetic_unskippable.feature")
+@ConfigurationParameter(
+    key = Constants.GLUE_PROPERTY_NAME,
+    value = "org.example.cucumber.calculator")
+public class TestSucceedCucumberUnskippable {}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedCucumberUnskippableSuite.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedCucumberUnskippableSuite.java
@@ -1,0 +1,16 @@
+package org.example;
+
+import io.cucumber.core.options.Constants;
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource(
+    "org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature")
+@ConfigurationParameter(
+    key = Constants.GLUE_PROPERTY_NAME,
+    value = "org.example.cucumber.calculator")
+public class TestSucceedCucumberUnskippableSuite {}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedUnskippable.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedUnskippable.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.api.civisibility.InstrumentationBridge;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
+import org.junit.jupiter.api.Test;
+
+public class TestSucceedUnskippable {
+
+  @Test
+  @Tags({@Tag(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)})
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedUnskippableSuite.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/java/org/example/TestSucceedUnskippableSuite.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.api.civisibility.InstrumentationBridge;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
+import org.junit.jupiter.api.Test;
+
+@Tags({@Tag(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)})
+public class TestSucceedUnskippableSuite {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+}

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/org/example/cucumber/calculator/basic_arithmetic_unskippable.feature
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/org/example/cucumber/calculator/basic_arithmetic_unskippable.feature
@@ -1,0 +1,10 @@
+Feature: Basic Arithmetic
+
+  Background: A Calculator
+    Given a calculator I just turned on
+
+  @datadog_itr_unskippable
+  Scenario: Addition
+  # Try to change one of the values below to provoke a failure
+    When I add 4 and 5
+    Then the result is 9

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/resources/org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/resources/org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature
@@ -1,0 +1,10 @@
+@datadog_itr_unskippable
+Feature: Basic Arithmetic
+
+  Background: A Calculator
+    Given a calculator I just turned on
+
+  Scenario: Addition
+  # Try to change one of the values below to provoke a failure
+    When I add 4 and 5
+    Then the result is 9

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 public abstract class InstrumentationBridge {
 
   public static final String ITR_SKIP_REASON = "Skipped by Datadog Intelligent Test Runner";
+  public static final String ITR_UNSKIPPABLE_TAG = "datadog_itr_unskippable";
 
   private static volatile TestEventsHandler.Factory TEST_EVENTS_HANDLER_FACTORY;
   private static volatile BuildEventsHandler.Factory BUILD_EVENTS_HANDLER_FACTORY;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Tags.java
@@ -71,6 +71,8 @@ public class Tags {
   public static final String TEST_ITR_TESTS_SKIPPING_ENABLED = "test.itr.tests_skipping.enabled";
   public static final String TEST_ITR_TESTS_SKIPPING_TYPE = "test.itr.tests_skipping.type";
   public static final String TEST_ITR_TESTS_SKIPPING_COUNT = "test.itr.tests_skipping.count";
+  public static final String TEST_ITR_UNSKIPPABLE = "test.itr.unskippable";
+  public static final String TEST_ITR_FORCED_RUN = "test.itr.forced_run";
 
   public static final String CI_PROVIDER_NAME = "ci.provider.name";
   public static final String CI_PIPELINE_ID = "ci.pipeline.id";


### PR DESCRIPTION
# What Does This Do
Implements a mechanism to mark tests as "unskippable" for CI Visibility Intelligent Test Runner.
This PR only contains implementation for JUnit 5, other frameworks will be covered in later pull-requests.

# Motivation
Having the ability to instruct Intelligent Test Runner to never skip a specific test is a feature requested by the customers.
