### PR TITLE
Use correct job name for gitlab relenv deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,10 +57,13 @@ build: &build
   script:
     - GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M" ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
+    - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
   artifacts:
     paths:
       - 'workspace/dd-java-agent/build/libs/*.jar'
       - 'upstream.env'
+    reports:
+      dotenv: build.env
 
 build_with_cache:
   <<: *build
@@ -95,7 +98,7 @@ deploy_to_reliability_env:
     project: DataDog/apm-reliability/datadog-reliability-env
     branch: $DOWNSTREAM_BRANCH
   variables:
-    UPSTREAM_PACKAGE_JOB: build
+    UPSTREAM_PACKAGE_JOB: $BUILD_JOB_NAME
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID


### PR DESCRIPTION
# What Does This Do

Uses the correct gitlab name for the build job so that reliability environment deployment can download the artifacts.

# Motivation

The scheduled build uses a job named `build_with_cache` but the relenv deployment always tried to download the artifacts from the `build` job.

# Additional Notes

We now use an environment variable to propagate the proper name.