### PR TITLE
Fix smoke tests for J9 JVMs

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -19,6 +19,13 @@ profiling_test_matrix: &profiling_test_matrix
       - "{{ jdk }}"
 {% endfor %}
 
+debugger_test_matrix: &debugger_test_matrix
+  parameters:
+    testJvm:
+{% for jdk in all_debugger_jdks %}
+      - "{{ jdk }}"
+{% endfor %}
+
 system_test_matrix: &system_test_matrix
   parameters:
     weblog-variant: [ 'spring-boot', 'spring-boot-jetty', 'spring-boot-openliberty', 'spring-boot-3-native', 'jersey-grizzly2', 'resteasy-netty3','ratpack', 'vertx3' ]
@@ -1130,7 +1137,7 @@ build_test_jobs: &build_test_jobs
       stage: debugger
       cacheType: base
       matrix:
-        <<: *profiling_test_matrix
+        <<: *debugger_test_matrix
 
   - tests:
       requires:
@@ -1144,6 +1151,18 @@ build_test_jobs: &build_test_jobs
       maxWorkers: 3
       matrix:
         <<: *test_matrix
+
+  - tests:
+      requires:
+        - ok_to_test
+      name: test_semeru8_debugger_smoke
+      maxWorkers: 4
+      gradleTarget: "stageMainDist dd-smoke-tests:debugger-integration-tests:test"
+      gradleParameters: "-PskipFlakyTests"
+      triggeredBy: *debugger_modules
+      stage: debugger
+      cacheType: smoke
+      testJvm: "semeru8"
 
   - tests:
       requires:

--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -70,6 +70,9 @@ if branch == "master" or branch.startswith("release/v") or "all" in labels:
 else:
     all_jdks = ALWAYS_ON_JDKS | (MASTER_ONLY_JDKS & labels)
 nocov_jdks = [j for j in all_jdks if j != "8"]
+# specific list for debugger project because J9-based JVM have issues with local vars
+# so need to test at least against one J9-based JVM
+all_debugger_jdks = all_jdks | {"semeru8"}
 
 # Is this a nightly or weekly build? These environment variables are set in
 # config.yml based on pipeline parameters.
@@ -82,6 +85,7 @@ vars = {
     "is_weekly": is_weekly,
     "is_regular": is_regular,
     "all_jdks": all_jdks,
+    "all_debugger_jdks": all_debugger_jdks,
     "nocov_jdks": nocov_jdks,
     "flaky": branch == "master" or "flaky" in labels or "all" in labels,
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
@@ -6,10 +6,16 @@ import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.probe.MetricProbe;
 import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class MetricProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
+
+  @AfterEach
+  void teardown() throws Exception {
+    processRemainingRequests();
+  }
 
   @Test
   @DisplayName("testMethodMetricInc")

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanDecorationProbesIntegrationTests.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanDecorationProbesIntegrationTests.java
@@ -16,9 +16,9 @@ import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.el.expressions.BooleanExpression;
 import com.datadog.debugger.probe.SpanDecorationProbe;
+import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.debugger.EvaluationError;
 import datadog.trace.test.agent.decoder.DecodedSpan;
-import datadog.trace.test.util.Flaky;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@Flaky
 public class SpanDecorationProbesIntegrationTests extends ServerAppDebuggerIntegrationTest {
 
   @Override
@@ -40,6 +39,10 @@ public class SpanDecorationProbesIntegrationTests extends ServerAppDebuggerInteg
   @Test
   @DisplayName("testMethodSimpleTagNoCondition")
   void testMethodSimpleTagNoCondition() throws Exception {
+    if (Platform.isJ9()) {
+      // skip for J9/OpenJ9 as we cannot get local variable debug info.
+      return;
+    }
     SpanDecorationProbe spanDecorationProbe =
         SpanDecorationProbe.builder()
             .probeId(PROBE_ID)
@@ -67,6 +70,10 @@ public class SpanDecorationProbesIntegrationTests extends ServerAppDebuggerInteg
   @Test
   @DisplayName("testMethodMultiTagsMultiConditions")
   void testMethodMultiTagsMultiConditions() throws Exception {
+    if (Platform.isJ9()) {
+      // skip for J9/OpenJ9 as we cannot get local variable debug info.
+      return;
+    }
     List<SpanDecorationProbe.Decoration> decorations =
         Arrays.asList(
             createDecoration(


### PR DESCRIPTION
# What Does This Do
skip tests that requires accessing arguments/local vars
fix flakiness of probe statuses and sending probe config

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
