### PR TITLE
Support `@Trace(noParent=true)` to always start a new trace at that method

### DIFF
--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceDecorator.java
@@ -46,6 +46,7 @@ public class TraceDecorator extends AsyncResultDecorator {
     CharSequence operationName = null;
     CharSequence resourceName = null;
     boolean measured = false;
+    boolean noParent = false;
 
     Trace traceAnnotation = method.getAnnotation(Trace.class);
     if (null != traceAnnotation) {
@@ -61,6 +62,12 @@ public class TraceDecorator extends AsyncResultDecorator {
       } catch (Throwable ignore) {
         // dd-trace-api < 1.10.0 on classpath
       }
+
+      try {
+        noParent = traceAnnotation.noParent();
+      } catch (Throwable ignore) {
+        // dd-trace-api < 1.22.0 on classpath
+      }
     }
 
     if (operationName == null || operationName.length() == 0) {
@@ -75,7 +82,11 @@ public class TraceDecorator extends AsyncResultDecorator {
       resourceName = DECORATE.spanNameForMethod(method);
     }
 
-    AgentSpan span = startSpan(INSTRUMENTATION_NAME, operationName);
+    AgentSpan span =
+        noParent
+            ? startSpan(INSTRUMENTATION_NAME, operationName, null)
+            : startSpan(INSTRUMENTATION_NAME, operationName);
+
     DECORATE.afterStart(span);
     span.setResourceName(resourceName);
 

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.TraceUtils
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import dd.test.trace.annotation.SayTracedHello
@@ -377,6 +378,127 @@ class TraceAnnotationsTest extends AgentTestRunner {
       trace(1) {
         span {
           resourceName "TracedSuperClass.testTracedSuperMethod"
+          operationName "trace.annotation"
+          parent()
+          errored false
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "test measured attribute"() {
+    setup:
+    TraceUtils.runUnderTrace("parent", () -> {
+      SayTracedHello.sayHello()
+      SayTracedHello.sayHelloMeasured()
+      SayTracedHello.sayHello()
+    })
+
+    expect:
+    assertTraces(1) {
+      trace(4) {
+        span {
+          hasServiceName()
+          resourceName "parent"
+          operationName "parent"
+          parent()
+          errored false
+          tags {
+            defaultTags()
+          }
+        }
+        span {
+          serviceName "test"
+          resourceName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
+          childOf(span(0))
+          errored false
+          measured false
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
+        }
+        span {
+          serviceName "test"
+          resourceName "SayTracedHello.sayHelloMeasured"
+          operationName "trace.annotation"
+          childOf(span(0))
+          errored false
+          measured true
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
+        }
+        span {
+          serviceName "test"
+          resourceName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
+          childOf(span(0))
+          errored false
+          measured false
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "test noParent attribute"() {
+    setup:
+    TraceUtils.runUnderTrace("parent", () -> {
+      SayTracedHello.sayHello()
+      SayTracedHello.sayHelloNoParent()
+      SayTracedHello.sayHello()
+    })
+
+    expect:
+    assertTraces(2) {
+      trace(3) {
+        span {
+          hasServiceName()
+          resourceName "parent"
+          operationName "parent"
+          parent()
+          errored false
+          tags {
+            defaultTags()
+          }
+        }
+        span {
+          serviceName "test"
+          resourceName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
+          childOf(span(0))
+          errored false
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
+        }
+        span {
+          serviceName "test"
+          resourceName "SayTracedHello.sayHello"
+          operationName "trace.annotation"
+          childOf(span(0))
+          errored false
+          tags {
+            "$Tags.COMPONENT" "trace"
+            defaultTags()
+          }
+        }
+      }
+      trace(1) {
+        span {
+          serviceName "test"
+          resourceName "SayTracedHello.sayHelloNoParent"
           operationName "trace.annotation"
           parent()
           errored false

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/java/dd/test/trace/annotation/SayTracedHello.java
@@ -54,6 +54,18 @@ public class SayTracedHello {
     return sayHello() + sayHAWithResource();
   }
 
+  @Trace(measured = true)
+  public static String sayHelloMeasured() {
+    activeSpan().setTag(DDTags.SERVICE_NAME, "test");
+    return "hello!";
+  }
+
+  @Trace(noParent = true)
+  public static String sayHelloNoParent() {
+    activeSpan().setTag(DDTags.SERVICE_NAME, "test");
+    return "hello!";
+  }
+
   @Trace(operationName = "ERROR")
   public static String sayERROR() {
     throw new RuntimeException();

--- a/dd-trace-api/src/main/java/datadog/trace/api/Trace.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Trace.java
@@ -19,4 +19,7 @@ public @interface Trace {
 
   /** Set whether to measure a trace. By default traces are not measured. */
   boolean measured() default false;
+
+  /** Set whether to start a new trace. By default it continues the current trace. */
+  boolean noParent() default false;
 }


### PR DESCRIPTION
# Motivation

This is the annotation equivalent of building a new span with no parent context.