### PR TITLE
Move dd-trace-core to separate section of shaded dd-java-agent jar

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -14,16 +14,17 @@ apply from: "$rootDir/gradle/publish.gradle"
 configurations {
   shadowInclude
   sharedShadowInclude
+  traceShadowInclude
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
 
 /*
- * 7 shadow jars are created
+ * Several shadow jars are created
  * - The main "dd-java-agent" jar that also has the bootstrap project
- * - 5 jars based on projects (instrumentation, jmxfetch, profiling, appsec, iast)
- * - 1 based on the shared dependencies
+ * - Major feature jars (trace, instrumentation, jmxfetch, profiling, appsec, iast, debugger, ci-visibility)
+ * - A shared dependencies jar
  * This general config is shared by all of them
  */
 
@@ -123,6 +124,15 @@ def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
   }
 }
 includeShadowJar(sharedShadowJar, 'shared')
+
+// place the tracer in its own shadow jar separate to instrumentation
+def traceShadowJar = tasks.register('traceShadowJar', ShadowJar) {
+  configurations = [project.configurations.traceShadowInclude]
+  it.destinationDirectory.set(file("${project.buildDir}/trace-lib"))
+  archiveClassifier = 'trace'
+  it.dependencies deps.excludeShared
+}
+includeShadowJar(traceShadowJar, 'trace')
 
 shadowJar generalShadowJarConfig >> {
   configurations = [project.configurations.shadowInclude]
@@ -224,6 +234,7 @@ dependencies {
   sharedShadowInclude project(':utils:version-utils'), {
     transitive = false
   }
+  traceShadowInclude project(':dd-trace-core')
 }
 
 tasks.withType(Test).configureEach {

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -132,6 +132,12 @@ if (project.gradle.startParameter.taskNames.any {it.endsWith("generateMuzzleRepo
 
 tasks.named('shadowJar').configure {
   duplicatesStrategy = DuplicatesStrategy.FAIL
+  dependencies {
+    // the tracer is now in a separate shadow jar
+    exclude(project(":dd-trace-core"))
+    exclude(dependency('com.datadoghq:sketches-java'))
+    exclude(dependency('com.google.re2j:re2j'))
+  }
   dependencies deps.excludeShared
 }
 

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/ResourcesFeatureInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/ResourcesFeatureInstrumentation.java
@@ -29,13 +29,13 @@ public final class ResourcesFeatureInstrumentation extends AbstractNativeImageIn
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit() {
       // the tracer jar is not listed on the image classpath, so manually inject its resources
-      // (drop inst/shared prefixes from embedded resources, so we can find them in native-image
+      // (drop trace/shared prefixes from embedded resources, so we can find them in native-image
       // as the final executable won't have our isolating class-loader to map these resources)
 
       String[] tracerResources = {
         "dd-java-agent.version",
         "dd-trace-api.version",
-        "inst/dd-trace-core.version",
+        "trace/dd-trace-core.version",
         "shared/dogstatsd/version.properties",
         "shared/okhttp3/internal/publicsuffix/publicsuffixes.gz"
       };


### PR DESCRIPTION
This will let us relocate some dependencies used by the tracer without affecting instrumentation for the same libraries.