### PR TITLE
Fix race condition for applying probe rate limits 

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -104,12 +104,13 @@ public class ConfigurationUpdater
     ConfigurationComparer changes =
         new ConfigurationComparer(currentConfiguration, newConfiguration, instrumentationResults);
     currentConfiguration = newConfiguration;
+    if (changes.hasRateLimitRelatedChanged()) {
+      // apply rate limit config first to avoid racing with execution/instrumentation of log probes
+      applyRateLimiter(changes);
+    }
     if (changes.hasProbeRelatedChanges()) {
       LOGGER.info("Applying new probe configuration, changes: {}", changes);
       handleProbesChanges(changes);
-    }
-    if (changes.hasRateLimitRelatedChanged()) {
-      applyRateLimiter(changes);
     }
   }
 


### PR DESCRIPTION
# What Does This Do
Apply rate limit for a probe before applying configuration change
that generate instrumentation and retransformation because execution
of the new instrumented code can happen before rate limit settings
are applied and then create default (snapshot ones) rate limit.

# Motivation
Fix flaky sampling smoke tests

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
