### PR TITLE
add heap histogram option

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -16,7 +16,10 @@
 package com.datadog.profiling.controller.openjdk;
 
 import static com.datadog.profiling.controller.ProfilingSupport.*;
+import static com.datadog.profiling.controller.ProfilingSupport.isObjectCountParallelized;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_ENABLED;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ULTRA_MINIMAL;
 
 import com.datadog.profiling.controller.ConfigurationException;
@@ -97,6 +100,16 @@ public final class OpenJdkController implements Controller {
 
     if (!isFileWriteDurationCorrect()) {
       disableEvent(recordingSettings, "jdk.FileWrite", EXPENSIVE_ON_CURRENT_JVM);
+    }
+
+    if (configProvider.getBoolean(
+        PROFILING_HEAP_HISTOGRAM_ENABLED, PROFILING_HEAP_HISTOGRAM_ENABLED_DEFAULT)) {
+      if (!isObjectCountParallelized()) {
+        log.warn(
+            "enabling Datadog heap histogram on JVM without an efficient implementation of the jdk.ObjectCount event. "
+                + "This may increase p99 latency. Consider upgrading to JDK 17.0.9+ or 21+ to reduce latency impact.");
+      }
+      enableEvent(recordingSettings, "jdk.ObjectCount", "user enabled histogram heap collection");
     }
 
     // Toggle settings from override file

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSupport.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilingSupport.java
@@ -26,6 +26,12 @@ public class ProfilingSupport {
     return isJavaVersionAtLeast(16);
   }
 
+  public static boolean isObjectCountParallelized() {
+    // parallelized jdk.ObjectCount implemented in JDK21 and backported to JDK17
+    // https://bugs.openjdk.org/browse/JDK-8307348
+    return (isJavaVersion(17) && isJavaVersionAtLeast(17, 0, 9)) || isJavaVersionAtLeast(21);
+  }
+
   public static boolean isNativeMethodSampleAvailable() {
     if (isOracleJDK8()) {
       return false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -182,5 +182,8 @@ public final class ProfilingConfig {
 
   public static final String PROFILING_ULTRA_MINIMAL = "profiling.ultra.minimal";
 
+  public static final String PROFILING_HEAP_HISTOGRAM_ENABLED = "profiling.heap.histogram.enabled";
+  public static final boolean PROFILING_HEAP_HISTOGRAM_ENABLED_DEFAULT = false;
+
   private ProfilingConfig() {}
 }


### PR DESCRIPTION
# What Does This Do

Collects a histogram of the heap once every 60s. This feature is opt in. The underlying data collection is done in parallel from JDK21+ and was backported to JDK17.0.9. If the user opts in on JDK versions where the collection is serial, a warning and recommendation to upgrade the JDK is printed.

# Motivation

# Additional Notes

Jira ticket: [PROF-8468]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8468]: https://datadoghq.atlassian.net/browse/PROF-8468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ