### PR TITLE
Add config fo custom redacted identifiers

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
@@ -1,8 +1,10 @@
 package datadog.trace.bootstrap.debugger.util;
 
+import datadog.trace.api.Config;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 public class Redaction {
   // Need to be a unique instance (new String) for reference equality (==) and
@@ -12,33 +14,49 @@ public class Redaction {
   /*
    * based on sentry list: https://github.com/getsentry/sentry-python/blob/fefb454287b771ac31db4e30fa459d9be2f977b8/sentry_sdk/scrubber.py#L17-L58
    */
-  private static final Set<String> KEYWORDS =
-      new HashSet<>(
-          Arrays.asList(
-              "password",
-              "passwd",
-              "secret",
-              "apikey",
-              "auth",
-              "credentials",
-              "mysqlpwd",
-              "privatekey",
-              "token",
-              "ipaddress",
-              "session",
-              // django
-              "csrftoken",
-              "sessionid",
-              // wsgi
-              "remoteaddr",
-              "xcsrftoken",
-              "xforwardedfor",
-              "setcookie",
-              "cookie",
-              "authorization",
-              "xapikey",
-              "xforwardedfor",
-              "xrealip"));
+  private static final Set<String> KEYWORDS = ConcurrentHashMap.newKeySet();
+
+  static {
+    KEYWORDS.addAll(
+        Arrays.asList(
+            "password",
+            "passwd",
+            "secret",
+            "apikey",
+            "auth",
+            "credentials",
+            "mysqlpwd",
+            "privatekey",
+            "token",
+            "ipaddress",
+            "session",
+            // django
+            "csrftoken",
+            "sessionid",
+            // wsgi
+            "remoteaddr",
+            "xcsrftoken",
+            "xforwardedfor",
+            "setcookie",
+            "cookie",
+            "authorization",
+            "xapikey",
+            "xforwardedfor",
+            "xrealip"));
+  }
+
+  private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+
+  public static void addUserDefinedKeywords(Config config) {
+    String redactedIdentifiers = config.getDebuggerRedactedIdentifiers();
+    if (redactedIdentifiers == null) {
+      return;
+    }
+    String[] identifiers = COMMA_PATTERN.split(redactedIdentifiers);
+    for (String identifier : identifiers) {
+      KEYWORDS.add(normalize(identifier));
+    }
+  }
 
   public static boolean isRedactedKeyword(String name) {
     if (name == null) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/RedactionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/RedactionTest.java
@@ -2,12 +2,13 @@ package datadog.trace.bootstrap.debugger.util;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import datadog.trace.api.Config;
 import org.junit.jupiter.api.Test;
 
 class RedactionTest {
 
   @Test
-  public void test() {
+  public void basic() {
     assertFalse(Redaction.isRedactedKeyword(null));
     assertFalse(Redaction.isRedactedKeyword(""));
     assertFalse(Redaction.isRedactedKeyword("foobar"));
@@ -18,5 +19,18 @@ class RedactionTest {
     assertTrue(Redaction.isRedactedKeyword("_Pass-Word_"));
     assertTrue(Redaction.isRedactedKeyword("$pass_worD"));
     assertTrue(Redaction.isRedactedKeyword("@passWord@"));
+  }
+
+  @Test
+  public void userDefinedKeywords() {
+    final String REDACTED_IDENTIFIERS = "dd.dynamic.instrumentation.redacted.identifiers";
+    System.setProperty(REDACTED_IDENTIFIERS, "_MotDePasse,$Passwort");
+    try {
+      Redaction.addUserDefinedKeywords(Config.get());
+      assertTrue(Redaction.isRedactedKeyword("mot-de-passe"));
+      assertTrue(Redaction.isRedactedKeyword("Passwort"));
+    } finally {
+      System.clearProperty(REDACTED_IDENTIFIERS);
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -12,6 +12,7 @@ import datadog.remoteconfig.Product;
 import datadog.remoteconfig.SizeCheckedInputStream;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.debugger.util.Redaction;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -21,7 +22,6 @@ import java.lang.instrument.Instrumentation;
 import java.lang.ref.WeakReference;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,14 +43,10 @@ public class DebuggerAgent {
     log.info("Starting Dynamic Instrumentation");
     ClassesToRetransformFinder classesToRetransformFinder = new ClassesToRetransformFinder();
     setupSourceFileTracking(instrumentation, classesToRetransformFinder);
-    String finalDebuggerSnapshotUrl = config.getFinalDebuggerSnapshotUrl();
-    String agentUrl = config.getAgentUrl();
-    boolean isSnapshotUploadThroughAgent = Objects.equals(finalDebuggerSnapshotUrl, agentUrl);
-
+    Redaction.addUserDefinedKeywords(config);
     DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery = sco.featuresDiscovery(config);
     ddAgentFeaturesDiscovery.discoverIfOutdated();
     agentVersion = ddAgentFeaturesDiscovery.getVersion();
-
     DebuggerSink debuggerSink = new DebuggerSink(config);
     debuggerSink.start();
     ConfigurationUpdater configurationUpdater =
@@ -71,19 +67,15 @@ public class DebuggerAgent {
       setupInstrumentTheWorldTransformer(
           config, instrumentation, debuggerSink, statsdMetricForwarder);
     }
-
     String probeFileLocation = config.getDebuggerProbeFileLocation();
-
     if (probeFileLocation != null) {
       Path probeFilePath = Paths.get(probeFileLocation);
       loadFromFile(probeFilePath, configurationUpdater, config.getDebuggerMaxPayloadSize());
       return;
     }
-
     configurationPoller = sco.configurationPoller(config);
     if (configurationPoller != null) {
       subscribeConfigurationPoller(config, configurationUpdater);
-
       try {
         /*
         Note: shutdown hooks are tricky because JVM holds reference for them forever preventing

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -22,6 +22,8 @@ public final class DebuggerConfig {
       "dynamic.instrumentation.instrument.the.world";
   public static final String DEBUGGER_EXCLUDE_FILES = "dynamic.instrumentation.exclude.files";
   public static final String DEBUGGER_CAPTURE_TIMEOUT = "dynamic.instrumentation.capture.timeout";
+  public static final String DEBUGGER_REDACTED_IDENTIFIERS =
+      "dynamic.instrumentation.redacted.identifiers";
 
   private DebuggerConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -179,6 +179,7 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_PAYLOAD_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_METRICS_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_POLL_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_PROBE_FILE_LOCATION;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_REDACTED_IDENTIFIERS;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_BATCH_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_FLUSH_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_TIMEOUT;
@@ -726,6 +727,7 @@ public class Config {
   private final boolean debuggerInstrumentTheWorld;
   private final String debuggerExcludeFiles;
   private final int debuggerCaptureTimeout;
+  private final String debuggerRedactedIdentifiers;
 
   private final boolean awsPropagationEnabled;
   private final boolean sqsPropagationEnabled;
@@ -1665,6 +1667,7 @@ public class Config {
     debuggerExcludeFiles = configProvider.getString(DEBUGGER_EXCLUDE_FILES);
     debuggerCaptureTimeout =
         configProvider.getInteger(DEBUGGER_CAPTURE_TIMEOUT, DEFAULT_DEBUGGER_CAPTURE_TIMEOUT);
+    debuggerRedactedIdentifiers = configProvider.getString(DEBUGGER_REDACTED_IDENTIFIERS, null);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");
@@ -2759,6 +2762,10 @@ public class Config {
 
   public String getDebuggerProbeFileLocation() {
     return debuggerProbeFileLocation;
+  }
+
+  public String getDebuggerRedactedIdentifiers() {
+    return debuggerRedactedIdentifiers;
   }
 
   public boolean isAwsPropagationEnabled() {


### PR DESCRIPTION
# What Does This Do
Add property/env `dynamic.instrumentation.redacted.identifiers` to customize the redaction data based fields or key names

# Motivation

# Additional Notes

Jira ticket: [DEBUG-1843]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
