### PR TITLE
Disable sampling for span decoration probe

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -246,10 +246,6 @@ public class ConfigurationUpdater
   }
 
   private void applyRateLimiter(ConfigurationComparer changes) {
-    Collection<LogProbe> probes = currentConfiguration.getLogProbes();
-    if (probes == null) {
-      return;
-    }
     // ensure rate is up-to-date for all new probes
     for (ProbeDefinition addedDefinitions : changes.getAddedDefinitions()) {
       if (addedDefinitions instanceof LogProbe) {
@@ -261,6 +257,11 @@ public class ConfigurationUpdater
                 ? sampling.getSnapshotsPerSecond()
                 : getDefaultRateLimitPerProbe(probe),
             probe.isCaptureSnapshot());
+      }
+      if (addedDefinitions instanceof SpanDecorationProbe) {
+        // Span decoration probes use the same instrumentation as log probes, but we don't want
+        // to sample here.
+        ProbeRateLimiter.setRate(addedDefinitions.getId(), -1, false);
       }
     }
     // remove rate for all removed probes

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Trace;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -18,7 +19,7 @@ import okhttp3.mockwebserver.RecordedRequest;
 public class ServerDebuggerTestApplication {
   private static final MockResponse EMPTY_HTTP_200 = new MockResponse().setResponseCode(200);
   private static final String LOG_FILENAME = System.getenv().get("DD_LOG_FILE");
-  private static final Map<String, Runnable> methodsByName = new HashMap<>();
+  private static final Map<String, Consumer<String>> methodsByName = new HashMap<>();
   private final MockWebServer webServer = new MockWebServer();
   private final String controlServerUrl;
   private final OkHttpClient httpClient = new OkHttpClient();
@@ -39,6 +40,8 @@ public class ServerDebuggerTestApplication {
   public static void registerMethods() {
     methodsByName.put("fullMethod", ServerDebuggerTestApplication::runFullMethod);
     methodsByName.put("tracedMethod", ServerDebuggerTestApplication::runTracedMethod);
+    methodsByName.put("loopingFullMethod", ServerDebuggerTestApplication::runLoopingFullMethod);
+    methodsByName.put("loopingTracedMethod", ServerDebuggerTestApplication::runLoopingTracedMethod);
   }
 
   public ServerDebuggerTestApplication(String controlServerUrl) {
@@ -93,17 +96,17 @@ public class ServerDebuggerTestApplication {
     }
   }
 
-  protected void execute(String methodName) {
-    Runnable method = methodsByName.get(methodName);
+  protected void execute(String methodName, String arg) {
+    Consumer<String> method = methodsByName.get(methodName);
     if (method == null) {
       throw new RuntimeException("cannot find method: " + methodName);
     }
     System.out.println("Executing method: " + methodName);
-    method.run();
+    method.accept(arg);
     System.out.println("Executed");
   }
 
-  private static void runFullMethod() {
+  private static void runFullMethod(String arg) {
     Map<String, String> map = new HashMap<>();
     map.put("key1", "val1");
     map.put("key2", "val2");
@@ -111,13 +114,29 @@ public class ServerDebuggerTestApplication {
     fullMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
   }
 
+  private static void runLoopingFullMethod(String arg) {
+    Map<String, String> map = new HashMap<>();
+    map.put("key1", "val1");
+    map.put("key2", "val2");
+    map.put("key3", "val3");
+    for (int i = 0; i < Integer.parseInt(arg); i++) {
+      fullMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
+    }
+  }
+
   @Trace
-  private static void runTracedMethod() {
+  private static void runTracedMethod(String arg) {
     Map<String, String> map = new HashMap<>();
     map.put("key1", "val1");
     map.put("key2", "val2");
     map.put("key3", "val3");
     tracedMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
+  }
+
+  private static void runLoopingTracedMethod(String arg) {
+    for (int i = 0; i < Integer.parseInt(arg); i++) {
+      runTracedMethod(arg);
+    }
   }
 
   private static String fullMethod(
@@ -182,7 +201,8 @@ public class ServerDebuggerTestApplication {
         case "/app/execute":
           {
             String methodName = request.getRequestUrl().queryParameter("methodname");
-            app.execute(methodName);
+            String arg = request.getRequestUrl().queryParameter("arg");
+            app.execute(methodName, arg);
             break;
           }
         case "/app/stop":

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -310,6 +310,7 @@ public abstract class BaseIntegrationTest {
   }
 
   protected void processRequests() throws InterruptedException {
+    long start = System.currentTimeMillis();
     RecordedRequest request;
     do {
       request = datadogAgentServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
@@ -322,7 +323,8 @@ public abstract class BaseIntegrationTest {
           return;
         }
       }
-    } while (request != null);
+    } while (request != null && (System.currentTimeMillis() - start < 30_000));
+    throw new RuntimeException("timeout!");
   }
 
   protected void processRemainingRequests() throws InterruptedException {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
@@ -93,8 +93,13 @@ public class ServerAppDebuggerIntegrationTest extends BaseIntegrationTest {
   }
 
   protected void execute(String appUrl, String methodName) throws IOException {
+    execute(appUrl, methodName, null);
+  }
+
+  protected void execute(String appUrl, String methodName, String arg) throws IOException {
     datadogAgentServer.enqueue(EMPTY_200_RESPONSE); // expect 1 snapshot
-    String url = String.format(appUrl + "/execute?methodname=%s", methodName);
+    String executeFormat = arg != null ? "/execute?methodname=%s&arg=%s" : "/execute?methodname=%s";
+    String url = String.format(appUrl + executeFormat, methodName, arg);
     sendRequest(url);
     LOG.info("Execution done");
   }


### PR DESCRIPTION

# What Does This Do
As span decoration probes are sharing the same instrumented code than Log probes, we also evaluate the sampling during the execution which does not bring any value in the case of Span decoration probes. We set the rate limiter for span decoration probe to a constant one.

# Motivation

# Additional Notes

Jira ticket: [DEBUG-1767]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1767]: https://datadoghq.atlassian.net/browse/DEBUG-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ