### PR TITLE
Fix baggage HTTP header encoding

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -71,7 +71,7 @@ class DatadogHttpCodec {
       for (final Map.Entry<String, String> entry : context.baggageItems()) {
         String header = invertedBaggageMapping.get(entry.getKey());
         header = header != null ? header : OT_BAGGAGE_PREFIX + entry.getKey();
-        setter.set(carrier, header, HttpCodec.encode(entry.getValue()));
+        setter.set(carrier, header, HttpCodec.encodeBaggage(entry.getValue()));
       }
 
       // inject x-datadog-tags

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -99,7 +99,7 @@ class HaystackHttpCodec {
         for (final Map.Entry<String, String> entry : context.baggageItems()) {
           String header = invertedBaggageMapping.get(entry.getKey());
           header = header != null ? header : OT_BAGGAGE_PREFIX + entry.getKey();
-          setter.set(carrier, header, HttpCodec.encode(entry.getValue()));
+          setter.set(carrier, header, HttpCodec.encodeBaggage(entry.getValue()));
         }
         log.debug(
             "{} - Haystack parent context injected - {}", context.getTraceId(), injectedTraceId);

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -194,6 +194,19 @@ public class HttpCodec {
     return encoded;
   }
 
+  /**
+   * Encodes baggage value according <a href="https://www.w3.org/TR/baggage/#value">W3C RFC</a>.
+   *
+   * @param value The baggage value.
+   * @return The encoded baggage value.
+   */
+  static String encodeBaggage(final String value) {
+    // Fix encoding to comply with https://www.w3.org/TR/baggage/#value and use percent-encoding
+    // (RFC3986)
+    // for space ( ) instead of plus (+) from 'application/x-www-form' MIME encoding
+    return encode(value).replace("+", "%20");
+  }
+
   /** URL decode value */
   static String decode(final String value) {
     String decoded = value;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -81,7 +81,7 @@ class W3CHttpCodec {
       for (final Map.Entry<String, String> entry : context.baggageItems()) {
         String header = invertedBaggageMapping.get(entry.getKey());
         header = header != null ? header : OT_BAGGAGE_PREFIX + entry.getKey();
-        setter.set(carrier, header, HttpCodec.encode(entry.getValue()));
+        setter.set(carrier, header, HttpCodec.encodeBaggage(entry.getValue()));
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

This will prevent encoding the baggage into HTTP header using the `application/x-www-form-urlencoded` MIME type format but use the W3C baggage RFC instead.

# Motivation

This will increase compatibility by using the right encoding.

# Additional Notes

The new encoding is compatible of the current decoding so no compatibility flag was introduce to restore the old behavior.
