### PR TITLE
Prevent calling size method from unknown classes

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -1,7 +1,9 @@
-package com.datadog.debugger.util;
+package datadog.trace.bootstrap.debugger.util;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class WellKnownClasses {
@@ -56,5 +58,31 @@ public class WellKnownClasses {
    */
   public static boolean isToStringSafe(String concreteType) {
     return toStringSafeClasses.contains(concreteType);
+  }
+
+  /**
+   * @return true if collection is the implementation of size method is side effect free and O(1)
+   *     complexity
+   */
+  public static boolean isSizeSafe(Collection<?> collection) {
+    String className = collection.getClass().getTypeName();
+    if (className.startsWith("java.")) {
+      // All Collection implementations from JDK base module are considered as safe
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @return true if map is the implementation of size method is side effect free and O(1)
+   *     complexity
+   */
+  public static boolean isSizeSafe(Map<?, ?> map) {
+    String className = map.getClass().getTypeName();
+    if (className.startsWith("java.")) {
+      // All Map implementations from JDK base module are considered as safe
+      return true;
+    }
+    return false;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/LenExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/LenExpression.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.CollectionValue;
@@ -27,14 +29,18 @@ public final class LenExpression implements ValueExpression<Value<? extends Numb
   @Override
   public Value<Number> evaluate(ValueReferenceResolver valueRefResolver) {
     Value<?> materialized = source == null ? Value.nullValue() : source.evaluate(valueRefResolver);
-    if (materialized.isNull()) {
-      return (NumericValue) Value.of(-1);
-    } else if (materialized.isUndefined()) {
-      return (NumericValue) Value.of(0);
-    } else if (materialized instanceof StringValue) {
-      return (NumericValue) Value.of(((StringValue) materialized).length());
-    } else if (materialized instanceof CollectionValue) {
-      return (NumericValue) Value.of(((CollectionValue) materialized).count());
+    try {
+      if (materialized.isNull()) {
+        return (NumericValue) Value.of(-1);
+      } else if (materialized.isUndefined()) {
+        return (NumericValue) Value.of(0);
+      } else if (materialized instanceof StringValue) {
+        return (NumericValue) Value.of(((StringValue) materialized).length());
+      } else if (materialized instanceof CollectionValue) {
+        return (NumericValue) Value.of(((CollectionValue) materialized).count());
+      }
+    } catch (RuntimeException ex) {
+      throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this));
     }
     log.warn("Can not compute length for {}", materialized);
     return Value.undefined();

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -5,6 +5,7 @@ import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
+import datadog.trace.bootstrap.debugger.util.WellKnownClasses;
 import java.lang.reflect.Array;
 import java.util.Collection;
 import java.util.List;
@@ -68,7 +69,12 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
 
   public int count() {
     if (listHolder instanceof Collection) {
-      return ((Collection<?>) listHolder).size();
+      if (WellKnownClasses.isSizeSafe((Collection<?>) listHolder)) {
+        return ((Collection<?>) listHolder).size();
+      } else {
+        throw new RuntimeException(
+            "Unsupported Collection class: " + listHolder.getClass().getTypeName());
+      }
     } else if (listHolder == Value.nullValue()) {
       return 0;
     } else if (arrayHolder != null) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
@@ -5,6 +5,7 @@ import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.expressions.ValueExpression;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
+import datadog.trace.bootstrap.debugger.util.WellKnownClasses;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -53,7 +54,11 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
 
   public int count() {
     if (mapHolder instanceof Map) {
-      return ((Map<?, ?>) mapHolder).size();
+      if (WellKnownClasses.isSizeSafe((Map<?, ?>) mapHolder)) {
+        return ((Map<?, ?>) mapHolder).size();
+      } else {
+        throw new RuntimeException("Unsupported Map class: " + mapHolder.getClass().getTypeName());
+      }
     } else if (mapHolder == Value.nullValue()) {
       return 0;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -11,6 +11,7 @@ import datadog.trace.bootstrap.debugger.Limits;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
 import datadog.trace.bootstrap.debugger.ProbeLocation;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
+import datadog.trace.bootstrap.debugger.util.WellKnownClasses;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.annotation.Annotation;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1544,7 +1544,6 @@ public class CapturedSnapshotTest {
     assertEquals(
         "Unsupported Collection class: com.datadog.debugger.CapturedSnapshot24$Holder",
         snapshot.getEvaluationErrors().get(0).getMessage());
-    assertEquals("len(holder)", snapshot.getEvaluationErrors().get(0).getExpr());
   }
 
   @Test
@@ -1554,7 +1553,6 @@ public class CapturedSnapshotTest {
     assertEquals(
         "Unsupported Map class: com.datadog.debugger.CapturedSnapshot26$Holder",
         snapshot.getEvaluationErrors().get(0).getMessage());
-    assertEquals("len(holder)", snapshot.getEvaluationErrors().get(0).getExpr());
   }
 
   private Snapshot doUnknownCount(String CLASS_NAME) throws IOException, URISyntaxException {
@@ -1570,6 +1568,7 @@ public class CapturedSnapshotTest {
     Assertions.assertEquals(1, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertEquals(1, snapshot.getEvaluationErrors().size());
+    assertEquals("len(holder)", snapshot.getEvaluationErrors().get(0).getExpr());
     return snapshot;
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1538,6 +1538,42 @@ public class CapturedSnapshotTest {
   }
 
   @Test
+  public void unknownCollectionCount() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot24";
+    Snapshot snapshot = doUnknownCount(CLASS_NAME);
+    assertEquals(
+        "Unsupported Collection class: com.datadog.debugger.CapturedSnapshot24$Holder",
+        snapshot.getEvaluationErrors().get(0).getMessage());
+    assertEquals("len(holder)", snapshot.getEvaluationErrors().get(0).getExpr());
+  }
+
+  @Test
+  public void unknownMapCount() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot26";
+    Snapshot snapshot = doUnknownCount(CLASS_NAME);
+    assertEquals(
+        "Unsupported Map class: com.datadog.debugger.CapturedSnapshot26$Holder",
+        snapshot.getEvaluationErrors().get(0).getMessage());
+    assertEquals("len(holder)", snapshot.getEvaluationErrors().get(0).getExpr());
+  }
+
+  private Snapshot doUnknownCount(String CLASS_NAME) throws IOException, URISyntaxException {
+    LogProbe logProbe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "doit", null)
+            .when(
+                new ProbeCondition(
+                    DSL.when(DSL.ge(DSL.len(DSL.ref("holder")), DSL.value(0))), "len(holder) >= 0"))
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "").get();
+    Assertions.assertEquals(1, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals(1, snapshot.getEvaluationErrors().size());
+    return snapshot;
+  }
+
+  @Test
   public void beforeForLoopLineProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot02";
     DebuggerTransformerTest.TestSnapshotListener listener =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -54,7 +54,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
@@ -702,20 +701,13 @@ public class SnapshotSerializationTest {
   }
 
   @Test
-  public void collectionValueThrows() throws IOException {
+  public void collectionUnknown() throws IOException {
     JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     CapturedContext context = new CapturedContext();
     CapturedContext.CapturedValue listLocal =
         CapturedContext.CapturedValue.of(
-            "listLocal",
-            List.class.getTypeName(),
-            new ArrayList<String>() {
-              @Override
-              public int size() {
-                throw new UnsupportedOperationException();
-              }
-            });
+            "listLocal", List.class.getTypeName(), new ArrayList<String>() {});
     context.addLocals(new CapturedContext.CapturedValue[] {listLocal});
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
@@ -723,24 +715,18 @@ public class SnapshotSerializationTest {
     Map<String, Object> locals = getLocalsFromJson(buffer);
     Map<String, Object> mapFieldObj = (Map<String, Object>) locals.get("listLocal");
     Assertions.assertEquals(
-        "java.lang.UnsupportedOperationException", mapFieldObj.get(NOT_CAPTURED_REASON));
+        "java.lang.RuntimeException: Unsupported Collection type: com.datadog.debugger.agent.SnapshotSerializationTest$1",
+        mapFieldObj.get(NOT_CAPTURED_REASON));
   }
 
   @Test
-  public void mapValueThrows() throws IOException {
+  public void mapValueUnknown() throws IOException {
     JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
     Snapshot snapshot = createSnapshot();
     CapturedContext context = new CapturedContext();
     CapturedContext.CapturedValue mapLocal =
         CapturedContext.CapturedValue.of(
-            "mapLocal",
-            Map.class.getTypeName(),
-            new HashMap<String, String>() {
-              @Override
-              public Set<Entry<String, String>> entrySet() {
-                throw new UnsupportedOperationException();
-              }
-            });
+            "mapLocal", Map.class.getTypeName(), new HashMap<String, String>() {});
     context.addLocals(new CapturedContext.CapturedValue[] {mapLocal});
     snapshot.setExit(context);
     String buffer = adapter.toJson(snapshot);
@@ -748,7 +734,8 @@ public class SnapshotSerializationTest {
     Map<String, Object> locals = getLocalsFromJson(buffer);
     Map<String, Object> mapFieldObj = (Map<String, Object>) locals.get("mapLocal");
     Assertions.assertEquals(
-        "java.lang.UnsupportedOperationException", mapFieldObj.get(NOT_CAPTURED_REASON));
+        "java.lang.RuntimeException: Unsupported Map type: com.datadog.debugger.agent.SnapshotSerializationTest$2",
+        mapFieldObj.get(NOT_CAPTURED_REASON));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/StringTokenWriterTest.java
@@ -99,20 +99,15 @@ class StringTokenWriterTest {
   }
 
   @Test
-  public void arrayListSizeThrows() throws Exception {
-    class MyArrayList<T> extends ArrayList<T> {
-      @Override
-      public int size() {
-        throw new UnsupportedOperationException("size");
-      }
-    }
+  public void collectionUnknown() throws Exception {
+    class MyArrayList<T> extends ArrayList<T> {}
     assertEquals(
-        "[](Error: java.lang.UnsupportedOperationException: size)",
+        "[](Error: java.lang.RuntimeException: Unsupported Collection type: com.datadog.debugger.util.StringTokenWriterTest$1MyArrayList)",
         serializeValue(new MyArrayList<>(), Limits.DEFAULT));
   }
 
   @Test
-  public void entrySetThrows() throws Exception {
+  public void mapUnknown() throws Exception {
     class MyMap<K, V> extends HashMap<K, V> {
       @Override
       public Set<Entry<K, V>> entrySet() {
@@ -120,7 +115,7 @@ class StringTokenWriterTest {
       }
     }
     assertEquals(
-        "{}(Error: java.lang.UnsupportedOperationException: entrySet)",
+        "{}(Error: java.lang.RuntimeException: Unsupported Map type: com.datadog.debugger.util.StringTokenWriterTest$1MyMap)",
         serializeValue(new MyMap<String, String>(), Limits.DEFAULT));
   }
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot24.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot24.java
@@ -1,9 +1,6 @@
 package com.datadog.debugger;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 
 public class CapturedSnapshot24 {
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot26.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot26.java
@@ -1,0 +1,53 @@
+package com.datadog.debugger;
+
+import java.util.HashMap;
+
+public class CapturedSnapshot26 {
+
+  private Holder<String, String> holder = new Holder<>(this);
+  private HolderWithException<String, String> holderWithException = new HolderWithException<>(this);
+
+  public static int main(String arg) {
+    CapturedSnapshot26 cs26 = new CapturedSnapshot26();
+    if ("exception".equals(arg)) {
+      return cs26.doItException(arg);
+    }
+    return cs26.doit(arg);
+  }
+
+  private int doit(String arg) {
+    holder.put("foo", "bar");
+    return holder.size();
+  }
+
+  private int doItException(String arg) {
+    holderWithException.put("foo", "bar");
+    return holderWithException.size();
+  }
+
+  static class Holder<K, V> extends HashMap<K, V> {
+    private final CapturedSnapshot26 capturedSnapshot26;
+
+    public Holder(CapturedSnapshot26 capturedSnapshot26) {
+      this.capturedSnapshot26 = capturedSnapshot26;
+    }
+
+    @Override
+    public int size() {
+      return super.size();
+    }
+  }
+
+  static class HolderWithException<K, V> extends HashMap<K, V> {
+    private final CapturedSnapshot26 capturedSnapshot26;
+
+    public HolderWithException(CapturedSnapshot26 capturedSnapshot26) {
+      this.capturedSnapshot26 = capturedSnapshot26;
+    }
+
+    @Override
+    public int size() {
+      throw new UnsupportedOperationException("not supported");
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
we are preventing to call on unsafe implementation. We are limiting to JDK implementation first.

# Motivation
Collection and Map interfaces can be implemented by anyone and therefore may not be safe to call. example: persistent layer that load lazily large amount of rows from DB.

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
