### PR TITLE
Add config for custom redacted types

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
@@ -1,7 +1,11 @@
 package datadog.trace.bootstrap.debugger.util;
 
 import datadog.trace.api.Config;
+import datadog.trace.util.ClassNameTrie;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
@@ -11,41 +15,44 @@ public class Redaction {
   // avoid internalization (intern) by the JVM because it's a string constant
   public static final String REDACTED_VALUE = new String("REDACTED".toCharArray());
 
-  /*
-   * based on sentry list: https://github.com/getsentry/sentry-python/blob/fefb454287b771ac31db4e30fa459d9be2f977b8/sentry_sdk/scrubber.py#L17-L58
-   */
+  private static final Pattern COMMA_PATTERN = Pattern.compile(",");
+  private static final List<String> PREDEFINED_KEYWORDS =
+      Arrays.asList(
+          "password",
+          "passwd",
+          "secret",
+          "apikey",
+          "auth",
+          "credentials",
+          "mysqlpwd",
+          "privatekey",
+          "token",
+          "ipaddress",
+          "session",
+          // django
+          "csrftoken",
+          "sessionid",
+          // wsgi
+          "remoteaddr",
+          "xcsrftoken",
+          "xforwardedfor",
+          "setcookie",
+          "cookie",
+          "authorization",
+          "xapikey",
+          "xforwardedfor",
+          "xrealip");
   private static final Set<String> KEYWORDS = ConcurrentHashMap.newKeySet();
+  private static ClassNameTrie typeTrie = ClassNameTrie.Builder.EMPTY_TRIE;
+  private static List<String> redactedClasses;
+  private static List<String> redactedPackages;
 
   static {
-    KEYWORDS.addAll(
-        Arrays.asList(
-            "password",
-            "passwd",
-            "secret",
-            "apikey",
-            "auth",
-            "credentials",
-            "mysqlpwd",
-            "privatekey",
-            "token",
-            "ipaddress",
-            "session",
-            // django
-            "csrftoken",
-            "sessionid",
-            // wsgi
-            "remoteaddr",
-            "xcsrftoken",
-            "xforwardedfor",
-            "setcookie",
-            "cookie",
-            "authorization",
-            "xapikey",
-            "xforwardedfor",
-            "xrealip"));
+    /*
+     * based on sentry list: https://github.com/getsentry/sentry-python/blob/fefb454287b771ac31db4e30fa459d9be2f977b8/sentry_sdk/scrubber.py#L17-L58
+     */
+    KEYWORDS.addAll(PREDEFINED_KEYWORDS);
   }
-
-  private static final Pattern COMMA_PATTERN = Pattern.compile(",");
 
   public static void addUserDefinedKeywords(Config config) {
     String redactedIdentifiers = config.getDebuggerRedactedIdentifiers();
@@ -58,12 +65,68 @@ public class Redaction {
     }
   }
 
+  public static void addUserDefinedTypes(Config config) {
+    String redactedTypes = config.getDebuggerRedactedTypes();
+    if (redactedTypes == null) {
+      return;
+    }
+    List<String> packages = null;
+    List<String> classes = null;
+    ClassNameTrie.Builder builder = new ClassNameTrie.Builder();
+    String[] types = COMMA_PATTERN.split(redactedTypes);
+    for (String type : types) {
+      builder.put(type, 1);
+      if (type.endsWith("*")) {
+        if (packages == null) {
+          packages = new ArrayList<>();
+        }
+        type =
+            type.endsWith(".*")
+                ? type.substring(0, type.length() - 2)
+                : type.substring(0, type.length() - 1);
+        packages.add(type);
+      } else {
+        if (classes == null) {
+          classes = new ArrayList<>();
+        }
+        classes.add(type);
+      }
+    }
+    typeTrie = builder.buildTrie();
+    redactedPackages = packages;
+    redactedClasses = classes;
+  }
+
   public static boolean isRedactedKeyword(String name) {
     if (name == null) {
       return false;
     }
     name = normalize(name);
     return KEYWORDS.contains(name);
+  }
+
+  public static boolean isRedactedType(String className) {
+    if (className == null) {
+      return false;
+    }
+    return typeTrie.apply(className) > 0;
+  }
+
+  public static List<String> getRedactedPackages() {
+    return redactedPackages != null ? redactedPackages : Collections.emptyList();
+  }
+
+  public static List<String> getRedactedClasses() {
+    return redactedClasses != null ? redactedClasses : Collections.emptyList();
+  }
+
+  public static void clearUserDefinedTypes() {
+    typeTrie = ClassNameTrie.Builder.EMPTY_TRIE;
+  }
+
+  public static void resetUserDefinedKeywords() {
+    KEYWORDS.clear();
+    KEYWORDS.addAll(PREDEFINED_KEYWORDS);
   }
 
   private static String normalize(String name) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ExpressionHelper.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ExpressionHelper.java
@@ -1,0 +1,13 @@
+package com.datadog.debugger.el.expressions;
+
+import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.Expression;
+import com.datadog.debugger.el.PrettyPrintVisitor;
+
+public class ExpressionHelper {
+  public static void throwRedactedException(Expression<?> expr) {
+    String strExpr = PrettyPrintVisitor.print(expr);
+    throw new EvaluationException(
+        "Could not evaluate the expression because '" + strExpr + "' was redacted", strExpr);
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
@@ -30,7 +30,8 @@ public class GetMemberExpression implements ValueExpression<Value<?>> {
     } catch (RuntimeException ex) {
       throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
     }
-    if (member == Redaction.REDACTED_VALUE) {
+    if (member == Redaction.REDACTED_VALUE
+        || (member != null && Redaction.isRedactedType(member.getClass().getTypeName()))) {
       String expr = PrettyPrintVisitor.print(this);
       throw new EvaluationException(
           "Could not evaluate the expression because '" + expr + "' was redacted", expr);

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/GetMemberExpression.java
@@ -32,9 +32,7 @@ public class GetMemberExpression implements ValueExpression<Value<?>> {
     }
     if (member == Redaction.REDACTED_VALUE
         || (member != null && Redaction.isRedactedType(member.getClass().getTypeName()))) {
-      String expr = PrettyPrintVisitor.print(this);
-      throw new EvaluationException(
-          "Could not evaluate the expression because '" + expr + "' was redacted", expr);
+      ExpressionHelper.throwRedactedException(this);
     }
     return Value.of(member);
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -34,9 +34,7 @@ public class IndexExpression implements ValueExpression<Value<?>> {
       if (targetValue instanceof MapValue) {
         Object objKey = keyValue.getValue();
         if (objKey instanceof String && Redaction.isRedactedKeyword((String) objKey)) {
-          String expr = PrettyPrintVisitor.print(this);
-          throw new EvaluationException(
-              "Could not evaluate the expression because '" + expr + "' was redacted", expr);
+          ExpressionHelper.throwRedactedException(this);
         } else {
           result = ((MapValue) targetValue).get(objKey);
         }
@@ -49,9 +47,7 @@ public class IndexExpression implements ValueExpression<Value<?>> {
     }
     Object obj = result.getValue();
     if (obj != null && Redaction.isRedactedType(obj.getClass().getTypeName())) {
-      String expr = PrettyPrintVisitor.print(this);
-      throw new EvaluationException(
-          "Could not evaluate the expression because '" + expr + "' was redacted", expr);
+      ExpressionHelper.throwRedactedException(this);
     }
     return result;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -47,6 +47,12 @@ public class IndexExpression implements ValueExpression<Value<?>> {
     } catch (IllegalArgumentException ex) {
       throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this), ex);
     }
+    Object obj = result.getValue();
+    if (obj != null && Redaction.isRedactedType(obj.getClass().getTypeName())) {
+      String expr = PrettyPrintVisitor.print(this);
+      throw new EvaluationException(
+          "Could not evaluate the expression because '" + expr + "' was redacted", expr);
+    }
     return result;
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
@@ -27,9 +27,7 @@ public final class ValueRefExpression implements ValueExpression<Value<?>> {
     }
     if (symbol == Redaction.REDACTED_VALUE
         || (symbol != null && Redaction.isRedactedType(symbol.getClass().getTypeName()))) {
-      String expr = PrettyPrintVisitor.print(this);
-      throw new EvaluationException(
-          "Could not evaluate the expression because '" + expr + "' was redacted", expr);
+      ExpressionHelper.throwRedactedException(this);
     }
     return Value.of(symbol);
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ValueRefExpression.java
@@ -25,7 +25,8 @@ public final class ValueRefExpression implements ValueExpression<Value<?>> {
     } catch (RuntimeException ex) {
       throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this));
     }
-    if (symbol == Redaction.REDACTED_VALUE) {
+    if (symbol == Redaction.REDACTED_VALUE
+        || (symbol != null && Redaction.isRedactedType(symbol.getClass().getTypeName()))) {
       String expr = PrettyPrintVisitor.print(this);
       throw new EvaluationException(
           "Could not evaluate the expression because '" + expr + "' was redacted", expr);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -44,6 +44,7 @@ public class DebuggerAgent {
     ClassesToRetransformFinder classesToRetransformFinder = new ClassesToRetransformFinder();
     setupSourceFileTracking(instrumentation, classesToRetransformFinder);
     Redaction.addUserDefinedKeywords(config);
+    Redaction.addUserDefinedTypes(config);
     DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery = sco.featuresDiscovery(config);
     ddAgentFeaturesDiscovery.discoverIfOutdated();
     agentVersion = ddAgentFeaturesDiscovery.getVersion();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DenyListHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DenyListHelper.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.agent;
 
 import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.debugger.util.Redaction;
 import datadog.trace.util.ClassNameTrie;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,6 +22,8 @@ public class DenyListHelper implements DebuggerContext.ClassFilter {
   public DenyListHelper(Configuration.FilterList denyList) {
     Collection<String> packages = new ArrayList<>(DENIED_PACKAGES);
     Collection<String> classes = new ArrayList<>(DENIED_CLASSES);
+    packages.addAll(Redaction.getRedactedPackages());
+    classes.addAll(Redaction.getRedactedClasses());
     if (denyList != null) {
       packages.addAll(denyList.getPackagePrefixes());
       classes.addAll(denyList.getClasses());

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -120,7 +120,7 @@ public class SerializerWithLimits {
       throw new IllegalArgumentException("Type is required for serialization");
     }
     tokenWriter.prologue(value, type);
-    if (value == REDACTED_VALUE) {
+    if (value == REDACTED_VALUE || Redaction.isRedactedType(type)) {
       tokenWriter.notCaptured(NotCapturedReason.REDACTED);
       tokenWriter.epilogue(value);
       return;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -33,6 +33,7 @@ import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import datadog.trace.bootstrap.debugger.util.Redaction;
 import datadog.trace.core.CoreTracer;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -41,6 +42,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import org.joor.Reflect;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,13 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     CoreTracer tracer = CoreTracer.builder().build();
     TracerInstaller.forceInstallGlobalTracer(tracer);
     tracer.addTraceInterceptor(traceInterceptor);
+  }
+
+  @Override
+  @AfterEach
+  public void after() {
+    super.after();
+    Redaction.clearUserDefinedTypes();
   }
 
   @Test
@@ -357,6 +366,92 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
         snapshot.getEvaluationErrors().get(1).getMessage());
     assertEquals(
         "Could not evaluate the expression because 'strMap[\"password\"]' was redacted",
+        snapshot.getEvaluationErrors().get(2).getMessage());
+  }
+
+  @Test
+  public void typeRedaction() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot28";
+    Config config = mock(Config.class);
+    when(config.getDebuggerRedactedTypes())
+        .thenReturn("com.datadog.debugger.CapturedSnapshot28$Creds");
+    Redaction.addUserDefinedTypes(config);
+    SpanDecorationProbe.Decoration decoration1 = createDecoration("tag1", "{creds}");
+    SpanDecorationProbe.Decoration decoration2 = createDecoration("tag2", "{this.creds}");
+    SpanDecorationProbe.Decoration decoration3 = createDecoration("tag3", "{credMap['dave']}");
+    List<SpanDecorationProbe.Decoration> decorations =
+        Arrays.asList(decoration1, decoration2, decoration3);
+    installSingleSpanDecoration(
+        CLASS_NAME, ACTIVE, decorations, "process", "int (java.lang.String)");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "secret123").get();
+    assertEquals(42, result);
+    MutableSpan span = traceInterceptor.getFirstSpan();
+    assertFalse(span.getTags().containsKey("tag1"));
+    assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.di.tag1.probe_id"));
+    assertEquals(
+        "Could not evaluate the expression because 'creds' was redacted",
+        span.getTags().get("_dd.di.tag1.evaluation_error"));
+    assertFalse(span.getTags().containsKey("tag2"));
+    assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.di.tag2.probe_id"));
+    assertEquals(
+        "Could not evaluate the expression because 'this.creds' was redacted",
+        span.getTags().get("_dd.di.tag2.evaluation_error"));
+    assertFalse(span.getTags().containsKey("tag3"));
+    assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.di.tag3.probe_id"));
+    assertEquals(
+        "Could not evaluate the expression because 'credMap[\"dave\"]' was redacted",
+        span.getTags().get("_dd.di.tag3.evaluation_error"));
+  }
+
+  @Test
+  public void typeRedactionConditions() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot28";
+    Config config = mock(Config.class);
+    when(config.getDebuggerRedactedTypes())
+        .thenReturn("com.datadog.debugger.CapturedSnapshot28$Creds");
+    Redaction.addUserDefinedTypes(config);
+    SpanDecorationProbe.Decoration decoration1 =
+        createDecoration(
+            DSL.contains(
+                DSL.getMember(DSL.getMember(DSL.ref("this"), "creds"), "secretCode"),
+                new StringValue("123")),
+            "contains(this.creds.secretCode, '123')",
+            "tag1",
+            "foo");
+    SpanDecorationProbe.Decoration decoration2 =
+        createDecoration(
+            DSL.eq(DSL.getMember(DSL.ref("creds"), "secretCode"), DSL.value("123")),
+            "creds.secretCode == '123'",
+            "tag2",
+            "foo");
+    SpanDecorationProbe.Decoration decoration3 =
+        createDecoration(
+            DSL.eq(DSL.index(DSL.ref("credMap"), DSL.value("dave")), DSL.value("123")),
+            "credMap['dave'] == '123'",
+            "tag3",
+            "foo");
+    List<SpanDecorationProbe.Decoration> decorations =
+        Arrays.asList(decoration1, decoration2, decoration3);
+    installSingleSpanDecoration(
+        CLASS_NAME, ACTIVE, decorations, "process", "int (java.lang.String)");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "secret123").get();
+    assertEquals(42, result);
+    assertFalse(traceInterceptor.getFirstSpan().getTags().containsKey("tag1"));
+    assertFalse(traceInterceptor.getFirstSpan().getTags().containsKey("tag2"));
+    assertFalse(traceInterceptor.getFirstSpan().getTags().containsKey("tag3"));
+    assertEquals(1, mockSink.getSnapshots().size());
+    Snapshot snapshot = mockSink.getSnapshots().get(0);
+    assertEquals(3, snapshot.getEvaluationErrors().size());
+    assertEquals(
+        "Could not evaluate the expression because 'this.creds' was redacted",
+        snapshot.getEvaluationErrors().get(0).getMessage());
+    assertEquals(
+        "Could not evaluate the expression because 'creds' was redacted",
+        snapshot.getEvaluationErrors().get(1).getMessage());
+    assertEquals(
+        "Could not evaluate the expression because 'credMap[\"dave\"]' was redacted",
         snapshot.getEvaluationErrors().get(2).getMessage());
   }
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot27.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot27.java
@@ -1,21 +1,22 @@
 package com.datadog.debugger;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Map;
 
 public class CapturedSnapshot27 {
   private HashMap<String, String> strMap = new HashMap<>();
+  private Map<String, Creds> credMap = new HashMap<>();
   {
     strMap.put("foo1", "bar1");
     strMap.put("foo3", "bar3");
+    credMap.put("dave", new Creds("dave", "secret456"));
   }
 
   private String password;
-
+  private Creds creds;
 
   private int doit(String arg) {
+    creds = new Creds("john", arg);
     password = arg;
     String secret = arg;
     strMap.put("password", arg);
@@ -25,6 +26,15 @@ public class CapturedSnapshot27 {
   public static int main(String arg) {
     CapturedSnapshot27 cs27 = new CapturedSnapshot27();
     return cs27.doit(arg);
+  }
 
+  static class Creds {
+    private String user;
+    private String secretCode;
+
+    public Creds(String user, String secretCode) {
+      this.user = user;
+      this.secretCode = secretCode;
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot28.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot28.java
@@ -14,11 +14,14 @@ import java.util.Map;
 
 public class CapturedSnapshot28 {
   private String password;
+  private Creds creds;
   private final Map<String, String> strMap = new HashMap<>();
+  private final Map<String, Creds> credMap = new HashMap<>();
   {
     strMap.put("foo1", "bar1");
     strMap.put("foo2", "bar2");
     strMap.put("foo3", "bar3");
+    credMap.put("dave", new Creds("dave", "secret456"));
   }
 
   public static int main(String arg) {
@@ -32,9 +35,20 @@ public class CapturedSnapshot28 {
   }
 
   private int process(String arg) {
+    creds = new Creds("john", arg);
     password = arg;
     String secret = arg;
     strMap.put("password", arg);
     return 42;
+  }
+
+  static class Creds {
+    private String user;
+    private String secretCode;
+
+    public Creds(String user, String secretCode) {
+      this.user = user;
+      this.secretCode = secretCode;
+    }
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -24,6 +24,7 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_CAPTURE_TIMEOUT = "dynamic.instrumentation.capture.timeout";
   public static final String DEBUGGER_REDACTED_IDENTIFIERS =
       "dynamic.instrumentation.redacted.identifiers";
+  public static final String DEBUGGER_REDACTED_TYPES = "dynamic.instrumentation.redacted.types";
 
   private DebuggerConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -180,6 +180,7 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_METRICS_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_POLL_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_PROBE_FILE_LOCATION;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_REDACTED_IDENTIFIERS;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_REDACTED_TYPES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_BATCH_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_FLUSH_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_UPLOAD_TIMEOUT;
@@ -728,6 +729,7 @@ public class Config {
   private final String debuggerExcludeFiles;
   private final int debuggerCaptureTimeout;
   private final String debuggerRedactedIdentifiers;
+  private final String debuggerRedactedTypes;
 
   private final boolean awsPropagationEnabled;
   private final boolean sqsPropagationEnabled;
@@ -1668,6 +1670,7 @@ public class Config {
     debuggerCaptureTimeout =
         configProvider.getInteger(DEBUGGER_CAPTURE_TIMEOUT, DEFAULT_DEBUGGER_CAPTURE_TIMEOUT);
     debuggerRedactedIdentifiers = configProvider.getString(DEBUGGER_REDACTED_IDENTIFIERS, null);
+    debuggerRedactedTypes = configProvider.getString(DEBUGGER_REDACTED_TYPES, null);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");
@@ -2766,6 +2769,10 @@ public class Config {
 
   public String getDebuggerRedactedIdentifiers() {
     return debuggerRedactedIdentifiers;
+  }
+
+  public String getDebuggerRedactedTypes() {
+    return debuggerRedactedTypes;
   }
 
   public boolean isAwsPropagationEnabled() {


### PR DESCRIPTION
# What Does This Do
Add property/env `dynamic.instrumentation.redacted.types` to customize the redaction data based on type.
Redaction happening at:
 - expression language for reference, index and getmember operations
 - serialization for snapshot or template values including maps For conditions (log or span decoration probes) evaluation of a redacted values triggers an evaluation exception that will be reported as evaluation error into a snapshot.

# Motivation
PII redaction

# Additional Notes

Jira ticket: [DEBUG-1846]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1846]: https://datadoghq.atlassian.net/browse/DEBUG-1846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ