### PR TITLE
JMXFetch 0.47.10

### DIFF
--- a/dd-java-agent/agent-jmxfetch/build.gradle
+++ b/dd-java-agent/agent-jmxfetch/build.gradle
@@ -11,7 +11,7 @@ plugins {
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  api('com.datadoghq:jmxfetch:0.47.9') {
+  api('com.datadoghq:jmxfetch:0.47.10') {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'org.slf4j', module: 'slf4j-jdk14'
     exclude group: 'com.beust', module: 'jcommander'


### PR DESCRIPTION
Main item of interest is a fix to avoid an exception if JMXFetch is just starting up, right as the JVM is shutting down:

https://github.com/DataDog/jmxfetch/releases/tag/0.47.10