### PR TITLE
Register that we will reflect on ConcurrentHashMap constructor at runtime

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
+++ b/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
@@ -30,6 +30,12 @@
     ]
   },
   {
+    "name" : "java.util.concurrent.ConcurrentHashMap",
+    "methods": [
+      {"name": "<init>", "parameterTypes": []}
+    ]
+  },
+  {
     "name" : "datadog.trace.agent.common.sampling.SpanSamplingRules$RuleAdapter",
     "methods": [
       {"name": "fromJson"}


### PR DESCRIPTION
# Motivation

This avoids the following exception when running a native-image that uses Netty-Reactor:
```
Caused by: java.lang.NoSuchMethodError: java.util.concurrent.ConcurrentHashMap.<init>()
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.methodhandles.Util_java_lang_invoke_MethodHandleNatives.resolve(Target_java_lang_invoke_MethodHandleNatives.java:345) ~[na:na]
        at java.base@17.0.6/java.lang.invoke.MethodHandleNatives.resolve(MethodHandleNatives.java:223) ~[na:na]
        at java.base@17.0.6/java.lang.invoke.MemberName$Factory.resolve(MemberName.java:1085) ~[na:na]
        at java.base@17.0.6/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1114) ~[na:na]
```

# Additional Notes
One of the helper classes in the Netty integration uses `GenericClassValue.constructing(ConcurrentHashMap.class)`

