### PR TITLE
Support tracing of custom (non-JDK) HttpURLConnection implementations

### DIFF
--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -11,6 +11,7 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
@@ -23,7 +24,9 @@ import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
 public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing
-    implements Instrumenter.ForBootstrap, Instrumenter.ForKnownTypes {
+    implements Instrumenter.ForBootstrap,
+        Instrumenter.ForKnownTypes,
+        Instrumenter.ForConfiguredType {
 
   public HttpUrlConnectionInstrumentation() {
     super("httpurlconnection");
@@ -35,6 +38,12 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing
     return new String[] {
       "sun.net.www.protocol.http.HttpURLConnection", "java.net.HttpURLConnection"
     };
+  }
+
+  @Override
+  public String configuredMatchingType() {
+    // this won't match any class unless the property is set
+    return InstrumenterConfig.get().getHttpURLConnectionClassName();
   }
 
   @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -55,6 +55,9 @@ public final class TraceInstrumentationConfig {
 
   public static final String JDBC_CONNECTION_CLASS_NAME = "trace.jdbc.connection.class.name";
 
+  public static final String HTTP_URL_CONNECTION_CLASS_NAME =
+      "trace.http.url.connection.class.name";
+
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       "trace.runtime.context.field.injection";
   public static final String SERIALVERSIONUID_FIELD_INJECTION =

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -26,6 +26,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATI
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED_DEFAULT;
+import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_URL_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
@@ -101,6 +102,8 @@ public class InstrumenterConfig {
   private final String jdbcPreparedStatementClassName;
   private final String jdbcConnectionClassName;
 
+  private final String httpURLConnectionClassName;
+
   private final boolean directAllocationProfilingEnabled;
 
   private final List<String> excludedClasses;
@@ -173,6 +176,8 @@ public class InstrumenterConfig {
     jdbcPreparedStatementClassName =
         configProvider.getString(JDBC_PREPARED_STATEMENT_CLASS_NAME, "");
     jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
+
+    httpURLConnectionClassName = configProvider.getString(HTTP_URL_CONNECTION_CLASS_NAME, "");
 
     directAllocationProfilingEnabled =
         configProvider.getBoolean(
@@ -285,6 +290,10 @@ public class InstrumenterConfig {
 
   public String getJdbcConnectionClassName() {
     return jdbcConnectionClassName;
+  }
+
+  public String getHttpURLConnectionClassName() {
+    return httpURLConnectionClassName;
   }
 
   public boolean isDirectAllocationProfilingEnabled() {
@@ -443,6 +452,9 @@ public class InstrumenterConfig {
         + '\''
         + ", jdbcConnectionClassName='"
         + jdbcConnectionClassName
+        + '\''
+        + ", httpURLConnectionClassName='"
+        + httpURLConnectionClassName
         + '\''
         + ", excludedClasses="
         + excludedClasses


### PR DESCRIPTION
# Motivation

We have a short list of instrumented `HttpURLConnection` types which most implementations delegate to. Occasionally an application server might register its own `HttpURLConnection` that doesn't delegate upwards, but instead calls a completely different service. This feature will allow users to temporarily add such an implementation for tracing without needing a new release of the tracer.

```
DD_TRACE_HTTP_URL_CONNECTION_CLASS_NAME=<fully.qualified.class.name>
```

System property equivalent:
```
-Ddd.trace.http.url.connection.class.name=<fully.qualified.class.name>
```

Jira ticket: [APMS-10509]


[APMS-10509]: https://datadoghq.atlassian.net/browse/APMS-10509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ