### PR TITLE
propagate span into lettuce CommandHandler event loop

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/AsyncCommandInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/AsyncCommandInstrumentation.java
@@ -1,0 +1,93 @@
+package datadog.trace.instrumentation.lettuce5;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.startTaskScope;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import io.lettuce.core.protocol.AsyncCommand;
+import java.util.Collections;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Instrumentation attaches the active span to an {@code io.lettuce.core.protocol.AsyncCommand} so
+ * the span can propagate with it into the {@code io.lettuce.core.protocol.CommandHandler} event
+ * loop.
+ */
+@AutoService(Instrumenter.class)
+public class AsyncCommandInstrumentation extends Instrumenter.Profiling
+    implements Instrumenter.ForSingleType {
+  public AsyncCommandInstrumentation() {
+    super("lettuce", "lettuce-5", "lettuce-5-async");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "io.lettuce.core.protocol.AsyncCommand";
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("io.lettuce.core.protocol.AsyncCommand", State.class.getName());
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isConstructor()
+            .and(
+                takesArguments(1)
+                    .and(takesArgument(0, named("io.lettuce.core.protocol.RedisCommand")))),
+        getClass().getName() + "$Capture");
+    transformation.applyAdvice(
+        isMethod().and(namedOneOf("complete", "completeExceptionally", "onComplete", "encode")),
+        getClass().getName() + "$Activate");
+    transformation.applyAdvice(
+        isMethod().and(named("cancel")).and(takesArguments(boolean.class)),
+        getClass().getName() + "$Cancel");
+  }
+
+  public static final class Capture {
+
+    @SuppressWarnings("rawtypes")
+    @Advice.OnMethodExit
+    public static void after(@Advice.This AsyncCommand asyncCommand) {
+      capture(InstrumentationContext.get(AsyncCommand.class, State.class), asyncCommand, false);
+    }
+  }
+
+  public static final class Activate {
+    @SuppressWarnings("rawtypes")
+    @Advice.OnMethodEnter
+    public static AgentScope before(@Advice.This AsyncCommand asyncCommand) {
+      return startTaskScope(
+          InstrumentationContext.get(AsyncCommand.class, State.class), asyncCommand);
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
+    public static void after(@Advice.Enter AgentScope scope) {
+      endTaskScope(scope);
+    }
+  }
+
+  public static final class Cancel {
+    @SuppressWarnings("rawtypes")
+    @Advice.OnMethodEnter
+    public static void before(@Advice.This AsyncCommand asyncCommand) {
+      AdviceUtils.cancelTask(
+          InstrumentationContext.get(AsyncCommand.class, State.class), asyncCommand);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/CommandHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/CommandHandlerInstrumentation.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.lettuce5;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.endTaskScope;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.startTaskScope;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
+import io.lettuce.core.protocol.AsyncCommand;
+import io.lettuce.core.protocol.RedisCommand;
+import java.util.Collections;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+
+/**
+ * This instrumentation activates the span associated with {@code
+ * io.lettuce.core.protocol.AsyncCommand} during decoding.
+ */
+@AutoService(Instrumenter.class)
+public class CommandHandlerInstrumentation extends Instrumenter.Profiling
+    implements Instrumenter.ForSingleType {
+
+  public CommandHandlerInstrumentation() {
+    super("lettuce", "lettuce-5", "lettuce-5-async");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "io.lettuce.core.protocol.CommandHandler";
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("io.lettuce.core.protocol.AsyncCommand", State.class.getName());
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("decode"))
+            .and(takesArgument(0, named("io.netty.channel.ChannelHandlerContext")))
+            .and(takesArgument(1, named("io.netty.buffer.ByteBuf")))
+            .and(takesArgument(2, named("io.lettuce.core.protocol.RedisCommand"))),
+        getClass().getName() + "$Decode");
+  }
+
+  public static class Decode {
+    @SuppressWarnings("rawtypes")
+    @Advice.OnMethodEnter
+    public static AgentScope before(@Advice.Argument(2) RedisCommand command) {
+      // if it's something we're tracing, it will always be an AsyncCommand
+      if (command instanceof AsyncCommand) {
+        return startTaskScope(
+            InstrumentationContext.get(AsyncCommand.class, State.class), (AsyncCommand) command);
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit
+    public static void after(@Advice.Enter AgentScope scope) {
+      endTaskScope(scope);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5AsyncClientTest.groovy
@@ -620,3 +620,29 @@ class Lettuce5SyncClientV1ForkedTest extends Lettuce5AsyncClientTest {
     return "redis.command"
   }
 }
+
+
+class Lettuce5AsyncProfilingForkedTest extends Lettuce5AsyncClientTest {
+
+  @Override
+  protected void configurePreAgent() {
+
+    super.configurePreAgent()
+    injectSysConfig('dd.profiling.enabled', 'true')
+  }
+
+  @Override
+  int version() {
+    return 2
+  }
+
+  @Override
+  String service() {
+    return "redis"
+  }
+
+  @Override
+  String operation() {
+    return "redis.query"
+  }
+}

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -663,3 +663,28 @@ class Lettuce5ReactiveClientV1ForkedTest extends Lettuce5ReactiveClientTest {
   }
 }
 
+class Lettuce5ReactiveClientProfilingForkedTest extends Lettuce5ReactiveClientTest {
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig('dd.profiling.enabled', 'true')
+  }
+
+  @Override
+  int version() {
+    return 2
+  }
+
+  @Override
+  String service() {
+    return "redis"
+  }
+
+  @Override
+  String operation() {
+    return "redis.query"
+  }
+}
+
+


### PR DESCRIPTION
# What Does This Do

Currently lettuce spans don't propagate to where the network IO is done, which prevents us from attributing CPU samples to the decoding loop, and prevents wallclock sampling of the event loop at all. This pair of instrumentations solves this problem by attaching the active span to an `AsyncCommand` when it is created (the existing `LettuceAsyncCommandsInstrumentation` currently creates the span before this happens). The `CommandHandler` processes commands and is made to reactivate the span by the `CommandHandlerInstrumentation`. 

This has no functional impact on traces, but allows for better attribution of resource consumption to the trace.

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
