### PR TITLE
Service naming: use the root service instead DD_SERVICE when flattening

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -21,7 +21,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     private NamingEntry(String rawDbType) {
       final NamingSchema.ForDatabase schema = SpanNaming.instance().namingSchema().database();
       this.dbType = schema.normalizedName(rawDbType);
-      this.service = schema.service(Config.get().getServiceName(), dbType);
+      this.service = schema.service(dbType);
       this.operation = UTF8BytesString.create(schema.operation(dbType));
     }
 

--- a/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
+++ b/dd-java-agent/instrumentation/aerospike-4/src/main/java/datadog/trace/instrumentation/aerospike4/AerospikeClientDecorator.java
@@ -17,10 +17,7 @@ import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabas
 public class AerospikeClientDecorator extends DBTypeProcessingDatabaseClientDecorator<Node> {
   private static final String DB_TYPE = "aerospike";
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
   public static final UTF8BytesString JAVA_AEROSPIKE = UTF8BytesString.create("java-aerospike");
   public static final UTF8BytesString OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -86,13 +86,19 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
       case "SQS.ReceiveMessage":
       case "SQS.DeleteMessage":
       case "SQS.DeleteMessageBatch":
-        span.setServiceName(SQS_SERVICE_NAME);
+        if (SQS_SERVICE_NAME != null) {
+          span.setServiceName(SQS_SERVICE_NAME);
+        }
         break;
       case "SNS.Publish":
-        span.setServiceName(SNS_SERVICE_NAME);
+        if (SNS_SERVICE_NAME != null) {
+          span.setServiceName(SNS_SERVICE_NAME);
+        }
         break;
       default:
-        span.setServiceName(GENERIC_SERVICE_NAME);
+        if (GENERIC_SERVICE_NAME != null) {
+          span.setServiceName(GENERIC_SERVICE_NAME);
+        }
         break;
     }
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -147,14 +147,20 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
       case "Sqs.ReceiveMessage":
       case "Sqs.DeleteMessage":
       case "Sqs.DeleteMessageBatch":
-        span.setServiceName(SQS_SERVICE_NAME);
+        if (SQS_SERVICE_NAME != null) {
+          span.setServiceName(SQS_SERVICE_NAME);
+        }
         break;
       case "Sns.PublishBatch":
       case "Sns.Publish":
-        span.setServiceName(SNS_SERVICE_NAME);
+        if (SNS_SERVICE_NAME != null) {
+          span.setServiceName(SNS_SERVICE_NAME);
+        }
         break;
       default:
-        span.setServiceName(GENERIC_SERVICE_NAME);
+        if (GENERIC_SERVICE_NAME != null) {
+          span.setServiceName(GENERIC_SERVICE_NAME);
+        }
         break;
     }
     span.setTag(InstrumentationTags.AWS_AGENT, COMPONENT_NAME);

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
@@ -27,11 +27,14 @@ public class SqsDecorator extends MessagingClientDecorator {
   private final CharSequence spanType;
   private final String serviceName;
 
-  private static final String LOCAL_SERVICE_NAME =
-      SQS_LEGACY_TRACING ? "sqs" : Config.get().getServiceName();
-
   public static final SqsDecorator CONSUMER_DECORATE =
-      new SqsDecorator(SPAN_KIND_CONSUMER, MESSAGE_CONSUMER, LOCAL_SERVICE_NAME);
+      new SqsDecorator(
+          SPAN_KIND_CONSUMER,
+          MESSAGE_CONSUMER,
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .inboundService("sqs", SQS_LEGACY_TRACING));
 
   public static final SqsDecorator BROKER_DECORATE =
       new SqsDecorator(

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -356,7 +356,7 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
       }
       trace(1) {
         span {
-          serviceName SpanNaming.instance().namingSchema().messaging().inboundService(Config.get().getServiceName(), "jms")
+          serviceName SpanNaming.instance().namingSchema().messaging().inboundService("jms", Config.get().isLegacyTracingEnabled(true, "jms")) ?: Config.get().getServiceName()
           operationName SpanNaming.instance().namingSchema().messaging().inboundOperation("jms")
           resourceName "Consumed from Queue somequeue"
           spanType DDSpanTypes.MESSAGE_CONSUMER

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
@@ -28,11 +28,14 @@ public class SqsDecorator extends MessagingClientDecorator {
   private final CharSequence spanType;
   private final String serviceName;
 
-  private static final String LOCAL_SERVICE_NAME =
-      SQS_LEGACY_TRACING ? "sqs" : Config.get().getServiceName();
-
   public static final SqsDecorator CONSUMER_DECORATE =
-      new SqsDecorator(SPAN_KIND_CONSUMER, MESSAGE_CONSUMER, LOCAL_SERVICE_NAME);
+      new SqsDecorator(
+          SPAN_KIND_CONSUMER,
+          MESSAGE_CONSUMER,
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .inboundService("sqs", SQS_LEGACY_TRACING));
 
   public static final SqsDecorator BROKER_DECORATE =
       new SqsDecorator(

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
@@ -401,7 +401,7 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
       }
       trace(1) {
         span {
-          serviceName SpanNaming.instance().namingSchema().messaging().inboundService(Config.get().getServiceName(), "jms")
+          serviceName SpanNaming.instance().namingSchema().messaging().inboundService("jms", Config.get().isLegacyTracingEnabled(true, "jms")) ?: Config.get().getServiceName()
           operationName SpanNaming.instance().namingSchema().messaging().inboundOperation("jms")
           resourceName "Consumed from Queue somequeue"
           spanType DDSpanTypes.MESSAGE_CONSUMER

--- a/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-2.0/src/main/java/datadog/trace/instrumentation/couchbase/client/CouchbaseClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.couchbase.client;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -11,10 +10,7 @@ class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   private static final String DB_TYPE = "couchbase";
 
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
 
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/main/java/datadog/trace/instrumentation/couchbase_31/client/CouchbaseClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.couchbase_31.client;
 
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -11,10 +10,7 @@ import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabas
 class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   private static final String DB_TYPE = "couchbase";
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));
   public static final CharSequence COUCHBASE_CLIENT = UTF8BytesString.create("couchbase-client");

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CouchbaseClientDecorator.java
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/main/java/datadog/trace/instrumentation/couchbase_32/client/CouchbaseClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.couchbase_32.client;
 
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -11,10 +10,7 @@ import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabas
 class CouchbaseClientDecorator extends DBTypeProcessingDatabaseClientDecorator {
   private static final String DB_TYPE = "couchbase";
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));
   public static final CharSequence COUCHBASE_CLIENT = UTF8BytesString.create("couchbase-client");

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClientDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.datastax.cassandra;
 import com.datastax.driver.core.Host;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -13,10 +12,7 @@ import datadog.trace.bootstrap.instrumentation.decorator.DBTypeProcessingDatabas
 public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDecorator<Session> {
   private static final String DB_TYPE = "cassandra";
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));
   public static final CharSequence JAVA_CASSANDRA = UTF8BytesString.create("java-cassandra");

--- a/dd-java-agent/instrumentation/datastax-cassandra-4/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/CassandraClientDecorator.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-4/src/main/java/datadog/trace/instrumentation/datastax/cassandra4/CassandraClientDecorator.java
@@ -5,7 +5,6 @@ import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.metadata.Node;
 import com.datastax.oss.driver.api.core.servererrors.CoordinatorException;
 import com.datastax.oss.driver.api.core.session.Session;
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -18,10 +17,7 @@ import java.util.Objects;
 public class CassandraClientDecorator extends DBTypeProcessingDatabaseClientDecorator<Session> {
   private static final String DB_TYPE = "cassandra";
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));
   public static final CharSequence JAVA_CASSANDRA = UTF8BytesString.create("java-cassandra");

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -21,10 +21,7 @@ public class ElasticsearchRestClientDecorator extends DBTypeProcessingDatabaseCl
   private static final int MAX_ELASTICSEARCH_BODY_CONTENT_LENGTH = 25000;
 
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), "elasticsearch");
+      SpanNaming.instance().namingSchema().database().service("elasticsearch");
 
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(

--- a/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/elasticsearch/src/main/java/datadog/trace/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.elasticsearch;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -11,10 +10,7 @@ public class ElasticsearchTransportClientDecorator extends DBTypeProcessingDatab
 
   private static final String DB_TYPE = "elasticsearch";
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
 
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));

--- a/dd-java-agent/instrumentation/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectDecorator.java
+++ b/dd-java-agent/instrumentation/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectDecorator.java
@@ -7,7 +7,6 @@ import static datadog.trace.instrumentation.hazelcast36.HazelcastConstants.HAZEL
 import static datadog.trace.instrumentation.hazelcast36.HazelcastConstants.INSTRUMENTATION_NAME;
 
 import com.hazelcast.core.DistributedObject;
-import datadog.trace.api.Config;
 import datadog.trace.api.Pair;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
@@ -28,10 +27,7 @@ public class DistributedObjectDecorator extends ClientDecorator {
       DDCaches.newFixedSizeCache(64);
 
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .cache()
-          .service(Config.get().getServiceName(), INSTRUMENTATION_NAME);
+      SpanNaming.instance().namingSchema().cache().service(INSTRUMENTATION_NAME);
 
   private static final Function<Pair<String, String>, String> COMPUTE_QUALIFIED_NAME =
       // Uses inner class for predictable name for Instrumenter.Default.helperClassNames()

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationDecorator.java
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationDecorator.java
@@ -8,7 +8,6 @@ import static datadog.trace.instrumentation.hazelcast39.HazelcastConstants.HAZEL
 import static datadog.trace.instrumentation.hazelcast39.HazelcastConstants.HAZELCAST_SERVICE;
 import static datadog.trace.instrumentation.hazelcast39.HazelcastConstants.INSTRUMENTATION_NAME;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -20,10 +19,7 @@ import datadog.trace.util.Strings;
 public class ClientInvocationDecorator extends ClientDecorator {
 
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .cache()
-          .service(Config.get().getServiceName(), INSTRUMENTATION_NAME);
+      SpanNaming.instance().namingSchema().cache().service(INSTRUMENTATION_NAME);
 
   public static final ClientInvocationDecorator DECORATE = new ClientInvocationDecorator();
 

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/HazelcastDecorator.java
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/HazelcastDecorator.java
@@ -7,7 +7,6 @@ import static datadog.trace.instrumentation.hazelcast4.HazelcastConstants.HAZELC
 import static datadog.trace.instrumentation.hazelcast4.HazelcastConstants.HAZELCAST_SERVICE;
 import static datadog.trace.instrumentation.hazelcast4.HazelcastConstants.INSTRUMENTATION_NAME;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -19,10 +18,7 @@ import datadog.trace.util.Strings;
 public class HazelcastDecorator extends ClientDecorator {
 
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .cache()
-          .service(Config.get().getServiceName(), INSTRUMENTATION_NAME);
+      SpanNaming.instance().namingSchema().cache().service(INSTRUMENTATION_NAME);
 
   public static final HazelcastDecorator DECORATE = new HazelcastDecorator();
 

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheDecorator.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheDecorator.java
@@ -38,10 +38,7 @@ public class IgniteCacheDecorator extends DBTypeProcessingDatabaseClientDecorato
 
   @Override
   protected String service() {
-    return SpanNaming.instance()
-        .namingSchema()
-        .cache()
-        .service(Config.get().getServiceName(), DB_TYPE);
+    return SpanNaming.instance().namingSchema().cache().service(DB_TYPE);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jakarta-jms/src/main/java/datadog/trace/instrumentation/jakarta/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jakarta-jms/src/main/java/datadog/trace/instrumentation/jakarta/jms/JMSDecorator.java
@@ -46,9 +46,6 @@ public final class JMSDecorator extends MessagingClientDecorator {
   private static final Join QUEUE_JOINER = PrefixJoin.of("Queue ");
   private static final Join TOPIC_JOINER = PrefixJoin.of("Topic ");
 
-  private static final String LOCAL_SERVICE_NAME =
-      JMS_LEGACY_TRACING ? "jms" : Config.get().getServiceName();
-
   private final DDCache<CharSequence, CharSequence> resourceNameCache =
       DDCaches.newFixedSizeCache(32);
 
@@ -69,15 +66,20 @@ public final class JMSDecorator extends MessagingClientDecorator {
           "Produced for ",
           Tags.SPAN_KIND_PRODUCER,
           InternalSpanTypes.MESSAGE_PRODUCER,
-          LOCAL_SERVICE_NAME);
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .outboundService(JMS.toString(), JMS_LEGACY_TRACING));
 
   public static final JMSDecorator CONSUMER_DECORATE =
       new JMSDecorator(
           "Consumed from ",
           Tags.SPAN_KIND_CONSUMER,
           InternalSpanTypes.MESSAGE_CONSUMER,
-          LOCAL_SERVICE_NAME);
-
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .inboundService(JMS.toString(), JMS_LEGACY_TRACING));
   public static final JMSDecorator BROKER_DECORATE =
       new JMSDecorator(
           "",

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_OPERATION;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDSpanId;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -34,7 +35,8 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
       UTF8BytesString.create("java-jdbc-statement");
   private static final UTF8BytesString JDBC_PREPARED_STATEMENT =
       UTF8BytesString.create("java-jdbc-prepared_statement");
-
+  private static final String DEFAULT_SERVICE_NAME =
+      SpanNaming.instance().namingSchema().database().service("jdbc");
   public static final String DBM_PROPAGATION_MODE_STATIC = "service";
   public static final String DBM_PROPAGATION_MODE_FULL = "full";
 
@@ -78,7 +80,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
 
   @Override
   protected String service() {
-    return "jdbc"; // Overridden by onConnection
+    return DEFAULT_SERVICE_NAME; // Overridden by onConnection
   }
 
   @Override
@@ -226,7 +228,9 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   @Override
   protected void postProcessServiceAndOperationName(
       AgentSpan span, DatabaseClientDecorator.NamingEntry namingEntry) {
-    span.setServiceName(namingEntry.getService());
+    if (namingEntry.getService() != null) {
+      span.setServiceName(namingEntry.getService());
+    }
     span.setOperationName(namingEntry.getOperation());
   }
 }

--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jedis;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -13,7 +12,7 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation(REDIS));
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), REDIS);
+      SpanNaming.instance().namingSchema().cache().service(REDIS);
   public static final JedisClientDecorator DECORATE = new JedisClientDecorator();
 
   @Override

--- a/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-3.0/src/main/java/datadog/trace/instrumentation/jedis30/JedisClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.jedis30;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -14,7 +13,7 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation(REDIS));
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), REDIS);
+      SpanNaming.instance().namingSchema().cache().service(REDIS);
   private static final CharSequence COMPONENT_NAME = UTF8BytesString.create("redis-command");
 
   @Override

--- a/dd-java-agent/instrumentation/jedis-4.0/src/main/java/redis/clients/jedis/JedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/jedis-4.0/src/main/java/redis/clients/jedis/JedisClientDecorator.java
@@ -1,6 +1,5 @@
 package redis.clients.jedis;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -13,7 +12,7 @@ public class JedisClientDecorator extends DBTypeProcessingDatabaseClientDecorato
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation(REDIS));
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), REDIS);
+      SpanNaming.instance().namingSchema().cache().service(REDIS);
   private static final CharSequence COMPONENT_NAME = UTF8BytesString.create("redis-command");
 
   @Override

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -46,9 +46,6 @@ public final class JMSDecorator extends MessagingClientDecorator {
   private static final Join QUEUE_JOINER = PrefixJoin.of("Queue ");
   private static final Join TOPIC_JOINER = PrefixJoin.of("Topic ");
 
-  private static final String LOCAL_SERVICE_NAME =
-      JMS_LEGACY_TRACING ? "jms" : Config.get().getServiceName();
-
   private final DDCache<CharSequence, CharSequence> resourceNameCache =
       DDCaches.newFixedSizeCache(32);
 
@@ -69,14 +66,20 @@ public final class JMSDecorator extends MessagingClientDecorator {
           "Produced for ",
           Tags.SPAN_KIND_PRODUCER,
           InternalSpanTypes.MESSAGE_PRODUCER,
-          LOCAL_SERVICE_NAME);
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .outboundService("jms", JMS_LEGACY_TRACING));
 
   public static final JMSDecorator CONSUMER_DECORATE =
       new JMSDecorator(
           "Consumed from ",
           Tags.SPAN_KIND_CONSUMER,
           InternalSpanTypes.MESSAGE_CONSUMER,
-          LOCAL_SERVICE_NAME);
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .inboundService("jms", JMS_LEGACY_TRACING));
 
   public static final JMSDecorator BROKER_DECORATE =
       new JMSDecorator(

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -53,16 +53,23 @@ public class KafkaDecorator extends MessagingClientDecorator {
       pc -> String.join(",", pc.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
   private static final Functions.Prefix CONSUMER_PREFIX = new Functions.Prefix("Consume Topic ");
 
-  private static final String LOCAL_SERVICE_NAME =
-      KAFKA_LEGACY_TRACING ? "kafka" : Config.get().getServiceName();
-
   public static final KafkaDecorator PRODUCER_DECORATE =
       new KafkaDecorator(
-          Tags.SPAN_KIND_PRODUCER, InternalSpanTypes.MESSAGE_PRODUCER, LOCAL_SERVICE_NAME);
+          Tags.SPAN_KIND_PRODUCER,
+          InternalSpanTypes.MESSAGE_PRODUCER,
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .outboundService(KAFKA, KAFKA_LEGACY_TRACING));
 
   public static final KafkaDecorator CONSUMER_DECORATE =
       new KafkaDecorator(
-          Tags.SPAN_KIND_CONSUMER, InternalSpanTypes.MESSAGE_CONSUMER, LOCAL_SERVICE_NAME);
+          Tags.SPAN_KIND_CONSUMER,
+          InternalSpanTypes.MESSAGE_CONSUMER,
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .inboundService(KAFKA, KAFKA_LEGACY_TRACING));
 
   public static final KafkaDecorator BROKER_DECORATE =
       new KafkaDecorator(

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -40,12 +40,14 @@ public class KafkaStreamsDecorator extends MessagingClientDecorator {
       DDCaches.newFixedSizeCache(32);
   private static final Functions.Prefix PREFIX = new Functions.Prefix("Consume Topic ");
 
-  private static final String LOCAL_SERVICE_NAME =
-      KAFKA_LEGACY_TRACING ? "kafka" : Config.get().getServiceName();
-
   public static final KafkaStreamsDecorator CONSUMER_DECORATE =
       new KafkaStreamsDecorator(
-          Tags.SPAN_KIND_CONSUMER, InternalSpanTypes.MESSAGE_CONSUMER, LOCAL_SERVICE_NAME);
+          Tags.SPAN_KIND_CONSUMER,
+          InternalSpanTypes.MESSAGE_CONSUMER,
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .inboundService(KAFKA, KAFKA_LEGACY_TRACING));
 
   public static final KafkaStreamsDecorator BROKER_DECORATE =
       new KafkaStreamsDecorator(

--- a/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-4/src/main/java/datadog/trace/instrumentation/lettuce4/LettuceClientDecorator.java
@@ -4,7 +4,6 @@ import static datadog.trace.instrumentation.lettuce4.InstrumentationPoints.getCo
 
 import com.lambdaworks.redis.RedisURI;
 import com.lambdaworks.redis.protocol.RedisCommand;
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -18,7 +17,7 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation("redis"));
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), "redis");
+      SpanNaming.instance().namingSchema().cache().service("redis");
   public static final LettuceClientDecorator DECORATE = new LettuceClientDecorator();
 
   @Override

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.lettuce5;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -15,7 +14,7 @@ public class LettuceClientDecorator extends DBTypeProcessingDatabaseClientDecora
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation("redis"));
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), "redis");
+      SpanNaming.instance().namingSchema().cache().service("redis");
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/mongo/common/src/main/java/datadog/trace/instrumentation/mongo/MongoDecorator.java
+++ b/dd-java-agent/instrumentation/mongo/common/src/main/java/datadog/trace/instrumentation/mongo/MongoDecorator.java
@@ -5,7 +5,6 @@ import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ConnectionId;
 import com.mongodb.connection.ServerId;
 import com.mongodb.event.CommandStartedEvent;
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -24,10 +23,7 @@ public abstract class MongoDecorator
   private static final String DB_TYPE =
       SpanNaming.instance().namingSchema().database().normalizedName("mongo");
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
   public static final UTF8BytesString OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));
 

--- a/dd-java-agent/instrumentation/opensearch/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientDecorator.java
+++ b/dd-java-agent/instrumentation/opensearch/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchRestClientDecorator.java
@@ -21,10 +21,7 @@ public class OpensearchRestClientDecorator extends DBTypeProcessingDatabaseClien
 
   private static final int MAX_OPENSEARCH_BODY_CONTENT_LENGTH = 25000;
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), "opensearch");
+      SpanNaming.instance().namingSchema().database().service("opensearch");
 
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(

--- a/dd-java-agent/instrumentation/opensearch/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientDecorator.java
+++ b/dd-java-agent/instrumentation/opensearch/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.opensearch;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -11,10 +10,7 @@ public class OpensearchTransportClientDecorator extends DBTypeProcessingDatabase
 
   private static final String DB_TYPE = "opensearch";
   private static final String SERVICE_NAME =
-      SpanNaming.instance()
-          .namingSchema()
-          .database()
-          .service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().database().service(DB_TYPE);
 
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().database().operation(DB_TYPE));

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -51,17 +51,30 @@ public class RabbitDecorator extends MessagingClientDecorator {
   public static final boolean TIME_IN_QUEUE_ENABLED =
       Config.get().isTimeInQueueEnabled(!RABBITMQ_LEGACY_TRACING, "rabbit", "rabbitmq");
 
-  private static final String LOCAL_SERVICE_NAME =
-      RABBITMQ_LEGACY_TRACING ? "rabbitmq" : Config.get().getServiceName();
   public static final RabbitDecorator CLIENT_DECORATE =
       new RabbitDecorator(
-          Tags.SPAN_KIND_CLIENT, InternalSpanTypes.MESSAGE_CLIENT, LOCAL_SERVICE_NAME);
+          Tags.SPAN_KIND_CLIENT,
+          InternalSpanTypes.MESSAGE_CLIENT,
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .outboundService("rabbitmq", RABBITMQ_LEGACY_TRACING));
   public static final RabbitDecorator PRODUCER_DECORATE =
       new RabbitDecorator(
-          Tags.SPAN_KIND_PRODUCER, InternalSpanTypes.MESSAGE_PRODUCER, LOCAL_SERVICE_NAME);
+          Tags.SPAN_KIND_PRODUCER,
+          InternalSpanTypes.MESSAGE_PRODUCER,
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .outboundService("rabbitmq", RABBITMQ_LEGACY_TRACING));
   public static final RabbitDecorator CONSUMER_DECORATE =
       new RabbitDecorator(
-          Tags.SPAN_KIND_CONSUMER, InternalSpanTypes.MESSAGE_CONSUMER, LOCAL_SERVICE_NAME);
+          Tags.SPAN_KIND_CONSUMER,
+          InternalSpanTypes.MESSAGE_CONSUMER,
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .inboundService("rabbitmq", RABBITMQ_LEGACY_TRACING));
   public static final RabbitDecorator BROKER_DECORATE =
       new RabbitDecorator(
           Tags.SPAN_KIND_BROKER,

--- a/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
+++ b/dd-java-agent/instrumentation/rediscala-1.8.0/src/main/java/datadog/trace/instrumentation/rediscala/RediscalaClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.rediscala;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -17,7 +16,7 @@ public class RediscalaClientDecorator
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation("redis"));
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), "redis");
+      SpanNaming.instance().namingSchema().cache().service("redis");
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
+++ b/dd-java-agent/instrumentation/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.redisson;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -14,7 +13,7 @@ public class RedissonClientDecorator
   public static final CharSequence OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation("redis"));
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), "redis");
+      SpanNaming.instance().namingSchema().cache().service("redis");
 
   private static final CharSequence COMPONENT_NAME = UTF8BytesString.create("redis-command");
 

--- a/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/dd-java-agent/instrumentation/spymemcached-2.10/src/main/java/datadog/trace/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -1,6 +1,5 @@
 package datadog.trace.instrumentation.spymemcached;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -15,7 +14,7 @@ public class MemcacheClientDecorator
   public static final String DB_TYPE = "memcached";
 
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), DB_TYPE);
+      SpanNaming.instance().namingSchema().cache().service(DB_TYPE);
   public static final UTF8BytesString OPERATION_NAME =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation(DB_TYPE));
   public static final MemcacheClientDecorator DECORATE = new MemcacheClientDecorator();

--- a/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client/VertxSqlClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client/VertxSqlClientDecorator.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_OPERATION;
 
 import datadog.trace.api.Pair;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -24,6 +25,8 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
       UTF8BytesString.create("vertx-sql-statement");
   private static final UTF8BytesString VERTX_PREPARED_STATEMENT =
       UTF8BytesString.create("vertx-sql-prepared_statement");
+  private static final String DEFAULT_SERVICE_NAME =
+      SpanNaming.instance().namingSchema().database().service("vertx-sql");
 
   @Override
   protected String[] instrumentationNames() {
@@ -32,7 +35,7 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
 
   @Override
   protected String service() {
-    return "vertx-sql"; // Overridden by onConnection
+    return DEFAULT_SERVICE_NAME; // Overridden by onConnection
   }
 
   @Override
@@ -105,7 +108,9 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
   @Override
   protected void postProcessServiceAndOperationName(
       AgentSpan span, DatabaseClientDecorator.NamingEntry namingEntry) {
-    span.setServiceName(namingEntry.getService());
+    if (namingEntry.getService() != null) {
+      span.setServiceName(namingEntry.getService());
+    }
     span.setOperationName(namingEntry.getOperation());
   }
 }

--- a/dd-java-agent/instrumentation/vertx-mysql-client-4.0/src/main/java/datadog/trace/instrumentation/vertx_sql_client_4/VertxSqlClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-4.0/src/main/java/datadog/trace/instrumentation/vertx_sql_client_4/VertxSqlClientDecorator.java
@@ -4,6 +4,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_OPERATION;
 
 import datadog.trace.api.Pair;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
@@ -24,6 +25,8 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
       UTF8BytesString.create("vertx-sql-statement");
   private static final UTF8BytesString VERTX_PREPARED_STATEMENT =
       UTF8BytesString.create("vertx-sql-prepared_statement");
+  private static final String DEFAULT_SERVICE_NAME =
+      SpanNaming.instance().namingSchema().database().service("vertx-sql");
 
   @Override
   protected String[] instrumentationNames() {
@@ -32,7 +35,7 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
 
   @Override
   protected String service() {
-    return "vertx-sql"; // Overridden by onConnection
+    return DEFAULT_SERVICE_NAME; // Overridden by onConnection
   }
 
   @Override
@@ -104,7 +107,9 @@ public class VertxSqlClientDecorator extends DatabaseClientDecorator<DBInfo> {
   @Override
   protected void postProcessServiceAndOperationName(
       AgentSpan span, DatabaseClientDecorator.NamingEntry namingEntry) {
-    span.setServiceName(namingEntry.getService());
+    if (namingEntry.getService() != null) {
+      span.setServiceName(namingEntry.getService());
+    }
     span.setOperationName(namingEntry.getOperation());
   }
 }

--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_redis_client/VertxRedisClientDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.vertx_redis_client;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
 import datadog.trace.api.naming.SpanNaming;
@@ -20,7 +19,7 @@ public class VertxRedisClientDecorator
   public static final VertxRedisClientDecorator DECORATE = new VertxRedisClientDecorator();
 
   private static final String SERVICE_NAME =
-      SpanNaming.instance().namingSchema().cache().service(Config.get().getServiceName(), "redis");
+      SpanNaming.instance().namingSchema().cache().service("redis");
   public static final CharSequence REDIS_COMMAND =
       UTF8BytesString.create(SpanNaming.instance().namingSchema().cache().operation("redis"));
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3244,14 +3244,14 @@ public class Config {
 
   public boolean isLegacyTracingEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return SpanNaming.instance().namingSchema().allowFakeServices()
+    return SpanNaming.instance().namingSchema().allowInferredServices()
         && configProvider.isEnabled(
             Arrays.asList(integrationNames), "", ".legacy.tracing.enabled", defaultEnabled);
   }
 
   public boolean isTimeInQueueEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
-    return SpanNaming.instance().namingSchema().allowFakeServices()
+    return SpanNaming.instance().namingSchema().allowInferredServices()
         && configProvider.isEnabled(
             Arrays.asList(integrationNames), "", ".time-in-queue.enabled", defaultEnabled);
   }

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -59,7 +59,7 @@ public interface NamingSchema {
    *
    * @return
    */
-  boolean allowFakeServices();
+  boolean allowInferredServices();
 
   interface ForCache {
     /**
@@ -74,12 +74,10 @@ public interface NamingSchema {
     /**
      * Calculate the service name for a cache span.
      *
-     * @param ddService the configured service name as set by the user.
      * @param cacheSystem the caching system (e.g. redis, memcached,..)
      * @return the service name
      */
-    @Nonnull
-    String service(@Nonnull String ddService, @Nonnull String cacheSystem);
+    String service(@Nonnull String cacheSystem);
   }
 
   interface ForClient {
@@ -124,7 +122,6 @@ public interface NamingSchema {
      *     return a default value
      * @return the service name for this span
      */
-    @Nonnull
     String serviceForRequest(@Nonnull String provider, @Nullable String cloudService);
 
     /**
@@ -158,12 +155,10 @@ public interface NamingSchema {
     /**
      * Calculate the service name for a database span.
      *
-     * @param ddService the configured service name as set by the user.
      * @param databaseType the database type (e.g. postgres, elasticsearch,..)
      * @return the service name
      */
-    @Nonnull
-    String service(@Nonnull String ddService, @Nonnull String databaseType);
+    String service(@Nonnull String databaseType);
   }
 
   interface ForMessaging {
@@ -179,12 +174,11 @@ public interface NamingSchema {
     /**
      * Calculate the service name for a messaging producer span.
      *
-     * @param ddService the configured service name as set by the user.
      * @param messagingSystem the messaging system (e.g. jms, kafka, amqp,..)
+     * @param useLegacyTracing if true legacy tracing service naming will be applied if compatible
      * @return the service name
      */
-    @Nonnull
-    String inboundService(@Nonnull String ddService, @Nonnull String messagingSystem);
+    String inboundService(@Nonnull String messagingSystem, boolean useLegacyTracing);
 
     /**
      * Calculate the operation name for a messaging producer span.
@@ -198,12 +192,11 @@ public interface NamingSchema {
     /**
      * Calculate the service name for a messaging producer span.
      *
-     * @param ddService the configured service name as set by the user.
      * @param messagingSystem the messaging system (e.g. jms, kafka, amqp,..)
+     * @param useLegacyTracing if true legacy tracing service naming will be applied if compatible
      * @return the service name
      */
-    @Nonnull
-    String outboundService(@Nonnull String ddService, @Nonnull String messagingSystem);
+    String outboundService(@Nonnull String messagingSystem, boolean useLegacyTracing);
 
     /**
      * Calculate the service name for a messaging time in queue synthetic span.

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/CacheNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/CacheNamingV0.java
@@ -5,10 +5,10 @@ import javax.annotation.Nonnull;
 
 public class CacheNamingV0 implements NamingSchema.ForCache {
 
-  private final boolean allowsFakeServices;
+  private final boolean allowInferredServices;
 
-  public CacheNamingV0(boolean allowsFakeServices) {
-    this.allowsFakeServices = allowsFakeServices;
+  public CacheNamingV0(boolean allowInferredServices) {
+    this.allowInferredServices = allowInferredServices;
   }
 
   @Nonnull
@@ -29,13 +29,11 @@ public class CacheNamingV0 implements NamingSchema.ForCache {
     return cacheSystem + postfix;
   }
 
-  @Nonnull
   @Override
-  public String service(@Nonnull String ddService, @Nonnull String cacheSystem) {
-    if (!allowsFakeServices) {
-      return ddService;
+  public String service(@Nonnull String cacheSystem) {
+    if (!allowInferredServices) {
+      return null;
     }
-
     if ("hazelcast".equals(cacheSystem)) {
       return "hazelcast-sdk";
     }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/CloudNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/CloudNamingV0.java
@@ -1,15 +1,14 @@
 package datadog.trace.api.naming.v0;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class CloudNamingV0 implements NamingSchema.ForCloud {
-  private final boolean allowsFakeServices;
+  private final boolean allowInferredServices;
 
-  public CloudNamingV0(boolean allowsFakeServices) {
-    this.allowsFakeServices = allowsFakeServices;
+  public CloudNamingV0(boolean allowInferredServices) {
+    this.allowInferredServices = allowInferredServices;
   }
 
   @Nonnull
@@ -22,12 +21,11 @@ public class CloudNamingV0 implements NamingSchema.ForCloud {
     return "aws.http";
   }
 
-  @Nonnull
   @Override
   public String serviceForRequest(
       @Nonnull final String provider, @Nullable final String cloudService) {
-    if (!allowsFakeServices) {
-      return Config.get().getServiceName();
+    if (!allowInferredServices) {
+      return null;
     }
 
     // we only manage aws. Future switch for other cloud providers will be needed in the future

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/DatabaseNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/DatabaseNamingV0.java
@@ -5,10 +5,10 @@ import javax.annotation.Nonnull;
 
 public class DatabaseNamingV0 implements NamingSchema.ForDatabase {
 
-  private final boolean allowsFakeServices;
+  private final boolean allowInferredServices;
 
-  public DatabaseNamingV0(boolean allowsFakeServices) {
-    this.allowsFakeServices = allowsFakeServices;
+  public DatabaseNamingV0(boolean allowInferredServices) {
+    this.allowInferredServices = allowInferredServices;
   }
 
   @Override
@@ -26,12 +26,11 @@ public class DatabaseNamingV0 implements NamingSchema.ForDatabase {
     return databaseType + postfix;
   }
 
-  @Nonnull
   @Override
-  public String service(@Nonnull String ddService, @Nonnull String databaseType) {
-    if (allowsFakeServices) {
+  public String service(@Nonnull String databaseType) {
+    if (allowInferredServices) {
       return databaseType;
     }
-    return ddService;
+    return null;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/MessagingNamingV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/MessagingNamingV0.java
@@ -1,13 +1,14 @@
 package datadog.trace.api.naming.v0;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.naming.NamingSchema;
 import javax.annotation.Nonnull;
 
 public class MessagingNamingV0 implements NamingSchema.ForMessaging {
-  private final boolean allowsFakeServices;
+  private final boolean allowInferredServices;
 
-  public MessagingNamingV0(boolean allowsFakeServices) {
-    this.allowsFakeServices = allowsFakeServices;
+  public MessagingNamingV0(final boolean allowInferredServices) {
+    this.allowInferredServices = allowInferredServices;
   }
 
   @Nonnull
@@ -19,14 +20,9 @@ public class MessagingNamingV0 implements NamingSchema.ForMessaging {
     return messagingSystem + ".produce";
   }
 
-  @Nonnull
   @Override
-  public String outboundService(
-      @Nonnull final String ddService, @Nonnull final String messagingSystem) {
-    if (allowsFakeServices) {
-      return messagingSystem;
-    }
-    return ddService;
+  public String outboundService(@Nonnull final String messagingSystem, boolean useLegacyTracing) {
+    return inboundService(messagingSystem, useLegacyTracing);
   }
 
   @Nonnull
@@ -42,14 +38,13 @@ public class MessagingNamingV0 implements NamingSchema.ForMessaging {
     }
   }
 
-  @Nonnull
   @Override
-  public String inboundService(
-      @Nonnull final String ddService, @Nonnull final String messagingSystem) {
-    if (allowsFakeServices) {
-      return messagingSystem;
+  public String inboundService(@Nonnull final String messagingSystem, boolean useLegacyTracing) {
+    if (allowInferredServices) {
+      return useLegacyTracing ? messagingSystem : Config.get().getServiceName();
+    } else {
+      return null;
     }
-    return ddService;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v0/NamingSchemaV0.java
@@ -6,13 +6,15 @@ import datadog.trace.api.naming.v1.PeerServiceNamingV1;
 
 public class NamingSchemaV0 implements NamingSchema {
 
-  private final boolean allowsFakeServices = !Config.get().isRemoveIntegrationServiceNamesEnabled();
-  private final NamingSchema.ForCache cacheNaming = new CacheNamingV0(allowsFakeServices);
+  private final boolean allowInferredServices =
+      !Config.get().isRemoveIntegrationServiceNamesEnabled();
+  private final NamingSchema.ForCache cacheNaming = new CacheNamingV0(allowInferredServices);
   private final NamingSchema.ForClient clientNaming = new ClientNamingV0();
-  private final NamingSchema.ForCloud cloudNaming = new CloudNamingV0(allowsFakeServices);
-  private final NamingSchema.ForDatabase databaseNaming = new DatabaseNamingV0(allowsFakeServices);
+  private final NamingSchema.ForCloud cloudNaming = new CloudNamingV0(allowInferredServices);
+  private final NamingSchema.ForDatabase databaseNaming =
+      new DatabaseNamingV0(allowInferredServices);
   private final NamingSchema.ForMessaging messagingNaming =
-      new MessagingNamingV0(allowsFakeServices);
+      new MessagingNamingV0(allowInferredServices);
   private final NamingSchema.ForPeerService peerServiceNaming =
       Config.get().isPeerServiceDefaultsEnabled()
           ? new PeerServiceNamingV1(Config.get().getPeerServiceComponentOverrides())
@@ -55,7 +57,7 @@ public class NamingSchemaV0 implements NamingSchema {
   }
 
   @Override
-  public boolean allowFakeServices() {
-    return allowsFakeServices;
+  public boolean allowInferredServices() {
+    return allowInferredServices;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/CacheNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/CacheNamingV1.java
@@ -10,9 +10,8 @@ public class CacheNamingV1 implements NamingSchema.ForCache {
     return cacheSystem + ".command";
   }
 
-  @Nonnull
   @Override
-  public String service(@Nonnull String ddService, @Nonnull String cacheSystem) {
-    return ddService;
+  public String service(@Nonnull String cacheSystem) {
+    return null;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/CloudNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/CloudNamingV1.java
@@ -1,6 +1,5 @@
 package datadog.trace.api.naming.v1;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.naming.NamingSchema;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.util.Strings;
@@ -37,11 +36,10 @@ public class CloudNamingV1 implements NamingSchema.ForCloud {
     }
   }
 
-  @Nonnull
   @Override
   public String serviceForRequest(
       @Nonnull final String provider, @Nullable final String cloudService) {
-    return Config.get().getServiceName(); // always use DD_SERVICE
+    return null;
   }
 
   @Nonnull

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/DatabaseNamingV1.java
@@ -33,9 +33,8 @@ public class DatabaseNamingV1 implements NamingSchema.ForDatabase {
     return prefix + ".query";
   }
 
-  @Nonnull
   @Override
-  public String service(@Nonnull String ddService, @Nonnull String databaseType) {
-    return ddService;
+  public String service(@Nonnull String databaseType) {
+    return null;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/MessagingNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/MessagingNamingV1.java
@@ -21,10 +21,9 @@ public class MessagingNamingV1 implements NamingSchema.ForMessaging {
     return normalizeForCloud(messagingSystem) + ".send";
   }
 
-  @Nonnull
   @Override
-  public String outboundService(@Nonnull String ddService, @Nonnull String messagingSystem) {
-    return ddService;
+  public String outboundService(@Nonnull String messagingSystem, boolean useLegacyTracing) {
+    return null;
   }
 
   @Nonnull
@@ -33,10 +32,9 @@ public class MessagingNamingV1 implements NamingSchema.ForMessaging {
     return normalizeForCloud(messagingSystem) + ".process";
   }
 
-  @Nonnull
   @Override
-  public String inboundService(@Nonnull String ddService, @Nonnull String messagingSystem) {
-    return ddService;
+  public String inboundService(@Nonnull String messagingSystem, boolean useLegacyTracing) {
+    return null;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/NamingSchemaV1.java
@@ -44,7 +44,7 @@ public class NamingSchemaV1 implements NamingSchema {
   }
 
   @Override
-  public boolean allowFakeServices() {
+  public boolean allowInferredServices() {
     return false;
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/naming/NamingV0ForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/naming/NamingV0ForkedTest.groovy
@@ -5,7 +5,7 @@ import datadog.trace.api.config.TracerConfig
 import datadog.trace.test.util.DDSpecification
 
 class NamingV0ForkedTest extends DDSpecification {
-  def "v0 should use DD_SERVICE when DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED is true"() {
+  def "v0 should not set service when DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED is true"() {
     setup:
     def ddService = "testService"
     injectSysConfig(TracerConfig.TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED, "true")
@@ -16,11 +16,11 @@ class NamingV0ForkedTest extends DDSpecification {
 
     then:
     assert SpanNaming.instance().version() == 0
-    assert !schema.allowFakeServices()
-    assert schema.messaging().inboundService(ddService, "anything") == ddService
-    assert schema.messaging().outboundService(ddService, "anything") == ddService
-    assert schema.database().service(ddService, "anything") == ddService
-    assert schema.cache().service(ddService, "anything") == ddService
-    assert schema.cloud().serviceForRequest("any", "anything") == ddService
+    assert !schema.allowInferredServices()
+    assert schema.messaging().inboundService("anything", true) == null
+    assert schema.messaging().outboundService("anything", true) == null
+    assert schema.database().service("anything") == null
+    assert schema.cache().service("anything") == null
+    assert schema.cloud().serviceForRequest("any", "anything") == null
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR mainly addresses use cases like split-by-servlet-context in which, using DD_SERVICE as a root service name is not working when flattening the service name.

Instead, the best choice will be picking the root service name. So, instead forcing using `Config.get().getServiceName()` that mainly resolves to DD_SERVICE, I just avoid setting the service name. However, if the the flattening (`dd.trace.remove.integration-service-names.enabled`) is enabled or the naming schema version is `v1` the span name is always intialized to the root one to avoid that, in case of a manual span naming, the children will follow the parent service name.

Lots of decorator have been changed since the naming API has been simplified 

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
