### PR TITLE
Rename spark streaming query attributes

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatadogSparkListener.java
@@ -634,11 +634,11 @@ public class DatadogSparkListener extends SparkListener {
           metrics.setSpanMetrics(batchSpan);
         }
 
-        batchSpan.setTag("id", event.id());
-        batchSpan.setTag("run_id", event.runId());
-        batchSpan.setTag("batch_id", getBatchIdFromBatchKey(batchKey));
+        batchSpan.setTag("streaming_query.id", event.id());
+        batchSpan.setTag("streaming_query.run_id", event.runId());
+        batchSpan.setTag("streaming_query.batch_id", getBatchIdFromBatchKey(batchKey));
         if (startedEvent != null) {
-          batchSpan.setTag("name", startedEvent.name());
+          batchSpan.setTag("streaming_query.name", startedEvent.name());
           batchSpan.setTag(DDTags.RESOURCE_NAME, startedEvent.name());
         }
 
@@ -669,10 +669,10 @@ public class DatadogSparkListener extends SparkListener {
         metrics.setSpanMetrics(batchSpan);
       }
 
-      batchSpan.setTag("id", progress.id());
-      batchSpan.setTag("run_id", progress.runId());
-      batchSpan.setTag("batch_id", progress.batchId());
-      batchSpan.setTag("name", progress.name());
+      batchSpan.setTag("streaming_query.id", progress.id());
+      batchSpan.setTag("streaming_query.run_id", progress.runId());
+      batchSpan.setTag("streaming_query.batch_id", progress.batchId());
+      batchSpan.setTag("streaming_query.name", progress.name());
       batchSpan.setTag(DDTags.RESOURCE_NAME, progress.name());
 
       batchSpan.setMetric("spark.num_input_rows", progress.numInputRows());

--- a/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/test/groovy/SparkStructuredStreamingTest.groovy
@@ -68,11 +68,11 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
           tags {
             defaultTags()
             // Streaming tags
-            "batch_id" 0
-            "name" "test-query"
+            "streaming_query.batch_id" 0
+            "streaming_query.name" "test-query"
             "app_id" String
-            "id" UUID
-            "run_id" UUID
+            "streaming_query.id" UUID
+            "streaming_query.run_id" UUID
             "spark.num_input_rows" 3
             "spark.add_batch_duration" Long
             "spark.get_batch_duration" Long
@@ -169,7 +169,7 @@ class SparkStructuredStreamingTest extends AgentTestRunner {
         span {
           operationName "spark.streaming_batch"
           spanType "spark"
-          assert span.tags["batch_id"] == 1
+          assert span.tags["streaming_query.batch_id"] == 1
           parent()
         }
         span {


### PR DESCRIPTION
# What Does This Do

Rename spark streaming query attributes to make it clear that it is coming from a streaming query
- id -> streaming_query.id
- name -> streaming_query.name
- run_id -> streaming_query. run_id
- batch_id -> streaming_query.batch_id

The renaming is already done in the backend

# Motivation

Make it clear that those fields are coming from the streaming_query

# Additional Notes

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
