### PR TITLE
Added Api Security request data classification

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '7.2.0'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '8.0.0'
   implementation group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
 
   testImplementation deps.bytebuddy

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/api/security/ApiSecurityRequestSampler.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/api/security/ApiSecurityRequestSampler.java
@@ -9,7 +9,7 @@ public class ApiSecurityRequestSampler {
   private final AtomicLong cumulativeCounter = new AtomicLong();
 
   public ApiSecurityRequestSampler(final Config config) {
-    sampling = computeSamplingParameter(config.getApiSecurityRequestSampling());
+    sampling = computeSamplingParameter(config.getApiSecurityRequestSampleRate());
   }
 
   public boolean sampleRequest() {
@@ -24,14 +24,14 @@ public class ApiSecurityRequestSampler {
   }
 
   static int computeSamplingParameter(final float pct) {
-    if (pct >= 100) {
+    if (pct >= 1) {
       return 100;
     }
-    if (pct <= 0) {
+    if (pct < 0) {
       // We don't support disabling Api Security by setting it, so we set it to 100%.
       // TODO: We probably want a warning here.
       return 100;
     }
-    return (int) pct;
+    return (int) (pct * 100);
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/CurrentAppSecConfig.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/CurrentAppSecConfig.java
@@ -85,8 +85,10 @@ public class CurrentAppSecConfig {
       mso.put("metadata", ddConfig.getRawConfig().getOrDefault("metadata", Collections.emptyMap()));
       mso.put("rules", ddConfig.getRawConfig().getOrDefault("rules", Collections.emptyList()));
       mso.put(
-          "preprocessors",
-          ddConfig.getRawConfig().getOrDefault("preprocessors", Collections.emptyList()));
+          "processors",
+          ddConfig.getRawConfig().getOrDefault("processors", Collections.emptyList()));
+      mso.put(
+          "scanners", ddConfig.getRawConfig().getOrDefault("scanners", Collections.emptyList()));
     }
     if (dirtyStatus.customRules) {
       mso.put("custom_rules", getMergedCustomRules());

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -100,7 +100,7 @@ public interface KnownAddresses {
 
   Address<String> USER_ID = new Address<>("usr.id");
 
-  Address<Map<String, Object>> WAF_CONTEXT_SETTINGS = new Address<>("waf.context.settings");
+  Address<Map<String, Object>> WAF_CONTEXT_PROCESSOR = new Address<>("waf.context.processor");
 
   static Address<?> forName(String name) {
     switch (name) {
@@ -150,8 +150,8 @@ public interface KnownAddresses {
         return GRPC_SERVER_REQUEST_METADATA;
       case "usr.id":
         return USER_ID;
-      case "waf.context.settings":
-        return WAF_CONTEXT_SETTINGS;
+      case "waf.context.processor":
+        return WAF_CONTEXT_PROCESSOR;
       default:
         return null;
     }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -150,7 +150,7 @@ public interface KnownAddresses {
         return GRPC_SERVER_REQUEST_METADATA;
       case "usr.id":
         return USER_ID;
-      case "waf.context.settings":
+      case "waf.context.processor":
         return WAF_CONTEXT_SETTINGS;
       default:
         return null;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -150,7 +150,7 @@ public interface KnownAddresses {
         return GRPC_SERVER_REQUEST_METADATA;
       case "usr.id":
         return USER_ID;
-      case "waf.context.processor":
+      case "waf.context.settings":
         return WAF_CONTEXT_SETTINGS;
       default:
         return null;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -559,7 +559,7 @@ public class GatewayBridge {
             KnownAddresses.RESPONSE_STATUS, String.valueOf(ctx.getResponseStatus()),
             KnownAddresses.RESPONSE_HEADERS_NO_COOKIES, ctx.getResponseHeaders(),
             // Extract api schema on response stage
-            KnownAddresses.WAF_CONTEXT_SETTINGS,
+            KnownAddresses.WAF_CONTEXT_PROCESSOR,
                 Collections.singletonMap("extract-schema", extractSchema));
 
     while (true) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -375,7 +375,7 @@ public class PowerWAFModule implements AppSecModule {
     }
 
     // TODO: get addresses dynamically when will it be implemented in waf
-    addressList.add(KnownAddresses.WAF_CONTEXT_SETTINGS);
+    addressList.add(KnownAddresses.WAF_CONTEXT_PROCESSOR);
     addressList.add(KnownAddresses.HEADERS_NO_COOKIES);
     addressList.add(KnownAddresses.REQUEST_QUERY);
     addressList.add(KnownAddresses.REQUEST_PATH_PARAMS);

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/api/security/ApiSecurityRequestSamplerTest.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/api/security/ApiSecurityRequestSamplerTest.groovy
@@ -7,12 +7,12 @@ import spock.lang.Shared
 class ApiSecurityRequestSamplerTest extends DDSpecification {
 
   @Shared
-  static final float DEFAULT_SAMPLE_RATE = Config.get().getApiSecurityRequestSampling()
+  static final float DEFAULT_SAMPLE_RATE = Config.get().getApiSecurityRequestSampleRate()
 
   void 'Api Security Request Sample Rate'() {
     given:
     def config = Spy(Config.get())
-    config.getApiSecurityRequestSampling() >> sampleRate
+    config.getApiSecurityRequestSampleRate() >> sampleRate
     def sampler = new ApiSecurityRequestSampler(config)
 
     when:
@@ -28,16 +28,16 @@ class ApiSecurityRequestSamplerTest extends DDSpecification {
     where:
     sampleRate               | expectedSampledRequests
     DEFAULT_SAMPLE_RATE      | [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]  // Default sample rate - 10%
-    0                        | [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-    10                       | [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]
-    25                       | [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]
-    33                       | [0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]
-    50                       | [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
-    75                       | [0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1]
-    90                       | [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0]
-    99                       | [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-    100                      | [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-    125                      | [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]    // Wrong sample rate - use 100%
-    -50                      | [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]    // Wrong sample rate - use 100%
+    0.0                      | [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    0.1                      | [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]
+    0.25                     | [0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1]
+    0.33                     | [0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]
+    0.5                      | [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+    0.75                     | [0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1]
+    0.9                      | [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0]
+    0.99                     | [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    1.0                      | [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    1.25                     | [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]    // Wrong sample rate - use 100%
+    -0.5                     | [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]    // Wrong sample rate - use 100%
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -31,13 +31,13 @@ class KnownAddressesSpecification extends Specification {
       'grpc.server.request.message',
       'grpc.server.request.metadata',
       'usr.id',
-      'waf.context.settings',
+      'waf.context.processor',
     ]
   }
 
   void 'number of known addresses is expected number'() {
     expect:
     Address.instanceCount() == 24
-    KnownAddresses.WAF_CONTEXT_SETTINGS.serial == Address.instanceCount() - 1
+    KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -87,7 +87,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
   static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
   static final boolean DEFAULT_API_SECURITY_ENABLED = false;
-  static final int DEFAULT_API_SECURITY_REQUEST_SAMPLING = 10; // 10 %
+  static final float DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE = 0.1f; // 10 %
 
   static final String DEFAULT_IAST_ENABLED = "false";
   static final boolean DEFAULT_IAST_DEBUG_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -22,7 +22,7 @@ public final class AppSecConfig {
   public static final String APPSEC_AUTOMATED_USER_EVENTS_TRACKING =
       "appsec.automated-user-events-tracking";
   public static final String API_SECURITY_ENABLED = "experimental.api-security.enabled";
-  public static final String API_SECURITY_REQUEST_SAMPLING = "api-security.request-sampling";
+  public static final String API_SECURITY_REQUEST_SAMPLE_RATE = "api-security.request.sample.rate";
 
   private AppSecConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -5,7 +5,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_WRITER_TYPE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_ENABLED;
-import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_REQUEST_SAMPLING;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_REPORTING_INBAND;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_WAF_METRICS;
@@ -115,7 +115,7 @@ import static datadog.trace.api.DDTags.SERVICE;
 import static datadog.trace.api.DDTags.SERVICE_TAG;
 import static datadog.trace.api.UserEventTrackingMode.SAFE;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENABLED;
-import static datadog.trace.api.config.AppSecConfig.API_SECURITY_REQUEST_SAMPLING;
+import static datadog.trace.api.config.AppSecConfig.API_SECURITY_REQUEST_SAMPLE_RATE;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_AUTOMATED_USER_EVENTS_TRACKING;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_HTML;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_JSON;
@@ -639,7 +639,7 @@ public class Config {
   private final String appSecHttpBlockedTemplateJson;
   private final UserEventTrackingMode appSecUserEventsTracking;
   private final boolean apiSecurityEnabled;
-  private final int apiSecurityRequestSampling;
+  private final float apiSecurityRequestSampleRate;
 
   private final IastDetectionMode iastDetectionMode;
   private final int iastMaxConcurrentRequests;
@@ -1444,9 +1444,9 @@ public class Config {
                 APPSEC_AUTOMATED_USER_EVENTS_TRACKING, SAFE.toString()));
     apiSecurityEnabled =
         configProvider.getBoolean(API_SECURITY_ENABLED, DEFAULT_API_SECURITY_ENABLED);
-    apiSecurityRequestSampling =
-        configProvider.getInteger(
-            API_SECURITY_REQUEST_SAMPLING, DEFAULT_API_SECURITY_REQUEST_SAMPLING);
+    apiSecurityRequestSampleRate =
+        configProvider.getFloat(
+            API_SECURITY_REQUEST_SAMPLE_RATE, DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE);
 
     iastDebugEnabled = configProvider.getBoolean(IAST_DEBUG_ENABLED, DEFAULT_IAST_DEBUG_ENABLED);
 
@@ -2412,8 +2412,8 @@ public class Config {
     return apiSecurityEnabled;
   }
 
-  public int getApiSecurityRequestSampling() {
-    return apiSecurityRequestSampling;
+  public float getApiSecurityRequestSampleRate() {
+    return apiSecurityRequestSampleRate;
   }
 
   public ProductActivation getIastActivation() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3895,6 +3895,10 @@ public class Config {
         + appSecWafTimeout
         + " us, appSecHttpBlockedTemplateJson="
         + appSecHttpBlockedTemplateJson
+        + ", apiSecurityEnabled="
+        + apiSecurityEnabled
+        + ", apiSecurityRequestSampleRate="
+        + apiSecurityRequestSampleRate
         + ", cwsEnabled="
         + cwsEnabled
         + ", cwsTlsRefresh="


### PR DESCRIPTION
# What Does This Do
Added data classification for Api Security. In addition, the schema extraction processor also take advantage of the data scanners to determine he classification of each value.
Also added sampler to reduce overhead. We assume that schema extraction and data classification will be performed for only 10% of requests.

# Motivation

# Additional Notes
Added env variable `DD_API_SECURITY_REQUEST_SAMPLE_RATE` to define Api Security request sampling rate. The value should be in range `0.0 - 1.0`. Where `0.0` - means 0% requests will be sampled, and `1.0` means 100% requests will be sampled.
Default value sampling rate for ApiSecurity is `0.1` (e.g. 10% or requests)
