### PR TITLE
Always populate test.command tag in session spans

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
@@ -57,6 +57,14 @@ public class DDTestSessionImpl implements DDTestSession {
 
     span.setResourceName(projectName);
 
+    // The backend requires all session spans to have the test command tag
+    // because it is used for session fingerprint calculation.
+    // We're setting it here to project name as a default that works
+    // reasonably well (although this is not the real command).
+    // In those cases where proper command can be determined,
+    // this tag will be overridden
+    span.setTag(Tags.TEST_COMMAND, projectName);
+
     testDecorator.afterStart(span);
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTest.groovy
@@ -177,6 +177,9 @@ abstract class CiVisibilityTest extends AgentTestRunner {
         "$Tags.TEST_TYPE" TestDecorator.TEST_TYPE
         if (testCommand) {
           "$Tags.TEST_COMMAND" testCommand
+        } else {
+          // the default command for sessions that run without build system instrumentation
+          "$Tags.TEST_COMMAND" dummyModule
         }
         if (testToolchain) {
           "$Tags.TEST_TOOLCHAIN" testToolchain


### PR DESCRIPTION
# What Does This Do
Ensures that CI Visibility's test session spans always have `test.command` tag.

# Motivation
`test.command` is part of the session fingerprint - the set of tags that are used by CI Visibility backend to identify sessions.
Due to that the backend requires these tags to always be populated.
