### PR TITLE
Fix  AppSec-related problems in akka-http

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -401,29 +401,18 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
   }
 
   private Flow<Void> callIGCallbackRequestHeaders(AgentSpan span, REQUEST_CARRIER carrier) {
-    CallbackProvider cbpAppsec = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
-    CallbackProvider cbpIast = tracer().getCallbackProvider(RequestContextSlot.IAST);
+    CallbackProvider cbp = tracer().getUniversalCallbackProvider();
     RequestContext requestContext = span.getRequestContext();
     AgentPropagation.ContextVisitor<REQUEST_CARRIER> getter = getter();
     if (requestContext == null || getter == null) {
       return Flow.ResultFlow.empty();
     }
-    if (cbpIast != null) {
+    if (cbp != null) {
       IGKeyClassifier igKeyClassifier =
           IGKeyClassifier.create(
               requestContext,
-              cbpIast.getCallback(EVENTS.requestHeader()),
-              cbpIast.getCallback(EVENTS.requestHeaderDone()));
-      if (null != igKeyClassifier) {
-        getter.forEachKey(carrier, igKeyClassifier);
-      }
-    }
-    if (cbpAppsec != null) {
-      IGKeyClassifier igKeyClassifier =
-          IGKeyClassifier.create(
-              requestContext,
-              cbpAppsec.getCallback(EVENTS.requestHeader()),
-              cbpAppsec.getCallback(EVENTS.requestHeaderDone()));
+              cbp.getCallback(EVENTS.requestHeader()),
+              cbp.getCallback(EVENTS.requestHeaderDone()));
       if (null != igKeyClassifier) {
         getter.forEachKey(carrier, igKeyClassifier);
         return igKeyClassifier.done();

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -424,6 +424,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
       startSpan(_, _, _) >> mSpan
       getCallbackProvider(RequestContextSlot.APPSEC) >> cbpAppSec
       getCallbackProvider(RequestContextSlot.IAST) >> CallbackProvider.CallbackProviderNoop.INSTANCE
+      getUniversalCallbackProvider() >> cbpAppSec // no iast callbacks, so this is equivalent
       getDataStreamsMonitoring() >> Mock(DataStreamsMonitoring)
     }
     def decorator = newDecorator(mTracer)

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -33,11 +33,6 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
   }
 
   @Override
-  boolean hasPeerInformation() {
-    return false
-  }
-
-  @Override
   boolean hasExtraErrorInformation() {
     return true
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -7,12 +7,15 @@ import okhttp3.HttpUrl
 import okhttp3.MultipartBody
 import okhttp3.Request
 import okhttp3.RequestBody
+import okhttp3.Response
 import spock.lang.Shared
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import static datadog.trace.agent.test.base.HttpServerTest.IG_ASK_FOR_RESPONSE_HEADER_TAGS_HEADER
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_JSON
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_MULTIPART
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static org.junit.Assume.assumeTrue
 
 abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttpTestWebServer> {
@@ -160,6 +163,9 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
       .method('POST', RequestBody.create(okhttp3.MediaType.get('application/json'), '{"a":"x"}\n'))
       .build()
     def response = client.newCall(request).execute()
+    if (isDataStreamsEnabled()) {
+      TEST_DATA_STREAMS_WRITER.waitForGroups(1)
+    }
 
     expect:
     response.body().charStream().text == '{"a":"x"}'
@@ -171,6 +177,29 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
     TEST_WRITER.get(0).any {
       it.getTag('request.body.converted') == '[a:[x]]'
     }
+  }
+
+  void 'content length and type are provided to IG on strict responses'() {
+    setup:
+    Request request = request(SUCCESS, 'GET', null)
+      .header(IG_EXTRA_SPAN_NAME_HEADER, 'ig-span')
+      .header(IG_ASK_FOR_RESPONSE_HEADER_TAGS_HEADER, 'true')
+      .build()
+    Response response = client.newCall(request).execute()
+    if (isDataStreamsEnabled()) {
+      TEST_DATA_STREAMS_WRITER.waitForGroups(1)
+    }
+
+    expect:
+    response.body().charStream().text == SUCCESS.body
+
+    when:
+    TEST_WRITER.waitForTraces(1)
+    def tags = TEST_WRITER.get(0).find { it.spanName == 'ig-span' }.tags
+
+    then:
+    tags['response.header.content-type'] != null
+    tags['response.header.content-length'] == SUCCESS.body.length() as String
   }
 }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -71,6 +71,9 @@ class LagomTest extends AgentTestRunner {
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 101
             "$Tags.HTTP_USER_AGENT" String
+            "$Tags.PEER_HOST_IPV4" '127.0.0.1'
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_CLIENT_IP" '127.0.0.1'
             defaultTags()
           }
         }
@@ -115,6 +118,9 @@ class LagomTest extends AgentTestRunner {
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 500
             "$Tags.HTTP_USER_AGENT" String
+            "$Tags.PEER_HOST_IPV4" '127.0.0.1'
+            "$Tags.PEER_PORT" Integer
+            "$Tags.HTTP_CLIENT_IP" '127.0.0.1'
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerHeaders.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerHeaders.java
@@ -3,30 +3,46 @@ package datadog.trace.instrumentation.akkahttp;
 import akka.http.javadsl.model.HttpHeader;
 import akka.http.javadsl.model.headers.RemoteAddress;
 import akka.http.javadsl.model.headers.TimeoutAccess;
+import akka.http.scaladsl.model.ContentType;
+import akka.http.scaladsl.model.HttpEntity;
 import akka.http.scaladsl.model.HttpMessage;
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 
-public class AkkaHttpServerHeaders<T extends HttpMessage>
-    implements AgentPropagation.ContextVisitor<T> {
+public class AkkaHttpServerHeaders {
+  private AkkaHttpServerHeaders() {}
 
-  @SuppressWarnings("rawtypes")
-  private static final AkkaHttpServerHeaders GETTER = new AkkaHttpServerHeaders();
+  private static final AgentPropagation.ContextVisitor<HttpRequest> GETTER_REQUEST =
+      AkkaHttpServerHeaders::forEachKeyRequest;
+  private static final AgentPropagation.ContextVisitor<HttpResponse> GETTER_RESPONSE =
+      AkkaHttpServerHeaders::forEachKeyResponse;
 
-  @SuppressWarnings("unchecked")
   public static AgentPropagation.ContextVisitor<HttpRequest> requestGetter() {
-    return (AgentPropagation.ContextVisitor<HttpRequest>) GETTER;
+    return GETTER_REQUEST;
   }
 
-  @SuppressWarnings("unchecked")
   public static AgentPropagation.ContextVisitor<HttpResponse> responseGetter() {
-    return (AgentPropagation.ContextVisitor<HttpResponse>) GETTER;
+    return GETTER_RESPONSE;
   }
 
-  @Override
-  public void forEachKey(
-      final HttpMessage carrier, final AgentPropagation.KeyClassifier classifier) {
+  private static void doForEachKey(
+      HttpMessage carrier,
+      akka.http.javadsl.model.HttpEntity entity,
+      AgentPropagation.KeyClassifier classifier) {
+    if (entity instanceof HttpEntity.Strict) {
+      HttpEntity.Strict strictEntity = (HttpEntity.Strict) entity;
+      ContentType contentType = strictEntity.contentType();
+      if (contentType != null) {
+        if (!classifier.accept("content-type", contentType.value())) {
+          return;
+        }
+      }
+      if (!classifier.accept("content-length", Long.toString(strictEntity.contentLength()))) {
+        return;
+      }
+    }
+
     for (final HttpHeader header : carrier.getHeaders()) {
       // skip synthetic headers
       if (header instanceof RemoteAddress || header instanceof TimeoutAccess) {
@@ -36,5 +52,15 @@ public class AkkaHttpServerHeaders<T extends HttpMessage>
         return;
       }
     }
+  }
+
+  private static void forEachKeyRequest(
+      HttpRequest req, AgentPropagation.KeyClassifier classifier) {
+    doForEachKey(req, req.entity(), classifier);
+  }
+
+  private static void forEachKeyResponse(
+      final HttpResponse resp, final AgentPropagation.KeyClassifier classifier) {
+    doForEachKey(resp, resp.entity(), classifier);
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerHeaders.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerHeaders.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.akkahttp;
 
 import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.headers.RemoteAddress;
+import akka.http.javadsl.model.headers.TimeoutAccess;
 import akka.http.scaladsl.model.HttpMessage;
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.model.HttpResponse;
@@ -26,6 +28,10 @@ public class AkkaHttpServerHeaders<T extends HttpMessage>
   public void forEachKey(
       final HttpMessage carrier, final AgentPropagation.KeyClassifier classifier) {
     for (final HttpHeader header : carrier.getHeaders()) {
+      // skip synthetic headers
+      if (header instanceof RemoteAddress || header instanceof TimeoutAccess) {
+        continue;
+      }
       if (!classifier.accept(header.lowercaseName(), header.value())) {
         return;
       }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/ConfigProvideRemoteAddressHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/ConfigProvideRemoteAddressHeaderInstrumentation.java
@@ -1,0 +1,52 @@
+package datadog.trace.instrumentation.akkahttp.appsec;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class ConfigProvideRemoteAddressHeaderInstrumentation extends Instrumenter.AppSec
+    implements Instrumenter.ForSingleType {
+  public ConfigProvideRemoteAddressHeaderInstrumentation() {
+    super("akka-http");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.typesafe.config.impl.SimpleConfig";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isPublic()
+            .and(named("getBoolean"))
+            .and(takesArguments(1))
+            .and(takesArgument(0, String.class))
+            .and(returns(boolean.class)),
+        ConfigProvideRemoteAddressHeaderInstrumentation.class.getName()
+            + "$EnableRemoteAddressHeaderAdvice");
+  }
+
+  static class EnableRemoteAddressHeaderAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
+    static boolean enter(@Advice.Argument(0) String configName) {
+      // ideally we'd use remote-address-attribute, but that's only available on 10.2,
+      // and doesn't work on http/2 until 10.2.3
+      return "remote-address-header".equals(configName);
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    static void exit(@Advice.Enter boolean enter, @Advice.Return(readOnly = false) boolean ret) {
+      if (enter) {
+        ret = true;
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/FormDataToStrictInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/FormDataToStrictInstrumentation.java
@@ -26,6 +26,7 @@ public class FormDataToStrictInstrumentation extends Instrumenter.AppSec
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".UnmarshallerHelpers",
+      packageName + ".UnmarshallerHelpers$UnmarkStrictFormOngoingOnUnsupportedException",
       packageName + ".AkkaBlockResponseFunction",
       packageName + ".BlockingResponseHelper",
       packageName + ".ScalaListCollector",

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/JacksonUnmarshallerInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/JacksonUnmarshallerInstrumentation.java
@@ -25,6 +25,7 @@ public class JacksonUnmarshallerInstrumentation extends Instrumenter.AppSec
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".UnmarshallerHelpers",
+      packageName + ".UnmarshallerHelpers$UnmarkStrictFormOngoingOnUnsupportedException",
       packageName + ".AkkaBlockResponseFunction",
       packageName + ".BlockingResponseHelper",
       packageName + ".ScalaListCollector",

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/MultipartUnmarshallersInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/MultipartUnmarshallersInstrumentation.java
@@ -26,6 +26,7 @@ public class MultipartUnmarshallersInstrumentation extends Instrumenter.AppSec
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".UnmarshallerHelpers",
+      packageName + ".UnmarshallerHelpers$UnmarkStrictFormOngoingOnUnsupportedException",
       packageName + ".AkkaBlockResponseFunction",
       packageName + ".BlockingResponseHelper",
       packageName + ".ScalaListCollector",

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/PredefinedFromEntityUnmarshallersInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/PredefinedFromEntityUnmarshallersInstrumentation.java
@@ -32,6 +32,7 @@ public class PredefinedFromEntityUnmarshallersInstrumentation extends Instrument
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".UnmarshallerHelpers",
+      packageName + ".UnmarshallerHelpers$UnmarkStrictFormOngoingOnUnsupportedException",
       packageName + ".AkkaBlockResponseFunction",
       packageName + ".BlockingResponseHelper",
       packageName + ".ScalaListCollector",

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/SprayUnmarshallerInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/SprayUnmarshallerInstrumentation.java
@@ -33,6 +33,7 @@ public class SprayUnmarshallerInstrumentation extends Instrumenter.AppSec
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".UnmarshallerHelpers",
+      packageName + ".UnmarshallerHelpers$UnmarkStrictFormOngoingOnUnsupportedException",
       packageName + ".AkkaBlockResponseFunction",
       packageName + ".BlockingResponseHelper",
       packageName + ".ScalaListCollector",

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/StrictFormCompanionInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/appsec/StrictFormCompanionInstrumentation.java
@@ -33,6 +33,7 @@ public class StrictFormCompanionInstrumentation extends Instrumenter.AppSec
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".UnmarshallerHelpers",
+      packageName + ".UnmarshallerHelpers$UnmarkStrictFormOngoingOnUnsupportedException",
       packageName + ".AkkaBlockResponseFunction",
       packageName + ".BlockingResponseHelper",
       packageName + ".ScalaListCollector",

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -106,11 +106,6 @@ class PlayServerTest extends HttpServerTest<Server> {
     true
   }
 
-  @Override
-  boolean hasPeerPort() {
-    false
-  }
-
   boolean testExceptionBody() {
     // I can't figure out how to set a proper exception handler to customize the response body.
     false

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1943,6 +1943,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   static final String IG_PARAMETERS_BLOCK_HEADER = "x-block-parameters"
   static final String IG_BODY_END_BLOCK_HEADER = "x-block-body-end"
   static final String IG_BODY_CONVERTED_HEADER = "x-block-body-converted"
+  static final String IG_ASK_FOR_RESPONSE_HEADER_TAGS_HEADER = "x-include-response-headers-in-tags"
   static final String IG_PEER_ADDRESS = "ig-peer-address"
   static final String IG_PEER_PORT = "ig-peer-port"
   static final String IG_RESPONSE_STATUS = "ig-response-status"
@@ -1964,6 +1965,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       String responseBlock
       boolean bodyEndBlock
       boolean bodyConvertedBlock
+      boolean responseHeadersInTags
     }
 
     static final String stringOrEmpty(String string) {
@@ -2013,6 +2015,9 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
       }
       if (IG_BODY_CONVERTED_HEADER.equalsIgnoreCase(key)) {
         context.bodyConvertedBlock = true
+      }
+      if (IG_ASK_FOR_RESPONSE_HEADER_TAGS_HEADER.equalsIgnoreCase(key)) {
+        context.responseHeadersInTags = true
       }
     } as TriConsumer<RequestContext, String, String>
 
@@ -2117,6 +2122,9 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     final TriConsumer<RequestContext, String, String> responseHeaderCb =
     { RequestContext rqCtxt, String key, String value ->
       Context context = rqCtxt.getData(RequestContextSlot.APPSEC)
+      if (context.responseHeadersInTags) {
+        context.tags["response.header.${key.toLowerCase()}"] = value
+      }
       if (IG_RESPONSE_HEADER.equalsIgnoreCase(key)) {
         context.igResponseHeaderValue = stringOrEmpty(context.igResponseHeaderValue) + value
       }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -381,17 +381,33 @@ public class InstrumentationGateway {
     switch (eventType.getId()) {
       case REQUEST_ENDED_ID:
         return (C)
-            new BiFunction<RequestContext, IGSpanInfo, Flow<Void>>() {
-              @Override
-              public Flow<Void> apply(RequestContext ctx, IGSpanInfo agentSpan) {
-                Flow<Void> flowAppSec =
-                    ((BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) callbackAppSec)
-                        .apply(ctx, agentSpan);
-                Flow<Void> flowIast =
-                    ((BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) callbackIast)
-                        .apply(ctx, agentSpan);
-                return mergeFlows(flowAppSec, flowIast);
-              }
+            (BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) (ctx, agentSpan) -> {
+              Flow<Void> flowAppSec =
+                  ((BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) callbackAppSec)
+                      .apply(ctx, agentSpan);
+              Flow<Void> flowIast =
+                  ((BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) callbackIast)
+                      .apply(ctx, agentSpan);
+              return mergeFlows(flowAppSec, flowIast);
+            };
+      case REQUEST_HEADER_ID:
+        return (C)
+            (TriConsumer<RequestContext, String, String>) (requestContext, s, s2) -> {
+                  ((TriConsumer<RequestContext, String, String>) callbackAppSec)
+                      .accept(requestContext, s, s2);
+              ((TriConsumer<RequestContext, String, String>) callbackIast)
+                  .accept(requestContext, s, s2);
+            };
+      case REQUEST_HEADER_DONE_ID:
+        return (C)
+            (Function<RequestContext, Flow<Void>>) requestContext -> {
+              Flow<Void> flowAppSec =
+                  ((Function<RequestContext, Flow<Void>>) callbackAppSec)
+                      .apply(requestContext);
+              Flow<Void> flowIast =
+                  ((Function<RequestContext, Flow<Void>>) callbackIast)
+                      .apply(requestContext);
+              return mergeFlows(flowAppSec, flowIast);
             };
     }
     return null;

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -381,34 +381,35 @@ public class InstrumentationGateway {
     switch (eventType.getId()) {
       case REQUEST_ENDED_ID:
         return (C)
-            (BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) (ctx, agentSpan) -> {
-              Flow<Void> flowAppSec =
-                  ((BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) callbackAppSec)
-                      .apply(ctx, agentSpan);
-              Flow<Void> flowIast =
-                  ((BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) callbackIast)
-                      .apply(ctx, agentSpan);
-              return mergeFlows(flowAppSec, flowIast);
-            };
+            (BiFunction<RequestContext, IGSpanInfo, Flow<Void>>)
+                (ctx, agentSpan) -> {
+                  Flow<Void> flowAppSec =
+                      ((BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) callbackAppSec)
+                          .apply(ctx, agentSpan);
+                  Flow<Void> flowIast =
+                      ((BiFunction<RequestContext, IGSpanInfo, Flow<Void>>) callbackIast)
+                          .apply(ctx, agentSpan);
+                  return mergeFlows(flowAppSec, flowIast);
+                };
       case REQUEST_HEADER_ID:
         return (C)
-            (TriConsumer<RequestContext, String, String>) (requestContext, s, s2) -> {
+            (TriConsumer<RequestContext, String, String>)
+                (requestContext, s, s2) -> {
                   ((TriConsumer<RequestContext, String, String>) callbackAppSec)
                       .accept(requestContext, s, s2);
-              ((TriConsumer<RequestContext, String, String>) callbackIast)
-                  .accept(requestContext, s, s2);
-            };
+                  ((TriConsumer<RequestContext, String, String>) callbackIast)
+                      .accept(requestContext, s, s2);
+                };
       case REQUEST_HEADER_DONE_ID:
         return (C)
-            (Function<RequestContext, Flow<Void>>) requestContext -> {
-              Flow<Void> flowAppSec =
-                  ((Function<RequestContext, Flow<Void>>) callbackAppSec)
-                      .apply(requestContext);
-              Flow<Void> flowIast =
-                  ((Function<RequestContext, Flow<Void>>) callbackIast)
-                      .apply(requestContext);
-              return mergeFlows(flowAppSec, flowIast);
-            };
+            (Function<RequestContext, Flow<Void>>)
+                requestContext -> {
+                  Flow<Void> flowAppSec =
+                      ((Function<RequestContext, Flow<Void>>) callbackAppSec).apply(requestContext);
+                  Flow<Void> flowIast =
+                      ((Function<RequestContext, Flow<Void>>) callbackIast).apply(requestContext);
+                  return mergeFlows(flowAppSec, flowIast);
+                };
     }
     return null;
   }


### PR DESCRIPTION
* Provide peer information on akka-http.
* Fix body interception after StrictForm unmarshaller fails.
* Filterout synthetic headers.
* Report content-{length,type} for strict entities.