### PR TITLE
Update Git unshallow logic to handle cases when HEAD points to a local-only commit

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
@@ -43,7 +43,19 @@ class GitClientTest extends Specification {
     shallow
   }
 
-  def "test unshallow"() {
+  def "test get upstream branch"() {
+    given:
+    givenGitRepo("ci/git/shallow/git")
+
+    when:
+    def gitClient = givenGitClient()
+    def upstreamBranch = gitClient.getUpstreamBranch()
+
+    then:
+    upstreamBranch == "origin/master"
+  }
+
+  def "test unshallow: #remoteSha"() {
     given:
     givenGitRepo("ci/git/shallow/git")
 
@@ -57,13 +69,16 @@ class GitClientTest extends Specification {
     commits.size() == 1
 
     when:
-    gitClient.unshallow()
+    gitClient.unshallow(remoteSha)
     shallow = gitClient.isShallow()
     commits = gitClient.getLatestCommits()
 
     then:
     !shallow
     commits.size() == 10
+
+    where:
+    remoteSha << [GitClient.HEAD, null]
   }
 
   def "test get git folder"() {


### PR DESCRIPTION
# What Does This Do
Updates Git repository unshallowing logic in CI Visibility:
- if HEAD points to a commit that does not exist in the remote repo, an attempt is made to calculate the HEAD of the tracked upstream branch and unshallow from that
- if current local branch does not track any remote branch, or if HEAD is detached, no SHA is specified for unshallowing, that is all the commit data is checked out from the remote repo

# Motivation
The command that is used for unshallowing currently has a drawback: if the local HEAD is a commit that has not been pushed to the remote, it will fail.
If that happens, the tracer should fall back to another command that will attempt to use the tracked branch for the current branch in order to unshallow.
It could be that the CI is working on a detached HEAD or maybe branch tracking hasn’t been set up. In that case, this command will also fail, and we will finally fallback to the behaviour where we just unshallow all the things.

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
