### PR TITLE
Improve http.request.path IAST source for servlet

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/source/WebModuleImpl.java
@@ -65,11 +65,6 @@ public class WebModuleImpl implements WebModule {
   }
 
   @Override
-  public void onGetPathInfo(@Nullable String s) {
-    onNamed(Collections.singleton(s), SourceTypes.REQUEST_PATH);
-  }
-
-  @Override
   public void onGetRequestURI(@Nullable String s) {
     onNamed(Collections.singleton(s), SourceTypes.REQUEST_URI);
   }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/request/HttpServletRequestCallSite.java
@@ -258,10 +258,10 @@ public class HttpServletRequestCallSite {
   public static String afterGetPathInfo(
       @CallSite.This final HttpServletRequest self, @CallSite.Return final String retValue) {
     if (null != retValue && !retValue.isEmpty()) {
-      final WebModule module = InstrumentationBridge.WEB;
+      final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.onGetPathInfo(retValue);
+          module.taint(SourceTypes.REQUEST_PATH, null, retValue);
         } catch (final Throwable e) {
           module.onUnexpectedException("afterGetPathInfo threw", e);
         }

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestCallSiteTest.groovy
@@ -180,7 +180,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
 
   void 'test getRequestURI'() {
     setup:
-    final iastModule = Mock(WebModule)
+    final iastModule = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(iastModule)
     final mock = Mock(HttpServletRequest){
       getRequestURI() >> 'retValue'
@@ -191,7 +191,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
     testSuite.getRequestURI()
 
     then:
-    1 * iastModule.onGetPathInfo('retValue')
+    1 * iastModule.taint(SourceTypes.REQUEST_PATH, null, 'retValue')
 
     where:
     clazz                     | _
@@ -201,7 +201,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
 
   void 'test getPathInfo'() {
     setup:
-    final iastModule = Mock(WebModule)
+    final iastModule = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(iastModule)
     final mock = Mock(HttpServletRequest){
       getPathInfo() >> 'retValue'
@@ -212,7 +212,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
     testSuite.getPathInfo()
 
     then:
-    1 * iastModule.onGetPathInfo('retValue')
+    1 * iastModule.taint(SourceTypes.REQUEST_PATH, null, 'retValue')
 
     where:
     clazz                     | _
@@ -222,7 +222,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
 
   void 'test getPathTranslated'() {
     setup:
-    final iastModule = Mock(WebModule)
+    final iastModule = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(iastModule)
     final mock = Mock(HttpServletRequest){
       getPathTranslated() >> 'retValue'
@@ -233,7 +233,7 @@ class HttpServletRequestCallSiteTest extends AgentTestRunner {
     testSuite.getPathTranslated()
 
     then:
-    1 * iastModule.onGetPathInfo('retValue')
+    1 * iastModule.taint(SourceTypes.REQUEST_PATH, null, 'retValue')
 
     where:
     clazz                     | _

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -805,7 +805,8 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     then:
     hasTainted { tainted ->
       tainted.value == '/getrequesturi' &&
-        tainted.ranges[0].source.origin == 'http.request.path'
+        tainted.ranges[0].source.origin == 'http.request.path' &&
+        tainted.ranges[0].source.value == '/getrequesturi'
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/source/WebModule.java
@@ -30,7 +30,5 @@ public interface WebModule extends IastModule {
   void onMultipartValues(
       @Nullable String headerName, @Nullable final Collection<String> headerValues);
 
-  void onGetPathInfo(@Nullable String s);
-
   void onGetRequestURI(@Nullable String s);
 }


### PR DESCRIPTION

# What Does This Do
Remove unnecessary callbacks, make sure we set the IAST source value (name is not needed).

# Motivation

# Additional Notes

* Jira ticket: [APPSEC-8636](https://datadoghq.atlassian.net/browse/APPSEC-8636)
* Follow up to https://github.com/DataDog/dd-trace-java/pull/5814


[APPSEC-8636]: https://datadoghq.atlassian.net/browse/APPSEC-8636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ