### PR TITLE
Remove application key header from settings and ITR requests

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/BackendApiFactory.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/BackendApiFactory.java
@@ -33,12 +33,7 @@ public class BackendApiFactory {
         throw new FatalAgentMisconfigurationError(
             "Agentless mode is enabled and api key is not set. Please set application key");
       }
-      String applicationKey = config.getApplicationKey();
-      if (applicationKey == null || applicationKey.isEmpty()) {
-        log.warn(
-            "Agentless mode is enabled and application key is not set. Some CI Visibility features will be unavailable");
-      }
-      return new IntakeApi(site, apiKey, applicationKey, timeoutMillis, retryPolicyFactory);
+      return new IntakeApi(site, apiKey, timeoutMillis, retryPolicyFactory);
     }
 
     DDAgentFeaturesDiscovery featuresDiscovery =

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/IntakeApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/IntakeApi.java
@@ -20,22 +20,15 @@ public class IntakeApi implements BackendApi {
 
   private static final String API_VERSION = "v2";
   private static final String DD_API_KEY_HEADER = "dd-api-key";
-  private static final String DD_APPLICATION_KEY_HEADER = "dd-application-key";
 
   private final String apiKey;
-  private final String applicationKey;
   private final HttpRetryPolicy.Factory retryPolicyFactory;
   private final HttpUrl hostUrl;
   private final OkHttpClient httpClient;
 
   public IntakeApi(
-      String site,
-      String apiKey,
-      String applicationKey,
-      long timeoutMillis,
-      HttpRetryPolicy.Factory retryPolicyFactory) {
+      String site, String apiKey, long timeoutMillis, HttpRetryPolicy.Factory retryPolicyFactory) {
     this.apiKey = apiKey;
-    this.applicationKey = applicationKey;
     this.retryPolicyFactory = retryPolicyFactory;
 
     final String ciVisibilityAgentlessUrlStr = Config.get().getCiVisibilityAgentlessUrl();
@@ -55,10 +48,6 @@ public class IntakeApi implements BackendApi {
     HttpUrl url = hostUrl.resolve(uri);
     Request.Builder requestBuilder =
         new Request.Builder().url(url).post(requestBody).addHeader(DD_API_KEY_HEADER, apiKey);
-
-    if (applicationKey != null) {
-      requestBuilder.addHeader(DD_APPLICATION_KEY_HEADER, applicationKey);
-    }
 
     Request request = requestBuilder.build();
     HttpRetryPolicy retryPolicy = retryPolicyFactory.create();

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -1004,16 +1004,12 @@ class GradleDaemonSmokeTest extends Specification {
     def ddApiKeyPath = testKitFolder.resolve(".dd.api.key")
     Files.write(ddApiKeyPath, "dummy".getBytes())
 
-    def ddApplicationKeyPath = testKitFolder.resolve(".dd.application.key")
-    Files.write(ddApplicationKeyPath, "dummy".getBytes())
-
     def gradleProperties =
       "org.gradle.jvmargs=" +
       "-javaagent:${agentShadowJar}=" +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.ENV)}=${TEST_ENVIRONMENT_NAME}," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.SERVICE_NAME)}=${TEST_SERVICE_NAME}," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.API_KEY_FILE)}=${ddApiKeyPath.toAbsolutePath().toString()}," +
-      "${Strings.propertyNameToSystemPropertyName(GeneralConfig.APPLICATION_KEY_FILE)}=${ddApplicationKeyPath.toAbsolutePath().toString()}," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_ENABLED)}=true," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED)}=true," +
       "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_GIT_UPLOAD_ENABLED)}=false," +

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -350,7 +350,6 @@ class MavenSmokeTest extends Specification {
     def processBuilder = createProcessBuilder(["test"])
 
     processBuilder.environment().put("DD_API_KEY", "01234567890abcdef123456789ABCDEF")
-    processBuilder.environment().put("DD_APPLICATION_KEY", "01234567890abcdef123456789ABCDEF")
 
     return runProcess(processBuilder.start())
   }


### PR DESCRIPTION
# What Does This Do
Removes application key header from requests that are made to CI Visibility endpoints.

# Motivation
The endpoints have been updated recently, and the API key is no longer required.