### PR TITLE
Limit akka-http version for latestDepTests following dropping of Java 8

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/build.gradle
+++ b/dd-java-agent/instrumentation/akka-http-10.0/build.gradle
@@ -138,10 +138,12 @@ dependencies {
   // TODO: test with Scala 3
   latestDepIastTestImplementation deps.scala213
   // Use akka-2.8.+ since latest akka-http release is still not compatible with akka-2.9.0-M1+.
-  latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '10.+'
+  // akka-http versions are limited to 10.5.2 as this is the final version with Java 8 support
+  // See: https://github.com/akka/akka-http/releases
+  latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-http_2.13', version: '[10.+,10.5.2)'
   latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-stream_2.13', version: '2.8.+'
   latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-actor_2.13', version: '2.8.+'
-  latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-http-jackson_2.13', version: '10.+'
+  latestDepIastTestImplementation group: 'com.typesafe.akka', name: 'akka-http-jackson_2.13', version: '[10.+,10.5.2)'
   latestDepIastTestImplementation(testFixtures(project(':dd-java-agent:agent-iast')))
 
   lagomTestImplementation deps.scala211


### PR DESCRIPTION
# What Does This Do
Limits the versions of latestDepTests for akka-http.
# Motivation
Java 8 has been dropped from the latest akka-http: https://github.com/akka/akka-http/releases/tag/v10.6.0-M1

# Additional Notes

