### PR TITLE
Telemetry v2 URL from DD_SITE

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -55,7 +55,7 @@ class CustomLogManagerTest extends Specification {
         "-Djava.util.logging.manager=jvmbootstraptest.MissingLogManager"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , ["DD_API_KEY": API_KEY, "DD_SITE": ""]
       , true) == 0
   }
 
@@ -87,7 +87,7 @@ class CustomLogManagerTest extends Specification {
         "-Ddd.app.customjmxbuilder=false"
       ] as String[]
       , "" as String[]
-      , ["JBOSS_HOME": "/", "DD_API_KEY": API_KEY]
+      , ["JBOSS_HOME": "/", "DD_API_KEY": API_KEY, "DD_SITE": ""]
       , true) == 0
   }
 

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -102,7 +102,8 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.ddprof.enabled=true",
     "-Ddd.profiling.ddprof.alloc.enabled=true",
     "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=${logLevel()}",
-    "-Dorg.slf4j.simpleLogger.defaultLogLevel=${logLevel()}"
+    "-Dorg.slf4j.simpleLogger.defaultLogLevel=${logLevel()}",
+    "-Ddd.site="
   ]
 
   @Shared

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -70,7 +70,6 @@ public final class GeneralConfig {
       "telemetry.dependency-collection.enabled";
 
   public static final String TELEMETRY_DEBUG_REQUESTS_ENABLED = "telemetry.debug.requests.enabled";
-  public static final String TELEMETRY_INTAKE_URL = "telemetry.intake.url";
 
   private GeneralConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -810,7 +810,6 @@ public class Config {
   private final float traceFlushIntervalSeconds;
 
   private final boolean telemetryDebugRequestsEnabled;
-  private final String telemetryIntakeUrl;
 
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
@@ -1798,8 +1797,6 @@ public class Config {
         configProvider.getBoolean(
             GeneralConfig.TELEMETRY_DEBUG_REQUESTS_ENABLED,
             ConfigDefaults.DEFAULT_TELEMETRY_DEBUG_REQUESTS_ENABLED);
-
-    this.telemetryIntakeUrl = configProvider.getString(GeneralConfig.TELEMETRY_INTAKE_URL);
 
     log.debug("New instance: {}", this);
   }
@@ -3367,10 +3364,6 @@ public class Config {
     return telemetryDebugRequestsEnabled;
   }
 
-  public String getTelemetryIntakeUrl() {
-    return telemetryIntakeUrl;
-  }
-
   private <T> Set<T> getSettingsSetFromEnvironment(
       String name, Function<String, T> mapper, boolean splitOnWS) {
     final String value = configProvider.getString(name, "");
@@ -3970,8 +3963,6 @@ public class Config {
         + spanAttributeSchemaVersion
         + ", telemetryDebugRequestsEnabled="
         + telemetryDebugRequestsEnabled
-        + ", telemetryIntakeUrl="
-        + telemetryIntakeUrl
         + ", telemetryMetricsEnabled="
         + telemetryMetricsEnabled
         + '}';

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
@@ -31,12 +31,12 @@ public class TelemetryClient {
 
     String prefix = "";
     if (site.endsWith("datad0g.com")) {
-      prefix = "all-http-intake.logs";
+      prefix = "all-http-intake.logs.";
     } else if (site.endsWith("datadoghq.com")) {
-      prefix = "instrumentation-telemetry-intake";
+      prefix = "instrumentation-telemetry-intake.";
     }
 
-    String telemetryUrl = "https://" + prefix + "." + site + "/api/v2/apmtelemetry";
+    String telemetryUrl = "https://" + prefix + site + "/api/v2/apmtelemetry";
     HttpUrl url;
     try {
       url = HttpUrl.get(telemetryUrl);

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
@@ -1,7 +1,6 @@
 package datadog.telemetry;
 
 import datadog.communication.http.OkHttpUtils;
-import datadog.trace.api.config.GeneralConfig;
 import java.io.IOException;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -24,27 +23,30 @@ public class TelemetryClient {
     return new TelemetryClient(okHttpClient, agentTelemetryUrl, null);
   }
 
-  public static TelemetryClient buildIntakeClient(
-      String telemetryIntakeUrl, long timeoutMillis, String apiKey) {
-    OkHttpClient intakeHttpClient = null;
-    HttpUrl intakeUrl = null;
-    if (telemetryIntakeUrl == null) {
-      log.warn("Cannot create Telemetry Intake client because Telemetry Intake URL unset.");
-      return null;
-    } else if (apiKey == null) {
+  public static TelemetryClient buildIntakeClient(String site, long timeoutMillis, String apiKey) {
+    if (apiKey == null) {
       log.warn("Cannot create Telemetry Intake because API_KEY unspecified.");
       return null;
-    } else {
-      try {
-        intakeUrl = HttpUrl.get(telemetryIntakeUrl);
-        intakeHttpClient = OkHttpUtils.buildHttpClient(intakeUrl, timeoutMillis);
-      } catch (IllegalArgumentException e) {
-        log.error(
-            "Can't create Telemetry Intake because of invalid URL {}",
-            GeneralConfig.TELEMETRY_INTAKE_URL);
-      }
     }
-    return new TelemetryClient(intakeHttpClient, intakeUrl, apiKey);
+
+    String prefix = "";
+    if (site.endsWith("datad0g.com")) {
+      prefix = "all-http-intake.logs";
+    } else if (site.endsWith("datadoghq.com")) {
+      prefix = "instrumentation-telemetry-intake";
+    }
+
+    String telemetryUrl = "https://" + prefix + "." + site + "/api/v2/apmtelemetry";
+    HttpUrl url;
+    try {
+      url = HttpUrl.get(telemetryUrl);
+    } catch (IllegalArgumentException e) {
+      log.error("Can't create Telemetry URL for {}", telemetryUrl);
+      return null;
+    }
+
+    OkHttpClient httpClient = OkHttpUtils.buildHttpClient(url, timeoutMillis);
+    return new TelemetryClient(httpClient, url, apiKey);
   }
 
   private static final Logger log = LoggerFactory.getLogger(TelemetryClient.class);

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -73,7 +73,7 @@ public class TelemetrySystem {
     TelemetryClient agentClient = TelemetryClient.buildAgentClient(sco.okHttpClient, sco.agentUrl);
     TelemetryClient intakeClient =
         TelemetryClient.buildIntakeClient(
-            config.getTelemetryIntakeUrl(),
+            config.getSite(),
             TimeUnit.SECONDS.toMillis(config.getAgentTimeout()),
             config.getApiKey());
     TelemetryService telemetryService =

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetrySystemSpecification.groovy
@@ -5,13 +5,14 @@ import datadog.communication.ddagent.SharedCommunicationObjects
 import datadog.communication.monitor.Monitoring
 import datadog.telemetry.dependency.DependencyService
 import datadog.telemetry.dependency.LocationsCollectingTransformer
+import datadog.trace.api.config.GeneralConfig
+import datadog.trace.test.util.DDSpecification
+import datadog.trace.util.Strings
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
-import spock.lang.Specification
-
 import java.lang.instrument.Instrumentation
 
-class TelemetrySystemSpecification extends Specification {
+class TelemetrySystemSpecification extends DDSpecification {
   Instrumentation inst = Mock()
 
   void 'installs dependencies transformer'() {
@@ -42,6 +43,8 @@ class TelemetrySystemSpecification extends Specification {
 
   void 'start-stop telemetry system'() {
     setup:
+    injectEnvConfig(Strings.toEnvVar(GeneralConfig.SITE), "datad0g.com")
+    injectEnvConfig(Strings.toEnvVar(GeneralConfig.API_KEY), "api-key")
     def instrumentation = Mock(Instrumentation)
 
     when:


### PR DESCRIPTION
# What Does This Do

Removes `telemetry.intake.url` in favor of constructing it out of DD_SITE according to [the clarified RFC rules](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/development.md#agentless)

# Motivation

Decide on Telemetry Intake URL without expecting a user setting it explicitly.

# Additional Notes

