### PR TITLE
Add sampling smoke tests for log probes

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/DebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/DebuggerTestApplication.java
@@ -8,6 +8,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 public class DebuggerTestApplication {
   private static final String LOG_FILENAME = System.getenv().get("DD_LOG_FILE");
@@ -20,13 +21,13 @@ public class DebuggerTestApplication {
 }
 
 class Main {
-  private static final Map<String, Runnable> methodsByName = new HashMap<>();
+  private static final Map<String, Consumer<String>> methodsByName = new HashMap<>();
   private static final String LOG_FILENAME = System.getenv().get("DD_LOG_FILE");
 
   static void run(String[] args) throws Exception {
     registerMethods();
     String methodName = args[0];
-    Runnable method = methodsByName.get(methodName);
+    Consumer<String> method = methodsByName.get(methodName);
     if (method == null) {
       throw new RuntimeException("cannot find method: " + methodName);
     }
@@ -34,7 +35,7 @@ class Main {
     System.out.println("Waiting for instrumentation...");
     waitForInstrumentation(LOG_FILENAME, Main.class.getName());
     System.out.println("Executing method: " + methodName);
-    method.run();
+    method.accept(args.length > 2 ? args[2] : null);
     System.out.println("Executed");
     waitForUpload(LOG_FILENAME, expectedUploads);
     System.out.println("Exiting...");
@@ -45,21 +46,32 @@ class Main {
     methodsByName.put("managementMethod", Main::managementMethod);
     methodsByName.put("fullMethod", Main::runFullMethod);
     methodsByName.put("multiProbesFullMethod", Main::runFullMethod);
+    methodsByName.put("loopingFullMethod", Main::runLoopingFullMethod);
   }
 
-  private static void emptyMethod() {}
+  private static void emptyMethod(String arg) {}
 
-  private static void managementMethod() {
+  private static void managementMethod(String arg) {
     OperatingSystemMXBean operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
     System.out.println(operatingSystemMXBean.getAvailableProcessors());
   }
 
-  private static void runFullMethod() {
+  private static void runFullMethod(String arg) {
     Map<String, String> map = new HashMap<>();
     map.put("key1", "val1");
     map.put("key2", "val2");
     map.put("key3", "val3");
     fullMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
+  }
+
+  private static void runLoopingFullMethod(String arg) {
+    Map<String, String> map = new HashMap<>();
+    map.put("key1", "val1");
+    map.put("key2", "val2");
+    map.put("key3", "val3");
+    for (int i = 0; i < Integer.parseInt(arg); i++) {
+      fullMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
+    }
   }
 
   private static String fullMethod(

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -72,7 +72,7 @@ public class ServerDebuggerTestApplication {
   }
 
   protected void waitForInstrumentation(String className) {
-    System.out.println("waitForInstrumentation on " + className);
+    System.out.println("waitForInstrumentation on " + className + " from: " + lastMatchedLine);
     try {
       lastMatchedLine =
           TestApplicationHelper.waitForInstrumentation(LOG_FILENAME, className, lastMatchedLine);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -91,6 +91,7 @@ public abstract class BaseIntegrationTest {
   protected final List<Predicate<Snapshot>> snapshotListeners = new ArrayList<>();
   protected final List<Predicate<DecodedTrace>> traceListeners = new ArrayList<>();
   protected final List<Predicate<ProbeStatus>> probeStatusListeners = new ArrayList<>();
+  protected int batchSize = 1; // to verify each snapshot upload one by one
 
   @BeforeAll
   static void setupAll() throws Exception {
@@ -146,8 +147,7 @@ public abstract class BaseIntegrationTest {
             "-Ddd.trace.agent.url=http://localhost:" + datadogAgentServer.getPort(),
             "-Ddd.jmxfetch.statsd.port=" + statsDServer.getPort(),
             "-Ddd.dynamic.instrumentation.classfile.dump.enabled=true",
-            // to verify each snapshot upload one by one
-            "-Ddd.dynamic.instrumentation.upload.batch.size=1",
+            "-Ddd.dynamic.instrumentation.upload.batch.size=" + batchSize,
             // flush uploads every 100ms to have quick tests
             "-Ddd.dynamic.instrumentation.upload.flush.interval=100"));
   }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
@@ -144,7 +144,7 @@ public class MetricProbesIntegrationTest extends SimpleAppDebuggerIntegrationTes
     MetricProbe metricProbe =
         MetricProbe.builder()
             .probeId(PROBE_ID)
-            .where("DebuggerTestApplication.java", 69)
+            .where("DebuggerTestApplication.java", 80)
             .kind(kind)
             .metricName(metricName)
             .valueScript(script)

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
@@ -41,11 +41,11 @@ public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest 
     final String METHOD_NAME = "fullMethod";
     final String EXPECTED_UPLOADS = "3"; // 2 + 1 for letting the trace being sent (async)
     SpanProbe spanProbe =
-        SpanProbe.builder().probeId(PROBE_ID).where(MAIN_CLASS_NAME, 68, 77).build();
+        SpanProbe.builder().probeId(PROBE_ID).where(MAIN_CLASS_NAME, 80, 89).build();
     setCurrentConfiguration(createSpanConfig(spanProbe));
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
     DecodedSpan decodedSpan = retrieveSpanRequest(DebuggerTracer.OPERATION_NAME);
-    assertEquals("Main.fullMethod:L68-77", decodedSpan.getResource());
+    assertEquals("Main.fullMethod:L80-89", decodedSpan.getResource());
   }
 
   @Test
@@ -53,7 +53,7 @@ public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest 
   void testSingleLineSpan() throws Exception {
     final String METHOD_NAME = "fullMethod";
     final String EXPECTED_UPLOADS = "2"; // 2 probe statuses: RECEIVED + ERROR
-    SpanProbe spanProbe = SpanProbe.builder().probeId(PROBE_ID).where(MAIN_CLASS_NAME, 68).build();
+    SpanProbe spanProbe = SpanProbe.builder().probeId(PROBE_ID).where(MAIN_CLASS_NAME, 80).build();
     setCurrentConfiguration(createSpanConfig(spanProbe));
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
     AtomicBoolean received = new AtomicBoolean(false);


### PR DESCRIPTION
# What Does This Do
add smoke tests for log probes snapshot & dynamic logs with default sampling and custom one

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
