### PR TITLE
Introduce symbol extraction for debugger

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -4,6 +4,7 @@ import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.Sink;
+import com.datadog.debugger.symbol.SymbolExtractionTransformer;
 import com.datadog.debugger.uploader.BatchUploader;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
@@ -90,6 +91,10 @@ public class DebuggerAgent {
       }
     } else {
       log.debug("No configuration poller available from SharedCommunicationObjects");
+    }
+    if (config.getDebuggerSymbolEnabled()) {
+      instrumentation.addTransformer(
+          new SymbolExtractionTransformer(debuggerSink.getSymbolSink(), config));
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
@@ -20,6 +21,7 @@ import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.TypeInsnNode;
 
@@ -200,6 +202,43 @@ public class ASMHelper {
         return "getFieldValue";
       default:
         throw new IllegalArgumentException("Unsupported type sort:" + sort);
+    }
+  }
+
+  public static List<LocalVariableNode> sortLocalVariables(List<LocalVariableNode> localVariables) {
+    List<LocalVariableNode> sortedLocalVars = new ArrayList<>(localVariables);
+    sortedLocalVars.sort(Comparator.comparingInt(o -> o.index));
+    return sortedLocalVars;
+  }
+
+  public static LocalVariableNode[] createLocalVarNodes(List<LocalVariableNode> sortedLocalVars) {
+    int maxIndex = sortedLocalVars.get(sortedLocalVars.size() - 1).index;
+    LocalVariableNode[] localVars = new LocalVariableNode[maxIndex + 1];
+    for (LocalVariableNode localVariableNode : sortedLocalVars) {
+      localVars[localVariableNode.index] = localVariableNode;
+    }
+    return localVars;
+  }
+
+  public static void adjustLocalVarsBasedOnArgs(
+      boolean isStatic,
+      LocalVariableNode[] localVars,
+      org.objectweb.asm.Type[] argTypes,
+      List<LocalVariableNode> sortedLocalVars) {
+    // assume that first local variables matches method arguments
+    // as stated into the JVM spec:
+    // https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.1
+    // so we reassigned local var in arg slots if they are empty
+    if (argTypes.length < localVars.length) {
+      int slot = isStatic ? 0 : 1;
+      int localVarTableIdx = slot;
+      for (org.objectweb.asm.Type t : argTypes) {
+        if (localVars[slot] == null && localVarTableIdx < sortedLocalVars.size()) {
+          localVars[slot] = sortedLocalVars.get(localVarTableIdx);
+        }
+        slot += t.getSize();
+        localVarTableIdx++;
+      }
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -1,14 +1,15 @@
 package com.datadog.debugger.instrumentation;
 
+import static com.datadog.debugger.instrumentation.ASMHelper.adjustLocalVarsBasedOnArgs;
+import static com.datadog.debugger.instrumentation.ASMHelper.createLocalVarNodes;
 import static com.datadog.debugger.instrumentation.ASMHelper.ldc;
+import static com.datadog.debugger.instrumentation.ASMHelper.sortLocalVariables;
 import static com.datadog.debugger.instrumentation.Types.STRING_TYPE;
 
 import com.datadog.debugger.instrumentation.DiagnosticMessage.Kind;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Where;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -75,29 +76,10 @@ public abstract class Instrumentor {
     if (methodNode.localVariables == null || methodNode.localVariables.isEmpty()) {
       return new LocalVariableNode[0];
     }
-    List<LocalVariableNode> sortedLocalVars = new ArrayList<>(methodNode.localVariables);
-    sortedLocalVars.sort(Comparator.comparingInt(o -> o.index));
-    int maxIndex = sortedLocalVars.get(sortedLocalVars.size() - 1).index;
-    LocalVariableNode[] localVars = new LocalVariableNode[maxIndex + 1];
+    List<LocalVariableNode> sortedLocalVars = sortLocalVariables(methodNode.localVariables);
+    LocalVariableNode[] localVars = createLocalVarNodes(sortedLocalVars);
+    adjustLocalVarsBasedOnArgs(isStatic, localVars, argTypes, sortedLocalVars);
     localVarBaseOffset = sortedLocalVars.get(0).index;
-    for (LocalVariableNode localVariableNode : sortedLocalVars) {
-      localVars[localVariableNode.index] = localVariableNode;
-    }
-    // assume that first local variables matches method arguments
-    // as stated into the JVM spec:
-    // https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.6.1
-    // so we reassigned local var in arg slots if they are empty
-    if (argTypes.length < localVars.length) {
-      int slot = isStatic ? 0 : 1;
-      int localVarTableIdx = slot;
-      for (Type t : argTypes) {
-        if (localVars[slot] == null && localVarTableIdx < sortedLocalVars.size()) {
-          localVars[slot] = sortedLocalVars.get(localVarTableIdx);
-        }
-        slot += t.getSize();
-        localVarTableIdx++;
-      }
-    }
     return localVars;
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -171,6 +171,7 @@ public class DebuggerSink implements Sink {
 
   // visible for testing
   void flush(DebuggerSink ignored) {
+    symbolSink.flush();
     List<String> diagnostics = probeStatusSink.getSerializedDiagnostics();
     List<String> snapshots = snapshotSink.getSerializedSnapshots();
     if (snapshots.size() + diagnostics.size() == 0) {
@@ -182,7 +183,6 @@ public class DebuggerSink implements Sink {
     if (diagnostics.size() > 0) {
       uploadPayloads(diagnostics);
     }
-    symbolSink.flush();
   }
 
   private void uploadPayloads(List<String> payloads) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -30,6 +30,7 @@ public class DebuggerSink implements Sink {
 
   private final ProbeStatusSink probeStatusSink;
   private final SnapshotSink snapshotSink;
+  private final SymbolSink symbolSink;
   private final DebuggerMetrics debuggerMetrics;
   private final BatchUploader batchUploader;
   private final String tags;
@@ -42,10 +43,11 @@ public class DebuggerSink implements Sink {
   public DebuggerSink(Config config) {
     this(
         config,
-        new BatchUploader(config),
+        new BatchUploader(config, config.getFinalDebuggerSnapshotUrl()),
         DebuggerMetrics.getInstance(config),
         new ProbeStatusSink(config),
-        new SnapshotSink(config));
+        new SnapshotSink(config),
+        new SymbolSink(config));
   }
 
   DebuggerSink(Config config, BatchUploader batchUploader) {
@@ -54,16 +56,18 @@ public class DebuggerSink implements Sink {
         batchUploader,
         DebuggerMetrics.getInstance(config),
         new ProbeStatusSink(config),
-        new SnapshotSink(config));
+        new SnapshotSink(config),
+        new SymbolSink(config));
   }
 
   public DebuggerSink(Config config, ProbeStatusSink probeStatusSink) {
     this(
         config,
-        new BatchUploader(config),
+        new BatchUploader(config, config.getFinalDebuggerSnapshotUrl()),
         DebuggerMetrics.getInstance(config),
         probeStatusSink,
-        new SnapshotSink(config));
+        new SnapshotSink(config),
+        new SymbolSink(config));
   }
 
   DebuggerSink(Config config, BatchUploader batchUploader, DebuggerMetrics debuggerMetrics) {
@@ -72,7 +76,8 @@ public class DebuggerSink implements Sink {
         batchUploader,
         debuggerMetrics,
         new ProbeStatusSink(config),
-        new SnapshotSink(config));
+        new SnapshotSink(config),
+        new SymbolSink(config));
   }
 
   public DebuggerSink(
@@ -80,12 +85,14 @@ public class DebuggerSink implements Sink {
       BatchUploader batchUploader,
       DebuggerMetrics debuggerMetrics,
       ProbeStatusSink probeStatusSink,
-      SnapshotSink snapshotSink) {
+      SnapshotSink snapshotSink,
+      SymbolSink symbolSink) {
     this.batchUploader = batchUploader;
     tags = getDefaultTagsMergedWithGlobalTags(config);
     this.debuggerMetrics = debuggerMetrics;
     this.probeStatusSink = probeStatusSink;
     this.snapshotSink = snapshotSink;
+    this.symbolSink = symbolSink;
     this.uploadFlushInterval = config.getDebuggerUploadFlushInterval();
   }
 
@@ -136,6 +143,10 @@ public class DebuggerSink implements Sink {
     return batchUploader;
   }
 
+  public SymbolSink getSymbolSink() {
+    return symbolSink;
+  }
+
   @Override
   public void addSnapshot(Snapshot snapshot) {
     boolean added = snapshotSink.offer(snapshot);
@@ -165,12 +176,13 @@ public class DebuggerSink implements Sink {
     if (snapshots.size() + diagnostics.size() == 0) {
       return;
     }
-    if (snapshots.size() >= 1) {
+    if (snapshots.size() > 0) {
       uploadPayloads(snapshots);
     }
-    if (diagnostics.size() >= 1) {
+    if (diagnostics.size() > 0) {
       uploadPayloads(diagnostics);
     }
+    symbolSink.flush();
   }
 
   private void uploadPayloads(List<String> payloads) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -36,8 +36,6 @@ public class SymbolSink {
   private final BatchUploader symbolUploader;
   private final BlockingQueue<ServiceVersion> scopes = new ArrayBlockingQueue<>(CAPACITY);
   private final BatchUploader.MultiPartContent event;
-  private long totalSize;
-  private long totalClasses;
 
   public SymbolSink(Config config) {
     this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl()));
@@ -71,8 +69,6 @@ public class SymbolSink {
             "Sending scope: {}, size={}",
             serviceVersion.getScopes().get(0).getName(),
             json.length());
-        // totalSize += json.length();
-        // totalClasses += serviceVersion.getScopes().get(0).getScopes().size();
         symbolUploader.uploadAsMultipart(
             "",
             event,
@@ -82,6 +78,5 @@ public class SymbolSink {
         ExceptionHelper.logException(LOGGER, e, "Error during scope serialization:");
       }
     }
-    LOGGER.debug("Total uploaded size={} classes={}", totalSize, totalClasses);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -1,0 +1,87 @@
+package com.datadog.debugger.sink;
+
+import com.datadog.debugger.symbol.Scope;
+import com.datadog.debugger.symbol.ServiceVersion;
+import com.datadog.debugger.uploader.BatchUploader;
+import com.datadog.debugger.util.ExceptionHelper;
+import com.datadog.debugger.util.MoshiHelper;
+import com.squareup.moshi.JsonAdapter;
+import datadog.trace.api.Config;
+import datadog.trace.util.TagsHelper;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SymbolSink {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SymbolSink.class);
+  private static final int CAPACITY = 1024;
+  private static final JsonAdapter<ServiceVersion> SERVICE_VERSION_ADAPTER =
+      MoshiHelper.createMoshiSymbol().adapter(ServiceVersion.class);
+  private static final String EVENT_FORMAT =
+      "{%n"
+          + "\"ddsource\": \"dd_debugger\",%n"
+          + "\"service\": \"%s\",%n"
+          + "\"runtimeId\": \"%s\"%n"
+          + "}";
+
+  private final String serviceName;
+  private final String env;
+  private final String version;
+  private final BatchUploader symbolUploader;
+  private final BlockingQueue<ServiceVersion> scopes = new ArrayBlockingQueue<>(CAPACITY);
+  private final BatchUploader.MultiPartContent event;
+  private long totalSize;
+  private long totalClasses;
+
+  public SymbolSink(Config config) {
+    this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl()));
+  }
+
+  SymbolSink(Config config, BatchUploader symbolUploader) {
+    this.serviceName = TagsHelper.sanitize(config.getServiceName());
+    this.env = config.getEnv();
+    this.version = config.getVersion();
+    this.symbolUploader = symbolUploader;
+    byte[] eventContent =
+        String.format(EVENT_FORMAT, serviceName, config.getRuntimeId())
+            .getBytes(StandardCharsets.UTF_8);
+    this.event = new BatchUploader.MultiPartContent(eventContent, "event", "event.json");
+  }
+
+  public boolean addScope(Scope jarScope) {
+    ServiceVersion serviceVersion =
+        new ServiceVersion(serviceName, env, version, "JAVA", Collections.singletonList(jarScope));
+    return scopes.offer(serviceVersion);
+  }
+
+  public void flush() {
+    List<ServiceVersion> scopesToSerialize = new ArrayList<>();
+    scopes.drainTo(scopesToSerialize);
+    LOGGER.debug("Sending {} scopes", scopesToSerialize.size());
+    for (ServiceVersion serviceVersion : scopesToSerialize) {
+      try {
+        String json = SERVICE_VERSION_ADAPTER.toJson(serviceVersion);
+        LOGGER.debug(
+            "Sending scope: {}, size={}",
+            serviceVersion.getScopes().get(0).getName(),
+            json.length());
+        // totalSize += json.length();
+        // totalClasses += serviceVersion.getScopes().get(0).getScopes().size();
+        symbolUploader.uploadAsMultipart(
+            "",
+            event,
+            new BatchUploader.MultiPartContent(
+                json.getBytes(StandardCharsets.UTF_8), "file", "file.json"));
+      } catch (Exception e) {
+        ExceptionHelper.logException(LOGGER, e, "Error during scope serialization:");
+      }
+    }
+    LOGGER.debug("Total uploaded size={} classes={}", totalSize, totalClasses);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -59,6 +59,9 @@ public class SymbolSink {
   }
 
   public void flush() {
+    if (scopes.isEmpty()) {
+      return;
+    }
     List<ServiceVersion> scopesToSerialize = new ArrayList<>();
     scopes.drainTo(scopesToSerialize);
     LOGGER.debug("Sending {} scopes", scopesToSerialize.size());

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/Scope.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/Scope.java
@@ -1,0 +1,149 @@
+package com.datadog.debugger.symbol;
+
+import com.squareup.moshi.Json;
+import java.util.List;
+
+public class Scope {
+  @Json(name = "scope_type")
+  private final ScopeType scopeType;
+
+  @Json(name = "source_file")
+  private final String sourceFile;
+
+  @Json(name = "start_line")
+  private final int startLine;
+
+  @Json(name = "end_line")
+  private final int endLine;
+
+  private final String name;
+
+  @Json(name = "language_specifics")
+  private final List<Object> languageSpecifics;
+
+  private final List<Symbol> symbols;
+  private final List<Scope> scopes;
+
+  public Scope(
+      ScopeType scopeType,
+      String sourceFile,
+      int startLine,
+      int endLine,
+      String name,
+      List<Object> languageSpecifics,
+      List<Symbol> symbols,
+      List<Scope> scopes) {
+    this.scopeType = scopeType;
+    this.sourceFile = sourceFile;
+    this.startLine = startLine;
+    this.endLine = endLine;
+    this.name = name;
+    this.languageSpecifics = languageSpecifics;
+    this.symbols = symbols;
+    this.scopes = scopes;
+  }
+
+  public ScopeType getScopeType() {
+    return scopeType;
+  }
+
+  public String getSourceFile() {
+    return sourceFile;
+  }
+
+  public int getStartLine() {
+    return startLine;
+  }
+
+  public int getEndLine() {
+    return endLine;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<Object> getLanguageSpecifics() {
+    return languageSpecifics;
+  }
+
+  public List<Symbol> getSymbols() {
+    return symbols;
+  }
+
+  public List<Scope> getScopes() {
+    return scopes;
+  }
+
+  @Override
+  public String toString() {
+    return "Scope{"
+        + "scopeType="
+        + scopeType
+        + ", sourceFile='"
+        + sourceFile
+        + '\''
+        + ", startLine="
+        + startLine
+        + ", endLine="
+        + endLine
+        + ", name='"
+        + name
+        + '\''
+        + ", languageSpecifics="
+        + languageSpecifics
+        + ", symbols="
+        + symbols
+        + ", scopes="
+        + scopes
+        + '}';
+  }
+
+  public static Builder builder(
+      ScopeType scopeType, String sourceFile, int startLine, int endLine) {
+    return new Builder(scopeType, sourceFile, startLine, endLine);
+  }
+
+  public static class Builder {
+    private final ScopeType scopeType;
+    private final String sourceFile;
+    private final int startLine;
+    private final int endLine;
+    private String name;
+    private List<Object> languageSpecifics;
+    private List<Symbol> symbols;
+    private List<Scope> scopes;
+
+    public Builder(ScopeType scopeType, String sourceFile, int startLine, int endLine) {
+      this.scopeType = scopeType;
+      this.sourceFile = sourceFile;
+      this.startLine = startLine;
+      this.endLine = endLine;
+    }
+
+    public Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder languageSpecifics(List<Object> languageSpecifics) {
+      this.languageSpecifics = languageSpecifics;
+      return this;
+    }
+
+    public Builder symbols(List<Symbol> symbols) {
+      this.symbols = symbols;
+      return this;
+    }
+
+    public Builder scopes(List<Scope> scopes) {
+      this.scopes = scopes;
+      return this;
+    }
+
+    public Scope build() {
+      return new Scope(
+          scopeType, sourceFile, startLine, endLine, name, languageSpecifics, symbols, scopes);
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/ScopeType.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/ScopeType.java
@@ -1,0 +1,9 @@
+package com.datadog.debugger.symbol;
+
+public enum ScopeType {
+  JAR,
+  CLASS,
+  METHOD,
+  LOCAL,
+  CLOSURE
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/ServiceVersion.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/ServiceVersion.java
@@ -1,0 +1,25 @@
+package com.datadog.debugger.symbol;
+
+import java.util.List;
+
+public class ServiceVersion {
+  private final String service;
+
+  private final String env;
+  private final String version;
+  private final String language;
+  private final List<Scope> scopes;
+
+  public ServiceVersion(
+      String service, String env, String version, String language, List<Scope> scopes) {
+    this.service = service;
+    this.env = env;
+    this.version = version;
+    this.language = language;
+    this.scopes = scopes;
+  }
+
+  public List<Scope> getScopes() {
+    return scopes;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/Symbol.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/Symbol.java
@@ -1,0 +1,51 @@
+package com.datadog.debugger.symbol;
+
+import com.squareup.moshi.Json;
+
+public class Symbol {
+  @Json(name = "symbol_type")
+  private final SymbolType symbolType;
+
+  private final String name;
+  private final int line;
+  private final String type;
+
+  public Symbol(SymbolType symbolType, String name, int line, String type) {
+    this.symbolType = symbolType;
+    this.name = name;
+    this.line = line;
+    this.type = type;
+  }
+
+  public SymbolType getSymbolType() {
+    return symbolType;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getLine() {
+    return line;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public String toString() {
+    return "Symbol{"
+        + "symbolType="
+        + symbolType
+        + ", name='"
+        + name
+        + '\''
+        + ", line="
+        + line
+        + ", type='"
+        + type
+        + '\''
+        + '}';
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractionTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractionTransformer.java
@@ -1,0 +1,144 @@
+package com.datadog.debugger.symbol;
+
+import com.datadog.debugger.agent.AllowListHelper;
+import com.datadog.debugger.agent.Configuration;
+import com.datadog.debugger.sink.SymbolSink;
+import datadog.trace.api.Config;
+import datadog.trace.util.AgentTaskScheduler;
+import datadog.trace.util.Strings;
+import java.lang.instrument.ClassFileTransformer;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SymbolExtractionTransformer implements ClassFileTransformer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SymbolExtractionTransformer.class);
+  private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+
+  private final SymbolSink sink;
+  private final Map<String, Scope> jarScopesByName = new HashMap<>();
+  private final AgentTaskScheduler.Scheduled<SymbolExtractionTransformer> scheduled;
+  private final Object jarScopeLock = new Object();
+  private final AllowListHelper allowListHelper;
+
+  public SymbolExtractionTransformer() {
+    this(new SymbolSink(Config.get()), Config.get());
+  }
+
+  public SymbolExtractionTransformer(SymbolSink sink, Config config) {
+    this.sink = sink;
+    this.scheduled =
+        AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
+            this::flushScopes, this, 5, 5, TimeUnit.SECONDS);
+    String includes = config.getDebuggerSymbolIncludes();
+    if (includes != null) {
+      this.allowListHelper = new AllowListHelper(buildFilterList(includes));
+    } else {
+      this.allowListHelper = null;
+    }
+  }
+
+  private Configuration.FilterList buildFilterList(String includes) {
+    String[] includeParts = COMMA_PATTERN.split(includes);
+    return new Configuration.FilterList(Arrays.asList(includeParts), Collections.emptyList());
+  }
+
+  void flushScopes(SymbolExtractionTransformer symbolExtractionTransformer) {
+    if (jarScopesByName.isEmpty()) {
+      return;
+    }
+    List<Scope> scopes;
+    synchronized (jarScopeLock) {
+      scopes = new ArrayList<>(jarScopesByName.values());
+      jarScopesByName.clear();
+    }
+    LOGGER.debug("dumping {} jar scopes to sink", scopes.size());
+    for (Scope scope : scopes) {
+      LOGGER.debug(
+          "dumping {} class scopes to sink from scope: {}",
+          scope.getScopes().size(),
+          scope.getName());
+      sink.addScope(scope);
+    }
+  }
+
+  @Override
+  public byte[] transform(
+      ClassLoader loader,
+      String className,
+      Class<?> classBeingRedefined,
+      ProtectionDomain protectionDomain,
+      byte[] classfileBuffer) {
+    if (className == null) {
+      return null;
+    }
+    if (allowListHelper == null) {
+      if (className.startsWith("java/")
+          || className.startsWith("javax/")
+          || className.startsWith("jdk/")
+          || className.startsWith("sun/")
+          || className.startsWith("com/sun/")
+          || className.startsWith("datadog/")
+          || className.startsWith("com/datadog/")) {
+        return null;
+      }
+    } else {
+      if (!allowListHelper.isAllowed(Strings.getClassName(className))) {
+        return null;
+      }
+    }
+    String jarName = "DEFAULT";
+    if (protectionDomain != null) {
+      CodeSource codeSource = protectionDomain.getCodeSource();
+      if (codeSource != null) {
+        URL location = codeSource.getLocation();
+        if (location != null) {
+          jarName = location.getFile();
+        }
+      }
+    }
+    LOGGER.debug("Extracting Symbols from: {}, located in: {}", className, jarName);
+    Scope jarScope = SymbolExtractor.extract(classfileBuffer, jarName);
+    synchronized (jarScopeLock) {
+      Scope scope = jarScopesByName.get(jarScope.getName());
+      if (scope != null) {
+        scope.getScopes().addAll(jarScope.getScopes());
+      } else {
+        jarScopesByName.put(jarScope.getName(), jarScope);
+      }
+    }
+    return null;
+  }
+  /*
+   private void dumpOriginalClassFile(String className, byte[] classfileBuffer) {
+     Path classFilePath = dumpClassFile(className + "_orig", classfileBuffer);
+     if (classFilePath != null) {
+       LOGGER.debug("Original class saved as: {}", classFilePath.toString());
+     }
+   }
+
+   private static Path dumpClassFile(String className, byte[] classfileBuffer) {
+     try {
+       Path classFilePath = Paths.get("/tmp/debugger/" + className + ".class");
+       Files.createDirectories(classFilePath.getParent());
+       Files.write(classFilePath, classfileBuffer, StandardOpenOption.CREATE);
+       return classFilePath;
+     } catch (IOException e) {
+       LOGGER.error("", e);
+       return null;
+     }
+   }
+
+  */
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractionTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractionTransformer.java
@@ -120,25 +120,4 @@ public class SymbolExtractionTransformer implements ClassFileTransformer {
     }
     return null;
   }
-  /*
-   private void dumpOriginalClassFile(String className, byte[] classfileBuffer) {
-     Path classFilePath = dumpClassFile(className + "_orig", classfileBuffer);
-     if (classFilePath != null) {
-       LOGGER.debug("Original class saved as: {}", classFilePath.toString());
-     }
-   }
-
-   private static Path dumpClassFile(String className, byte[] classfileBuffer) {
-     try {
-       Path classFilePath = Paths.get("/tmp/debugger/" + className + ".class");
-       Files.createDirectories(classFilePath.getParent());
-       Files.write(classFilePath, classfileBuffer, StandardOpenOption.CREATE);
-       return classFilePath;
-     } catch (IOException e) {
-       LOGGER.error("", e);
-       return null;
-     }
-   }
-
-  */
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
@@ -1,0 +1,200 @@
+package com.datadog.debugger.symbol;
+
+import static com.datadog.debugger.instrumentation.ASMHelper.adjustLocalVarsBasedOnArgs;
+import static com.datadog.debugger.instrumentation.ASMHelper.createLocalVarNodes;
+import static com.datadog.debugger.instrumentation.ASMHelper.sortLocalVariables;
+
+import com.datadog.debugger.instrumentation.ASMHelper;
+import datadog.trace.util.Strings;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.LocalVariableNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.slf4j.LoggerFactory;
+
+public class SymbolExtractor {
+
+  public static Scope extract(byte[] classFileBuffer, String jarName) {
+    ClassNode classNode = parseClassFile(classFileBuffer);
+    return extractScopes(classNode, jarName);
+  }
+
+  private static Scope extractScopes(ClassNode classNode, String jarName) {
+    try {
+      List<Scope> methodScopes = new ArrayList<>();
+      for (MethodNode method : classNode.methods) {
+        MethodLineInfo methodLineInfo = extractMethodLineInfo(method);
+        List<Scope> varScopes = new ArrayList<>();
+        List<Symbol> methodSymbols = new ArrayList<>();
+        int localVarBaseSlot = extractArgs(method, methodSymbols, methodLineInfo.start);
+        extractScopesFromVariables(
+            classNode.sourceFile, method, methodLineInfo.lineMap, varScopes, localVarBaseSlot);
+        Scope methodScope =
+            Scope.builder(
+                    ScopeType.METHOD,
+                    classNode.sourceFile,
+                    methodLineInfo.start,
+                    methodLineInfo.end)
+                .name(method.name)
+                .scopes(varScopes)
+                .symbols(methodSymbols)
+                .build();
+        methodScopes.add(methodScope);
+      }
+      int classStartLine = Integer.MAX_VALUE;
+      int classEndLine = 0;
+      for (Scope scope : methodScopes) {
+        classStartLine = Math.min(classStartLine, scope.getStartLine());
+        classEndLine = Math.max(classEndLine, scope.getEndLine());
+      }
+      List<Symbol> fields = new ArrayList<>();
+      for (FieldNode fieldNode : classNode.fields) {
+        SymbolType symbolType =
+            ASMHelper.isStaticField(fieldNode) ? SymbolType.STATIC_FIELD : SymbolType.FIELD;
+        fields.add(
+            new Symbol(symbolType, fieldNode.name, 0, Type.getType(fieldNode.desc).getClassName()));
+      }
+      Scope classScope =
+          Scope.builder(ScopeType.CLASS, classNode.sourceFile, classStartLine, classEndLine)
+              .name(Strings.getClassName(classNode.name))
+              .scopes(methodScopes)
+              .symbols(fields)
+              .build();
+      return Scope.builder(ScopeType.JAR, jarName, 0, 0)
+          .name(jarName)
+          .scopes(new ArrayList<>(Collections.singletonList(classScope)))
+          .build();
+    } catch (Exception ex) {
+      LoggerFactory.getLogger(SymbolExtractor.class).info("", ex);
+      return null;
+    }
+  }
+
+  private static int extractArgs(
+      MethodNode method, List<Symbol> methodSymbols, int methodStartLine) {
+    boolean isStatic = (method.access & Opcodes.ACC_STATIC) != 0;
+    int slot = isStatic ? 0 : 1;
+    if (method.localVariables == null || method.localVariables.size() == 0) {
+      return slot;
+    }
+    Type[] argTypes = Type.getArgumentTypes(method.desc);
+    if (argTypes.length == 0) {
+      return slot;
+    }
+    List<LocalVariableNode> sortedLocalVars = sortLocalVariables(method.localVariables);
+    LocalVariableNode[] localVarsBySlot = createLocalVarNodes(sortedLocalVars);
+    adjustLocalVarsBasedOnArgs(isStatic, localVarsBySlot, argTypes, sortedLocalVars);
+    for (Type argType : argTypes) {
+      if (slot >= localVarsBySlot.length) {
+        break;
+      }
+      String argName = localVarsBySlot[slot] != null ? localVarsBySlot[slot].name : "p" + slot;
+      methodSymbols.add(
+          new Symbol(SymbolType.ARG, argName, methodStartLine, argType.getClassName()));
+      slot += argType.getSize();
+    }
+    return slot;
+  }
+
+  private static void extractScopesFromVariables(
+      String sourceFile,
+      MethodNode methodNode,
+      Map<Label, Integer> monotonicLineMap,
+      List<Scope> varScopes,
+      int locaVarBaseSlot) {
+    if (methodNode.localVariables == null) {
+      return;
+    }
+    // using a LinkedHashMap only for having a stable order of local scopes (tests)
+    Map<LabelNode, List<LocalVariableNode>> varsByEndLabel = new LinkedHashMap<>();
+    for (int i = locaVarBaseSlot; i < methodNode.localVariables.size(); i++) {
+      LocalVariableNode localVariable = methodNode.localVariables.get(i);
+      varsByEndLabel.merge(
+          localVariable.end,
+          new ArrayList<>(Collections.singletonList(localVariable)),
+          (curr, next) -> {
+            curr.addAll(next);
+            return curr;
+          });
+    }
+    for (Map.Entry<LabelNode, List<LocalVariableNode>> entry : varsByEndLabel.entrySet()) {
+      List<Symbol> varSymbols = new ArrayList<>();
+      int minLine = Integer.MAX_VALUE;
+      for (LocalVariableNode var : entry.getValue()) {
+        int line = monotonicLineMap.get(var.start.getLabel());
+        minLine = Math.min(line, minLine);
+        varSymbols.add(
+            new Symbol(SymbolType.LOCAL, var.name, line, Type.getType(var.desc).getClassName()));
+      }
+      int endLine = monotonicLineMap.get(entry.getKey().getLabel());
+      Scope varScope =
+          Scope.builder(ScopeType.LOCAL, sourceFile, minLine, endLine).symbols(varSymbols).build();
+      varScopes.add(varScope);
+    }
+  }
+
+  private static int getFirstLine(MethodNode methodNode) {
+    AbstractInsnNode node = methodNode.instructions.getFirst();
+    while (node != null) {
+      if (node.getType() == AbstractInsnNode.LINE) {
+        LineNumberNode lineNumberNode = (LineNumberNode) node;
+        return lineNumberNode.line;
+      }
+      node = node.getNext();
+    }
+    return 0;
+  }
+
+  private static MethodLineInfo extractMethodLineInfo(MethodNode methodNode) {
+    Map<Label, Integer> map = new HashMap<>();
+    int startLine = getFirstLine(methodNode);
+    int maxLine = startLine;
+    AbstractInsnNode node = methodNode.instructions.getFirst();
+    while (node != null) {
+      if (node.getType() == AbstractInsnNode.LINE) {
+        LineNumberNode lineNumberNode = (LineNumberNode) node;
+        maxLine = Math.max(lineNumberNode.line, maxLine);
+      }
+      if (node.getType() == AbstractInsnNode.LABEL) {
+        if (node instanceof LabelNode) {
+          LabelNode labelNode = (LabelNode) node;
+          map.put(labelNode.getLabel(), maxLine);
+        }
+      }
+      node = node.getNext();
+    }
+    return new MethodLineInfo(startLine, maxLine, map);
+  }
+
+  private static ClassNode parseClassFile(byte[] classfileBuffer) {
+    ClassReader reader = new ClassReader(classfileBuffer);
+    ClassNode classNode = new ClassNode();
+    reader.accept(classNode, ClassReader.SKIP_FRAMES);
+    return classNode;
+  }
+
+  public static class MethodLineInfo {
+    final int start;
+    final int end;
+    final Map<Label, Integer> lineMap;
+
+    public MethodLineInfo(int start, int end, Map<Label, Integer> lineMap) {
+      this.start = start;
+      this.end = end;
+      this.lineMap = lineMap;
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolType.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolType.java
@@ -1,0 +1,8 @@
+package com.datadog.debugger.symbol;
+
+public enum SymbolType {
+  FIELD,
+  STATIC_FIELD,
+  ARG,
+  LOCAL
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -18,10 +18,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import okhttp3.Call;
 import okhttp3.Callback;
-import okhttp3.ConnectionPool;
 import okhttp3.Dispatcher;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
+import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -32,6 +32,30 @@ import org.slf4j.LoggerFactory;
 
 /** Handles batching logic of upload requests sent to the intake */
 public class BatchUploader {
+  public static class MultiPartContent {
+    private final byte[] content;
+    private final String partName;
+    private final String fileName;
+
+    public MultiPartContent(byte[] content, String partName, String fileName) {
+      this.content = content;
+      this.partName = partName;
+      this.fileName = fileName;
+    }
+
+    public byte[] getContent() {
+      return content;
+    }
+
+    public String getPartName() {
+      return partName;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+  }
+
   private static final Logger log = LoggerFactory.getLogger(BatchUploader.class);
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
   private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
@@ -54,23 +78,23 @@ public class BatchUploader {
 
   private final Phaser inflightRequests = new Phaser(1);
 
-  public BatchUploader(Config config) {
-    this(config, new RatelimitedLogger(log, MINUTES_BETWEEN_ERROR_LOG, TimeUnit.MINUTES));
+  public BatchUploader(Config config, String endpoint) {
+    this(config, endpoint, new RatelimitedLogger(log, MINUTES_BETWEEN_ERROR_LOG, TimeUnit.MINUTES));
   }
 
-  BatchUploader(Config config, RatelimitedLogger ratelimitedLogger) {
-    this(config, ratelimitedLogger, ContainerInfo.get().containerId);
+  BatchUploader(Config config, String endpoint, RatelimitedLogger ratelimitedLogger) {
+    this(config, endpoint, ratelimitedLogger, ContainerInfo.get().containerId);
   }
 
   // Visible for testing
-  BatchUploader(Config config, RatelimitedLogger ratelimitedLogger, String containerId) {
+  BatchUploader(
+      Config config, String endpoint, RatelimitedLogger ratelimitedLogger, String containerId) {
     instrumentTheWorld = config.isDebuggerInstrumentTheWorld();
-    String url = config.getFinalDebuggerSnapshotUrl();
-    if (url == null || url.length() == 0) {
-      throw new IllegalArgumentException("Snapshot url is empty");
+    if (endpoint == null || endpoint.length() == 0) {
+      throw new IllegalArgumentException("Endpoint url is empty");
     }
-    urlBase = HttpUrl.get(url);
-    log.debug("Started SnapshotUploader with target url {}", urlBase);
+    urlBase = HttpUrl.get(endpoint);
+    log.debug("Started BatchUploader with target url {}", urlBase);
     apiKey = config.getApiKey();
     this.ratelimitedLogger = ratelimitedLogger;
     responseCallback = new ResponseCallback(ratelimitedLogger, inflightRequests);
@@ -84,10 +108,6 @@ public class BatchUploader {
             new SynchronousQueue<>(),
             new AgentThreadFactory(DEBUGGER_HTTP_DISPATCHER));
     this.containerId = containerId;
-    // Reusing connections causes non daemon threads to be created which causes agent to prevent app
-    // from exiting. See https://github.com/square/okhttp/issues/4029 for some details.
-    ConnectionPool connectionPool = new ConnectionPool(MAX_RUNNING_REQUESTS, 1, TimeUnit.SECONDS);
-
     Duration requestTimeout = Duration.ofSeconds(config.getDebuggerUploadTimeout());
     client =
         OkHttpUtils.buildHttpClient(
@@ -110,21 +130,41 @@ public class BatchUploader {
   }
 
   public void upload(byte[] batch, String tags) {
+    doUpload(() -> makeUploadRequest(batch, tags));
+  }
+
+  public void uploadAsMultipart(String tags, MultiPartContent... parts) {
+    doUpload(() -> makeMultipartUploadRequest(tags, parts));
+  }
+
+  private void makeMultipartUploadRequest(String tags, MultiPartContent[] parts) {
+    int contentLength = 0;
+    MultipartBody.Builder builder = new MultipartBody.Builder().setType(MultipartBody.FORM);
+    for (MultiPartContent part : parts) {
+      RequestBody fileBody = RequestBody.create(APPLICATION_JSON, part.content);
+      contentLength += part.content.length;
+      builder.addFormDataPart(part.partName, part.fileName, fileBody);
+    }
+    MultipartBody body = builder.build();
+    buildAndSendRequest(body, contentLength, tags);
+  }
+
+  private void doUpload(Runnable makeRequest) {
     if (instrumentTheWorld) {
       // no upload in Instrument-The-World mode
       return;
     }
     try {
       if (canEnqueueMoreRequests()) {
-        makeUploadRequest(batch, tags);
+        makeRequest.run();
         debuggerMetrics.count("batch.uploaded", 1);
       } else {
         debuggerMetrics.count("request.queue.full", 1);
         ratelimitedLogger.warn("Cannot upload batch data: too many enqueued requests!");
       }
-    } catch (final IllegalStateException | IOException e) {
+    } catch (Exception ex) {
       debuggerMetrics.count("batch.upload.error", 1);
-      ratelimitedLogger.warn("Problem uploading batch!", e);
+      ratelimitedLogger.warn("Problem uploading batch!", ex);
     }
   }
 
@@ -136,11 +176,15 @@ public class BatchUploader {
     return client;
   }
 
-  private void makeUploadRequest(byte[] json, String tags) throws IOException {
+  private void makeUploadRequest(byte[] json, String tags) {
+    int contentLength = json.length;
     // use RequestBody.create(MediaType, byte[]) to avoid changing Content-Type to
     // "Content-Type: application/json; charset=UTF-8" which is not recognized
-    int contentLength = json.length;
     RequestBody body = RequestBody.create(APPLICATION_JSON, json);
+    buildAndSendRequest(body, contentLength, tags);
+  }
+
+  private void buildAndSendRequest(RequestBody body, int contentLength, String tags) {
     debuggerMetrics.histogram("batch.uploader.request.size", contentLength);
     if (log.isDebugEnabled()) {
       log.debug("Uploading batch data size={} bytes", contentLength);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiHelper.java
@@ -46,4 +46,8 @@ public class MoshiHelper {
     ParameterizedType type = Types.newParameterizedType(Map.class, String.class, Object.class);
     return new Moshi.Builder().build().adapter(type);
   }
+
+  public static Moshi createMoshiSymbol() {
+    return new Moshi.Builder().build();
+  }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -117,7 +117,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "foobar", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(2, result);
+    assertEquals(2, result);
     verify(probeStatusSink)
         .addError(eq(PROBE_ID), eq("Cannot find method CapturedSnapshot01::foobar"));
   }
@@ -129,15 +129,15 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
+    assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    Assertions.assertNotNull(snapshot.getCaptures().getEntry());
-    Assertions.assertNotNull(snapshot.getCaptures().getReturn());
+    assertNotNull(snapshot.getCaptures().getEntry());
+    assertNotNull(snapshot.getCaptures().getReturn());
     assertCaptureArgs(snapshot.getCaptures().getEntry(), "arg", "java.lang.String", "1");
     assertCaptureArgs(snapshot.getCaptures().getReturn(), "arg", "java.lang.String", "1");
     assertTrue(snapshot.getDuration() > 0);
     assertTrue(snapshot.getStack().size() > 0);
-    Assertions.assertEquals("CapturedSnapshot01.main", snapshot.getStack().get(0).getFunction());
+    assertEquals("CapturedSnapshot01.main", snapshot.getStack().get(0).getFunction());
   }
 
   @Test
@@ -147,7 +147,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)", "8");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
+    assertEquals(3, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertNull(snapshot.getCaptures().getEntry());
     assertNull(snapshot.getCaptures().getReturn());
@@ -155,7 +155,7 @@ public class CapturedSnapshotTest {
     assertCaptureArgs(snapshot.getCaptures().getLines().get(8), "arg", "java.lang.String", "1");
     assertCaptureLocals(snapshot.getCaptures().getLines().get(8), "var1", "int", "1");
     assertTrue(snapshot.getStack().size() > 0);
-    Assertions.assertEquals("CapturedSnapshot01.java", snapshot.getStack().get(0).getFileName());
+    assertEquals("CapturedSnapshot01.java", snapshot.getStack().get(0).getFileName());
   }
 
   @Test
@@ -167,8 +167,8 @@ public class CapturedSnapshotTest {
     DebuggerContext.init((id, clazz) -> null, null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertEquals(0, listener.snapshots.size());
+    assertEquals(3, result);
+    assertEquals(0, listener.snapshots.size());
   }
 
   @Test
@@ -186,8 +186,8 @@ public class CapturedSnapshotTest {
         null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertEquals(0, listener.snapshots.size());
+    assertEquals(3, result);
+    assertEquals(0, listener.snapshots.size());
   }
 
   @Test
@@ -197,7 +197,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "(String, Object)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     assertOneSnapshot(listener);
   }
 
@@ -208,7 +208,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "()");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     assertOneSnapshot(listener);
   }
 
@@ -218,7 +218,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installSingleProbe(CLASS_NAME, "<init>", "()");
     Class<?> testClass = Class.forName(CLASS_NAME);
-    Assertions.assertNotNull(testClass);
+    assertNotNull(testClass);
     testClass.newInstance();
     assertOneSnapshot(listener);
   }
@@ -229,7 +229,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installSingleProbe(CLASS_NAME, "main", null);
     Class<?> testClass = Class.forName(CLASS_NAME);
-    Assertions.assertNotNull(testClass);
+    assertNotNull(testClass);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(45, result);
     assertEquals(0, listener.snapshots.size());
@@ -242,7 +242,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "(Throwable)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "init").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     assertOneSnapshot(listener);
   }
 
@@ -253,7 +253,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "(int)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
   }
 
@@ -264,7 +264,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "(int, int, int)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
   }
 
@@ -275,14 +275,14 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME + "$Inherited", "<init>", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureFields(
         snapshot.getCaptures().getEntry(), "obj2", "java.lang.Object", (String) null);
     CapturedContext.CapturedValue obj2 = snapshot.getCaptures().getReturn().getFields().get("obj2");
     Map<String, CapturedContext.CapturedValue> fields = getFields(obj2);
-    Assertions.assertEquals(24, fields.get("intValue").getValue());
-    Assertions.assertEquals(3.14, fields.get("doubleValue").getValue());
+    assertEquals(24, fields.get("intValue").getValue());
+    assertEquals(3.14, fields.get("doubleValue").getValue());
   }
 
   @Test
@@ -295,7 +295,7 @@ public class CapturedSnapshotTest {
             createProbe(PROBE_ID2, CLASS_NAME, "<init>", "(String, long, String)"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     long result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(4_000_000_001L, result);
+    assertEquals(4_000_000_001L, result);
     assertSnapshots(listener, 2, PROBE_ID2, PROBE_ID1);
   }
 
@@ -309,7 +309,7 @@ public class CapturedSnapshotTest {
             createProbe(PROBE_ID2, CLASS_NAME, "f2", "(int)"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(48, result);
+    assertEquals(48, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     Snapshot snapshot0 = snapshots.get(0);
     assertCaptureArgs(snapshot0.getCaptures().getEntry(), "value", "int", "31");
@@ -328,7 +328,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, probe, probe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(48, result);
+    assertEquals(48, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     Snapshot snapshot0 = snapshots.get(0);
     assertCaptureArgs(snapshot0.getCaptures().getEntry(), "value", "int", "31");
@@ -342,9 +342,9 @@ public class CapturedSnapshotTest {
       DebuggerTransformerTest.TestSnapshotListener listener,
       int expectedCount,
       ProbeId... probeIds) {
-    Assertions.assertEquals(expectedCount, listener.snapshots.size());
+    assertEquals(expectedCount, listener.snapshots.size());
     for (int i = 0; i < probeIds.length; i++) {
-      Assertions.assertEquals(probeIds[i].getId(), listener.snapshots.get(i).getProbe().getId());
+      assertEquals(probeIds[i].getId(), listener.snapshots.get(i).getProbe().getId());
     }
     return listener.snapshots;
   }
@@ -356,7 +356,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "f", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     assertOneSnapshot(listener);
   }
 
@@ -373,7 +373,7 @@ public class CapturedSnapshotTest {
                 PROBE_ID, CLASS_NAME, "synchronizedBlock", "(int)", LINE_START + "-" + LINE_END));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "synchronizedBlock").get();
-    Assertions.assertEquals(76, result);
+    assertEquals(76, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 10);
     int count = 31;
     for (int i = 0; i < 10; i++) {
@@ -401,7 +401,7 @@ public class CapturedSnapshotTest {
                 PROBE_ID, CLASS_NAME, "synchronizedBlock", "(int)", LINE_START + "-" + LINE_END));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "synchronizedBlock").get();
-    Assertions.assertEquals(76, result);
+    assertEquals(76, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertNull(snapshot.getCaptures().getEntry());
     assertNull(snapshot.getCaptures().getReturn());
@@ -417,7 +417,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".java", 4));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(48, result);
+    assertEquals(48, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertNull(snapshot.getCaptures().getEntry());
     assertNull(snapshot.getCaptures().getReturn());
@@ -434,7 +434,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, "CapturedSnapshot10.java", 11));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(2, result);
+    assertEquals(2, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertNull(snapshot.getCaptures().getEntry());
     assertNull(snapshot.getCaptures().getReturn());
@@ -454,7 +454,7 @@ public class CapturedSnapshotTest {
             createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", 11));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(2, result);
+    assertEquals(2, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertNull(snapshot.getCaptures().getEntry());
     assertNull(snapshot.getCaptures().getReturn());
@@ -474,7 +474,7 @@ public class CapturedSnapshotTest {
             createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", 21));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(42 * 42, result);
+    assertEquals(42 * 42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertNull(snapshot.getCaptures().getEntry());
     assertNull(snapshot.getCaptures().getReturn());
@@ -496,7 +496,7 @@ public class CapturedSnapshotTest {
             createProbe(PROBE_ID2, CLASS_NAME, "main", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(2, result);
+    assertEquals(2, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     Snapshot snapshot0 = snapshots.get(0);
     assertNull(snapshot0.getCaptures().getEntry());
@@ -504,13 +504,13 @@ public class CapturedSnapshotTest {
     Assertions.assertEquals(1, snapshot0.getCaptures().getLines().size());
     Assertions.assertEquals(
         "com.datadog.debugger.CapturedSnapshot11", snapshot0.getProbe().getLocation().getType());
-    Assertions.assertEquals("main", snapshot0.getProbe().getLocation().getMethod());
+    assertEquals("main", snapshot0.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot0.getCaptures().getLines().get(10), "arg", "java.lang.String", "2");
     assertCaptureLocals(snapshot0.getCaptures().getLines().get(10), "var1", "int", "1");
     Snapshot snapshot1 = snapshots.get(1);
-    Assertions.assertEquals(
+    assertEquals(
         "com.datadog.debugger.CapturedSnapshot11", snapshot1.getProbe().getLocation().getType());
-    Assertions.assertEquals("main", snapshot1.getProbe().getLocation().getMethod());
+    assertEquals("main", snapshot1.getProbe().getLocation().getMethod());
     assertCaptureArgs(snapshot1.getCaptures().getEntry(), "arg", "java.lang.String", "2");
     assertCaptureReturnValue(snapshot1.getCaptures().getReturn(), "int", "2");
   }
@@ -524,7 +524,7 @@ public class CapturedSnapshotTest {
     String source = getFixtureContent("/" + FILE_NAME);
     Class<?> testClass = ScalaHelper.compileAndLoad(source, CLASS_NAME, FILE_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(48, result);
+    assertEquals(48, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertNull(snapshot.getCaptures().getEntry());
     assertNull(snapshot.getCaptures().getReturn());
@@ -543,7 +543,7 @@ public class CapturedSnapshotTest {
     GroovyClassLoader groovyClassLoader = new GroovyClassLoader();
     Class<?> testClass = groovyClassLoader.parseClass(source);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(48, result);
+    assertEquals(48, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertNull(snapshot.getCaptures().getEntry());
     assertNull(snapshot.getCaptures().getReturn());
@@ -559,13 +559,13 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".kt", 4));
     URL resource = CapturedSnapshotTest.class.getResource("/" + CLASS_NAME + ".kt");
-    Assertions.assertNotNull(resource);
+    assertNotNull(resource);
     List<File> filesToDelete = new ArrayList<>();
     Class<?> testClass = KotlinHelper.compileAndLoad(CLASS_NAME, resource.getFile(), filesToDelete);
     try {
       Object companion = Reflect.on(testClass).get("Companion");
       int result = Reflect.on(companion).call("main", "").get();
-      Assertions.assertEquals(48, result);
+      assertEquals(48, result);
       Snapshot snapshot = assertOneSnapshot(listener);
       assertNull(snapshot.getCaptures().getEntry());
       assertNull(snapshot.getCaptures().getReturn());
@@ -589,7 +589,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
+    assertEquals(143, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     Snapshot simpleSnapshot = snapshots.get(0);
     Map<String, String> expectedSimpleFields = new HashMap<>();
@@ -621,7 +621,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
+    assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     CapturedContext.CapturedValue returnValue =
         snapshot.getCaptures().getReturn().getLocals().get("@return");
@@ -631,11 +631,10 @@ public class CapturedSnapshotTest {
     CapturedContext.CapturedValue s1 = fields.get("s1");
     Map<String, CapturedContext.CapturedValue> s1Fields =
         (Map<String, CapturedContext.CapturedValue>) s1.getValue();
-    Assertions.assertEquals("101", String.valueOf(s1Fields.get("intValue").getValue()));
-    Assertions.assertEquals("foo1", s1Fields.get("strValue").getValue());
-    Assertions.assertEquals("null", String.valueOf(s1Fields.get("listValue").getValue()));
-    Assertions.assertEquals(
-        DEPTH_REASON, String.valueOf(s1Fields.get("listValue").getNotCapturedReason()));
+    assertEquals("101", String.valueOf(s1Fields.get("intValue").getValue()));
+    assertEquals("foo1", s1Fields.get("strValue").getValue());
+    assertEquals("null", String.valueOf(s1Fields.get("listValue").getValue()));
+    assertEquals(DEPTH_REASON, String.valueOf(s1Fields.get("listValue").getNotCapturedReason()));
   }
 
   @Test
@@ -647,7 +646,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
+    assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, String> expectedFields = new HashMap<>();
     expectedFields.put("intValue", "42");
@@ -666,14 +665,13 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
+    assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     CapturedContext.CapturedValue simpleData =
         snapshot.getCaptures().getReturn().getLocals().get("simpleData");
     Map<String, CapturedContext.CapturedValue> fields = getFields(simpleData);
-    Assertions.assertEquals(1, fields.size());
-    Assertions.assertEquals(
-        DEPTH_REASON, fields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
+    assertEquals(1, fields.size());
+    assertEquals(DEPTH_REASON, fields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
   }
 
   @Test
@@ -685,13 +683,13 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
+    assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     CapturedContext.CapturedValue simpleData =
         snapshot.getCaptures().getReturn().getLocals().get("simpleData");
     Map<String, CapturedContext.CapturedValue> simpleDataFields = getFields(simpleData);
-    Assertions.assertEquals(1, simpleDataFields.size());
-    Assertions.assertEquals(
+    assertEquals(1, simpleDataFields.size());
+    assertEquals(
         DEPTH_REASON, simpleDataFields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
   }
 
@@ -704,15 +702,15 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
+    assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     CapturedContext.CapturedValue simpleData =
         snapshot.getCaptures().getReturn().getLocals().get("simpleData");
     Map<String, CapturedContext.CapturedValue> simpleDataFields = getFields(simpleData);
-    Assertions.assertEquals(4, simpleDataFields.size());
-    Assertions.assertEquals("foo", simpleDataFields.get("strValue").getValue());
-    Assertions.assertEquals(42, simpleDataFields.get("intValue").getValue());
-    Assertions.assertEquals(DEPTH_REASON, simpleDataFields.get("listValue").getNotCapturedReason());
+    assertEquals(4, simpleDataFields.size());
+    assertEquals("foo", simpleDataFields.get("strValue").getValue());
+    assertEquals(42, simpleDataFields.get("intValue").getValue());
+    assertEquals(DEPTH_REASON, simpleDataFields.get("listValue").getNotCapturedReason());
   }
 
   @Test
@@ -725,29 +723,28 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
+    assertEquals(143, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     CapturedContext.CapturedValue returnValue =
         snapshot.getCaptures().getReturn().getLocals().get("@return");
-    Assertions.assertEquals("CapturedSnapshot04$CompositeData", returnValue.getType());
+    assertEquals("CapturedSnapshot04$CompositeData", returnValue.getType());
     Map<String, CapturedContext.CapturedValue> fields = getFields(returnValue);
-    Assertions.assertEquals(3, fields.size());
-    Assertions.assertEquals(
-        FIELD_COUNT_REASON, fields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
+    assertEquals(3, fields.size());
+    assertEquals(FIELD_COUNT_REASON, fields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
     Map<String, CapturedContext.CapturedValue> s1Fields =
         (Map<String, CapturedContext.CapturedValue>) fields.get("s1").getValue();
-    Assertions.assertEquals("foo1", s1Fields.get("strValue").getValue());
-    Assertions.assertEquals(101, s1Fields.get("intValue").getValue());
+    assertEquals("foo1", s1Fields.get("strValue").getValue());
+    assertEquals(101, s1Fields.get("intValue").getValue());
     Map<String, CapturedContext.CapturedValue> s2Fields =
         (Map<String, CapturedContext.CapturedValue>) fields.get("s2").getValue();
-    Assertions.assertEquals("foo2", s2Fields.get("strValue").getValue());
-    Assertions.assertEquals(202, s2Fields.get("intValue").getValue());
+    assertEquals("foo2", s2Fields.get("strValue").getValue());
+    assertEquals(202, s2Fields.get("intValue").getValue());
 
     CapturedContext.CapturedValue compositeData =
         snapshot.getCaptures().getReturn().getLocals().get("compositeData");
     Map<String, CapturedContext.CapturedValue> compositeDataFields = getFields(compositeData);
-    Assertions.assertEquals(3, compositeDataFields.size());
-    Assertions.assertEquals(
+    assertEquals(3, compositeDataFields.size());
+    assertEquals(
         FIELD_COUNT_REASON,
         compositeDataFields.get("@" + NOT_CAPTURED_REASON).getNotCapturedReason());
     assertTrue(compositeDataFields.containsKey("s1"));
@@ -765,7 +762,7 @@ public class CapturedSnapshotTest {
       Reflect.on(testClass).call("main", "triggerUncaughtException").get();
       Assertions.fail("should not reach this code");
     } catch (ReflectException ex) {
-      Assertions.assertEquals("oops", ex.getCause().getCause().getMessage());
+      assertEquals("oops", ex.getCause().getCause().getMessage());
     }
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureThrowable(
@@ -784,7 +781,7 @@ public class CapturedSnapshotTest {
             CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "triggerCaughtException", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "triggerCaughtException").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureThrowable(
         snapshot.getCaptures().getCaughtExceptions().get(0),
@@ -808,7 +805,7 @@ public class CapturedSnapshotTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", "1").get();
-      Assertions.assertEquals(3, result);
+      assertEquals(3, result);
     }
     assertTrue(listener.snapshots.size() < 20);
   }
@@ -828,7 +825,7 @@ public class CapturedSnapshotTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", "").get();
-      Assertions.assertEquals(48, result);
+      assertEquals(48, result);
     }
     assertTrue(listener.snapshots.size() < 20, "actual snapshots: " + listener.snapshots.size());
   }
@@ -865,7 +862,7 @@ public class CapturedSnapshotTest {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
       assertTrue((i == 2 && result == 2) || result == 3);
     }
-    Assertions.assertEquals(1, listener.snapshots.size());
+    assertEquals(1, listener.snapshots.size());
     assertCaptureArgs(
         listener.snapshots.get(0).getCaptures().getReturn(), "arg", "java.lang.String", "5");
   }
@@ -883,7 +880,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "0").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, CapturedContext.CapturedValue> staticFields =
         snapshot.getCaptures().getReturn().getStaticFields();
@@ -906,8 +903,8 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "0").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertEquals(0, listener.snapshots.size());
+    assertEquals(3, result);
+    assertEquals(0, listener.snapshots.size());
   }
 
   @Test
@@ -928,7 +925,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(1, listener.snapshots.size());
+    assertEquals(1, listener.snapshots.size());
     List<EvaluationError> evaluationErrors = listener.snapshots.get(0).getEvaluationErrors();
     Assertions.assertEquals(1, evaluationErrors.size());
     Assertions.assertEquals("nullTyped.fld.fld", evaluationErrors.get(0).getExpr());
@@ -990,8 +987,8 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, probe1, probe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertEquals(expectedSnapshots, listener.snapshots.size());
+    assertEquals(3, result);
+    assertEquals(expectedSnapshots, listener.snapshots.size());
     return listener.snapshots;
   }
 
@@ -1109,7 +1106,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "f", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureFieldCount(snapshot.getCaptures().getEntry(), 5);
     assertCaptureFields(snapshot.getCaptures().getEntry(), "intValue", "int", "24");
@@ -1150,7 +1147,7 @@ public class CapturedSnapshotTest {
         installProbes(INHERITED_CLASS_NAME, probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "inherited").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     // Only Declared fields in the current class are captured, not inherited fields
     assertCaptureFieldCount(snapshot.getCaptures().getEntry(), 5);
@@ -1170,7 +1167,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, "<init>", "()");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     long result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(4_000_000_001L, result);
+    assertEquals(4_000_000_001L, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, CapturedContext.CapturedValue> staticFields =
         snapshot.getCaptures().getEntry().getStaticFields();
@@ -1195,7 +1192,7 @@ public class CapturedSnapshotTest {
         installProbes(INHERITED_CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "inherited").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, CapturedContext.CapturedValue> staticFields =
         snapshot.getCaptures().getReturn().getStaticFields();
@@ -1215,10 +1212,10 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "33"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "static", "email@address").get();
-    Assertions.assertEquals(8, result);
+    assertEquals(8, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     CapturedContext context = snapshot.getCaptures().getLines().get(33);
-    Assertions.assertNotNull(context);
+    assertNotNull(context);
     assertCaptureLocals(context, "idx", "int", "5");
   }
 
@@ -1232,10 +1229,10 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "44"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "capturing", "email@address").get();
-    Assertions.assertEquals(8, result);
+    assertEquals(8, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     CapturedContext context = snapshot.getCaptures().getLines().get(44);
-    Assertions.assertNotNull(context);
+    assertNotNull(context);
     assertCaptureLocals(context, "idx", "int", "5");
     assertCaptureFields(context, "strValue", "java.lang.String", "email@address");
   }
@@ -1260,7 +1257,7 @@ public class CapturedSnapshotTest {
     // it's important there is no null key in this map, as Jackson is not happy about it
     // it's means here that argument names are not resolved correctly
     Assertions.assertFalse(arguments.containsKey(null));
-    Assertions.assertEquals(4, arguments.size());
+    assertEquals(4, arguments.size());
     assertTrue(arguments.containsKey("this"));
     assertTrue(arguments.containsKey("apiKey"));
     assertTrue(arguments.containsKey("uriInfo"));
@@ -1276,16 +1273,14 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, nativeMethodProbe, abstractMethodProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(1, result);
+    assertEquals(1, result);
     ArgumentCaptor<ProbeId> probeIdCaptor = ArgumentCaptor.forClass(ProbeId.class);
     ArgumentCaptor<String> strCaptor = ArgumentCaptor.forClass(String.class);
     verify(probeStatusSink, times(2)).addError(probeIdCaptor.capture(), strCaptor.capture());
-    Assertions.assertEquals(PROBE_ID1.getId(), probeIdCaptor.getAllValues().get(0).getId());
-    Assertions.assertEquals(
-        "Cannot instrument an abstract or native method", strCaptor.getAllValues().get(0));
-    Assertions.assertEquals(PROBE_ID2.getId(), probeIdCaptor.getAllValues().get(1).getId());
-    Assertions.assertEquals(
-        "Cannot instrument an abstract or native method", strCaptor.getAllValues().get(1));
+    assertEquals(PROBE_ID1.getId(), probeIdCaptor.getAllValues().get(0).getId());
+    assertEquals("Cannot instrument an abstract or native method", strCaptor.getAllValues().get(0));
+    assertEquals(PROBE_ID2.getId(), probeIdCaptor.getAllValues().get(1).getId());
+    assertEquals("Cannot instrument an abstract or native method", strCaptor.getAllValues().get(1));
   }
 
   @Test
@@ -1300,7 +1295,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(CLASS_NAME, abstractMethodProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
-    Assertions.assertNotNull(testClass);
+    assertNotNull(testClass);
   }
 
   @Test
@@ -1310,7 +1305,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "overload", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(63, result);
+    assertEquals(63, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 4, PROBE_ID, PROBE_ID, PROBE_ID, PROBE_ID);
     assertCaptureReturnValue(snapshots.get(0).getCaptures().getReturn(), "int", "42");
     assertCaptureArgs(snapshots.get(1).getCaptures().getEntry(), "s", "java.lang.String", "1");
@@ -1326,7 +1321,7 @@ public class CapturedSnapshotTest {
     Map<String, byte[]> classFileBuffers = compile(CLASS_NAME, SourceCompiler.DebugInfo.NONE);
     Class<?> testClass = loadClass(CLASS_NAME, classFileBuffers);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(48, result);
+    assertEquals(48, result);
     assertOneSnapshot(listener);
   }
 
@@ -1343,8 +1338,8 @@ public class CapturedSnapshotTest {
       instr.removeTransformer(currentTransformer);
     }
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(2, result);
-    Assertions.assertEquals(1, listener.snapshots.size());
+    assertEquals(2, result);
+    assertEquals(1, listener.snapshots.size());
     ProbeImplementation probeImplementation = listener.snapshots.get(0).getProbe();
     assertTrue(probeImplementation.isCaptureSnapshot());
     assertEquals("main", probeImplementation.getLocation().getMethod());
@@ -1365,8 +1360,8 @@ public class CapturedSnapshotTest {
       instr.removeTransformer(currentTransformer);
     }
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(2, result);
-    Assertions.assertEquals(0, listener.snapshots.size());
+    assertEquals(2, result);
+    assertEquals(0, listener.snapshots.size());
   }
 
   @Test
@@ -1376,7 +1371,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "processWithArg", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(50, result);
+    assertEquals(50, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureArgs(snapshot.getCaptures().getEntry(), "obj", "java.lang.Integer", "42");
     assertCaptureFields(
@@ -1392,7 +1387,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "14"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, String> expectedFields = new HashMap<>();
     expectedFields.put("detailMessage", "For input string: \"a\"");
@@ -1415,7 +1410,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
+    assertEquals(3, result);
     assertOneSnapshot(listener);
   }
 
@@ -1432,7 +1427,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
+    assertEquals(3, result);
     assertOneSnapshot(listener);
   }
 
@@ -1449,10 +1444,10 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertEquals(0, listener.snapshots.size());
+    assertEquals(3, result);
+    assertEquals(0, listener.snapshots.size());
     assertTrue(listener.skipped);
-    Assertions.assertEquals(DebuggerContext.SkipCause.CONDITION, listener.cause);
+    assertEquals(DebuggerContext.SkipCause.CONDITION, listener.cause);
   }
 
   @Test
@@ -1469,7 +1464,7 @@ public class CapturedSnapshotTest {
       Reflect.on(testClass).call("main", "triggerUncaughtException").get();
       Assertions.fail("should not reach this code");
     } catch (ReflectException ex) {
-      Assertions.assertEquals("oops", ex.getCause().getCause().getMessage());
+      assertEquals("oops", ex.getCause().getCause().getMessage());
     }
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureThrowable(
@@ -1478,10 +1473,9 @@ public class CapturedSnapshotTest {
         "oops",
         "CapturedSnapshot05.triggerUncaughtException",
         7);
-    Assertions.assertEquals(2, snapshot.getEvaluationErrors().size());
-    Assertions.assertEquals(
-        "Cannot find symbol: after", snapshot.getEvaluationErrors().get(0).getMessage());
-    Assertions.assertEquals(
+    assertEquals(2, snapshot.getEvaluationErrors().size());
+    assertEquals("Cannot find symbol: after", snapshot.getEvaluationErrors().get(0).getMessage());
+    assertEquals(
         "java.lang.IllegalStateException: oops",
         snapshot.getEvaluationErrors().get(1).getMessage());
   }
@@ -1494,7 +1488,7 @@ public class CapturedSnapshotTest {
         installProbes(ENUM_CLASS, createProbe(PROBE_ID, ENUM_CLASS, "<init>", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(2, result);
+    assertEquals(2, result);
     assertSnapshots(listener, 3, PROBE_ID);
     Map<String, CapturedContext.CapturedValue> arguments =
         listener.snapshots.get(0).getCaptures().getEntry().getArguments();
@@ -1511,7 +1505,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "convert", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(2, result);
+    assertEquals(2, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureReturnValue(
         snapshot.getCaptures().getReturn(),
@@ -1527,7 +1521,7 @@ public class CapturedSnapshotTest {
         installProbes(INNER_CLASS, createProbe(PROBE_ID, INNER_CLASS, "size", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(1, result);
+    assertEquals(1, result);
   }
 
   @Test
@@ -1541,7 +1535,7 @@ public class CapturedSnapshotTest {
       Reflect.on(testClass).call("main", "exception").get();
       Assertions.fail("should not reach this code");
     } catch (ReflectException ex) {
-      Assertions.assertEquals("not supported", ex.getCause().getCause().getMessage());
+      assertEquals("not supported", ex.getCause().getCause().getMessage());
     }
   }
 
@@ -1587,7 +1581,7 @@ public class CapturedSnapshotTest {
         installSingleProbe(CLASS_NAME, null, null, "46");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "synchronizedBlock").get();
-    Assertions.assertEquals(76, result);
+    assertEquals(76, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureLocals(snapshot.getCaptures().getLines().get(46), "count", "int", "31");
   }
@@ -1608,7 +1602,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, probe1, probe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
+    assertEquals(3, result);
     List<Snapshot> snapshots = assertSnapshots(listener, 2, PROBE_ID1, PROBE_ID2);
     for (Snapshot snapshot : snapshots) {
       assertEquals("msg1=hello", snapshot.getMessage());
@@ -1820,6 +1814,7 @@ public class CapturedSnapshotTest {
     when(config.getDebuggerExcludeFiles()).thenReturn(excludeFileName);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     DebuggerTransformerTest.TestSnapshotListener listener =
         new DebuggerTransformerTest.TestSnapshotListener();
@@ -1846,9 +1841,9 @@ public class CapturedSnapshotTest {
   }
 
   private Snapshot assertOneSnapshot(DebuggerTransformerTest.TestSnapshotListener listener) {
-    Assertions.assertEquals(1, listener.snapshots.size());
+    assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
-    Assertions.assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
+    assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
     return snapshot;
   }
 
@@ -1866,6 +1861,7 @@ public class CapturedSnapshotTest {
     when(config.isDebuggerVerifyByteCode()).thenReturn(true);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     Collection<LogProbe> logProbes = configuration.getLogProbes();
     instrumentationListener = new MockInstrumentationListener();
     probeStatusSink = mock(ProbeStatusSink.class);
@@ -1897,7 +1893,7 @@ public class CapturedSnapshotTest {
 
   private ProbeImplementation resolver(
       String id, Class<?> callingClass, String expectedClassName, Collection<LogProbe> logProbes) {
-    Assertions.assertEquals(expectedClassName, callingClass.getName());
+    assertEquals(expectedClassName, callingClass.getName());
     for (LogProbe probe : logProbes) {
       if (probe.getId().equals(id)) {
         return probe;
@@ -1919,30 +1915,29 @@ public class CapturedSnapshotTest {
   private void assertCaptureArgs(
       CapturedContext context, String name, String typeName, String value) {
     CapturedContext.CapturedValue capturedValue = context.getArguments().get(name);
-    Assertions.assertEquals(typeName, capturedValue.getType());
-    Assertions.assertEquals(value, getValue(capturedValue));
+    assertEquals(typeName, capturedValue.getType());
+    assertEquals(value, getValue(capturedValue));
   }
 
   private void assertCaptureLocals(
       CapturedContext context, String name, String typeName, String value) {
     CapturedContext.CapturedValue localVar = context.getLocals().get(name);
-    Assertions.assertEquals(typeName, localVar.getType());
-    Assertions.assertEquals(value, getValue(localVar));
+    assertEquals(typeName, localVar.getType());
+    assertEquals(value, getValue(localVar));
   }
 
   private void assertCaptureLocals(
       CapturedContext context, String name, String typeName, Map<String, String> expectedFields) {
     CapturedContext.CapturedValue localVar = context.getLocals().get(name);
-    Assertions.assertEquals(typeName, localVar.getType());
+    assertEquals(typeName, localVar.getType());
     Map<String, CapturedContext.CapturedValue> fields = getFields(localVar);
     for (Map.Entry<String, String> entry : expectedFields.entrySet()) {
       assertTrue(fields.containsKey(entry.getKey()));
       CapturedContext.CapturedValue fieldCapturedValue = fields.get(entry.getKey());
       if (fieldCapturedValue.getNotCapturedReason() != null) {
-        Assertions.assertEquals(
-            entry.getValue(), String.valueOf(fieldCapturedValue.getNotCapturedReason()));
+        assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getNotCapturedReason()));
       } else {
-        Assertions.assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
+        assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
       }
     }
   }
@@ -1950,18 +1945,18 @@ public class CapturedSnapshotTest {
   private void assertCaptureFields(
       CapturedContext context, String name, String typeName, String value) {
     CapturedContext.CapturedValue field = context.getFields().get(name);
-    Assertions.assertEquals(typeName, field.getType());
-    Assertions.assertEquals(value, getValue(field));
+    assertEquals(typeName, field.getType());
+    assertEquals(value, getValue(field));
   }
 
   private void assertCaptureFields(
       CapturedContext context, String name, String typeName, Collection<?> collection) {
     CapturedContext.CapturedValue field = context.getFields().get(name);
-    Assertions.assertEquals(typeName, field.getType());
+    assertEquals(typeName, field.getType());
     Iterator<?> iterator = collection.iterator();
     for (Object obj : getCollection(field)) {
       if (iterator.hasNext()) {
-        Assertions.assertEquals(iterator.next(), obj);
+        assertEquals(iterator.next(), obj);
       } else {
         Assertions.fail("not same number of elements");
       }
@@ -1971,38 +1966,37 @@ public class CapturedSnapshotTest {
   private void assertCaptureFields(
       CapturedContext context, String name, String typeName, Map<Object, Object> expectedMap) {
     CapturedContext.CapturedValue field = context.getFields().get(name);
-    Assertions.assertEquals(typeName, field.getType());
+    assertEquals(typeName, field.getType());
     Map<Object, Object> map = getMap(field);
-    Assertions.assertEquals(expectedMap.size(), map.size());
+    assertEquals(expectedMap.size(), map.size());
     for (Map.Entry<Object, Object> entry : map.entrySet()) {
       assertTrue(expectedMap.containsKey(entry.getKey()));
-      Assertions.assertEquals(expectedMap.get(entry.getKey()), entry.getValue());
+      assertEquals(expectedMap.get(entry.getKey()), entry.getValue());
     }
   }
 
   private void assertCaptureFieldCount(CapturedContext context, int expectedFieldCount) {
-    Assertions.assertEquals(expectedFieldCount, context.getFields().size());
+    assertEquals(expectedFieldCount, context.getFields().size());
   }
 
   private void assertCaptureReturnValue(CapturedContext context, String typeName, String value) {
     CapturedContext.CapturedValue returnValue = context.getLocals().get("@return");
-    Assertions.assertEquals(typeName, returnValue.getType());
-    Assertions.assertEquals(value, getValue(returnValue));
+    assertEquals(typeName, returnValue.getType());
+    assertEquals(value, getValue(returnValue));
   }
 
   private void assertCaptureReturnValue(
       CapturedContext context, String typeName, Map<String, String> expectedFields) {
     CapturedContext.CapturedValue returnValue = context.getLocals().get("@return");
-    Assertions.assertEquals(typeName, returnValue.getType());
+    assertEquals(typeName, returnValue.getType());
     Map<String, CapturedContext.CapturedValue> fields = getFields(returnValue);
     for (Map.Entry<String, String> entry : expectedFields.entrySet()) {
       assertTrue(fields.containsKey(entry.getKey()));
       CapturedContext.CapturedValue fieldCapturedValue = fields.get(entry.getKey());
       if (fieldCapturedValue.getNotCapturedReason() != null) {
-        Assertions.assertEquals(
-            entry.getValue(), String.valueOf(fieldCapturedValue.getNotCapturedReason()));
+        assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getNotCapturedReason()));
       } else {
-        Assertions.assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
+        assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
       }
     }
   }
@@ -2019,13 +2013,13 @@ public class CapturedSnapshotTest {
       String message,
       String methodName,
       int lineNumber) {
-    Assertions.assertNotNull(throwable);
-    Assertions.assertEquals(typeName, throwable.getType());
-    Assertions.assertEquals(message, throwable.getMessage());
-    Assertions.assertNotNull(throwable.getStacktrace());
+    assertNotNull(throwable);
+    assertEquals(typeName, throwable.getType());
+    assertEquals(message, throwable.getMessage());
+    assertNotNull(throwable.getStacktrace());
     Assertions.assertFalse(throwable.getStacktrace().isEmpty());
-    Assertions.assertEquals(methodName, throwable.getStacktrace().get(0).getFunction());
-    Assertions.assertEquals(lineNumber, throwable.getStacktrace().get(0).getLineNumber());
+    assertEquals(methodName, throwable.getStacktrace().get(0).getFunction());
+    assertEquals(lineNumber, throwable.getStacktrace().get(0).getLineNumber());
   }
 
   private static String getValue(CapturedContext.CapturedValue capturedValue) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -60,6 +60,7 @@ public class ConfigurationUpdaterTest {
   void setUp() {
     lenient().when(tracerConfig.getFinalDebuggerSnapshotUrl()).thenReturn("http://localhost");
     lenient().when(tracerConfig.getDebuggerUploadBatchSize()).thenReturn(100);
+    lenient().when(tracerConfig.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost");
 
     debuggerSinkWithMockStatusSink = new DebuggerSink(tracerConfig, probeStatusSink);
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -353,6 +353,7 @@ public class DebuggerTransformerTest {
     Config config = mock(Config.class);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     return config;
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -488,6 +488,7 @@ public class LogProbesInstrumentationTest {
     when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     currentTransformer = new DebuggerTransformer(config, configuration);
     instr.addTransformer(currentTransformer);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -1179,6 +1179,7 @@ public class MetricProbesInstrumentationTest {
     when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     probeStatusSink = mock(ProbeStatusSink.class);
     currentTransformer =
         new DebuggerTransformer(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -584,6 +584,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     probeStatusSink = mock(ProbeStatusSink.class);
     currentTransformer =
         new DebuggerTransformer(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
@@ -145,6 +145,7 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
     when(config.isDebuggerVerifyByteCode()).thenReturn(true);
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     probeStatusSink = mock(ProbeStatusSink.class);
     currentTransformer =
         new DebuggerTransformer(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -71,6 +71,7 @@ public class DebuggerSinkTest {
     when(config.getEnv()).thenReturn("test");
     when(config.getVersion()).thenReturn("foo");
     when(config.getDebuggerUploadBatchSize()).thenReturn(1);
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
 
     EXPECTED_SNAPSHOT_TAGS =
         "^env:test,version:foo,debugger_version:\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?~[0-9a-f]+,agent_version:null,host_name:"

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -1,0 +1,53 @@
+package com.datadog.debugger.sink;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datadog.debugger.symbol.Scope;
+import com.datadog.debugger.symbol.ScopeType;
+import com.datadog.debugger.uploader.BatchUploader;
+import datadog.trace.api.Config;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SymbolSinkTest {
+
+  @Test
+  public void testFlush() {
+    SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
+    Config config = mock(Config.class);
+    when(config.getServiceName()).thenReturn("service1");
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock);
+    symbolSink.addScope(Scope.builder(ScopeType.JAR, null, 0, 0).build());
+    symbolSink.flush();
+    assertEquals(2, symbolUploaderMock.multiPartContents.size());
+    BatchUploader.MultiPartContent eventContent = symbolUploaderMock.multiPartContents.get(0);
+    assertEquals("event", eventContent.getPartName());
+    assertEquals("event.json", eventContent.getFileName());
+    String strEventContent = new String(eventContent.getContent());
+    assertTrue(strEventContent.contains("\"ddsource\": \"dd_debugger\""));
+    assertTrue(strEventContent.contains("\"service\": \"service1\""));
+    BatchUploader.MultiPartContent symbolContent = symbolUploaderMock.multiPartContents.get(1);
+    assertEquals("file", symbolContent.getPartName());
+    assertEquals("file.json", symbolContent.getFileName());
+    assertEquals(
+        "{\"language\":\"JAVA\",\"scopes\":[{\"end_line\":0,\"scope_type\":\"JAR\",\"start_line\":0}],\"service\":\"service1\"}",
+        new String(symbolContent.getContent()));
+  }
+
+  static class SymbolUploaderMock extends BatchUploader {
+    final List<MultiPartContent> multiPartContents = new ArrayList<>();
+
+    public SymbolUploaderMock() {
+      super(Config.get(), "http://localhost");
+    }
+
+    @Override
+    public void uploadAsMultipart(String tags, MultiPartContent... parts) {
+      multiPartContents.addAll(Arrays.asList(parts));
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 class SymbolExtractionTransformerTest {
-  private static final String SYMBOL_PACKAGE = "com.datadog.debugger.symbol";
+  private static final String SYMBOL_PACKAGE = "com.datadog.debugger.symbol.";
+  private static final String SYMBOL_PACKAGE_DIR = SYMBOL_PACKAGE.replace('.', '/');
 
   private Instrumentation instr = ByteBuddyAgent.install();
   private Config config;
@@ -30,21 +31,20 @@ class SymbolExtractionTransformerTest {
     config = Mockito.mock(Config.class);
     when(config.getDebuggerSymbolIncludes()).thenReturn(SYMBOL_PACKAGE);
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
+    when(config.getDebuggerSymbolFlushThreshold()).thenReturn(1);
   }
 
   @Test
   public void noIncludesFilterOutDatadogClass() throws IOException, URISyntaxException {
     config = Mockito.mock(Config.class);
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction01";
-    final String SOURCE_FILE = "SymbolExtraction01.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction01";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     assertFalse(
         symbolSinkMock.jarScopes.stream()
             .flatMap(scope -> scope.getScopes().stream())
@@ -53,15 +53,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction01() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction01";
-    final String SOURCE_FILE = "SymbolExtraction01.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction01";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction01.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 2, 20, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 2, 2, SOURCE_FILE, 0, 0);
@@ -119,15 +118,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction02() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction02";
-    final String SOURCE_FILE = "SymbolExtraction02.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction02";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction02.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
@@ -147,15 +145,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction03() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction03";
-    final String SOURCE_FILE = "SymbolExtraction03.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction03";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction03.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 4, 28, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 4, 4, SOURCE_FILE, 0, 0);
@@ -215,15 +212,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction04() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction04";
-    final String SOURCE_FILE = "SymbolExtraction04.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction04";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction04.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 18, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
@@ -287,15 +283,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction05() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction05";
-    final String SOURCE_FILE = "SymbolExtraction05.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction05";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction05.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 15, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
@@ -333,15 +328,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction06() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction06";
-    final String SOURCE_FILE = "SymbolExtraction06.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction06";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction06.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 13, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
@@ -379,15 +373,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction07() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction07";
-    final String SOURCE_FILE = "SymbolExtraction07.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction07";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction07.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 10, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
@@ -411,15 +404,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction08() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction08";
-    final String SOURCE_FILE = "SymbolExtraction08.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction08";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction08.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE, 2, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
@@ -445,15 +437,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction09() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction09";
-    final String SOURCE_FILE = "SymbolExtraction09.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction09";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction09.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 5, 12, SOURCE_FILE, 3, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 5, 5, SOURCE_FILE, 0, 0);
@@ -495,15 +486,15 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction10() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction10";
-    final String SOURCE_FILE = "SymbolExtraction10.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction10";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction10.java";
+    when(config.getDebuggerSymbolFlushThreshold()).thenReturn(2);
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", "1").get();
-    transformer.flushScopes(null);
     assertEquals(2, symbolSinkMock.jarScopes.get(0).getScopes().size());
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE, 2, 0);
@@ -546,15 +537,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction11() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction11";
-    final String SOURCE_FILE = "SymbolExtraction11.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction11";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction11.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", 1).get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE, 2, 1);
     assertSymbol(
@@ -580,15 +570,14 @@ class SymbolExtractionTransformerTest {
 
   @Test
   public void symbolExtraction12() throws IOException, URISyntaxException {
-    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction12";
-    final String SOURCE_FILE = "SymbolExtraction12.java";
+    final String CLASS_NAME = SYMBOL_PACKAGE + "SymbolExtraction12";
+    final String SOURCE_FILE = SYMBOL_PACKAGE_DIR + "SymbolExtraction12.java";
     SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
     SymbolExtractionTransformer transformer =
         new SymbolExtractionTransformer(symbolSinkMock, config);
     instr.addTransformer(transformer);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     Reflect.on(testClass).call("main", 1).get();
-    transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
     assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 6, 20, SOURCE_FILE, 7, 0);
     assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 6, 6, SOURCE_FILE, 0, 0);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -63,42 +63,58 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 2, 20, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 2, 2, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 2, 20, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 2, 2, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 4, 20, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 4, 20, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 4);
-    assertEquals(4, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 8, 15, SOURCE_FILE);
-    assertEquals(3, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 4, 20, SOURCE_FILE, 1, 2);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "foo", Integer.TYPE.getTypeName(), 8);
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        Integer.TYPE.getTypeName(),
+        4);
     assertSymbol(
-        local0.getSymbols().get(1), SymbolType.LOCAL, "bar", Integer.TYPE.getTypeName(), 9);
-    assertSymbol(local0.getSymbols().get(2), SymbolType.LOCAL, "j", Integer.TYPE.getTypeName(), 11);
-    Scope local1 = mainMethodScope.getScopes().get(1);
-    assertScope(local1, ScopeType.LOCAL, null, 7, 15, SOURCE_FILE);
-    assertEquals(1, local1.getSymbols().size());
-    assertSymbol(local1.getSymbols().get(0), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 7);
-    Scope local2 = mainMethodScope.getScopes().get(2);
-    assertScope(local2, ScopeType.LOCAL, null, 6, 17, SOURCE_FILE);
-    assertEquals(1, local2.getSymbols().size());
+        mainMethodLocalScope.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "var3",
+        Integer.TYPE.getTypeName(),
+        19);
+    Scope ifLine5Scope = mainMethodLocalScope.getScopes().get(0);
+    assertScope(ifLine5Scope, ScopeType.LOCAL, null, 6, 17, SOURCE_FILE, 1, 1);
     assertSymbol(
-        local2.getSymbols().get(0), SymbolType.LOCAL, "var2", Integer.TYPE.getTypeName(), 6);
-    Scope local3 = mainMethodScope.getScopes().get(3);
-    assertScope(local3, ScopeType.LOCAL, null, 4, 20, SOURCE_FILE);
-    assertEquals(3, local3.getSymbols().size());
+        ifLine5Scope.getSymbols().get(0), SymbolType.LOCAL, "var2", Integer.TYPE.getTypeName(), 6);
+    Scope forLine7Scope = ifLine5Scope.getScopes().get(0);
+    assertScope(forLine7Scope, ScopeType.LOCAL, null, 7, 15, SOURCE_FILE, 1, 1);
     assertSymbol(
-        local3.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 4);
+        forLine7Scope.getSymbols().get(0), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 7);
+    Scope forBodyLine7Scope = forLine7Scope.getScopes().get(0);
+    assertScope(forBodyLine7Scope, ScopeType.LOCAL, null, 8, 15, SOURCE_FILE, 1, 3);
     assertSymbol(
-        local3.getSymbols().get(1), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 4);
+        forBodyLine7Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "foo",
+        Integer.TYPE.getTypeName(),
+        8);
     assertSymbol(
-        local3.getSymbols().get(2), SymbolType.LOCAL, "var3", Integer.TYPE.getTypeName(), 19);
+        forBodyLine7Scope.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "bar",
+        Integer.TYPE.getTypeName(),
+        9);
+    assertSymbol(
+        forBodyLine7Scope.getSymbols().get(2),
+        SymbolType.LOCAL,
+        "j",
+        Integer.TYPE.getTypeName(),
+        11);
+    Scope whileLine12 = forBodyLine7Scope.getScopes().get(0);
+    assertScope(whileLine12, ScopeType.LOCAL, null, 13, 14, SOURCE_FILE, 0, 1);
+    assertSymbol(
+        whileLine12.getSymbols().get(0), SymbolType.LOCAL, "var4", Integer.TYPE.getTypeName(), 13);
   }
 
   @Test
@@ -113,21 +129,20 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 6, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 6, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
-    assertEquals(1, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 5, 6, SOURCE_FILE);
-    assertEquals(1, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 5, 6, SOURCE_FILE, 0, 1);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "var1", String.class.getTypeName(), 5);
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        String.class.getTypeName(),
+        5);
   }
 
   @Test
@@ -142,41 +157,60 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 4, 28, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 4, 4, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 4, 28, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 4, 4, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 6, 28, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 6, 28, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 6);
-    assertEquals(3, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 20, 21, SOURCE_FILE);
-    assertEquals(1, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 6, 28, SOURCE_FILE, 2, 2);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "var4", String.class.getTypeName(), 20);
-    Scope local1 = mainMethodScope.getScopes().get(1);
-    assertScope(local1, ScopeType.LOCAL, null, 12, 24, SOURCE_FILE);
-    assertEquals(4, local1.getSymbols().size());
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        String.class.getTypeName(),
+        6);
     assertSymbol(
-        local1.getSymbols().get(0), SymbolType.LOCAL, "var31", String.class.getTypeName(), 12);
+        mainMethodLocalScope.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "var5",
+        String.class.getTypeName(),
+        27);
+    Scope elseLine10Scope = mainMethodLocalScope.getScopes().get(0);
+    assertScope(elseLine10Scope, ScopeType.LOCAL, null, 12, 24, SOURCE_FILE, 1, 4);
     assertSymbol(
-        local1.getSymbols().get(1), SymbolType.LOCAL, "var32", String.class.getTypeName(), 13);
+        elseLine10Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var31",
+        String.class.getTypeName(),
+        12);
     assertSymbol(
-        local1.getSymbols().get(2), SymbolType.LOCAL, "var30", String.class.getTypeName(), 15);
+        elseLine10Scope.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "var32",
+        String.class.getTypeName(),
+        13);
     assertSymbol(
-        local1.getSymbols().get(3), SymbolType.LOCAL, "var3", String.class.getTypeName(), 17);
-    Scope local2 = mainMethodScope.getScopes().get(2);
-    assertScope(local2, ScopeType.LOCAL, null, 6, 28, SOURCE_FILE);
-    assertEquals(3, local2.getSymbols().size());
+        elseLine10Scope.getSymbols().get(2),
+        SymbolType.LOCAL,
+        "var30",
+        String.class.getTypeName(),
+        15);
     assertSymbol(
-        local2.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 6);
+        elseLine10Scope.getSymbols().get(3),
+        SymbolType.LOCAL,
+        "var3",
+        String.class.getTypeName(),
+        17);
+    Scope ifLine19Scope = elseLine10Scope.getScopes().get(0);
+    assertScope(ifLine19Scope, ScopeType.LOCAL, null, 20, 21, SOURCE_FILE, 0, 1);
     assertSymbol(
-        local2.getSymbols().get(1), SymbolType.LOCAL, "var1", String.class.getTypeName(), 6);
-    assertSymbol(
-        local2.getSymbols().get(2), SymbolType.LOCAL, "var5", String.class.getTypeName(), 27);
+        ifLine19Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var4",
+        String.class.getTypeName(),
+        20);
   }
 
   @Test
@@ -191,44 +225,64 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 18, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 18, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 18, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 18, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
-    assertEquals(5, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 10, 12, SOURCE_FILE);
-    assertEquals(1, local0.getSymbols().size());
-    assertSymbol(local0.getSymbols().get(0), SymbolType.LOCAL, "k", Integer.TYPE.getTypeName(), 10);
-    Scope local1 = mainMethodScope.getScopes().get(1);
-    assertScope(local1, ScopeType.LOCAL, null, 9, 15, SOURCE_FILE);
-    assertEquals(2, local1.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 5, 18, SOURCE_FILE, 1, 1);
     assertSymbol(
-        local1.getSymbols().get(0), SymbolType.LOCAL, "var3", String.class.getTypeName(), 9);
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        String.class.getTypeName(),
+        5);
+    Scope forLine6Scope = mainMethodLocalScope.getScopes().get(0);
+    assertScope(forLine6Scope, ScopeType.LOCAL, null, 6, 15, SOURCE_FILE, 1, 1);
     assertSymbol(
-        local1.getSymbols().get(1), SymbolType.LOCAL, "var5", String.class.getTypeName(), 14);
-    Scope local2 = mainMethodScope.getScopes().get(2);
-    assertScope(local2, ScopeType.LOCAL, null, 7, 15, SOURCE_FILE);
-    assertEquals(2, local2.getSymbols().size());
-    assertSymbol(local2.getSymbols().get(0), SymbolType.LOCAL, "j", Integer.TYPE.getTypeName(), 8);
+        forLine6Scope.getSymbols().get(0), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 6);
+    Scope forBodyLine6Scope = forLine6Scope.getScopes().get(0);
+    assertScope(forBodyLine6Scope, ScopeType.LOCAL, null, 7, 15, SOURCE_FILE, 1, 2);
     assertSymbol(
-        local2.getSymbols().get(1), SymbolType.LOCAL, "var2", String.class.getTypeName(), 7);
-    Scope local3 = mainMethodScope.getScopes().get(3);
-    assertScope(local3, ScopeType.LOCAL, null, 6, 15, SOURCE_FILE);
-    assertEquals(1, local3.getSymbols().size());
-    assertSymbol(local3.getSymbols().get(0), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 6);
-    Scope local4 = mainMethodScope.getScopes().get(4);
-    assertScope(local4, ScopeType.LOCAL, null, 5, 18, SOURCE_FILE);
-    assertEquals(2, local4.getSymbols().size());
+        forBodyLine6Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "j",
+        Integer.TYPE.getTypeName(),
+        8);
     assertSymbol(
-        local4.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
+        forBodyLine6Scope.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "var2",
+        String.class.getTypeName(),
+        7);
+    Scope forBodyLine8Scope = forBodyLine6Scope.getScopes().get(0);
+    assertScope(forBodyLine8Scope, ScopeType.LOCAL, null, 9, 15, SOURCE_FILE, 1, 2);
     assertSymbol(
-        local4.getSymbols().get(1), SymbolType.LOCAL, "var1", String.class.getTypeName(), 5);
+        forBodyLine8Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var3",
+        String.class.getTypeName(),
+        9);
+    assertSymbol(
+        forBodyLine8Scope.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "var5",
+        String.class.getTypeName(),
+        14);
+    Scope forLine10Scope = forBodyLine8Scope.getScopes().get(0);
+    assertScope(forLine10Scope, ScopeType.LOCAL, null, 10, 12, SOURCE_FILE, 1, 1);
+    assertSymbol(
+        forLine10Scope.getSymbols().get(0), SymbolType.LOCAL, "k", Integer.TYPE.getTypeName(), 10);
+    Scope forBodyLine10Scope = forLine10Scope.getScopes().get(0);
+    assertScope(forBodyLine10Scope, ScopeType.LOCAL, null, 11, 12, SOURCE_FILE, 0, 1);
+    assertSymbol(
+        forBodyLine10Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var4",
+        String.class.getTypeName(),
+        11);
   }
 
   @Test
@@ -243,28 +297,38 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 15, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 15, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 15, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 15, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
-    assertEquals(2, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 7, 13, SOURCE_FILE);
-    assertEquals(2, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 5, 15, SOURCE_FILE, 1, 1);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 7);
-    assertSymbol(local0.getSymbols().get(1), SymbolType.LOCAL, "j", Integer.TYPE.getTypeName(), 8);
-    Scope local1 = mainMethodScope.getScopes().get(1);
-    assertScope(local1, ScopeType.LOCAL, null, 5, 15, SOURCE_FILE);
-    assertEquals(2, local1.getSymbols().size());
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "i",
+        Integer.TYPE.getTypeName(),
+        5);
+    Scope whileLine6Scope = mainMethodLocalScope.getScopes().get(0);
+    assertScope(whileLine6Scope, ScopeType.LOCAL, null, 7, 13, SOURCE_FILE, 1, 2);
     assertSymbol(
-        local1.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
-    assertSymbol(local1.getSymbols().get(1), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 5);
+        whileLine6Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        Integer.TYPE.getTypeName(),
+        7);
+    assertSymbol(
+        whileLine6Scope.getSymbols().get(1), SymbolType.LOCAL, "j", Integer.TYPE.getTypeName(), 8);
+    Scope whileLine9Scope = whileLine6Scope.getScopes().get(0);
+    assertScope(whileLine9Scope, ScopeType.LOCAL, null, 10, 11, SOURCE_FILE, 0, 1);
+    assertSymbol(
+        whileLine9Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var2",
+        Integer.TYPE.getTypeName(),
+        10);
   }
 
   @Test
@@ -279,34 +343,38 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 13, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 13, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 13, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 13, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
-    assertEquals(2, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 9, 11, SOURCE_FILE);
-    assertEquals(2, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 5, 13, SOURCE_FILE, 2, 1);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "var3", Integer.TYPE.getTypeName(), 10);
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        Integer.TYPE.getTypeName(),
+        5);
+    Scope catchLine9Scope = mainMethodLocalScope.getScopes().get(0);
+    assertScope(catchLine9Scope, ScopeType.LOCAL, null, 9, 11, SOURCE_FILE, 0, 2);
     assertSymbol(
-        local0.getSymbols().get(1),
+        catchLine9Scope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var3",
+        Integer.TYPE.getTypeName(),
+        10);
+    assertSymbol(
+        catchLine9Scope.getSymbols().get(1),
         SymbolType.LOCAL,
         "rte",
         RuntimeException.class.getTypeName(),
         9);
-    Scope local1 = mainMethodScope.getScopes().get(1);
-    assertScope(local1, ScopeType.LOCAL, null, 5, 13, SOURCE_FILE);
-    assertEquals(2, local1.getSymbols().size());
+    Scope tryLine6Scope = mainMethodLocalScope.getScopes().get(1);
+    assertScope(tryLine6Scope, ScopeType.LOCAL, null, 7, 8, SOURCE_FILE, 0, 1);
     assertSymbol(
-        local1.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
-    assertSymbol(
-        local1.getSymbols().get(1), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 5);
+        tryLine6Scope.getSymbols().get(0), SymbolType.LOCAL, "var2", Integer.TYPE.getTypeName(), 7);
   }
 
   @Test
@@ -321,22 +389,24 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 10, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 10, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 10, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 10, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
-    assertEquals(1, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 5, 10, SOURCE_FILE);
-    assertEquals(2, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 5, 10, SOURCE_FILE, 1, 1);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
-    assertSymbol(local0.getSymbols().get(1), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 5);
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "i",
+        Integer.TYPE.getTypeName(),
+        5);
+    Scope doLine6Scope = mainMethodLocalScope.getScopes().get(0);
+    assertScope(doLine6Scope, ScopeType.LOCAL, null, 7, 8, SOURCE_FILE, 0, 1);
+    assertSymbol(
+        doLine6Scope.getSymbols().get(0), SymbolType.LOCAL, "j", Integer.TYPE.getTypeName(), 7);
   }
 
   @Test
@@ -351,28 +421,26 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 11, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 11, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
-    assertEquals(2, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 8, 9, SOURCE_FILE);
-    assertEquals(1, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 5, 11, SOURCE_FILE, 1, 1);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "var3", Integer.TYPE.getTypeName(), 8);
-    Scope local1 = mainMethodScope.getScopes().get(1);
-    assertScope(local1, ScopeType.LOCAL, null, 5, 11, SOURCE_FILE);
-    assertEquals(2, local1.getSymbols().size());
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        Integer.TYPE.getTypeName(),
+        5);
+    Scope line6Scope = mainMethodLocalScope.getScopes().get(0);
+    assertScope(line6Scope, ScopeType.LOCAL, null, 7, 9, SOURCE_FILE, 0, 2);
     assertSymbol(
-        local1.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
+        line6Scope.getSymbols().get(0), SymbolType.LOCAL, "var2", Integer.TYPE.getTypeName(), 7);
     assertSymbol(
-        local1.getSymbols().get(1), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 5);
+        line6Scope.getSymbols().get(1), SymbolType.LOCAL, "var3", Integer.TYPE.getTypeName(), 8);
   }
 
   @Test
@@ -387,38 +455,42 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", "1").get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 5, 12, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(3, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 5, 5, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 5, 12, SOURCE_FILE, 3, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 5, 5, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 7, 12, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 7, 12, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 7);
-    assertEquals(1, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 7, 12, SOURCE_FILE);
-    assertEquals(2, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 7, 12, SOURCE_FILE, 0, 2);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "outside", Integer.TYPE.getTypeName(), 7);
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "outside",
+        Integer.TYPE.getTypeName(),
+        7);
     assertSymbol(
-        local0.getSymbols().get(1), SymbolType.LOCAL, "lambda", Supplier.class.getTypeName(), 8);
+        mainMethodLocalScope.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "lambda",
+        Supplier.class.getTypeName(),
+        8);
     Scope lambdaMethodScope = classScope.getScopes().get(2);
-    assertScope(lambdaMethodScope, ScopeType.METHOD, "lambda$main$0", 9, 10, SOURCE_FILE);
-    assertEquals(1, lambdaMethodScope.getSymbols().size());
+    assertScope(lambdaMethodScope, ScopeType.METHOD, "lambda$main$0", 9, 10, SOURCE_FILE, 1, 1);
     assertSymbol(
         lambdaMethodScope.getSymbols().get(0),
         SymbolType.ARG,
         "outside",
         Integer.TYPE.getTypeName(),
         9);
-    assertEquals(1, lambdaMethodScope.getScopes().size());
-    Scope lambdaLocal0 = lambdaMethodScope.getScopes().get(0);
-    assertScope(lambdaLocal0, ScopeType.LOCAL, null, 9, 10, SOURCE_FILE);
-    assertEquals(1, lambdaLocal0.getSymbols().size());
+    Scope lambdaMethodLocalScope = lambdaMethodScope.getScopes().get(0);
+    assertScope(lambdaMethodLocalScope, ScopeType.LOCAL, null, 9, 10, SOURCE_FILE, 0, 1);
     assertSymbol(
-        lambdaLocal0.getSymbols().get(0), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 9);
+        lambdaMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        Integer.TYPE.getTypeName(),
+        9);
   }
 
   @Test
@@ -434,47 +506,42 @@ class SymbolExtractionTransformerTest {
     transformer.flushScopes(null);
     assertEquals(2, symbolSinkMock.jarScopes.get(0).getScopes().size());
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE, 2, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 6, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 6, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
-    assertEquals(1, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 5, 6, SOURCE_FILE);
-    assertEquals(1, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 5, 6, SOURCE_FILE, 0, 1);
     assertSymbol(
-        local0.getSymbols().get(0),
+        mainMethodLocalScope.getSymbols().get(0),
         SymbolType.LOCAL,
         "winner",
         "com.datadog.debugger.symbol.SymbolExtraction10$Inner",
         5);
     Scope innerClassScope = symbolSinkMock.jarScopes.get(0).getScopes().get(1);
-    assertScope(innerClassScope, ScopeType.CLASS, CLASS_NAME + "$Inner", 9, 13, SOURCE_FILE);
-    assertEquals(1, innerClassScope.getSymbols().size());
-    assertEquals(2, innerClassScope.getScopes().size());
+    assertScope(innerClassScope, ScopeType.CLASS, CLASS_NAME + "$Inner", 9, 13, SOURCE_FILE, 2, 1);
     assertSymbol(
         innerClassScope.getSymbols().get(0),
         SymbolType.FIELD,
         "field1",
         Integer.TYPE.getTypeName(),
         0);
-    assertScope(innerClassScope.getScopes().get(0), ScopeType.METHOD, "<init>", 9, 10, SOURCE_FILE);
+    assertScope(
+        innerClassScope.getScopes().get(0), ScopeType.METHOD, "<init>", 9, 10, SOURCE_FILE, 0, 0);
     Scope addToMethod = innerClassScope.getScopes().get(1);
-    assertScope(addToMethod, ScopeType.METHOD, "addTo", 12, 13, SOURCE_FILE);
-    assertEquals(1, addToMethod.getSymbols().size());
+    assertScope(addToMethod, ScopeType.METHOD, "addTo", 12, 13, SOURCE_FILE, 1, 1);
     assertSymbol(
         addToMethod.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 12);
-    assertEquals(1, addToMethod.getScopes().size());
-    Scope addToLocal0 = addToMethod.getScopes().get(0);
-    assertScope(addToLocal0, ScopeType.LOCAL, null, 12, 13, SOURCE_FILE);
-    assertEquals(1, addToLocal0.getSymbols().size());
+    Scope addToMethodLocalScope = addToMethod.getScopes().get(0);
+    assertScope(addToMethodLocalScope, ScopeType.LOCAL, null, 12, 13, SOURCE_FILE, 0, 1);
     assertSymbol(
-        addToLocal0.getSymbols().get(0), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 12);
+        addToMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        Integer.TYPE.getTypeName(),
+        12);
   }
 
   @Test
@@ -489,25 +556,26 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", 1).get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE);
-    assertEquals(1, classScope.getSymbols().size());
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE, 2, 1);
     assertSymbol(
         classScope.getSymbols().get(0), SymbolType.FIELD, "field1", Integer.TYPE.getTypeName(), 0);
-    assertEquals(2, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 4, SOURCE_FILE);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 4, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 6, 11, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 6, 11, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 6);
-    assertEquals(1, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 6, 11, SOURCE_FILE);
-    assertEquals(2, local0.getSymbols().size());
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 6, 11, SOURCE_FILE, 1, 1);
     assertSymbol(
-        local0.getSymbols().get(0), SymbolType.LOCAL, "arg", Integer.TYPE.getTypeName(), 6);
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "var1",
+        Integer.TYPE.getTypeName(),
+        6);
+    Scope ifLine7Scope = mainMethodLocalScope.getScopes().get(0);
+    assertScope(ifLine7Scope, ScopeType.LOCAL, null, 8, 9, SOURCE_FILE, 0, 1);
     assertSymbol(
-        local0.getSymbols().get(1), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 6);
+        ifLine7Scope.getSymbols().get(0), SymbolType.LOCAL, "var2", Integer.TYPE.getTypeName(), 8);
   }
 
   @Test
@@ -522,30 +590,32 @@ class SymbolExtractionTransformerTest {
     Reflect.on(testClass).call("main", 1).get();
     transformer.flushScopes(null);
     Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
-    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 6, 20, SOURCE_FILE);
-    assertEquals(0, classScope.getSymbols().size());
-    assertEquals(7, classScope.getScopes().size());
-    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 6, 6, SOURCE_FILE);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 6, 20, SOURCE_FILE, 7, 0);
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 6, 6, SOURCE_FILE, 0, 0);
     Scope mainMethodScope = classScope.getScopes().get(1);
-    assertScope(mainMethodScope, ScopeType.METHOD, "main", 8, 13, SOURCE_FILE);
-    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 8, 13, SOURCE_FILE, 1, 1);
     assertSymbol(
         mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 8);
-    assertEquals(1, mainMethodScope.getScopes().size());
-    Scope local0 = mainMethodScope.getScopes().get(0);
-    assertScope(local0, ScopeType.LOCAL, null, 8, 13, SOURCE_FILE);
-    assertEquals(2, local0.getSymbols().size());
-    assertSymbol(local0.getSymbols().get(0), SymbolType.LOCAL, "list", List.class.getTypeName(), 8);
+    Scope mainMethodLocalScope = mainMethodScope.getScopes().get(0);
+    assertScope(mainMethodLocalScope, ScopeType.LOCAL, null, 8, 13, SOURCE_FILE, 0, 2);
     assertSymbol(
-        local0.getSymbols().get(1), SymbolType.LOCAL, "sum", Integer.TYPE.getTypeName(), 12);
+        mainMethodLocalScope.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "list",
+        List.class.getTypeName(),
+        8);
+    assertSymbol(
+        mainMethodLocalScope.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "sum",
+        Integer.TYPE.getTypeName(),
+        12);
     Scope fooMethodScope = classScope.getScopes().get(2);
-    assertScope(fooMethodScope, ScopeType.METHOD, "foo", 17, 20, SOURCE_FILE);
-    assertEquals(1, fooMethodScope.getSymbols().size());
+    assertScope(fooMethodScope, ScopeType.METHOD, "foo", 17, 20, SOURCE_FILE, 0, 1);
     assertSymbol(
         fooMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 17);
     Scope lambdaFoo3MethodScope = classScope.getScopes().get(3);
-    assertScope(lambdaFoo3MethodScope, ScopeType.METHOD, "lambda$foo$3", 19, 19, SOURCE_FILE);
-    assertEquals(1, lambdaFoo3MethodScope.getSymbols().size());
+    assertScope(lambdaFoo3MethodScope, ScopeType.METHOD, "lambda$foo$3", 19, 19, SOURCE_FILE, 0, 1);
     assertSymbol(
         lambdaFoo3MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -553,8 +623,7 @@ class SymbolExtractionTransformerTest {
         Integer.TYPE.getTypeName(),
         19);
     Scope lambdaFoo2MethodScope = classScope.getScopes().get(4);
-    assertScope(lambdaFoo2MethodScope, ScopeType.METHOD, "lambda$foo$2", 19, 19, SOURCE_FILE);
-    assertEquals(1, lambdaFoo2MethodScope.getSymbols().size());
+    assertScope(lambdaFoo2MethodScope, ScopeType.METHOD, "lambda$foo$2", 19, 19, SOURCE_FILE, 0, 1);
     assertSymbol(
         lambdaFoo2MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -562,8 +631,8 @@ class SymbolExtractionTransformerTest {
         Integer.class.getTypeName(),
         19);
     Scope lambdaMain1MethodScope = classScope.getScopes().get(5);
-    assertScope(lambdaMain1MethodScope, ScopeType.METHOD, "lambda$main$1", 11, 11, SOURCE_FILE);
-    assertEquals(1, lambdaMain1MethodScope.getSymbols().size());
+    assertScope(
+        lambdaMain1MethodScope, ScopeType.METHOD, "lambda$main$1", 11, 11, SOURCE_FILE, 0, 1);
     assertSymbol(
         lambdaMain1MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -571,8 +640,8 @@ class SymbolExtractionTransformerTest {
         Integer.TYPE.getTypeName(),
         11);
     Scope lambdaMain0MethodScope = classScope.getScopes().get(6);
-    assertScope(lambdaMain0MethodScope, ScopeType.METHOD, "lambda$main$0", 11, 11, SOURCE_FILE);
-    assertEquals(1, lambdaMain0MethodScope.getSymbols().size());
+    assertScope(
+        lambdaMain0MethodScope, ScopeType.METHOD, "lambda$main$0", 11, 11, SOURCE_FILE, 0, 1);
     assertSymbol(
         lambdaMain0MethodScope.getSymbols().get(0),
         SymbolType.ARG,
@@ -587,12 +656,16 @@ class SymbolExtractionTransformerTest {
       String name,
       int startLine,
       int endLine,
-      String sourceFile) {
+      String sourceFile,
+      int nbScopes,
+      int nbSymbols) {
     assertEquals(scopeType, scope.getScopeType());
     assertEquals(name, scope.getName());
     assertEquals(startLine, scope.getStartLine());
     assertEquals(endLine, scope.getEndLine());
     assertEquals(sourceFile, scope.getSourceFile());
+    assertEquals(nbScopes, scope.getScopes().size());
+    assertEquals(nbSymbols, scope.getSymbols().size());
   }
 
   private void assertSymbol(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -1,0 +1,618 @@
+package com.datadog.debugger.symbol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+import static utils.InstrumentationTestHelper.compileAndLoadClass;
+
+import com.datadog.debugger.sink.SymbolSink;
+import datadog.trace.api.Config;
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.joor.Reflect;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class SymbolExtractionTransformerTest {
+  private static final String SYMBOL_PACKAGE = "com.datadog.debugger.symbol";
+
+  private Instrumentation instr = ByteBuddyAgent.install();
+  private Config config;
+
+  @BeforeEach
+  public void setUp() {
+    config = Mockito.mock(Config.class);
+    when(config.getDebuggerSymbolIncludes()).thenReturn(SYMBOL_PACKAGE);
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
+  }
+
+  @Test
+  public void noIncludesFilterOutDatadogClass() throws IOException, URISyntaxException {
+    config = Mockito.mock(Config.class);
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction01";
+    final String SOURCE_FILE = "SymbolExtraction01.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    assertFalse(
+        symbolSinkMock.jarScopes.stream()
+            .flatMap(scope -> scope.getScopes().stream())
+            .anyMatch(scope -> scope.getName().equals(CLASS_NAME)));
+  }
+
+  @Test
+  public void symbolExtraction01() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction01";
+    final String SOURCE_FILE = "SymbolExtraction01.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 2, 20, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 2, 2, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 4, 20, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 4);
+    assertEquals(4, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 8, 15, SOURCE_FILE);
+    assertEquals(3, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "foo", Integer.TYPE.getTypeName(), 8);
+    assertSymbol(
+        local0.getSymbols().get(1), SymbolType.LOCAL, "bar", Integer.TYPE.getTypeName(), 9);
+    assertSymbol(local0.getSymbols().get(2), SymbolType.LOCAL, "j", Integer.TYPE.getTypeName(), 11);
+    Scope local1 = mainMethodScope.getScopes().get(1);
+    assertScope(local1, ScopeType.LOCAL, null, 7, 15, SOURCE_FILE);
+    assertEquals(1, local1.getSymbols().size());
+    assertSymbol(local1.getSymbols().get(0), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 7);
+    Scope local2 = mainMethodScope.getScopes().get(2);
+    assertScope(local2, ScopeType.LOCAL, null, 6, 17, SOURCE_FILE);
+    assertEquals(1, local2.getSymbols().size());
+    assertSymbol(
+        local2.getSymbols().get(0), SymbolType.LOCAL, "var2", Integer.TYPE.getTypeName(), 6);
+    Scope local3 = mainMethodScope.getScopes().get(3);
+    assertScope(local3, ScopeType.LOCAL, null, 4, 20, SOURCE_FILE);
+    assertEquals(3, local3.getSymbols().size());
+    assertSymbol(
+        local3.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 4);
+    assertSymbol(
+        local3.getSymbols().get(1), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 4);
+    assertSymbol(
+        local3.getSymbols().get(2), SymbolType.LOCAL, "var3", Integer.TYPE.getTypeName(), 19);
+  }
+
+  @Test
+  public void symbolExtraction02() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction02";
+    final String SOURCE_FILE = "SymbolExtraction02.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 6, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
+    assertEquals(1, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 5, 6, SOURCE_FILE);
+    assertEquals(1, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "var1", String.class.getTypeName(), 5);
+  }
+
+  @Test
+  public void symbolExtraction03() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction03";
+    final String SOURCE_FILE = "SymbolExtraction03.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 4, 28, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 4, 4, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 6, 28, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 6);
+    assertEquals(3, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 20, 21, SOURCE_FILE);
+    assertEquals(1, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "var4", String.class.getTypeName(), 20);
+    Scope local1 = mainMethodScope.getScopes().get(1);
+    assertScope(local1, ScopeType.LOCAL, null, 12, 24, SOURCE_FILE);
+    assertEquals(4, local1.getSymbols().size());
+    assertSymbol(
+        local1.getSymbols().get(0), SymbolType.LOCAL, "var31", String.class.getTypeName(), 12);
+    assertSymbol(
+        local1.getSymbols().get(1), SymbolType.LOCAL, "var32", String.class.getTypeName(), 13);
+    assertSymbol(
+        local1.getSymbols().get(2), SymbolType.LOCAL, "var30", String.class.getTypeName(), 15);
+    assertSymbol(
+        local1.getSymbols().get(3), SymbolType.LOCAL, "var3", String.class.getTypeName(), 17);
+    Scope local2 = mainMethodScope.getScopes().get(2);
+    assertScope(local2, ScopeType.LOCAL, null, 6, 28, SOURCE_FILE);
+    assertEquals(3, local2.getSymbols().size());
+    assertSymbol(
+        local2.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 6);
+    assertSymbol(
+        local2.getSymbols().get(1), SymbolType.LOCAL, "var1", String.class.getTypeName(), 6);
+    assertSymbol(
+        local2.getSymbols().get(2), SymbolType.LOCAL, "var5", String.class.getTypeName(), 27);
+  }
+
+  @Test
+  public void symbolExtraction04() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction04";
+    final String SOURCE_FILE = "SymbolExtraction04.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 18, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 18, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
+    assertEquals(5, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 10, 12, SOURCE_FILE);
+    assertEquals(1, local0.getSymbols().size());
+    assertSymbol(local0.getSymbols().get(0), SymbolType.LOCAL, "k", Integer.TYPE.getTypeName(), 10);
+    Scope local1 = mainMethodScope.getScopes().get(1);
+    assertScope(local1, ScopeType.LOCAL, null, 9, 15, SOURCE_FILE);
+    assertEquals(2, local1.getSymbols().size());
+    assertSymbol(
+        local1.getSymbols().get(0), SymbolType.LOCAL, "var3", String.class.getTypeName(), 9);
+    assertSymbol(
+        local1.getSymbols().get(1), SymbolType.LOCAL, "var5", String.class.getTypeName(), 14);
+    Scope local2 = mainMethodScope.getScopes().get(2);
+    assertScope(local2, ScopeType.LOCAL, null, 7, 15, SOURCE_FILE);
+    assertEquals(2, local2.getSymbols().size());
+    assertSymbol(local2.getSymbols().get(0), SymbolType.LOCAL, "j", Integer.TYPE.getTypeName(), 8);
+    assertSymbol(
+        local2.getSymbols().get(1), SymbolType.LOCAL, "var2", String.class.getTypeName(), 7);
+    Scope local3 = mainMethodScope.getScopes().get(3);
+    assertScope(local3, ScopeType.LOCAL, null, 6, 15, SOURCE_FILE);
+    assertEquals(1, local3.getSymbols().size());
+    assertSymbol(local3.getSymbols().get(0), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 6);
+    Scope local4 = mainMethodScope.getScopes().get(4);
+    assertScope(local4, ScopeType.LOCAL, null, 5, 18, SOURCE_FILE);
+    assertEquals(2, local4.getSymbols().size());
+    assertSymbol(
+        local4.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
+    assertSymbol(
+        local4.getSymbols().get(1), SymbolType.LOCAL, "var1", String.class.getTypeName(), 5);
+  }
+
+  @Test
+  public void symbolExtraction05() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction05";
+    final String SOURCE_FILE = "SymbolExtraction05.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 15, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 15, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
+    assertEquals(2, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 7, 13, SOURCE_FILE);
+    assertEquals(2, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 7);
+    assertSymbol(local0.getSymbols().get(1), SymbolType.LOCAL, "j", Integer.TYPE.getTypeName(), 8);
+    Scope local1 = mainMethodScope.getScopes().get(1);
+    assertScope(local1, ScopeType.LOCAL, null, 5, 15, SOURCE_FILE);
+    assertEquals(2, local1.getSymbols().size());
+    assertSymbol(
+        local1.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
+    assertSymbol(local1.getSymbols().get(1), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 5);
+  }
+
+  @Test
+  public void symbolExtraction06() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction06";
+    final String SOURCE_FILE = "SymbolExtraction06.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 13, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 13, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
+    assertEquals(2, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 9, 11, SOURCE_FILE);
+    assertEquals(2, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "var3", Integer.TYPE.getTypeName(), 10);
+    assertSymbol(
+        local0.getSymbols().get(1),
+        SymbolType.LOCAL,
+        "rte",
+        RuntimeException.class.getTypeName(),
+        9);
+    Scope local1 = mainMethodScope.getScopes().get(1);
+    assertScope(local1, ScopeType.LOCAL, null, 5, 13, SOURCE_FILE);
+    assertEquals(2, local1.getSymbols().size());
+    assertSymbol(
+        local1.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
+    assertSymbol(
+        local1.getSymbols().get(1), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 5);
+  }
+
+  @Test
+  public void symbolExtraction07() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction07";
+    final String SOURCE_FILE = "SymbolExtraction07.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 10, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 10, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
+    assertEquals(1, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 5, 10, SOURCE_FILE);
+    assertEquals(2, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
+    assertSymbol(local0.getSymbols().get(1), SymbolType.LOCAL, "i", Integer.TYPE.getTypeName(), 5);
+  }
+
+  @Test
+  public void symbolExtraction08() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction08";
+    final String SOURCE_FILE = "SymbolExtraction08.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 11, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
+    assertEquals(2, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 8, 9, SOURCE_FILE);
+    assertEquals(1, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "var3", Integer.TYPE.getTypeName(), 8);
+    Scope local1 = mainMethodScope.getScopes().get(1);
+    assertScope(local1, ScopeType.LOCAL, null, 5, 11, SOURCE_FILE);
+    assertEquals(2, local1.getSymbols().size());
+    assertSymbol(
+        local1.getSymbols().get(0), SymbolType.LOCAL, "arg", String.class.getTypeName(), 5);
+    assertSymbol(
+        local1.getSymbols().get(1), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 5);
+  }
+
+  @Test
+  public void symbolExtraction09() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction09";
+    final String SOURCE_FILE = "SymbolExtraction09.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 5, 12, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(3, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 5, 5, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 7, 12, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 7);
+    assertEquals(1, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 7, 12, SOURCE_FILE);
+    assertEquals(2, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "outside", Integer.TYPE.getTypeName(), 7);
+    assertSymbol(
+        local0.getSymbols().get(1), SymbolType.LOCAL, "lambda", Supplier.class.getTypeName(), 8);
+    Scope lambdaMethodScope = classScope.getScopes().get(2);
+    assertScope(lambdaMethodScope, ScopeType.METHOD, "lambda$main$0", 9, 10, SOURCE_FILE);
+    assertEquals(1, lambdaMethodScope.getSymbols().size());
+    assertSymbol(
+        lambdaMethodScope.getSymbols().get(0),
+        SymbolType.ARG,
+        "outside",
+        Integer.TYPE.getTypeName(),
+        9);
+    assertEquals(1, lambdaMethodScope.getScopes().size());
+    Scope lambdaLocal0 = lambdaMethodScope.getScopes().get(0);
+    assertScope(lambdaLocal0, ScopeType.LOCAL, null, 9, 10, SOURCE_FILE);
+    assertEquals(1, lambdaLocal0.getSymbols().size());
+    assertSymbol(
+        lambdaLocal0.getSymbols().get(0), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 9);
+  }
+
+  @Test
+  public void symbolExtraction10() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction10";
+    final String SOURCE_FILE = "SymbolExtraction10.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", "1").get();
+    transformer.flushScopes(null);
+    assertEquals(2, symbolSinkMock.jarScopes.get(0).getScopes().size());
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 6, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 3, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 5, 6, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", String.class.getTypeName(), 5);
+    assertEquals(1, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 5, 6, SOURCE_FILE);
+    assertEquals(1, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0),
+        SymbolType.LOCAL,
+        "winner",
+        "com.datadog.debugger.symbol.SymbolExtraction10$Inner",
+        5);
+    Scope innerClassScope = symbolSinkMock.jarScopes.get(0).getScopes().get(1);
+    assertScope(innerClassScope, ScopeType.CLASS, CLASS_NAME + "$Inner", 9, 13, SOURCE_FILE);
+    assertEquals(1, innerClassScope.getSymbols().size());
+    assertEquals(2, innerClassScope.getScopes().size());
+    assertSymbol(
+        innerClassScope.getSymbols().get(0),
+        SymbolType.FIELD,
+        "field1",
+        Integer.TYPE.getTypeName(),
+        0);
+    assertScope(innerClassScope.getScopes().get(0), ScopeType.METHOD, "<init>", 9, 10, SOURCE_FILE);
+    Scope addToMethod = innerClassScope.getScopes().get(1);
+    assertScope(addToMethod, ScopeType.METHOD, "addTo", 12, 13, SOURCE_FILE);
+    assertEquals(1, addToMethod.getSymbols().size());
+    assertSymbol(
+        addToMethod.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 12);
+    assertEquals(1, addToMethod.getScopes().size());
+    Scope addToLocal0 = addToMethod.getScopes().get(0);
+    assertScope(addToLocal0, ScopeType.LOCAL, null, 12, 13, SOURCE_FILE);
+    assertEquals(1, addToLocal0.getSymbols().size());
+    assertSymbol(
+        addToLocal0.getSymbols().get(0), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 12);
+  }
+
+  @Test
+  public void symbolExtraction11() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction11";
+    final String SOURCE_FILE = "SymbolExtraction11.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", 1).get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 3, 11, SOURCE_FILE);
+    assertEquals(1, classScope.getSymbols().size());
+    assertSymbol(
+        classScope.getSymbols().get(0), SymbolType.FIELD, "field1", Integer.TYPE.getTypeName(), 0);
+    assertEquals(2, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 3, 4, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 6, 11, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 6);
+    assertEquals(1, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 6, 11, SOURCE_FILE);
+    assertEquals(2, local0.getSymbols().size());
+    assertSymbol(
+        local0.getSymbols().get(0), SymbolType.LOCAL, "arg", Integer.TYPE.getTypeName(), 6);
+    assertSymbol(
+        local0.getSymbols().get(1), SymbolType.LOCAL, "var1", Integer.TYPE.getTypeName(), 6);
+  }
+
+  @Test
+  public void symbolExtraction12() throws IOException, URISyntaxException {
+    final String CLASS_NAME = SYMBOL_PACKAGE + ".SymbolExtraction12";
+    final String SOURCE_FILE = "SymbolExtraction12.java";
+    SymbolSinkMock symbolSinkMock = new SymbolSinkMock(config);
+    SymbolExtractionTransformer transformer =
+        new SymbolExtractionTransformer(symbolSinkMock, config);
+    instr.addTransformer(transformer);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    Reflect.on(testClass).call("main", 1).get();
+    transformer.flushScopes(null);
+    Scope classScope = symbolSinkMock.jarScopes.get(0).getScopes().get(0);
+    assertScope(classScope, ScopeType.CLASS, CLASS_NAME, 6, 20, SOURCE_FILE);
+    assertEquals(0, classScope.getSymbols().size());
+    assertEquals(7, classScope.getScopes().size());
+    assertScope(classScope.getScopes().get(0), ScopeType.METHOD, "<init>", 6, 6, SOURCE_FILE);
+    Scope mainMethodScope = classScope.getScopes().get(1);
+    assertScope(mainMethodScope, ScopeType.METHOD, "main", 8, 13, SOURCE_FILE);
+    assertEquals(1, mainMethodScope.getSymbols().size());
+    assertSymbol(
+        mainMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 8);
+    assertEquals(1, mainMethodScope.getScopes().size());
+    Scope local0 = mainMethodScope.getScopes().get(0);
+    assertScope(local0, ScopeType.LOCAL, null, 8, 13, SOURCE_FILE);
+    assertEquals(2, local0.getSymbols().size());
+    assertSymbol(local0.getSymbols().get(0), SymbolType.LOCAL, "list", List.class.getTypeName(), 8);
+    assertSymbol(
+        local0.getSymbols().get(1), SymbolType.LOCAL, "sum", Integer.TYPE.getTypeName(), 12);
+    Scope fooMethodScope = classScope.getScopes().get(2);
+    assertScope(fooMethodScope, ScopeType.METHOD, "foo", 17, 20, SOURCE_FILE);
+    assertEquals(1, fooMethodScope.getSymbols().size());
+    assertSymbol(
+        fooMethodScope.getSymbols().get(0), SymbolType.ARG, "arg", Integer.TYPE.getTypeName(), 17);
+    Scope lambdaFoo3MethodScope = classScope.getScopes().get(3);
+    assertScope(lambdaFoo3MethodScope, ScopeType.METHOD, "lambda$foo$3", 19, 19, SOURCE_FILE);
+    assertEquals(1, lambdaFoo3MethodScope.getSymbols().size());
+    assertSymbol(
+        lambdaFoo3MethodScope.getSymbols().get(0),
+        SymbolType.ARG,
+        "x",
+        Integer.TYPE.getTypeName(),
+        19);
+    Scope lambdaFoo2MethodScope = classScope.getScopes().get(4);
+    assertScope(lambdaFoo2MethodScope, ScopeType.METHOD, "lambda$foo$2", 19, 19, SOURCE_FILE);
+    assertEquals(1, lambdaFoo2MethodScope.getSymbols().size());
+    assertSymbol(
+        lambdaFoo2MethodScope.getSymbols().get(0),
+        SymbolType.ARG,
+        "x",
+        Integer.class.getTypeName(),
+        19);
+    Scope lambdaMain1MethodScope = classScope.getScopes().get(5);
+    assertScope(lambdaMain1MethodScope, ScopeType.METHOD, "lambda$main$1", 11, 11, SOURCE_FILE);
+    assertEquals(1, lambdaMain1MethodScope.getSymbols().size());
+    assertSymbol(
+        lambdaMain1MethodScope.getSymbols().get(0),
+        SymbolType.ARG,
+        "x",
+        Integer.TYPE.getTypeName(),
+        11);
+    Scope lambdaMain0MethodScope = classScope.getScopes().get(6);
+    assertScope(lambdaMain0MethodScope, ScopeType.METHOD, "lambda$main$0", 11, 11, SOURCE_FILE);
+    assertEquals(1, lambdaMain0MethodScope.getSymbols().size());
+    assertSymbol(
+        lambdaMain0MethodScope.getSymbols().get(0),
+        SymbolType.ARG,
+        "x",
+        Integer.class.getTypeName(),
+        11);
+  }
+
+  private static void assertScope(
+      Scope scope,
+      ScopeType scopeType,
+      String name,
+      int startLine,
+      int endLine,
+      String sourceFile) {
+    assertEquals(scopeType, scope.getScopeType());
+    assertEquals(name, scope.getName());
+    assertEquals(startLine, scope.getStartLine());
+    assertEquals(endLine, scope.getEndLine());
+    assertEquals(sourceFile, scope.getSourceFile());
+  }
+
+  private void assertSymbol(
+      Symbol symbol, SymbolType symbolType, String name, String type, int line) {
+    assertEquals(symbolType, symbol.getSymbolType());
+    assertEquals(name, symbol.getName());
+    assertEquals(type, symbol.getType());
+    assertEquals(line, symbol.getLine());
+  }
+
+  static class SymbolSinkMock extends SymbolSink {
+    final List<Scope> jarScopes = new ArrayList<>();
+
+    public SymbolSinkMock(Config config) {
+      super(config);
+    }
+
+    @Override
+    public boolean addScope(Scope jarScope) {
+      return jarScopes.add(jarScope);
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction01.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction01.java
@@ -1,0 +1,22 @@
+package com.datadog.debugger.symbol;
+public class SymbolExtraction01 {
+  public static int main(String arg) {
+    int var1 = 1;
+    if (Integer.parseInt(arg) == 2) {
+      int var2 = 2;
+      for (int i = 0; i <= 9; i++) {
+        int foo = 13;
+        int bar = 13;
+        System.out.println(i + foo + bar);
+        int j = 0;
+        while (j < 10) {
+          int var4 = 1;
+          j++;
+        }
+      }
+      return var2;
+    }
+    int var3 = 3;
+    return var1 + var3;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction02.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction02.java
@@ -1,0 +1,8 @@
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction02 {
+  public static int main(String arg) {
+    String var1 = "var1";
+    return var1.length();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction03.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction03.java
@@ -1,0 +1,30 @@
+
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction03 {
+  public static int main(String arg) {
+    String var1 = "var1";
+    if (arg.equals("foo")) {
+      String var2 = "var2";
+      System.out.println(var2);
+    } else {
+      System.out.println(var1);
+      String var31 = "var31";
+      String var32 = "var32";
+      System.out.println(var1);
+      String var30 = "var30";
+      System.out.println(var1);
+      String var3 = "var3";
+      System.out.println(var3);
+      if (arg.equals(var3)) {
+        String var4 = "var4";
+        System.out.println(var4);
+      }
+      if (arg.equals(var1)) {
+        return var3.length();
+      }
+    }
+    String var5 = "var5";
+    return var1.length();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction04.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction04.java
@@ -1,0 +1,20 @@
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction04 {
+  public static int main(String arg) {
+    String var1 = "var1";
+    for (int i = 0; i < 10; i++) {
+      String var2 = "var2";
+      for (int j = 0; j < 10; j++) {
+        String var3 = "var3";
+        for (int k = 0; k < 10; k++) {
+          String var4 = "var4";
+          System.out.println("var4 = " + var4);
+        }
+        String var5 = "var5";
+        System.out.println("var5 = " + var5);
+      }
+    }
+    return var1.length();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction05.java
@@ -1,0 +1,17 @@
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction05 {
+  public static int main(String arg) {
+    int i = 0;
+    while (i < 10) {
+      int var1 = 10;
+      int j = 0;
+      while (j < 10) {
+        int var2 = 1;
+        j++;
+      }
+      i++;
+    }
+    return arg.length();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction06.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction06.java
@@ -1,0 +1,15 @@
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction06 {
+  public static int main(String arg) {
+    int var1 = 1;
+    try {
+      int var2 = 2;
+      throw new RuntimeException("" + var1);
+    } catch (RuntimeException rte) {
+      int var3 = 3;
+      System.out.println("rte = " + rte.getMessage() + var3);
+    }
+    return arg.length();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction07.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction07.java
@@ -1,0 +1,12 @@
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction07 {
+  public static int main(String arg) {
+    int i = 10;
+    do {
+      int j = i + 12;
+      i--;
+    } while (i > 0);
+    return arg.length();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction08.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction08.java
@@ -6,7 +6,7 @@ public class SymbolExtraction08 {
     {
       int var2 = 2;
       int var3 = 3;
-      int var4 = var2 + var3; // Wow, why is this not in the LocalVariableTable?
+      int var4 = var2 + var3; // var4 is not in the LocalVariableTable because last statement of the scope
     }
     return arg.length();
   }

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction08.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction08.java
@@ -1,0 +1,13 @@
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction08 {
+  public static int main(String arg) {
+    int var1 = 1;
+    {
+      int var2 = 2;
+      int var3 = 3;
+      int var4 = var2 + var3; // Wow, why is this not in the LocalVariableTable?
+    }
+    return arg.length();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction09.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction09.java
@@ -1,0 +1,14 @@
+package com.datadog.debugger.symbol;
+
+import java.util.function.Supplier;
+
+public class SymbolExtraction09 {
+  public static int main(String arg) {
+    int outside = 12;
+    Supplier<Integer> lambda = () -> {
+      int var1 = 1;
+      return var1 + outside;
+    };
+    return lambda.get();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction10.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction10.java
@@ -1,0 +1,16 @@
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction10 {
+  public static int main(String arg) {
+    Inner winner = new Inner();
+    return winner.addTo(12);
+  }
+
+  static class Inner {
+    private final int field1 = 1;
+    public int addTo(int arg) {
+      int var1 = 2;
+      return var1 + arg;
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction11.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction11.java
@@ -1,0 +1,13 @@
+package com.datadog.debugger.symbol;
+
+public class SymbolExtraction11 {
+  private final int field1 = 1;
+  public static int main(int arg) {
+    int var1 = 1;
+    if (arg == 42) {
+      int var2 = 2;
+      return var2;
+    }
+    return var1 + arg;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction12.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symbol/SymbolExtraction12.java
@@ -1,0 +1,22 @@
+package com.datadog.debugger.symbol;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SymbolExtraction12 {
+  public static int main(int arg) {
+    List<Integer> list = Arrays.asList(1, 2, 3);
+    int sum = list
+        .stream()
+        .mapToInt(x -> x + 1).map(x -> x - 12)
+        .sum();
+    return sum;
+  }
+
+  public static int foo(int arg) {
+    return Arrays.asList(1, 2, 3, 4)
+        .stream()
+        .mapToInt(x -> x + 1).map(x -> x - 12)
+        .sum();
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -153,6 +153,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD = false;
   static final int DEFAULT_DEBUGGER_CAPTURE_TIMEOUT = 100; // milliseconds
   static final boolean DEFAULT_DEBUGGER_SYMBOL_ENABLED = false;
+  static final int DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD = 100; // nb of classes
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   static final String DEFAULT_TRACE_ANNOTATIONS = null;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -152,6 +152,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DEBUGGER_VERIFY_BYTECODE = true;
   static final boolean DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD = false;
   static final int DEFAULT_DEBUGGER_CAPTURE_TIMEOUT = 100; // milliseconds
+  static final boolean DEFAULT_DEBUGGER_SYMBOL_ENABLED = false;
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   static final String DEFAULT_TRACE_ANNOTATIONS = null;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -25,6 +25,8 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_REDACTED_IDENTIFIERS =
       "dynamic.instrumentation.redacted.identifiers";
   public static final String DEBUGGER_REDACTED_TYPES = "dynamic.instrumentation.redacted.types";
+  public static final String DEBUGGER_SYMBOL_ENABLED = "dynamic.instrumentation.symbol.enabled";
+  public static final String DEBUGGER_SYMBOL_INCLUDES = "dynamic.instrumentation.symbol.includes";
 
   private DebuggerConfig() {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -27,6 +27,8 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_REDACTED_TYPES = "dynamic.instrumentation.redacted.types";
   public static final String DEBUGGER_SYMBOL_ENABLED = "dynamic.instrumentation.symbol.enabled";
   public static final String DEBUGGER_SYMBOL_INCLUDES = "dynamic.instrumentation.symbol.includes";
+  public static final String DEBUGGER_SYMBOL_FLUSH_THRESHOLD =
+      "dynamic.instrumentation.symbol.flush.threshold";
 
   private DebuggerConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -45,6 +45,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_POLL_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_SYMBOL_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_BATCH_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_FLUSH_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_TIMEOUT;
@@ -183,6 +184,7 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_PROBE_FILE_LOCATI
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_REDACTED_IDENTIFIERS;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_REDACTED_TYPES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_SYMBOL_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_SYMBOL_FLUSH_THRESHOLD;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_SYMBOL_INCLUDES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_BATCH_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_FLUSH_INTERVAL;
@@ -735,6 +737,7 @@ public class Config {
   private final String debuggerRedactedTypes;
   private final boolean debuggerSymbolEnabled;
   private final String debuggerSymbolIncludes;
+  private final int debuggerSymbolFlushThreshold;
 
   private final boolean awsPropagationEnabled;
   private final boolean sqsPropagationEnabled;
@@ -1679,6 +1682,9 @@ public class Config {
     debuggerSymbolEnabled =
         configProvider.getBoolean(DEBUGGER_SYMBOL_ENABLED, DEFAULT_DEBUGGER_SYMBOL_ENABLED);
     debuggerSymbolIncludes = configProvider.getString(DEBUGGER_SYMBOL_INCLUDES, null);
+    debuggerSymbolFlushThreshold =
+        configProvider.getInteger(
+            DEBUGGER_SYMBOL_FLUSH_THRESHOLD, DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");
@@ -2767,6 +2773,10 @@ public class Config {
 
   public String getDebuggerSymbolIncludes() {
     return debuggerSymbolIncludes;
+  }
+
+  public int getDebuggerSymbolFlushThreshold() {
+    return debuggerSymbolFlushThreshold;
   }
 
   public String getFinalDebuggerProbeUrl() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -44,6 +44,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_INSTRUMENT_THE_W
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_POLL_INTERVAL;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_SYMBOL_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_BATCH_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_FLUSH_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_UPLOAD_TIMEOUT;
@@ -181,6 +182,8 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_POLL_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_PROBE_FILE_LOCATION;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_REDACTED_IDENTIFIERS;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_REDACTED_TYPES;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_SYMBOL_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_SYMBOL_INCLUDES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_BATCH_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_FLUSH_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_TIMEOUT;
@@ -730,6 +733,8 @@ public class Config {
   private final int debuggerCaptureTimeout;
   private final String debuggerRedactedIdentifiers;
   private final String debuggerRedactedTypes;
+  private final boolean debuggerSymbolEnabled;
+  private final String debuggerSymbolIncludes;
 
   private final boolean awsPropagationEnabled;
   private final boolean sqsPropagationEnabled;
@@ -1671,6 +1676,9 @@ public class Config {
         configProvider.getInteger(DEBUGGER_CAPTURE_TIMEOUT, DEFAULT_DEBUGGER_CAPTURE_TIMEOUT);
     debuggerRedactedIdentifiers = configProvider.getString(DEBUGGER_REDACTED_IDENTIFIERS, null);
     debuggerRedactedTypes = configProvider.getString(DEBUGGER_REDACTED_TYPES, null);
+    debuggerSymbolEnabled =
+        configProvider.getBoolean(DEBUGGER_SYMBOL_ENABLED, DEFAULT_DEBUGGER_SYMBOL_ENABLED);
+    debuggerSymbolIncludes = configProvider.getString(DEBUGGER_SYMBOL_INCLUDES, null);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");
@@ -2753,6 +2761,14 @@ public class Config {
     return debuggerCaptureTimeout;
   }
 
+  public boolean getDebuggerSymbolEnabled() {
+    return debuggerSymbolEnabled;
+  }
+
+  public String getDebuggerSymbolIncludes() {
+    return debuggerSymbolIncludes;
+  }
+
   public String getFinalDebuggerProbeUrl() {
     // by default poll from datadog agent
     return "http://" + agentHost + ":" + agentPort;
@@ -2761,6 +2777,10 @@ public class Config {
   public String getFinalDebuggerSnapshotUrl() {
     // by default send to datadog agent
     return agentUrl + "/debugger/v1/input";
+  }
+
+  public String getFinalDebuggerSymDBUrl() {
+    return agentUrl + "/symdb/v1/input";
   }
 
   public String getDebuggerProbeFileLocation() {


### PR DESCRIPTION
# What Does This Do
Add a ClassFileTransformer to intercept classes to load and extract symbols (class, methods, arguments fields, local variables) and upload them to the new datadog agent endpoint `/symdb/v1/input`. Disabled by default need to put the config
`dd.dynamic.instrumentation.symbol.enabled=true`
JDK and datadog classes are filtered out by default, but you can explicitly include packages with
`dd.dynamic.instrumentation.symbol.includes`

# Motivation

# Additional Notes
[DEBUG-1811]
<!-- When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state. -->


[DEBUG-1811]: https://datadoghq.atlassian.net/browse/DEBUG-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ