### PR TITLE
Update ddprof to 0.76.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.74.0",
+    ddprof        : "0.76.0",
     asm           : "9.5",
     cafe_crypto   : "0.1.0"
   ]


### PR DESCRIPTION
# What Does This Do
Updates the ddprof dependency to 0.76.0

# Motivation
https://github.com/DataDog/java-profiler/releases/tag/v_0.76.0

# Additional Notes
