### PR TITLE
add resource name to profile samples

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -16,6 +16,7 @@ import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isAllocationPro
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isCpuProfilerEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isLiveHeapSizeTrackingEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isMemoryLeakProfilingEnabled;
+import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isResourceNameContextAttributeEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isSpanNameContextAttributeEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.isWallClockProfilerEnabled;
 import static com.datadog.profiling.ddprof.DatadogProfilerConfig.omitLineNumbers;
@@ -58,6 +59,7 @@ public final class DatadogProfiler {
   private static final int[] EMPTY = new int[0];
 
   private static final String OPERATION = "_dd.trace.operation";
+  private static final String RESOURCE = "_dd.trace.resource";
 
   private static final int MAX_NUM_ENDPOINTS = 8192;
 
@@ -172,6 +174,9 @@ public final class DatadogProfiler {
     this.orderedContextAttributes = new ArrayList<>(contextAttributes);
     if (isSpanNameContextAttributeEnabled(configProvider)) {
       orderedContextAttributes.add(OPERATION);
+    }
+    if (isResourceNameContextAttributeEnabled(configProvider)) {
+      orderedContextAttributes.add(RESOURCE);
     }
     this.contextSetter = new ContextSetter(profiler, orderedContextAttributes);
     this.queueTimeThreshold =
@@ -365,6 +370,10 @@ public final class DatadogProfiler {
 
   public int operationNameOffset() {
     return offsetOf(OPERATION);
+  }
+
+  public int resourceNameOffset() {
+    return offsetOf(RESOURCE);
   }
 
   public int offsetOf(String attribute) {

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -3,6 +3,7 @@ package com.datadog.profiling.ddprof;
 import static datadog.trace.api.Platform.isJ9;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ALLOCATION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_RESOURCE_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT;
@@ -287,6 +288,10 @@ public class DatadogProfilerConfig {
 
   public static boolean isSpanNameContextAttributeEnabled(ConfigProvider configProvider) {
     return configProvider.getBoolean(PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED, true);
+  }
+
+  public static boolean isResourceNameContextAttributeEnabled(ConfigProvider configProvider) {
+    return configProvider.getBoolean(PROFILING_CONTEXT_ATTRIBUTES_RESOURCE_NAME_ENABLED, true);
   }
 
   public static String getString(ConfigProvider configProvider, String key, String defaultValue) {

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
@@ -13,6 +13,7 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
 
   private static final DatadogProfiler DDPROF = DatadogProfiler.getInstance();
   private static final int SPAN_NAME_INDEX = DDPROF.operationNameOffset();
+  private static final int RESOURCE_NAME_INDEX = DDPROF.resourceNameOffset();
   private static final boolean WALLCLOCK_ENABLED =
       DatadogProfilerConfig.isWallClockProfilerEnabled();
 
@@ -42,12 +43,14 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
   public void setContext(ProfilerContext profilerContext) {
     DDPROF.setSpanContext(profilerContext.getSpanId(), profilerContext.getRootSpanId());
     DDPROF.setContextValue(SPAN_NAME_INDEX, profilerContext.getEncodedOperationName());
+    DDPROF.setContextValue(RESOURCE_NAME_INDEX, profilerContext.getEncodedResourceName());
   }
 
   @Override
   public void clearContext() {
     DDPROF.clearSpanContext();
     DDPROF.clearContextValue(SPAN_NAME_INDEX);
+    DDPROF.clearContextValue(RESOURCE_NAME_INDEX);
   }
 
   @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -170,6 +170,9 @@ public final class ProfilingConfig {
   public static final String PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED =
       "profiling.context.attributes.span.name.enabled";
 
+  public static final String PROFILING_CONTEXT_ATTRIBUTES_RESOURCE_NAME_ENABLED =
+      "profiling.context.attributes.resource.name.enabled";
+
   public static final String PROFILING_QUEUEING_TIME_ENABLED =
       "profiling.experimental.queueing.time.enabled";
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -136,6 +136,7 @@ public class DDSpanContext
   private final ProfilingContextIntegration profilingContextIntegration;
   private boolean injectBaggageAsTags;
   private volatile int encodedOperationName;
+  private volatile int encodedResourceName;
 
   public DDSpanContext(
       final DDTraceId traceId,
@@ -381,6 +382,11 @@ public class DDSpanContext
     return encodedOperationName;
   }
 
+  @Override
+  public int getEncodedResourceName() {
+    return encodedResourceName;
+  }
+
   public String getServiceName() {
     return serviceName;
   }
@@ -410,6 +416,7 @@ public class DDSpanContext
     if (priority >= this.resourceNamePriority) {
       this.resourceNamePriority = priority;
       this.resourceName = resourceName;
+      this.encodedResourceName = profilingContextIntegration.encode(resourceName);
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -265,7 +265,9 @@ class DDSpanContextTest extends DDCoreSpecification {
 
     then: "encoded operation name matches operation name"
     1 * profilingContextIntegration.encode("fakeOperation") >> 1
+    1 * profilingContextIntegration.encode("fakeResource") >> -1
     span.context.encodedOperationName == 1
+    span.context.encodedResourceName == -1
 
     when:
     span.setOperationName("newOperationName")
@@ -273,6 +275,13 @@ class DDSpanContextTest extends DDCoreSpecification {
     then:
     1 * profilingContextIntegration.encode("newOperationName") >> 2
     span.context.encodedOperationName == 2
+
+    when:
+    span.setResourceName("newResourceName")
+
+    then:
+    1 * profilingContextIntegration.encode("newResourceName") >> -2
+    span.context.encodedResourceName == -2
   }
 
   private static String dataTag(String tag) {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilerContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilerContext.java
@@ -8,4 +8,6 @@ public interface ProfilerContext {
   long getRootSpanId();
 
   int getEncodedOperationName();
+
+  int getEncodedResourceName();
 }


### PR DESCRIPTION
# What Does This Do

Adds APM resource name labels to profile samples, which allows flamegraphs to be filtered by resource name. This is enabled by default but can be disabled with `-Ddd.profiling.context.attributes.resource.name.enabled=false`.

# Motivation

# Additional Notes

Jira ticket: [PROF-8531]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8531]: https://datadoghq.atlassian.net/browse/PROF-8531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ