### PR TITLE
byte-buddy 1.14.8

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,8 +38,8 @@ dependencies {
   implementation("org.apache.maven", "maven-aether-provider", "3.3.9")
 
   implementation("com.google.guava", "guava", "20.0")
-  implementation("org.ow2.asm", "asm", "9.5")
-  implementation("org.ow2.asm", "asm-tree", "9.5")
+  implementation("org.ow2.asm", "asm", "9.6")
+  implementation("org.ow2.asm", "asm-tree", "9.6")
 
   testImplementation("org.spockframework", "spock-core", "2.2-groovy-3.0")
   testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.5")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.8")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.5' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.8' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
     ddprof        : "0.79.0",
-    asm           : "9.5",
+    asm           : "9.6",
     cafe_crypto   : "0.1.0"
   ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.9.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.14.5",
+    bytebuddy     : "1.14.8",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
Changes since we last updated byte-buddy:
* Correctly read versions from class file that would use both bytes.
* Correct field and static method access on subtypes in MemberSubstitution.
* Correctly read minor version from class file.
* Add PatchMode.SUBSTITUTE and ResettableClassFileTransformer.Substitutable for in-order patching.
* Allow for explicit specification of differential matcher when patching an AgentBuilder.
* Correctly resolve accessors for fields with capitalized first letter.

This PR also updates ASM to 9.6