### PR TITLE
Support StatsD client tuning

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -39,6 +39,10 @@ public final class GeneralConfig {
   public static final String DOGSTATSD_ARGS = "dogstatsd.args";
   public static final String DOGSTATSD_NAMED_PIPE = "dogstatsd.pipe.name";
 
+  public static final String STATSD_CLIENT_QUEUE_SIZE = "statsd.client.queue.size";
+  public static final String STATSD_CLIENT_SOCKET_BUFFER = "statsd.client.socket.buffer";
+  public static final String STATSD_CLIENT_SOCKET_TIMEOUT = "statsd.client.socket.timeout";
+
   public static final String RUNTIME_METRICS_ENABLED = "runtime.metrics.enabled";
   public static final String RUNTIME_ID_ENABLED = "runtime-id.enabled";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -206,6 +206,9 @@ import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.SERVICE_NAME;
 import static datadog.trace.api.config.GeneralConfig.SITE;
 import static datadog.trace.api.config.GeneralConfig.STARTUP_LOGS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.STATSD_CLIENT_QUEUE_SIZE;
+import static datadog.trace.api.config.GeneralConfig.STATSD_CLIENT_SOCKET_BUFFER;
+import static datadog.trace.api.config.GeneralConfig.STATSD_CLIENT_SOCKET_TIMEOUT;
 import static datadog.trace.api.config.GeneralConfig.TAGS;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_DEPENDENCY_COLLECTION_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_HEARTBEAT_INTERVAL;
@@ -560,6 +563,10 @@ public class Config {
 
   private final String dogStatsDNamedPipe;
   private final int dogStatsDStartDelay;
+
+  private final Integer statsDClientQueueSize;
+  private final Integer statsDClientSocketBuffer;
+  private final Integer statsDClientSocketTimeout;
 
   private final boolean runtimeMetricsEnabled;
   private final boolean jmxFetchEnabled;
@@ -1224,6 +1231,10 @@ public class Config {
     dogStatsDStartDelay =
         configProvider.getInteger(
             DOGSTATSD_START_DELAY, DEFAULT_DOGSTATSD_START_DELAY, JMX_FETCH_START_DELAY);
+
+    statsDClientQueueSize = configProvider.getInteger(STATSD_CLIENT_QUEUE_SIZE);
+    statsDClientSocketBuffer = configProvider.getInteger(STATSD_CLIENT_SOCKET_BUFFER);
+    statsDClientSocketTimeout = configProvider.getInteger(STATSD_CLIENT_SOCKET_TIMEOUT);
 
     runtimeMetricsEnabled = configProvider.getBoolean(RUNTIME_METRICS_ENABLED, true);
 
@@ -2086,6 +2097,18 @@ public class Config {
 
   public int getDogStatsDStartDelay() {
     return dogStatsDStartDelay;
+  }
+
+  public Integer getStatsDClientQueueSize() {
+    return statsDClientQueueSize;
+  }
+
+  public Integer getStatsDClientSocketBuffer() {
+    return statsDClientSocketBuffer;
+  }
+
+  public Integer getStatsDClientSocketTimeout() {
+    return statsDClientSocketTimeout;
   }
 
   public boolean isRuntimeMetricsEnabled() {


### PR DESCRIPTION
# What Does This Do

Adds support for configuration of StatsD client queue size:
```
DD_STATSD_CLIENT_QUEUE_SIZE=<items>
```
as well as buffer size and timeout when using UDS:
```
DD_STATSD_CLIENT_SOCKET_BUFFER=<bytes>
DD_STATSD_CLIENT_SOCKET_TIMEOUT=<ms>
```
System property equivalents:
```
-Ddd.statsd.client.queue.size=<items>
-Ddd.statsd.client.socket.buffer=<bytes>
-Ddd.statsd.client.socket.timeout=<ms>
```

Jira ticket: [APMS-10560]

[APMS-10560]: https://datadoghq.atlassian.net/browse/APMS-10560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ