### PR TITLE
Use package prefix to direct search for helper dependencies in OSGi

### DIFF
--- a/dd-java-agent/instrumentation/osgi-4.3/src/main/java/datadog/trace/instrumentation/osgi43/BundleReferenceInstrumentation.java
+++ b/dd-java-agent/instrumentation/osgi-4.3/src/main/java/datadog/trace/instrumentation/osgi43/BundleReferenceInstrumentation.java
@@ -46,11 +46,7 @@ public final class BundleReferenceInstrumentation extends Instrumenter.Tracing
 
   @Override
   public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".BundleWiringHelper",
-      packageName + ".BundleWiringHelper$1",
-      packageName + ".BundleWiringHelper$2"
-    };
+    return new String[] {packageName + ".BundleWiringHelper"};
   }
 
   @Override


### PR DESCRIPTION
# Motivation

When tracing a library we often need to inject a helper type into its class-loader. Occasionally when a library is deployed across multiple OSGi bundles the helper being injected may need to refer to a super-type that isn't imported. This is usually because the bundle being injected doesn't directly use the super-type, it only uses sub-types exported from a different package. The super-type is in a separate bundle indirectly used by the original bundle, but its package is not accessible due to modularity rules.

When this happens the tracer must temporarily bypass these modularity rules to access that super-type. Previously the tracer did this by searching all direct bundle dependencies for the type. However in rare circumstances this can lead to loader constraint issues.

For example, an application might have a dynamically updated `URLClassLoader` that has the bundle class-loader as its parent, and the bundle might import a package from the system bundle. Both the system bundle and the dynamic loader have access to log4j2, but from different jar locations, and the app bundle doesn't import any log4j2 packages.
```
+----------------+
| system bundle  |        log4j2
+----------------+
        |
+----------------+
|   app bundle   |
+----------------+
        |
+----------------+
| dynamic loader |        log4j2
+----------------+
```
Assume we inject a log4j2 helper class into the dynamic loader for tracing purposes. That triggers a load request for a log4j2 interface type. The dynamic loader delegates this request to its parent, the app bundle class-loader, which would normally throw a `ClassNotFoundException` because it doesn't provide or import any log4j2 types. However our OSGi support will also check direct dependencies, and in this case it would find the log4j interface type in the system bundle. Unfortunately this is a different type to the one in the dynamic loader, if we returned this then we could break a loader constraint.

Note that we cannot easily tell that a downstream class-loader will find the class. Ideally we would like to defer our wider search until the entire multi-class-loader search has been exhausted, but that is not feasible. Similarly class-loader design makes it hard to pass information back to the original class-loader, because it immediately discards any parent CNF exceptions.

We therefore need to direct our search to only those bundles which the original bundle imports related packages from. In other words if the app bundle imported a log4j2 package from the system bundle, and the type being looked up was under a related package then we can be relatively confident about returning that type from the search. In the previous example, the original bundle doesn't import any log4j2 packages and therefore we wouldn't bother searching the system bundle for log4j2 types.

This modified search still satisfies the [original injection issue](https://github.com/DataDog/dd-trace-java/pull/2321) while avoiding the above loader constraint issue.
