### PR TITLE
Switch default propagation style from datadog to datadog,tracecontext

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -278,14 +278,26 @@ class OpenTracing31Test extends AgentTestRunner {
     tracer.inject(context, Format.Builtin.TEXT_MAP, adapter)
 
     then:
+    def expectedTraceparent = "00-${context.delegate.traceId.toHexStringPadded(32)}" +
+      "-${DDSpanId.toHexStringPadded(context.delegate.spanId)}" +
+      "-" + (propagatedPriority > 0 ? "01" : "00")
+    def expectedTracestate = "dd=s:${propagatedPriority}"
+    def expectedDatadogTags = null
+    if (propagatedPriority > 0) {
+      def effectiveSamplingMechanism = contextPriority == UNSET ? AGENT_RATE : samplingMechanism
+      expectedDatadogTags = "_dd.p.dm=-" + effectiveSamplingMechanism
+      expectedTracestate+= ";t.dm:-" + effectiveSamplingMechanism
+    }
+
     def expectedTextMap = [
       "x-datadog-trace-id"         : "$context.delegate.traceId",
       "x-datadog-parent-id"        : "$context.delegate.spanId",
       "x-datadog-sampling-priority": propagatedPriority.toString(),
+      "traceparent"                : expectedTraceparent,
+      "tracestate"                 : expectedTracestate,
     ]
-    if (propagatedPriority > 0) {
-      def effectiveSamplingMechanism = contextPriority == UNSET ? AGENT_RATE : samplingMechanism
-      expectedTextMap.put("x-datadog-tags", "_dd.p.dm=-" + effectiveSamplingMechanism)
+    if (expectedDatadogTags != null) {
+      expectedTextMap.put("x-datadog-tags", expectedDatadogTags)
     }
     textMap == expectedTextMap
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -293,14 +293,25 @@ class OpenTracing32Test extends AgentTestRunner {
     tracer.inject(context, Format.Builtin.TEXT_MAP, adapter)
 
     then:
+    def expectedTraceparent = "00-${context.delegate.traceId.toHexStringPadded(32)}" +
+      "-${DDSpanId.toHexStringPadded(context.delegate.spanId)}" +
+      "-" + (propagatedPriority > 0 ? "01" : "00")
+    def expectedTracestate = "dd=s:${propagatedPriority}"
+    def expectedDatadogTags = null
+    if (propagatedPriority > 0) {
+      def effectiveSamplingMechanism = contextPriority == UNSET ? AGENT_RATE : samplingMechanism
+      expectedDatadogTags = "_dd.p.dm=-" + effectiveSamplingMechanism
+      expectedTracestate+= ";t.dm:-" + effectiveSamplingMechanism
+    }
     def expectedTextMap = [
       "x-datadog-trace-id"         : "$context.delegate.traceId",
       "x-datadog-parent-id"        : "$context.delegate.spanId",
       "x-datadog-sampling-priority": propagatedPriority.toString(),
+      "traceparent"                : expectedTraceparent,
+      "tracestate"                 : expectedTracestate
     ]
-    if (propagatedPriority > 0) {
-      def effectiveSamplingMechanism = contextPriority == UNSET ? AGENT_RATE : samplingMechanism
-      expectedTextMap.put("x-datadog-tags", "_dd.p.dm=-" + effectiveSamplingMechanism)
+    if (expectedDatadogTags != null) {
+      expectedTextMap.put("x-datadog-tags", expectedDatadogTags)
     }
     textMap == expectedTextMap
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -1,8 +1,12 @@
 package datadog.trace.api;
 
-import java.util.Arrays;
+import static datadog.trace.api.TracePropagationStyle.DATADOG;
+import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
+import static java.util.Arrays.asList;
+
 import java.util.BitSet;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public final class ConfigDefaults {
@@ -64,6 +68,10 @@ public final class ConfigDefaults {
   static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 30; // in seconds
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
+  static final Set<TracePropagationStyle> DEFAULT_TRACE_PROPAGATION_STYLE =
+      new LinkedHashSet<>(asList(DATADOG, TRACECONTEXT));
+  static final Set<PropagationStyle> DEFAULT_PROPAGATION_STYLE =
+      new LinkedHashSet<>(asList(PropagationStyle.DATADOG));
   static final boolean DEFAULT_JMX_FETCH_ENABLED = true;
   static final boolean DEFAULT_TRACE_AGENT_V05_ENABLED = false;
 
@@ -96,7 +104,7 @@ public final class ConfigDefaults {
   public static final int DEFAULT_IAST_VULNERABILITIES_PER_REQUEST = 2;
   public static final int DEFAULT_IAST_REQUEST_SAMPLING = 33;
   static final Set<String> DEFAULT_IAST_WEAK_HASH_ALGORITHMS =
-      new HashSet<>(Arrays.asList("SHA1", "SHA-1", "MD2", "MD5", "RIPEMD128", "MD4"));
+      new HashSet<>(asList("SHA1", "SHA-1", "MD2", "MD5", "RIPEMD128", "MD4"));
   static final String DEFAULT_IAST_WEAK_CIPHER_ALGORITHMS =
       "^(?:PBEWITH(?:HMACSHA(?:2(?:24ANDAES_(?:128|256)|56ANDAES_(?:128|256))|384ANDAES_(?:128|256)|512ANDAES_(?:128|256)|1ANDAES_(?:128|256))|SHA1AND(?:RC(?:2_(?:128|40)|4_(?:128|40))|DESEDE)|MD5AND(?:TRIPLEDES|DES))|DES(?:EDE(?:WRAP)?)?|BLOWFISH|ARCFOUR|RC2).*$";
   static final boolean DEFAULT_IAST_REDACTION_ENABLED = true;

--- a/dd-trace-ot/src/ot33CompatibilityTest/groovy/OT33ApiTest.groovy
+++ b/dd-trace-ot/src/ot33CompatibilityTest/groovy/OT33ApiTest.groovy
@@ -1,4 +1,5 @@
 import datadog.opentracing.DDTracer
+import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.internal.util.LongStringUtils
 import datadog.trace.common.writer.ListWriter
@@ -97,17 +98,27 @@ class OT33ApiTest extends DDSpecification {
     tracer.inject(context, Format.Builtin.TEXT_MAP, adapter)
 
     then:
+    def traceId = span.delegate.context.traceId as DDTraceId
+    def spanId = span.delegate.context.spanId
+    def expectedTraceparent = "00-${traceId.toHexStringPadded(32)}" +
+      "-${DDSpanId.toHexStringPadded(spanId)}" +
+      "-" + (propagatedPriority > 0 ? "01" : "00")
+    def expectedTracestate = "dd=s:${propagatedPriority}"
+    def effectiveSamplingMechanism = contextPriority == UNSET ? AGENT_RATE : samplingMechanism
+    if (propagatedPriority > 0) {
+      expectedTracestate+= ";t.dm:-" + effectiveSamplingMechanism
+    }
     def expectedTextMap = [
       "x-datadog-trace-id"         : context.toTraceId(),
       "x-datadog-parent-id"        : context.toSpanId(),
       "x-datadog-sampling-priority": propagatedPriority.toString(),
+      "traceparent"                : expectedTraceparent,
+      "tracestate"                 : expectedTracestate,
     ]
     def datadogTags = []
     if (propagatedPriority > 0) {
-      def effectiveSamplingMechanism = contextPriority == UNSET ? AGENT_RATE : samplingMechanism
       datadogTags << "_dd.p.dm=-$effectiveSamplingMechanism"
     }
-    def traceId = span.delegate.context.traceId as DDTraceId
     if (traceId.toHighOrderLong() != 0) {
       datadogTags << "_dd.p.tid=" + LongStringUtils.toHexStringPadded(traceId.toHighOrderLong(), 16)
     }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -80,6 +80,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_PERF_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PRIORITY_SAMPLING_FORCE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_PROPAGATION_STYLE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
@@ -103,6 +104,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_V05_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_PROPAGATION_STYLE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_REPORT_HOSTNAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESOLVER_ENABLED;
@@ -1239,19 +1241,14 @@ public class Config {
       }
       // Now we can check if we should pick the default injection/extraction
       tracePropagationStylesToExtract =
-          extract.isEmpty() ? Collections.singleton(TracePropagationStyle.DATADOG) : extract;
-      tracePropagationStylesToInject =
-          inject.isEmpty() ? Collections.singleton(TracePropagationStyle.DATADOG) : inject;
+          extract.isEmpty() ? DEFAULT_TRACE_PROPAGATION_STYLE : extract;
+      tracePropagationStylesToInject = inject.isEmpty() ? DEFAULT_TRACE_PROPAGATION_STYLE : inject;
       // These setting are here for backwards compatibility until they can be removed in a major
       // release of the tracer
       propagationStylesToExtract =
-          deprecatedExtract.isEmpty()
-              ? Collections.singleton(PropagationStyle.DATADOG)
-              : deprecatedExtract;
+          deprecatedExtract.isEmpty() ? DEFAULT_PROPAGATION_STYLE : deprecatedExtract;
       propagationStylesToInject =
-          deprecatedInject.isEmpty()
-              ? Collections.singleton(PropagationStyle.DATADOG)
-              : deprecatedInject;
+          deprecatedInject.isEmpty() ? DEFAULT_PROPAGATION_STYLE : deprecatedInject;
     }
 
     clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -25,6 +25,7 @@ import static datadog.trace.api.TracePropagationStyle.B3MULTI
 import static datadog.trace.api.TracePropagationStyle.B3SINGLE
 import static datadog.trace.api.TracePropagationStyle.DATADOG
 import static datadog.trace.api.TracePropagationStyle.HAYSTACK
+import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_ENABLED
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CLASSFILE_DUMP_ENABLED
@@ -624,8 +625,8 @@ class ConfigTest extends DDSpecification {
     config.splitByTags == [].toSet()
     config.propagationStylesToExtract.toList() == [PropagationStyle.DATADOG]
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG]
-    config.tracePropagationStylesToExtract.toList() == [DATADOG]
-    config.tracePropagationStylesToInject.toList() == [DATADOG]
+    config.tracePropagationStylesToExtract.toList() == [DATADOG, TRACECONTEXT]
+    config.tracePropagationStylesToInject.toList() == [DATADOG, TRACECONTEXT]
     config.longRunningTraceEnabled == false
   }
 
@@ -2200,7 +2201,7 @@ class ConfigTest extends DDSpecification {
     return bs
   }
 
-  def "check trace propagation style overrides for "() {
+  def "check trace propagation style overrides for"() {
     setup:
     if (pse) {
       environmentVariables.set('DD_PROPAGATION_STYLE_EXTRACT', pse.toString())
@@ -2228,21 +2229,21 @@ class ConfigTest extends DDSpecification {
 
     where:
     // spotless:off
-    pse                      | psi                      | tps      | tpse               | tpsi    | ePSE                       | ePSI                       | eTPSE               | eTPSI
-    PropagationStyle.DATADOG | PropagationStyle.B3      | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.B3]      | [DATADOG]           | [B3SINGLE, B3MULTI]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE, B3MULTI] | [DATADOG]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]          | [HAYSTACK]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3SINGLE           | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]          | [HAYSTACK]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]          | [B3MULTI]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3SINGLE           | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]          | [B3MULTI]
-    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | B3SINGLE           | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]          | [B3MULTI]
-    null                     | null                     | HAYSTACK | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [HAYSTACK]          | [HAYSTACK]
-    null                     | null                     | HAYSTACK | B3SINGLE           | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]          | [B3MULTI]
-    null                     | null                     | null     | B3SINGLE           | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]          | [B3MULTI]
-    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG]           | [DATADOG]
-    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG]           | [DATADOG]
-    null                     | null                     | null     | "b3 single header" | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]          | [DATADOG]
-    null                     | null                     | null     | "b3"               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3MULTI]           | [DATADOG]
+    pse                      | psi                      | tps      | tpse               | tpsi    | ePSE                       | ePSI                       | eTPSE                   | eTPSI
+    PropagationStyle.DATADOG | PropagationStyle.B3      | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.B3]      | [DATADOG]               | [B3SINGLE, B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE, B3MULTI]     | [DATADOG]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]              | [HAYSTACK]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3SINGLE           | null    | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]              | [HAYSTACK]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | null               | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [HAYSTACK]              | [B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | HAYSTACK | B3SINGLE           | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]              | [B3MULTI]
+    PropagationStyle.B3      | PropagationStyle.DATADOG | null     | B3SINGLE           | B3MULTI | [PropagationStyle.B3]      | [PropagationStyle.DATADOG] | [B3SINGLE]              | [B3MULTI]
+    null                     | null                     | HAYSTACK | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [HAYSTACK]              | [HAYSTACK]
+    null                     | null                     | HAYSTACK | B3SINGLE           | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]              | [B3MULTI]
+    null                     | null                     | null     | B3SINGLE           | B3MULTI | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]              | [B3MULTI]
+    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG, TRACECONTEXT] | [DATADOG, TRACECONTEXT]
+    null                     | null                     | null     | null               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [DATADOG, TRACECONTEXT] | [DATADOG, TRACECONTEXT]
+    null                     | null                     | null     | "b3 single header" | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3SINGLE]              | [DATADOG, TRACECONTEXT]
+    null                     | null                     | null     | "b3"               | null    | [PropagationStyle.DATADOG] | [PropagationStyle.DATADOG] | [B3MULTI]               | [DATADOG, TRACECONTEXT]
     // spotless:on
   }
 
@@ -2347,7 +2348,7 @@ class ConfigTest extends DDSpecification {
     "450"         | 450
   }
 
-  def "partial flush and min spans interaction #"() {
+  def "partial flush and min spans interaction"() {
     when:
     def prop = new Properties()
     if (configuredPartialEnabled != null) {


### PR DESCRIPTION
# What Does This Do

This PR changes the default propagator style from `datadog` to `datadog,tracecontext`.

# Motivation

This will improve W3C tracecontext standard compatibility by default. 

# Additional Notes

System-tests are failing are they are not ready for the W3C trace context change initiative:
```
E       AssertionError: assert 'traceparent' not in {'traceparent': '00-00000000000000001d98b30ac29490fa-2af1f8d62c1057b4-01', 'tracestate': 'dd=s:1;t.dm:-1', 'x-datadog-parent-id': '3094528017726199732', 'x-datadog-sampling-priority': '1', ...}
```
This will be handled later when merging project branch to master, expecting the system-tests to be ready by then.

Jira ticket: [APMJAVA-1122]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1122]: https://datadoghq.atlassian.net/browse/APMJAVA-1122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ