### PR TITLE
Remove direct references to Taintable from advices

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -228,12 +228,17 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taint(
-      byte origin, @Nullable String name, @Nullable String value, @Nullable Taintable t) {
+  public void taintObject(
+      byte origin, @Nullable String name, @Nullable String value, @Nullable Object t) {
     if (t == null) {
       return;
     }
-    t.$$DD$setSource(new Source(origin, name, value));
+    if (t instanceof Taintable) {
+      ((Taintable) t).$$DD$setSource(new Source(origin, name, value));
+    } else {
+      final TaintedObjects taintedObjects = TaintedObjects.activeTaintedObjects();
+      taintObject(taintedObjects, t, new Source(origin, name, value));
+    }
   }
 
   @Override

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
@@ -6,9 +6,7 @@ import datadog.trace.api.iast.IastCallSites;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
-import datadog.trace.api.iast.source.WebModule;
-import java.util.Collections;
+import datadog.trace.api.iast.propagation.PropagationModule;
 
 /**
  * Detects when a header name is directly called from user code. This uses call site instrumentation
@@ -23,18 +21,15 @@ public class HeaderNameCallSite {
   @CallSite.After(
       "java.lang.String akka.http.scaladsl.model.HttpHeader.name()") // subtype of the first
   public static String after(@CallSite.This HttpHeader header, @CallSite.Return String result) {
-    WebModule module = InstrumentationBridge.WEB;
+    PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null) {
       return result;
     }
     try {
-      if (header instanceof Taintable && ((Taintable) header).$DD$isTainted()) {
-        module.onHeaderNames(Collections.singletonList(result));
-      }
-      return result;
+      module.taintIfInputIsTainted(SourceTypes.REQUEST_HEADER_NAME, result, result, header);
     } catch (final Throwable e) {
       module.onUnexpectedException("onHeaderNames threw", e);
-      return result;
     }
+    return result;
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpHeaderSubclassesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpHeaderSubclassesInstrumentation.java
@@ -14,7 +14,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -59,7 +58,7 @@ public class HttpHeaderSubclassesInstrumentation extends Instrumenter.Iast
     static void onExit(@Advice.This HttpHeader h, @Advice.Return String retVal) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
-      if (propagation == null || !(h instanceof Taintable)) {
+      if (propagation == null) {
         return;
       }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
@@ -17,7 +17,6 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.bytebuddy.asm.Advice;
@@ -67,27 +66,19 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
         return;
       }
 
-      if (!((Object) thiz instanceof Taintable)) {
-        return;
-      }
-      if (!((Taintable) (Object) thiz).$DD$isTainted()) {
+      if (!propagation.isTainted(thiz)) {
         return;
       }
 
       Iterator<HttpHeader> iterator = headers.iterator();
       while (iterator.hasNext()) {
         HttpHeader h = iterator.next();
-        if (!(h instanceof Taintable)) {
-          continue;
-        }
-
-        Taintable t = (Taintable) h;
-        if (t.$DD$isTainted()) {
+        if (propagation.isTainted(h)) {
           continue;
         }
         // unfortunately, the call to h.value() is instrumented, but
         // because the call to taint() only happens after, the call is a noop
-        propagation.taint(SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value(), t);
+        propagation.taintObject(SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value(), h);
       }
     }
   }
@@ -103,10 +94,8 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
         return;
       }
 
-      if (entity instanceof Taintable) {
-        if (((Taintable) entity).$DD$isTainted()) {
-          return;
-        }
+      if (propagation.isTainted(entity)) {
+        return;
       }
 
       propagation.taintIfInputIsTainted(entity, thiz);

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/RequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/RequestContextInstrumentation.java
@@ -13,7 +13,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.bytebuddy.asm.Advice;
@@ -50,10 +49,7 @@ public class RequestContextInstrumentation extends Instrumenter.Iast
         @Advice.This RequestContext requestContext, @Advice.Return HttpRequest request) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
-      if (propagation == null
-          || !(requestContext instanceof Taintable)
-          || !((Object) request instanceof Taintable)
-          || ((Taintable) (Object) request).$DD$isTainted()) {
+      if (propagation == null || propagation.isTainted(request)) {
         return;
       }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.akkahttp.iast.helpers;
 import akka.http.scaladsl.server.RequestContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
@@ -17,7 +16,7 @@ public class TaintRequestContextFunction
     RequestContext reqCtx = v1._1();
 
     PropagationModule mod = InstrumentationBridge.PROPAGATION;
-    if (mod == null || !(reqCtx instanceof Taintable)) {
+    if (mod == null) {
       return v1;
     }
     mod.taintObject(SourceTypes.REQUEST_BODY, reqCtx);

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.akkahttp.iast.helpers;
 import akka.http.scaladsl.model.HttpRequest;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import scala.Tuple1;
@@ -18,7 +17,7 @@ public class TaintRequestFunction implements JFunction1<Tuple1<HttpRequest>, Tup
     HttpRequest httpRequest = v1._1();
 
     PropagationModule mod = InstrumentationBridge.PROPAGATION;
-    if (mod == null || !((Object) httpRequest instanceof Taintable)) {
+    if (mod == null) {
       return v1;
     }
     mod.taintObject(SourceTypes.REQUEST_BODY, httpRequest);

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.akkahttp.iast.helpers;
 import akka.http.scaladsl.model.Uri;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
@@ -16,7 +15,7 @@ public class TaintUriFunction implements JFunction1<Tuple1<Uri>, Tuple1<Uri>> {
     Uri uri = v1._1();
 
     PropagationModule mod = InstrumentationBridge.PROPAGATION;
-    if (mod == null || !(uri instanceof Taintable)) {
+    if (mod == null) {
       return v1;
     }
     mod.taintObject(SourceTypes.REQUEST_QUERY, uri);

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpHeaderSubclassesInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpHeaderSubclassesInstrumentation.java
@@ -12,7 +12,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -59,7 +58,7 @@ public class HttpHeaderSubclassesInstrumentation extends Instrumenter.Iast
     static void onExit(@Advice.This HttpHeader h, @Advice.Return String retVal) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
-      if (propagation == null || !(h instanceof Taintable)) {
+      if (propagation == null) {
         return;
       }
 

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpRequestInstrumentation.java
@@ -15,7 +15,6 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.bytebuddy.asm.Advice;
@@ -67,27 +66,19 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
         return;
       }
 
-      if (!((Object) thiz instanceof Taintable)) {
-        return;
-      }
-      if (!((Taintable) (Object) thiz).$DD$isTainted()) {
+      if (!propagation.isTainted(thiz)) {
         return;
       }
 
       Iterator<HttpHeader> iterator = headers.iterator();
       while (iterator.hasNext()) {
         HttpHeader h = iterator.next();
-        if (!(h instanceof Taintable)) {
-          continue;
-        }
-
-        Taintable t = (Taintable) h;
-        if (t.$DD$isTainted()) {
+        if (propagation.isTainted(h)) {
           continue;
         }
         // unfortunately, the call to h.value() is instrumented, but
         // because the call to taint() only happens after, the call is a noop
-        propagation.taint(SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value(), t);
+        propagation.taintObject(SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value(), h);
       }
     }
   }
@@ -103,10 +94,8 @@ public class HttpRequestInstrumentation extends Instrumenter.Iast
         return;
       }
 
-      if (entity instanceof Taintable) {
-        if (((Taintable) entity).$DD$isTainted()) {
-          return;
-        }
+      if (propagation.isTainted(entity)) {
+        return;
       }
 
       propagation.taintIfInputIsTainted(entity, thiz);

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/RequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/RequestContextInstrumentation.java
@@ -11,7 +11,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.bytebuddy.asm.Advice;
@@ -50,10 +49,7 @@ public class RequestContextInstrumentation extends Instrumenter.Iast
         @Advice.This RequestContext requestContext, @Advice.Return HttpRequest request) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
-      if (propagation == null
-          || !(requestContext instanceof Taintable)
-          || !((Object) request instanceof Taintable)
-          || ((Taintable) (Object) request).$DD$isTainted()) {
+      if (propagation == null || propagation.isTainted(request)) {
         return;
       }
 

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestContextFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestContextFunction.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import org.apache.pekko.http.scaladsl.server.RequestContext;
 import scala.Tuple1;
@@ -17,7 +16,7 @@ public class TaintRequestContextFunction
     RequestContext reqCtx = v1._1();
 
     PropagationModule mod = InstrumentationBridge.PROPAGATION;
-    if (mod == null || !(reqCtx instanceof Taintable)) {
+    if (mod == null) {
       return v1;
     }
     mod.taintObject(SourceTypes.REQUEST_BODY, reqCtx);

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestFunction.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
@@ -18,7 +17,7 @@ public class TaintRequestFunction implements JFunction1<Tuple1<HttpRequest>, Tup
     HttpRequest httpRequest = v1._1();
 
     PropagationModule mod = InstrumentationBridge.PROPAGATION;
-    if (mod == null || !((Object) httpRequest instanceof Taintable)) {
+    if (mod == null) {
       return v1;
     }
     mod.taintObject(SourceTypes.REQUEST_BODY, httpRequest);

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUriFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUriFunction.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
-import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import org.apache.pekko.http.scaladsl.model.Uri;
 import scala.Tuple1;
@@ -16,7 +15,7 @@ public class TaintUriFunction implements JFunction1<Tuple1<Uri>, Tuple1<Uri>> {
     Uri uri = v1._1();
 
     PropagationModule mod = InstrumentationBridge.PROPAGATION;
-    if (mod == null || !(uri instanceof Taintable)) {
+    if (mod == null) {
       return v1;
     }
     mod.taintObject(SourceTypes.REQUEST_QUERY, uri);

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -49,9 +49,13 @@ public interface PropagationModule extends IastModule {
    */
   void taintObjects(byte origin, @Nullable Object[] toTaint);
 
-  void taintObjects(byte origin, @Nullable Collection<Object> toTaint);
+  /**
+   * Taint a non-String object. It might be {@link Taintable} or not. It is tainted with a source
+   * with the specified value.
+   */
+  void taintObject(byte origin, @Nullable String name, @Nullable String value, @Nullable Object t);
 
-  void taint(byte origin, @Nullable String name, @Nullable String value, @Nullable Taintable t);
+  void taintObjects(byte origin, @Nullable Collection<Object> toTaint);
 
   void taintIfInputIsTaintedWithMarks(
       @Nullable final String toTaint, @Nullable final Object input, int mark);


### PR DESCRIPTION
# What Does This Do
Removes direct references to `Taintable` from advices

# Motivation
There are cases where we might not be able to introduce the interface (e.g. already loaded classes). So it's better to let the propagation module handle the taint logic.

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
