### PR TITLE
Lock down CircleCI build images and remove workaround

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -635,7 +635,7 @@ jobs:
     <<: *tests
 
     docker:
-      - image: << pipeline.parameters.docker_image >>:<< parameters.testJvm >>
+      - image: << pipeline.parameters.docker_image >>:{{ docker_image_prefix }}<< parameters.testJvm >>
         environment:
           - CI_USE_TEST_AGENT=true
       - image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.11.0
@@ -676,7 +676,7 @@ jobs:
     resource_class: medium
 
     docker:
-      - image: << pipeline.parameters.docker_image >>:7
+      - image: << pipeline.parameters.docker_image >>:{{ docker_image_prefix }}8
       - image: datadog/agent:7.34.0
         environment:
           - DD_APM_ENABLED=true
@@ -687,7 +687,7 @@ jobs:
     <<: *defaults
     resource_class: medium
     docker:
-      - image: << pipeline.parameters.docker_image >>:7
+      - image: << pipeline.parameters.docker_image >>:{{ docker_image_prefix }}7
 
     steps:
       - setup_code

--- a/.circleci/start_docker_autoforward.sh
+++ b/.circleci/start_docker_autoforward.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -eux
 
-# workaround for https://github.com/docker/docker-py/issues/3113
-pip3 install --force-reinstall "urllib3<2"
-
 if [[ -n "${DOCKER_CERT_PATH:-}" ]]; then
     TLS_ARGS="
         --secure


### PR DESCRIPTION
# What Does This Do

Locks down the version of the `dd-trace-java-docker-build` image in a few places that was missing it. Also removes the `urllib3` downgrade workaround from #6015 

# Motivation

Using the versioned images makes sure that we don't get accidental breakage from newer releases of the tools in the image.