### PR TITLE
Add support for names in jackson propagation

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/iast/NamedContext.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/iast/NamedContext.java
@@ -1,0 +1,89 @@
+package datadog.trace.bootstrap.instrumentation.iast;
+
+import datadog.trace.api.iast.IastContext;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Taintable.Source;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.ContextStore;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Provides a context to store the current name in order to taint values in parsing operations (e.g.
+ * JSON parsing)
+ */
+public abstract class NamedContext {
+
+  public abstract void taintValue(@Nullable String value);
+
+  public abstract void taintName(@Nullable String name);
+
+  @Nonnull
+  public static <E> NamedContext getOrCreate(
+      @Nonnull final ContextStore<E, NamedContext> store, @Nonnull final E target) {
+    NamedContext result = store.get(target);
+    if (result != null) {
+      return result;
+    }
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null) {
+      final Source source = module.findSource(target);
+      if (source != null) {
+        result = new NamedContextImpl(module, source);
+      }
+    }
+    result = result == null ? NoOp.INSTANCE : result;
+    store.put(target, result);
+    return result;
+  }
+
+  private static class NoOp extends NamedContext {
+
+    private static final NamedContext INSTANCE = new NoOp();
+
+    @Override
+    public void taintValue(@Nullable final String value) {}
+
+    @Override
+    public void taintName(@Nullable final String name) {}
+  }
+
+  private static class NamedContextImpl extends NamedContext {
+    @Nonnull private final PropagationModule module;
+    @Nonnull private final Source source;
+    @Nullable private String currentName;
+
+    private boolean fetched;
+    @Nullable private IastContext context;
+
+    public NamedContextImpl(@Nonnull final PropagationModule module, @Nonnull final Source source) {
+      this.module = module;
+      this.source = source;
+    }
+
+    @Override
+    public void taintValue(@Nullable final String value) {
+      module.taint(iastCtx(), value, source.getOrigin(), currentName, source.getValue());
+    }
+
+    @Override
+    @SuppressWarnings("StringEquality")
+    @SuppressFBWarnings("ES_COMPARING_PARAMETER_STRING_WITH_EQ")
+    public void taintName(@Nullable final String name) {
+      // prevent tainting the same name more than once
+      if (currentName != name) {
+        currentName = name;
+        module.taint(iastCtx(), name, source.getOrigin(), name, source.getValue());
+      }
+    }
+
+    private IastContext iastCtx() {
+      if (!fetched) {
+        fetched = true;
+        context = IastContext.Provider.get();
+      }
+      return context;
+    }
+  }
+}

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/iast/NamedContextTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/iast/NamedContextTest.groovy
@@ -1,0 +1,86 @@
+package datadog.trace.bootstrap.instrumentation.iast
+
+
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.Taintable.Source
+import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.ContextStore
+import datadog.trace.test.util.DDSpecification
+
+class NamedContextTest extends DDSpecification {
+
+  protected PropagationModule module
+  protected ContextStore store
+
+  void setup() {
+    module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+    store = Mock(ContextStore)
+  }
+
+  void 'test that the context taints names and values'() {
+    given:
+    final source = new SourceImpl(origin: SourceTypes.REQUEST_PARAMETER_NAME)
+    final target = new Object()
+    final name = 'name'
+    final value = 'value'
+
+    when:
+    final context = NamedContext.getOrCreate(store, target)
+
+    then:
+    1 * store.get(target) >> null
+    1 * module.findSource(target) >> source
+    1 * store.put(target, _)
+
+    when:
+    context.taintName(name)
+
+    then:
+    1 * module.taint(_, name, source.origin, name, source.value)
+
+    when:
+    context.taintName(name)
+
+    then:
+    0 * _
+
+    when:
+    context.taintValue(value)
+
+    then:
+    1 * module.taint(_, value, source.origin, name, source.value)
+    0 * _
+  }
+
+  void 'test context for non tainted'() {
+    given:
+    final target = 'test'
+
+    when:
+    final ctx = NamedContext.getOrCreate(store, target)
+
+    then:
+    1 * module.findSource(target) >> null
+    1 * store.put(target, _)
+
+    when:
+    ctx.taintName('name')
+
+    then:
+    0 * _
+
+    when:
+    ctx.taintValue('value')
+
+    then:
+    0 * _
+  }
+
+  private static class SourceImpl implements Source {
+    byte origin
+    String name
+    String value
+  }
+}

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/iastTest/groovy/datadog/trace/instrumentation/akkahttp/iast/IastAkkaTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/iastTest/groovy/datadog/trace/instrumentation/akkahttp/iast/IastAkkaTest.groovy
@@ -507,19 +507,19 @@ class IastAkkaTest extends IastRequestTestRunner {
     then:
     toc.hasTaintedObject {
       value 'var1'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(), nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var1', nullValue())
     }
     toc.hasTaintedObject {
       value 'var2'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(), nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var2', nullValue())
     }
     toc.hasTaintedObject {
       value 'foo'
-      range 0, 3, source(SourceTypes.REQUEST_BODY, nullValue(), nullValue())
+      range 0, 3, source(SourceTypes.REQUEST_BODY, 'var1', nullValue())
     }
     toc.hasTaintedObject {
       value 'foo2'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(), nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var2', nullValue())
     }
 
     where:

--- a/dd-java-agent/instrumentation/jackson-core/build.gradle
+++ b/dd-java-agent/instrumentation/jackson-core/build.gradle
@@ -2,7 +2,7 @@ muzzle {
   pass {
     group = 'com.fasterxml.jackson.core'
     module = 'jackson-core'
-    versions = "[2.0.0,3)"
+    versions = "[2.0.0,)"
     assertInverse = true
   }
 
@@ -10,7 +10,7 @@ muzzle {
     name = 'jackson-databind'
     group = 'com.fasterxml.jackson.core'
     module = 'jackson-databind'
-    versions = "[2.0.0,3)"
+    versions = "[2.0.0,)"
     assertInverse = true
   }
 }
@@ -19,9 +19,11 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
 
+final jacksonVersion = '2.14.0'
 dependencies {
-  compileOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.0')
-  compileOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0')
-  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.0')
-  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0')
+  compileOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion)
+  compileOnly(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion)
+
+  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion)
+  testImplementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion)
 }

--- a/dd-java-agent/instrumentation/jackson-core/jackson-core-1/build.gradle
+++ b/dd-java-agent/instrumentation/jackson-core/jackson-core-1/build.gradle
@@ -1,6 +1,9 @@
 muzzle {
   pass {
-    coreJdk()
+    group = 'org.codehaus.jackson'
+    module = 'jackson-core-asl'
+    versions = "[0.9.6,)"
+    assertInverse = true
   }
 }
 
@@ -8,7 +11,9 @@ apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
 
+final jacksonVersion = '1.9.13'
 dependencies {
-  compileOnly group: 'org.codehaus.jackson', name: 'jackson-core-asl', version: '1.9.13'
-  testImplementation group: 'org.codehaus.jackson', name: 'jackson-core-asl', version: '1.9.13'
+  compileOnly(group: 'org.codehaus.jackson', name: 'jackson-core-asl', version: jacksonVersion)
+
+  testImplementation(group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: jacksonVersion)
 }

--- a/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/test/groovy/Json1ParserInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/test/groovy/Json1ParserInstrumentationTest.groovy
@@ -1,88 +1,78 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.Taintable.Source
 import datadog.trace.api.iast.propagation.PropagationModule
-import org.codehaus.jackson.JsonFactory
-import org.codehaus.jackson.JsonParser
-import org.codehaus.jackson.JsonToken
+import groovy.json.JsonOutput
+import org.codehaus.jackson.map.ObjectMapper
+
+import java.nio.charset.Charset
 
 class Json1ParserInstrumentationTest extends AgentTestRunner {
 
-  private final static String JSON_STRING = '{"key1":"value1","key2":"value2","key3":"value3"}'
+  private final static String JSON_STRING = '{"root":"root_value","nested":{"nested_array":["array_0","array_1"]}}'
 
   @Override
   protected void configurePreAgent() {
     injectSysConfig("dd.iast.enabled", "true")
   }
 
-  void 'test getCurrentName()'() {
-    setup:
-    final propagationModule = Mock(PropagationModule)
-    InstrumentationBridge.registerIastModule(propagationModule)
-    skipUntil(jsonParser, JsonToken.FIELD_NAME)
+  void 'test json parsing (tainted)'() {
+    given:
+    final source = new SourceImpl(origin: SourceTypes.REQUEST_BODY, name: 'body', value: JSON_STRING)
+    final module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    and:
+    final reader = new ObjectMapper().reader(Map)
 
     when:
-    final result = jsonParser.getCurrentName()
+    final taintedResult = reader.readValue(target) as Map
 
     then:
-    result == 'key1'
-    1 * propagationModule.taintIfTainted('key1', jsonParser)
+    JsonOutput.toJson(taintedResult) == JSON_STRING
+    _ * module.taintIfTainted(_, _)
+    _ * module.findSource(_) >> source
+    1 * module.taint(_, 'root', source.origin, 'root', JSON_STRING)
+    1 * module.taint(_, 'root_value', source.origin, 'root', JSON_STRING)
+    1 * module.taint(_, 'nested', source.origin, 'nested', JSON_STRING)
+    1 * module.taint(_, 'nested_array', source.origin, 'nested_array', JSON_STRING)
+    1 * module.taint(_, 'array_0', source.origin, 'nested_array', JSON_STRING)
+    1 * module.taint(_, 'array_1', source.origin, 'nested_array', JSON_STRING)
     0 * _
 
     where:
-    jsonParser << [
-      new JsonFactory().createJsonParser(JSON_STRING),
-      new JsonFactory().createJsonParser(new ByteArrayInputStream(JSON_STRING.getBytes()))
-    ]
+    target << testSuite()
   }
 
-  void 'test getText()'() {
-    setup:
-    final propagationModule = Mock(PropagationModule)
-    InstrumentationBridge.registerIastModule(propagationModule)
-    skipUntil(jsonParser, JsonToken.FIELD_NAME)
+  void 'test json parsing (not tainted)'() {
+    given:
+    final module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    and:
+    final reader = new ObjectMapper().reader(Map)
 
     when:
-    final result = jsonParser.getText()
+    final taintedResult = reader.readValue(target) as Map
 
     then:
-    result == 'key1'
-    1 * propagationModule.taintIfTainted('key1', jsonParser)
+    JsonOutput.toJson(taintedResult) == JSON_STRING
+    _ * module.taintIfTainted(_, _)
+    _ * module.findSource(_) >> null
     0 * _
 
     where:
-    jsonParser << [
-      new JsonFactory().createJsonParser(JSON_STRING),
-      new JsonFactory().createJsonParser(new ByteArrayInputStream(JSON_STRING.getBytes()))
-    ]
+    target << testSuite()
   }
 
-  void 'test nextTextValue()'() {
-    setup:
-    final propagationModule = Mock(PropagationModule)
-    InstrumentationBridge.registerIastModule(propagationModule)
-    skipUntil(jsonParser, JsonToken.FIELD_NAME)
-
-    when:
-    final result = jsonParser.nextTextValue()
-
-    then:
-    result == 'value1'
-    1 * propagationModule.taintIfTainted('value1', jsonParser)
-    0 * _
-
-    where:
-    jsonParser << [
-      new JsonFactory().createJsonParser(JSON_STRING),
-      new JsonFactory().createJsonParser(new ByteArrayInputStream(JSON_STRING.getBytes()))
-    ]
+  private static List<Object> testSuite() {
+    return [JSON_STRING, new ByteArrayInputStream(JSON_STRING.getBytes(Charset.defaultCharset()))]
   }
 
-  private void skipUntil(final JsonParser parser, final JsonToken token) {
-    JsonToken current
-    while ((current = parser.nextToken()) != null) {
-      if (current == token) {
-        break
-      }
-    }
+  private static class SourceImpl implements Source {
+    byte origin
+    String name
+    String value
   }
 }

--- a/dd-java-agent/instrumentation/jackson-core/src/test/groovy/Json2FactoryInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jackson-core/src/test/groovy/Json2FactoryInstrumentationTest.groovy
@@ -96,8 +96,7 @@ class Json2FactoryInstrumentationTest extends AgentTestRunner {
     parser != null
     json == [key: 'value']
     1 * propagationModule.taintIfTainted(_ as JsonParser, url)
-    1 * propagationModule.taintIfTainted('key', _ as JsonParser)
-    1 * propagationModule.taintIfTainted('value', _ as JsonParser)
+    1 * propagationModule.findSource(_ as JsonParser) >> null
     1 * ssrfModule.onURLConnection(url)
     0 * _
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/iastTest/groovy/datadog/trace/instrumentation/pekkohttp/iast/IastPekkoTest.groovy
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/iastTest/groovy/datadog/trace/instrumentation/pekkohttp/iast/IastPekkoTest.groovy
@@ -507,19 +507,19 @@ class IastPekkoTest extends IastRequestTestRunner {
     then:
     toc.hasTaintedObject {
       value 'var1'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(), nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var1', nullValue())
     }
     toc.hasTaintedObject {
       value 'var2'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(), nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var2', nullValue())
     }
     toc.hasTaintedObject {
       value 'foo'
-      range 0, 3, source(SourceTypes.REQUEST_BODY, nullValue(), nullValue())
+      range 0, 3, source(SourceTypes.REQUEST_BODY, 'var1', nullValue())
     }
     toc.hasTaintedObject {
       value 'foo2'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(), nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var2', nullValue())
     }
 
     where:

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/iastTest/groovy/datadog/trace/instrumentation/springwebflux/server/IastTestController.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/iastTest/groovy/datadog/trace/instrumentation/springwebflux/server/IastTestController.groovy
@@ -85,8 +85,24 @@ class IastTestController {
 
   @Canonical
   static class MyJsonObject {
-    String var1
-    List<String> var2
+    private String var1
+    private List<String> var2
+
+    String getVar1() {
+      return var1
+    }
+
+    void setVar1(String var1) {
+      this.var1 = var1
+    }
+
+    List<String> getVar2() {
+      return var2
+    }
+
+    void setVar2(List<String> var2) {
+      this.var2 = var2
+    }
 
     @Override
     String toString() {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/iastTest/groovy/datadog/trace/instrumentation/springwebflux/server/IastWebFluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/iastTest/groovy/datadog/trace/instrumentation/springwebflux/server/IastWebFluxTest.groovy
@@ -277,19 +277,19 @@ class IastWebFluxTest extends IastRequestTestRunner {
     then:
     toc.hasTaintedObject {
       value 'var1'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(),  nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var1',  nullValue())
     }
     toc.hasTaintedObject {
       value 'var2'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(),  nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var2',  nullValue())
     }
     toc.hasTaintedObject {
       value 'foo'
-      range 0, 3, source(SourceTypes.REQUEST_BODY, nullValue(),  nullValue())
+      range 0, 3, source(SourceTypes.REQUEST_BODY, 'var1',  nullValue())
     }
     toc.hasTaintedObject {
       value 'foo2'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(),  nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var2',  nullValue())
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/iastTest/groovy/datadog/trace/instrumentation/springwebflux6/server/IastWebFluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/iastTest/groovy/datadog/trace/instrumentation/springwebflux6/server/IastWebFluxTest.groovy
@@ -280,19 +280,19 @@ class IastWebFluxTest extends IastRequestTestRunner {
     then:
     toc.hasTaintedObject {
       value 'var1'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(),  nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var1',  nullValue())
     }
     toc.hasTaintedObject {
       value 'var2'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(),  nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var2',  nullValue())
     }
     toc.hasTaintedObject {
       value 'foo'
-      range 0, 3, source(SourceTypes.REQUEST_BODY, nullValue(),  nullValue())
+      range 0, 3, source(SourceTypes.REQUEST_BODY, 'var1',  nullValue())
     }
     toc.hasTaintedObject {
       value 'foo2'
-      range 0, 4, source(SourceTypes.REQUEST_BODY, nullValue(),  nullValue())
+      range 0, 4, source(SourceTypes.REQUEST_BODY, 'var2',  nullValue())
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
Adds a new context to store property names to be used when tainting values in Jackson deserialization.

# Motivation

# Additional Notes

Jira ticket: [APPSEC-11919]


[APPSEC-11919]: https://datadoghq.atlassian.net/browse/APPSEC-11919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ