### PR TITLE
Fix getting upstream branch name for unshallowing

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
@@ -67,7 +67,7 @@ public class GitClient {
   }
 
   /**
-   * Returns the full symbolic name of the upstream (remote tracking) branch for the currently
+   * Returns the SHA of the head commit of the upstream (remote tracking) branch for the currently
    * checked-out local branch. If the local branch is not tracking any remote branches, a {@link
    * datadog.trace.civisibility.utils.ShellCommandExecutor.ShellCommandFailedException} exception
    * will be thrown.
@@ -79,7 +79,7 @@ public class GitClient {
    * @throws InterruptedException If current thread was interrupted while waiting for Git command to
    *     finish
    */
-  public String getUpstreamBranch() throws IOException, TimeoutException, InterruptedException {
+  public String getUpstreamBranchSha() throws IOException, TimeoutException, InterruptedException {
     return commandExecutor
         .executeCommand(IOUtils::readFully, "git", "rev-parse", "@{upstream}")
         .trim();

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
@@ -81,13 +81,7 @@ public class GitClient {
    */
   public String getUpstreamBranch() throws IOException, TimeoutException, InterruptedException {
     return commandExecutor
-        .executeCommand(
-            IOUtils::readFully,
-            "git",
-            "rev-parse",
-            "--abbrev-ref",
-            "--symbolic-full-name",
-            "@{upstream}")
+        .executeCommand(IOUtils::readFully, "git", "rev-parse", "@{upstream}")
         .trim();
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
@@ -150,7 +150,7 @@ public class GitDataUploaderImpl implements GitDataUploader {
     }
 
     try {
-      String upstreamBranch = gitClient.getUpstreamBranch();
+      String upstreamBranch = gitClient.getUpstreamBranchSha();
       gitClient.unshallow(upstreamBranch);
     } catch (ShellCommandExecutor.ShellCommandFailedException e) {
       LOGGER.debug(

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
@@ -43,16 +43,16 @@ class GitClientTest extends Specification {
     shallow
   }
 
-  def "test get upstream branch"() {
+  def "test get upstream branch SHA"() {
     given:
     givenGitRepo("ci/git/shallow/git")
 
     when:
     def gitClient = givenGitClient()
-    def upstreamBranch = gitClient.getUpstreamBranch()
+    def upstreamBranch = gitClient.getUpstreamBranchSha()
 
     then:
-    upstreamBranch == "master"
+    upstreamBranch == "98b944cc44f18bfb78e3021de2999cdcda8efdf6"
   }
 
   def "test unshallow: #remoteSha"() {

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
@@ -52,7 +52,7 @@ class GitClientTest extends Specification {
     def upstreamBranch = gitClient.getUpstreamBranch()
 
     then:
-    upstreamBranch == "origin/master"
+    upstreamBranch == "master"
   }
 
   def "test unshallow: #remoteSha"() {


### PR DESCRIPTION
# What Does This Do
Fixes logic that gets upstream branch reference to return commit SHA which corresponds to the last commit in the branch, rather than the branch name.

# Motivation
Previous version of the logic returned branch in the form of `upstream/branch` - e.g. `origin/master` - and this form cannot be used by `git fetch` command.

Jira ticket: [CIAPP-7835]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIAPP-7835]: https://datadoghq.atlassian.net/browse/CIAPP-7835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ