### PR TITLE
Add support for OpenTelemetry record exception span event

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
@@ -8,6 +8,7 @@ import static io.opentelemetry.api.trace.StatusCode.UNSET;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -74,7 +75,10 @@ public class OtelSpan implements Span {
 
   @Override
   public Span recordException(Throwable exception, Attributes additionalAttributes) {
-    // Not supported
+    if (this.recording) {
+      // Store exception as span tags as span events are not supported yet
+      this.delegate.addThrowable(exception, ErrorPriorities.UNSET);
+    }
     return this;
   }
 

--- a/dd-java-agent/instrumentation/spring-ws-2/src/main/java/datadog/trace/instrumentation/springws2/MethodEndpointInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-ws-2/src/main/java/datadog/trace/instrumentation/springws2/MethodEndpointInstrumentation.java
@@ -2,12 +2,12 @@ package datadog.trace.instrumentation.springws2;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.bootstrap.instrumentation.api.ErrorPriorities.UNSET;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
@@ -43,14 +43,8 @@ public class MethodEndpointInstrumentation extends Instrumenter.Tracing
         if (rootSpan != null) {
           span = rootSpan;
         }
-        // Check if the span is already in error
-        boolean error = span.isError();
-        // Capture the exception
-        span.addThrowable(throwable);
-        // Restore the error state using UNSET priority to not override prior decision
-        if (!error) {
-          span.setError(false, ErrorPriorities.UNSET);
-        }
+        // Capture the exception without setting span as errored
+        span.addThrowable(throwable, UNSET);
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -1,6 +1,7 @@
 package datadog.trace.core;
 
 import static datadog.trace.api.cache.RadixTreeCache.HTTP_STATUSES;
+import static datadog.trace.bootstrap.instrumentation.api.ErrorPriorities.UNSET;
 
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
@@ -15,7 +16,6 @@ import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilerContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
@@ -105,7 +105,7 @@ public class DDSpanContext
   /** True indicates that the span reports an error */
   private volatile boolean errorFlag;
 
-  private volatile byte errorFlagPriority = ErrorPriorities.UNSET;
+  private volatile byte errorFlagPriority = UNSET;
 
   private volatile boolean measured;
 
@@ -431,7 +431,7 @@ public class DDSpanContext
   }
 
   public void setErrorFlag(final boolean errorFlag, final byte priority) {
-    if (priority >= this.errorFlagPriority) {
+    if (priority > UNSET && priority >= this.errorFlagPriority) {
       this.errorFlag = errorFlag;
       this.errorFlagPriority = priority;
     }


### PR DESCRIPTION
# What Does This Do

This PR brings support for _record exception_ event in OpenTelemetry Span API ([documentation](https://opentelemetry.io/docs/specs/otel/trace/api/#record-exception)). 

# Motivation

This should increase our compatibility with the OpenTelemetry API.

# Additional Notes

There are few limitation though:
* We will only keep one event (the last one),
* We will drop the event timestamp and attributes.

I also backported the new `setErrorFlag()` behavior to a past instrumentation that needed it (`spring-ws-2`).
