### PR TITLE
Less verbose dependency collection debug logs

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/LocationsCollectingTransformer.java
@@ -36,13 +36,12 @@ class LocationsCollectingTransformer implements ClassFileTransformer {
   }
 
   private boolean addDependency(final ProtectionDomain domain) {
-    log.debug("Saw new protection domain: {}", domain);
     final CodeSource codeSource = domain.getCodeSource();
-    if (null != codeSource) {
-      final URL location = codeSource.getLocation();
-      if (null != location) {
-        dependencyService.addURL(location);
-      }
+    final URL location = codeSource != null ? codeSource.getLocation() : null;
+    final ClassLoader classLoader = domain.getClassLoader();
+    log.debug("New protection domain with location {} and class loader {}", location, classLoader);
+    if (location != null) {
+      dependencyService.addURL(location);
     }
     return true;
   }


### PR DESCRIPTION
# What Does This Do

# Motivation
Logging each new protection domain while collecting dependencies led to long multi-line debug logs with mostly irrelevant information.

# Additional Notes

Old log:

```
[dd.trace 2023-09-18 15:28:40:334 +0000] [s0-admin-1] DEBUG datadog.telemetry.dependency.LocationsCollectingTransformer - Saw new protection domain: ProtectionDomain  (jar:file:/app/app.jar!/BOOT-INF/lib/netty-resolver-4.1.70.Final.jar!/ <no signer certificates>)
 org.springframework.boot.loader.LaunchedURLClassLoader@4defd42
 <no principals>
 java.security.Permissions@23d0b9f5 (
 ("java.io.FilePermission" "/app/app.jar" "read")
)
```

New log:

```
[dd.trace 2023-09-18 15:23:41:196 +0000] [s0-admin-1] DEBUG datadog.telemetry.dependency.LocationsCollectingTransformer - New protection domain with location jar:file:/app/app.jar!/BOOT-INF/lib/netty-resolver-4.1.70.Final.jar!/ and class loader org.springframework.boot.loader.LaunchedURLClassLoader@34f392be
```
