### PR TITLE
Flush data streams stats when lambda stops

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1109,7 +1109,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   public void flush() {
     pendingTraceBuffer.flush();
     writer.flush();
-    dataStreamsMonitoring.flushAll();
+    dataStreamsMonitoring.flush();
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1109,6 +1109,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   public void flush() {
     pendingTraceBuffer.flush();
     writer.flush();
+    dataStreamsMonitoring.flushAll();
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsMonitoring.java
@@ -38,5 +38,5 @@ public interface DataStreamsMonitoring extends AgentDataStreamsMonitoring, AutoC
   @Override
   void close();
 
-  void flushAll();
+  void flush();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamsMonitoring.java
@@ -37,4 +37,6 @@ public interface DataStreamsMonitoring extends AgentDataStreamsMonitoring, AutoC
 
   @Override
   void close();
+
+  void flushAll();
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DataStreamsWritingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DataStreamsWritingTest.groovy
@@ -133,9 +133,17 @@ class DataStreamsWritingTest extends DDCoreSpecification {
     when:
     def dataStreams = new DefaultDataStreamsMonitoring(fakeConfig, sharedCommObjects, timeSource, { traceConfig })
     dataStreams.start()
-    dataStreams.add(new StatsPoint([], 9, 0, timeSource.currentTimeNanos, 0, 0))
-    dataStreams.add(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, 0, 0))
-    dataStreams.flushAll()
+    dataStreams.flush()
+    dataStreams.flush()
+
+    then:
+    // flushing nothing
+    assert requestBodies.size() == 0
+
+    when:
+    dataStreams.add(new StatsPoint([], 9, 0, timeSource.currentTimeNanos, 0, 0, 0))
+    dataStreams.add(new StatsPoint(["type:testType", "group:testGroup", "topic:testTopic"], 1, 2, timeSource.currentTimeNanos, 0, 0, 0))
+    dataStreams.flush()
 
     then:
     assert requestBodies.size() == 1


### PR DESCRIPTION
# What Does This Do

Flush Data Streams Monitoring stats when tracer is stopped.
For example, when Lambda function exits.

# Motivation

Data Streams stats were missing when executing Lambda functions

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
