### PR TITLE
Add redefinition listener to disable taintable visitor in case of failure

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -4,6 +4,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.GlobalIgnoresMatcher
 import static net.bytebuddy.matcher.ElementMatchers.isDefaultFinalizer;
 
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
+import datadog.trace.agent.tooling.bytebuddy.iast.TaintableRedefinitionStrategyListener;
 import datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers;
 import datadog.trace.agent.tooling.bytebuddy.memoize.MemoizedMatchers;
 import datadog.trace.agent.tooling.bytebuddy.outline.TypePoolFacade;
@@ -119,6 +120,7 @@ public class AgentInstaller {
             .with(AgentStrategies.transformerDecorator())
             .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
             .with(AgentStrategies.rediscoveryStrategy())
+            .with(redefinitionStrategyListener(enabledSystems))
             .with(AgentStrategies.locationStrategy())
             .with(AgentStrategies.poolStrategy())
             .with(AgentBuilder.DescriptionStrategy.Default.POOL_ONLY)
@@ -135,6 +137,7 @@ public class AgentInstaller {
           agentBuilder
               .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
               .with(AgentStrategies.rediscoveryStrategy())
+              .with(redefinitionStrategyListener(enabledSystems))
               .with(new RedefinitionLoggingListener())
               .with(new TransformLoggingListener());
     }
@@ -252,6 +255,15 @@ public class AgentInstaller {
       } else {
         System.setProperty(TypeDefinition.RAW_TYPES_PROPERTY, savedPropertyValue);
       }
+    }
+  }
+
+  private static AgentBuilder.RedefinitionStrategy.Listener redefinitionStrategyListener(
+      final Set<Instrumenter.TargetSystem> enabledSystems) {
+    if (enabledSystems.contains(Instrumenter.TargetSystem.IAST)) {
+      return TaintableRedefinitionStrategyListener.INSTANCE;
+    } else {
+      return AgentBuilder.RedefinitionStrategy.Listener.NoOp.INSTANCE;
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/iast/TaintableRedefinitionStrategyListener.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/iast/TaintableRedefinitionStrategyListener.java
@@ -1,0 +1,36 @@
+package datadog.trace.agent.tooling.bytebuddy.iast;
+
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import net.bytebuddy.agent.builder.AgentBuilder;
+
+/**
+ * {@link TaintableVisitor} redefines the structure of a class by adding interfaces and fields,
+ * meaning that it cannot be applied to already loaded classes.
+ *
+ * <p>This listener will disable the visitor to prevent a failure with the whole redefinition batch.
+ */
+public final class TaintableRedefinitionStrategyListener
+    extends AgentBuilder.RedefinitionStrategy.Listener.Adapter {
+
+  public static final TaintableRedefinitionStrategyListener INSTANCE =
+      new TaintableRedefinitionStrategyListener();
+
+  private TaintableRedefinitionStrategyListener() {}
+
+  @Override
+  @Nonnull
+  public Iterable<? extends List<Class<?>>> onError(
+      final int index,
+      @Nonnull final List<Class<?>> batch,
+      @Nonnull final Throwable throwable,
+      @Nonnull final List<Class<?>> types) {
+    if (TaintableVisitor.ENABLED) {
+      TaintableVisitor.ENABLED = false;
+      return Collections.singletonList(batch);
+    } else {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/iast/TaintableVisitor.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/iast/TaintableVisitor.java
@@ -22,6 +22,7 @@ import net.bytebuddy.utility.OpenedClassReader;
 public class TaintableVisitor implements AsmVisitorWrapper {
 
   public static volatile boolean DEBUG = false;
+  static volatile boolean ENABLED = true;
 
   private static final String INTERFACE_NAME = "datadog/trace/api/iast/Taintable";
   private static final String SOURCE_CLASS_NAME = "L" + INTERFACE_NAME + "$Source;";
@@ -55,9 +56,21 @@ public class TaintableVisitor implements AsmVisitorWrapper {
       final MethodList<?> methods,
       final int writerFlags,
       final int readerFlags) {
-    return types.contains(instrumentedType.getName())
-        ? new AddTaintableInterfaceVisitor(classVisitor)
-        : classVisitor;
+    if (ENABLED) {
+      return types.contains(instrumentedType.getName())
+          ? new AddTaintableInterfaceVisitor(classVisitor)
+          : classVisitor;
+    } else {
+      return NoOp.INSTANCE.wrap(
+          instrumentedType,
+          classVisitor,
+          implementationContext,
+          typePool,
+          fields,
+          methods,
+          writerFlags,
+          readerFlags);
+    }
   }
 
   private static class AddTaintableInterfaceVisitor extends ClassVisitor {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/iast/MrReturnAdvice.java
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/iast/MrReturnAdvice.java
@@ -1,0 +1,10 @@
+package datadog.trace.agent.tooling.bytebuddy.iast;
+
+import net.bytebuddy.asm.Advice;
+
+public class MrReturnAdvice {
+  @Advice.OnMethodExit
+  public static void sayHello(@Advice.Return(readOnly = false) String result) {
+    result = "Hello Mr!";
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/iast/TaintableVisitorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/iast/TaintableVisitorTest.groovy
@@ -18,6 +18,16 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named
 
 class TaintableVisitorTest extends DDSpecification {
 
+  private boolean wasEnabled
+
+  void setup() {
+    wasEnabled = TaintableVisitor.ENABLED
+  }
+
+  void cleanup() {
+    TaintableVisitor.ENABLED = wasEnabled
+  }
+
   void 'test taintable visitor'() {
     given:
     final className = 'datadog.trace.agent.tooling.bytebuddy.iast.TaintableTest'

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/iast/TaintableVisitorTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/bytebuddy/iast/TaintableVisitorTest.groovy
@@ -1,13 +1,22 @@
 package datadog.trace.agent.tooling.bytebuddy.iast
 
+import datadog.trace.agent.tooling.bytebuddy.LoadedTaintableClass
 import datadog.trace.api.iast.Taintable
-import groovy.transform.CompileDynamic
+import datadog.trace.test.util.DDSpecification
 import net.bytebuddy.ByteBuddy
+import net.bytebuddy.agent.ByteBuddyAgent
+import net.bytebuddy.agent.builder.AgentBuilder
 import net.bytebuddy.description.modifier.Visibility
-import spock.lang.Specification
+import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.dynamic.DynamicType
+import net.bytebuddy.utility.JavaModule
+import net.bytebuddy.utility.nullability.MaybeNull
 
-@CompileDynamic
-class TaintableVisitorTest extends Specification {
+import java.security.ProtectionDomain
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named
+
+class TaintableVisitorTest extends DDSpecification {
 
   void 'test taintable visitor'() {
     given:
@@ -80,5 +89,52 @@ class TaintableVisitorTest extends Specification {
 
     then:
     1 * source.getOrigin()
+  }
+
+  void 'test taintable visitor with already loaded class'() {
+    given:
+    final instance = new LoadedTaintableClass()
+    final listener = Mock(AgentBuilder.RedefinitionStrategy.Listener)
+
+    when:
+    final result = instance.sayHello()
+
+    then:
+    result == 'Hello!'
+
+    when:
+    new AgentBuilder.Default()
+      .disableClassFormatChanges()
+      .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
+      .with(TaintableRedefinitionStrategyListener.INSTANCE)
+      .with(listener)
+      .type(named(LoadedTaintableClass.name))
+      .transform(new AgentBuilder.Transformer.ForAdvice().advice(named('sayHello'), 'datadog.trace.agent.tooling.bytebuddy.iast.MrReturnAdvice'))
+      .transform(new AgentBuilder.Transformer() {
+        @Override
+        DynamicType.Builder<?> transform(DynamicType.Builder<?> builder,
+          TypeDescription typeDescription,
+          @MaybeNull ClassLoader classLoader,
+          @MaybeNull JavaModule module,
+          ProtectionDomain protectionDomain) {
+          return builder.visit(new TaintableVisitor(LoadedTaintableClass.name))
+        }
+      })
+      .installOn(ByteBuddyAgent.instrumentation)
+
+    then:
+    final modifiedResult = instance.sayHello()
+
+    then:
+    modifiedResult == 'Hello Mr!'
+    // failing initial batch
+    1 * listener.onBatch(0, { List<Class<?>> list -> list.contains(LoadedTaintableClass) }, _)
+    1 * listener.onError(0, { List<Class<?>> list -> list.contains(LoadedTaintableClass) }, _, _) >> []
+
+    // successful batch after disabling the visitor
+    1 * listener.onBatch(1, { List<Class<?>> list -> list.contains(LoadedTaintableClass) }, _)
+
+    // finally two batches where executed
+    1 * listener.onComplete(2, { List<Class<?>> list -> list.contains(LoadedTaintableClass) }, _)
   }
 }

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/bytebuddy/LoadedTaintableClass.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/bytebuddy/LoadedTaintableClass.java
@@ -1,0 +1,8 @@
+package datadog.trace.agent.tooling.bytebuddy;
+
+public class LoadedTaintableClass {
+
+  public String sayHello() {
+    return "Hello!";
+  }
+}


### PR DESCRIPTION
# What Does This Do
Introduces a new `AgentBuilder.RedefinitionStrategy.Listener` to disable our `datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor` in cases of a failure while retransforming already loaded classes.

# Motivation
Since classes are retransformed in batches, a failure transforming a class with the visitor might cause the whole batch to fail. This PR ensures that the taintable visitor will be disabled and a new attempt at retransformation will occur.

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
