### PR TITLE
Fix trace and span id generation

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/IdGenerationStrategy.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/IdGenerationStrategy.java
@@ -1,5 +1,7 @@
 package datadog.trace.api;
 
+import static java.lang.Long.MAX_VALUE;
+
 import java.security.SecureRandom;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
@@ -58,7 +60,7 @@ public abstract class IdGenerationStrategy {
 
     @Override
     protected long getNonZeroPositiveLong() {
-      return ThreadLocalRandom.current().nextLong(1, Long.MAX_VALUE);
+      return ThreadLocalRandom.current().nextLong(0, MAX_VALUE) + 1;
     }
   }
 
@@ -105,9 +107,9 @@ public abstract class IdGenerationStrategy {
 
     @Override
     protected long getNonZeroPositiveLong() {
-      long value = secureRandom.nextLong() & Long.MAX_VALUE;
+      long value = secureRandom.nextLong() & MAX_VALUE;
       while (value == 0) {
-        value = secureRandom.nextLong() & Long.MAX_VALUE;
+        value = secureRandom.nextLong() & MAX_VALUE;
       }
       return value;
     }


### PR DESCRIPTION
# What Does This Do

This PR introduce a minor fix for trace and span id generation.

# Motivation

The `RANDOM` generator generated number between `[1, 2^63-1[` instead of `[1, 2^63-1]`.

# Additional Notes
