### PR TITLE
Fix IAST ranges for StringBuffer.toString

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Range.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Range.java
@@ -81,4 +81,9 @@ public final class Range implements Ranged {
   public boolean isMarked(final int mark) {
     return (marks & mark) != NOT_MARKED;
   }
+
+  /** Check if this is an "unbound" range, covering the whole object. */
+  public boolean isUnbound() {
+    return start == 0 && length == Integer.MAX_VALUE;
+  }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
@@ -133,7 +133,10 @@ public class StringModuleImpl implements StringModule {
     if (to == null) {
       return;
     }
-    taintedObjects.taint(result, to.getRanges());
+    // A StringBuilder / StringBuffer might be tainted without bounds, so we
+    // need to make sure the resulting ranges are within bounds of the string.
+    final Range[] ranges = Ranges.unboundToBound(result, to.getRanges());
+    taintedObjects.taint(result, ranges);
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -74,6 +74,18 @@ public final class Ranges {
     }
   }
 
+  /** Detects when we have a single unbound range and returns a single bound range. */
+  public static Range[] unboundToBound(final String s, final Range[] ranges) {
+    if (ranges == null || ranges.length != 1) {
+      return ranges;
+    }
+    final Range range = ranges[0];
+    if (range.isUnbound()) {
+      return new Range[] {new Range(0, s.length(), range.getSource(), range.getMarks())};
+    }
+    return ranges;
+  }
+
   public static Range[] mergeRanges(
       final int offset, @Nonnull final Range[] rangesLeft, @Nonnull final Range[] rangesRight) {
     final long nRanges = rangesLeft.length + rangesRight.length;


### PR DESCRIPTION
# What Does This Do
A StringBuffer or StringBuilder object might be tainted directly. In that case, we'll use an open Range (signaling that the full object is tainted, without a specific length). On StringBuffer#toString, this will lead to a String with an open Range, which the rest of our code base does not expect.

# Motivation
This is required to be able to taint StringBuffers in IAST sources (but probably cannot be triggered with any released version).

# Additional Notes

Jira ticket: [APPSEC-11732](https://datadoghq.atlassian.net/browse/APPSEC-11732)


[APPSEC-11732]: https://datadoghq.atlassian.net/browse/APPSEC-11732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ