### PR TITLE
Flush telemetry data on JVM shutdown

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -335,6 +335,9 @@ public class Agent {
     if (profilingEnabled) {
       shutdownProfilingAgent(sync);
     }
+    if (telemetryEnabled) {
+      stopTelemetry();
+    }
   }
 
   public static synchronized Class<?> installAgentCLI() throws Exception {
@@ -779,6 +782,21 @@ public class Agent {
     }
 
     StaticEventLogger.end("Telemetry");
+  }
+
+  private static void stopTelemetry() {
+    if (AGENT_CLASSLOADER == null) {
+      return;
+    }
+
+    try {
+      final Class<?> telemetrySystem =
+          AGENT_CLASSLOADER.loadClass("datadog.telemetry.TelemetrySystem");
+      final Method stopTelemetry = telemetrySystem.getMethod("stop");
+      stopTelemetry.invoke(null);
+    } catch (final Throwable ex) {
+      log.error("Error encountered while stopping telemetry", ex);
+    }
   }
 
   private static void initializeCrashUploader() {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/shutdown/ShutdownHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/shutdown/ShutdownHelper.java
@@ -1,13 +1,32 @@
 package datadog.trace.bootstrap.instrumentation.shutdown;
 
 import datadog.trace.bootstrap.Agent;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class ShutdownHelper {
   private static final Logger log = LoggerFactory.getLogger(ShutdownHelper.class);
 
+  private static final Queue<Runnable> AGENT_SHUTDOWN_HOOKS = new ConcurrentLinkedQueue<>();
+
+  public static void registerAgentShutdownHook(Runnable hook) {
+    AGENT_SHUTDOWN_HOOKS.offer(hook);
+  }
+
   public static void shutdownAgent() {
+    log.debug("Executing agent shutdown hooks ...");
+    while (!AGENT_SHUTDOWN_HOOKS.isEmpty()) {
+      Runnable hook = AGENT_SHUTDOWN_HOOKS.poll();
+      try {
+        hook.run();
+      } catch (Exception e) {
+        log.error("Error while runnign agent shutdown hook", e);
+      }
+    }
+    log.debug("Agent shutdown hooks executed");
+
     log.debug("Shutting down agent ...");
     Agent.shutdown(true);
     log.debug("Agent was properly shut down");

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/shutdown/ShutdownHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/shutdown/ShutdownHelper.java
@@ -7,20 +7,7 @@ import org.slf4j.LoggerFactory;
 public final class ShutdownHelper {
   private static final Logger log = LoggerFactory.getLogger(ShutdownHelper.class);
 
-  public static volatile Runnable TELEMETRY_SHUTDOWN_HOOK;
-
   public static void shutdownAgent() {
-    log.debug("Executing telemetry shutdown hook ...");
-    if (TELEMETRY_SHUTDOWN_HOOK != null) {
-      try {
-        TELEMETRY_SHUTDOWN_HOOK.run();
-        TELEMETRY_SHUTDOWN_HOOK = null;
-      } catch (Exception e) {
-        log.error("Error while running telemetry shutdown hook", e);
-      }
-    }
-    log.debug("Telemetry shutdown hook executed");
-
     log.debug("Shutting down agent ...");
     Agent.shutdown(true);
     log.debug("Agent was properly shut down");

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -64,7 +64,7 @@ public class TelemetrySystem {
     TelemetryService telemetryService = new TelemetryService(sco.okHttpClient, sco.agentUrl);
     TELEMETRY_THREAD = createTelemetryRunnable(telemetryService, dependencyService);
     TELEMETRY_THREAD.start();
-    ShutdownHelper.registerAgentShutdownHook(TelemetrySystem::stop);
+    ShutdownHelper.TELEMETRY_SHUTDOWN_HOOK = TelemetrySystem::stop;
   }
 
   public static void stop() {

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -160,11 +160,17 @@ class TelemetryRunnableSpecification extends Specification {
     1 * telemetryService.sendIntervalRequests()
     1 * timeSource.getCurrentTimeMillis() >> 120 * 1000 + 7
     1 * sleeperMock.sleep(9993)
-    0 * _
 
     when:
     t.interrupt()
     t.join()
+
+    // flush pending data before shutdown
+    then:
+    1 * metricCollector.prepareMetrics()
+    1 * metricCollector.drain() >> []
+    1 * periodicAction.doIteration(telemetryService)
+    1 * telemetryService.sendIntervalRequests()
 
     then:
     1 * telemetryService.sendAppClosingRequest()

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
@@ -55,7 +55,8 @@ class TelemetrySystemSpecification extends Specification {
 
     then:
     TelemetrySystem.TELEMETRY_THREAD == null ||
-      TelemetrySystem.TELEMETRY_THREAD.isInterrupted()
+      TelemetrySystem.TELEMETRY_THREAD.isInterrupted() ||
+      !TelemetrySystem.TELEMETRY_THREAD.isAlive()
   }
 
   private SharedCommunicationObjects sharedCommunicationObjects() {


### PR DESCRIPTION
# What Does This Do
Ensures that pending telemetry data is sent to the backend before JVM shuts down.

# Motivation
Current telemetry implementation reports aggregated metrics in periodic requests.
Telemetry-reporting loop runs in a daemon thread, so when the JVM shuts down metrics data that was queued since the last request gets discarded.

Loosing a few seconds' worth of metrics data may be fine for APM use cases, where it is not uncommon for a JVM to run for several days.

Future PRs will introduce telemetry metrics for CI Visibility.
Since the lifetimes of JVMs instrumented with CI Visibility are very different (it is typical for the process to live for a few minutes or even seconds), there is a need to flush pending telemetry data before shutting down the JVM.

This may also be beneficial for serverless setups where JVMs are short-lived as well.

# Additional Notes
`ShutdownHelper#shutdownAgent` that executes agent shutdown hooks (including waiting for telemetry data flush) runs on enter to `java.lang.Shutdown#runHooks`.

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
