### PR TITLE
Fix sampling for line probe without condition

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -327,20 +327,12 @@ public class CapturedContext implements ValueReferenceResolver {
           ValueReferences.DURATION_EXTENSION_NAME, duration / 1_000_000.0); // convert to ms
     }
     this.thisClassName = thisClassName;
-    boolean shouldEvaluate = resolveEvaluateAt(probeImplementation, methodLocation);
+    boolean shouldEvaluate =
+        MethodLocation.isSame(methodLocation, probeImplementation.getEvaluateAt());
     if (shouldEvaluate) {
       probeImplementation.evaluate(this, status, methodLocation);
     }
     return status;
-  }
-
-  private static boolean resolveEvaluateAt(
-      ProbeImplementation probeImplementation, MethodLocation methodLocation) {
-    if (methodLocation == MethodLocation.DEFAULT) {
-      // line probe, no evaluation of probe's evaluateAt
-      return true;
-    }
-    return MethodLocation.isSame(methodLocation, probeImplementation.getEvaluateAt());
   }
 
   public Status getStatus(String probeId) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/MethodLocation.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/MethodLocation.java
@@ -7,7 +7,7 @@ public enum MethodLocation {
 
   public static boolean isSame(MethodLocation methodLocation, MethodLocation evaluateAt) {
     if (methodLocation == MethodLocation.DEFAULT) {
-      // line probe always assume we are the right location
+      // line probe, no evaluation of probe's evaluateAt
       return true;
     }
     if (methodLocation == MethodLocation.ENTRY) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/MethodLocation.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/MethodLocation.java
@@ -6,6 +6,10 @@ public enum MethodLocation {
   EXIT;
 
   public static boolean isSame(MethodLocation methodLocation, MethodLocation evaluateAt) {
+    if (methodLocation == MethodLocation.DEFAULT) {
+      // line probe always assume we are the right location
+      return true;
+    }
     if (methodLocation == MethodLocation.ENTRY) {
       return evaluateAt == MethodLocation.DEFAULT || evaluateAt == MethodLocation.ENTRY;
     }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/MethodLocation.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/MethodLocation.java
@@ -8,6 +8,7 @@ public enum MethodLocation {
   public static boolean isSame(MethodLocation methodLocation, MethodLocation evaluateAt) {
     if (methodLocation == MethodLocation.DEFAULT) {
       // line probe, no evaluation of probe's evaluateAt
+      // MethodLocation.DEFAULT is used for line probe when evaluating the context
       return true;
     }
     if (methodLocation == MethodLocation.ENTRY) {


### PR DESCRIPTION
# What Does This Do
In the case of a line probe MethodLocation is DEFAULT and we should not consider the evaluteAt attribute as it is meant for method probe only

# Motivation
no sampling for line probe without condition
# Additional Notes

Jira ticket: [DEBUG-1908]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1908]: https://datadoghq.atlassian.net/browse/DEBUG-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ