### PR TITLE
Fix boolean expression eval as template parameter

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/BooleanValueExpressionAdapter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/BooleanValueExpressionAdapter.java
@@ -1,0 +1,30 @@
+package com.datadog.debugger.el;
+
+import com.datadog.debugger.el.expressions.BooleanExpression;
+import com.datadog.debugger.el.expressions.ValueExpression;
+import com.datadog.debugger.el.values.BooleanValue;
+import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
+
+public class BooleanValueExpressionAdapter implements ValueExpression<BooleanValue> {
+
+  private final BooleanExpression booleanExpression;
+
+  public BooleanValueExpressionAdapter(BooleanExpression booleanExpression) {
+    this.booleanExpression = booleanExpression;
+  }
+
+  @Override
+  public BooleanValue evaluate(ValueReferenceResolver valueRefResolver) {
+    Boolean result = booleanExpression.evaluate(valueRefResolver);
+    if (result == null) {
+      throw new EvaluationException(
+          "Boolean expression returning null", PrettyPrintVisitor.print(this));
+    }
+    return new BooleanValue(result);
+  }
+
+  @Override
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(booleanExpression);
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
@@ -16,6 +16,7 @@ import com.datadog.debugger.el.expressions.IfExpression;
 import com.datadog.debugger.el.expressions.IndexExpression;
 import com.datadog.debugger.el.expressions.IsEmptyExpression;
 import com.datadog.debugger.el.expressions.LenExpression;
+import com.datadog.debugger.el.expressions.MatchesExpression;
 import com.datadog.debugger.el.expressions.NotExpression;
 import com.datadog.debugger.el.expressions.StartsWithExpression;
 import com.datadog.debugger.el.expressions.StringPredicateExpression;
@@ -192,7 +193,16 @@ public class DSL {
     return new ContainsExpression(valueExpression, str);
   }
 
+  public static StringPredicateExpression matches(
+      ValueExpression<?> valueExpression, StringValue str) {
+    return new MatchesExpression(valueExpression, str);
+  }
+
   public static WhenExpression when(BooleanExpression expression) {
     return new WhenExpression(expression);
+  }
+
+  public static BooleanValueExpressionAdapter bool(BooleanExpression expression) {
+    return new BooleanValueExpressionAdapter(expression);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -12,11 +12,41 @@ import com.datadog.debugger.el.values.StringValue;
 import com.squareup.moshi.JsonReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 /** Converts json representation to object model */
 public class JsonToExpressionConverter {
+
+  private static final Set<String> PREDICATE_FUNCTIONS =
+      new HashSet<>(
+          Arrays.asList(
+              "not",
+              "==",
+              "eq",
+              "!=",
+              "neq",
+              "ne",
+              ">=",
+              "ge",
+              ">",
+              "gt",
+              "<=",
+              "le",
+              "<",
+              "lt",
+              "or",
+              "and",
+              "hasAny",
+              "hasAll",
+              "isEmpty",
+              "startsWith",
+              "endsWith",
+              "contains",
+              "matches"));
 
   @FunctionalInterface
   interface BinaryPredicateExpressionFunction<T extends Expression> {
@@ -31,7 +61,13 @@ public class JsonToExpressionConverter {
   public static BooleanExpression createPredicate(JsonReader reader) throws IOException {
     reader.beginObject();
     String predicateType = reader.nextName();
-    BooleanExpression expr = null;
+    BooleanExpression expr = internalCreatePredicate(reader, predicateType);
+    reader.endObject();
+    return expr;
+  }
+
+  private static BooleanExpression internalCreatePredicate(JsonReader reader, String predicateType)
+      throws IOException {
     switch (predicateType) {
       case "not":
         {
@@ -40,8 +76,7 @@ public class JsonToExpressionConverter {
             throw new UnsupportedOperationException(
                 "Operation 'not' expects a predicate as its argument");
           }
-          expr = DSL.not(createPredicate(reader));
-          break;
+          return DSL.not(createPredicate(reader));
         }
       case "==":
       case "eq":
@@ -52,9 +87,9 @@ public class JsonToExpressionConverter {
                 "Operation 'eq' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createBinaryValuePredicate(reader, DSL::eq);
+          BooleanExpression expr = createBinaryValuePredicate(reader, DSL::eq);
           reader.endArray();
-          break;
+          return expr;
         }
       case "!=":
       case "neq":
@@ -66,9 +101,9 @@ public class JsonToExpressionConverter {
                 "Operation 'ne' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = DSL.not(createBinaryValuePredicate(reader, DSL::eq));
+          BooleanExpression expr = DSL.not(createBinaryValuePredicate(reader, DSL::eq));
           reader.endArray();
-          break;
+          return expr;
         }
       case ">=":
       case "ge":
@@ -79,9 +114,9 @@ public class JsonToExpressionConverter {
                 "Operation 'ge' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createBinaryValuePredicate(reader, DSL::ge);
+          BooleanExpression expr = createBinaryValuePredicate(reader, DSL::ge);
           reader.endArray();
-          break;
+          return expr;
         }
       case ">":
       case "gt":
@@ -92,9 +127,9 @@ public class JsonToExpressionConverter {
                 "Operation 'gt' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createBinaryValuePredicate(reader, DSL::gt);
+          BooleanExpression expr = createBinaryValuePredicate(reader, DSL::gt);
           reader.endArray();
-          break;
+          return expr;
         }
       case "<=":
       case "le":
@@ -105,9 +140,9 @@ public class JsonToExpressionConverter {
                 "Operation 'le' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createBinaryValuePredicate(reader, DSL::le);
+          BooleanExpression expr = createBinaryValuePredicate(reader, DSL::le);
           reader.endArray();
-          break;
+          return expr;
         }
       case "<":
       case "lt":
@@ -118,9 +153,9 @@ public class JsonToExpressionConverter {
                 "Operation 'lt' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createBinaryValuePredicate(reader, DSL::lt);
+          BooleanExpression expr = createBinaryValuePredicate(reader, DSL::lt);
           reader.endArray();
-          break;
+          return expr;
         }
       case "or":
         {
@@ -130,9 +165,9 @@ public class JsonToExpressionConverter {
                 "Operation 'or' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createCompositeLogicalPredicate(reader, DSL::or);
+          BooleanExpression expr = createCompositeLogicalPredicate(reader, DSL::or);
           reader.endArray();
-          break;
+          return expr;
         }
       case "and":
         {
@@ -142,9 +177,9 @@ public class JsonToExpressionConverter {
                 "Operation 'and' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createCompositeLogicalPredicate(reader, DSL::and);
+          BooleanExpression expr = createCompositeLogicalPredicate(reader, DSL::and);
           reader.endArray();
-          break;
+          return expr;
         }
       case "hasAny":
         {
@@ -154,9 +189,9 @@ public class JsonToExpressionConverter {
                 "Operation 'hasAny' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createHasAnyPredicate(reader);
+          BooleanExpression expr = createHasAnyPredicate(reader);
           reader.endArray();
-          break;
+          return expr;
         }
       case "hasAll":
         {
@@ -166,9 +201,9 @@ public class JsonToExpressionConverter {
                 "Operation 'hasAll' expects the arguments to be defined as array");
           }
           reader.beginArray();
-          expr = createHasAllPredicate(reader);
+          BooleanExpression expr = createHasAllPredicate(reader);
           reader.endArray();
-          break;
+          return expr;
         }
       case "isEmpty":
         {
@@ -177,29 +212,27 @@ public class JsonToExpressionConverter {
             throw new UnsupportedOperationException(
                 "Operation 'isEmpty' expects exactly one value argument");
           }
-          expr = DSL.isEmpty(asValueExpression(reader));
-          break;
+          return DSL.isEmpty(asValueExpression(reader));
         }
       case "startsWith":
         {
-          expr = createStringPredicateExpression(reader, DSL::startsWith);
-          break;
+          return createStringPredicateExpression(reader, DSL::startsWith);
         }
       case "endsWith":
         {
-          expr = createStringPredicateExpression(reader, DSL::endsWith);
-          break;
+          return createStringPredicateExpression(reader, DSL::endsWith);
         }
       case "contains":
         {
-          expr = createStringPredicateExpression(reader, DSL::contains);
-          break;
+          return createStringPredicateExpression(reader, DSL::contains);
+        }
+      case "matches":
+        {
+          return createStringPredicateExpression(reader, DSL::matches);
         }
       default:
         throw new UnsupportedOperationException("Unsupported operation '" + predicateType + "'");
     }
-    reader.endObject();
-    return expr;
   }
 
   public static BooleanExpression createHasAnyPredicate(JsonReader reader) throws IOException {
@@ -260,6 +293,9 @@ public class JsonToExpressionConverter {
           reader.beginObject();
           try {
             String fieldName = reader.nextName();
+            if (PREDICATE_FUNCTIONS.contains(fieldName)) {
+              return DSL.bool(internalCreatePredicate(reader, fieldName));
+            }
             switch (fieldName) {
               case "ref":
                 {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/BooleanValueExpressionAdapterTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/BooleanValueExpressionAdapterTest.java
@@ -1,0 +1,50 @@
+package com.datadog.debugger.el;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadog.debugger.el.expressions.BooleanExpression;
+import com.datadog.debugger.el.values.BooleanValue;
+import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
+import org.junit.jupiter.api.Test;
+
+class BooleanValueExpressionAdapterTest {
+
+  @Test
+  public void testLiteral() {
+    {
+      BooleanValueExpressionAdapter booleanValueExpressionAdapter =
+          new BooleanValueExpressionAdapter(BooleanExpression.TRUE);
+      BooleanValue resultValue = booleanValueExpressionAdapter.evaluate(null);
+      assertTrue(resultValue.getValue());
+    }
+    {
+      BooleanValueExpressionAdapter booleanValueExpressionAdapter =
+          new BooleanValueExpressionAdapter(BooleanExpression.FALSE);
+      BooleanValue resultValue = booleanValueExpressionAdapter.evaluate(null);
+      assertFalse(resultValue.getValue());
+    }
+  }
+
+  @Test
+  public void testExpression() {
+    BooleanValueExpressionAdapter booleanValueExpressionAdapter =
+        new BooleanValueExpressionAdapter(DSL.eq(DSL.value(1), DSL.value(1)));
+    BooleanValue resultValue = booleanValueExpressionAdapter.evaluate(null);
+    assertTrue(resultValue.getValue());
+  }
+
+  @Test
+  public void testNull() {
+    BooleanValueExpressionAdapter booleanValueExpressionAdapter =
+        new BooleanValueExpressionAdapter(
+            new BooleanExpression() {
+              @Override
+              public Boolean evaluate(ValueReferenceResolver valueRefResolver) {
+                return null;
+              }
+            });
+    EvaluationException ex =
+        assertThrows(EvaluationException.class, () -> booleanValueExpressionAdapter.evaluate(null));
+    assertEquals("Boolean expression returning null", ex.getMessage());
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -120,13 +120,15 @@ public class ConfigurationTest {
     ArrayList<LogProbe> logProbes = new ArrayList<>(config.getLogProbes());
     assertEquals(1, logProbes.size());
     LogProbe logProbe0 = logProbes.get(0);
-    assertEquals(6, logProbe0.getSegments().size());
+    assertEquals(8, logProbe0.getSegments().size());
     assertEquals("this is a log line customized! uuid=", logProbe0.getSegments().get(0).getStr());
     assertEquals("uuid", logProbe0.getSegments().get(1).getExpr());
     assertEquals(" result=", logProbe0.getSegments().get(2).getStr());
     assertEquals("result", logProbe0.getSegments().get(3).getExpr());
     assertEquals(" garbageStart=", logProbe0.getSegments().get(4).getStr());
     assertEquals("garbageStart", logProbe0.getSegments().get(5).getExpr());
+    assertEquals(" contain=", logProbe0.getSegments().get(6).getStr());
+    assertEquals("contains(arg, 'foo')", logProbe0.getSegments().get(7).getExpr());
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateBuilderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogMessageTemplateBuilderTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.ValueScript;
+import com.datadog.debugger.el.values.StringValue;
 import com.datadog.debugger.probe.LogProbe;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.EvaluationError;
@@ -65,6 +68,24 @@ class LogMessageTemplateBuilderTest {
         });
     String message = summaryBuilder.evaluate(capturedContext, new LogProbe.LogStatus(probe));
     assertEquals("foo", message);
+  }
+
+  @Test
+  public void booleanArgTemplate() {
+    List<LogProbe.Segment> segments = new ArrayList<>();
+    segments.add(
+        new LogProbe.Segment(
+            new ValueScript(
+                DSL.bool(DSL.contains(DSL.ref("arg"), new StringValue("o"))), "{arg}")));
+    LogProbe probe = LogProbe.builder().template("{contains(arg, 'o')}", segments).build();
+    LogMessageTemplateBuilder summaryBuilder = new LogMessageTemplateBuilder(probe.getSegments());
+    CapturedContext capturedContext = new CapturedContext();
+    capturedContext.addArguments(
+        new CapturedContext.CapturedValue[] {
+          CapturedContext.CapturedValue.of("arg", String.class.getTypeName(), "foo")
+        });
+    String message = summaryBuilder.evaluate(capturedContext, new LogProbe.LogStatus(probe));
+    assertEquals("true", message);
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/resources/test_log_probe.json
+++ b/dd-java-agent/agent-debugger/src/test/resources/test_log_probe.json
@@ -18,7 +18,7 @@
       "typeName": "VetController",
       "methodName": "showVetList"
     },
-    "template": "this is a log line customized! uuid={uuid} result={result} garbageStart={garbageStart}",
+    "template": "this is a log line customized! uuid={uuid} result={result} garbageStart={garbageStart} contain={contains(arg, 'foo')}",
     "segments": [
       {
         "str": "this is a log line customized! uuid="
@@ -35,6 +35,11 @@
       }, {
         "dsl": "garbageStart",
         "json": {"ref": "garbageStart"}
+      }, {
+        "str": " contain="
+      }, {
+        "dsl": "contains(arg, 'foo')",
+        "json": {"contains": [{"ref": "arg"}, "foo"]}
       }
     ]
   }]


### PR DESCRIPTION
# What Does This Do
Add support of any predicate or boolean expression inside a log template message is evaluated as 'true' or 'false' by converting this expression as value expression with an adapter
Refactor the parsing of the DSL to support all boolean functions

# Motivation
Support having a boolean expression inside a log template parameter liek `{contains(arg, 'foo')}`
# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
