### PR TITLE
Add spark streaming watermark gap metric

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -682,6 +682,11 @@ public class DatadogSparkListener extends SparkListener {
       Long watermark = convertStringDateToMillis(progress.eventTime().get("watermark"));
       if (watermark != null) {
         batchSpan.setMetric("spark.event_time.watermark", watermark);
+
+        Long progressTimestamp = convertStringDateToMillis(progress.timestamp());
+        if (watermark > 0 && progressTimestamp != null) {
+          batchSpan.setMetric("spark.event_time.watermark_gap", progressTimestamp - watermark);
+        }
       }
       Long maxEventTime = convertStringDateToMillis(progress.eventTime().get("max"));
       if (maxEventTime != null) {


### PR DESCRIPTION
# What Does This Do

Add the spark streaming metric `spark.event_time.watermark_gap` corresponding to the gap between batch timestamp and global watermark for the batch

# Motivation

Expose the same metric as in the Spark UI https://github.com/apache/spark/blob/v3.5.0/sql/core/src/main/scala/org/apache/spark/sql/streaming/ui/StreamingQueryStatisticsPage.scala#L181

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
