### PR TITLE
Add support for AWS CodePipeline CI provider

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AwsCodePipelineInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AwsCodePipelineInfo.java
@@ -1,0 +1,26 @@
+package datadog.trace.civisibility.ci;
+
+import datadog.trace.api.git.GitInfo;
+
+class AwsCodePipelineInfo implements CIProviderInfo {
+
+  public static final String AWS_CODEPIPELINE = "CODEBUILD_INITIATOR";
+  public static final String AWS_CODEPIPELINE_PROVIDER_NAME = "awscodepipeline";
+  public static final String AWS_CODEPIPELINE_EXECUTION_ID = "DD_PIPELINE_EXECUTION_ID";
+  public static final String AWS_CODEPIPELINE_ACTION_EXECUTION_ID = "DD_ACTION_EXECUTION_ID";
+  public static final String AWS_CODEPIPELINE_ARN = "CODEBUILD_BUILD_ARN";
+
+  @Override
+  public GitInfo buildCIGitInfo() {
+    return GitInfo.NOOP;
+  }
+
+  @Override
+  public CIInfo buildCIInfo() {
+    return CIInfo.builder()
+        .ciProviderName(AWS_CODEPIPELINE_PROVIDER_NAME)
+        .ciPipelineId(System.getenv(AWS_CODEPIPELINE_EXECUTION_ID))
+        .ciEnvVars(AWS_CODEPIPELINE_EXECUTION_ID, AWS_CODEPIPELINE_ACTION_EXECUTION_ID, AWS_CODEPIPELINE_ARN)
+        .build();
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AwsCodePipelineInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AwsCodePipelineInfo.java
@@ -20,7 +20,10 @@ class AwsCodePipelineInfo implements CIProviderInfo {
     return CIInfo.builder()
         .ciProviderName(AWS_CODEPIPELINE_PROVIDER_NAME)
         .ciPipelineId(System.getenv(AWS_CODEPIPELINE_EXECUTION_ID))
-        .ciEnvVars(AWS_CODEPIPELINE_EXECUTION_ID, AWS_CODEPIPELINE_ACTION_EXECUTION_ID, AWS_CODEPIPELINE_ARN)
+        .ciEnvVars(
+            AWS_CODEPIPELINE_EXECUTION_ID,
+            AWS_CODEPIPELINE_ACTION_EXECUTION_ID,
+            AWS_CODEPIPELINE_ARN)
         .build();
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CIProviderInfoFactory.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CIProviderInfoFactory.java
@@ -51,6 +51,9 @@ public class CIProviderInfoFactory {
       return new CodefreshInfo();
     } else if (System.getenv(TeamcityInfo.TEAMCITY) != null) {
       return new TeamcityInfo();
+    } else if (System.getenv(AwsCodePipelineInfo.AWS_CODEPIPELINE) != null
+        && System.getenv(AwsCodePipelineInfo.AWS_CODEPIPELINE).startsWith("codepipeline")) {
+      return new AwsCodePipelineInfo();
     } else {
       return new UnknownCIInfo(targetFolder, currentPath);
     }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/AwsCodePipelineInfoTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ci/AwsCodePipelineInfoTest.groovy
@@ -1,0 +1,30 @@
+package datadog.trace.civisibility.ci
+
+import java.nio.file.Path
+
+class AwsCodePipelineInfoTest extends CITagsProviderTest {
+
+  @Override
+  String getProviderName() {
+    return AwsCodePipelineInfo.AWS_CODEPIPELINE_PROVIDER_NAME
+  }
+
+  @Override
+  Map<String, String> buildRemoteGitInfoEmpty() {
+    final Map<String, String> map = new HashMap<>()
+    map.put(AwsCodePipelineInfo.AWS_CODEPIPELINE, "codepipeline")
+    return map
+  }
+
+  @Override
+  Map<String, String> buildRemoteGitInfoMismatchLocalGit() {
+    final Map<String, String> map = new HashMap<>()
+    map.put(AwsCodePipelineInfo.AWS_CODEPIPELINE, "codepipeline")
+    return map
+  }
+
+  @Override
+  Path getWorkspacePath() {
+    null
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/test/resources/ci/awscodepipeline.json
+++ b/dd-java-agent/agent-ci-visibility/src/test/resources/ci/awscodepipeline.json
@@ -1,0 +1,62 @@
+[
+  [
+    {
+      "CODEBUILD_BUILD_ARN": "arn:aws:codebuild:eu-north-1:12345678:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19",
+      "CODEBUILD_INITIATOR": "codepipeline/test-pipeline",
+      "DD_ACTION_EXECUTION_ID": "35519dc3-7c45-493c-9ba6-cd78ea11f69d",
+      "DD_GIT_BRANCH": "user-supplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "DD_PIPELINE_EXECUTION_ID": "bb1f15ed-fde2-494d-8e13-88785bca9cc0"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CODEBUILD_BUILD_ARN\":\"arn:aws:codebuild:eu-north-1:12345678:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19\",\"DD_PIPELINE_EXECUTION_ID\":\"bb1f15ed-fde2-494d-8e13-88785bca9cc0\",\"DD_ACTION_EXECUTION_ID\":\"35519dc3-7c45-493c-9ba6-cd78ea11f69d\"}",
+      "ci.pipeline.id": "bb1f15ed-fde2-494d-8e13-88785bca9cc0",
+      "ci.provider.name": "awscodepipeline",
+      "git.branch": "user-supplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
+    }
+  ],
+  [
+    {
+      "CODEBUILD_INITIATOR": "lambdafunction/test-lambda",
+      "DD_GIT_BRANCH": "user-supplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
+    },
+    {
+      "git.branch": "user-supplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
+    }
+  ]
+]


### PR DESCRIPTION
# What Does This Do
Adds support for AWS CodePipeline CI provider.
Some metadata is extracted from available environment variables.

Jira ticket: [CIAPP-786]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIAPP-786]: https://datadoghq.atlassian.net/browse/CIAPP-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ