### PR TITLE
Imlpement ITR unskippable tests for JUnit 4

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -167,12 +167,15 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
       String json = toJson(Collections.singletonMap("category", toJson(categories)), true);
       test.setTag(Tags.TEST_TRAITS, json);
 
-      if (categories.contains(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)) {
-        test.setTag(Tags.TEST_ITR_UNSKIPPABLE, true);
+      for (String category : categories) {
+        if (category.endsWith(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)) {
+          test.setTag(Tags.TEST_ITR_UNSKIPPABLE, true);
 
-        SkippableTest thisTest = new SkippableTest(testSuiteName, testName, testParameters, null);
-        if (testModule.isSkippable(thisTest)) {
-          test.setTag(Tags.TEST_ITR_FORCED_RUN, true);
+          SkippableTest thisTest = new SkippableTest(testSuiteName, testName, testParameters, null);
+          if (testModule.isSkippable(thisTest)) {
+            test.setTag(Tags.TEST_ITR_FORCED_RUN, true);
+          }
+          break;
         }
       }
     }

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber/src/main/java/datadog/trace/instrumentation/junit4/JUnit4CucumberItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber/src/main/java/datadog/trace/instrumentation/junit4/JUnit4CucumberItrInstrumentation.java
@@ -1,0 +1,92 @@
+package datadog.trace.instrumentation.junit4;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.InstrumentationBridge;
+import datadog.trace.api.civisibility.config.SkippableTest;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.cucumber.core.gherkin.Pickle;
+import java.util.List;
+import java.util.Set;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.AssumptionViolatedException;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+
+@AutoService(Instrumenter.class)
+public class JUnit4CucumberItrInstrumentation extends Instrumenter.CiVisibility
+    implements Instrumenter.ForTypeHierarchy {
+
+  public JUnit4CucumberItrInstrumentation() {
+    super("ci-visibility", "junit-4", "junit-4-cucumber");
+  }
+
+  @Override
+  public boolean isApplicable(Set<TargetSystem> enabledSystems) {
+    return super.isApplicable(enabledSystems) && Config.get().isCiVisibilityItrEnabled();
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "io.cucumber.junit.PickleRunners$PickleRunner";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".TestEventsHandlerHolder",
+      packageName + ".SkippedByItr",
+      packageName + ".JUnit4Utils",
+      packageName + ".TracingListener",
+      packageName + ".CucumberTracingListener",
+    };
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("run").and(takesArgument(0, named("org.junit.runner.notification.RunNotifier"))),
+        JUnit4CucumberItrInstrumentation.class.getName() + "$CucumberItrAdvice");
+  }
+
+  public static class CucumberItrAdvice {
+    @SuppressFBWarnings("NP_BOOLEAN_RETURN_NULL")
+    @Advice.OnMethodEnter(skipOn = Boolean.class)
+    public static Boolean run(
+        @Advice.FieldValue("pickle") Pickle pickle,
+        @Advice.FieldValue("description") Description description,
+        @Advice.Argument(0) RunNotifier notifier) {
+
+      List<String> tags = pickle.getTags();
+      for (String tag : tags) {
+        if (tag.endsWith(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)) {
+          return null;
+        }
+      }
+
+      SkippableTest test = JUnit4Utils.toSkippableTest(description);
+      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(test)) {
+        notifier.fireTestAssumptionFailed(
+            new Failure(
+                description,
+                new AssumptionViolatedException(InstrumentationBridge.ITR_SKIP_REASON)));
+        return Boolean.FALSE;
+      } else {
+        return null;
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/groovy/CucumberTest.groovy
@@ -10,6 +10,8 @@ import datadog.trace.instrumentation.junit4.CucumberTracingListener
 import datadog.trace.instrumentation.junit4.TestEventsHandlerHolder
 import org.example.cucumber.TestFailedCucumber
 import org.example.cucumber.TestSucceedCucumber
+import org.example.cucumber.TestSucceedCucumberUnskippable
+import org.example.cucumber.TestSucceedCucumberUnskippableSuite
 import org.example.cucumber.TestSucceedExamplesCucumber
 import org.junit.runner.JUnitCore
 
@@ -130,6 +132,60 @@ class CucumberTest extends CiVisibilityTest {
 
     where:
     testTags = [(Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner", (Tags.TEST_SKIPPED_BY_ITR): true]
+  }
+
+  def "test ITR test unskippable"() {
+    setup:
+    givenSkippableTests([new SkippableTest("Basic Arithmetic", "Addition", null, null),])
+    runTestClasses(TestSucceedCucumberUnskippable)
+
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
+        testSuiteId = testFeatureSpan(it, 2, testSessionId, testModuleId, "Basic Arithmetic", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testScenarioSpan(it, 0, testSessionId, testModuleId, testSuiteId, "Basic Arithmetic", "Addition", CIConstants.TEST_PASS, testTags, null, false, ["datadog_itr_unskippable"])
+      }
+    })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true, (Tags.TEST_ITR_FORCED_RUN): true]
+  }
+
+  def "test ITR test unskippable suite"() {
+    setup:
+    givenSkippableTests([new SkippableTest("Basic Arithmetic", "Addition", null, null),])
+    runTestClasses(TestSucceedCucumberUnskippableSuite)
+
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
+        testSuiteId = testFeatureSpan(it, 2, testSessionId, testModuleId, "Basic Arithmetic", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testScenarioSpan(it, 0, testSessionId, testModuleId, testSuiteId, "Basic Arithmetic", "Addition", CIConstants.TEST_PASS, testTags, null, false, ["datadog_itr_unskippable"])
+      }
+    })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true, (Tags.TEST_ITR_FORCED_RUN): true]
   }
 
   private void runTestClasses(Class<?>... tests) {

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/java/org/example/cucumber/TestSucceedCucumberUnskippable.java
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/java/org/example/cucumber/TestSucceedCucumberUnskippable.java
@@ -1,0 +1,11 @@
+package org.example.cucumber;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = "classpath:org/example/cucumber/calculator/basic_arithmetic_unskippable.feature",
+    glue = "org.example.cucumber.calculator")
+public class TestSucceedCucumberUnskippable {}

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/java/org/example/cucumber/TestSucceedCucumberUnskippableSuite.java
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/java/org/example/cucumber/TestSucceedCucumberUnskippableSuite.java
@@ -1,0 +1,12 @@
+package org.example.cucumber;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features =
+        "classpath:org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature",
+    glue = "org.example.cucumber.calculator")
+public class TestSucceedCucumberUnskippableSuite {}

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/resources/org/example/cucumber/calculator/basic_arithmetic_unskippable.feature
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/resources/org/example/cucumber/calculator/basic_arithmetic_unskippable.feature
@@ -1,0 +1,10 @@
+Feature: Basic Arithmetic
+
+  Background: A Calculator
+    Given a calculator I just turned on
+
+  @datadog_itr_unskippable
+  Scenario: Addition
+  # Try to change one of the values below to provoke a failure
+    When I add 4 and 5
+    Then the result is 9

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/resources/org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber/src/test/resources/org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature
@@ -1,0 +1,10 @@
+@datadog_itr_unskippable
+Feature: Basic Arithmetic
+
+  Background: A Calculator
+    Given a calculator I just turned on
+
+  Scenario: Addition
+  # Try to change one of the values below to provoke a failure
+    When I add 4 and 5
+    Then the result is 9

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -12,7 +12,6 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.junit.rules.RuleChain;
-import org.junit.runner.Runner;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 
@@ -57,8 +56,7 @@ public class JUnit4Instrumentation extends Instrumenter.CiVisibility
 
   public static class JUnit4Advice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void addTracingListener(
-        @Advice.This final Runner runner, @Advice.Argument(0) final RunNotifier runNotifier) {
+    public static void addTracingListener(@Advice.Argument(0) final RunNotifier runNotifier) {
       // No public accessor to get already installed listeners.
       // The installed RunListeners list are obtained using reflection.
       final List<RunListener> runListeners = JUnit4Utils.runListenersFromRunNotifier(runNotifier);

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4ItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4ItrInstrumentation.java
@@ -2,14 +2,18 @@ package datadog.trace.instrumentation.junit4;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.extendsClass;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.config.SkippableTest;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -40,7 +44,9 @@ public class JUnit4ItrInstrumentation extends Instrumenter.CiVisibility
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return extendsClass(named(hierarchyMarkerType()));
+    return extendsClass(named(hierarchyMarkerType()))
+        // ITR skipping for Cucumber is done in a dedicated instrumentation
+        .and(not(extendsClass(named("io.cucumber.junit.FeatureRunner"))));
   }
 
   @Override
@@ -80,6 +86,15 @@ public class JUnit4ItrInstrumentation extends Instrumenter.CiVisibility
       if (ignoreAnnotation != null) {
         // class is ignored, ITR not applicable
         return null;
+      }
+
+      Class<?> testClass = description.getTestClass();
+      Method testMethod = JUnit4Utils.getTestMethod(description);
+      List<String> categories = JUnit4Utils.getCategories(testClass, testMethod);
+      for (String category : categories) {
+        if (category.endsWith(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)) {
+          return null;
+        }
       }
 
       SkippableTest test = JUnit4Utils.toSkippableTest(description);

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -22,6 +22,8 @@ import org.example.TestSkippedClass
 import org.example.TestSucceed
 import org.example.TestSucceedAndSkipped
 import org.example.TestSucceedSuite
+import org.example.TestSucceedUnskippable
+import org.example.TestSucceedUnskippableSuite
 import org.example.TestSucceedWithCategories
 import org.junit.runner.JUnitCore
 
@@ -532,6 +534,96 @@ class JUnit4Test extends CiVisibilityTest {
       (Tags.TEST_SKIPPED_BY_ITR): true
     ]
     testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
+  }
+
+  def "test ITR unskippable"() {
+    setup:
+    givenSkippableTests([new SkippableTest("org.example.TestSucceedUnskippable", "test_succeed", null, null),])
+    runTests(TestSucceedUnskippable)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedUnskippable", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedUnskippable", "test_succeed", "test_succeed()V", CIConstants.TEST_PASS,
+          testTags, null, false, [TestSucceedUnskippable.datadog_itr_unskippable.name])
+      }
+    })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true, (Tags.TEST_ITR_FORCED_RUN): true]
+  }
+
+  def "test ITR unskippable suite"() {
+    setup:
+    givenSkippableTests([
+      new SkippableTest("org.example.TestSucceedUnskippableSuite", "test_succeed", null, null),
+    ])
+    runTests(TestSucceedUnskippableSuite)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedUnskippableSuite", CIConstants.TEST_PASS,
+          null, null, false, [TestSucceedUnskippableSuite.datadog_itr_unskippable.name])
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedUnskippableSuite", "test_succeed", "test_succeed()V", CIConstants.TEST_PASS,
+          testTags, null, false, [TestSucceedUnskippableSuite.datadog_itr_unskippable.name])
+      }
+    })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true, (Tags.TEST_ITR_FORCED_RUN): true]
+  }
+
+  def "test unskippable ITR test that is not supposed to be skipped"() {
+    setup:
+    givenSkippableTests([])
+    runTests(TestSucceedUnskippable)
+
+    expect:
+    ListWriterAssert.assertTraces(TEST_WRITER, 2, false, SORT_TRACES_BY_DESC_SIZE_THEN_BY_NAMES, {
+      long testSessionId
+      long testModuleId
+      long testSuiteId
+      trace(3, true) {
+        testSessionId = testSessionSpan(it, 1, CIConstants.TEST_PASS)
+        testModuleId = testModuleSpan(it, 0, testSessionId, CIConstants.TEST_PASS, [
+          (Tags.TEST_ITR_TESTS_SKIPPING_ENABLED): true,
+          (Tags.TEST_ITR_TESTS_SKIPPING_TYPE): "test",
+          (Tags.TEST_ITR_TESTS_SKIPPING_COUNT): 0,
+        ])
+        testSuiteId = testSuiteSpan(it, 2, testSessionId, testModuleId, "org.example.TestSucceedUnskippable", CIConstants.TEST_PASS)
+      }
+      trace(1) {
+        testSpan(it, 0, testSessionId, testModuleId, testSuiteId, "org.example.TestSucceedUnskippable", "test_succeed", "test_succeed()V", CIConstants.TEST_PASS,
+          testTags, null, false, [TestSucceedUnskippable.datadog_itr_unskippable.name])
+      }
+    })
+
+    where:
+    testTags = [(Tags.TEST_ITR_UNSKIPPABLE): true]
   }
 
   def "test suite runner"() {

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedUnskippable.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedUnskippable.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class TestSucceedUnskippable {
+
+  @Category(datadog_itr_unskippable.class)
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  public interface datadog_itr_unskippable {}
+}

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedUnskippableSuite.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestSucceedUnskippableSuite.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(TestSucceedUnskippableSuite.datadog_itr_unskippable.class)
+public class TestSucceedUnskippableSuite {
+
+  @Test
+  public void test_succeed() {
+    assertTrue(true);
+  }
+
+  public interface datadog_itr_unskippable {}
+}


### PR DESCRIPTION
# What Does This Do
Implements a mechanism to mark JUnit 4 tests as "unskippable" for CI Visibility Intelligent Test Runner.

# Motivation
Having the ability to instruct Intelligent Test Runner to never skip a specific test is a feature requested by the customers.