### PR TITLE
Reset classloader matcher cache when new matchers are created

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
@@ -127,6 +127,9 @@ public final class ClassLoaderMatchers {
   /** Sequence of class resource-names, in order of assigned hasClassId. */
   static final List<String> hasClassResourceNames = new ArrayList<>();
 
+  /** Size of {@link #hasClassResourceNames} when the class loader cache entry was built */
+  private static volatile int lastClassResourceNameCount = 0;
+
   /** Cache of classloader-instance -> has-class mask. */
   static final DDCache<ClassLoader, BitSet> hasClassCache = DDCaches.newFixedSizeWeakKeyCache(512);
 
@@ -136,6 +139,13 @@ public final class ClassLoaderMatchers {
   static final BitSet NO_CLASS_NAME_MATCHES = new BitSet();
 
   static BitSet hasClassMask(ClassLoader loader) {
+    final int classResourceNameCount = hasClassResourceNames.size();
+    if (lastClassResourceNameCount != classResourceNameCount) {
+      if (lastClassResourceNameCount > 0) {
+        resetState();
+      }
+      lastClassResourceNameCount = classResourceNameCount;
+    }
     return hasClassCache.computeIfAbsent(loader, ClassLoaderMatchers::buildHasClassMask);
   }
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatchersTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ClassLoaderMatchersTest.groovy
@@ -44,6 +44,30 @@ class ClassLoaderMatchersTest extends DDSpecification {
     LogContextScopeListener.name == "datadog.trace.agent.tooling.log.LogContextScopeListener"
   }
 
+  void 'matcher cache resets when new matchers are created'() {
+    setup:
+    ClassLoaderMatchers.resetState()
+    final firstClass = getClass()
+    final secondClass = NonDelegatingClassLoader
+    assert firstClass.classLoader == secondClass.classLoader
+    final classLoader = firstClass.classLoader
+
+    when:
+    final firstMatcher = ClassLoaderMatchers.hasClassNamed(firstClass.name)
+
+    then:
+    firstMatcher.matches(classLoader)
+
+    when:
+    final secondMatcher = ClassLoaderMatchers.hasClassNamed(secondClass.name)
+
+    then:
+    secondMatcher.matches(classLoader)
+
+    cleanup:
+    ClassLoaderMatchers.resetState()
+  }
+
   /*
    * A URLClassloader which only delegates java.* classes
    */


### PR DESCRIPTION
# What Does This Do
Resets the classloader matcher cache when new matchers are requested.

# Motivation
While testing, and because of configuration changes, we have encountered failures due to the cache being stale (e.g. activating a new product like IAST that triggers new instrumentations).

# Additional Notes
I don't think this case can happen at runtime (at least not at the moment), so instead of protecting the cache we could make it work by doing the reset in the tests (e.g. `AgentTestRunner`).

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
