### PR TITLE
Relocate OkHttp to avoid conflicts

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -48,6 +48,14 @@ ext.generalShadowJarConfig = {
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'datadog.trace.bootstrap.PatchLogger'
 
+  final String projectName = "${project.name}"
+
+  // Prevents conflict with other OkHttp instances, but don't relocate instrumentation
+  if (!projectName.equals('instrumentation')) {
+    relocate 'okhttp3', 'datadog.okhttp3'
+    relocate 'okio',  'datadog.okio'
+  }
+
   if (!project.hasProperty("disableShadowRelocate") || !disableShadowRelocate) {
     // shadow OT impl to prevent casts to implementation
     relocate 'datadog.trace.common', 'datadog.trace.agent.common'

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/LinkAtBuildTimeInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/LinkAtBuildTimeInstrumentation.java
@@ -30,7 +30,7 @@ public final class LinkAtBuildTimeInstrumentation extends AbstractNativeImageIns
         @Advice.Argument(0) Class<?> declaringClass,
         @Advice.Return(readOnly = false) boolean linkAtBuildTime) {
       // skip AndroidPlatform from build-time linking because we're not building on Android
-      if ("okhttp3.internal.platform.AndroidPlatform".equals(declaringClass.getName())) {
+      if ("datadog.okhttp3.internal.platform.AndroidPlatform".equals(declaringClass.getName())) {
         linkAtBuildTime = false;
       }
     }

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/ResourcesFeatureInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/ResourcesFeatureInstrumentation.java
@@ -37,7 +37,7 @@ public final class ResourcesFeatureInstrumentation extends AbstractNativeImageIn
         "dd-trace-api.version",
         "trace/dd-trace-core.version",
         "shared/dogstatsd/version.properties",
-        "shared/okhttp3/internal/publicsuffix/publicsuffixes.gz"
+        "shared/datadog/okhttp3/internal/publicsuffix/publicsuffixes.gz"
       };
 
       for (String original : tracerResources) {

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/classloading/ShadowPackageRenamingTest.groovy
@@ -17,7 +17,7 @@ class ShadowPackageRenamingTest extends Specification {
     final URL agentOkioDep =
       ddClass
       .getClassLoader()
-      .loadClass("okio.BufferedSink")
+      .loadClass("datadog.okio.BufferedSink")
       .getProtectionDomain()
       .getCodeSource()
       .getLocation()


### PR DESCRIPTION
# What Does This Do
Relocates OkHttp used in the agent so it doesn't clash with versions used in the App

# Motivation
Fixes: https://github.com/DataDog/dd-trace-java/issues/6017
