### PR TITLE
Move agent-crashtracking to shared section of shaded dd-java-agent jar

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -234,6 +234,9 @@ dependencies {
   sharedShadowInclude project(':utils:version-utils'), {
     transitive = false
   }
+  sharedShadowInclude project(':dd-java-agent:agent-crashtracking'), {
+    transitive = false
+  }
   traceShadowInclude project(':dd-trace-core')
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -129,6 +129,7 @@ final class CachedData {
       exclude(project(':utils:socket-utils'))
       exclude(project(':utils:time-utils'))
       exclude(project(':utils:version-utils'))
+      exclude(project(':dd-java-agent:agent-crashtracking'))
       exclude(dependency('org.slf4j::'))
 
       // okhttp and its transitives (both fork and non-fork)


### PR DESCRIPTION
This will let us relocate some dependencies used by the tracer without affecting instrumentation for the same libraries.