### PR TITLE
Fix changelog generation crash on community contribution

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -121,7 +121,7 @@ jobs:
               var line = `${decorate(pullRequest)}${pullRequest.title} (#${pullRequest.number}`
               // Add author if community labeled
               if (pullRequest.labels.some(label => label.name == "tag: community")) {
-                line += ` - thanks @${pull.user.login} for the contribution!`
+                line += ` - thanks @${pullRequest.user.login} for the contribution!`
               }
               line += ')'
               return line;


### PR DESCRIPTION
# What Does This Do

Fix a crash when generating a release changelog with community contribution.

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
