### PR TITLE
Exclude optional 'com.google.code.findbugs:jsr305' dependency…

### DIFF
--- a/dd-java-agent/instrumentation/mule-4/build.gradle
+++ b/dd-java-agent/instrumentation/mule-4/build.gradle
@@ -13,6 +13,8 @@ muzzle {
     module = 'mule-core'
     versions = '[,]'
     assertInverse = true
+
+    excludeDependency 'com.google.code.findbugs:jsr305' // avoid dependency issue with mule-4.5.0
   }
 
   fail {


### PR DESCRIPTION
… to avoid the following dependency resolver issue with mule-4.5.0:
```
Execution failed for task ':dd-java-agent:instrumentation:mule-4:muzzle-AssertPass-org.mule.runtime-mule-core-4.5.0'.
> A failure occurred while executing MuzzleAction
   > Could not isolate value MuzzleWorkParameters_Decorated@3017f52e of type MuzzleWorkParameters
      > Could not resolve all files for configuration ':dd-java-agent:instrumentation:mule-4:muzzle-AssertPass-org.mule.runtime-mule-core-4.5.0'.
         > Could not find com.google.code.findbugs:jsr305:.
           Required by:
               project :dd-java-agent:instrumentation:mule-4 > org.mule.runtime:mule-core:4.5.0 > com.google.guava:guava:32.1.1-jre
```