### PR TITLE
Only invalidate current OTel context if we created it

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ContextTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ContextTest.groovy
@@ -172,6 +172,15 @@ class OpenTelemetry14ContextTest extends AgentTestRunner {
     !currentSpan.spanContext.isValid()
   }
 
+  def "test setting non-Datadog context"() {
+    when:
+    def rootScope = Context.root().makeCurrent()
+    then:
+    Context.current() == Context.root()
+    cleanup:
+    rootScope.close()
+  }
+
   def "test mixing manual and OTel instrumentation"() {
     setup:
     def otelParentSpan = tracer.spanBuilder("some-name").startSpan()


### PR DESCRIPTION
... otherwise when there's no active span leave the non-Datadog context in place.