### PR TITLE
Improve IAST coverage by not relying on an active context for tainting purposes

### DIFF
--- a/benchmark/load/insecure-bank/benchmark.json
+++ b/benchmark/load/insecure-bank/benchmark.json
@@ -24,6 +24,12 @@
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.iast.enabled=true"
       }
     },
+    "iast_GLOBAL": {
+      "env": {
+        "VARIANT": "iast_GLOBAL",
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.iast.enabled=true -Ddd.iast.context.mode=GLOBAL"
+      }
+    },
     "iast_FULL": {
       "env": {
         "VARIANT": "iast_FULL",

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Dependencies.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Dependencies.java
@@ -2,6 +2,7 @@ package com.datadog.iast;
 
 import com.datadog.iast.overhead.OverheadController;
 import datadog.trace.api.Config;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.util.stacktrace.StackWalker;
 import javax.annotation.Nonnull;
 
@@ -12,15 +13,19 @@ public class Dependencies {
   private final OverheadController overheadController;
   private final StackWalker stackWalker;
 
+  final IastContext.Provider contextProvider;
+
   public Dependencies(
       @Nonnull final Config config,
       @Nonnull final Reporter reporter,
       @Nonnull final OverheadController overheadController,
-      @Nonnull final StackWalker stackWalker) {
+      @Nonnull final StackWalker stackWalker,
+      @Nonnull final IastContext.Provider contextProvider) {
     this.config = config;
     this.reporter = reporter;
     this.overheadController = overheadController;
     this.stackWalker = stackWalker;
+    this.contextProvider = contextProvider;
   }
 
   public Config getConfig() {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastGlobalContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastGlobalContext.java
@@ -1,0 +1,53 @@
+package com.datadog.iast;
+
+import com.datadog.iast.taint.TaintedMap;
+import com.datadog.iast.taint.TaintedObjects;
+import datadog.trace.api.iast.IastContext;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class IastGlobalContext implements IastContext {
+
+  private final TaintedObjects taintedObjects;
+
+  public IastGlobalContext(final TaintedObjects taintedObjects) {
+    this.taintedObjects = taintedObjects;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  @Override
+  public TaintedObjects getTaintedObjects() {
+    return taintedObjects;
+  }
+
+  public static class Provider extends IastContext.Provider {
+
+    // (16384 * 4) buckets: approx 256K
+    static final int MAP_SIZE = TaintedMap.DEFAULT_CAPACITY * (1 << 2);
+    static final int MAX_AGE = TaintedMap.DEFAULT_MAX_AGE;
+    static final TimeUnit MAX_AGE_UNIT = TaintedMap.DEFAULT_MAX_AGE_UNIT;
+
+    // Map that with purge option
+    final IastContext globalContext =
+        new IastGlobalContext(
+            TaintedObjects.build(TaintedMap.buildWithPurge(MAP_SIZE, MAX_AGE, MAX_AGE_UNIT)));
+
+    @Nullable
+    @Override
+    public IastContext resolve() {
+      return globalContext;
+    }
+
+    @Override
+    public IastContext buildRequestContext() {
+      return new IastRequestContext(globalContext.getTaintedObjects());
+    }
+
+    @Override
+    public void releaseRequestContext(@Nonnull final IastContext context) {
+      // nothing to release in global mode
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastRequestContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastRequestContext.java
@@ -1,42 +1,55 @@
 package com.datadog.iast;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
+
 import com.datadog.iast.model.VulnerabilityBatch;
 import com.datadog.iast.overhead.OverheadContext;
+import com.datadog.iast.taint.TaintedMap;
 import com.datadog.iast.taint.TaintedObjects;
+import com.datadog.iast.util.Wrapper;
+import datadog.trace.api.Config;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.telemetry.IastMetricCollector;
 import datadog.trace.api.iast.telemetry.IastMetricCollector.HasMetricCollector;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class IastRequestContext implements IastContext, HasMetricCollector {
 
+  static final int MAP_SIZE = TaintedMap.DEFAULT_CAPACITY;
+
   private final VulnerabilityBatch vulnerabilityBatch;
   private final AtomicBoolean spanDataIsSet;
-  private final TaintedObjects taintedObjects;
   private final OverheadContext overheadContext;
-  @Nullable private final IastMetricCollector collector;
+  private TaintedObjects taintedObjects;
+  @Nullable private IastMetricCollector collector;
   @Nullable private volatile String strictTransportSecurity;
   @Nullable private volatile String xContentTypeOptions;
   @Nullable private volatile String xForwardedProto;
   @Nullable private volatile String contentType;
 
+  /**
+   * Use {@link IastRequestContext#IastRequestContext(TaintedObjects)} instead as we require more
+   * control over the tainted objects dictionaries
+   */
+  @Deprecated
   public IastRequestContext() {
-    this(TaintedObjects.acquire(), null);
+    // map without purge (it will be cleared on request end)
+    this(TaintedObjects.build(TaintedMap.build(MAP_SIZE)));
   }
 
   public IastRequestContext(final TaintedObjects taintedObjects) {
-    this(taintedObjects, null);
-  }
-
-  public IastRequestContext(
-      final TaintedObjects taintedObjects, @Nullable final IastMetricCollector collector) {
     this.vulnerabilityBatch = new VulnerabilityBatch();
     this.spanDataIsSet = new AtomicBoolean(false);
-    this.overheadContext = new OverheadContext();
+    this.overheadContext = new OverheadContext(Config.get().getIastVulnerabilitiesPerRequest());
     this.taintedObjects = taintedObjects;
-    this.collector = collector;
   }
 
   public VulnerabilityBatch getVulnerabilityBatch() {
@@ -98,5 +111,60 @@ public class IastRequestContext implements IastContext, HasMetricCollector {
   @Nullable
   public IastMetricCollector getMetricCollector() {
     return collector;
+  }
+
+  public void setCollector(@Nonnull final IastMetricCollector collector) {
+    this.collector = collector;
+  }
+
+  public void setTaintedObjects(@Nonnull final TaintedObjects taintedObjects) {
+    this.taintedObjects = taintedObjects;
+  }
+
+  public static class Provider extends IastContext.Provider {
+
+    // 16384 buckets: approx 64K
+    static final int MAP_SIZE = TaintedMap.DEFAULT_CAPACITY;
+
+    final Queue<TaintedObjects> pool =
+        new ArrayBlockingQueue<>(
+            Math.max(
+                Config.get().getIastMaxConcurrentRequests(), DEFAULT_IAST_MAX_CONCURRENT_REQUESTS));
+
+    @Nullable
+    @Override
+    public IastContext resolve() {
+      final AgentSpan span = AgentTracer.activeSpan();
+      if (span == null) {
+        return null;
+      }
+      final RequestContext ctx = span.getRequestContext();
+      if (ctx == null) {
+        return null;
+      }
+      return ctx.getData(RequestContextSlot.IAST);
+    }
+
+    @Override
+    public IastContext buildRequestContext() {
+      TaintedObjects taintedObjects = pool.poll();
+      if (taintedObjects == null) {
+        taintedObjects = TaintedObjects.build(TaintedMap.build(MAP_SIZE));
+      }
+      return new IastRequestContext(taintedObjects);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void releaseRequestContext(@Nonnull final IastContext context) {
+      final TaintedObjects taintedObjects = context.getTaintedObjects();
+      taintedObjects.clear();
+      // add the root instance to the pool
+      if (taintedObjects instanceof Wrapper) {
+        pool.offer(((Wrapper<TaintedObjects>) taintedObjects).unwrap());
+      } else {
+        pool.offer(taintedObjects);
+      }
+    }
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestStartedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestStartedHandler.java
@@ -2,15 +2,18 @@ package com.datadog.iast;
 
 import com.datadog.iast.overhead.OverheadController;
 import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.iast.IastContext;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
 public class RequestStartedHandler implements Supplier<Flow<Object>> {
 
   private final OverheadController overheadController;
+  private final IastContext.Provider contextProvider;
 
   public RequestStartedHandler(@Nonnull final Dependencies dependencies) {
     this.overheadController = dependencies.getOverheadController();
+    this.contextProvider = dependencies.contextProvider;
   }
 
   @Override
@@ -22,6 +25,6 @@ public class RequestStartedHandler implements Supplier<Flow<Object>> {
   }
 
   protected IastRequestContext newContext() {
-    return new IastRequestContext();
+    return (IastRequestContext) contextProvider.buildRequestContext();
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/overhead/OverheadContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/overhead/OverheadContext.java
@@ -3,17 +3,12 @@ package com.datadog.iast.overhead;
 import static datadog.trace.api.iast.IastDetectionMode.UNLIMITED;
 
 import com.datadog.iast.util.NonBlockingSemaphore;
-import datadog.trace.api.Config;
 
 public class OverheadContext {
 
   private final NonBlockingSemaphore availableVulnerabilities;
 
-  public OverheadContext() {
-    this(Config.get().getIastVulnerabilitiesPerRequest());
-  }
-
-  OverheadContext(final int vulnerabilitiesPerRequest) {
+  public OverheadContext(final int vulnerabilitiesPerRequest) {
     availableVulnerabilities =
         vulnerabilitiesPerRequest == UNLIMITED
             ? NonBlockingSemaphore.unlimited()

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
@@ -1,17 +1,15 @@
 package com.datadog.iast.taint;
 
-import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_MAX_CONCURRENT_REQUESTS;
 import static java.util.Collections.emptyIterator;
 
 import com.datadog.iast.IastSystem;
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.json.TaintedObjectEncoding;
-import datadog.trace.api.Config;
+import com.datadog.iast.util.Wrapper;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ArrayBlockingQueue;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -20,36 +18,24 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("UnusedReturnValue")
 public interface TaintedObjects extends Iterable<TaintedObject> {
 
+  static TaintedObjects build(@Nonnull final TaintedMap map) {
+    final TaintedObjectsImpl taintedObjects = new TaintedObjectsImpl(map);
+    return IastSystem.DEBUG ? new TaintedObjectsDebugAdapter(taintedObjects) : taintedObjects;
+  }
+
   @Nullable
   TaintedObject taint(@Nonnull Object obj, @Nonnull Range[] ranges);
 
   @Nullable
   TaintedObject get(@Nonnull Object obj);
 
-  void release();
+  void clear();
 
   int count();
 
-  static TaintedObjects acquire() {
-    TaintedObjectsImpl taintedObjects = TaintedObjectsImpl.pool.poll();
-    if (taintedObjects == null) {
-      taintedObjects = new TaintedObjectsImpl();
-    }
-    return IastSystem.DEBUG ? new TaintedObjectsDebugAdapter(taintedObjects) : taintedObjects;
-  }
-
   class TaintedObjectsImpl implements TaintedObjects {
 
-    private static final ArrayBlockingQueue<TaintedObjectsImpl> pool =
-        new ArrayBlockingQueue<>(
-            Math.max(
-                Config.get().getIastMaxConcurrentRequests(), DEFAULT_IAST_MAX_CONCURRENT_REQUESTS));
-
     private final TaintedMap map;
-
-    public TaintedObjectsImpl() {
-      this(TaintedMap.build());
-    }
 
     private TaintedObjectsImpl(final @Nonnull TaintedMap map) {
       this.map = map;
@@ -70,9 +56,8 @@ public interface TaintedObjects extends Iterable<TaintedObject> {
     }
 
     @Override
-    public void release() {
+    public void clear() {
       map.clear();
-      pool.offer(this);
     }
 
     @Override
@@ -87,7 +72,7 @@ public interface TaintedObjects extends Iterable<TaintedObject> {
     }
   }
 
-  final class TaintedObjectsDebugAdapter implements TaintedObjects {
+  final class TaintedObjectsDebugAdapter implements TaintedObjects, Wrapper<TaintedObjectsImpl> {
     static final Logger LOGGER = LoggerFactory.getLogger(TaintedObjects.class);
 
     private final TaintedObjectsImpl delegated;
@@ -114,19 +99,19 @@ public interface TaintedObjects extends Iterable<TaintedObject> {
     }
 
     @Override
-    public void release() {
+    public void clear() {
       if (IastSystem.DEBUG && LOGGER.isDebugEnabled()) {
         try {
           final List<TaintedObject> entries = new ArrayList<>();
           for (final TaintedObject to : delegated.map) {
             entries.add(to);
           }
-          LOGGER.debug("release {}: map={}", id, TaintedObjectEncoding.toJson(entries));
+          LOGGER.debug("clear {}: map={}", id, TaintedObjectEncoding.toJson(entries));
         } catch (final Throwable e) {
           LOGGER.error("Failed to debug tainted objects release", e);
         }
       }
-      delegated.release();
+      delegated.clear();
     }
 
     @Override
@@ -149,6 +134,11 @@ public interface TaintedObjects extends Iterable<TaintedObject> {
         }
       }
     }
+
+    @Override
+    public TaintedObjectsImpl unwrap() {
+      return delegated;
+    }
   }
 
   final class NoOp implements TaintedObjects {
@@ -168,7 +158,7 @@ public interface TaintedObjects extends Iterable<TaintedObject> {
     }
 
     @Override
-    public void release() {}
+    public void clear() {}
 
     @Override
     public int count() {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestStartedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestStartedHandler.java
@@ -18,15 +18,12 @@ public class TelemetryRequestStartedHandler extends RequestStartedHandler {
 
   @Override
   protected IastRequestContext newContext() {
+    final IastRequestContext ctx = super.newContext();
     final Config config = Config.get();
     final Verbosity verbosity = config.getIastTelemetryVerbosity();
-    final TaintedObjects taintedObjects =
-        TaintedObjectsWithTelemetry.build(verbosity, TaintedObjects.acquire());
-    final IastMetricCollector collector = new IastMetricCollector();
-    final IastRequestContext ctx = new IastRequestContext(taintedObjects, collector);
-    if (taintedObjects instanceof TaintedObjectsWithTelemetry) {
-      ((TaintedObjectsWithTelemetry) taintedObjects).initContext(ctx);
-    }
+    final TaintedObjects withTelemetry = TaintedObjectsWithTelemetry.build(verbosity, ctx);
+    ctx.setTaintedObjects(withTelemetry);
+    ctx.setCollector(new IastMetricCollector());
     return ctx;
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/Wrapper.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/Wrapper.java
@@ -1,0 +1,6 @@
+package com.datadog.iast.util;
+
+public interface Wrapper<E> {
+
+  E unwrap();
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/GrpcRequestMessageHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/GrpcRequestMessageHandlerTest.groovy
@@ -27,12 +27,8 @@ class GrpcRequestMessageHandlerTest extends IastModuleImplTestBase {
   void setup() {
     propagation = Spy(new PropagationModuleImpl())
     InstrumentationBridge.registerIastModule(propagation)
-  }
-
-  @Override
-  protected IastRequestContext buildIastRequestContext() {
     collector = Spy(new IastMetricCollector())
-    return new IastRequestContext(TaintedObjects.NoOp.INSTANCE, collector)
+    ctx.collector = collector
   }
 
   void 'the handler does nothing without propagation'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastGlobalContextTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastGlobalContextTest.groovy
@@ -1,0 +1,68 @@
+package com.datadog.iast
+
+import com.datadog.iast.model.Range
+import com.datadog.iast.taint.TaintedObjects
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Shared
+
+class IastGlobalContextTest extends DDSpecification {
+
+  @Shared
+  protected static final AgentTracer.TracerAPI ORIGINAL_TRACER = AgentTracer.get()
+
+  private RequestContext reqCtx = Stub(RequestContext)
+
+  private AgentSpan span = Stub(AgentSpan) {
+    getSpanId() >> 123456
+    getRequestContext() >> reqCtx
+  }
+
+  protected AgentTracer.TracerAPI tracer = Stub(AgentTracer.TracerAPI) {
+    activeSpan() >> span
+  }
+
+  private IastGlobalContext.Provider provider
+
+  void setup() {
+    AgentTracer.forceRegister(tracer)
+    provider = new IastGlobalContext.Provider()
+  }
+
+  void cleanup() {
+    AgentTracer.forceRegister(ORIGINAL_TRACER)
+  }
+
+  void 'provider scopes the context to a request using the global tainted map'() {
+    given:
+    final iastReqCtx = provider.buildRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> iastReqCtx
+
+    when:
+    def resolvedCtx = provider.resolve()
+
+    then:
+    resolvedCtx !== iastReqCtx
+    resolvedCtx === provider.globalContext
+    iastReqCtx.taintedObjects === resolvedCtx.taintedObjects
+  }
+
+  void 'release does nothing to the tainted objects'() {
+    when:
+    final ctx = provider.buildRequestContext()
+    final TaintedObjects to = ctx.taintedObjects
+    to.taint(UUID.randomUUID(), [] as Range[])
+
+    then:
+    to.count() == 1
+
+    when:
+    provider.releaseRequestContext(ctx)
+
+    then:
+    to.count() == 1
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplTestBase.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastModuleImplTestBase.groovy
@@ -5,6 +5,7 @@ import com.datadog.iast.overhead.OverheadController
 import datadog.trace.api.Config
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.internal.TraceSegment
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
@@ -13,10 +14,17 @@ import datadog.trace.util.stacktrace.StackWalker
 import datadog.trace.util.stacktrace.StackWalkerFactory
 import spock.lang.Shared
 
+import static datadog.trace.api.iast.IastContext.Mode.GLOBAL
+
 class IastModuleImplTestBase extends DDSpecification {
 
   @Shared
   protected static final AgentTracer.TracerAPI ORIGINAL_TRACER = AgentTracer.get()
+
+  @Shared
+  protected static final IastContext.Provider ORIGINAL_CONTEXT_PROVIDER = IastContext.Provider.INSTANCE
+
+  protected IastContext.Provider contextProvider
 
   protected IastRequestContext ctx
 
@@ -39,6 +47,7 @@ class IastModuleImplTestBase extends DDSpecification {
   protected List<Object> objectHolder
 
   void setup() {
+    contextProvider = buildIastContextProvider()
     ctx = buildIastRequestContext()
     traceSegment = buildTraceSegment()
     reqCtx = buildRequestContext()
@@ -48,18 +57,28 @@ class IastModuleImplTestBase extends DDSpecification {
     overheadController = buildOverheadController()
     stackWalker = StackWalkerFactory.INSTANCE
 
-    dependencies = new Dependencies(Config.get(), reporter, overheadController, stackWalker)
+    dependencies = new Dependencies(Config.get(), reporter, overheadController, stackWalker, contextProvider)
     objectHolder = []
 
     AgentTracer.forceRegister(tracer)
+    IastContext.Provider.register(contextProvider)
   }
 
   void cleanup() {
+    contextProvider.releaseRequestContext(ctx)
+
     AgentTracer.forceRegister(ORIGINAL_TRACER)
+    IastContext.Provider.register(ORIGINAL_CONTEXT_PROVIDER)
+  }
+
+  protected IastContext.Provider buildIastContextProvider() {
+    return Config.get().getIastContextMode() == GLOBAL
+      ? new IastGlobalContext.Provider()
+      : new IastRequestContext.Provider()
   }
 
   protected IastRequestContext buildIastRequestContext() {
-    return new IastRequestContext()
+    return contextProvider.buildRequestContext() as IastRequestContext
   }
 
   protected TraceSegment buildTraceSegment() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastRequestContextTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastRequestContextTest.groovy
@@ -1,0 +1,76 @@
+package com.datadog.iast
+
+import com.datadog.iast.model.Range
+import com.datadog.iast.taint.TaintedObjects
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Shared
+
+class IastRequestContextTest extends DDSpecification {
+
+  @Shared
+  protected static final AgentTracer.TracerAPI ORIGINAL_TRACER = AgentTracer.get()
+
+  private RequestContext reqCtx = Mock(RequestContext)
+
+  private AgentSpan span = Mock(AgentSpan) {
+    getSpanId() >> 123456
+    getRequestContext() >> reqCtx
+  }
+
+  protected AgentTracer.TracerAPI tracer = Mock(AgentTracer.TracerAPI) {
+    activeSpan() >> span
+  }
+
+  private IastRequestContext.Provider provider
+
+  void setup() {
+    AgentTracer.forceRegister(tracer)
+    provider = new IastRequestContext.Provider()
+  }
+
+  void cleanup() {
+    AgentTracer.forceRegister(ORIGINAL_TRACER)
+  }
+
+  void 'provider scopes the context to a request'() {
+    given:
+    final initialCtx = provider.buildRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> initialCtx
+
+    when:
+    def resolved = provider.resolve()
+
+    then:
+    1 * tracer.activeSpan() >> null
+    resolved == null
+
+    when:
+    resolved = provider.resolve()
+
+    then:
+    1 * tracer.activeSpan() >> span
+    resolved === initialCtx
+  }
+
+  void 'provider uses a pool of tainted objects'() {
+    when:
+    final ctx = provider.buildRequestContext()
+    final TaintedObjects to = ctx.taintedObjects
+    to.taint(UUID.randomUUID(), [] as Range[])
+
+    then:
+    to.count() == 1
+    provider.pool.size() == 0
+
+    when:
+    provider.releaseRequestContext(ctx)
+
+    then:
+    to.count() == 0
+    provider.pool.size() == 1
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 import static com.datadog.iast.IastTag.ANALYZED
+import static com.datadog.iast.test.TaintedObjectsUtils.noOpTaintedObjects
 import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED
 
 class ReporterTest extends DDSpecification {
@@ -40,7 +41,7 @@ class ReporterTest extends DDSpecification {
     given:
     final Reporter reporter = new Reporter()
     final traceSegment = Mock(TraceSegment)
-    final ctx = new IastRequestContext()
+    final ctx = new IastRequestContext(noOpTaintedObjects())
     final reqCtx = Stub(RequestContext)
     final spanId = 123456
     reqCtx.getData(RequestContextSlot.IAST) >> ctx
@@ -85,7 +86,7 @@ class ReporterTest extends DDSpecification {
     given:
     final Reporter reporter = new Reporter()
     final traceSegment = Mock(TraceSegment)
-    final ctx = new IastRequestContext()
+    final ctx = new IastRequestContext(noOpTaintedObjects())
     final reqCtx = Stub(RequestContext)
     final spanId = 123456
     reqCtx.getData(RequestContextSlot.IAST) >> ctx
@@ -151,7 +152,7 @@ class ReporterTest extends DDSpecification {
     final serviceName = 'service-name'
     final span = Mock(AgentSpan)
     final scope = Mock(AgentScope)
-    final ctx = new IastRequestContext()
+    final ctx = new IastRequestContext(noOpTaintedObjects())
     final reqCtx = Stub(RequestContext)
     reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final reporter = new Reporter()
@@ -203,7 +204,7 @@ class ReporterTest extends DDSpecification {
     given:
     final tracerAPI = Mock(TracerAPI)
     AgentTracer.forceRegister(tracerAPI)
-    final ctx = new IastRequestContext()
+    final ctx = new IastRequestContext(noOpTaintedObjects())
     final reqCtx = Stub(RequestContext)
     reqCtx.getData(RequestContextSlot.IAST) >> ctx
     final reporter = new Reporter((vul) -> true)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/RequestStartedHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/RequestStartedHandlerTest.groovy
@@ -3,6 +3,7 @@ package com.datadog.iast
 import com.datadog.iast.overhead.OverheadController
 import datadog.trace.api.Config
 import datadog.trace.api.gateway.Flow
+import datadog.trace.api.iast.IastContext
 import datadog.trace.test.util.DDSpecification
 import datadog.trace.util.stacktrace.StackWalker
 import groovy.transform.CompileDynamic
@@ -14,8 +15,9 @@ class RequestStartedHandlerTest extends DDSpecification {
     given:
     final OverheadController overheadController = Mock(OverheadController)
     final StackWalker stackWalker = Mock(StackWalker)
+    final IastContext.Provider provider = Mock(IastContext.Provider)
     final dependencies = new Dependencies(
-      Config.get(), new Reporter(), overheadController, stackWalker
+      Config.get(), new Reporter(), overheadController, stackWalker, provider
       )
     def handler = new RequestStartedHandler(dependencies)
 
@@ -26,6 +28,7 @@ class RequestStartedHandlerTest extends DDSpecification {
     flow.getAction() == Flow.Action.Noop.INSTANCE
     flow.getResult() instanceof IastRequestContext
     1 * overheadController.acquireRequest() >> true
+    1 * provider.buildRequestContext() >> Mock(IastRequestContext)
     0 * _
   }
 
@@ -33,8 +36,9 @@ class RequestStartedHandlerTest extends DDSpecification {
     given:
     final OverheadController overheadController = Mock(OverheadController)
     final StackWalker stackWalker = Mock(StackWalker)
+    final IastContext.Provider provider = Mock(IastContext.Provider)
     final dependencies = new Dependencies(
-      Config.get(), new Reporter(), overheadController, stackWalker
+      Config.get(), new Reporter(), overheadController, stackWalker, provider
       )
     def handler = new RequestStartedHandler(dependencies)
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
@@ -67,7 +67,7 @@ class OverheadControllerTest extends DDSpecification {
     config.getIastRequestSampling() >> 100
     def maxRequests = config.iastMaxConcurrentRequests
     def taskSchedler = Stub(AgentTaskScheduler)
-    def overheadController = new OverheadControllerImpl(config, taskSchedler)
+    def overheadController = OverheadController.build(config, taskSchedler)
 
     when: 'Acquire max concurrent requests'
     assert maxRequests > 0
@@ -89,7 +89,7 @@ class OverheadControllerTest extends DDSpecification {
     config.getIastRequestSampling() >> 100
     config.getIastMaxConcurrentRequests() >> UNLIMITED
     def taskScheduler = Stub(AgentTaskScheduler)
-    def overheadController = new OverheadControllerImpl(config, taskScheduler)
+    def overheadController = OverheadController.build(config, taskScheduler)
 
     when: 'Acquire max concurrent requests'
     def acquired = (1..1_000_000).collect({ overheadController.acquireRequest() })
@@ -101,7 +101,7 @@ class OverheadControllerTest extends DDSpecification {
   void 'getContext defaults to global context if span is null'() {
     given:
     def taskSchedler = Stub(AgentTaskScheduler)
-    def overheadController = OverheadController.build(Config.get(), taskSchedler)
+    def overheadController = OverheadController.build(Config.get(), taskSchedler) as OverheadControllerImpl
 
     when:
     def context = overheadController.getContext(null)
@@ -113,7 +113,7 @@ class OverheadControllerTest extends DDSpecification {
   void 'getContext defaults to request context if span is null'() {
     given:
     def taskSchedler = Stub(AgentTaskScheduler)
-    def overheadController = OverheadController.build(Config.get(), taskSchedler)
+    def overheadController = OverheadController.build(Config.get(), taskSchedler) as OverheadControllerImpl
     def span = Stub(AgentSpan)
     span.getRequestContext() >> null
 
@@ -127,7 +127,7 @@ class OverheadControllerTest extends DDSpecification {
   void 'getContext returns null if there is no IAST request context'() {
     given:
     def taskSchedler = Stub(AgentTaskScheduler)
-    def overheadController = OverheadController.build(Config.get(), taskSchedler)
+    def overheadController = OverheadController.build(Config.get(), taskSchedler) as OverheadControllerImpl
     def span = getAgentSpanWithNoIASTRequest()
 
     when:
@@ -201,7 +201,7 @@ class OverheadControllerTest extends DDSpecification {
   def 'Available requests always ends up at max'() {
     setup:
     def taskSchedler = Stub(AgentTaskScheduler)
-    def overheadController = OverheadController.build(Config.get(), taskSchedler)
+    def overheadController = OverheadController.build(Config.get(), taskSchedler) as OverheadControllerImpl
 
     def nThreads = 32
     def nIters = 50000
@@ -285,7 +285,7 @@ class OverheadControllerTest extends DDSpecification {
 
   private AgentSpan getAgentSpanWithOverheadContext() {
     def iastRequestContext = Stub(IastRequestContext)
-    iastRequestContext.getOverheadContext() >> new OverheadContext()
+    iastRequestContext.getOverheadContext() >> new OverheadContext(Config.get().getIastVulnerabilitiesPerRequest())
     def requestContext = Stub(RequestContext)
     requestContext.getData(RequestContextSlot.IAST) >> iastRequestContext
     def span = Stub(AgentSpan)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsLogTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsLogTest.groovy
@@ -8,6 +8,8 @@ import datadog.trace.api.iast.SourceTypes
 import datadog.trace.test.util.DDSpecification
 import groovy.transform.CompileDynamic
 
+import static com.datadog.iast.test.TaintedObjectsUtils.taintedObjects
+
 @CompileDynamic
 class TaintedObjectsLogTest extends DDSpecification {
 
@@ -30,7 +32,7 @@ class TaintedObjectsLogTest extends DDSpecification {
     given:
     IastSystem.DEBUG = true
     logger.setLevel(Level.ALL)
-    TaintedObjects taintedObjects = TaintedObjects.acquire()
+    TaintedObjects taintedObjects = taintedObjects()
     final value = "A"
 
     when:
@@ -52,12 +54,12 @@ class TaintedObjectsLogTest extends DDSpecification {
     given:
     IastSystem.DEBUG = true
     logger.level = Level.ALL
-    TaintedObjects taintedObjects = TaintedObjects.acquire()
+    TaintedObjects taintedObjects = taintedObjects()
     final obj = 'A'
     taintedObjects.taint(obj, Ranges.forCharSequence(obj, new Source(SourceTypes.NONE, null, null)))
 
     when:
-    taintedObjects.release()
+    taintedObjects.clear()
 
     then:
     noExceptionThrown()
@@ -67,7 +69,7 @@ class TaintedObjectsLogTest extends DDSpecification {
     given:
     IastSystem.DEBUG = true
     logger.level = Level.ALL
-    TaintedObjects taintedObjects = TaintedObjects.acquire()
+    TaintedObjects taintedObjects = taintedObjects()
     final obj = 'A'
 
     when:

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsNoOpTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsNoOpTest.groovy
@@ -22,7 +22,7 @@ class TaintedObjectsNoOpTest extends Specification {
     !instance.iterator().hasNext()
 
     when:
-    instance.release()
+    instance.clear()
 
     then:
     noExceptionThrown()

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/TelemetryRequestEndedHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/TelemetryRequestEndedHandlerTest.groovy
@@ -1,11 +1,9 @@
 package com.datadog.iast.telemetry
 
 import com.datadog.iast.IastModuleImplTestBase
-import com.datadog.iast.IastRequestContext
 import com.datadog.iast.RequestEndedHandler
 import com.datadog.iast.model.Source
 import com.datadog.iast.taint.Ranges
-import com.datadog.iast.taint.TaintedObjects
 import com.datadog.iast.telemetry.taint.TaintedObjectsWithTelemetry
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
@@ -18,7 +16,12 @@ import groovy.transform.CompileDynamic
 import groovy.transform.ToString
 
 import static com.datadog.iast.telemetry.TelemetryRequestEndedHandler.TRACE_METRIC_PREFIX
-import static datadog.trace.api.iast.telemetry.IastMetric.*
+import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_SINK
+import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_SOURCE
+import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_TAINTED
+import static datadog.trace.api.iast.telemetry.IastMetric.INSTRUMENTED_SOURCE
+import static datadog.trace.api.iast.telemetry.IastMetric.REQUEST_TAINTED
+import static datadog.trace.api.iast.telemetry.IastMetric.Scope
 
 @CompileDynamic
 class TelemetryRequestEndedHandlerTest extends IastModuleImplTestBase {
@@ -32,12 +35,8 @@ class TelemetryRequestEndedHandlerTest extends IastModuleImplTestBase {
     globalCollector = IastMetricCollector.get()
     globalCollector.prepareMetrics()
     globalCollector.drain()
-  }
-
-  @Override
-  protected IastRequestContext buildIastRequestContext() {
-    final TaintedObjects to = TaintedObjectsWithTelemetry.build(Verbosity.DEBUG, TaintedObjects.acquire())
-    return new IastRequestContext(to, new IastMetricCollector())
+    ctx.taintedObjects = TaintedObjectsWithTelemetry.build(Verbosity.DEBUG, ctx)
+    ctx.collector = new IastMetricCollector()
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/taint/TaintedObjectsWithTelemetryTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/taint/TaintedObjectsWithTelemetryTest.groovy
@@ -1,60 +1,28 @@
 package com.datadog.iast.telemetry.taint
 
-import com.datadog.iast.IastRequestContext
+import com.datadog.iast.IastModuleImplTestBase
 import com.datadog.iast.model.Range
-import com.datadog.iast.taint.Ranges
-import com.datadog.iast.taint.TaintedObject
-import com.datadog.iast.taint.TaintedObjects
-import datadog.trace.api.gateway.RequestContext
-import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.iast.telemetry.IastMetric
 import datadog.trace.api.iast.telemetry.IastMetricCollector
 import datadog.trace.api.iast.telemetry.Verbosity
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer
-import datadog.trace.test.util.DDSpecification
-import groovy.transform.CompileDynamic
-import spock.lang.Shared
 
-@CompileDynamic
-class TaintedObjectsWithTelemetryTest extends DDSpecification {
-
-  @Shared
-  protected static final AgentTracer.TracerAPI ORIGINAL_TRACER = AgentTracer.get()
+class TaintedObjectsWithTelemetryTest extends IastModuleImplTestBase {
 
   private IastMetricCollector mockCollector
 
   void setup() {
     mockCollector = Mock(IastMetricCollector)
-    final iastCtx = Stub(IastRequestContext) {
-      getMetricCollector() >> mockCollector
-    }
-    final ctx = Stub(RequestContext) {
-      getData(RequestContextSlot.IAST) >> iastCtx
-    }
-    final span = Stub(AgentSpan) {
-      getRequestContext() >> ctx
-    }
-    final api = Stub(AgentTracer.TracerAPI) {
-      activeSpan() >> span
-    }
-    AgentTracer.forceRegister(api)
-  }
-
-  void cleanup() {
-    AgentTracer.forceRegister(ORIGINAL_TRACER)
+    ctx.collector = mockCollector
   }
 
   void 'test request.tainted with #verbosity'() {
     given:
-    final tainteds = [tainted(), tainted()]
-    final taintedObjects = TaintedObjectsWithTelemetry.build(verbosity, Mock(TaintedObjects) {
-      iterator() >> tainteds.iterator()
-      count() >> tainteds.size()
-    })
+    final tainteds = [UUID.randomUUID(), UUID.randomUUID()]
+    tainteds.each { ctx.taintedObjects.taint(it, [] as Range[])}
+    ctx.taintedObjects = TaintedObjectsWithTelemetry.build(verbosity, ctx)
 
     when:
-    taintedObjects.release()
+    ctx.taintedObjects.clear()
 
     then:
     if (IastMetric.REQUEST_TAINTED.isEnabled(verbosity)) {
@@ -69,10 +37,10 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
   void 'test executed.tainted with #verbosity'() {
     given:
-    final taintedObjects = TaintedObjectsWithTelemetry.build(verbosity, Mock(TaintedObjects))
+    ctx.taintedObjects = TaintedObjectsWithTelemetry.build(verbosity, ctx)
 
     when:
-    taintedObjects.taint('test', new Range[0])
+    ctx.taintedObjects.taint('test', new Range[0])
 
     then:
     if (IastMetric.EXECUTED_TAINTED.isEnabled(verbosity)) {
@@ -83,9 +51,5 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
     where:
     verbosity << Verbosity.values().toList()
-  }
-
-  private TaintedObject tainted() {
-    return new TaintedObject(UUID.randomUUID(), Ranges.EMPTY)
   }
 }

--- a/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/TaintedObjectsUtils.groovy
+++ b/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/TaintedObjectsUtils.groovy
@@ -1,0 +1,17 @@
+package com.datadog.iast.test
+
+import com.datadog.iast.taint.TaintedMap
+import com.datadog.iast.taint.TaintedObjects
+
+class TaintedObjectsUtils {
+
+  private static final int TEST_TAINTED_MAP_SIZE = 1 << 8
+
+  static TaintedObjects taintedObjects() {
+    return TaintedObjects.build(TaintedMap.build(TEST_TAINTED_MAP_SIZE))
+  }
+
+  static TaintedObjects noOpTaintedObjects() {
+    return TaintedObjects.build(TaintedMap.NoOp.INSTANCE)
+  }
+}

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -21,17 +21,21 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     List<String> command = []
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
-    command.addAll([
-      withSystemProperty(IAST_ENABLED, true),
-      withSystemProperty(IAST_DETECTION_MODE, 'FULL'),
-      withSystemProperty(IAST_DEBUG_ENABLED, true),
-    ])
+    command.addAll(iastJvmOpts())
     command.addAll((String[]) ['-jar', springBootShadowJar, "--server.port=${httpPort}"])
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))
     // Spring will print all environment variables to the log, which may pollute it and affect log assertions.
     processBuilder.environment().clear()
     return processBuilder
+  }
+
+  protected List<String> iastJvmOpts() {
+    return [
+      withSystemProperty(IAST_ENABLED, true),
+      withSystemProperty(IAST_DETECTION_MODE, 'FULL'),
+      withSystemProperty(IAST_DEBUG_ENABLED, true),
+    ]
   }
 
   void 'IAST subsystem starts'() {

--- a/dd-smoke-tests/jersey-2/src/test/groovy/datadog/smoketest/Jersey2SmokeTest.groovy
+++ b/dd-smoke-tests/jersey-2/src/test/groovy/datadog/smoketest/Jersey2SmokeTest.groovy
@@ -3,6 +3,8 @@ package datadog.smoketest
 import datadog.trace.api.Platform
 import datadog.trace.api.config.IastConfig
 
+import static datadog.trace.api.iast.IastContext.Mode.GLOBAL
+
 class Jersey2SmokeTest extends AbstractJerseySmokeTest {
 
   @Override
@@ -12,12 +14,8 @@ class Jersey2SmokeTest extends AbstractJerseySmokeTest {
     List<String> command = []
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
-    command.addAll([
-      withSystemProperty(IastConfig.IAST_ENABLED, true),
-      withSystemProperty(IastConfig.IAST_DETECTION_MODE, 'FULL'),
-      withSystemProperty(IastConfig.IAST_DEBUG_ENABLED, true),
-      withSystemProperty('integration.grizzly.enabled', true)
-    ])
+    command.addAll(iastJvmOpts())
+    command.add(withSystemProperty('integration.grizzly.enabled', true))
     if (Platform.isJavaVersionAtLeast(17)) {
       command.addAll((String[]) ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'])
     }
@@ -25,5 +23,22 @@ class Jersey2SmokeTest extends AbstractJerseySmokeTest {
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))
     return processBuilder
+  }
+
+  protected List<String> iastJvmOpts() {
+    return [
+      withSystemProperty(IastConfig.IAST_ENABLED, true),
+      withSystemProperty(IastConfig.IAST_DETECTION_MODE, 'FULL'),
+      withSystemProperty(IastConfig.IAST_DEBUG_ENABLED, true),
+    ]
+  }
+
+  static class WithGlobalContext extends Jersey2SmokeTest {
+    @Override
+    protected List<String> iastJvmOpts() {
+      final opts = super.iastJvmOpts()
+      opts.add(withSystemProperty(IastConfig.IAST_CONTEXT_MODE, GLOBAL.name()))
+      return opts
+    }
   }
 }

--- a/dd-smoke-tests/jersey-3/src/test/groovy/datadog/smoketest/Jersey3SmokeTest.groovy
+++ b/dd-smoke-tests/jersey-3/src/test/groovy/datadog/smoketest/Jersey3SmokeTest.groovy
@@ -1,6 +1,7 @@
 package datadog.smoketest
 
 import static datadog.trace.api.config.IastConfig.*
+import static datadog.trace.api.iast.IastContext.Mode.GLOBAL
 
 class Jersey3SmokeTest extends AbstractJerseySmokeTest {
 
@@ -11,17 +12,30 @@ class Jersey3SmokeTest extends AbstractJerseySmokeTest {
     List<String> command = []
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
-    command.addAll([
-      withSystemProperty(IAST_ENABLED, true),
-      withSystemProperty(IAST_DETECTION_MODE, 'FULL'),
-      withSystemProperty(IAST_DEBUG_ENABLED, true),
-      withSystemProperty('integration.grizzly.enabled', true)
-    ])
+    command.addAll(iastJvmOpts())
+    command.add(withSystemProperty('integration.grizzly.enabled', true))
     //command.add("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000")
     //command.add("-Xdebug")
     command.addAll((String[]) ['-jar', jarPath, httpPort])
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))
     return processBuilder
+  }
+
+  protected List<String> iastJvmOpts() {
+    return [
+      withSystemProperty(IAST_ENABLED, true),
+      withSystemProperty(IAST_DETECTION_MODE, 'FULL'),
+      withSystemProperty(IAST_DEBUG_ENABLED, true),
+    ]
+  }
+
+  static class WithGlobalContext extends Jersey3SmokeTest {
+    @Override
+    protected List<String> iastJvmOpts() {
+      final opts = super.iastJvmOpts()
+      opts.add(withSystemProperty(IAST_CONTEXT_MODE, GLOBAL.name()))
+      return opts
+    }
   }
 }

--- a/dd-smoke-tests/spring-boot-2.6-webmvc/src/test/groovy/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/spring-boot-2.6-webmvc/src/test/groovy/IastSpringBootSmokeTest.groovy
@@ -1,6 +1,16 @@
 import datadog.smoketest.AbstractIastSpringBootTest
-import groovy.transform.CompileDynamic
+import datadog.trace.api.config.IastConfig
 
-@CompileDynamic
+import static datadog.trace.api.iast.IastContext.Mode.GLOBAL
+
 class IastSpringBootSmokeTest extends AbstractIastSpringBootTest {
+
+  static class WithGlobalContext extends IastSpringBootSmokeTest {
+    @Override
+    protected List<String> iastJvmOpts() {
+      final opts = super.iastJvmOpts()
+      opts.add(withSystemProperty(IastConfig.IAST_CONTEXT_MODE, GLOBAL.name()))
+      return opts
+    }
+  }
 }

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -1,8 +1,11 @@
 package datadog.smoketest
 
+import datadog.trace.api.config.IastConfig
 import groovy.transform.CompileDynamic
 import okhttp3.Request
 import okhttp3.Response
+
+import static datadog.trace.api.iast.IastContext.Mode.GLOBAL
 
 @CompileDynamic
 class IastSpringBootSmokeTest extends AbstractIastSpringBootTest {
@@ -23,6 +26,15 @@ class IastSpringBootSmokeTest extends AbstractIastSpringBootTest {
     hasTainted {
       it.value == 'jackie' &&
         it.ranges[0].source.origin == 'http.request.header'
+    }
+  }
+
+  static class WithGlobalContext extends IastSpringBootSmokeTest {
+    @Override
+    protected List<String> iastJvmOpts() {
+      final opts = super.iastJvmOpts()
+      opts.add(withSystemProperty(IastConfig.IAST_CONTEXT_MODE, GLOBAL.name()))
+      return opts
     }
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/IastConfig.java
@@ -18,8 +18,8 @@ public final class IastConfig {
   public static final String IAST_REDACTION_VALUE_PATTERN = "iast.redaction.value.pattern";
   public static final String IAST_STACKTRACE_LEAK_SUPPRESS = "iast.stacktrace-leak.suppress";
   public static final String IAST_MAX_RANGE_COUNT = "iast.max-range-count";
-
   public static final String IAST_TRUNCATION_MAX_VALUE_LENGTH = "iast.truncation.max.value.length";
+  public static final String IAST_CONTEXT_MODE = "iast.context.mode";
 
   private IastConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -252,6 +252,7 @@ import static datadog.trace.api.config.GeneralConfig.TRACE_TRIAGE;
 import static datadog.trace.api.config.GeneralConfig.TRIAGE_REPORT_DIR;
 import static datadog.trace.api.config.GeneralConfig.TRIAGE_REPORT_TRIGGER;
 import static datadog.trace.api.config.GeneralConfig.VERSION;
+import static datadog.trace.api.config.IastConfig.IAST_CONTEXT_MODE;
 import static datadog.trace.api.config.IastConfig.IAST_DEBUG_ENABLED;
 import static datadog.trace.api.config.IastConfig.IAST_DETECTION_MODE;
 import static datadog.trace.api.config.IastConfig.IAST_REDACTION_ENABLED;
@@ -437,6 +438,7 @@ import static datadog.trace.util.Strings.propertyNameToEnvironmentVariableName;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.api.config.TracerConfig;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.IastDetectionMode;
 import datadog.trace.api.iast.telemetry.Verbosity;
 import datadog.trace.api.naming.SpanNaming;
@@ -707,6 +709,7 @@ public class Config {
   private final int iastMaxRangeCount;
   private final int iastTruncationMaxValueLength;
   private final boolean iastStacktraceLeakSuppress;
+  private final IastContext.Mode iastContextMode;
 
   private final boolean ciVisibilityTraceSanitationEnabled;
   private final boolean ciVisibilityAgentlessEnabled;
@@ -1563,6 +1566,8 @@ public class Config {
 
     iastDebugEnabled = configProvider.getBoolean(IAST_DEBUG_ENABLED, DEFAULT_IAST_DEBUG_ENABLED);
 
+    iastContextMode =
+        configProvider.getEnum(IAST_CONTEXT_MODE, IastContext.Mode.class, IastContext.Mode.REQUEST);
     iastDetectionMode =
         configProvider.getEnum(IAST_DETECTION_MODE, IastDetectionMode.class, DEFAULT);
     iastMaxConcurrentRequests = iastDetectionMode.getIastMaxConcurrentRequests(configProvider);
@@ -2708,6 +2713,10 @@ public class Config {
 
   public boolean isIastStacktraceLeakSuppress() {
     return iastStacktraceLeakSuppress;
+  }
+
+  public IastContext.Mode getIastContextMode() {
+    return iastContextMode;
   }
 
   public boolean isCiVisibilityEnabled() {

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/IastContextTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/IastContextTest.groovy
@@ -64,4 +64,16 @@ class IastContextTest extends DDSpecification {
     then:
     context == iastCtx
   }
+
+  void 'test get context with provider instance'() {
+    given:
+    final provider = Mock(IastContext.Provider)
+    IastContext.Provider.register(provider)
+
+    when:
+    IastContext.Provider.get()
+
+    then:
+    1 * provider.resolve() >> null
+  }
 }


### PR DESCRIPTION
# What Does This Do
Adds a new feature flag to IAST in order to scope the tainted map globally instead of a map per request. 

The main changes are:

- New feature flag `dd.iast.context.mode` with values `REQUEST` (by default) or `GLOBAL`
- When in GLOBAL mode, sampling of requests is automatically removed (concurrent requests stays the same)
- When in GLOBAL mode, there is no pool of tainted objects, only a singleton instance exists
- When in GLOBAL mode, the size of the tainted objects is calculated as `4 * default_size`
- When in GLOBAL mode, we lose the metric for the number of tainteds created in a request 

# Motivation
When the tainted map is scoped to a request, only taint operations with an active span are executed, which brings two problems:

- If there's is no active context we will lose the taint
- Accessing the thread local per taint operation can be slow in high propagation scenarios

A global instance will help solving both issues but it will introduce other constraints of its own, e.g. concurrency increases and the possibility of losing taints due to collisions in the map is way bigger.

# Additional Notes

Jira ticket: [APPSEC-11483]


[APPSEC-11483]: https://datadoghq.atlassian.net/browse/APPSEC-11483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ