### PR TITLE
fix wallclock profiler enablement logic

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -106,8 +106,8 @@ public class DatadogProfilerConfig {
     boolean isUltraMinimal = getBoolean(configProvider, PROFILING_ULTRA_MINIMAL, false);
     boolean isTracingEnabled = configProvider.getBoolean(TRACE_ENABLED, true);
     boolean disableUnlessOptedIn = isUltraMinimal || !isTracingEnabled || isJ9();
-    return getBoolean(
-        configProvider, PROFILING_DATADOG_PROFILER_WALL_ENABLED, disableUnlessOptedIn);
+    boolean enabledByDefault = !disableUnlessOptedIn;
+    return getBoolean(configProvider, PROFILING_DATADOG_PROFILER_WALL_ENABLED, enabledByDefault);
   }
 
   public static int getWallInterval(ConfigProvider configProvider) {


### PR DESCRIPTION
# What Does This Do

Fixes the enablement logic for the wallclock profiler, which was broken in #5583.

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
