### PR TITLE
Do not start profiler if running in AWS Lambda.

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -846,6 +846,11 @@ public class Agent {
   private static void startProfilingAgent(final boolean isStartingFirst) {
     StaticEventLogger.begin("ProfilingAgent");
 
+    if (isAwsLambdaRuntime()) {
+      log.info("Profiling not supported in AWS Lambda runtimes");
+      return;
+    }
+
     final ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(AGENT_CLASSLOADER);
@@ -909,6 +914,11 @@ public class Agent {
     }
 
     StaticEventLogger.end("ProfilingAgent");
+  }
+
+  private static boolean isAwsLambdaRuntime() {
+    String val = System.getenv("AWS_LAMBDA_FUNCTION_NAME");
+    return val != null && !val.isEmpty();
   }
 
   private static ScopeListener createScopeListener(String className) throws Throwable {

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -84,9 +84,12 @@ public class ProfilingAgent {
   public static synchronized void run(final boolean isStartingFirst, ClassLoader agentClasLoader)
       throws IllegalArgumentException, IOException {
     if (profiler == null) {
+      if (isAwsLambdaRuntime()) {
+        log.debug("Profiling not supported in AWS Lambda runtimes");
+        return;
+      }
       final Config config = Config.get();
       final ConfigProvider configProvider = ConfigProvider.getInstance();
-
       boolean startForceFirst =
           configProvider.getBoolean(
               PROFILING_START_FORCE_FIRST, PROFILING_START_FORCE_FIRST_DEFAULT);
@@ -163,6 +166,11 @@ public class ProfilingAgent {
         log.debug("Failed to initialize profiling agent!", e);
       }
     }
+  }
+
+  private static boolean isAwsLambdaRuntime() {
+    String val = System.getenv("AWS_LAMBDA_FUNCTION_NAME");
+    return val != null && !val.isEmpty();
   }
 
   private static boolean isStartForceFirstSafe() {

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -84,12 +84,9 @@ public class ProfilingAgent {
   public static synchronized void run(final boolean isStartingFirst, ClassLoader agentClasLoader)
       throws IllegalArgumentException, IOException {
     if (profiler == null) {
-      if (isAwsLambdaRuntime()) {
-        log.debug("Profiling not supported in AWS Lambda runtimes");
-        return;
-      }
       final Config config = Config.get();
       final ConfigProvider configProvider = ConfigProvider.getInstance();
+
       boolean startForceFirst =
           configProvider.getBoolean(
               PROFILING_START_FORCE_FIRST, PROFILING_START_FORCE_FIRST_DEFAULT);
@@ -166,11 +163,6 @@ public class ProfilingAgent {
         log.debug("Failed to initialize profiling agent!", e);
       }
     }
-  }
-
-  private static boolean isAwsLambdaRuntime() {
-    String val = System.getenv("AWS_LAMBDA_FUNCTION_NAME");
-    return val != null && !val.isEmpty();
   }
 
   private static boolean isStartForceFirstSafe() {


### PR DESCRIPTION
# What Does This Do

When it detects the tracer running in AWS Lambda, refuse to start the profiler.

# Motivation

Profiling is not yet supported in Java in AWS Lambda. Node and Python though are currently in public beta. We are specifically not charging customers in this public beta. However, if a customer were to turn on profiling with the java tracer, they would be billed. We want to prevent the situation where the customer is billed for profiles created in serverless environments.

# Additional Notes
