### PR TITLE
Fix blocking in netty 3.8

### DIFF
--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/ChannelFutureListenerInstrumentation.java
@@ -56,9 +56,11 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Tracing
       packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
       packageName + ".server.NettyHttpServerDecorator$IgnoreBlockingExceptionHandler",
       packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.BlockAllWritesHandler",
       packageName + ".server.HttpServerRequestTracingHandler",
       packageName + ".server.HttpServerResponseTracingHandler",
-      packageName + ".server.HttpServerTracingHandler"
+      packageName + ".server.HttpServerTracingHandler",
+      packageName + ".server.MaybeBlockResponseHandler",
     };
   }
 

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelPipelineInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/NettyChannelPipelineInstrumentation.java
@@ -62,6 +62,7 @@ public class NettyChannelPipelineInstrumentation extends Instrumenter.Tracing
       packageName + ".server.NettyHttpServerDecorator$NettyBlockResponseFunction",
       packageName + ".server.NettyHttpServerDecorator$IgnoreBlockingExceptionHandler",
       packageName + ".server.BlockingResponseHandler",
+      packageName + ".server.BlockAllWritesHandler",
       packageName + ".server.HttpServerRequestTracingHandler",
       packageName + ".server.HttpServerResponseTracingHandler",
       packageName + ".server.HttpServerTracingHandler",

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/BlockAllWritesHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/BlockAllWritesHandler.java
@@ -1,0 +1,26 @@
+package datadog.trace.instrumentation.netty38.server;
+
+import org.jboss.netty.channel.ChannelDownstreamHandler;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelDownstreamHandler;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BlockAllWritesHandler extends SimpleChannelDownstreamHandler {
+  public static final ChannelDownstreamHandler INSTANCE = new BlockAllWritesHandler();
+  private static final Logger log = LoggerFactory.getLogger(BlockAllWritesHandler.class);
+
+  private BlockAllWritesHandler() {}
+
+  @Override
+  public void writeRequested(ChannelHandlerContext ctx, MessageEvent e) {
+    if (e.getMessage() instanceof HttpResponse) {
+      log.debug("Blocking write of {}", e);
+      e.getFuture().setSuccess();
+    } else {
+      ctx.sendDownstream(e);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/BlockingResponseHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/BlockingResponseHandler.java
@@ -7,8 +7,10 @@ import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.Channels;
 import org.jboss.netty.channel.MessageEvent;
@@ -58,25 +60,39 @@ public class BlockingResponseHandler extends SimpleChannelUpstreamHandler {
       return;
     }
 
-    // the http encoder may be placed after the decoder (and therefore this handler),
-    // so when sending the downstream message, we may not reach the encoder as the message
-    // is processed starting in the current point of the pipeline, not from the globally last
-    // handler
-    ChannelHandlerContext ctxForDownstream =
-        ctx.getPipeline().getContext(HttpServerResponseTracingHandler.class);
-    if (ctxForDownstream == null) {
-      ctxForDownstream = ctx.getPipeline().getContext(HttpServerTracingHandler.class);
+    // the usual disposition of the pipeline is:
+    // ...
+    // (1) BlockingResponseHandler (upstream, this handler)
+    // (2) HttpServerResponseTracingHandler / HttpServerTracingHandler (downstream / duplex)
+    // (3) MaybeBlockResponseHandler (downstream)
+    // ...
+    // when writing our blocking response, we want (2) to analyze it to report
+    // the status code, etc., but we need not run MaybeBlockResponseHandler
+    // because response blocking on a blocking response is not supported.
+    // We add a handler after (3) blocking all further writes, in case something
+    // tries to write after we've written the blocking response
+    ChannelHandlerContext ctxForDownstream = null;
+    try {
+      ctx.getPipeline()
+          .addAfter(
+              MaybeBlockResponseHandler.class.getName(),
+              "block_all_writes",
+              BlockAllWritesHandler.INSTANCE);
+      // write will start AFTER the referenced handler. It will start in (2)
+      ctxForDownstream = ctx.getPipeline().getContext(MaybeBlockResponseHandler.class.getName());
+    } catch (NoSuchElementException nse) {
+      if (HAS_WARNED) {
+        log.debug(
+            "Unable to block because MaybeBlockResponseHandler was not found on the pipeline");
+      } else {
+        log.warn("Unable to block because MaybeBlockResponseHandler was not found on the pipeline");
+        HAS_WARNED = true;
+      }
+    } catch (IllegalArgumentException iae) {
+      // already added
     }
 
     if (ctxForDownstream == null) {
-      if (HAS_WARNED) {
-        log.debug(
-            "Unable to block because HttpServerResponseTracingHandler was not found on the pipeline");
-      } else {
-        log.warn(
-            "Unable to block because HttpServerResponseTracingHandler was not found on the pipeline");
-        HAS_WARNED = true;
-      }
       ctx.sendUpstream(e);
       return;
     }
@@ -110,16 +126,17 @@ public class BlockingResponseHandler extends SimpleChannelUpstreamHandler {
     this.hasBlockedAlready = true;
     segment.effectivelyBlocked();
 
-    Channels.write(ctxForDownstream.getChannel(), response)
-        .addListener(
-            fut -> {
-              if (!fut.isSuccess()) {
-                log.warn("Write of blocking response failed", fut.getCause());
-              }
-              // close the connection because it can be in an invalid state at this point
-              // For instance, in a POST request we will still be receiving data from the
-              // client
-              fut.getChannel().close();
-            });
+    ChannelFuture future = Channels.future(ctx.getChannel());
+    future.addListener(
+        fut -> {
+          if (!fut.isSuccess()) {
+            log.warn("Write of blocking response failed", fut.getCause());
+          }
+          // close the connection because it can be in an invalid state at this point
+          // For instance, in a POST request we will still be receiving data from the
+          // client
+          fut.getChannel().close();
+        });
+    Channels.write(ctxForDownstream, future, response);
   }
 }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/NettyHttpServerDecorator.java
@@ -175,6 +175,7 @@ public class NettyHttpServerDecorator
     public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) throws Exception {
       if ((e.getCause() instanceof BlockingException)) {
         NettyBlockResponseFunction.log.info("Suppressing handling of BlockingException");
+        e.getFuture().setSuccess();
       } else {
         super.exceptionCaught(ctx, e);
       }

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/client/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/client/PlayWSClientTest.groovy
@@ -1,4 +1,4 @@
-package client
+package datadog.trace.instrumentation.play23.test.client
 
 import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.agent.test.naming.TestingNettyHttpNamingConventions

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/server/PlayAsyncServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/server/PlayAsyncServerTest.groovy
@@ -1,4 +1,4 @@
-package server
+package datadog.trace.instrumentation.play23.test.server
 
 import datadog.trace.agent.test.base.HttpServer
 

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/server/PlayServerTest.groovy
@@ -1,4 +1,4 @@
-package server
+package datadog.trace.instrumentation.play23.test.server
 
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
@@ -34,6 +34,11 @@ class PlayServerTest extends HttpServerTest<TestServer> {
   // We don't have instrumentation for this version of netty yet
   @Override
   boolean hasHandlerSpan() {
+    true
+  }
+
+  @Override
+  boolean testUserBlocking() {
     true
   }
 

--- a/dd-java-agent/instrumentation/play-2.3/src/test/scala/datadog/trace/instrumentation/play23/test/server/AsyncServer.scala
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/scala/datadog/trace/instrumentation/play23/test/server/AsyncServer.scala
@@ -1,5 +1,6 @@
-package server
+package datadog.trace.instrumentation.play23.test.server
 
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint._
 import datadog.trace.agent.test.base.{HttpServer, HttpServerTest}
 import play.api.mvc.{Action, Handler, Results}
@@ -95,10 +96,18 @@ class AsyncServer extends HttpServer {
       Action.async { result =>
         HttpServerTest.controller(
           EXCEPTION,
-          new AsyncBlockClosureAdapter(() => {
+          new AsyncBlockClosureAdapter({
             throw new Exception(EXCEPTION.getBody)
           })
         )
+      }
+
+    case ("GET", "/user-block") =>
+      Action.async {
+        HttpServerTest.controller(USER_BLOCK, AsyncBlockClosureAdapter {
+          Blocking.forUser("user-to-block").blockIfMatch()
+          Future.successful(Results.Ok("should never be reached"))
+        })
       }
   }
 

--- a/dd-java-agent/instrumentation/play-2.3/src/test/scala/datadog/trace/instrumentation/play23/test/server/ControllerClosureAdapter.scala
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/scala/datadog/trace/instrumentation/play23/test/server/ControllerClosureAdapter.scala
@@ -1,4 +1,4 @@
-package server
+package datadog.trace.instrumentation.play23.test.server
 
 import datadog.trace.agent.test.base.HttpServerTest
 import groovy.lang.Closure
@@ -12,11 +12,14 @@ class ControllerClosureAdapter(response: Result) extends Closure[Result]((): Uni
     )
 }
 
-class BlockClosureAdapter(block: () => Result) extends Closure[Result]((): Unit) {
+class BlockClosureAdapter(block: => Result) extends Closure[Result]((): Unit) {
   override def call(): Result =
-    block().withHeaders(
+    block.withHeaders(
       (HttpServerTest.getIG_RESPONSE_HEADER, HttpServerTest.getIG_RESPONSE_HEADER_VALUE)
     )
+}
+object BlockClosureAdapter {
+  def apply(block: => Result): BlockClosureAdapter = new BlockClosureAdapter(block)
 }
 
 class AsyncControllerClosureAdapter(response: Future[Result])
@@ -30,13 +33,17 @@ class AsyncControllerClosureAdapter(response: Future[Result])
     )
 }
 
-class AsyncBlockClosureAdapter(block: () => Future[Result])
+class AsyncBlockClosureAdapter(block: => Future[Result])
     extends Closure[Future[Result]]((): Unit) {
   import scala.concurrent.ExecutionContext.Implicits.global
   override def call(): Future[Result] =
-    block().map(
+    block.map(
       _.withHeaders(
         (HttpServerTest.getIG_RESPONSE_HEADER, HttpServerTest.getIG_RESPONSE_HEADER_VALUE)
       )
     )
+}
+
+object AsyncBlockClosureAdapter {
+  def apply(block: => Future[Result]): AsyncBlockClosureAdapter = new AsyncBlockClosureAdapter(block)
 }

--- a/dd-java-agent/instrumentation/play-2.3/src/test/scala/datadog/trace/instrumentation/play23/test/server/Settings.scala
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/scala/datadog/trace/instrumentation/play23/test/server/Settings.scala
@@ -1,4 +1,4 @@
-package server
+package datadog.trace.instrumentation.play23.test.server
 
 import play.api.GlobalSettings
 import play.api.mvc.{RequestHeader, Result, Results}

--- a/dd-java-agent/instrumentation/play-2.3/src/test/scala/datadog/trace/instrumentation/play23/test/server/SyncServer.scala
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/scala/datadog/trace/instrumentation/play23/test/server/SyncServer.scala
@@ -1,5 +1,6 @@
-package server
+package datadog.trace.instrumentation.play23.test.server
 
+import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint._
 import datadog.trace.agent.test.base.{HttpServer, HttpServerTest}
 import play.api.mvc.{Action, Handler, Results}
@@ -78,10 +79,18 @@ class SyncServer extends HttpServer {
         )
       }
     case ("GET", "/exception") =>
-      Action { request =>
-        HttpServerTest.controller(EXCEPTION, new BlockClosureAdapter(() => {
+      Action {
+        HttpServerTest.controller(EXCEPTION, BlockClosureAdapter {
           throw new Exception(EXCEPTION.getBody)
-        }))
+        })
+      }
+
+    case ("GET", "/user-block") =>
+      Action {
+        HttpServerTest.controller(USER_BLOCK, BlockClosureAdapter {
+          Blocking.forUser("user-to-block").blockIfMatch()
+          Results.Ok("should never be reached")
+        })
       }
   }
 


### PR DESCRIPTION
The problem shows with play 2.3. After committing the blocking response and throwing BlockingExcpetion, another response is produced by the Play handler. So suppress this response. There was also a missing call to mark the future as completed.
