### PR TITLE
Add multipart support as IAST source for servlet

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -48,6 +48,17 @@ public class WebModuleImpl implements WebModule {
   }
 
   @Override
+  public void onMultipartNames(@Nullable final Collection<String> headerNames) {
+    onNamed(headerNames, SourceTypes.REQUEST_MULTIPART_PARAMETER);
+  }
+
+  @Override
+  public void onMultipartValues(
+      @Nullable final String headerName, @Nullable final Collection<String> headerValues) {
+    onNamed(headerName, headerValues, SourceTypes.REQUEST_MULTIPART_PARAMETER);
+  }
+
+  @Override
   public void onCookieNames(@Nullable Iterable<String> cookieNames) {
     onNamed(cookieNames, SourceTypes.REQUEST_COOKIE_NAME);
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/MultipartInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/MultipartInstrumentation.java
@@ -57,7 +57,7 @@ public class MultipartInstrumentation extends Instrumenter.Iast
 
   public static class GetNameAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static String onExit(@Advice.Return final String name) {
       final WebModule module = InstrumentationBridge.WEB;
       if (module != null) {
@@ -69,7 +69,7 @@ public class MultipartInstrumentation extends Instrumenter.Iast
 
   public static class GetHeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static String onExit(
         @Advice.Return final String value, @Advice.Argument(0) final String name) {
       final WebModule module = InstrumentationBridge.WEB;

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/MultipartInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/MultipartInstrumentation.java
@@ -1,0 +1,112 @@
+package datadog.trace.instrumentation.servlet3;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.source.WebModule;
+import java.util.Collection;
+import java.util.Collections;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class MultipartInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+
+  public MultipartInstrumentation() {
+    super("servlet", "multipart");
+  }
+
+  public String muzzleDirective() {
+    return "servlet-3.x";
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "javax.servlet.http.Part";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("getName").and(isPublic()).and(takesArguments(0)),
+        getClass().getName() + "$GetNameAdvice");
+    transformation.applyAdvice(
+        named("getHeader").and(isPublic()).and(takesArguments(String.class)),
+        getClass().getName() + "$GetHeaderAdvice");
+    transformation.applyAdvice(
+        named("getHeaders").and(isPublic()).and(takesArguments(String.class)),
+        getClass().getName() + "$GetHeadersAdvice");
+    transformation.applyAdvice(
+        named("getHeaderNames").and(isPublic()).and(takesArguments(0)),
+        getClass().getName() + "$GetHeaderNamesAdvice");
+  }
+
+  public static class GetNameAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    public static String onExit(@Advice.Return final String name) {
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        module.onMultipartValues("Content-Disposition", Collections.singleton(name));
+      }
+      return name;
+    }
+  }
+
+  public static class GetHeaderAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    public static String onExit(
+        @Advice.Return final String value, @Advice.Argument(0) final String name) {
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        module.onMultipartValues(name, Collections.singleton(value));
+      }
+      return value;
+    }
+  }
+
+  public static class GetHeadersAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
+    public static void onExit(
+        @Advice.Argument(0) final String headerName,
+        @Advice.Return Collection<String> headerValues) {
+      if (null == headerValues) {
+        return;
+      }
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        module.onMultipartValues(headerName, headerValues);
+      }
+    }
+  }
+
+  public static class GetHeaderNamesAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
+    public static void onExit(@Advice.Return final Collection<String> headerNames) {
+      if (null == headerNames) {
+        return;
+      }
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        module.onMultipartNames(headerNames);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/MultipartInstrumentationForkedTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/MultipartInstrumentationForkedTest.groovy
@@ -1,0 +1,72 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.source.WebModule
+import foo.bar.smoketest.MockPart
+
+class MultipartInstrumentationForkedTest extends AgentTestRunner {
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  @Override
+  void cleanup() {
+    InstrumentationBridge.clearIastModules()
+  }
+
+  void 'test getName'() {
+    given:
+    final module = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(module)
+    final part = new MockPart("partName", "headerValue")
+
+    when:
+    part.getName()
+
+    then:
+    1 * module.onMultipartValues(_, _)
+    0 * _
+  }
+
+  void 'test getHeader'(){
+    given:
+    final module = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(module)
+    final part = new MockPart("partName", "headerValue")
+
+    when:
+    part.getHeader("headerName")
+
+    then:
+    1 * module.onMultipartValues(_, _)
+    0 * _
+  }
+
+  void 'test getHeaders'(){
+    given:
+    final module = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(module)
+    final part = new MockPart("partName", "headerValue")
+
+    when:
+    part.getHeaders("headerName")
+
+    then:
+    1 *  module.onMultipartValues(_, _)
+    0 * _
+  }
+
+  void 'test getHeaderNames'(){
+    given:
+    final module = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(module)
+    final part = new MockPart("partName", "headerValue")
+
+    when:
+    part.getHeaderNames()
+
+    then:
+    1 * module.onMultipartNames(_)
+    0 * _
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/MockPart.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/java/foo/bar/smoketest/MockPart.java
@@ -1,0 +1,63 @@
+package foo.bar.smoketest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+import javax.servlet.http.Part;
+
+public class MockPart implements Part {
+  String name;
+  String headerValue;
+
+  public MockPart(String name, String headerValue) {
+    this.name = name;
+    this.headerValue = headerValue;
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    return null;
+  }
+
+  @Override
+  public String getContentType() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getSubmittedFileName() {
+    return null;
+  }
+
+  @Override
+  public long getSize() {
+    return 0;
+  }
+
+  @Override
+  public void write(String fileName) throws IOException {}
+
+  @Override
+  public void delete() throws IOException {}
+
+  @Override
+  public String getHeader(String name) {
+    return headerValue;
+  }
+
+  @Override
+  public Collection<String> getHeaders(String name) {
+    return Collections.singleton(headerValue);
+  }
+
+  @Override
+  public Collection<String> getHeaderNames() {
+    return Collections.singleton(name);
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaMultipartInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaMultipartInstrumentation.java
@@ -53,7 +53,7 @@ public class JakartaMultipartInstrumentation extends Instrumenter.Iast
 
   public static class GetNameAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static String onExit(@Advice.Return final String name) {
       final WebModule module = InstrumentationBridge.WEB;
       if (module != null) {
@@ -65,7 +65,7 @@ public class JakartaMultipartInstrumentation extends Instrumenter.Iast
 
   public static class GetHeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static String onExit(
         @Advice.Return final String value, @Advice.Argument(0) final String name) {
       final WebModule module = InstrumentationBridge.WEB;
@@ -78,7 +78,7 @@ public class JakartaMultipartInstrumentation extends Instrumenter.Iast
 
   public static class GetHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static void onExit(
         @Advice.Argument(0) final String headerName,
         @Advice.Return Collection<String> headerValues) {
@@ -94,7 +94,7 @@ public class JakartaMultipartInstrumentation extends Instrumenter.Iast
 
   public static class GetHeaderNamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    @Source(SourceTypes.REQUEST_HEADER_NAME)
+    @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static void onExit(@Advice.Return final Collection<String> headerNames) {
       if (null == headerNames) {
         return;

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaMultipartInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaMultipartInstrumentation.java
@@ -1,0 +1,108 @@
+package datadog.trace.instrumentation.servlet5;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.source.WebModule;
+import java.util.Collection;
+import java.util.Collections;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class JakartaMultipartInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+
+  public JakartaMultipartInstrumentation() {
+    super("servlet", "servlet-5", "multipart");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "jakarta.servlet.http.Part";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("getName").and(isPublic()).and(takesArguments(0)),
+        getClass().getName() + "$GetNameAdvice");
+    transformation.applyAdvice(
+        named("getHeader").and(isPublic()).and(takesArguments(String.class)),
+        getClass().getName() + "$GetHeaderAdvice");
+    transformation.applyAdvice(
+        named("getHeaders").and(isPublic()).and(takesArguments(String.class)),
+        getClass().getName() + "$GetHeadersAdvice");
+    transformation.applyAdvice(
+        named("getHeaderNames").and(isPublic()).and(takesArguments(0)),
+        getClass().getName() + "$GetHeaderNamesAdvice");
+  }
+
+  public static class GetNameAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    public static String onExit(@Advice.Return final String name) {
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        module.onMultipartValues("Content-Disposition", Collections.singleton(name));
+      }
+      return name;
+    }
+  }
+
+  public static class GetHeaderAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    public static String onExit(
+        @Advice.Return final String value, @Advice.Argument(0) final String name) {
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        module.onMultipartValues(name, Collections.singleton(value));
+      }
+      return value;
+    }
+  }
+
+  public static class GetHeadersAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    public static void onExit(
+        @Advice.Argument(0) final String headerName,
+        @Advice.Return Collection<String> headerValues) {
+      if (null == headerValues) {
+        return;
+      }
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        module.onMultipartValues(headerName, headerValues);
+      }
+    }
+  }
+
+  public static class GetHeaderNamesAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    @Source(SourceTypes.REQUEST_HEADER_NAME)
+    public static void onExit(@Advice.Return final Collection<String> headerNames) {
+      if (null == headerNames) {
+        return;
+      }
+      final WebModule module = InstrumentationBridge.WEB;
+      if (module != null) {
+        module.onMultipartNames(headerNames);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaMultipartInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaMultipartInstrumentationTest.groovy
@@ -1,0 +1,72 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.source.WebModule
+import foo.bar.smoketest.MockPart
+
+class JakartaMultipartInstrumentationTest extends AgentTestRunner {
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  @Override
+  void cleanup() {
+    InstrumentationBridge.clearIastModules()
+  }
+
+  void 'test getName'() {
+    given:
+    final module = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(module)
+    final part = new MockPart("partName", "headerValue")
+
+    when:
+    part.getName()
+
+    then:
+    1 * module.onMultipartValues(_, _)
+    0 * _
+  }
+
+  void 'test getHeader'(){
+    given:
+    final module = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(module)
+    final part = new MockPart("partName", "headerValue")
+
+    when:
+    part.getHeader("headerName")
+
+    then:
+    1 * module.onMultipartValues(_, _)
+    0 * _
+  }
+
+  void 'test getHeaders'(){
+    given:
+    final module = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(module)
+    final part = new MockPart("partName", "headerValue")
+
+    when:
+    part.getHeaders("headerName")
+
+    then:
+    1 *  module.onMultipartValues(_, _)
+    0 * _
+  }
+
+  void 'test getHeaderNames'(){
+    given:
+    final module = Mock(WebModule)
+    InstrumentationBridge.registerIastModule(module)
+    final part = new MockPart("partName", "headerValue")
+
+    when:
+    part.getHeaderNames()
+
+    then:
+    1 * module.onMultipartNames(_)
+    0 * _
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/MockPart.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/java/foo/bar/smoketest/MockPart.java
@@ -1,0 +1,63 @@
+package foo.bar.smoketest;
+
+import jakarta.servlet.http.Part;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+public class MockPart implements Part {
+  String name;
+  String headerValue;
+
+  public MockPart(String name, String headerValue) {
+    this.name = name;
+    this.headerValue = headerValue;
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    return null;
+  }
+
+  @Override
+  public String getContentType() {
+    return null;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getSubmittedFileName() {
+    return null;
+  }
+
+  @Override
+  public long getSize() {
+    return 0;
+  }
+
+  @Override
+  public void write(String fileName) throws IOException {}
+
+  @Override
+  public void delete() throws IOException {}
+
+  @Override
+  public String getHeader(String name) {
+    return headerValue;
+  }
+
+  @Override
+  public Collection<String> getHeaders(String name) {
+    return Collections.singleton(headerValue);
+  }
+
+  @Override
+  public Collection<String> getHeaderNames() {
+    return Collections.singleton(name);
+  }
+}

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.Principal;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
@@ -39,6 +40,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
@@ -314,6 +316,18 @@ public class IastWebController {
     response.addHeader("X-Content-Type-Options", "dosniff");
     response.setStatus(HttpStatus.OK.value());
     return "ok";
+  }
+
+  @PostMapping("/multipart")
+  public String handleFileUpload(
+      @RequestParam("theFile") MultipartFile file, @RequestParam("param1") String param1) {
+    String fileContent = "NO_FILE";
+    try {
+      fileContent = Arrays.toString(file.getBytes());
+      file.getOriginalFilename();
+    } catch (IOException e) {
+    }
+    return "fileName: " + file.getName();
   }
 
   @GetMapping(value = "/xcontenttypeoptionsecure", produces = "text/html")

--- a/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
@@ -26,6 +26,9 @@ public abstract class SourceTypes {
   public static final String REQUEST_PATH_PARAMETER_STRING = "http.request.path.parameter";
   public static final byte REQUEST_MATRIX_PARAMETER = 9;
   public static final String REQUEST_MATRIX_PARAMETER_STRING = "http.request.matrix.parameter";
+  public static final byte REQUEST_MULTIPART_PARAMETER = 10;
+  public static final String REQUEST_MULTIPART_PARAMETER_STRING =
+      "http.request.multipart.parameter";
 
   private static final byte[] VALUES = {
     REQUEST_PARAMETER_NAME,
@@ -66,6 +69,8 @@ public abstract class SourceTypes {
         return SourceTypes.REQUEST_PATH_PARAMETER_STRING;
       case SourceTypes.REQUEST_MATRIX_PARAMETER:
         return SourceTypes.REQUEST_MATRIX_PARAMETER_STRING;
+      case SourceTypes.REQUEST_MULTIPART_PARAMETER:
+        return SourceTypes.REQUEST_MULTIPART_PARAMETER_STRING;
       default:
         return null;
     }

--- a/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
@@ -40,7 +40,8 @@ public abstract class SourceTypes {
     REQUEST_BODY,
     REQUEST_QUERY,
     REQUEST_PATH_PARAMETER,
-    REQUEST_MATRIX_PARAMETER
+    REQUEST_MATRIX_PARAMETER,
+    REQUEST_MULTIPART_PARAMETER
   };
 
   public static byte[] values() {

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -24,4 +24,9 @@ public interface WebModule extends IastModule {
   void onHeaderValues(@Nullable String headerName, @Nullable Collection<String> headerValue);
 
   void onCookieNames(@Nullable Iterable<String> cookieNames);
+
+  void onMultipartNames(@Nullable final Collection<String> headerNames);
+
+  void onMultipartValues(
+      @Nullable String headerName, @Nullable final Collection<String> headerValues);
 }


### PR DESCRIPTION
# What Does This Do
Adds instrumentation for Multipart headers so they can be tainted for IAST use

# Motivation
To cover all of the possible tainted object sources.

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
