### PR TITLE
Try to locate tracer JAR using class loader resource lookup when bootstrapping the agent

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -10,6 +10,7 @@ import java.lang.instrument.Instrumentation;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -203,13 +204,10 @@ public final class AgentBootstrap {
 
   private static synchronized URL installAgentJar(final Instrumentation inst)
       throws IOException, URISyntaxException {
-    URL ddJavaAgentJarURL = null;
-
     // First try Code Source
     final CodeSource codeSource = thisClass.getProtectionDomain().getCodeSource();
-
     if (codeSource != null) {
-      ddJavaAgentJarURL = codeSource.getLocation();
+      URL ddJavaAgentJarURL = codeSource.getLocation();
       if (ddJavaAgentJarURL != null) {
         final File ddJavaAgentJarPath = new File(ddJavaAgentJarURL.toURI());
 
@@ -222,7 +220,44 @@ public final class AgentBootstrap {
     }
 
     System.out.println("Could not get bootstrap jar from code source, using -javaagent arg");
+    File javaagentFile = getAgentFileFromJavaagentArg(inst);
+    if (javaagentFile != null) {
+      URL ddJavaAgentJarURL = javaagentFile.toURI().toURL();
+      checkJarManifestMainClassIsThis(ddJavaAgentJarURL);
+      inst.appendToBootstrapClassLoaderSearch(new JarFile(javaagentFile));
+      return ddJavaAgentJarURL;
+    }
 
+    System.out.println(
+        "Could not get agent jar from -javaagent arg, using ClassLoader#getResource");
+    URL thisClassUrl;
+    String thisClassResourceName = thisClass.getName().replace('.', '/') + ".class";
+    ClassLoader classLoader = thisClass.getClassLoader();
+    if (classLoader == null) {
+      thisClassUrl = ClassLoader.getSystemResource(thisClassResourceName);
+    } else {
+      thisClassUrl = classLoader.getResource(thisClassResourceName);
+    }
+
+    if (thisClassUrl == null) {
+      throw new IllegalStateException(
+          "Could not locate agent bootstrap class resource, not installing tracing agent");
+    }
+
+    javaagentFile = new File(new URI(thisClassUrl.getFile().split("!")[0]));
+    if (!javaagentFile.isDirectory()) {
+      URL ddJavaAgentJarURL = javaagentFile.toURI().toURL();
+      checkJarManifestMainClassIsThis(ddJavaAgentJarURL);
+      inst.appendToBootstrapClassLoaderSearch(new JarFile(javaagentFile));
+      return ddJavaAgentJarURL;
+    }
+
+    throw new IllegalStateException(
+        "Could not determine agent jar location, not installing tracing agent");
+  }
+
+  private static File getAgentFileFromJavaagentArg(Instrumentation inst) throws IOException {
+    URL ddJavaAgentJarURL;
     // ManagementFactory indirectly references java.util.logging.LogManager
     // - On Oracle-based JDKs after 1.8
     // - On IBM-based JDKs since at least 1.7
@@ -236,33 +271,36 @@ public final class AgentBootstrap {
         if (agentArgument == null) {
           agentArgument = arg;
         } else {
-          throw new IllegalStateException(
-              "Multiple javaagents specified and code source unavailable, not installing tracing agent");
+          System.out.println(
+              "Could not get bootstrap jar from -javaagent arg: multiple javaagents specified");
+          return null;
         }
       }
     }
 
     if (agentArgument == null) {
-      throw new IllegalStateException(
-          "Could not find javaagent parameter and code source unavailable, not installing tracing agent");
+      System.out.println("Could not get bootstrap jar from -javaagent arg: no argument specified");
+      return null;
     }
 
     // argument is of the form -javaagent:/path/to/dd-java-agent.jar=optionalargumentstring
     final Matcher matcher = Pattern.compile("-javaagent:([^=]+).*").matcher(agentArgument);
 
     if (!matcher.matches()) {
-      throw new IllegalStateException("Unable to parse javaagent parameter: " + agentArgument);
+      System.out.println(
+          "Could not get bootstrap jar from -javaagent arg: unable to parse javaagent parameter: "
+              + agentArgument);
+      return null;
     }
 
     final File javaagentFile = new File(matcher.group(1));
     if (!(javaagentFile.exists() || javaagentFile.isFile())) {
-      throw new IllegalStateException("Unable to find javaagent file: " + javaagentFile);
+      System.out.println(
+          "Could not get bootstrap jar from -javaagent arg: unable to find javaagent file: "
+              + javaagentFile);
+      return null;
     }
-    ddJavaAgentJarURL = javaagentFile.toURI().toURL();
-    checkJarManifestMainClassIsThis(ddJavaAgentJarURL);
-    inst.appendToBootstrapClassLoaderSearch(new JarFile(javaagentFile));
-
-    return ddJavaAgentJarURL;
+    return javaagentFile;
   }
 
   @SuppressForbidden


### PR DESCRIPTION
# What Does This Do
Updates agent bootstrap logic to try to locate tracer JAR by finding the `AgentBootstrap.class` resource using the class' classloader.

# Motivation
Currently the lookup is done using `ProtectionDomain`/`CodeSource` and by parsing the `-javaagent` argument if the first approach fails.
However the second approach may fail too if multiple agents are specified (which, for example, is possible in CI Visibility when a test JVM is forked both with the tracer and with the Jacoco agent).

Jira ticket: [CIVIS-7865]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
