### PR TITLE
Fix flaky metric smoke tests

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -66,6 +66,10 @@ public class ProbeStatusSink {
     List<String> serializedDiagnostics = new ArrayList<>();
     for (ProbeStatus message : diagnostics) {
       try {
+        LOGGER.debug(
+            "Sending probe status[{}] for probe id: {}",
+            message.getDiagnostics().getStatus(),
+            message.getDiagnostics().getProbeId().getId());
         serializedDiagnostics.add(PROBE_STATUS_ADAPTER.toJson(message));
       } catch (Exception e) {
         ExceptionHelper.logException(LOGGER, e, "Error during probe status serialization:");

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/TestApplicationHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/TestApplicationHelper.java
@@ -86,6 +86,11 @@ public class TestApplicationHelper {
   }
 
   public static void waitForUpload(String logFileName, int expectedUploads) throws IOException {
+    if (expectedUploads == -1) {
+      System.out.println("wait for " + TIMEOUT_S + "s");
+      LockSupport.parkNanos(Duration.ofSeconds(TIMEOUT_S).toNanos());
+      return;
+    }
     System.out.println("waitForUpload #" + expectedUploads);
     AtomicInteger uploadCount = new AtomicInteger(0);
     waitForSpecificLogLine(

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
@@ -71,7 +71,8 @@ public class MetricProbesIntegrationTest extends SimpleAppDebuggerIntegrationTes
       String metricName, MetricProbe.MetricKind kind, ValueScript script, String expectedMsgFormat)
       throws IOException {
     final String METHOD_NAME = "fullMethod";
-    final String EXPECTED_UPLOADS = "3"; // 2 + 1 for letting the metric being sent (async)
+    final String EXPECTED_UPLOADS =
+        "-1"; // wait for TIMEOUT_S for letting the metric being sent (async)
     MetricProbe metricProbe =
         MetricProbe.builder()
             .probeId(PROBE_ID)
@@ -140,7 +141,8 @@ public class MetricProbesIntegrationTest extends SimpleAppDebuggerIntegrationTes
       String metricName, MetricProbe.MetricKind kind, ValueScript script, String expectedMsgFormat)
       throws IOException {
     final String METHOD_NAME = "fullMethod";
-    final String EXPECTED_UPLOADS = "3"; // 2 + 1 for letting the metric being sent (async)
+    final String EXPECTED_UPLOADS =
+        "-1"; // wait for TIMEOUT_S for letting the metric being sent (async)
     MetricProbe metricProbe =
         MetricProbe.builder()
             .probeId(PROBE_ID)


### PR DESCRIPTION
# What Does This Do
Application in test wait for a timeout instead of uploads

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
