### PR TITLE
Akka: skip synthetic header Raw-Request-Uri

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerHeaders.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/AkkaHttpServerHeaders.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.akkahttp;
 
 import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.headers.RawRequestURI;
 import akka.http.javadsl.model.headers.RemoteAddress;
 import akka.http.javadsl.model.headers.TimeoutAccess;
 import akka.http.scaladsl.model.ContentType;
@@ -45,7 +46,9 @@ public class AkkaHttpServerHeaders {
 
     for (final HttpHeader header : carrier.getHeaders()) {
       // skip synthetic headers
-      if (header instanceof RemoteAddress || header instanceof TimeoutAccess) {
+      if (header instanceof RemoteAddress
+          || header instanceof TimeoutAccess
+          || header instanceof RawRequestURI) {
         continue;
       }
       if (!classifier.accept(header.lowercaseName(), header.value())) {

--- a/dd-java-agent/instrumentation/play-2.6/build.gradle
+++ b/dd-java-agent/instrumentation/play-2.6/build.gradle
@@ -13,6 +13,7 @@ muzzle {
     module = "play_$scalaVersion"
     versions = "[$playVersion,)"
     assertInverse = true
+    javaVersion = 11
   }
   pass {
     name = 'play26Plus'
@@ -20,6 +21,7 @@ muzzle {
     module = 'play_2.12'
     versions = "[$playVersion,)"
     assertInverse = true
+    javaVersion = 11
   }
   pass {
     name = 'play26Plus'
@@ -27,6 +29,7 @@ muzzle {
     module = 'play_2.13'
     versions = "[$playVersion,)"
     assertInverse = true
+    javaVersion = 11
   }
 
   pass {


### PR DESCRIPTION
Prevents the content of the request uri to be reported to the WAF as a header.
