### PR TITLE
Extract trace context from embedded SQS message attribute '_datadog'

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/messaging/DatadogAttributeParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/messaging/DatadogAttributeParser.java
@@ -1,0 +1,66 @@
+package datadog.trace.bootstrap.instrumentation.messaging;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Parses trace context from an embedded '_datadog' message attribute. */
+public final class DatadogAttributeParser {
+  private static final Logger log = LoggerFactory.getLogger(DatadogAttributeParser.class);
+
+  private static final Base64.Decoder BASE_64 = Base64.getDecoder();
+
+  /** Parses trace context properties from the given JSON and passes them to the classifier. */
+  public static void forEachProperty(AgentPropagation.KeyClassifier classifier, String json) {
+    if (null == json) {
+      return;
+    }
+    try {
+      if (acceptJsonProperty(classifier, json, "x-datadog-trace-id")) {
+        acceptJsonProperty(classifier, json, "x-datadog-parent-id");
+        acceptJsonProperty(classifier, json, "x-datadog-sampling-priority");
+      }
+      if (Config.get().isDataStreamsEnabled()) {
+        acceptJsonProperty(classifier, json, "dd-pathway-ctx-base64");
+      }
+    } catch (Exception e) {
+      log.debug("Problem extracting _datadog context", e);
+    }
+  }
+
+  /** Parses trace context properties from the given JSON and passes them to the classifier. */
+  public static void forEachProperty(AgentPropagation.KeyClassifier classifier, ByteBuffer json) {
+    if (null == json) {
+      return;
+    }
+    try {
+      forEachProperty(classifier, UTF_8.decode(BASE_64.decode(json)).toString());
+    } catch (Exception e) {
+      log.debug("Problem decoding _datadog context", e);
+    }
+  }
+
+  // Simple parser that assumes values are JSON strings that don't contain escaped quotes
+  private static boolean acceptJsonProperty(
+      AgentPropagation.KeyClassifier classifier, String json, String key) {
+    int keyStart = json.indexOf(key);
+    if (keyStart > 0) {
+      int separator = json.indexOf(':', keyStart + key.length());
+      if (separator > 0) {
+        int valueStart = json.indexOf('"', separator + 1);
+        if (valueStart > 0) {
+          int valueEnd = json.indexOf('"', valueStart + 1);
+          if (valueEnd > 0) {
+            return classifier.accept(key, json.substring(valueStart + 1, valueEnd));
+          }
+        }
+      }
+    }
+    return false;
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/MessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/MessageExtractAdapter.java
@@ -1,7 +1,9 @@
 package datadog.trace.instrumentation.aws.v1.sqs;
 
 import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.messaging.DatadogAttributeParser;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,22 +15,27 @@ public final class MessageExtractAdapter implements AgentPropagation.ContextVisi
 
   @Override
   public void forEachKey(Message carrier, AgentPropagation.KeyClassifier classifier) {
-    for (Map.Entry<String, String> entry : carrier.getAttributes().entrySet()) {
-      String key = entry.getKey();
-      if ("AWSTraceHeader".equalsIgnoreCase(key)) {
-        key = "X-Amzn-Trace-Id";
-      }
-      if (!classifier.accept(key, entry.getValue())) {
-        return;
+    Map<String, String> systemAttributes = carrier.getAttributes();
+    if (systemAttributes.containsKey("AWSTraceHeader")) {
+      // alias 'AWSTraceHeader' to 'X-Amzn-Trace-Id' because it uses the same format
+      classifier.accept("X-Amzn-Trace-Id", systemAttributes.get("AWSTraceHeader"));
+    }
+    Map<String, MessageAttributeValue> messageAttributes = carrier.getMessageAttributes();
+    if (messageAttributes.containsKey("_datadog")) {
+      MessageAttributeValue datadog = messageAttributes.get("_datadog");
+      if ("String".equals(datadog.getDataType())) {
+        DatadogAttributeParser.forEachProperty(classifier, datadog.getStringValue());
+      } else if ("Binary".equals(datadog.getDataType())) {
+        DatadogAttributeParser.forEachProperty(classifier, datadog.getBinaryValue());
       }
     }
   }
 
   public long extractTimeInQueueStart(final Message carrier) {
     try {
-      Map<String, String> attributes = carrier.getAttributes();
-      if (attributes.containsKey("SentTimestamp")) {
-        return Long.parseLong(attributes.get("SentTimestamp"));
+      Map<String, String> systemAttributes = carrier.getAttributes();
+      if (systemAttributes.containsKey("SentTimestamp")) {
+        return Long.parseLong(systemAttributes.get("SentTimestamp"));
       }
     } catch (Exception e) {
       log.debug("Unable to get SQS sent time", e);

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -1,4 +1,5 @@
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static java.nio.charset.StandardCharsets.UTF_8
 
 import com.amazon.sqs.javamessaging.ProviderConfiguration
 import com.amazon.sqs.javamessaging.SQSConnectionFactory
@@ -7,6 +8,8 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.AnonymousAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder
+import com.amazonaws.services.sqs.model.Message
+import com.amazonaws.services.sqs.model.MessageAttributeValue
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.TraceUtils
 import datadog.trace.api.Config
@@ -16,6 +19,7 @@ import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.naming.SpanNaming
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.aws.v1.sqs.TracingList
 import org.elasticmq.rest.sqs.SQSRestServerBuilder
 import spock.lang.Shared
 
@@ -145,6 +149,86 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
 
     cleanup:
     client.shutdown()
+  }
+
+  def "trace details propagated via embedded SQS message attribute (string)"() {
+    setup:
+    TEST_WRITER.clear()
+
+    when:
+    def message = new Message()
+    message.addMessageAttributesEntry('_datadog', new MessageAttributeValue().withDataType('String').withStringValue(
+      "{\"x-datadog-trace-id\": \"4948377316357291421\", \"x-datadog-parent-id\": \"6746998015037429512\", \"x-datadog-sampling-priority\": \"1\"}"
+      ))
+    def messages = new TracingList([message], "http://localhost:${address.port}/000000000000/somequeue")
+
+    messages.forEach {/* consume to create message spans */ }
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          serviceName expectedService("SQS", "ReceiveMessage")
+          operationName expectedOperation("SQS", "ReceiveMessage")
+          resourceName "SQS.ReceiveMessage"
+          spanType DDSpanTypes.MESSAGE_CONSUMER
+          errored false
+          measured true
+          traceId(4948377316357291421 as BigInteger)
+          parentSpanId(6746998015037429512 as BigInteger)
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            "aws.service" "AmazonSQS"
+            "aws_service" "sqs"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags(true)
+          }
+        }
+      }
+    }
+  }
+
+  def "trace details propagated via embedded SQS message attribute (binary)"() {
+    setup:
+    TEST_WRITER.clear()
+
+    when:
+    def message = new Message()
+    message.addMessageAttributesEntry('_datadog', new MessageAttributeValue().withDataType('Binary').withBinaryValue(
+      UTF_8.encode('eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0OTQ4Mzc3MzE2MzU3MjkxNDIxIiwieC1kYXRhZG9nLXBhcmVudC1pZCI6IjY3NDY5OTgwMTUwMzc0Mjk1MTIiLCJ4LWRhdGFkb2ctc2FtcGxpbmctcHJpb3JpdHkiOiIxIn0=')
+      ))
+    def messages = new TracingList([message], "http://localhost:${address.port}/000000000000/somequeue")
+
+    messages.forEach {/* consume to create message spans */ }
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          serviceName expectedService("SQS", "ReceiveMessage")
+          operationName expectedOperation("SQS", "ReceiveMessage")
+          resourceName "SQS.ReceiveMessage"
+          spanType DDSpanTypes.MESSAGE_CONSUMER
+          errored false
+          measured true
+          traceId(4948377316357291421 as BigInteger)
+          parentSpanId(6746998015037429512 as BigInteger)
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            "aws.service" "AmazonSQS"
+            "aws_service" "sqs"
+            "aws.operation" "ReceiveMessageRequest"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            defaultTags(true)
+          }
+        }
+      }
+    }
   }
 
   def "trace details propagated from SQS to JMS"() {

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
@@ -1,28 +1,32 @@
-import datadog.trace.api.DDTags
-import datadog.trace.core.datastreams.StatsGroup
-import spock.lang.IgnoreIf
-
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static java.nio.charset.StandardCharsets.UTF_8
 
 import com.amazon.sqs.javamessaging.ProviderConfiguration
 import com.amazon.sqs.javamessaging.SQSConnectionFactory
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.TraceUtils
 import datadog.trace.api.Config
+import datadog.trace.api.DDTags
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.api.naming.SpanNaming
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.datastreams.StatsGroup
+import datadog.trace.instrumentation.aws.v2.sqs.TracingList
 import org.elasticmq.rest.sqs.SQSRestServerBuilder
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
+import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.core.SdkSystemSetting
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 
 import javax.jms.Session
@@ -180,6 +184,92 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
 
     cleanup:
     client.close()
+  }
+
+  @IgnoreIf({instance.isDataStreamsEnabled()})
+  def "trace details propagated via embedded SQS message attribute (string)"() {
+    setup:
+    TEST_WRITER.clear()
+
+    when:
+    def message = Message.builder().messageAttributes(['_datadog': MessageAttributeValue.builder().dataType('String').stringValue(
+      "{\"x-datadog-trace-id\": \"4948377316357291421\", \"x-datadog-parent-id\": \"6746998015037429512\", \"x-datadog-sampling-priority\": \"1\"}"
+      ).build()]).build()
+    def messages = new TracingList([message],
+    "http://localhost:${address.port}/000000000000/somequeue",
+    "00000000-0000-0000-0000-000000000000")
+
+    messages.forEach {/* consume to create message spans */ }
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          serviceName expectedService("Sqs", "ReceiveMessage")
+          operationName expectedOperation("Sqs", "ReceiveMessage")
+          resourceName "Sqs.ReceiveMessage"
+          spanType DDSpanTypes.MESSAGE_CONSUMER
+          errored false
+          measured true
+          traceId(4948377316357291421 as BigInteger)
+          parentSpanId(6746998015037429512 as BigInteger)
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            "aws.service" "Sqs"
+            "aws_service" "Sqs"
+            "aws.operation" "ReceiveMessage"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.requestId" "00000000-0000-0000-0000-000000000000"
+            defaultTags(true)
+          }
+        }
+      }
+    }
+  }
+
+  @IgnoreIf({instance.isDataStreamsEnabled()})
+  def "trace details propagated via embedded SQS message attribute (binary)"() {
+    setup:
+    TEST_WRITER.clear()
+
+    when:
+    def message = Message.builder().messageAttributes(['_datadog': MessageAttributeValue.builder().dataType('Binary').binaryValue(SdkBytes.fromByteBuffer(
+      UTF_8.encode('eyJ4LWRhdGFkb2ctdHJhY2UtaWQiOiI0OTQ4Mzc3MzE2MzU3MjkxNDIxIiwieC1kYXRhZG9nLXBhcmVudC1pZCI6IjY3NDY5OTgwMTUwMzc0Mjk1MTIiLCJ4LWRhdGFkb2ctc2FtcGxpbmctcHJpb3JpdHkiOiIxIn0=')
+      )).build()]).build()
+    def messages = new TracingList([message],
+    "http://localhost:${address.port}/000000000000/somequeue",
+    "00000000-0000-0000-0000-000000000000")
+
+    messages.forEach {/* consume to create message spans */ }
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          serviceName expectedService("Sqs", "ReceiveMessage")
+          operationName expectedOperation("Sqs", "ReceiveMessage")
+          resourceName "Sqs.ReceiveMessage"
+          spanType DDSpanTypes.MESSAGE_CONSUMER
+          errored false
+          measured true
+          traceId(4948377316357291421 as BigInteger)
+          parentSpanId(6746998015037429512 as BigInteger)
+          tags {
+            "$Tags.COMPONENT" "java-aws-sdk"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CONSUMER
+            "aws.service" "Sqs"
+            "aws_service" "Sqs"
+            "aws.operation" "ReceiveMessage"
+            "aws.agent" "java-aws-sdk"
+            "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.requestId" "00000000-0000-0000-0000-000000000000"
+            defaultTags(true)
+          }
+        }
+      }
+    }
   }
 
   @IgnoreIf({instance.isDataStreamsEnabled()})

--- a/dd-java-agent/instrumentation/spring-messaging-4/src/main/java/datadog/trace/instrumentation/springmessaging/SpringMessageExtractAdapter.java
+++ b/dd-java-agent/instrumentation/spring-messaging-4/src/main/java/datadog/trace/instrumentation/springmessaging/SpringMessageExtractAdapter.java
@@ -3,7 +3,9 @@ package datadog.trace.instrumentation.springmessaging;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.messaging.DatadogAttributeParser;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.nio.ByteBuffer;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
@@ -11,6 +13,7 @@ import org.springframework.messaging.Message;
 
 public final class SpringMessageExtractAdapter
     implements AgentPropagation.ContextVisitor<Message<?>> {
+
   private static final Function<String, String> KEY_MAPPER =
       new Function<String, String>() {
         @SuppressForbidden
@@ -31,9 +34,16 @@ public final class SpringMessageExtractAdapter
   @Override
   public void forEachKey(Message<?> carrier, AgentPropagation.KeyClassifier classifier) {
     for (Map.Entry<String, ?> header : carrier.getHeaders().entrySet()) {
-      if (header.getValue() instanceof String) {
+      Object headerValue = header.getValue();
+      if ("_datadog".equals(header.getKey())) {
+        if (headerValue instanceof String) {
+          DatadogAttributeParser.forEachProperty(classifier, (String) headerValue);
+        } else if (headerValue instanceof ByteBuffer) {
+          DatadogAttributeParser.forEachProperty(classifier, (ByteBuffer) headerValue);
+        }
+      } else if (headerValue instanceof String) {
         String lowerCaseKey = cache.computeIfAbsent(header.getKey(), KEY_MAPPER);
-        if (!classifier.accept(lowerCaseKey, (String) header.getValue())) {
+        if (!classifier.accept(lowerCaseKey, (String) headerValue)) {
           return;
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -248,22 +248,6 @@ public class DefaultPathwayContext implements PathwayContext {
 
     @Override
     public boolean accept(String key, String value) {
-      if (PathwayContext.DATADOG_KEY.equalsIgnoreCase(key)) {
-        try {
-          int startIndex = value.indexOf("\"dd-pathway-ctx-base64\": ");
-          int startValueIndex =
-              value.indexOf("\"", startIndex + "\"dd-pathway-ctx-base64\": ".length());
-          int endValueIndex = value.indexOf("\"", startValueIndex + 1);
-          if (startIndex == -1 || startValueIndex == -1 || endValueIndex == -1) {
-            return false;
-          }
-          String ddPathwayCtxBase64Value = value.substring(startValueIndex + 1, endValueIndex);
-          ddPathwayCtxBase64Value = ddPathwayCtxBase64Value.trim();
-          extractedContext = strDecode(timeSource, wellKnownTags, ddPathwayCtxBase64Value);
-        } catch (IOException | IndexOutOfBoundsException e) {
-          return false;
-        }
-      }
       if (PathwayContext.PROPAGATION_KEY_BASE64.equalsIgnoreCase(key)) {
         try {
           extractedContext = strDecode(timeSource, wellKnownTags, value);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
@@ -438,8 +438,7 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
     context.setCheckpoint(new LinkedHashMap<>(["type": "internal"]), pointConsumer)
 
     def encoded = context.strEncode()
-    def jsonPathway = String.format("{\"%s\": \"%s\"}", PathwayContext.PROPAGATION_KEY_BASE64, encoded)
-    Map<String, String> carrier = [(PathwayContext.DATADOG_KEY): jsonPathway, "someotherkey": "someothervalue"]
+    Map<String, String> carrier = [(PathwayContext.PROPAGATION_KEY_BASE64): encoded, "someotherkey": "someothervalue"]
     timeSource.advance(MILLISECONDS.toNanos(1))
     def decodedContext = DefaultPathwayContext.extract(carrier, contextVisitor, timeSource, wellKnownTags)
     timeSource.advance(MILLISECONDS.toNanos(25))
@@ -459,8 +458,7 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
 
     when:
     def secondEncode = decodedContext.strEncode()
-    def secondJsonPathway = String.format("{\"%s\": \"%s\"}", PathwayContext.PROPAGATION_KEY_BASE64, secondEncode)
-    carrier = [(PathwayContext.DATADOG_KEY): secondJsonPathway]
+    carrier = [(PathwayContext.PROPAGATION_KEY_BASE64): secondEncode]
     timeSource.advance(MILLISECONDS.toNanos(2))
     def secondDecode = DefaultPathwayContext.extract(carrier, contextVisitor, timeSource, wellKnownTags)
     timeSource.advance(MILLISECONDS.toNanos(30))


### PR DESCRIPTION
# Motivation

The `_datadog` message attribute is used by DSM and certain language tracers to propagate context instead of AWS' `AWSTraceHeader`. The attribute contains trace context as a JSON string, or encoded with Base64 as a binary value.
