### PR TITLE
Add name in sources for vertx 4 header names and param values

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/MultiMapInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/MultiMapInstrumentation.java
@@ -120,7 +120,7 @@ public abstract class MultiMapInstrumentation extends Instrumenter.Iast {
             final String name = entry.getKey();
             final String value = entry.getValue();
             if (keys.add(name)) {
-              propagation.taint(ctx, name, nameOrigin);
+              propagation.taint(ctx, name, nameOrigin, name);
             }
             propagation.taint(ctx, value, source.getOrigin(), name);
           }
@@ -141,7 +141,7 @@ public abstract class MultiMapInstrumentation extends Instrumenter.Iast {
           final IastContext ctx = IastContext.Provider.get();
           final byte nameOrigin = namedSource(source.getOrigin());
           for (final String name : result) {
-            propagation.taint(ctx, name, nameOrigin);
+            propagation.taint(ctx, name, nameOrigin, name);
           }
         }
       }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/MultiMapInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/MultiMapInstrumentationTest.groovy
@@ -95,7 +95,7 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.findSource(instance) >> { mockedSource(origin) }
-    1 * module.taint(_, 'key', namedSource(origin))
+    1 * module.taint(_, 'key', namedSource(origin), 'key')
 
     where:
     instance << multiMaps()
@@ -122,7 +122,7 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.findSource(instance) >> { mockedSource(origin) }
-    1 * module.taint(_, 'key', namedSource(origin))
+    1 * module.taint(_, 'key', namedSource(origin), 'key')
     1 * module.taint(_, 'value1', origin, 'key')
     1 * module.taint(_, 'value2', origin, 'key')
 

--- a/dd-smoke-tests/vertx-3.4/application/src/main/java/datadog/smoketest/vertx_3_4/IastHandler.java
+++ b/dd-smoke-tests/vertx-3.4/application/src/main/java/datadog/smoketest/vertx_3_4/IastHandler.java
@@ -8,6 +8,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Cookie;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Vector;
 
@@ -26,6 +27,13 @@ public enum IastHandler implements Handler<RoutingContext> {
       rc.response().end("Received " + value.get("header"));
     }
   },
+  HEADER_NAMES("/headernames") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      final Collection<String> names = rc.request().headers().names();
+      rc.response().end("Received " + String.join(",", names));
+    }
+  },
   PARAM("/param") {
     @Override
     public void handle(final RoutingContext rc) {
@@ -38,6 +46,13 @@ public enum IastHandler implements Handler<RoutingContext> {
     public void handle(final RoutingContext rc) {
       final MultiMap value = rc.request().params();
       rc.response().end("Received " + value.get("param"));
+    }
+  },
+  PARAM_NAMES("/paramnames") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      final Collection<String> names = rc.request().params().names();
+      rc.response().end("Received " + String.join(",", names));
     }
   },
   FORM_ATTRIBUTE("/form_attribute") {

--- a/dd-smoke-tests/vertx-3.9/application/src/main/java/datadog/smoketest/vertx_3_9/IastHandler.java
+++ b/dd-smoke-tests/vertx-3.9/application/src/main/java/datadog/smoketest/vertx_3_9/IastHandler.java
@@ -8,6 +8,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Vector;
 
@@ -27,6 +28,13 @@ public enum IastHandler implements Handler<RoutingContext> {
       rc.response().end("Received " + value.get("header"));
     }
   },
+  HEADER_NAMES("/headernames") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      final Collection<String> names = rc.request().headers().names();
+      rc.response().end("Received " + String.join(",", names));
+    }
+  },
   PARAM("/param") {
     @Override
     public void handle(final RoutingContext rc) {
@@ -39,6 +47,13 @@ public enum IastHandler implements Handler<RoutingContext> {
     public void handle(final RoutingContext rc) {
       final MultiMap value = rc.request().params();
       rc.response().end("Received " + value.get("param"));
+    }
+  },
+  PARAM_NAMES("/paramnames") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      final Collection<String> names = rc.request().params().names();
+      rc.response().end("Received " + String.join(",", names));
     }
   },
   FORM_ATTRIBUTE("/form_attribute") {

--- a/dd-smoke-tests/vertx-4.2/application/src/main/java/datadog/smoketest/vertx_4_2/IastHandler.java
+++ b/dd-smoke-tests/vertx-4.2/application/src/main/java/datadog/smoketest/vertx_4_2/IastHandler.java
@@ -9,6 +9,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Vector;
 
@@ -28,6 +29,13 @@ public enum IastHandler implements Handler<RoutingContext> {
       rc.response().end("Received " + value.get("header"));
     }
   },
+  HEADER_NAMES("/headernames") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      final Collection<String> names = rc.request().headers().names();
+      rc.response().end("Received " + String.join(",", names));
+    }
+  },
   PARAM("/param") {
     @Override
     public void handle(final RoutingContext rc) {
@@ -40,6 +48,13 @@ public enum IastHandler implements Handler<RoutingContext> {
     public void handle(final RoutingContext rc) {
       final MultiMap value = rc.request().params();
       rc.response().end("Received " + value.get("param"));
+    }
+  },
+  PARAM_NAMES("/paramnames") {
+    @Override
+    public void handle(final RoutingContext rc) {
+      final Collection<String> names = rc.request().params().names();
+      rc.response().end("Received " + String.join(",", names));
     }
   },
   FORM_ATTRIBUTE("/form_attribute") {


### PR DESCRIPTION
# What Does This Do
Adds the source name to the header and parameter names for Vertx.4 which was removed after the refactor in https://github.com/DataDog/dd-trace-java/pull/6033
