### PR TITLE
Add OpenTelemetry context propagator instrumentation support

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelExtractedContext.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelExtractedContext.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class OtelExtractedContext implements AgentSpan.Context {
+public class OtelExtractedContext implements AgentSpan.Context {
   private static final Logger LOGGER = LoggerFactory.getLogger(OtelExtractedContext.class);
   private final DDTraceId traceId;
   private final long spanId;
@@ -27,7 +27,7 @@ class OtelExtractedContext implements AgentSpan.Context {
         context.isSampled() ? PrioritySampling.SAMPLER_KEEP : PrioritySampling.UNSET;
   }
 
-  static AgentSpan.Context extract(Context context) {
+  public static AgentSpan.Context extract(Context context) {
     Span span = Span.fromContext(context);
     SpanContext spanContext = span.getSpanContext();
     if (spanContext instanceof OtelSpanContext) {

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OtelSpan.java
@@ -137,6 +137,10 @@ public class OtelSpan implements Span {
     return activateSpan(this.delegate);
   }
 
+  public AgentSpan.Context getAgentSpanContext() {
+    return this.delegate.context();
+  }
+
   private static class NoopSpan implements Span {
     private static final Span INSTANCE = new NoopSpan();
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/propagation/AgentTextMapPropagator.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/propagation/AgentTextMapPropagator.java
@@ -1,0 +1,98 @@
+package datadog.trace.instrumentation.opentelemetry14.context.propagation;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context.Extracted;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.instrumentation.opentelemetry14.OtelExtractedContext;
+import datadog.trace.instrumentation.opentelemetry14.OtelSpan;
+import datadog.trace.instrumentation.opentelemetry14.context.OtelContext;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanId;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.Arrays;
+import java.util.Collection;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+public class AgentTextMapPropagator implements TextMapPropagator {
+  private final Collection<String> fields;
+
+  public AgentTextMapPropagator() {
+    // Cannot suppose the current injector from AgentTracer so declare them all
+    this.fields =
+        Arrays.asList(
+            // W3C headers
+            "traceparent",
+            "tracestate",
+            // DD headers
+            "x-datadog-trace-id",
+            "x-datadog-parent-id",
+            "x-datadog-sampling-priority",
+            "x-datadog-origin",
+            "x-datadog-tags",
+            // B3 single headers
+            "X-B3-TraceId",
+            "X-B3-SpanId",
+            "X-B3-Sampled",
+            // B3 multi header
+            "b3");
+  }
+
+  @Override
+  public Collection<String> fields() {
+    return this.fields;
+  }
+
+  @Override
+  public <C> void inject(Context context, @Nullable C carrier, TextMapSetter<C> setter) {
+    if (carrier == null) {
+      return;
+    }
+    Span span = Span.fromContext(context);
+    if (span.getSpanContext().isValid()) {
+      AgentSpan.Context agentSpanContext = OtelExtractedContext.extract(context);
+      AgentTracer.propagate().inject(agentSpanContext, carrier, setter::set);
+    }
+  }
+
+  @Override
+  public <C> Context extract(Context context, @Nullable C carrier, TextMapGetter<C> getter) {
+    if (carrier == null) {
+      return context;
+    }
+    Extracted extracted =
+        AgentTracer.propagate()
+            .extract(
+                carrier,
+                (carrier1, classifier) -> {
+                  for (String key : getter.keys(carrier1)) {
+                    classifier.accept(key, getter.get(carrier1, key));
+                  }
+                });
+    if (extracted == null) {
+      return context;
+    } else {
+      SpanContext spanContext = extractSpanContext(extracted);
+      return new OtelContext(Span.wrap(spanContext), OtelSpan.invalid());
+    }
+  }
+
+  private static SpanContext extractSpanContext(Extracted extracted) {
+    String traceId = extracted.getTraceId().toHexString();
+    String spanId = SpanId.fromLong(extracted.getSpanId());
+    TraceFlags traceFlags =
+        extracted.getSamplingPriority() > 0 ? TraceFlags.getSampled() : TraceFlags.getDefault();
+    // Do not support tracestate extraction from PropagationTags:
+    // As OtelSpanContext used in OtelSpanBuilder only implements AgentSpan.Context,
+    // PropagationTags from ExtractedContext are lost.
+    TraceState traceState = TraceState.getDefault();
+    return SpanContext.createFromRemoteParent(traceId, spanId, traceFlags, traceState);
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/propagation/OtelContextPropagators.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/propagation/OtelContextPropagators.java
@@ -1,0 +1,14 @@
+package datadog.trace.instrumentation.opentelemetry14.context.propagation;
+
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+
+public class OtelContextPropagators implements ContextPropagators {
+  public static final ContextPropagators INSTANCE = new OtelContextPropagators();
+  private final TextMapPropagator propagator = new AgentTextMapPropagator();
+
+  @Override
+  public TextMapPropagator getTextMapPropagator() {
+    return this.propagator;
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -25,12 +25,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
     injectSysConfig("dd.integration.opentelemetry.experimental.enabled", "true")
   }
 
-  @Override
-  void setup() {
-    // Reset OTel context storage
-    ThreadLocalContextStorage.THREAD_LOCAL_STORAGE.remove()
-  }
-
   def "test parent span using active span"() {
     setup:
     def parentSpan = tracer.spanBuilder("some-name").startSpan()
@@ -464,5 +458,13 @@ class OpenTelemetry14Test extends AgentTestRunner {
         }
       }
     }
+  }
+
+  @Override
+  void cleanup() {
+    // Test for context leak
+    assert Context.current() == Context.root()
+    // Safely reset OTel context storage
+    ThreadLocalContextStorage.THREAD_LOCAL_STORAGE.remove()
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
@@ -1,22 +1,19 @@
+package opentelemetry14.context
+
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
-import datadog.trace.api.DDTraceId
-import datadog.trace.instrumentation.opentelemetry14.context.OtelContext
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextKey
 import io.opentelemetry.context.ThreadLocalContextStorage
-import io.opentelemetry.context.propagation.TextMapGetter
-import io.opentelemetry.context.propagation.TextMapSetter
 import spock.lang.Subject
 
-import javax.annotation.Nullable
-
 import static datadog.trace.bootstrap.instrumentation.api.ScopeSource.MANUAL
+import static datadog.trace.instrumentation.opentelemetry14.context.OtelContext.DATADOG_CONTEXT_ROOT_SPAN_KEY
+import static datadog.trace.instrumentation.opentelemetry14.context.OtelContext.OTEL_CONTEXT_SPAN_KEY
 
-class OpenTelemetry14ContextTest extends AgentTestRunner {
+class ContextTest extends AgentTestRunner {
   @Subject
   def tracer = GlobalOpenTelemetry.get().tracerProvider.get("context-instrumentation")
 
@@ -248,8 +245,8 @@ class OpenTelemetry14ContextTest extends AgentTestRunner {
     setup:
     def parentSpan = tracer.spanBuilder("some-name").startSpan()
     def parentScope = parentSpan.makeCurrent()
-    def currentSpanKey = ContextKey.named(OtelContext.OTEL_CONTEXT_SPAN_KEY)
-    def rootSpanKey = ContextKey.named(OtelContext.DATADOG_CONTEXT_ROOT_SPAN_KEY)
+    def currentSpanKey = ContextKey.named(OTEL_CONTEXT_SPAN_KEY)
+    def rootSpanKey = ContextKey.named(DATADOG_CONTEXT_ROOT_SPAN_KEY)
 
     when:
     def current = Context.current()
@@ -279,61 +276,5 @@ class OpenTelemetry14ContextTest extends AgentTestRunner {
     cleanup:
     parentScope.close()
     parentSpan.end()
-  }
-
-  def "test context extraction and injection"() {
-    setup:
-    def propagator = W3CTraceContextPropagator.getInstance()
-    def httpHeaders = ['traceparent': traceparent]
-    def context = propagator.extract(Context.root(), httpHeaders, new TextMapGetter<Map<String, String>>() {
-        @Override
-        Iterable<String> keys(Map<String, String> carrier) {
-          return carrier.keySet()
-        }
-
-        @Override
-        String get(@Nullable Map<String, String> carrier, String key) {
-          return carrier.get(key)
-        }
-      })
-
-    def localSpan = tracer.spanBuilder("some-name")
-      .setParent(context)
-      .startSpan()
-
-    when:
-    def localSpanContext = localSpan.getSpanContext()
-    def localSpanId = localSpanContext.getSpanId()
-    def spanSampled = localSpanContext.getTraceFlags().isSampled()
-    def scope = localSpan.makeCurrent()
-    Map<String, String> injectedHeaders = [:]
-    propagator.inject(Context.current(), injectedHeaders, new TextMapSetter<Map<String, String>>() {
-        @Override
-        void set(@Nullable Map<String, String> carrier, String key, String value) {
-          carrier.put(key, value)
-        }
-      })
-    scope.close()
-    localSpan.end()
-
-    then:
-    assertTraces(1) {
-      trace(1) {
-        span {
-          operationName "some-name"
-          traceDDId(DDTraceId.fromHex(traceId))
-          parentSpanId(DDSpanId.fromHex(spanId).toLong() as BigInteger)
-        }
-      }
-    }
-    spanSampled == sampled
-    injectedHeaders == ['traceparent': "00-$traceId-$localSpanId-$sampleFlag" as String]
-
-    where:
-    traceId | spanId | sampled
-    '00000000000000001111111111111111' | '2222222222222222' | true
-    '00000000000000001111111111111111' | '2222222222222222' | false
-    sampleFlag = sampled ? '01' : '00'
-    traceparent = "00-$traceId-$spanId-$sampleFlag" as String
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
@@ -24,12 +24,6 @@ class ContextTest extends AgentTestRunner {
     injectSysConfig("dd.integration.opentelemetry.experimental.enabled", "true")
   }
 
-  @Override
-  void setup() {
-    // Reset OTel context storage
-    ThreadLocalContextStorage.THREAD_LOCAL_STORAGE.remove()
-  }
-
   def "test Span.current/makeCurrent()"() {
     setup:
     def builder = tracer.spanBuilder("some-name")
@@ -276,5 +270,13 @@ class ContextTest extends AgentTestRunner {
     cleanup:
     parentScope.close()
     parentSpan.end()
+  }
+
+  @Override
+  void cleanup() {
+    // Test for context leak
+    assert Context.current() == Context.root()
+    // Safely reset OTel context storage
+    ThreadLocalContextStorage.THREAD_LOCAL_STORAGE.remove()
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
@@ -1,0 +1,118 @@
+package opentelemetry14.context.propagation
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.DD128bTraceId
+import datadog.trace.api.DDSpanId
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.TextMapGetter
+import io.opentelemetry.context.propagation.TextMapPropagator
+import io.opentelemetry.context.propagation.TextMapSetter
+import spock.lang.Subject
+
+import javax.annotation.Nullable
+
+abstract class AbstractPropagatorTest extends AgentTestRunner {
+  @Subject
+  def tracer = GlobalOpenTelemetry.get().tracerProvider.get("propagator" + Math.random()) // TODO FIX LATER
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig("dd.integration.opentelemetry.experimental.enabled", "true")
+    injectSysConfig("dd.trace.propagation.style", style())
+  }
+
+  /**
+   * Gets the propagation style to configure to the agent.
+   * @return The propagation style.
+   */
+  abstract String style()
+
+  /**
+   * Gets the propagator to test.
+   * @return The propagator to test.
+   */
+  abstract TextMapPropagator propagator()
+
+  /**
+   * Get the test values as an array:
+   * <ol>
+   *   <li>Headers map</li>
+   *   <li>Trace id</li>
+   *   <li>Span id</li>
+   *   <li>Whether the parent span is sampled</li>
+   *  </ol>
+   *
+   * @return The tests values.
+   */
+  abstract values()
+
+  /**
+   * Evaluates the injected headers of a child span from a continuing trace.
+   * @param headers The injected headers.
+   * @param traceId The continued trace identifier.
+   * @param spanId The child span identifier.
+   * @param sampled Whether the child span is sampled.
+   */
+  abstract void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled)
+
+  def "test context extraction and injection"() {
+    setup:
+    def propagator = propagator()
+
+    when:
+    def context = propagator.extract(Context.root(), headers, new TextMap())
+
+    then:
+    context != Context.root()
+
+    when:
+    def localSpan = tracer.spanBuilder("some-name")
+      .setParent(context)
+      .startSpan()
+    def localSpanContext = localSpan.getSpanContext()
+    def localSpanId = localSpanContext.getSpanId()
+    def spanSampled = localSpanContext.getTraceFlags().isSampled()
+    def scope = localSpan.makeCurrent()
+    Map<String, String> injectedHeaders = [:]
+    propagator.inject(Context.current(), injectedHeaders, new TextMap())
+    scope.close()
+    localSpan.end()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "some-name"
+          traceDDId(DD128bTraceId.fromHex(traceId))
+          parentSpanId(DDSpanId.fromHex(spanId).toLong() as BigInteger)
+        }
+      }
+    }
+    spanSampled == sampled
+    assertInjectedHeaders(injectedHeaders, traceId, localSpanId, sampled)
+
+    where:
+    values << values()
+    (headers, traceId, spanId, sampled) = values
+  }
+
+  static class TextMap implements TextMapGetter<Map<String, String>>, TextMapSetter<Map<String, String>> {
+    @Override
+    Iterable<String> keys(Map<String, String> carrier) {
+      return carrier.keySet()
+    }
+
+    @Override
+    String get(@Nullable Map<String, String> carrier, String key) {
+      return carrier.get(key)
+    }
+
+    @Override
+    void set(@Nullable Map<String, String> carrier, String key, String value) {
+      carrier.put(key, value)
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.api.DD128bTraceId
 import datadog.trace.api.DDSpanId
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.context.Context
+import io.opentelemetry.context.ThreadLocalContextStorage
 import io.opentelemetry.context.propagation.TextMapGetter
 import io.opentelemetry.context.propagation.TextMapPropagator
 import io.opentelemetry.context.propagation.TextMapSetter
@@ -97,6 +98,14 @@ abstract class AbstractPropagatorTest extends AgentTestRunner {
     where:
     values << values()
     (headers, traceId, spanId, sampled) = values
+  }
+
+  @Override
+  void cleanup() {
+    // Test for context leak
+    assert Context.current() == Context.root()
+    // Safely reset OTel context storage
+    ThreadLocalContextStorage.THREAD_LOCAL_STORAGE.remove()
   }
 
   static class TextMap implements TextMapGetter<Map<String, String>>, TextMapSetter<Map<String, String>> {

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AgentPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AgentPropagatorTest.groovy
@@ -1,0 +1,12 @@
+package opentelemetry14.context.propagation
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.context.propagation.TextMapPropagator
+
+abstract class AgentPropagatorTest extends AbstractPropagatorTest {
+  @Override
+  TextMapPropagator propagator() {
+    // Get agent propagator injected by instrumentation
+    return GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator()
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/B3MultiPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/B3MultiPropagatorTest.groovy
@@ -1,0 +1,32 @@
+package opentelemetry14.context.propagation
+
+import static datadog.trace.core.propagation.B3HttpCodec.SAMPLING_PRIORITY_KEY
+import static datadog.trace.core.propagation.B3HttpCodec.SPAN_ID_KEY
+import static datadog.trace.core.propagation.B3HttpCodec.TRACE_ID_KEY
+
+class B3MultiPropagatorTest extends AgentPropagatorTest {
+  @Override
+  String style() {
+    return 'b3multi'
+  }
+
+  @Override
+  def values() {
+    // spotless:off
+    return [
+      [[(TRACE_ID_KEY): '1', (SPAN_ID_KEY):'2'],                                                                             '1' ,                               '2' ,               false],
+      [[(TRACE_ID_KEY): '1111111111111111', (SPAN_ID_KEY):'2222222222222222'],                                               '1111111111111111'                , '2222222222222222', false],
+      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222'],                               '11111111111111111111111111111111', '2222222222222222', false],
+      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222', (SAMPLING_PRIORITY_KEY): '0'], '11111111111111111111111111111111', '2222222222222222', false],
+      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222', (SAMPLING_PRIORITY_KEY): '1'], '11111111111111111111111111111111', '2222222222222222', true],
+    ]
+    // spotless:on
+  }
+
+  @Override
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
+    assert headers[TRACE_ID_KEY] == traceId.padLeft(32, '0')
+    assert headers[SPAN_ID_KEY] == spanId.padLeft(8, '0')
+    assert headers[SAMPLING_PRIORITY_KEY] == "1" // Deterministic sampler with rate to 1
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/B3SinglePropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/B3SinglePropagatorTest.groovy
@@ -1,0 +1,29 @@
+package opentelemetry14.context.propagation
+
+import static datadog.trace.core.propagation.B3HttpCodec.B3_KEY
+
+class B3SinglePropagatorTest extends AgentPropagatorTest {
+  @Override
+  String style() {
+    return 'b3single'
+  }
+
+  @Override
+  def values() {
+    // spotless:off
+    return [
+      [[(B3_KEY): '1-2'], '1' , '2' , false],
+      [[(B3_KEY): '1111111111111111-2222222222222222'],                   '1111111111111111',                 '2222222222222222', false],
+      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222'],   '11111111111111111111111111111111', '2222222222222222', false],
+      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222-0'], '11111111111111111111111111111111', '2222222222222222', false],
+      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222-1'], '11111111111111111111111111111111', '2222222222222222', true],
+    ]
+    // spotless:on
+  }
+
+  @Override
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
+    def sampledValue = "1" // Deterministic sampler with rate to 1
+    assert headers[B3_KEY] == "${traceId.padLeft(32, '0')}-${spanId.padLeft(8, '0')}-$sampledValue"
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/DatadogPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/DatadogPropagatorTest.groovy
@@ -1,0 +1,41 @@
+package opentelemetry14.context.propagation
+
+
+import datadog.trace.api.DDTraceId
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.UNSET
+import static java.lang.Long.parseLong
+
+class DatadogPropagatorTest extends AgentPropagatorTest {
+  @Override
+  String style() {
+    return 'datadog'
+  }
+
+  def values() {
+    // spotless:off
+    return [
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}"],                                                                                                 '00000000000000001111111111111111', '2222222222222222', false],
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-tags': '_dd.p.tid=1111111111111111'],                                                 '11111111111111111111111111111111', '2222222222222222', false],
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-sampling-priority': "$SAMPLER_KEEP", 'x-datadog-tags': '_dd.p.tid=1111111111111111'], '11111111111111111111111111111111', '2222222222222222', true],
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-sampling-priority': "$UNSET", 'x-datadog-tags': '_dd.p.tid=1111111111111111'],        '11111111111111111111111111111111', '2222222222222222', false],
+    ]
+    // spotless:on
+  }
+
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
+    assert headers['x-datadog-trace-id'] == Long.toString(DDTraceId.fromHex(traceId).toLong())
+    assert headers['x-datadog-parent-id'] == spanId.replaceAll('^0+(?!$)', '')
+    def tags = []
+    if (!sampled) {
+      tags+= '_dd.p.dm=-1'
+    }
+    def highOrderBits = traceId.substring(0, 16)
+    if (highOrderBits != '0000000000000000') {
+      tags+= '_dd.p.tid='+highOrderBits
+    }
+    assert headers['x-datadog-tags'] == tags.join(',')
+    assert headers['x-datadog-sampling-priority'] == '1' // Deterministic sampler with rate to 1
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/OtelW3cPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/OtelW3cPropagatorTest.groovy
@@ -1,0 +1,34 @@
+package opentelemetry14.context.propagation
+
+
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.propagation.TextMapPropagator
+
+class OtelW3cPropagatorTest extends AbstractPropagatorTest {
+  @Override
+  String style() {
+    return 'datadog'
+  }
+
+  @Override
+  TextMapPropagator propagator() {
+    // OpenTelemetry API W3C propagator
+    return W3CTraceContextPropagator.getInstance()
+  }
+
+  @Override
+  def values() {
+    // spotless:off
+    return [
+      [['traceparent': '00-00000000000000001111111111111111-2222222222222222-00'], '00000000000000001111111111111111', '2222222222222222', false],
+      [['traceparent': '00-00000000000000001111111111111111-2222222222222222-01'], '00000000000000001111111111111111', '2222222222222222', true],
+    ]
+    // spotless:on
+  }
+
+  @Override
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
+    def sampleFlag = sampled ? '01' : '00'
+    assert headers['traceparent'] ==  "00-$traceId-$spanId-$sampleFlag"
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/W3cPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/W3cPropagatorTest.groovy
@@ -1,0 +1,24 @@
+package opentelemetry14.context.propagation
+
+class W3cPropagatorTest extends AgentPropagatorTest {
+  @Override
+  String style() {
+    return 'tracecontext'
+  }
+
+  @Override
+  def values() {
+    // spotless:off
+    return [
+      [['traceparent': '00-11111111111111111111111111111111-2222222222222222-00'], '11111111111111111111111111111111', '2222222222222222', false],
+      [['traceparent': '00-11111111111111111111111111111111-2222222222222222-01'], '11111111111111111111111111111111', '2222222222222222', true],
+    ]
+    // spotless:on
+  }
+
+  @Override
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
+    def traceFlags = "01" // Deterministic sampler with rate to 1
+    assert headers['traceparent'] == "00-$traceId-$spanId-$traceFlags"
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR brings the support for the OpenTelemetry context propagator API.

# Motivation

Previously, getting the context propagator from the GlobalOpenTelemetry would return a noop propagator, leading to the loss of context while trying to propagate it.
The returned propagator is now be based on the agent internal propagator. 

# Additional Notes

I start refactoring the OTel instrumentation by creating package dedicated to the different APIs for the new instrumentation parts. I will keep refactoring the rest of the instrumentation in a dedicated PR.

The test `test parent span using active span` was broken by https://github.com/DataDog/dd-trace-java/pull/5880 and need to be fixed in another PR too. It should be fixed with #5970. 