### PR TITLE
Use _component_override for peer service source

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PeerServiceCalculatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PeerServiceCalculatorTest.groovy
@@ -116,7 +116,7 @@ class PeerServiceCalculatorTest extends DDSpecification {
 
     where:
     tags                                                                                   | expected       | source
-    ["component": "java-couchbase", "span.kind": "client"]                                 | "couchbase"    | "config_override"
+    ["component": "java-couchbase", "span.kind": "client"]                                 | "couchbase"    | "_component_override"
     ["peer.hostname": "host1", "span.kind": "client", "component" : "my-http-client"]      | "host1"        | "peer.hostname"
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/PeerServiceNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/PeerServiceNamingV1.java
@@ -58,7 +58,7 @@ public class PeerServiceNamingV1 implements NamingSchema.ForPeerService {
     final String override = overridesByComponent.get(componentString);
     // check if value can be overridden
     if (override != null) {
-      set(unsafeTags, override, "config_override");
+      set(unsafeTags, override, "_component_override");
       return;
     }
     // otherwise try to lookup by component specific precursor


### PR DESCRIPTION
# What Does This Do

.... when the peer service value has been manually overridden by component

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
