### PR TITLE
Match tainted objects with sources when checking unbounded vulnerabilities

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -59,6 +59,15 @@ public final class Ranges {
     return new Range[] {new Range(0, Integer.MAX_VALUE, source, mark)};
   }
 
+  @Nullable
+  public static Range findUnbound(@Nonnull final Range[] ranges) {
+    if (ranges.length != 1) {
+      return null;
+    }
+    final Range range = ranges[0];
+    return range.getStart() == 0 && range.getLength() == Integer.MAX_VALUE ? range : null;
+  }
+
   public static void copyShift(
       final @Nonnull Range[] src, final @Nonnull Range[] dst, final int dstPos, final int shift) {
     copyShift(src, dst, dstPos, shift, src.length);


### PR DESCRIPTION
# What Does This Do
When reporting a vulnerability where the source tainted value has a single unbounded range (happens when we lose propagation over objects like `URL`, `URI`, ...), try to match the original source value with the final representation of the tainted object to do a better reporting,.

# Motivation
From a customer standpoint sometimes is difficult to correlate the vulnerability with its original source in the cases that we lose exact propagation (for instance when creating URLs).

# Additional Notes

Jira ticket: [APPSEC-11922]


[APPSEC-11922]: https://datadoghq.atlassian.net/browse/APPSEC-11922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ