### PR TITLE
Changed HttpServletRequest.getRequestURI reported souce to http.request.path

### DIFF
--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -251,24 +251,8 @@ public class HttpServletRequestCallSite {
     }
   }
 
-  @Source(SourceTypes.REQUEST_URI)
-  @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getRequestURI()")
-  public static String afterGetRequestURI(
-      @CallSite.This final HttpServletRequest self, @CallSite.Return final String retValue) {
-    if (null != retValue && !retValue.isEmpty()) {
-      final WebModule module = InstrumentationBridge.WEB;
-      if (module != null) {
-        try {
-          module.onGetRequestURI(retValue);
-        } catch (final Throwable e) {
-          module.onUnexpectedException("afterGetRequestURI threw", e);
-        }
-      }
-    }
-    return retValue;
-  }
-
   @Source(SourceTypes.REQUEST_PATH)
+  @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getRequestURI()")
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getPathInfo()")
   @CallSite.After("java.lang.String javax.servlet.http.HttpServletRequest.getPathTranslated()")
   public static String afterGetPathInfo(

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
@@ -191,7 +191,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
     testSuite.getRequestURI()
 
     then:
-    1 * iastModule.onGetRequestURI('retValue')
+    1 * iastModule.onGetPathInfo('retValue')
 
     where:
     clazz                     | _

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -805,7 +805,7 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     then:
     hasTainted { tainted ->
       tainted.value == '/getrequesturi' &&
-        tainted.ranges[0].source.origin == 'http.request.uri'
+        tainted.ranges[0].source.origin == 'http.request.path'
     }
   }
 


### PR DESCRIPTION
# What Does This Do
It changes to http.request.path the source reported when a vulnerability is found and the source of the tainted object was acquired using HttpServletRequest.getRequestURI since this API doesn't return the full URL.

# Motivation
To be consistent when reporting vulnerability sources.

# Additional Notes

Jira ticket: [APPSEC-11729]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-11729]: https://datadoghq.atlassian.net/browse/APPSEC-11729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ