### PR TITLE
Rename operation name spark.batch to spark.streaming_batch

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -178,7 +178,7 @@ public class DatadogSparkListener extends SparkListener {
     }
 
     AgentTracer.SpanBuilder builder =
-        buildSparkSpan("spark.batch", jobProperties).withStartTimestamp(timeMs * 1000);
+        buildSparkSpan("spark.streaming_batch", jobProperties).withStartTimestamp(timeMs * 1000);
 
     // Streaming spans will always be the root span, capturing all parameters on those
     captureApplicationParameters(builder);
@@ -281,8 +281,8 @@ public class DatadogSparkListener extends SparkListener {
     /*-
      * The spark.job span hierarchy depends on the setup:
      *
-     * spark.application | spark.batch | databricks.task depending on the environment where spark is running
-     *               \          |         /
+     * spark.application | spark.streaming_batch | databricks.task depending on the environment where spark is running
+     *               \          |                   /
      *                    [spark.sql] optional, only present if using spark-sql
      *                          |
      *                      spark.job

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
@@ -61,7 +61,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
     assertTraces(2) {
       trace(5) {
         span {
-          operationName "spark.batch"
+          operationName "spark.streaming_batch"
           resourceName "test-query"
           spanType "spark"
           parent()
@@ -167,7 +167,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
       }
       trace(5) {
         span {
-          operationName "spark.batch"
+          operationName "spark.streaming_batch"
           spanType "spark"
           assert span.tags["batch_id"] == 1
           parent()
@@ -218,7 +218,24 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
     assertTraces(1) {
       trace(5, true) {
         span {
-          operationName "spark.batch"
+          operationName "spark.job"
+          spanType "spark"
+          errored true
+          childOf(span(1))
+        }
+        span {
+          operationName "spark.sql"
+          spanType "spark"
+          childOf(span(3))
+        }
+        span {
+          operationName "spark.stage"
+          spanType "spark"
+          errored true
+          childOf(span(0))
+        }
+        span {
+          operationName "spark.streaming_batch"
           resourceName "failing-query"
           spanType "spark"
           errored true
@@ -227,27 +244,10 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
           parent()
         }
         span {
-          operationName "spark.job"
-          spanType "spark"
-          errored true
-          childOf(span(2))
-        }
-        span {
-          operationName "spark.sql"
-          spanType "spark"
-          childOf(span(0))
-        }
-        span {
-          operationName "spark.stage"
-          spanType "spark"
-          errored true
-          childOf(span(1))
-        }
-        span {
           operationName "spark.task"
           spanType "spark"
           errored true
-          childOf(span(3))
+          childOf(span(2))
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

Rename `spark.batch` operation name to `spark.streaming_batch`. This is a breaking change that is already done in the backend.

# Motivation

It’s not clear that spark.batch is a spark stream operation. By using streaming_batch we match the [spark streaming listener terminology and make it clear it’s a stream](https://spark.apache.org/docs/2.2.1/api/java/org/apache/spark/streaming/scheduler/StreamingListener.html)

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
