### PR TITLE
Fix Spark streaming flaky test

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
@@ -216,7 +216,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
     sparkSession.stop()
 
     assertTraces(1) {
-      trace(5) {
+      trace(5, true) {
         span {
           operationName "spark.batch"
           resourceName "failing-query"
@@ -227,21 +227,21 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
           parent()
         }
         span {
+          operationName "spark.job"
+          spanType "spark"
+          errored true
+          childOf(span(2))
+        }
+        span {
           operationName "spark.sql"
           spanType "spark"
           childOf(span(0))
         }
         span {
-          operationName "spark.job"
-          spanType "spark"
-          errored true
-          childOf(span(1))
-        }
-        span {
           operationName "spark.stage"
           spanType "spark"
           errored true
-          childOf(span(2))
+          childOf(span(1))
         }
         span {
           operationName "spark.task"


### PR DESCRIPTION
# What Does This Do

When there is a failure in spark, events can be out of order. Using the parameter `sortByName=true` so that the order does not matter for this test

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
