### PR TITLE
IAST Servlet.getRequestURL instrumentation

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -69,11 +69,6 @@ public class WebModuleImpl implements WebModule {
     onNamed(Collections.singleton(s), SourceTypes.REQUEST_PATH);
   }
 
-  @Override
-  public void onGetRequestURI(@Nullable String s) {
-    onNamed(Collections.singleton(s), SourceTypes.REQUEST_URI);
-  }
-
   private static void onNamed(@Nullable final Iterable<String> names, final byte source) {
     if (names == null) {
       return;

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -251,11 +251,28 @@ public class HttpServletRequestCallSite {
     }
   }
 
+  @Source(SourceTypes.REQUEST_URI)
+  @CallSite.After("java.lang.StringBuffer javax.servlet.http.HttpServletRequest.getRequestURL()")
+  public static StringBuffer afterGetRequestURL(
+      @CallSite.This final HttpServletRequest self, @CallSite.Return final StringBuffer retValue) {
+    if (null != retValue && retValue.length() > 0) {
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module != null) {
+        try {
+          module.taintObject(SourceTypes.REQUEST_URI, null, retValue.toString(), retValue);
+        } catch (final Throwable e) {
+          module.onUnexpectedException("afterGetRequestURL threw", e);
+        }
+      }
+    }
+    return retValue;
+  }
+
   @Source(SourceTypes.REQUEST_PATH)
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getRequestURI()")
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getPathInfo()")
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getPathTranslated()")
-  public static String afterGetPathInfo(
+  public static String afterGetPath(
       @CallSite.This final HttpServletRequest self, @CallSite.Return final String retValue) {
     if (null != retValue && !retValue.isEmpty()) {
       final WebModule module = InstrumentationBridge.WEB;

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
@@ -182,7 +182,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
     setup:
     final iastModule = Mock(WebModule)
     InstrumentationBridge.registerIastModule(iastModule)
-    final mock = Mock(HttpServletRequest){
+    final mock = Mock(clazz){
       getRequestURI() >> 'retValue'
     }
     final testSuite = new TestHttpServletRequestCallSiteSuite(mock)
@@ -198,6 +198,29 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
     HttpServletRequest        | _
     HttpServletRequestWrapper | _
   }
+
+  void 'test getRequestURL'() {
+    setup:
+    final module = Mock(PropagationModule)
+    final retValue = new StringBuffer("retValue")
+    InstrumentationBridge.registerIastModule(module)
+    final mock = Mock(clazz){
+      getRequestURL() >> retValue
+    }
+    final testSuite = new TestHttpServletRequestCallSiteSuite(mock)
+
+    when:
+    testSuite.getRequestURL()
+
+    then:
+    1 * module.taintObject(_,_,_,_)
+
+    where:
+    clazz                     | _
+    HttpServletRequest        | _
+    HttpServletRequestWrapper | _
+  }
+
 
   void 'test getPathInfo'() {
     setup:

--- a/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/TestHttpServletRequestCallSiteSuite.java
+++ b/dd-java-agent/instrumentation/servlet/src/test/java/datadog/smoketest/controller/TestHttpServletRequestCallSiteSuite.java
@@ -16,6 +16,10 @@ public class TestHttpServletRequestCallSiteSuite {
     return request.getHeader(headerName);
   }
 
+  public StringBuffer getRequestURL() {
+    return request.getRequestURL();
+  }
+
   public Enumeration<?> getHeaders(final String headerName) {
     return request.getHeaders(headerName);
   }

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -343,6 +343,12 @@ public class IastWebController {
     return String.format("Request.getRequestURI returns %s", pathInfo);
   }
 
+  @GetMapping("/getrequesturl")
+  String requestURL(HttpServletRequest request) {
+    StringBuffer requestURL = request.getRequestURL();
+    return String.format("Request.getRequestURL returns %s", requestURL);
+  }
+
   private void withProcess(final Operation<Process> op) {
     Process process = null;
     try {

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -494,6 +494,21 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     }
   }
 
+  void 'getRequestURL taints its output'() {
+    setup:
+    String url = "http://localhost:${httpPort}/getrequesturl"
+    def request = new Request.Builder().url(url).get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    hasTainted { tainted ->
+      tainted.value == url &&
+        tainted.ranges[0].source.origin == 'http.request.uri'
+    }
+  }
+
   void 'request header taint string'() {
     setup:
     String url = "http://localhost:${httpPort}/request_header/test"

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -31,6 +31,4 @@ public interface WebModule extends IastModule {
       @Nullable String headerName, @Nullable final Collection<String> headerValues);
 
   void onGetPathInfo(@Nullable String s);
-
-  void onGetRequestURI(@Nullable String s);
 }


### PR DESCRIPTION
# What Does This Do
Adds instrumentation to Servlet.getServletURL call

# Motivation
To be able to taint the output of the function so it can be used by IAST to detect vulnerabilities.

# Additional Notes

Jira ticket: [APPSEC-11729](https://datadoghq.atlassian.net/browse/APPSEC-11729)



[APPSEC-11729]: https://datadoghq.atlassian.net/browse/APPSEC-11729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ