### PR TITLE
Add Graal Native image support for jctools

### DIFF
--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/AnnotationSubstitutionProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/AnnotationSubstitutionProcessorInstrumentation.java
@@ -34,19 +34,20 @@ public final class AnnotationSubstitutionProcessorInstrumentation
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      "datadog.trace.instrumentation.graal.nativeimage.Target_org_jctools_counters_FixedSizeStripedLongCounterFields",
-      "datadog.trace.instrumentation.graal.nativeimage.Target_org_jctools_util_UnsafeRefArrayAccess"
+      packageName + ".Target_org_jctools_counters_FixedSizeStripedLongCounterFields",
+      packageName + ".Target_org_jctools_util_UnsafeRefArrayAccess"
     };
   }
 
   @Override
   public String[] muzzleIgnoredClassNames() {
-    // ignore JVMCI classes which are part of GraalVM but aren't available in public repositories
     return new String[] {
+      // JVMCI classes which are part of GraalVM but aren't available in public repositories
       "jdk.vm.ci.meta.ResolvedJavaType",
       "jdk.vm.ci.meta.ResolvedJavaField",
-      "datadog.trace.instrumentation.graal.nativeimage.Target_org_jctools_counters_FixedSizeStripedLongCounterFields",
-      "datadog.trace.instrumentation.graal.nativeimage.Target_org_jctools_util_UnsafeRefArrayAccess"
+      // ignore helper class names as usual
+      packageName + ".Target_org_jctools_counters_FixedSizeStripedLongCounterFields",
+      packageName + ".Target_org_jctools_util_UnsafeRefArrayAccess"
     };
   }
 

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/AnnotationSubstitutionProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/AnnotationSubstitutionProcessorInstrumentation.java
@@ -6,6 +6,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.util.List;
+import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
 public final class AnnotationSubstitutionProcessorInstrumentation
@@ -23,11 +25,36 @@ public final class AnnotationSubstitutionProcessorInstrumentation
             .and(named("lookup"))
             .and(takesArgument(0, named("jdk.vm.ci.meta.ResolvedJavaField"))),
         packageName + ".DeleteFieldAdvice");
+    transformation.applyAdvice(
+        isMethod().and(named("findTargetClasses")),
+        AnnotationSubstitutionProcessorInstrumentation.class.getName()
+            + "$FindTargetClassesAdvice");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      "datadog.trace.instrumentation.graal.nativeimage.Target_org_jctools_counters_FixedSizeStripedLongCounterFields",
+      "datadog.trace.instrumentation.graal.nativeimage.Target_org_jctools_util_UnsafeRefArrayAccess"
+    };
   }
 
   @Override
   public String[] muzzleIgnoredClassNames() {
     // ignore JVMCI classes which are part of GraalVM but aren't available in public repositories
-    return new String[] {"jdk.vm.ci.meta.ResolvedJavaType", "jdk.vm.ci.meta.ResolvedJavaField"};
+    return new String[] {
+      "jdk.vm.ci.meta.ResolvedJavaType",
+      "jdk.vm.ci.meta.ResolvedJavaField",
+      "datadog.trace.instrumentation.graal.nativeimage.Target_org_jctools_counters_FixedSizeStripedLongCounterFields",
+      "datadog.trace.instrumentation.graal.nativeimage.Target_org_jctools_util_UnsafeRefArrayAccess"
+    };
+  }
+
+  public static class FindTargetClassesAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(@Advice.Return(readOnly = false) List<Class<?>> result) {
+      result.add(Target_org_jctools_counters_FixedSizeStripedLongCounterFields.class);
+      result.add(Target_org_jctools_util_UnsafeRefArrayAccess.class);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_org_jctools_counters_FixedSizeStripedLongCounterFields.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_org_jctools_counters_FixedSizeStripedLongCounterFields.java
@@ -1,0 +1,12 @@
+package datadog.trace.instrumentation.graal.nativeimage;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.jctools.counters.FixedSizeStripedLongCounterFields")
+public final class Target_org_jctools_counters_FixedSizeStripedLongCounterFields {
+  @Alias
+  @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayBaseOffset, declClass = long[].class)
+  public static long COUNTER_ARRAY_BASE;
+}

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_org_jctools_util_UnsafeRefArrayAccess.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_org_jctools_util_UnsafeRefArrayAccess.java
@@ -1,0 +1,12 @@
+package datadog.trace.instrumentation.graal.nativeimage;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "org.jctools.util.UnsafeRefArrayAccess")
+public final class Target_org_jctools_util_UnsafeRefArrayAccess {
+  @Alias
+  @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayIndexShift, declClass = Object[].class)
+  public static int REF_ELEMENT_SHIFT;
+}


### PR DESCRIPTION
Review of https://github.com/DataDog/dd-trace-java/pull/6020 (authored by @luneo7)

# What Does This Do
Adds Graal `RecomputeFieldValue` for the required jctools so native image works correctly.
All projects that uses it (netty, quarkus) already does the same thing for the shaded classes (eg.: https://github.com/quarkusio/quarkus/blob/6a38570b295b4f696a39da0c6cf27ab90f81431f/extensions/opentelemetry/runtime/src/main/java/io/quarkus/opentelemetry/runtime/graal/UnsafeRefArrayAccess.java#L8 && https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/internal/svm/UnsafeRefArrayAccessSubstitution.java ) .

# Motivation
This will avoid the crash reported in https://github.com/DataDog/dd-trace-java/issues/6019
