### PR TITLE
Fix module coverage calculation issue where data from one module could influence data from another module

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemModule.java
@@ -3,7 +3,6 @@ package datadog.trace.civisibility;
 import datadog.trace.api.civisibility.DDTestModule;
 import datadog.trace.api.civisibility.events.BuildEventsHandler;
 import datadog.trace.civisibility.ipc.ModuleExecutionResult;
-import org.jacoco.core.data.ExecutionDataStore;
 
 /** Test module abstraction that is used by build system instrumentations (e.g. Maven, Gradle) */
 public interface DDBuildSystemModule extends DDTestModule {
@@ -11,6 +10,5 @@ public interface DDBuildSystemModule extends DDTestModule {
 
   BuildEventsHandler.ModuleInfo getModuleInfo();
 
-  void onModuleExecutionResultReceived(
-      ModuleExecutionResult result, ExecutionDataStore coverageData);
+  void onModuleExecutionResultReceived(ModuleExecutionResult result);
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemSessionImpl.java
@@ -115,7 +115,7 @@ public class DDBuildSystemSessionImpl extends DDTestSessionImpl implements DDBui
       }
     }
 
-    return testModuleRegistry.onModuleExecutionResultReceived(result, moduleCoverageData);
+    return testModuleRegistry.onModuleExecutionResultReceived(result);
   }
 
   private SignalResponse onRepoIndexRequestReceived(RepoIndexRequest request) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/TestModuleRegistry.java
@@ -6,7 +6,6 @@ import datadog.trace.civisibility.ipc.ModuleExecutionResult;
 import datadog.trace.civisibility.ipc.SignalResponse;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.jacoco.core.data.ExecutionDataStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +27,7 @@ public class TestModuleRegistry {
     testModuleById.remove(module.getId());
   }
 
-  public SignalResponse onModuleExecutionResultReceived(
-      ModuleExecutionResult result, ExecutionDataStore coverageData) {
+  public SignalResponse onModuleExecutionResultReceived(ModuleExecutionResult result) {
     long moduleId = result.getModuleId();
     DDBuildSystemModule module = testModuleById.get(moduleId);
     if (module == null) {
@@ -41,7 +39,7 @@ public class TestModuleRegistry {
       return new ErrorResponse(message);
     }
 
-    module.onModuleExecutionResultReceived(result, coverageData);
+    module.onModuleExecutionResultReceived(result);
     return AckResponse.INSTANCE;
   }
 }


### PR DESCRIPTION
# What Does This Do
Fixes module coverage percentage calculation issue.

# Motivation
Module coverage percentage should be calculated based only on the tests that were run as part of that module.
Percentage calculation should be reproducible and the value should not depend on the timing of individual modules execution.

# Additional Notes
The issue was caused by the fact that module and session objects were sharing `ExecutionData` instances that were stored in their `ExecutionDataStore`s.
Whenever data was updated in the session if, for instance a Module B finished, this update could propagate to Module A because Module A and session shared their state.

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
