### PR TITLE
Add tainted range based redaction for XSS vulnerabilities

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/SensitiveHandlerImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/SensitiveHandlerImpl.java
@@ -45,6 +45,7 @@ public class SensitiveHandlerImpl implements SensitiveHandler {
     tokenizers.put(VulnerabilityType.COMMAND_INJECTION, CommandRegexpTokenizer::new);
     tokenizers.put(VulnerabilityType.SSRF, UrlRegexpTokenizer::new);
     tokenizers.put(VulnerabilityType.UNVALIDATED_REDIRECT, UrlRegexpTokenizer::new);
+    tokenizers.put(VulnerabilityType.XSS, TaintedRangeBasedTokenizer::new);
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/TaintedRangeBasedTokenizer.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/TaintedRangeBasedTokenizer.java
@@ -1,0 +1,58 @@
+package com.datadog.iast.sensitive;
+
+import com.datadog.iast.model.Evidence;
+import com.datadog.iast.model.Range;
+import com.datadog.iast.util.Ranged;
+import java.util.NoSuchElementException;
+
+public class TaintedRangeBasedTokenizer implements SensitiveHandler.Tokenizer {
+
+  private final String value;
+  private final Range[] ranges;
+
+  private Ranged current;
+
+  private int rangesIndex;
+
+  private int pos;
+
+  public TaintedRangeBasedTokenizer(final Evidence evidence) {
+    this.ranges = evidence.getRanges();
+    this.value = evidence.getValue();
+    rangesIndex = 0;
+    pos = 0; // current value position
+  }
+
+  @Override
+  public boolean next() {
+    current = buildNext();
+    return current != null;
+  }
+
+  @Override
+  public Ranged current() {
+    if (current == null) {
+      throw new NoSuchElementException();
+    }
+    return current;
+  }
+
+  private Ranged buildNext() {
+    for (; rangesIndex < ranges.length; rangesIndex++) {
+      Range range = ranges[rangesIndex];
+      if (range.getStart() <= pos) {
+        pos = range.getStart() + range.getLength();
+      } else {
+        Ranged next = Ranged.build(pos, range.getStart() - pos);
+        pos = range.getStart() + range.getLength();
+        return next;
+      }
+    }
+    if (pos < value.length()) {
+      Ranged next = Ranged.build(pos, value.length() - pos);
+      pos = value.length();
+      return next;
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/Ranged.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/Ranged.java
@@ -95,8 +95,8 @@ public interface Ranged {
     return offset < 0;
   }
 
-  static Ranged build(int start, int end) {
-    return new RangedImpl(start, end);
+  static Ranged build(int start, int length) {
+    return new RangedImpl(start, length);
   }
 
   class RangedImpl implements Ranged {

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -1686,3 +1686,208 @@ suite:
           }
         ]
       }
+
+  - type: 'VULNERABILITIES'
+    description: 'Length based redaction '
+    input: >
+      [
+        {
+          "type": "XSS",
+          "evidence": {
+            "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS vulnerability but can be extended to future ones",
+            "ranges": [
+              { "start" : 123, "length" : 3, "source": { "origin": "http.request.parameter", "name": "type", "value": "XSS" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "type", "value": "XSS" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "XSS",
+            "evidence": {
+              "valueParts": [
+                { "redacted": true },
+                { "source": 0, "value": "XSS" },
+                { "redacted": true }
+              ]
+            }
+          }
+        ]
+      } 
+
+  - type: 'VULNERABILITIES'
+    description: 'Length based redaction - with redactable source '
+    input: >
+      [
+        {
+          "type": "XSS",
+          "evidence": {
+            "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS vulnerability but can be extended to future ones",
+            "ranges": [
+              { "start" : 123, "length" : 3, "source": { "origin": "http.request.parameter", "name": "password", "value": "XSS" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "password", "redacted": true, "pattern": "abc" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "XSS",
+            "evidence": {
+              "valueParts": [
+                { "redacted": true },
+                { "source": 0, "redacted": true, "pattern": "abc"},
+                { "redacted": true }
+              ]
+            }
+          }
+        ]
+      } 
+
+  - type: 'VULNERABILITIES'
+    description: 'Length based redaction - multiple ranges'
+    input: >
+      [
+        {
+          "type": "XSS",
+          "evidence": {
+            "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS vulnerability but can be extended to future ones",
+            "ranges": [
+              { "start" : 16, "length" : 10, "source": { "origin": "http.request.parameter", "name": "text", "value": "super long" }},
+              { "start" : 123, "length" : 3, "source": { "origin": "http.request.parameter", "name": "type", "value": "XSS" }}
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "text", "value": "super long" },
+          { "origin": "http.request.parameter", "name": "type", "value": "XSS"}
+        ],
+        "vulnerabilities": [
+          {
+            "type": "XSS",
+            "evidence": {
+              "valueParts": [
+                { "redacted": true },
+                { "source": 0, "value": "super long" },
+                { "redacted": true },
+                {"source": 1, "value": "XSS"}, 
+                { "redacted": true }
+              ]
+            }
+          }
+        ]
+      } 
+
+  - type: 'VULNERABILITIES'
+    description: 'Length based redaction - first range at the beginning '
+    input: >
+      [
+        {
+          "type": "XSS",
+          "evidence": {
+            "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS vulnerability but can be extended to future ones",
+            "ranges": [
+              { "start" : 0, "length" : 4, "source": { "origin": "http.request.parameter", "name": "text", "value": "this" }},
+              { "start" : 123, "length" : 3, "source": { "origin": "http.request.parameter", "name": "type", "value": "XSS" }}
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "text", "value": "this" },
+          { "origin": "http.request.parameter", "name": "type", "value": "XSS"}
+        ],
+        "vulnerabilities": [
+          {
+            "type": "XSS",
+            "evidence": {
+              "valueParts": [
+                { "source": 0, "value": "this" },
+                { "redacted": true },
+                {"source": 1, "value": "XSS"}, 
+                { "redacted": true }
+              ]
+            }
+          }
+        ]
+      } 
+
+  - type: 'VULNERABILITIES'
+    description: 'Length based redaction - last range at the end '
+    input: >
+      [
+        {
+          "type": "XSS",
+          "evidence": {
+            "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS",
+            "ranges": [
+              { "start" : 0, "length" : 4, "source": { "origin": "http.request.parameter", "name": "text", "value": "this" }},
+              { "start" : 123, "length" : 3, "source": { "origin": "http.request.parameter", "name": "type", "value": "XSS" }}
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "text", "value": "this" },
+          { "origin": "http.request.parameter", "name": "type", "value": "XSS"}
+        ],
+        "vulnerabilities": [
+          {
+            "type": "XSS",
+            "evidence": {
+              "valueParts": [
+                { "source": 0, "value": "this" },
+                { "redacted": true },
+                {"source": 1, "value": "XSS"}
+              ]
+            }
+          }
+        ]
+      } 
+
+  - type: 'VULNERABILITIES'
+    description: 'Length based redaction - whole text '
+    input: >
+      [
+        {
+          "type": "XSS",
+          "evidence": {
+            "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS",
+            "ranges": [
+              { "start" : 0, "length" : 126, "source": { "origin": "http.request.parameter", "name": "text", "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS" }}
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "text", "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS"}
+        ],
+        "vulnerabilities": [
+          {
+            "type": "XSS",
+            "evidence": {
+              "valueParts": [
+                { "source": 0, "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS" }
+              ]
+            }
+          }
+        ]
+      } 

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -1688,7 +1688,7 @@ suite:
       }
 
   - type: 'VULNERABILITIES'
-    description: 'Length based redaction '
+    description: 'Tainted range based redaction '
     input: >
       [
         {
@@ -1721,7 +1721,7 @@ suite:
       } 
 
   - type: 'VULNERABILITIES'
-    description: 'Length based redaction - with redactable source '
+    description: 'Tainted range based redaction - with redactable source '
     input: >
       [
         {
@@ -1754,7 +1754,7 @@ suite:
       } 
 
   - type: 'VULNERABILITIES'
-    description: 'Length based redaction - multiple ranges'
+    description: 'Tainted range based redaction - multiple ranges'
     input: >
       [
         {
@@ -1791,7 +1791,7 @@ suite:
       } 
 
   - type: 'VULNERABILITIES'
-    description: 'Length based redaction - first range at the beginning '
+    description: 'Tainted range based redaction - first range at the beginning '
     input: >
       [
         {
@@ -1827,7 +1827,7 @@ suite:
       } 
 
   - type: 'VULNERABILITIES'
-    description: 'Length based redaction - last range at the end '
+    description: 'Tainted range based redaction - last range at the end '
     input: >
       [
         {
@@ -1862,7 +1862,7 @@ suite:
       } 
 
   - type: 'VULNERABILITIES'
-    description: 'Length based redaction - whole text '
+    description: 'Tainted range based redaction - whole text '
     input: >
       [
         {


### PR DESCRIPTION
# What Does This Do

Add new TaintedRangeBasedTokenizer to XSS vulnerability

# Motivation

redact IAST XSS Vulnerability

# Additional Notes

TaintedRangeBasedTokenizer involves redact everything in the evidence value that is not within a range

`dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml` is really helpful to understand the behaviour  
