### PR TITLE
Added trusted IPs protocol

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -8,6 +8,7 @@ import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_EXCLUSIONS;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_IP_BLOCKING;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_REQUEST_BLOCKING;
+import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_TRUSTED_IPS;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_USER_BLOCKING;
 
 import com.datadog.appsec.AppSecSystem;
@@ -93,7 +94,8 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_REQUEST_BLOCKING
             | CAPABILITY_ASM_USER_BLOCKING
             | CAPABILITY_ASM_CUSTOM_RULES
-            | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE);
+            | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
+            | CAPABILITY_ASM_TRUSTED_IPS);
   }
 
   private void subscribeRulesAndData() {
@@ -328,7 +330,8 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_REQUEST_BLOCKING
             | CAPABILITY_ASM_USER_BLOCKING
             | CAPABILITY_ASM_CUSTOM_RULES
-            | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE);
+            | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
+            | CAPABILITY_ASM_TRUSTED_IPS);
     this.configurationPoller.removeListener(Product.ASM_DD);
     this.configurationPoller.removeListener(Product.ASM_DATA);
     this.configurationPoller.removeListener(Product.ASM);

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -213,7 +213,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     }
     1 * poller.addConfigurationEndListener(_) >> { listeners.savedConfEndListener = it[0] }
     1 * poller.addCapabilities(2L)
-    1 * poller.addCapabilities(956L)
+    1 * poller.addCapabilities(1980L)
     0 * _._
     initialWafConfig.get() != null
 
@@ -350,7 +350,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     }
     1 * poller.addConfigurationEndListener(_) >> { listeners.savedConfEndListener = it[0] }
     1 * poller.addCapabilities(2L)
-    1 * poller.addCapabilities(956L)
+    1 * poller.addCapabilities(1980L)
     0 * _._
 
     when:
@@ -406,7 +406,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     poller = null
 
     then:
-    1 * poller.removeCapabilities(958L)
+    1 * poller.removeCapabilities(1982L)
     4 * poller.removeListener(_)
     1 * poller.removeConfigurationEndListener(_)
     1 * poller.stop()

--- a/remote-config/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
@@ -61,6 +61,7 @@ public class RemoteConfigRequest {
     public static final long CAPABILITY_ASM_USER_BLOCKING = 1 << 7;
     public static final long CAPABILITY_ASM_CUSTOM_RULES = 1 << 8;
     public static final long CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE = 1 << 9;
+    public static final long CAPABILITY_ASM_TRUSTED_IPS = 1 << 10;
 
     @Json(name = "state")
     private final ClientState clientState;


### PR DESCRIPTION
# What Does This Do
Added Trusted IPs capability.

# Motivation
Organizations often require that their security tools provide a way to specify and manage a list of trusted IP addresses, primarily to reduce outage from blocking on false positives or true positives or misconfigurations.
