### PR TITLE
Fix NPE when there is no config in agent response

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -272,6 +272,10 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   private static void discoverStatsDPort(final Map<String, Object> info) {
     try {
       Map<String, ?> config = (Map<String, ?>) info.get("config");
+      if (config == null) {
+        log.debug("config missing from trace agent /info response");
+        return;
+      }
       final Object statsdPortObj = config.get("statsd_port");
       if (statsdPortObj == null) {
         log.debug("statsd_port missing from trace agent /info response");
@@ -279,8 +283,8 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
       }
       int statsdPort = ((Number) statsdPortObj).intValue();
       DDAgentStatsDClientManager.setDefaultStatsDPort(statsdPort);
-    } catch (Throwable ignore) {
-      log.debug("statsd_port missing from trace agent /info response", ignore);
+    } catch (Exception ex) {
+      log.debug("statsd_port missing from trace agent /info response", ex);
     }
   }
 


### PR DESCRIPTION
# What Does This Do
Replace catch `Throwable` to `Exception`

# Motivation
Avoid NPE when no config in agent response on `/info`

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
