### PR TITLE
Add `weblogic.net.http.HttpURLConnection` to list of traced connection classes

### DIFF
--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/HttpUrlConnectionInstrumentation.java
@@ -33,7 +33,9 @@ public class HttpUrlConnectionInstrumentation extends Instrumenter.Tracing
   public String[] knownMatchingTypes() {
     // we deliberately exclude various subclasses that are simple delegators
     return new String[] {
-      "sun.net.www.protocol.http.HttpURLConnection", "java.net.HttpURLConnection"
+      "sun.net.www.protocol.http.HttpURLConnection",
+      "java.net.HttpURLConnection",
+      "weblogic.net.http.HttpURLConnection"
     };
   }
 


### PR DESCRIPTION
It overrides `connect`, `getInputStream`, and `getOutputStream` without delegating

Jira ticket: [APMS-10509]


[APMS-10509]: https://datadoghq.atlassian.net/browse/APMS-10509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ