### PR TITLE
Avoid potential blocking operation on tracer shutdown

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -269,7 +269,6 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
       thread.join(THREAD_JOIN_TIMOUT_MS);
     } catch (InterruptedException ignored) {
     }
-    inbox.clear();
   }
 
   private class InboxProcessor implements Runnable {


### PR DESCRIPTION
Avoid calling `inbox.clear()` from the producer side when shutting down DSM, as it might block

First reported in https://github.com/DataDog/dd-trace-java/issues/6010