### PR TITLE
Donwgrade urllib3 to work around testcontainer tunnel timeouts

### DIFF
--- a/.circleci/start_docker_autoforward.sh
+++ b/.circleci/start_docker_autoforward.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eux
 
+# workaround for https://github.com/docker/docker-py/issues/3113
+pip3 install --force-reinstall "urllib3<2"
+
 if [[ -n "${DOCKER_CERT_PATH:-}" ]]; then
     TLS_ARGS="
         --secure


### PR DESCRIPTION
# What Does This Do

Forcefully downgrades the `urllib3` python dependency used by the testcontainer tunnels to `1.x` to avoid failures and test timeouts.

# Motivation

https://github.com/docker/docker-py/issues/3113
