### PR TITLE
Fix the X-Content-Type-Options header string

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
@@ -58,7 +58,7 @@ public class HttpHeader {
           }
         };
     public static final HttpHeader X_CONTENT_TYPE_OPTIONS =
-        new ContextAwareHeader("X-Content-Type") {
+        new ContextAwareHeader("X-Content-Type-Options") {
           @Override
           public void onHeader(final IastRequestContext ctx, final String value) {
             ctx.setxContentTypeOptions(value);

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
@@ -92,7 +92,7 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
     module.onHeader("Strict-Transport-Security", "invalid max age")
 
     then:
-    3 * tracer.activeSpan()
+    4 * tracer.activeSpan()
     1 * overheadController.consumeQuota(_,_)
     0 * _
   }

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -316,6 +316,13 @@ public class IastWebController {
     return "ok";
   }
 
+  @GetMapping(value = "/xcontenttypeoptionsecure", produces = "text/html")
+  public String xContentTypeOptionsSecure(HttpServletResponse response) {
+    response.addHeader("X-Content-Type-Options", "nosniff");
+    response.setStatus(HttpStatus.OK.value());
+    return "ok";
+  }
+
   private void withProcess(final Operation<Process> op) {
     Process process = null;
     try {

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -194,7 +194,7 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     def response = client.newCall(request).execute()
     then:
     response.isSuccessful()
-    !hasVulnerability { vul ->
+    noVulnerability { vul ->
       vul.type == 'XCONTENTTYPE_HEADER_MISSING'
     }
   }

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -186,6 +186,20 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     }
   }
 
+  void 'X content type options missing header vulnerability is absent'() {
+    setup:
+    String url = "http://localhost:${httpPort}/xcontenttypeoptionsecure"
+    def request = new Request.Builder().url(url).get().build()
+    when:
+    def response = client.newCall(request).execute()
+    then:
+    response.isSuccessful()
+    !hasVulnerability { vul ->
+      vul.type == 'XCONTENTTYPE_HEADER_MISSING'
+    }
+  }
+
+
   void 'no HttpOnly cookie vulnerability is present'() {
     setup:
     String url = "http://localhost:${httpPort}/insecure_cookie"


### PR DESCRIPTION
# What Does This Do
Fix the header string for the X-Content-Type-Options vulnerability detection

# Motivation
The functionality wasn't working

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
