### PR TITLE
[AIT-8165] Add DSM API changes to support kinesis use case

### DIFF
--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -29,6 +29,7 @@ excludedClassesCoverage += [
   'datadog.trace.api.experimental.DataStreamsCheckpointer',
   'datadog.trace.api.experimental.DataStreamsCheckpointer.NoOp',
   'datadog.trace.api.experimental.DataStreamsContextCarrier',
+  'datadog.trace.api.experimental.DataStreamsContextCarrier.NoOp',
   'datadog.appsec.api.blocking.*',
 ]
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/experimental/DataStreamsCheckpointer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/experimental/DataStreamsCheckpointer.java
@@ -18,7 +18,7 @@ public interface DataStreamsCheckpointer {
   /**
    * @param type The type of the checkpoint, usually the streaming technology being used. Examples:
    *     kafka, kinesis, sns etc.
-   * @paren source The source of data. For instance: topic, exchange or stream name.
+   * @param source The source of data. For instance: topic, exchange or stream name.
    * @param carrier An interface to the context carrier, from which the context will be extracted.
    *     I.e. wrapper around message headers.
    */
@@ -27,7 +27,7 @@ public interface DataStreamsCheckpointer {
   /**
    * @param type The type of the checkpoint, usually the streaming technology being used. Examples:
    *     kafka, kinesis, sns etc.
-   * @paren target The destination to which the data is being sent. For instance: topic, exchange or
+   * @param target The destination to which the data is being sent. For instance: topic, exchange or
    *     stream name.
    * @param carrier An interface to the context carrier, to which the context will be injected. I.e.
    *     wrapper around message headers.

--- a/dd-trace-api/src/main/java/datadog/trace/api/experimental/DataStreamsContextCarrier.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/experimental/DataStreamsContextCarrier.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.experimental;
 
+import java.util.Collections;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -13,4 +14,18 @@ public interface DataStreamsContextCarrier {
    * @param value to be set
    */
   void set(String key, String value);
+
+  final class NoOp implements DataStreamsContextCarrier {
+    public static final DataStreamsContextCarrier INSTANCE = new NoOp();
+
+    private NoOp() {}
+
+    @Override
+    public Set<Entry<String, Object>> entries() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public void set(String key, String value) {}
+  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -216,6 +216,16 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
 
   @Override
   public void setConsumeCheckpoint(String type, String source, DataStreamsContextCarrier carrier) {
+    doSetConsumeCheckpoint(type, source, carrier, 0);
+  }
+
+  @Override
+  public void setConsumeCheckpoint(String type, String source, long timestamp) {
+    doSetConsumeCheckpoint(type, source, DataStreamsContextCarrier.NoOp.INSTANCE, timestamp);
+  }
+
+  private void doSetConsumeCheckpoint(
+      String type, String source, DataStreamsContextCarrier carrier, long timestamp) {
     if (type == null || type.isEmpty() || source == null || source.isEmpty()) {
       log.warn("setConsumeCheckpoint should be called with non-empty type and source");
       return;
@@ -233,7 +243,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
     sortedTags.put(TOPIC_TAG, source);
     sortedTags.put(TYPE_TAG, type);
 
-    setCheckpoint(span, sortedTags, 0);
+    setCheckpoint(span, sortedTags, timestamp);
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
@@ -18,4 +18,14 @@ public interface AgentDataStreamsMonitoring extends DataStreamsCheckpointer {
    */
   void setCheckpoint(
       AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
+
+  /**
+   * Not added to DataStreamsCheckpointer to not add it to the public API
+   *
+   * @param type The type of the checkpoint, usually the streaming technology being used. Examples:
+   *     kafka, kinesis, sns etc.
+   * @param source The source of data. For instance: topic, exchange or stream name.
+   * @param timestamp unix timestamp for the beginning of the messaging system edge
+   */
+  void setConsumeCheckpoint(String type, String source, long timestamp);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1027,6 +1027,9 @@ public class AgentTracer {
         String type, String source, DataStreamsContextCarrier carrier) {}
 
     @Override
+    public void setConsumeCheckpoint(String type, String source, long timestamp) {}
+
+    @Override
     public void setProduceCheckpoint(
         String type, String target, DataStreamsContextCarrier carrier) {}
   }


### PR DESCRIPTION
# What Does This Do

Modified the DSM API to allow adding consumer checkpoints for kinesis. Where we don't have a full pathway context but only have a timestamp

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
