### PR TITLE
[AIT-8165] Add DSM API changes to support kinesis use case

### DIFF
--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -29,6 +29,7 @@ excludedClassesCoverage += [
   'datadog.trace.api.experimental.DataStreamsCheckpointer',
   'datadog.trace.api.experimental.DataStreamsCheckpointer.NoOp',
   'datadog.trace.api.experimental.DataStreamsContextCarrier',
+  'datadog.trace.api.experimental.DataStreamsContextCarrier.NoOp',
   'datadog.appsec.api.blocking.*',
 ]
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/experimental/DataStreamsCheckpointer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/experimental/DataStreamsCheckpointer.java
@@ -18,7 +18,7 @@ public interface DataStreamsCheckpointer {
   /**
    * @param type The type of the checkpoint, usually the streaming technology being used. Examples:
    *     kafka, kinesis, sns etc.
-   * @paren source The source of data. For instance: topic, exchange or stream name.
+   * @param source The source of data. For instance: topic, exchange or stream name.
    * @param carrier An interface to the context carrier, from which the context will be extracted.
    *     I.e. wrapper around message headers.
    */
@@ -27,7 +27,7 @@ public interface DataStreamsCheckpointer {
   /**
    * @param type The type of the checkpoint, usually the streaming technology being used. Examples:
    *     kafka, kinesis, sns etc.
-   * @paren target The destination to which the data is being sent. For instance: topic, exchange or
+   * @param target The destination to which the data is being sent. For instance: topic, exchange or
    *     stream name.
    * @param carrier An interface to the context carrier, to which the context will be injected. I.e.
    *     wrapper around message headers.

--- a/dd-trace-api/src/main/java/datadog/trace/api/experimental/DataStreamsContextCarrier.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/experimental/DataStreamsContextCarrier.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.experimental;
 
+import java.util.Collections;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -13,4 +14,18 @@ public interface DataStreamsContextCarrier {
    * @param value to be set
    */
   void set(String key, String value);
+
+  final class NoOp implements DataStreamsContextCarrier {
+    public static final DataStreamsContextCarrier INSTANCE = new NoOp();
+
+    private NoOp() {}
+
+    @Override
+    public Set<Entry<String, Object>> entries() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public void set(String key, String value) {}
+  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -633,6 +633,7 @@ public class DDSpanContext
     return pathwayContext;
   }
 
+  @Override
   public void mergePathwayContext(PathwayContext pathwayContext) {
     if (pathwayContext == null) {
       return;

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsMonitoring.java
@@ -5,13 +5,10 @@ import datadog.trace.bootstrap.instrumentation.api.AgentDataStreamsMonitoring;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
-import datadog.trace.bootstrap.instrumentation.api.StatsPoint;
 import datadog.trace.core.propagation.HttpCodec;
 
 public interface DataStreamsMonitoring extends AgentDataStreamsMonitoring, AutoCloseable {
   void start();
-
-  PathwayContext newPathwayContext();
 
   /**
    * Get a context extractor that support {@link PathwayContext} extraction.
@@ -35,8 +32,6 @@ public interface DataStreamsMonitoring extends AgentDataStreamsMonitoring, AutoC
    * @param carrier The carrier of the {@link PathwayContext} to extract and inject.
    */
   void mergePathwayContextIntoSpan(AgentSpan span, DataStreamsContextCarrier carrier);
-
-  void add(StatsPoint statsPoint);
 
   void clear();
 

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -47,6 +47,8 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.java.lang.ProcessImplInstrumentationHelpers",
   "datadog.trace.bootstrap.instrumentation.api.Tags",
   "datadog.trace.bootstrap.instrumentation.api.CommonTagValues",
+  // Caused by empty 'default' interface method
+  "datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentPropagation",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopContext",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
@@ -18,4 +18,8 @@ public interface AgentDataStreamsMonitoring extends DataStreamsCheckpointer {
    */
   void setCheckpoint(
       AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp);
+
+  PathwayContext newPathwayContext();
+
+  void add(StatsPoint statsPoint);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -173,6 +173,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
 
     PathwayContext getPathwayContext();
 
+    default void mergePathwayContext(PathwayContext pathwayContext) {}
+
     interface Extracted extends Context {
       String getForwarded();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1023,6 +1023,14 @@ public class AgentTracer {
         AgentSpan span, LinkedHashMap<String, String> sortedTags, long defaultTimestamp) {}
 
     @Override
+    public PathwayContext newPathwayContext() {
+      return NoopPathwayContext.INSTANCE;
+    }
+
+    @Override
+    public void add(StatsPoint statsPoint) {}
+
+    @Override
     public void setConsumeCheckpoint(
         String type, String source, DataStreamsContextCarrier carrier) {}
 


### PR DESCRIPTION
# What Does This Do

Revised #5982 to include only the NoOp context carrier, and move interface methods to make them accessible from instrumentation. The consume method did not work as expected

# Motivation

# Additional Notes

<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->
