### PR TITLE
Change redacted values in snapshot & log templates

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 public class Redaction {
   // Need to be a unique instance (new String) for reference equality (==) and
   // avoid internalization (intern) by the JVM because it's a string constant
-  public static final String REDACTED_VALUE = new String("REDACTED".toCharArray());
+  public static final String REDACTED_VALUE = new String("redacted".toCharArray());
 
   private static final Pattern COMMA_PATTERN = Pattern.compile(",");
   private static final List<String> PREDEFINED_KEYWORDS =

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/RedactedException.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/RedactedException.java
@@ -1,0 +1,7 @@
+package com.datadog.debugger.el;
+
+public class RedactedException extends EvaluationException {
+  public RedactedException(String message, String expr) {
+    super(message, expr);
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ExpressionHelper.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ExpressionHelper.java
@@ -1,13 +1,13 @@
 package com.datadog.debugger.el.expressions;
 
-import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Expression;
 import com.datadog.debugger.el.PrettyPrintVisitor;
+import com.datadog.debugger.el.RedactedException;
 
 public class ExpressionHelper {
   public static void throwRedactedException(Expression<?> expr) {
     String strExpr = PrettyPrintVisitor.print(expr);
-    throw new EvaluationException(
+    throw new RedactedException(
         "Could not evaluate the expression because '" + strExpr + "' was redacted", strExpr);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/LogMessageTemplateBuilder.java
@@ -3,11 +3,13 @@ package com.datadog.debugger.agent;
 import static com.datadog.debugger.util.ValueScriptHelper.serializeValue;
 
 import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.RedactedException;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.probe.LogProbe;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.EvaluationError;
+import datadog.trace.bootstrap.debugger.util.Redaction;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +51,9 @@ public class LogMessageTemplateBuilder {
             LOGGER.debug("Evaluation error: ", ex);
             status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
             status.setLogTemplateErrors(true);
-            sb.append("{").append(ex.getMessage()).append("}");
+            String msg =
+                ex instanceof RedactedException ? Redaction.REDACTED_VALUE : ex.getMessage();
+            sb.append("{").append(msg).append("}");
           }
         }
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -44,7 +44,8 @@ public class MoshiSnapshotHelper {
   public static final String COLLECTION_SIZE_REASON = "collectionSize";
   public static final String TIMEOUT_REASON = "timeout";
   public static final String DEPTH_REASON = "depth";
-  public static final String REDACTED_REASON = "redacted";
+  public static final String REDACTED_IDENT_REASON = "redactedIdent";
+  public static final String REDACTED_TYPE_REASON = "redactedType";
   public static final String TYPE = "type";
   public static final String VALUE = "value";
   public static final String FIELDS = "fields";
@@ -462,10 +463,16 @@ public class MoshiSnapshotHelper {
               jsonWriter.value(TIMEOUT_REASON);
               break;
             }
-          case REDACTED:
+          case REDACTED_IDENT:
             {
               jsonWriter.name(NOT_CAPTURED_REASON);
-              jsonWriter.value(REDACTED_REASON);
+              jsonWriter.value(REDACTED_IDENT_REASON);
+              break;
+            }
+          case REDACTED_TYPE:
+            {
+              jsonWriter.name(NOT_CAPTURED_REASON);
+              jsonWriter.value(REDACTED_TYPE_REASON);
               break;
             }
           default:

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -50,7 +50,8 @@ public class SerializerWithLimits {
     MAX_DEPTH,
     FIELD_COUNT,
     TIMEOUT,
-    REDACTED
+    REDACTED_IDENT,
+    REDACTED_TYPE
   }
 
   public interface TokenWriter {
@@ -120,8 +121,14 @@ public class SerializerWithLimits {
       throw new IllegalArgumentException("Type is required for serialization");
     }
     tokenWriter.prologue(value, type);
-    if (value == REDACTED_VALUE || Redaction.isRedactedType(type)) {
-      tokenWriter.notCaptured(NotCapturedReason.REDACTED);
+    NotCapturedReason reason = null;
+    if (value == REDACTED_VALUE) {
+      reason = NotCapturedReason.REDACTED_IDENT;
+    } else if (Redaction.isRedactedType(type)) {
+      reason = NotCapturedReason.REDACTED_TYPE;
+    }
+    if (reason != null) {
+      tokenWriter.notCaptured(reason);
       tokenWriter.epilogue(value);
       return;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
@@ -1,5 +1,8 @@
 package com.datadog.debugger.util;
 
+import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_IDENT_REASON;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_TYPE_REASON;
+
 import com.datadog.debugger.el.Value;
 import datadog.trace.bootstrap.debugger.EvaluationError;
 import java.lang.reflect.Field;
@@ -155,8 +158,11 @@ public class StringTokenWriter implements SerializerWithLimits.TokenWriter {
       case FIELD_COUNT:
         sb.append(", ...");
         break;
-      case REDACTED:
-        sb.append("{redacted}");
+      case REDACTED_IDENT:
+        sb.append("{").append(REDACTED_IDENT_REASON).append("}");
+        break;
+      case REDACTED_TYPE:
+        sb.append("{").append(REDACTED_TYPE_REASON).append("}");
         break;
       default:
         throw new RuntimeException("Unsupported NotCapturedReason: " + reason);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -4,7 +4,10 @@ import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.DEPTH_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.FIELD_COUNT_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.NOT_CAPTURED_REASON;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_IDENT_REASON;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_TYPE_REASON;
 import static com.datadog.debugger.util.TestHelper.setFieldInConfig;
+import static datadog.trace.bootstrap.debugger.util.Redaction.REDACTED_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1627,17 +1630,23 @@ public class CapturedSnapshotTest {
     Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertEquals(
-        "arg=secret123 secret={Could not evaluate the expression because 'secret' was redacted} password={Could not evaluate the expression because 'this.password' was redacted} fromMap={Could not evaluate the expression because 'strMap[\"password\"]' was redacted}",
+        "arg=secret123 secret={"
+            + REDACTED_VALUE
+            + "} password={"
+            + REDACTED_VALUE
+            + "} fromMap={"
+            + REDACTED_VALUE
+            + "}",
         snapshot.getMessage());
     CapturedContext.CapturedValue secretLocalVar =
         snapshot.getCaptures().getReturn().getLocals().get("secret");
     CapturedContext.CapturedValue secretValued =
         VALUE_ADAPTER.fromJson(secretLocalVar.getStrValue());
-    assertEquals("redacted", secretValued.getNotCapturedReason());
+    assertEquals(REDACTED_IDENT_REASON, secretValued.getNotCapturedReason());
     Map<String, CapturedContext.CapturedValue> thisFields =
         getFields(snapshot.getCaptures().getReturn().getArguments().get("this"));
     CapturedContext.CapturedValue passwordField = thisFields.get("password");
-    assertEquals("redacted", passwordField.getNotCapturedReason());
+    assertEquals(REDACTED_IDENT_REASON, passwordField.getNotCapturedReason());
     Map<String, String> strMap = (Map<String, String>) thisFields.get("strMap").getValue();
     assertNull(strMap.get("password"));
   }
@@ -1737,12 +1746,20 @@ public class CapturedSnapshotTest {
     Assertions.assertEquals(42, result);
     Snapshot snapshot = assertOneSnapshot(listener);
     assertEquals(
-        "arg=secret123 credentials={Could not evaluate the expression because 'creds' was redacted} user={Could not evaluate the expression because 'this.creds' was redacted} code={Could not evaluate the expression because 'creds' was redacted} dave={Could not evaluate the expression because 'credMap[\"dave\"]' was redacted}",
+        "arg=secret123 credentials={"
+            + REDACTED_VALUE
+            + "} user={"
+            + REDACTED_VALUE
+            + "} code={"
+            + REDACTED_VALUE
+            + "} dave={"
+            + REDACTED_VALUE
+            + "}",
         snapshot.getMessage());
     Map<String, CapturedContext.CapturedValue> thisFields =
         getFields(snapshot.getCaptures().getReturn().getArguments().get("this"));
     CapturedContext.CapturedValue credsField = thisFields.get("creds");
-    assertEquals("redacted", credsField.getNotCapturedReason());
+    assertEquals(REDACTED_TYPE_REASON, credsField.getNotCapturedReason());
     Map<String, String> credMap = (Map<String, String>) thisFields.get("credMap").getValue();
     assertNull(credMap.get("dave"));
   }


### PR DESCRIPTION
# What Does This Do
in log template use `{redacted}` instead of the evaluation error message 

for snapshot indicated the by which part it was redacted:
- `redactedIdent` for keyword redaction
- `redactedType` for type redaction

# Motivation

# Additional Notes

Jira ticket: [DEBUG-1897]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1897]: https://datadoghq.atlassian.net/browse/DEBUG-1897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ