### PR TITLE
Track payload size in Rabbit & SQS integrations

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -143,7 +143,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     }
     AgentPropagation.ContextVisitor<REQUEST_CARRIER> getter = getter();
     if (null != carrier && null != getter) {
-      tracer().getDataStreamsMonitoring().setCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0, 0);
+      tracer().getDataStreamsMonitoring().setCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0, () -> 0);
     }
     return span;
   }

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/TracingServerInterceptor.java
@@ -70,7 +70,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
 
     AgentTracer.get()
         .getDataStreamsMonitoring()
-        .setCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0, 0);
+        .setCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0, () -> 0);
 
     RequestContext reqContext = span.getRequestContext();
     if (reqContext != null) {

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/TracingIterator.java
@@ -97,7 +97,7 @@ public class TracingIterator<L extends Iterator<Message>> implements Iterator<Me
         sortedTags.put(TYPE_TAG, "sqs");
         AgentTracer.get()
             .getDataStreamsMonitoring()
-            .setCheckpoint(span, sortedTags, 0, computePayloadSizeBytes(message));
+            .setCheckpoint(span, sortedTags, 0, () -> computePayloadSizeBytes(message));
 
         CONSUMER_DECORATE.afterStart(span);
         CONSUMER_DECORATE.onConsume(span, queueUrl, requestId);

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
@@ -176,6 +176,7 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
       verifyAll(second) {
         edgeTags == ["direction:in", "topic:somequeue", "type:sqs"]
         edgeTags.size() == 3
+        !it.payloadSize.isEmpty()
       }
     }
 

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -69,7 +69,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
 
     AgentTracer.get()
         .getDataStreamsMonitoring()
-        .setCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0, 0);
+        .setCheckpoint(span, SERVER_PATHWAY_EDGE_TAGS, 0, () -> 0);
 
     RequestContext reqContext = span.getRequestContext();
     if (reqContext != null) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -93,7 +93,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
 
           AgentTracer.get()
               .getDataStreamsMonitoring()
-              .setCheckpoint(span, sortedTags, val.timestamp(), computePayloadSizeBytes(val));
+              .setCheckpoint(span, sortedTags, val.timestamp(), () -> computePayloadSizeBytes(val));
         } else {
           span = startSpan(operationName, null);
         }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -255,7 +255,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
               span,
               sortedTags,
               produceMillis,
-              (body != null ? body.length : 0) + computeHeadersSizeBytes(headers));
+              () -> ((body != null ? body.length : 0) + computeHeadersSizeBytes(headers)));
     }
 
     CONSUMER_DECORATE.afterStart(span);

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -178,6 +178,7 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
       verifyAll(second) {
         edgeTags == ["direction:in", "topic:" + queueName, "type:rabbitmq"]
         edgeTags.size() == 3
+        !payloadSize.isEmpty()
       }
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import org.jctools.queues.MpscBlockingConsumerArrayQueue;
 import org.slf4j.Logger;
@@ -208,10 +209,11 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
       AgentSpan span,
       LinkedHashMap<String, String> sortedTags,
       long defaultTimestamp,
-      long payloadSizeBytes) {
+      LongSupplier payloadSizeBytes) {
     PathwayContext pathwayContext = span.context().getPathwayContext();
     if (pathwayContext != null) {
-      pathwayContext.setCheckpoint(sortedTags, this::add, defaultTimestamp, payloadSizeBytes);
+      pathwayContext.setCheckpoint(
+          sortedTags, this::add, defaultTimestamp, payloadSizeBytes.getAsLong());
       if (pathwayContext.getHash() != 0) {
         span.setTag(PATHWAY_HASH, Long.toUnsignedString(pathwayContext.getHash()));
       }
@@ -237,7 +239,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
     sortedTags.put(TOPIC_TAG, source);
     sortedTags.put(TYPE_TAG, type);
 
-    setCheckpoint(span, sortedTags, 0, 0);
+    setCheckpoint(span, sortedTags, 0, () -> 0);
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.experimental.DataStreamsCheckpointer;
 import java.util.LinkedHashMap;
+import java.util.function.LongSupplier;
 
 public interface AgentDataStreamsMonitoring extends DataStreamsCheckpointer {
   void trackBacklog(LinkedHashMap<String, String> sortedTags, long value);
@@ -15,14 +16,15 @@ public interface AgentDataStreamsMonitoring extends DataStreamsCheckpointer {
    *     checkpoint in the chain. Zero should be passed if we can't extract the timestamp from the
    *     message / payload itself (for instance: produce operations; http produce / consume etc).
    *     Value will be ignored for checkpoints happening not at the start of the pipeline.
-   * @param payloadSizeBytes size of the message (body + headers) in bytes. Zero should be passed if
-   *     the size cannot be evaluated.
+   * @param payloadSizeBytes a lambda that will be evaluated to compute the size of the message
+   *     (body + headers) in bytes, only if DSM is enabled. Zero should be passed if the size cannot
+   *     be evaluated.
    */
   void setCheckpoint(
       AgentSpan span,
       LinkedHashMap<String, String> sortedTags,
       long defaultTimestamp,
-      long payloadSizeBytes);
+      LongSupplier payloadSizeBytes);
 
   PathwayContext newPathwayContext();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.LongSupplier;
 
 public class AgentTracer {
   private static final String DEFAULT_INSTRUMENTATION_NAME = "datadog";
@@ -1026,7 +1027,7 @@ public class AgentTracer {
         AgentSpan span,
         LinkedHashMap<String, String> sortedTags,
         long defaultTimestamp,
-        long payloadSizeBytes) {}
+        LongSupplier payloadSizeBytes) {}
 
     @Override
     public PathwayContext newPathwayContext() {


### PR DESCRIPTION
follow up on #6045 
adding the same capabilities for other messaging systems, as it was done in .net in https://github.com/DataDog/dd-trace-dotnet/pull/4520