### PR TITLE
Handle serialization exceptions in IAST

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
@@ -3,9 +3,12 @@ package com.datadog.iast.model.json;
 import com.datadog.iast.model.VulnerabilityBatch;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class VulnerabilityEncoding {
 
+  private static final Logger log = LoggerFactory.getLogger(VulnerabilityEncoding.class);
   private static final int MAX_SPAN_TAG_SIZE = 25000;
 
   static final Moshi MOSHI =
@@ -18,10 +21,15 @@ public class VulnerabilityEncoding {
       MOSHI.adapter(TruncatedVulnerabilities.class);
 
   public static String toJson(final VulnerabilityBatch value) {
-    String json = BATCH_ADAPTER.toJson(value);
-    return json.getBytes().length > MAX_SPAN_TAG_SIZE
-        ? getExceededTagSizeJson(new TruncatedVulnerabilities(value.getVulnerabilities()))
-        : json;
+    try {
+      String json = BATCH_ADAPTER.toJson(value);
+      return json.getBytes().length > MAX_SPAN_TAG_SIZE
+          ? getExceededTagSizeJson(new TruncatedVulnerabilities(value.getVulnerabilities()))
+          : json;
+    } catch (Exception ex) {
+      log.debug("Vulnerability serialization error", ex);
+      return "{\"vulnerabilities\":[]}";
+    }
   }
 
   static String getExceededTagSizeJson(final TruncatedVulnerabilities truncatedVulnerabilities) {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
@@ -539,6 +539,25 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   }
 
+  void 'exception during serialization is caught'() {
+    given:
+    final value = new VulnerabilityBatch()
+    final type = Mock(VulnerabilityType) {
+      name() >> { throw new RuntimeException("ERROR") }
+    }
+    final vuln = new Vulnerability(type, null, null)
+    value.add(vuln)
+
+    when:
+    final result = VulnerabilityEncoding.toJson(value)
+
+    then:
+    JSONAssert.assertEquals('''{
+      "vulnerabilities": [
+      ]
+    }''', result, true)
+  }
+
   private static String generateLargeString(){
     int targetSize = 25 * 1024
     StringBuilder sb = new StringBuilder()


### PR DESCRIPTION
# What Does This Do

# Motivation
Prevent serialization exceptions from breaking traces. See https://github.com/DataDog/dd-trace-java/pull/6099

# Additional Notes
