### PR TITLE
add inert lightweight mode option for profiling

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -17,6 +17,7 @@ import static datadog.trace.util.Strings.toEnvVar;
 import datadog.trace.api.Config;
 import datadog.trace.api.EndpointCheckpointer;
 import datadog.trace.api.Platform;
+import datadog.trace.api.ProductActivation;
 import datadog.trace.api.StatsDClientManager;
 import datadog.trace.api.WithGlobalTracer;
 import datadog.trace.api.config.AppSecConfig;
@@ -853,7 +854,8 @@ public class Agent {
    * on JFR.
    */
   private static ProfilingContextIntegration createProfilingContextIntegration() {
-    if (Config.get().isProfilingEnabled() && !Platform.isWindows()) {
+    if (Config.get().getProfilingActivation().atLeast(ProductActivation.ENABLED_LIGHTWEIGHT)
+        && !Platform.isWindows()) {
       try {
         return (ProfilingContextIntegration)
             AGENT_CLASSLOADER

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -223,7 +223,7 @@ public class AgentInstaller {
     if (cfg.isTraceEnabled()) {
       enabledSystems.add(Instrumenter.TargetSystem.TRACING);
     }
-    if (cfg.isProfilingEnabled()) {
+    if (cfg.getProfilingActivation().atLeast(ProductActivation.ENABLED_INACTIVE)) {
       enabledSystems.add(Instrumenter.TargetSystem.PROFILING);
     }
     if (cfg.getAppSecActivation() != ProductActivation.FULLY_DISABLED) {

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -15,6 +15,7 @@ import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.uploader.ProfileUploader;
 import datadog.trace.api.Config;
 import datadog.trace.api.Platform;
+import datadog.trace.api.ProductActivation;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.io.IOException;
@@ -102,7 +103,7 @@ public class ProfilingAgent {
         // early startup is disabled;
         return;
       }
-      if (!config.isProfilingEnabled()) {
+      if (!config.getProfilingActivation().atLeast(ProductActivation.ENABLED_LIGHTWEIGHT)) {
         log.debug("Profiling: disabled");
         return;
       }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -8,7 +8,7 @@ package datadog.trace.api.config;
  */
 public final class ProfilingConfig {
   public static final String PROFILING_ENABLED = "profiling.enabled";
-  public static final boolean PROFILING_ENABLED_DEFAULT = false;
+  public static final String PROFILING_ENABLED_DEFAULT = "false";
   public static final String PROFILING_ALLOCATION_ENABLED = "profiling.allocation.enabled";
   public static final String PROFILING_HEAP_ENABLED = "profiling.heap.enabled";
   public static final boolean PROFILING_HEAP_ENABLED_DEFAULT = false;

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -111,7 +111,7 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.name("logs_correlation_enabled");
     writer.value(config.isLogsInjectionEnabled());
     writer.name("profiling_enabled");
-    writer.value(config.isProfilingEnabled());
+    writer.value(config.getProfilingActivation().toString());
     writer.name("remote_config_enabled");
     writer.value(config.isRemoteConfigEnabled());
     writer.name("debugger_enabled");

--- a/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/util/SystemAccess.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.util;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.ProductActivation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +20,8 @@ public final class SystemAccess {
 
   /** Enable JMX accesses */
   public static void enableJmx() {
-    if (!Config.get().isProfilingEnabled() && !Config.get().isHealthMetricsEnabled()) {
+    if (Config.get().getProfilingActivation() != ProductActivation.FULLY_ENABLED
+        && !Config.get().isHealthMetricsEnabled()) {
       log.debug("Will not enable JMX access. Profiling and metrics are both disabled.");
       return;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.core
 
+import datadog.trace.api.ProductActivation
+
 import static datadog.trace.api.DDTags.PROFILING_ENABLED
 import static datadog.trace.api.DDTags.SCHEMA_VERSION_TAG_KEY
 
@@ -79,7 +81,7 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
       (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
       (PID_TAG)         : Config.get().getProcessId(),
       (SCHEMA_VERSION_TAG_KEY) : SpanNaming.instance().version(),
-      (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0
+      (PROFILING_ENABLED)     : Config.get().getProfilingActivation().atLeast(ProductActivation.FULLY_ENABLED) ? 1 : 0
     ]
 
     when:
@@ -356,7 +358,7 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
         (LANGUAGE_TAG_KEY)      : LANGUAGE_TAG_VALUE,
         (THREAD_NAME)           : thread.name, (THREAD_ID): thread.id, (PID_TAG): Config.get().getProcessId(),
         (SCHEMA_VERSION_TAG_KEY): SpanNaming.instance().version(),
-        (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0
+        (PROFILING_ENABLED)     : Config.get().getProfilingActivation().atLeast(ProductActivation.FULLY_ENABLED) ? 1 : 0
       ]
 
     where:
@@ -379,7 +381,7 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
       (LANGUAGE_TAG_KEY)      : LANGUAGE_TAG_VALUE,
       (PID_TAG)               : Config.get().getProcessId(),
       (SCHEMA_VERSION_TAG_KEY): SpanNaming.instance().version(),
-      (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0
+      (PROFILING_ENABLED)     : Config.get().getProfilingActivation().atLeast(ProductActivation.FULLY_ENABLED) ? 1 : 0
     ]
 
     cleanup:

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2285,8 +2285,8 @@ public class Config {
     return spanSamplingRulesFile;
   }
 
-  public boolean isProfilingEnabled() {
-    return instrumenterConfig.isProfilingEnabled();
+  public ProductActivation getProfilingActivation() {
+    return instrumenterConfig.getProfilingActivation();
   }
 
   public boolean isProfilingAgentless() {
@@ -3005,7 +3005,9 @@ public class Config {
     result.putAll(runtimeTags);
     result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
     result.put(SCHEMA_VERSION_TAG_KEY, SpanNaming.instance().version());
-    result.put(PROFILING_ENABLED, isProfilingEnabled() ? 1 : 0);
+    result.put(
+        PROFILING_ENABLED,
+        getProfilingActivation().atLeast(ProductActivation.FULLY_ENABLED) ? 1 : 0);
 
     if (reportHostName) {
       final String hostName = getHostName();

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -88,7 +88,7 @@ public class InstrumenterConfig {
   private final boolean traceEnabled;
   private final boolean traceOtelEnabled;
   private final boolean logs128bTraceIdEnabled;
-  private final boolean profilingEnabled;
+  private final ProductActivation profilingActivation;
   private final boolean ciVisibilityEnabled;
   private final ProductActivation appSecActivation;
   private final ProductActivation iastActivation;
@@ -147,7 +147,9 @@ public class InstrumenterConfig {
             TRACE_128_BIT_TRACEID_LOGGING_ENABLED, DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED);
 
     if (!Platform.isNativeImageBuilder()) {
-      profilingEnabled = configProvider.getBoolean(PROFILING_ENABLED, PROFILING_ENABLED_DEFAULT);
+      profilingActivation =
+          ProductActivation.fromString(
+              configProvider.getString(PROFILING_ENABLED, PROFILING_ENABLED_DEFAULT));
       ciVisibilityEnabled =
           configProvider.getBoolean(CIVISIBILITY_ENABLED, DEFAULT_CIVISIBILITY_ENABLED);
       appSecActivation =
@@ -160,7 +162,7 @@ public class InstrumenterConfig {
       telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
     } else {
       // disable these features in native-image
-      profilingEnabled = false;
+      profilingActivation = ProductActivation.FULLY_DISABLED;
       ciVisibilityEnabled = false;
       appSecActivation = ProductActivation.FULLY_DISABLED;
       iastActivation = ProductActivation.FULLY_DISABLED;
@@ -248,8 +250,8 @@ public class InstrumenterConfig {
     return logs128bTraceIdEnabled;
   }
 
-  public boolean isProfilingEnabled() {
-    return profilingEnabled;
+  public ProductActivation getProfilingActivation() {
+    return profilingActivation;
   }
 
   public boolean isCiVisibilityEnabled() {
@@ -431,8 +433,8 @@ public class InstrumenterConfig {
         + traceOtelEnabled
         + ", logs128bTraceIdEnabled="
         + logs128bTraceIdEnabled
-        + ", profilingEnabled="
-        + profilingEnabled
+        + ", profilingActivation="
+        + profilingActivation
         + ", ciVisibilityEnabled="
         + ciVisibilityEnabled
         + ", appSecActivation="

--- a/internal-api/src/main/java/datadog/trace/api/ProductActivation.java
+++ b/internal-api/src/main/java/datadog/trace/api/ProductActivation.java
@@ -5,17 +5,37 @@ public enum ProductActivation {
    * The product is initialized, its instrumentation is applied and the logic in the instrumentation
    * advice is applied. It cannot be disabled at runtime.
    */
-  FULLY_ENABLED,
+  FULLY_ENABLED(2),
   /**
    * Completely disabled. The product is not initialized in any way. It cannot be enabled at
    * runtime.
    */
-  FULLY_DISABLED,
+  FULLY_DISABLED(-1),
   /**
    * The product is initialized, its instrumentation applied, but its logic is disabled to the
    * greatest extent possible. It can be enabled and disabled at runtime through remote config.
    */
-  ENABLED_INACTIVE;
+  ENABLED_INACTIVE(0),
+
+  /**
+   * The product is enabled but in a product-defined lightweight mode, some features are disabled.
+   */
+  ENABLED_LIGHTWEIGHT(1);
+
+  private final int level;
+
+  ProductActivation(int level) {
+    this.level = level;
+  }
+
+  /**
+   * Product activations are expected to be ordered, so that each level is enables and does not
+   * disable features available at the previous level. This allows asserting a minimum level of
+   * activation.
+   */
+  public boolean atLeast(ProductActivation productActivation) {
+    return level >= productActivation.level;
+  }
 
   public static ProductActivation fromString(String s) {
     if ("true".equalsIgnoreCase(s) || "1".equals(s)) {
@@ -23,6 +43,9 @@ public enum ProductActivation {
     }
     if ("inactive".equalsIgnoreCase(s)) {
       return ENABLED_INACTIVE;
+    }
+    if ("lightweight".equalsIgnoreCase(s)) {
+      return ENABLED_LIGHTWEIGHT;
     }
     return FULLY_DISABLED;
   }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -295,7 +295,7 @@ class ConfigTest extends DDSpecification {
     config.isLongRunningTraceEnabled()
     config.getLongRunningTraceFlushInterval() == 250
 
-    config.profilingEnabled == true
+    config.profilingActivation == ProductActivation.FULLY_ENABLED
     config.profilingUrl == "new url"
     config.mergedProfilingTags == [b: "2", f: "6", (HOST_TAG): "test-host", (RUNTIME_ID_TAG): config.getRuntimeId(), (RUNTIME_VERSION_TAG): config.getRuntimeVersion(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
     config.profilingStartDelay == 1111
@@ -473,7 +473,7 @@ class ConfigTest extends DDSpecification {
     config.getLongRunningTraceFlushInterval() == 333
     config.traceRateLimit == 200
 
-    config.profilingEnabled == true
+    config.profilingActivation == ProductActivation.FULLY_ENABLED
     config.profilingUrl == "new url"
     config.mergedProfilingTags == [b: "2", f: "6", (HOST_TAG): "test-host", (RUNTIME_ID_TAG): config.getRuntimeId(), (RUNTIME_VERSION_TAG): config.getRuntimeVersion(), (SERVICE_TAG): config.serviceName, (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE]
     config.profilingStartDelay == 1111


### PR DESCRIPTION
# What Does This Do

Adds a lightweight config mode for profiling. This currently doesn't do anything except enable the context integration (so the profiler gets updates about AMP tracing context).

# Motivation

# Additional Notes

Jira ticket: [PROF-8537]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8537]: https://datadoghq.atlassian.net/browse/PROF-8537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ