### PR TITLE
Make sure internal 'datadog.trace.api.Functions' class is relocated in dd-trace-ot

### DIFF
--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -114,7 +114,7 @@ shadowJar {
   relocate('datadog.', 'ddtrot.dd.') {
     exclude('datadog.opentracing.*')
     exclude('datadog.opentracing.resolver.*')
-    exclude('datadog.trace.api.*')
+    exclude('%regex[datadog/trace/api/(?!Functions|Endpoint)[^/]*]')
     exclude('datadog.trace.api.config.*')
     exclude('datadog.trace.api.experimental.*')
     exclude('datadog.trace.api.interceptor.*')


### PR DESCRIPTION
# Motivation

`DDTracer` uses `Functions.UTF8_ENCODE` when creating spans. `Functions` is currently excluded from relocation while `UTF8BytesString` which it depends on is relocated. This can lead to class-cast issues when attaching `dd-java-agent` and `dd-trace-ot` even when automatic tracing is explicitly disabled.

A similar issue can occur with the `Endpoint*` internal API so we also relocate that.

# Additional Notes

An alternative solution would have been to not relocate the `datadog.trace.bootstrap.instrumentation.api` package. But that then exposes more of the internal API, which could potentially lead to similar class-cast issues later on.

Note: the solution here is more complicated than it would have been if we didn't put `internal-api` types such as `datadog.trace.ap.iFunctions` in the same package as `dd-trace-api` types. Because these types share the same package we had to use a more complicated regexp pattern, rather than the simpler package matcher.
