### PR TITLE
instrument Exception and Error classes to avoid instrumenting generic throwables used for control flow

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionProfiling.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionProfiling.java
@@ -42,13 +42,13 @@ public final class ExceptionProfiling {
     this.recordExceptionMessage = recordExceptionMessage;
   }
 
-  public ExceptionSampleEvent process(final Throwable t, final int stackDepth) {
+  public ExceptionSampleEvent process(final Throwable t) {
     // always record the exception in histogram
     final boolean firstHit = histogram.record(t);
 
     final boolean sampled = sampler.sample();
     if (firstHit || sampled) {
-      return new ExceptionSampleEvent(t, stackDepth, sampled, firstHit);
+      return new ExceptionSampleEvent(t, sampled, firstHit);
     }
     return null;
   }

--- a/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java11/datadog/trace/bootstrap/instrumentation/jfr/exceptions/ExceptionSampleEvent.java
@@ -18,10 +18,6 @@ public class ExceptionSampleEvent extends Event implements ContextualEvent {
   @Label("Exception message")
   private final String message;
 
-  /** JFR may truncate the stack trace - so store original length as well. */
-  @Label("Exception stackdepth")
-  private final int stackDepth;
-
   @Label("Sampled")
   private final boolean sampled;
 
@@ -34,8 +30,7 @@ public class ExceptionSampleEvent extends Event implements ContextualEvent {
   @Label("Span Id")
   private long spanId;
 
-  public ExceptionSampleEvent(
-      Throwable e, final int stackDepth, boolean sampled, boolean firstOccurrence) {
+  public ExceptionSampleEvent(Throwable e, boolean sampled, boolean firstOccurrence) {
     /*
      * TODO: we should have some tests for this class.
      * Unfortunately at the moment this is not easily possible because we cannot build tests with groovy that
@@ -44,7 +39,6 @@ public class ExceptionSampleEvent extends Event implements ContextualEvent {
      */
     this.type = e.getClass().getName();
     this.message = getMessage(e);
-    this.stackDepth = stackDepth;
     this.sampled = sampled;
     this.firstOccurrence = firstOccurrence;
     captureContext();

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -42,7 +42,8 @@
 1 io.opentelemetry.javaagent.*
 1 java.*
 # allow exception profiling instrumentation
-0 java.lang.Throwable
+0 java.lang.Exception
+0 java.lang.Error
 # allow ProcessImpl instrumentation
 0 java.lang.ProcessImpl
 0 java.net.http.*

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java/datadog/exceptions/instrumentation/ThrowableInstrumentation.java
@@ -1,21 +1,15 @@
 package datadog.exceptions.instrumentation;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresField;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Platform;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.matcher.ElementMatcher;
 
-/** Provides instrumentation of {@linkplain Throwable} constructor. */
+/** Provides instrumentation of {@linkplain Exception} and {@linkplain Error} constructors. */
 @AutoService(Instrumenter.class)
 public final class ThrowableInstrumentation extends Instrumenter.Profiling
-    implements Instrumenter.ForBootstrap,
-        Instrumenter.ForSingleType,
-        Instrumenter.WithTypeStructure {
+    implements Instrumenter.ForBootstrap, Instrumenter.ForKnownTypes {
 
   public ThrowableInstrumentation() {
     super("throwables");
@@ -27,17 +21,14 @@ public final class ThrowableInstrumentation extends Instrumenter.Profiling
   }
 
   @Override
-  public String instrumentedType() {
-    return "java.lang.Throwable";
-  }
-
-  @Override
-  public ElementMatcher<TypeDescription> structureMatcher() {
-    return declaresField(named("stackTrace"));
-  }
-
-  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(isConstructor(), packageName + ".ThrowableInstanceAdvice");
+  }
+
+  @Override
+  public String[] knownMatchingTypes() {
+    return new String[] {
+      "java.lang.Exception", "java.lang.Error", "kotlin.Exception", "kotlin.Error"
+    };
   }
 }

--- a/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
+++ b/dd-java-agent/instrumentation/exception-profiling/src/main/java11/datadog/exceptions/instrumentation/ThrowableInstanceAdvice.java
@@ -11,12 +11,7 @@ import net.bytebuddy.asm.Advice;
 
 public class ThrowableInstanceAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  public static void onExit(
-      @Advice.This final Throwable t,
-      @Advice.FieldValue("stackTrace") StackTraceElement[] stackTrace) {
-    if (t.getClass().getName().endsWith(".ResourceLeakDetector$TraceRecord")) {
-      return;
-    }
+  public static void onExit(@Advice.This final Object t) {
     /*
      * This instrumentation handler is sensitive to any throwables thrown from its body -
      * it will go into infinite loop of trying to handle the new throwable instance and generating
@@ -47,8 +42,7 @@ public class ThrowableInstanceAdvice {
        * JFR will assign the stacktrace depending on the place where the event is committed.
        * Therefore we need to commit the event here, right in the 'Exception' constructor
        */
-      final ExceptionSampleEvent event =
-          ExceptionProfiling.getInstance().process(t, stackTrace == null ? 0 : stackTrace.length);
+      final ExceptionSampleEvent event = ExceptionProfiling.getInstance().process((Throwable) t);
       if (event != null && event.shouldCommit()) {
         event.commit();
       }


### PR DESCRIPTION
# What Does This Do

This instruments the `Exception` and `Error` classes in  the `java.lang` and [`kotlin`](https://github.com/JetBrains/kotlin/blob/236a76f779d208cadd4462fb99cb2b6d2336eee2/libraries/stdlib/js/src/kotlin/exceptions.kt#L15) packages, instead of `Throwable` which avoids several throwable types used for control flow, such as Scala's [`ControlThrowable`](https://www.scala-lang.org/api/3.0.2/scala/util/control/ControlThrowable.html). This also avoids resource tracking mechanisms such as Netty's `ResourceLeakDetector` which we were filtering out. 

Avoiding the instrumentation altogether in these non-exceptional cases is important because the instrumentation interferes with escape analysis and ensuing optimisations which can reduce the cost of these exception types to practically nothing.

# Motivation

# Additional Notes

Jira ticket: [PROF-8556]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8556]: https://datadoghq.atlassian.net/browse/PROF-8556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ