### PR TITLE
Add Graal Native image support for jctools

### DIFF
--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_org_jctools_counters_FixedSizeStripedLongCounterFields.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_org_jctools_counters_FixedSizeStripedLongCounterFields.java
@@ -1,0 +1,12 @@
+package datadog.trace.instrumentation.graal.nativeimage;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.jctools.counters.FixedSizeStripedLongCounterFields")
+public final class Target_org_jctools_counters_FixedSizeStripedLongCounterFields {
+  @Alias
+  @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayBaseOffset, declClass = long[].class)
+  public static long COUNTER_ARRAY_BASE;
+}

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_org_jctools_util_UnsafeRefArrayAccess.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_org_jctools_util_UnsafeRefArrayAccess.java
@@ -1,0 +1,12 @@
+package datadog.trace.instrumentation.graal.nativeimage;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.jctools.util.UnsafeRefArrayAccess")
+public final class Target_org_jctools_util_UnsafeRefArrayAccess {
+  @Alias
+  @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayIndexShift, declClass = Object[].class)
+  public static int REF_ELEMENT_SHIFT;
+}


### PR DESCRIPTION
# What Does This Do
Adds Graal `RecomputeFieldValue` for the required jctools so native image works correctly.
All projects that uses it (netty, quarkus) already does the same thing for the shaded classes (eg.: https://github.com/quarkusio/quarkus/blob/6a38570b295b4f696a39da0c6cf27ab90f81431f/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/graal/UnsafeRefArrayAccess.java#L8 && https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/svm/UnsafeRefArrayAccessSubstitution.java ) .

# Motivation
Fixes: https://github.com/DataDog/dd-trace-java/issues/6019
