### PR TITLE
Fix sampling with probe condition

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -329,7 +329,7 @@ public class CapturedContext implements ValueReferenceResolver {
     this.thisClassName = thisClassName;
     boolean shouldEvaluate = resolveEvaluateAt(probeImplementation, methodLocation);
     if (shouldEvaluate) {
-      probeImplementation.evaluate(this, status);
+      probeImplementation.evaluate(this, status, methodLocation);
     }
     return status;
   }
@@ -340,11 +340,7 @@ public class CapturedContext implements ValueReferenceResolver {
       // line probe, no evaluation of probe's evaluateAt
       return true;
     }
-    MethodLocation localEvaluateAt = probeImplementation.getEvaluateAt();
-    if (methodLocation == MethodLocation.ENTRY) {
-      return localEvaluateAt == MethodLocation.DEFAULT || localEvaluateAt == MethodLocation.ENTRY;
-    }
-    return localEvaluateAt == methodLocation;
+    return MethodLocation.isSame(methodLocation, probeImplementation.getEvaluateAt());
   }
 
   public Status getStatus(String probeId) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -192,25 +192,8 @@ public class DebuggerContext {
    * @return true if can proceed to capture data
    */
   public static boolean isReadyToCapture(Class<?> callingClass, String... probeIds) {
-    // TODO provide overloaded version without string array
     try {
-      if (probeIds == null || probeIds.length == 0) {
-        return false;
-      }
-      boolean result = false;
-      for (String probeId : probeIds) {
-        ProbeImplementation probeImplementation = resolveProbe(probeId, callingClass);
-        if (probeImplementation != null && probeImplementation.hasCondition()) {
-          // if at least one probe has a condition we capture anyway because
-          // we will sample at commit
-          result = true;
-          break;
-        }
-        // if all probes are rate limited, we don't capture
-        result |= ProbeRateLimiter.tryProbe(probeId);
-      }
-      result = result && checkAndSetInProbe();
-      return result;
+      return checkAndSetInProbe();
     } catch (Exception ex) {
       LOGGER.debug("Error in isReadyToCapture: ", ex);
       return false;

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -191,7 +191,7 @@ public class DebuggerContext {
    *
    * @return true if can proceed to capture data
    */
-  public static boolean isReadyToCapture(String... probeIds) {
+  public static boolean isReadyToCapture(Class<?> callingClass, String... probeIds) {
     // TODO provide overloaded version without string array
     try {
       if (probeIds == null || probeIds.length == 0) {
@@ -199,6 +199,13 @@ public class DebuggerContext {
       }
       boolean result = false;
       for (String probeId : probeIds) {
+        ProbeImplementation probeImplementation = resolveProbe(probeId, callingClass);
+        if (probeImplementation != null && probeImplementation.hasCondition()) {
+          // if at least one probe has a condition we capture anyway because
+          // we will sample at commit
+          result = true;
+          break;
+        }
         // if all probes are rate limited, we don't capture
         result |= ProbeRateLimiter.tryProbe(probeId);
       }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/MethodLocation.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/MethodLocation.java
@@ -3,5 +3,12 @@ package datadog.trace.bootstrap.debugger;
 public enum MethodLocation {
   DEFAULT,
   ENTRY,
-  EXIT
+  EXIT;
+
+  public static boolean isSame(MethodLocation methodLocation, MethodLocation evaluateAt) {
+    if (methodLocation == MethodLocation.ENTRY) {
+      return evaluateAt == MethodLocation.DEFAULT || evaluateAt == MethodLocation.ENTRY;
+    }
+    return methodLocation == evaluateAt;
+  }
 }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeImplementation.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeImplementation.java
@@ -16,7 +16,8 @@ public interface ProbeImplementation {
 
   String getStrTags();
 
-  void evaluate(CapturedContext context, CapturedContext.Status status);
+  void evaluate(
+      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation);
 
   void commit(
       CapturedContext entryContext,
@@ -84,7 +85,8 @@ public interface ProbeImplementation {
     }
 
     @Override
-    public void evaluate(CapturedContext context, CapturedContext.Status status) {}
+    public void evaluate(
+        CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {}
 
     @Override
     public void commit(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -258,11 +258,6 @@ public class ConfigurationUpdater
                 : getDefaultRateLimitPerProbe(probe),
             probe.isCaptureSnapshot());
       }
-      if (addedDefinitions instanceof SpanDecorationProbe) {
-        // Span decoration probes use the same instrumentation as log probes, but we don't want
-        // to sample here.
-        ProbeRateLimiter.setRate(addedDefinitions.getId(), -1, false);
-      }
     }
     // remove rate for all removed probes
     for (ProbeDefinition removedDefinition : changes.getRemovedDefinitions()) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -127,6 +127,8 @@ public class CapturedContextInstrumentor extends Instrumentor {
       }
       if (beforeLabel != null) {
         InsnList insnList = new InsnList();
+        ldc(insnList, Type.getObjectType(classNode.name));
+        // stack [class, array]
         pushProbesIds(insnList);
         // stack [array]
         invokeStatic(
@@ -134,6 +136,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
             DEBUGGER_CONTEXT_TYPE,
             "isReadyToCapture",
             Type.BOOLEAN_TYPE,
+            CLASS_TYPE,
             STRING_ARRAY_TYPE);
         // stack [boolean]
         LabelNode targetNode = new LabelNode();
@@ -314,10 +317,17 @@ public class CapturedContextInstrumentor extends Instrumentor {
       methodNode.instructions.insert(methodEnterLabel, insnList);
       return;
     }
+    ldc(insnList, Type.getObjectType(classNode.name));
+    // stack [class]
     pushProbesIds(insnList);
-    // stack [array]
+    // stack [class, array]
     invokeStatic(
-        insnList, DEBUGGER_CONTEXT_TYPE, "isReadyToCapture", Type.BOOLEAN_TYPE, STRING_ARRAY_TYPE);
+        insnList,
+        DEBUGGER_CONTEXT_TYPE,
+        "isReadyToCapture",
+        Type.BOOLEAN_TYPE,
+        CLASS_TYPE,
+        STRING_ARRAY_TYPE);
     // stack [boolean]
     LabelNode targetNode = new LabelNode();
     LabelNode gotoNode = new LabelNode();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -363,11 +363,17 @@ public class LogProbe extends ProbeDefinition {
   }
 
   @Override
-  public void evaluate(CapturedContext context, CapturedContext.Status status) {
+  public void evaluate(
+      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {
     if (!(status instanceof LogStatus)) {
       throw new IllegalStateException("Invalid status: " + status.getClass());
     }
+
     LogStatus logStatus = (LogStatus) status;
+    if (!hasCondition()) {
+      // sample when no condition associated
+      sample(logStatus, methodLocation);
+    }
     logStatus.setCondition(evaluateCondition(context, logStatus));
     CapturedContext.CapturedThrowable throwable = context.getThrowable();
     if (logStatus.hasConditionErrors() && throwable != null) {
@@ -375,9 +381,26 @@ public class LogProbe extends ProbeDefinition {
           new EvaluationError(
               "uncaught exception", throwable.getType() + ": " + throwable.getMessage()));
     }
-    if (logStatus.getCondition()) {
+    if (hasCondition() && logStatus.getCondition()) {
+      // sample if probe has condition and condition is true
+      sample(logStatus, methodLocation);
+    }
+    if (logStatus.isSampled() && logStatus.getCondition()) {
       LogMessageTemplateBuilder logMessageBuilder = new LogMessageTemplateBuilder(segments);
       logStatus.setMessage(logMessageBuilder.evaluate(context, logStatus));
+    }
+  }
+
+  private void sample(LogStatus logStatus, MethodLocation methodLocation) {
+    // sample only once and when we need to evaluate
+    if (!MethodLocation.isSame(methodLocation, evaluateAt)) {
+      return;
+    }
+    boolean sampled = ProbeRateLimiter.tryProbe(id);
+    logStatus.setSampled(sampled);
+    if (!sampled) {
+      LOGGER.debug("{} not sampled!", id);
+      DebuggerAgent.getSink().skipSnapshot(id, DebuggerContext.SkipCause.RATE);
     }
   }
 
@@ -430,13 +453,6 @@ public class LogProbe extends ProbeDefinition {
     int maxDepth = capture != null ? capture.maxReferenceDepth : -1;
     Snapshot snapshot = new Snapshot(Thread.currentThread(), this, maxDepth);
     if (entryStatus.shouldSend() && exitStatus.shouldSend()) {
-      // only rate limit if a condition is defined
-      if (probeCondition != null) {
-        if (!ProbeRateLimiter.tryProbe(id)) {
-          sink.skipSnapshot(id, DebuggerContext.SkipCause.RATE);
-          return;
-        }
-      }
       snapshot.setTraceId(traceId);
       snapshot.setSpanId(spanId);
       if (isCaptureSnapshot()) {
@@ -506,13 +522,6 @@ public class LogProbe extends ProbeDefinition {
     Snapshot snapshot = new Snapshot(Thread.currentThread(), this, maxDepth);
     boolean shouldCommit = false;
     if (status.shouldSend()) {
-      // only rate limit if a condition is defined
-      if (probeCondition != null) {
-        if (!ProbeRateLimiter.tryProbe(id)) {
-          sink.skipSnapshot(id, DebuggerContext.SkipCause.RATE);
-          return;
-        }
-      }
       snapshot.setTraceId(lineContext.getTraceId());
       snapshot.setSpanId(lineContext.getSpanId());
       if (isCaptureSnapshot()) {
@@ -554,6 +563,7 @@ public class LogProbe extends ProbeDefinition {
     private boolean condition = true;
     private boolean hasLogTemplateErrors;
     private boolean hasConditionErrors;
+    private boolean sampled = true;
     private String message;
 
     public LogStatus(ProbeImplementation probeImplementation) {
@@ -567,7 +577,7 @@ public class LogProbe extends ProbeDefinition {
 
     @Override
     public boolean shouldFreezeContext() {
-      return probeImplementation.isCaptureSnapshot() && shouldSend();
+      return sampled && probeImplementation.isCaptureSnapshot() && shouldSend();
     }
 
     @Override
@@ -576,7 +586,7 @@ public class LogProbe extends ProbeDefinition {
     }
 
     public boolean shouldSend() {
-      return condition && !hasConditionErrors;
+      return sampled && condition && !hasConditionErrors;
     }
 
     public boolean shouldReportError() {
@@ -613,6 +623,14 @@ public class LogProbe extends ProbeDefinition {
 
     public String getMessage() {
       return message;
+    }
+
+    public void setSampled(boolean sampled) {
+      this.sampled = sampled;
+    }
+
+    public boolean isSampled() {
+      return sampled;
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -143,7 +143,8 @@ public abstract class ProbeDefinition implements ProbeImplementation {
   }
 
   @Override
-  public void evaluate(CapturedContext context, CapturedContext.Status status) {}
+  public void evaluate(
+      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {}
 
   @Override
   public void commit(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -145,7 +145,8 @@ public class SpanDecorationProbe extends ProbeDefinition {
   }
 
   @Override
-  public void evaluate(CapturedContext context, CapturedContext.Status status) {
+  public void evaluate(
+      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {
     for (Decoration decoration : decorations) {
       if (decoration.when != null) {
         try {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1814,24 +1814,30 @@ public class CapturedSnapshotTest {
 
   @Test
   public void samplingMethodProbe() throws IOException, URISyntaxException {
-    doSamplingTest(this::methodProbe);
+    doSamplingTest(this::methodProbe, 1, 1);
   }
 
   @Test
   public void samplingProbeCondition() throws IOException, URISyntaxException {
-    doSamplingTest(this::simpleConditionTest);
+    doSamplingTest(this::simpleConditionTest, 1, 1);
+  }
+
+  @Test
+  public void samplingDupMethodProbeCondition() throws IOException, URISyntaxException {
+    doSamplingTest(this::mergedProbesWithAdditionalProbeConditionTest, 2, 2);
   }
 
   @Test
   public void samplingLineProbe() throws IOException, URISyntaxException {
-    doSamplingTest(this::singleLineProbe);
+    doSamplingTest(this::singleLineProbe, 1, 1);
   }
 
   interface TestMethod {
     void run() throws IOException, URISyntaxException;
   }
 
-  private void doSamplingTest(TestMethod testRun) throws IOException, URISyntaxException {
+  private void doSamplingTest(TestMethod testRun, int expectedGlobalCount, int expectedProbeCount)
+      throws IOException, URISyntaxException {
     MockSampler probeSampler = new MockSampler();
     MockSampler globalSampler = new MockSampler();
     ProbeRateLimiter.setSamplerSupplier(rate -> rate < 101 ? probeSampler : globalSampler);
@@ -1841,8 +1847,8 @@ public class CapturedSnapshotTest {
     } finally {
       ProbeRateLimiter.setSamplerSupplier(null);
     }
-    assertEquals(1, globalSampler.callCount);
-    assertEquals(1, probeSampler.callCount);
+    assertEquals(expectedGlobalCount, globalSampler.callCount);
+    assertEquals(expectedProbeCount, probeSampler.callCount);
   }
 
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(


### PR DESCRIPTION
# What Does This Do
Move sampling into context evaluation
Sampling is now done into LogProbe context evaluation:
 - if no condition sample at eval entry
 - if has condition, sample after condition and if condition is true

keep sample status in LogStatus, use to know if:
- we should freeze eval context
- we should send snapshot

# Motivation
Sampling was done unconditionally before capturing, and with condition was also performed at commit which reduce the number of snapshot matching the condition

# Additional Notes

Jira ticket: [DEBUG-1890]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1890]: https://datadoghq.atlassian.net/browse/DEBUG-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ