### PR TITLE
Fix deadlock occuring when stopping SignalServer

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalServerRunnable.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalServerRunnable.java
@@ -9,6 +9,7 @@ import java.nio.channels.SocketChannel;
 import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +17,7 @@ import org.slf4j.LoggerFactory;
 class SignalServerRunnable implements Runnable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SignalServerRunnable.class);
-
+  private static final long SELECT_TIMEOUT = TimeUnit.SECONDS.toMillis(5);
   private static final Map<SignalType, Function<ByteBuffer, Signal>> DESERIALIZERS =
       new EnumMap<>(SignalType.class);
 
@@ -51,7 +52,7 @@ class SignalServerRunnable implements Runnable {
   }
 
   private void processSelectableKeys() throws IOException {
-    selector.select();
+    selector.select(SELECT_TIMEOUT);
 
     Iterator<SelectionKey> keyIterator = selector.selectedKeys().iterator();
     while (keyIterator.hasNext()) {


### PR DESCRIPTION
# What Does This Do
Fixes deadlock that can occur when `SignalServer` is stopped.

# Motivation
`SignalServer` that hangs while trying to stop prevents JVM from exiting.

# Additional Notes
`SignalServer` is used by CI Visibility for communication between the build system and the JVMs that are forked for tests execution.

The deadlock happened because the thread that stops the server was sending interruption signal, then waited for the server thread to finish, and only after it closed the selector used by the server.
The problem was that if selector was not closed, the server thread could simply ignore the interruption signal (if it was waiting for the `select()` method to return when the signal was received).
The fix is to add a 5-second timeout to the `select()` method, so that the interruption flag is checked at least once in 5 seconds.
