### PR TITLE
Fix tracer logging when instrumenting Gradle Daemon

### DIFF
--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
@@ -1,5 +1,6 @@
 package datadog.trace.logging.ddlogger;
 
+import datadog.trace.api.Resettable;
 import datadog.trace.logging.LogLevel;
 import datadog.trace.logging.LogLevelSwitcher;
 import datadog.trace.logging.LoggerHelper;
@@ -10,7 +11,7 @@ import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
-public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher {
+public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher, Resettable {
 
   private volatile LoggerHelperFactory helperFactory = null;
 
@@ -74,5 +75,10 @@ public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher {
       }
     }
     return factory;
+  }
+
+  @Override
+  public void reset() {
+    helperFactory = null;
   }
 }

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
@@ -1,6 +1,5 @@
 package datadog.trace.logging.ddlogger;
 
-import datadog.trace.api.Resettable;
 import datadog.trace.logging.LogLevel;
 import datadog.trace.logging.LogLevelSwitcher;
 import datadog.trace.logging.LoggerHelper;
@@ -11,7 +10,7 @@ import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 
-public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher, Resettable {
+public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher {
 
   private volatile LoggerHelperFactory helperFactory = null;
 
@@ -78,7 +77,7 @@ public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher, Resett
   }
 
   @Override
-  public void reset() {
+  public void reinitialize() {
     helperFactory = null;
   }
 }

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleDaemonLoggingInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleDaemonLoggingInstrumentation.java
@@ -1,0 +1,53 @@
+package datadog.trace.instrumentation.gradle;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.Resettable;
+import net.bytebuddy.asm.Advice;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+@AutoService(Instrumenter.class)
+public class GradleDaemonLoggingInstrumentation extends Instrumenter.CiVisibility
+    implements Instrumenter.ForSingleType {
+
+  public GradleDaemonLoggingInstrumentation() {
+    super("gradle", "gradle-daemon-logging");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.gradle.launcher.daemon.bootstrap.DaemonMain";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        named("initialiseLogging"),
+        GradleDaemonLoggingInstrumentation.class.getName() + "$ReinitialiseLogging");
+  }
+
+  /**
+   * Gradle Daemon closes original {@link System.out} and {@link System.err} streams (see {@link
+   * org.gradle.launcher.daemon.bootstrap.DaemonMain#daemonStarted}), and replaces them with Gradle
+   * Daemon log streams (see {@link
+   * org.gradle.launcher.daemon.bootstrap.DaemonMain#initialiseLogging}).
+   *
+   * <p>{@link datadog.trace.logging.simplelogger.SLCompatFactory} that contains logging settings
+   * gets initialized before Gradle Daemon, so DD logging settings refer to the original streams
+   * that the daemon closes. They need to refer to the new streams created by the daemon, so here we
+   * reset the settings letting them re-initialize to capture the new streams.
+   */
+  public static class ReinitialiseLogging {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void reinitialiseTracerLogging() {
+      ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+      if (loggerFactory instanceof Resettable) {
+        Resettable resettable = (Resettable) loggerFactory;
+        resettable.reset();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleDaemonLoggingInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleDaemonLoggingInstrumentation.java
@@ -4,10 +4,8 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Resettable;
+import datadog.trace.logging.GlobalLogLevelSwitcher;
 import net.bytebuddy.asm.Advice;
-import org.slf4j.ILoggerFactory;
-import org.slf4j.LoggerFactory;
 
 @AutoService(Instrumenter.class)
 public class GradleDaemonLoggingInstrumentation extends Instrumenter.CiVisibility
@@ -43,11 +41,7 @@ public class GradleDaemonLoggingInstrumentation extends Instrumenter.CiVisibilit
   public static class ReinitialiseLogging {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void reinitialiseTracerLogging() {
-      ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
-      if (loggerFactory instanceof Resettable) {
-        Resettable resettable = (Resettable) loggerFactory;
-        resettable.reset();
-      }
+      GlobalLogLevelSwitcher.get().reinitialize();
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Resettable.java
+++ b/internal-api/src/main/java/datadog/trace/api/Resettable.java
@@ -1,0 +1,5 @@
+package datadog.trace.api;
+
+public interface Resettable {
+  void reset();
+}

--- a/internal-api/src/main/java/datadog/trace/api/Resettable.java
+++ b/internal-api/src/main/java/datadog/trace/api/Resettable.java
@@ -1,5 +1,0 @@
-package datadog.trace.api;
-
-public interface Resettable {
-  void reset();
-}

--- a/internal-api/src/main/java/datadog/trace/logging/GlobalLogLevelSwitcher.java
+++ b/internal-api/src/main/java/datadog/trace/logging/GlobalLogLevelSwitcher.java
@@ -43,4 +43,11 @@ public class GlobalLogLevelSwitcher implements LogLevelSwitcher {
       delegate.restore();
     }
   }
+
+  @Override
+  public void reinitialize() {
+    if (delegate != null) {
+      delegate.reinitialize();
+    }
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/logging/LogLevelSwitcher.java
+++ b/internal-api/src/main/java/datadog/trace/logging/LogLevelSwitcher.java
@@ -12,4 +12,7 @@ public interface LogLevelSwitcher {
 
   /** Restore the LogLevel to the original setting. */
   void restore();
+
+  /** Re-execute logging settings initialization */
+  void reinitialize();
 }


### PR DESCRIPTION
# What Does This Do
Fixes tracer logging to work when instrumenting Gradle Daemon.

# Motivation
Tracer logs contain data that is important for debugging.

When Gradle Daemon initialises, it closes original `System.out` and `System.err` streams, replacing them with daemon log streams.
Tracer logging is initialised before the daemon, so it refers to the original streams that are closed.
In order for the logging to work, it needs to refer to the daemon log streams.
This is achieved by reinitialising logging settings after Gradle Daemon has finished its initialisation.

Jira ticket: [CIVIS-7730]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-7730]: https://datadoghq.atlassian.net/browse/CIVIS-7730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ