### PR TITLE
Fix NPE in IAST evidence redaction

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/EvidenceAdapter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/EvidenceAdapter.java
@@ -443,7 +443,8 @@ public class EvidenceAdapter extends FormattingAdapter<Evidence> {
           valueParts.add(new TaintedValuePart(adapter, source, chunk, false));
         } else {
           final int length = chunk.length();
-          final int matching = source.getValue().indexOf(chunk);
+          final String sourceValue = source.getValue();
+          final int matching = (sourceValue == null) ? 0 : sourceValue.indexOf(chunk);
           final String pattern;
           if (matching >= 0) {
             // if matches append the matching part from the redacted value

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/EvidenceAdapter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/EvidenceAdapter.java
@@ -444,7 +444,7 @@ public class EvidenceAdapter extends FormattingAdapter<Evidence> {
         } else {
           final int length = chunk.length();
           final String sourceValue = source.getValue();
-          final int matching = (sourceValue == null) ? 0 : sourceValue.indexOf(chunk);
+          final int matching = (sourceValue == null) ? -1 : sourceValue.indexOf(chunk);
           final String pattern;
           if (matching >= 0) {
             // if matches append the matching part from the redacted value

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -248,6 +248,38 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
+    description: 'Query with single quoted string literal and null source'
+    input: >
+      [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'user'",
+            "ranges": [
+              { "start" : 38, "length" : 4, "source": { "origin": "http.request.body" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.body" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "select * from users where username = '" },
+                { "redacted": true, "source": 0, "pattern": "****" },
+                { "value": "'" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
     description: '$1 query with double quoted string literal $2'
     parameters:
       $1:

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -1753,6 +1753,40 @@ suite:
         ]
       } 
 
+
+  - type: 'VULNERABILITIES'
+    description: 'Tainted range based redaction - with null source '
+    input: >
+      [
+        {
+          "type": "XSS",
+          "evidence": {
+            "value": "this could be a super long text, so we need to reduce it before send it to the backend. This redaction strategy applies to XSS vulnerability but can be extended to future ones",
+            "ranges": [
+              { "start" : 123, "length" : 3, "source": { "origin": "http.request.body" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.body" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "XSS",
+            "evidence": {
+              "valueParts": [
+                { "redacted": true },
+                { "source": 0, "value": "XSS" },
+                { "redacted": true }
+              ]
+            }
+          }
+        ]
+      }
+
   - type: 'VULNERABILITIES'
     description: 'Tainted range based redaction - multiple ranges'
     input: >


### PR DESCRIPTION

# What Does This Do
When serializing vulnerability evidence, we could trigger an NPE when the data source has no value (e.g. this happens with request body as source). The end result is losing these vulnerabilities.

# Motivation

# Additional Notes

Jira ticket: [APPSEC-11847]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-11847]: https://datadoghq.atlassian.net/browse/APPSEC-11847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ