### PR TITLE
Fix NPE when tracing named parameterised tests in JUnit 4 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -293,6 +293,9 @@ public abstract class JUnit4Utils {
 
   public static boolean isSuiteContainingChildren(final Description description) {
     Class<?> testClass = description.getTestClass();
+    if (testClass == null) {
+      return false;
+    }
     for (Method method : testClass.getMethods()) {
       if (method.getAnnotation(Test.class) != null) {
         return true;

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -456,8 +456,8 @@ class JUnit4Test extends CiVisibilityTest {
     })
 
     where:
-    testTags_0 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}']
-    testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
+    testTags_0 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[str1]"}}']
+    testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[\\"str2\\"]"}}']
   }
 
   def "test ITR skipping"() {
@@ -529,11 +529,11 @@ class JUnit4Test extends CiVisibilityTest {
 
     where:
     testTags_0 = [
-      (Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[0]"}}',
+      (Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[str1]"}}',
       (Tags.TEST_SKIP_REASON): "Skipped by Datadog Intelligent Test Runner",
       (Tags.TEST_SKIPPED_BY_ITR): true
     ]
-    testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[1]"}}']
+    testTags_1 = [(Tags.TEST_PARAMETERS): '{"metadata":{"test_name":"parameterized_test_succeed[\\"str2\\"]"}}']
   }
 
   def "test ITR unskippable"() {

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestParameterized.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/java/org/example/TestParameterized.java
@@ -11,7 +11,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class TestParameterized {
 
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name = "{1}")
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {{new ParamObject(), "str1", 0}, {new ParamObject(), "\"str2\"", 1}});


### PR DESCRIPTION
# What Does This Do
Fixes `NullPointerException` when JUnit 4 tracing listener receives events from a named parameterised test case.

# Motivation
When a named parameterised test case is executed, there is a "test suite started" notification with a description that corresponds to a set of parameters.
The tracing listener is not interested in this event, but it should discard it rather than fail with exception.

# Additional Notes

Jira ticket: [CIVIS-7864]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-7864]: https://datadoghq.atlassian.net/browse/CIVIS-7864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ