### PR TITLE
Fix dependency service for spaced paths

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -117,7 +117,7 @@ public class DependencyResolver {
       fileName = lastPart.substring(lastPart.lastIndexOf("/") + 1);
 
       return Dependency.guessFallbackNoPom(manifest, fileName, jarConnection.getInputStream());
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.debug("unable to open nested jar manifest for {}", uri, e);
     }
     log.debug(

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
@@ -84,9 +84,12 @@ public class DependencyService implements Runnable {
         uri =
             new URI(
                 location.getProtocol(),
+                location.getUserInfo(),
                 location.getHost(),
+                location.getPort(),
                 location.getPath(),
-                location.getQuery());
+                location.getQuery(),
+                null);
       } catch (URISyntaxException e) {
         log.warn("Error converting URL to URI", e);
         // silently ignored

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
@@ -81,7 +81,12 @@ public class DependencyService implements Runnable {
 
     if (uri == null) {
       try {
-        uri = location.toURI();
+        uri =
+            new URI(
+                location.getProtocol(),
+                location.getHost(),
+                location.getPath(),
+                location.getQuery());
       } catch (URISyntaxException e) {
         log.warn("Error converting URL to URI", e);
         // silently ignored

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
@@ -152,6 +152,33 @@ class DependencyResolverSpecification extends DepSpecification {
     temp.delete()
   }
 
+  void 'try to determine non existing lib name'() throws IOException {
+    setup:
+    File temp = File.createTempFile('temp', '.zip')
+    temp.delete()
+
+    expect:
+    DependencyResolver.extractDependenciesFromJar(temp).isEmpty()
+  }
+
+  void 'try to determine invalid jar lib'() throws IOException {
+    setup:
+    File temp = File.createTempFile('temp', '.jar')
+    temp.write("just a text file")
+
+    expect:
+    DependencyResolver.extractDependenciesFromJar(temp).isEmpty()
+  }
+
+  void 'try to determine invalid jar lib'() throws IOException {
+    setup:
+    File temp = File.createTempFile('temp', '.jar')
+    temp.write("just a text file")
+
+    expect:
+    DependencyResolver.getNestedDependency(temp.toURI()) == null
+  }
+
   void 'spring boot dependency'() throws IOException {
     setup:
     org.springframework.boot.loader.jar.JarFile.registerUrlProtocolHandler()

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyServiceSpecification.groovy
@@ -74,6 +74,14 @@ class DependencyServiceSpecification extends DepSpecification {
     assertThat(set.first().version, is('4.12'))
   }
 
+  void 'convertToURI works with a spaced URL'() {
+    when:
+    URI uri = depService.convertToURI(new URL("file:/C:/Program Files/IBM/WebSphere/AppServer_1/plugins/com.ibm.cds_2.1.0.jar"))
+
+    then:
+    uri.path == "/C:/Program Files/IBM/WebSphere/AppServer_1/plugins/com.ibm.cds_2.1.0.jar"
+  }
+
   void 'build dependency set from a fat jar'() {
     when:
     File budgetappJar = getJar('budgetapp.jar')


### PR DESCRIPTION
# What Does This Do

Fixes an exception converting spaced paths for discovered dependencies:
```
java.net.URISyntaxException: Illegal character in path at index 16: file:/C:/Program Files/IBM/WebSphere/AppServer_1/plugins/com.ibm.cds_2.1.0.jar
	at java.net.URI$Parser.fail(URI.java:2858)
	at java.net.URI$Parser.checkChars(URI.java:3031)
	at java.net.URI$Parser.parseHierarchical(URI.java:3115)
	at java.net.URI$Parser.parse(URI.java:3063)
	at java.net.URI.<init>(URI.java:599)
	at java.net.URL.toURI(URL.java:975)
	at datadog.telemetry.dependency.DependencyService.convertToURI(DependencyService.java:84)
	at datadog.telemetry.dependency.DependencyService.addURL(DependencyService.java:66)
	at datadog.telemetry.dependency.LocationsCollectingTransformer.addDependency(LocationsCollectingTransformer.java:44)
	at datadog.telemetry.dependency.LocationsCollectingTransformer$$Lambda$77/0x000000004cf014f0.apply(Unknown Source)
	at datadog.trace.api.cache.FixedSizeWeakKeyCache.produceAndStoreValue(FixedSizeWeakKeyCache.java:100)
	at datadog.trace.api.cache.FixedSizeWeakKeyCache.computeIfAbsent(FixedSizeWeakKeyCache.java:77)
	at datadog.telemetry.dependency.LocationsCollectingTransformer.transform(LocationsCollectingTransformer.java:32)
	at sun.instrument.TransformerManager.transform(TransformerManager.java:200)
	at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:450)
	at java.lang.ClassLoader.defineClassImpl(Native Method)
	at java.lang.ClassLoader.defineClassInternal(ClassLoader.java:397)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:358)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:154)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:730)
	at java.net.URLClassLoader.access$400(URLClassLoader.java:96)
	at java.net.URLClassLoader$ClassFinder.run(URLClassLoader.java:1187)
	at java.security.AccessController.doPrivileged(AccessController.java:774)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:605)
	at java.lang.ClassLoader.loadClassHelper(ClassLoader.java:945)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:890)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:873)
	at java.lang.Class.forNameImpl(Native Method)
	at java.lang.Class.forName(Class.java:333)
	at org.eclipse.osgi.baseadaptor.HookRegistry.loadConfigurators(HookRegistry.java:176)
	at org.eclipse.osgi.baseadaptor.HookRegistry.initialize(HookRegistry.java:100)
	at org.eclipse.osgi.baseadaptor.BaseAdaptor.<init>(BaseAdaptor.java:98)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:83)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:57)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:437)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.createAdaptor(EclipseStarter.java:738)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.startup(EclipseStarter.java:259)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:177)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:508)
	at org.eclipse.core.launcher.Main.invokeFramework(Main.java:340)
	at org.eclipse.core.launcher.Main.basicRun(Main.java:282)
	at org.eclipse.core.launcher.Main.run(Main.java:981)
	at com.ibm.wsspi.bootstrap.WSPreLauncher.launchEclipse(WSPreLauncher.java:422)
	at com.ibm.wsspi.bootstrap.WSPreLauncher.main(WSPreLauncher.java:179)
```

# Motivation

Reported bug.

# Additional Notes

Jira ticket: [APMS-10545]

[APMS-10545]: https://datadoghq.atlassian.net/browse/APMS-10545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ