### PR TITLE
remove recommendation to install deprecated "action on save" intelliJ plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,8 +200,6 @@ Suggested plugins and settings:
   * With java use the following import layout (groovy should still use the default) to ensure consistency with google-java-format:
     ![import layout](https://user-images.githubusercontent.com/734411/43430811-28442636-94ae-11e8-86f1-f270ddcba023.png)
 * [Google Java Format](https://plugins.jetbrains.com/plugin/8527-google-java-format)
-* [Save Actions](https://plugins.jetbrains.com/plugin/7642-save-actions)
-  ![Recommended Settings](https://user-images.githubusercontent.com/35850765/124003079-838f4280-d9a4-11eb-9250-5c517631e362.png)
 
 ## Troubleshooting
 


### PR DESCRIPTION
the plugin is not maintained anymore since Dec 2021, and is not compatible with recent IntelliJ version. 
https://plugins.jetbrains.com/plugin/7642-save-actions

Moreover, its features are mostly covered by the built-in Tools/Actions on Save settings and the git pre-commit hook.