### PR TITLE
Use process.isAlive() in PortUtils

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
@@ -114,12 +114,8 @@ public class PortUtils {
         throw new RuntimeException("Interrupted while waiting for " + port + " to be opened");
       }
 
-      // Note: we should have used `process.isAlive()` here but it is java8 only
-      try {
-        process.exitValue();
+      if (!process.isAlive()) {
         throw new RuntimeException("Process died before port " + port + " was opened");
-      } catch (final IllegalThreadStateException e) {
-        // process is still alive, things are good.
       }
 
       if (isPortOpen(port)) {


### PR DESCRIPTION
# What Does This Do

# Motivation
Small clean up of Java 7 support leftovers.

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
