### PR TITLE
do not record queue time before JFR is initialised

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/QueueTimerHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/QueueTimerHelper.java
@@ -4,6 +4,7 @@ import datadog.trace.api.profiling.QueueTiming;
 import datadog.trace.api.profiling.Timer;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.jfr.InstrumentationBasedProfiling;
 
 public class QueueTimerHelper {
 
@@ -14,7 +15,9 @@ public class QueueTimerHelper {
   }
 
   public static void startQueuingTimer(State state, Class<?> schedulerClass, Object task) {
-    if (task != null && state != null) {
+    // avoid calling this before JFR is initialised because it will lead to reading the wrong
+    // TSC frequency before JFR has set it up properly
+    if (task != null && state != null && InstrumentationBasedProfiling.isJFRReady()) {
       QueueTiming timing =
           (QueueTiming) AgentTracer.get().getTimer().start(Timer.TimerType.QUEUEING);
       timing.setTask(task);

--- a/dd-java-agent/instrumentation/netty-concurrent-4/src/test/groovy/TimingTest.groovy
+++ b/dd-java-agent/instrumentation/netty-concurrent-4/src/test/groovy/TimingTest.groovy
@@ -1,5 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.timer.TestTimer
+import datadog.trace.bootstrap.instrumentation.jfr.InstrumentationBasedProfiling
 import io.netty.util.concurrent.DefaultEventExecutorGroup
 
 import java.util.concurrent.TimeUnit
@@ -12,6 +13,7 @@ class TimingTest extends AgentTestRunner {
   protected void configurePreAgent() {
     injectSysConfig("dd.profiling.enabled", "true")
     injectSysConfig("dd.profiling.experimental.queueing.time.enabled", "true")
+    InstrumentationBasedProfiling.enableInstrumentationBasedProfiling()
     super.configurePreAgent()
   }
 


### PR DESCRIPTION
# What Does This Do

Because the profiler's TSC hacks into JFR, it can read the frequency before it has been initialised, and get a default value instead, which is then saved into a constant. This delays recording queue time until JFR has been initialised, so we won't read the frequency before it's available.

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
