### PR TITLE
Skip problematic JDK for spark tests

### DIFF
--- a/dd-java-agent/instrumentation/spark/spark_2.12/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.12/build.gradle
@@ -19,6 +19,9 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuiteForDir('latestDepTest', 'test')
 
 ext {
+  // Hadoop does not behave correctly with OpenJ9 https://issues.apache.org/jira/browse/HADOOP-18174
+  excludeJdk = ['SEMERU8', 'SEMERU11']
+
   // Spark does not support Java > 11 until 3.3.0 https://issues.apache.org/jira/browse/SPARK-33772
   maxJavaVersionForTests = JavaVersion.VERSION_11
 }

--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -20,6 +20,10 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuiteForDir('latestDepTest', 'test')
 
 ext {
+  // Hadoop does not behave correctly with OpenJ9 https://issues.apache.org/jira/browse/HADOOP-18174
+  // Hadoop 3.3.1 (used by spark 3.2) does not support IBM java https://issues.apache.org/jira/browse/HADOOP-17971
+  excludeJdk = ['SEMERU8', 'SEMERU11', 'IBM8']
+
   // Spark does not support Java > 11 until 3.3.0 https://issues.apache.org/jira/browse/SPARK-33772
   maxJavaVersionForTests = JavaVersion.VERSION_11
 }


### PR DESCRIPTION
# What Does This Do

For Spark Tests, skip JDKs:
- OpenJ9 because of https://issues.apache.org/jira/browse/HADOOP-18174
- IBM8 because of https://issues.apache.org/jira/browse/HADOOP-17971

# Motivation

Failing on master: https://github.com/DataDog/dd-trace-java/runs/17880700556

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
