### PR TITLE
Add multiple context extraction support

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
@@ -4,6 +4,8 @@ import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.core.propagation.PropagationTags
+
+import static datadog.trace.api.TracePropagationStyle.NONE
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.context.TraceScope
@@ -136,11 +138,11 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def builder = tracer.spanBuilder("some name")
     if (parentId) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, parentId, SAMPLER_DROP, null, PropagationTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, parentId, SAMPLER_DROP, null, PropagationTags.factory().empty(), NONE)
       builder.setParent(tracer.converter.toSpanContext(ctx))
     }
     if (linkId) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, linkId, SAMPLER_DROP, null, PropagationTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, linkId, SAMPLER_DROP, null, PropagationTags.factory().empty(), NONE)
       builder.addLink(tracer.converter.toSpanContext(ctx))
     }
     def result = builder.startSpan()

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -10,6 +10,7 @@ import datadog.trace.instrumentation.opentracing31.OTTracer
 import datadog.trace.instrumentation.opentracing31.TypeConverter
 import spock.lang.Shared
 
+import static datadog.trace.api.TracePropagationStyle.NONE
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 import datadog.trace.context.TraceScope
@@ -45,7 +46,7 @@ class OpenTracing31Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, PropagationTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, PropagationTags.factory().empty(), NONE)
       builder.addReference(addReference, tracer.tracer.converter.toSpanContext(ctx))
     }
     def result = builder.start()

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -23,6 +23,7 @@ import spock.lang.Shared
 import spock.lang.Subject
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.api.TracePropagationStyle.NONE
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
 import static datadog.trace.api.sampling.PrioritySampling.UNSET
@@ -50,7 +51,7 @@ class OpenTracing32Test extends AgentTestRunner {
         .withTag("boolean", true)
     }
     if (addReference) {
-      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, PropagationTags.factory().empty())
+      def ctx = new ExtractedContext(DDTraceId.ONE, 2, SAMPLER_DROP, null, PropagationTags.factory().empty(), NONE)
       builder.addReference(addReference, tracer.tracer.converter.toSpanContext(ctx))
     }
     def result = builder.start()

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -79,6 +79,8 @@ public final class ConfigDefaults {
 
   static final int DEFAULT_CLOCK_SYNC_PERIOD = 30; // seconds
 
+  static final boolean DEFAULT_TRACE_PROPAGATION_EXTRACT_FIRST = false;
+
   static final boolean DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED = false;
   static final int DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT = 10;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -84,6 +84,7 @@ public final class TracerConfig {
   public static final String TRACE_PROPAGATION_STYLE = "trace.propagation.style";
   public static final String TRACE_PROPAGATION_STYLE_EXTRACT = "trace.propagation.style.extract";
   public static final String TRACE_PROPAGATION_STYLE_INJECT = "trace.propagation.style.inject";
+  public static final String TRACE_PROPAGATION_EXTRACT_FIRST = "trace.propagation.extract.first";
 
   public static final String ENABLE_TRACE_AGENT_V05 = "trace.agent.v0.5.enabled";
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1191,6 +1191,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     private DDSpan buildSpan() {
+      if (parent instanceof TagContext) {
+        List<AgentSpanLink> terminatedContextLinks =
+            ((TagContext) parent).getTerminatedContextLinks();
+        if (!terminatedContextLinks.isEmpty()) {
+          links.addAll(terminatedContextLinks);
+        }
+      }
       DDSpan span = DDSpan.create(instrumentationName, timestampMicro, buildSpanContext(), links);
       if (span.isLocalRootSpan()) {
         EndpointTracker tracker = tracer.onRootSpanStarted(span);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1191,19 +1191,26 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
 
     private DDSpan buildSpan() {
-      if (parent instanceof TagContext) {
-        List<AgentSpanLink> terminatedContextLinks =
-            ((TagContext) parent).getTerminatedContextLinks();
-        if (!terminatedContextLinks.isEmpty()) {
-          links.addAll(terminatedContextLinks);
-        }
-      }
+      addTerminatedContextAsLinks();
       DDSpan span = DDSpan.create(instrumentationName, timestampMicro, buildSpanContext(), links);
       if (span.isLocalRootSpan()) {
         EndpointTracker tracker = tracer.onRootSpanStarted(span);
         span.setEndpointTracker(tracker);
       }
       return span;
+    }
+
+    private void addTerminatedContextAsLinks() {
+      if (this.parent instanceof TagContext) {
+        List<AgentSpanLink> terminatedContextLinks =
+            ((TagContext) this.parent).getTerminatedContextLinks();
+        if (!terminatedContextLinks.isEmpty()) {
+          if (this.links == null) {
+            this.links = new ArrayList<>();
+          }
+          this.links.addAll(terminatedContextLinks);
+        }
+      }
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/B3HttpCodec.java
@@ -1,5 +1,7 @@
 package datadog.trace.core.propagation;
 
+import static datadog.trace.api.TracePropagationStyle.B3MULTI;
+import static datadog.trace.api.TracePropagationStyle.B3SINGLE;
 import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
 
 import datadog.trace.api.Config;
@@ -7,6 +9,7 @@ import datadog.trace.api.DD128bTraceId;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
@@ -161,7 +164,7 @@ class B3HttpCodec {
     final List<HttpCodec.Extractor> extractors = new ArrayList<>(2);
     extractors.add(newSingleExtractor(config, traceConfigSupplier));
     extractors.add(newMultiExtractor(config, traceConfigSupplier));
-    return new HttpCodec.CompoundExtractor(extractors);
+    return new HttpCodec.CompoundExtractor(extractors, config.isTracePropagationExtractFirst());
   }
 
   public static HttpCodec.Extractor newMultiExtractor(
@@ -210,6 +213,11 @@ class B3HttpCodec {
   private static final class B3MultiContextInterpreter extends B3BaseContextInterpreter {
     private B3MultiContextInterpreter(Config config) {
       super(config);
+    }
+
+    @Override
+    public TracePropagationStyle style() {
+      return B3MULTI;
     }
 
     @Override
@@ -265,6 +273,11 @@ class B3HttpCodec {
   private static final class B3SingleContextInterpreter extends B3BaseContextInterpreter {
     public B3SingleContextInterpreter(Config config) {
       super(config);
+    }
+
+    @Override
+    public TracePropagationStyle style() {
+      return B3SINGLE;
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -17,6 +17,7 @@ import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.propagation.PropagationTags.HeaderType;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
@@ -77,8 +78,7 @@ class DatadogHttpCodec {
       }
 
       // inject x-datadog-tags
-      String datadogTags =
-          context.getPropagationTags().headerValue(PropagationTags.HeaderType.DATADOG);
+      String datadogTags = context.getPropagationTags().headerValue(HeaderType.DATADOG);
       if (datadogTags != null) {
         setter.set(carrier, DATADOG_TAGS_KEY, datadogTags);
       }
@@ -103,12 +103,10 @@ class DatadogHttpCodec {
     private static final int IGNORE = -1;
 
     private final boolean isAwsPropagationEnabled;
-    private final PropagationTags.Factory datadogTagsFactory;
 
     private DatadogContextInterpreter(Config config) {
       super(config);
       isAwsPropagationEnabled = config.isAwsPropagationEnabled();
-      datadogTagsFactory = PropagationTags.factory(config);
     }
 
     @Override
@@ -187,8 +185,7 @@ class DatadogHttpCodec {
                 endToEndStartTime = extractEndToEndStartTime(firstHeaderValue(value));
                 break;
               case DD_TAGS:
-                propagationTags =
-                    datadogTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, value);
+                propagationTags = propagationTagsFactory.fromHeaderValue(HeaderType.DATADOG, value);
                 break;
               case OT_BAGGAGE:
                 {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.propagation;
 
+import static datadog.trace.api.TracePropagationStyle.DATADOG;
 import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
 import static datadog.trace.core.propagation.XRayHttpCodec.XRayContextInterpreter.handleXRayTraceHeader;
 import static datadog.trace.core.propagation.XRayHttpCodec.X_AMZN_TRACE_ID;
@@ -12,6 +13,7 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.core.DDSpanContext;
@@ -107,6 +109,11 @@ class DatadogHttpCodec {
       super(config);
       isAwsPropagationEnabled = config.isAwsPropagationEnabled();
       datadogTagsFactory = PropagationTags.factory(config);
+    }
+
+    @Override
+    public TracePropagationStyle style() {
+      return DATADOG;
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -2,6 +2,7 @@ package datadog.trace.core.propagation;
 
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import java.util.Map;
@@ -20,8 +21,20 @@ public class ExtractedContext extends TagContext {
       final long spanId,
       final int samplingPriority,
       final CharSequence origin,
-      final PropagationTags propagationTags) {
-    this(traceId, spanId, samplingPriority, origin, 0, null, null, null, propagationTags, null);
+      final PropagationTags propagationTags,
+      final TracePropagationStyle propagationStyle) {
+    this(
+        traceId,
+        spanId,
+        samplingPriority,
+        origin,
+        0,
+        null,
+        null,
+        null,
+        propagationTags,
+        null,
+        propagationStyle);
   }
 
   public ExtractedContext(
@@ -34,8 +47,9 @@ public class ExtractedContext extends TagContext {
       final Map<String, String> tags,
       final HttpHeaders httpHeaders,
       final PropagationTags propagationTags,
-      final TraceConfig traceConfig) {
-    super(origin, tags, httpHeaders, baggage, samplingPriority, traceConfig);
+      final TraceConfig traceConfig,
+      final TracePropagationStyle propagationStyle) {
+    super(origin, tags, httpHeaders, baggage, samplingPriority, traceConfig, propagationStyle);
     this.traceId = traceId;
     this.spanId = spanId;
     this.endToEndStartTime = endToEndStartTime;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.propagation;
 
+import static datadog.trace.api.TracePropagationStyle.HAYSTACK;
 import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
 
 import datadog.trace.api.Config;
@@ -7,6 +8,7 @@ import datadog.trace.api.DD64bTraceId;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
@@ -137,6 +139,11 @@ class HaystackHttpCodec {
 
     private HaystackContextInterpreter(Config config) {
       super(config);
+    }
+
+    @Override
+    public TracePropagationStyle style() {
+      return HAYSTACK;
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -189,9 +189,10 @@ public class HttpCodec {
         TagContext extracted = extractor.extract(carrier, getter);
         // Check if context is valid
         if (extracted instanceof ExtractedContext) {
+          ExtractedContext extractedContext = (ExtractedContext) extracted;
           // If no prior valid context, store it as first valid context
           if (context == null) {
-            context = (ExtractedContext) extracted;
+            context = extractedContext;
             // Stop extraction if only extracting first valid context and drop everything else
             if (this.extractFirst) {
               break;
@@ -204,7 +205,9 @@ public class HttpCodec {
               boolean comingFromTraceContext = extracted.getPropagationStyle() == TRACECONTEXT;
               if (comingFromTraceContext) {
                 // Propagate newly extracted W3C tracestate to first valid context
-                // TODO
+                String extractedTracestate =
+                    extractedContext.getPropagationTags().getW3CTracestate();
+                context.getPropagationTags().updateW3CTracestate(extractedTracestate);
               }
             } else {
               // Terminate extracted context and add it as span link

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -8,6 +8,7 @@ import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.core.DDSpanContext;
+import datadog.trace.core.DDSpanLink;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -198,12 +199,17 @@ public class HttpCodec {
           }
           // If another valid context is extracted
           else {
-            boolean comingFromTraceContext = extracted.getPropagationStyle() == TRACECONTEXT;
             boolean traceIdMatches = context.getTraceId().equals(extracted.getTraceId());
-            if (comingFromTraceContext && traceIdMatches) {
-              // Propagate newly extracted W3C tracestate to first valid context
-              // TODO
-              //              context.
+            if (traceIdMatches) {
+              boolean comingFromTraceContext = extracted.getPropagationStyle() == TRACECONTEXT;
+              if (comingFromTraceContext) {
+                // Propagate newly extracted W3C tracestate to first valid context
+                // TODO
+              }
+            } else {
+              // Terminate extracted context and add it as span link
+              context.addTerminatedContextLink(DDSpanLink.from((ExtractedContext) extracted));
+              // TODO Note: Other vendor tracestate will be lost here
             }
           }
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -67,6 +67,20 @@ public abstract class PropagationTags {
   public abstract void updateTraceIdHighOrderBits(long highOrderBits);
 
   /**
+   * Gets the parent span identifier to propagate as tag.
+   *
+   * @return The parent span identifiers (hexadecimal encoded, {@code null} if undefined).
+   */
+  public abstract CharSequence getParentSpanId();
+
+  /**
+   * Updates the parent span identifier to propagate as tag.
+   *
+   * @param parentSpanId The parent span identifier (as an unsigned long, {@code 0} to unset).
+   */
+  public abstract void updateParentSpanId(long parentSpanId);
+
+  /**
    * Constructs a header value that includes valid propagated _dd.p.* tags and possibly a new
    * sampling decision tag _dd.p.dm based on the current state. Returns null if the value length
    * exceeds a configured limit or empty.

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -67,6 +67,22 @@ public abstract class PropagationTags {
   public abstract void updateTraceIdHighOrderBits(long highOrderBits);
 
   /**
+   * Gets the original <a href="https://www.w3.org/TR/trace-context/#tracestate-header">W3C
+   * tracestate header</a> value.
+   *
+   * @return The original W3C tracestate header value.
+   */
+  public abstract String getW3CTracestate();
+
+  /**
+   * Stores the original <a href="https://www.w3.org/TR/trace-context/#tracestate-header">W3C
+   * tracestate header</a> value.
+   *
+   * @param tracestate The original W3C tracestate header value.
+   */
+  public abstract void updateW3CTracestate(String tracestate);
+
+  /**
    * Constructs a header value that includes valid propagated _dd.p.* tags and possibly a new
    * sampling decision tag _dd.p.dm based on the current state. Returns null if the value length
    * exceeds a configured limit or empty.

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -67,20 +67,6 @@ public abstract class PropagationTags {
   public abstract void updateTraceIdHighOrderBits(long highOrderBits);
 
   /**
-   * Gets the parent span identifier to propagate as tag.
-   *
-   * @return The parent span identifiers (hexadecimal encoded, {@code null} if undefined).
-   */
-  public abstract CharSequence getParentSpanId();
-
-  /**
-   * Updates the parent span identifier to propagate as tag.
-   *
-   * @param parentSpanId The parent span identifier (as an unsigned long, {@code 0} to unset).
-   */
-  public abstract void updateParentSpanId(long parentSpanId);
-
-  /**
    * Constructs a header value that includes valid propagated _dd.p.* tags and possibly a new
    * sampling decision tag _dd.p.dm based on the current state. Returns null if the value length
    * exceeds a configured limit or empty.

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
 import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
+import static datadog.trace.core.propagation.PropagationTags.HeaderType.W3C;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -82,7 +83,7 @@ class W3CHttpCodec {
     private <C> void injectTraceState(
         DDSpanContext context, C carrier, AgentPropagation.Setter<C> setter) {
       PropagationTags propagationTags = context.getPropagationTags();
-      String tracestate = propagationTags.headerValue(PropagationTags.HeaderType.W3C);
+      String tracestate = propagationTags.headerValue(W3C);
       if (tracestate != null && !tracestate.isEmpty()) {
         setter.set(carrier, TRACE_STATE_KEY, tracestate);
       }
@@ -116,15 +117,12 @@ class W3CHttpCodec {
     private static final int E2E_START = 3;
     private static final int IGNORE = -1;
 
-    private final PropagationTags.Factory datadogTagsFactory;
-
     // We need to delay handling of the tracestate header until after traceparent
     private String tracestateHeader = null;
     private String traceparentHeader = null;
 
     private W3CContextInterpreter(Config config) {
       super(config);
-      datadogTagsFactory = PropagationTags.factory(config);
     }
 
     @Override
@@ -274,8 +272,8 @@ class W3CHttpCodec {
                 "Found no traceparent header but tracestate header '" + tracestateHeader + "'");
           }
           // Now we know that we have at least a traceparent header
-          parseTraceParentHeader(traceparentHeader, this);
-          parseTraceStateHeader(tracestateHeader, this, datadogTagsFactory);
+          parseTraceParentHeader(traceparentHeader);
+          parseTraceStateHeader(tracestateHeader);
         } catch (RuntimeException e) {
           onlyTagContext();
           log.debug("Exception when building context", e);
@@ -284,7 +282,7 @@ class W3CHttpCodec {
       return super.build();
     }
 
-    static void parseTraceParentHeader(String tp, ContextInterpreter context) {
+    void parseTraceParentHeader(String tp) {
       int length = tp == null ? 0 : tp.length();
       if (length < TRACE_PARENT_LENGTH) {
         throw new IllegalStateException("The length of traceparent '" + tp + "' is too short");
@@ -301,9 +299,9 @@ class W3CHttpCodec {
             "Illegal all zero 64 bit trace id "
                 + tp.substring(TRACE_PARENT_TID_START, TRACE_PARENT_TID_END));
       }
-      context.traceId = traceId;
-      context.spanId = DDSpanId.fromHex(tp, TRACE_PARENT_SID_START, 16, true);
-      if (context.spanId == 0) {
+      this.traceId = traceId;
+      this.spanId = DDSpanId.fromHex(tp, TRACE_PARENT_SID_START, 16, true);
+      if (this.spanId == 0) {
         throw new IllegalStateException(
             "Illegal all zero span id "
                 + tp.substring(TRACE_PARENT_SID_START, TRACE_PARENT_SID_END));
@@ -313,35 +311,34 @@ class W3CHttpCodec {
       }
       long flags = LongStringUtils.parseUnsignedLongHex(tp, TRACE_PARENT_FLAGS_START, 2, true);
       if ((flags & TRACE_PARENT_FLAGS_SAMPLED) != 0) {
-        context.samplingPriority = SAMPLER_KEEP;
+        this.samplingPriority = SAMPLER_KEEP;
       } else {
-        context.samplingPriority = SAMPLER_DROP;
+        this.samplingPriority = SAMPLER_DROP;
       }
     }
 
-    static void parseTraceStateHeader(
-        String ts, ContextInterpreter context, PropagationTags.Factory factory) {
-      if (ts == null || ts.isEmpty()) {
-        context.propagationTags = factory.empty();
+    void parseTraceStateHeader(String tracestate) {
+      if (tracestate == null || tracestate.isEmpty()) {
+        this.propagationTags = this.propagationTagsFactory.empty();
       } else {
-        context.propagationTags = factory.fromHeaderValue(PropagationTags.HeaderType.W3C, ts);
+        this.propagationTags = this.propagationTagsFactory.fromHeaderValue(W3C, tracestate);
       }
-      int ptagsPriority = context.propagationTags.getSamplingPriority();
-      int contextPriority = context.samplingPriority;
+      int ptagsPriority = this.propagationTags.getSamplingPriority();
+      int contextPriority = this.samplingPriority;
       if ((contextPriority == SAMPLER_DROP && ptagsPriority > 0)
           || (contextPriority == SAMPLER_KEEP && ptagsPriority <= 0)
           || ptagsPriority == PrioritySampling.UNSET) {
         // Override Datadog sampling priority with W3C one
-        context.propagationTags.updateTraceSamplingPriority(
+        this.propagationTags.updateTraceSamplingPriority(
             contextPriority, SamplingMechanism.EXTERNAL_OVERRIDE);
       } else {
         // Use more detailed Datadog sampling priority in context
-        context.samplingPriority = ptagsPriority;
+        this.samplingPriority = ptagsPriority;
       }
       // Use the origin
-      context.origin = context.propagationTags.getOrigin();
+      this.origin = this.propagationTags.getOrigin();
       // Ensure TraceId high-order bits match
-      context.propagationTags.updateTraceIdHighOrderBits(context.traceId.toHighOrderLong());
+      this.propagationTags.updateTraceIdHighOrderBits(this.traceId.toHighOrderLong());
     }
 
     private static String trim(String input) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -263,7 +263,7 @@ class W3CHttpCodec {
      */
     @Override
     protected TagContext build() {
-      // If there is neither a traceparent or a tracestate header, then ignore this
+      // If there is neither a traceparent nor a tracestate header, then ignore this
       if (traceparentHeader == null && tracestateHeader == null) {
         onlyTagContext();
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -82,7 +82,6 @@ class W3CHttpCodec {
     private <C> void injectTraceState(
         DDSpanContext context, C carrier, AgentPropagation.Setter<C> setter) {
       PropagationTags propagationTags = context.getPropagationTags();
-      propagationTags.updateParentSpanId(context.getSpanId());
       String tracestate = propagationTags.headerValue(PropagationTags.HeaderType.W3C);
       if (tracestate != null && !tracestate.isEmpty()) {
         setter.set(carrier, TRACE_STATE_KEY, tracestate);

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.propagation;
 
+import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
 import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
@@ -12,6 +13,7 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.internal.util.LongStringUtils;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
@@ -108,6 +110,11 @@ class W3CHttpCodec {
     private W3CContextInterpreter(Config config) {
       super(config);
       datadogTagsFactory = PropagationTags.factory(config);
+    }
+
+    @Override
+    public TracePropagationStyle style() {
+      return TRACECONTEXT;
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/XRayHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/XRayHttpCodec.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.propagation;
 
 import static datadog.trace.api.DDTags.ORIGIN_KEY;
+import static datadog.trace.api.TracePropagationStyle.XRAY;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -12,6 +13,7 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.core.DDSpanContext;
@@ -134,6 +136,11 @@ class XRayHttpCodec {
 
     private XRayContextInterpreter(Config config) {
       super(config);
+    }
+
+    @Override
+    public TracePropagationStyle style() {
+      return XRAY;
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -88,7 +88,15 @@ public class PTagsFactory implements PropagationTags.Factory {
      * of the trace id, wrapped into a {@link TagValue}, <code>null</code> if not set.
      */
     private volatile TagValue traceIdHighOrderBitsHexTagValue;
-
+    /**
+     * The original <a href="https://www.w3.org/TR/trace-context/#tracestate-header">W3C tracestate
+     * header</a> value.
+     */
+    protected volatile String tracestate;
+    /**
+     * The {@link PTagsFactory#PROPAGATION_ERROR_TAG_KEY propagation tag error} value, {@code null
+     * if no error while parsing header}.
+     */
     protected volatile String error;
 
     public PTags(
@@ -290,6 +298,16 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     TagValue getDecisionMakerTagValue() {
       return decisionMakerTagValue;
+    }
+
+    @Override
+    public String getW3CTracestate() {
+      return this.tracestate;
+    }
+
+    @Override
+    public void updateW3CTracestate(String tracestate) {
+      this.tracestate = tracestate;
     }
 
     String getError() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -5,6 +5,7 @@ import static datadog.trace.core.propagation.PropagationTags.HeaderType.W3C;
 import static datadog.trace.core.propagation.ptags.PTagsCodec.DECISION_MAKER_TAG;
 import static datadog.trace.core.propagation.ptags.PTagsCodec.TRACE_ID_TAG;
 
+import datadog.trace.api.DDSpanId;
 import datadog.trace.api.internal.util.LongStringUtils;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
@@ -88,6 +89,10 @@ public class PTagsFactory implements PropagationTags.Factory {
      * of the trace id, wrapped into a {@link TagValue}, <code>null</code> if not set.
      */
     private volatile TagValue traceIdHighOrderBitsHexTagValue;
+    /** The parent span identifier (as an unsigned long, {@code 0}) if not set) */
+    private volatile long parentSpanId;
+    /** The parent span identifier (hexadecimal encoded, {@code null} if not set) */
+    private CharSequence parentSpanIdValue;
 
     protected volatile String error;
 
@@ -202,6 +207,20 @@ public class PTagsFactory implements PropagationTags.Factory {
                 ? null
                 : TagValue.from(LongStringUtils.toHexStringPadded(highOrderBits, 16));
         clearCachedHeader(DATADOG);
+      }
+    }
+
+    @Override
+    public CharSequence getParentSpanId() {
+      return this.parentSpanIdValue;
+    }
+
+    @Override
+    public void updateParentSpanId(long parentSpanId) {
+      if (this.parentSpanId != parentSpanId) {
+        this.parentSpanId = parentSpanId;
+        this.parentSpanIdValue = parentSpanId == 0 ? null : DDSpanId.toHexString(parentSpanId);
+        clearCachedHeader(W3C);
       }
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -5,7 +5,6 @@ import static datadog.trace.core.propagation.PropagationTags.HeaderType.W3C;
 import static datadog.trace.core.propagation.ptags.PTagsCodec.DECISION_MAKER_TAG;
 import static datadog.trace.core.propagation.ptags.PTagsCodec.TRACE_ID_TAG;
 
-import datadog.trace.api.DDSpanId;
 import datadog.trace.api.internal.util.LongStringUtils;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
@@ -89,10 +88,6 @@ public class PTagsFactory implements PropagationTags.Factory {
      * of the trace id, wrapped into a {@link TagValue}, <code>null</code> if not set.
      */
     private volatile TagValue traceIdHighOrderBitsHexTagValue;
-    /** The parent span identifier (as an unsigned long, {@code 0}) if not set) */
-    private volatile long parentSpanId;
-    /** The parent span identifier (hexadecimal encoded, {@code null} if not set) */
-    private CharSequence parentSpanIdValue;
 
     protected volatile String error;
 
@@ -207,20 +202,6 @@ public class PTagsFactory implements PropagationTags.Factory {
                 ? null
                 : TagValue.from(LongStringUtils.toHexStringPadded(highOrderBits, 16));
         clearCachedHeader(DATADOG);
-      }
-    }
-
-    @Override
-    public CharSequence getParentSpanId() {
-      return this.parentSpanIdValue;
-    }
-
-    @Override
-    public void updateParentSpanId(long parentSpanId) {
-      if (this.parentSpanId != parentSpanId) {
-        this.parentSpanId = parentSpanId;
-        this.parentSpanIdValue = parentSpanId == 0 ? null : DDSpanId.toHexString(parentSpanId);
-        clearCachedHeader(W3C);
       }
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -223,15 +223,6 @@ public class W3CPTagsCodec extends PTagsCodec {
         sb.append(origin);
       }
     }
-    // Append parent span (p)
-    CharSequence parentSpanId = ptags.getParentSpanId();
-    if (parentSpanId != null) {
-      if (sb.length() > EMPTY_SIZE) {
-        sb.append(';');
-      }
-      sb.append("p:");
-      sb.append(parentSpanId);
-    }
     return sb.length();
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -205,10 +205,12 @@ public class W3CPTagsCodec extends PTagsCodec {
   @Override
   protected int appendPrefix(StringBuilder sb, PTags ptags) {
     sb.append("dd=");
+    // Append sampling priority (s)
     if (ptags.getSamplingPriority() != PrioritySampling.UNSET) {
       sb.append("s:");
       sb.append(ptags.getSamplingPriority());
     }
+    // Append origin (o)
     CharSequence origin = ptags.getOrigin();
     if (origin != null) {
       if (sb.length() > EMPTY_SIZE) {
@@ -220,6 +222,15 @@ public class W3CPTagsCodec extends PTagsCodec {
       } else {
         sb.append(origin);
       }
+    }
+    // Append parent span (p)
+    CharSequence parentSpanId = ptags.getParentSpanId();
+    if (parentSpanId != null) {
+      if (sb.length() > EMPTY_SIZE) {
+        sb.append(';');
+      }
+      sb.append("p:");
+      sb.append(parentSpanId);
     }
     return sb.length();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -674,7 +674,6 @@ public class W3CPTagsCodec extends PTagsCodec {
     private final int ddMemberStart;
     private final int ddMemberValueEnd;
     private final int maxUnknownSize;
-    private String error;
 
     public W3CPTags(
         PTagsFactory factory,
@@ -694,15 +693,6 @@ public class W3CPTagsCodec extends PTagsCodec {
       this.ddMemberStart = ddMemberStart;
       this.ddMemberValueEnd = ddMemberValueEnd;
       this.maxUnknownSize = maxUnknownSize;
-      this.error = null;
-    }
-
-    @Override
-    String getError() {
-      if (this.error != null) {
-        return this.error;
-      }
-      return super.getError();
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -251,7 +251,6 @@ public class W3CPTagsCodec extends PTagsCodec {
       size = 0;
     }
     // Append all other non-Datadog list-members
-    // TODO we need to ensure that there are only 32 segments including our own :(
     int newSize = cleanUpAndAppendSuffix(sb, ptags, size);
     if (newSize != size) {
       // We don't care about the total size in bytes here, but only the fact that we added something

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -1,5 +1,6 @@
 package datadog.trace.lambda;
 
+import static datadog.trace.api.TracePropagationStyle.DATADOG;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.squareup.moshi.JsonAdapter;
@@ -92,7 +93,12 @@ public class LambdaHandler {
               propagationTagsFactory.fromHeaderValue(
                   PropagationTags.HeaderType.DATADOG, response.headers().get(DATADOG_TAGS_KEY));
           return new ExtractedContext(
-              DDTraceId.from(traceID), DDSpanId.ZERO, samplingPriority, null, propagationTags);
+              DDTraceId.from(traceID),
+              DDSpanId.ZERO,
+              samplingPriority,
+              null,
+              propagationTags,
+              DATADOG);
         } else {
           log.debug(
               "could not find traceID or sampling priority in notifyStartInvocation, not injecting the context");

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -25,6 +25,7 @@ import static datadog.trace.api.DDTags.PID_TAG
 import static datadog.trace.api.DDTags.RUNTIME_ID_TAG
 import static datadog.trace.api.DDTags.THREAD_ID
 import static datadog.trace.api.DDTags.THREAD_NAME
+import static datadog.trace.api.TracePropagationStyle.DATADOG
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class CoreSpanBuilderTest extends DDCoreSpecification {
@@ -335,9 +336,9 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     span.context().propagationTags.headerValue(PropagationTags.HeaderType.DATADOG) == extractedContext.propagationTags.headerValue(PropagationTags.HeaderType.DATADOG)
 
     where:
-    extractedContext                                                                                                                                                                                                                | _
-    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value"), null) | _
-    new ExtractedContext(DDTraceId.from(3), 4, PrioritySampling.SAMPLER_KEEP, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"], null, PropagationTags.factory().empty(), null)                     | _
+    extractedContext                                                                                                                                                                                                                         | _
+    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, null, 0, [:], [:], null, PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value"), null, DATADOG) | _
+    new ExtractedContext(DDTraceId.from(3), 4, PrioritySampling.SAMPLER_KEEP, "some-origin", 0, ["asdf": "qwer"], [(ORIGIN_KEY): "some-origin", "zxcv": "1234"], null, PropagationTags.factory().empty(), null, DATADOG)                     | _
   }
 
   def "TagContext should populate default span details"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextPropagationTagsTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.core.propagation.ExtractedContext
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
 
+import static datadog.trace.api.TracePropagationStyle.DATADOG
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 
@@ -23,7 +24,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     setup:
     tracer = tracerBuilder().writer(writer).build()
     def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags)
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags, DATADOG)
       .withRequestContextDataAppSec("dummy")
     def span = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
@@ -52,7 +53,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     setup:
     tracer = tracerBuilder().writer(writer).build()
     def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags)
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags, DATADOG)
       .withRequestContextDataAppSec("dummy")
     def rootSpan = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
@@ -82,7 +83,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     setup:
     tracer = tracerBuilder().writer(writer).build()
     def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags)
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags, DATADOG)
       .withRequestContextDataAppSec("dummy")
     def span = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)
@@ -109,7 +110,7 @@ class DDSpanContextPropagationTagsTest extends DDCoreSpecification {
     setup:
     tracer = tracerBuilder().writer(writer).build()
     def propagationTags = tracer.propagationTagsFactory.fromHeaderValue(PropagationTags.HeaderType.DATADOG, header)
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags)
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, priority, "789", propagationTags, DATADOG)
       .withRequestContextDataAppSec("dummy")
     def rootSpan = (DDSpan) tracer.buildSpan("top")
       .asChildOf((AgentSpan.Context) extracted)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -9,6 +9,7 @@ import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.propagation.ExtractedContext
 import datadog.trace.core.test.DDCoreSpecification
 
+import static datadog.trace.api.TracePropagationStyle.DATADOG
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
 import static datadog.trace.core.DDSpanContext.SPAN_SAMPLING_MECHANISM_TAG
@@ -181,7 +182,7 @@ class DDSpanContextTest extends DDCoreSpecification {
 
   def "set TraceSegment tags and data on correct span"() {
     setup:
-    def extracted = new ExtractedContext(DDTraceId.from(123), 456, SAMPLER_KEEP, "789", tracer.getPropagationTagsFactory().empty())
+    def extracted = new ExtractedContext(DDTraceId.from(123), 456, SAMPLER_KEEP, "789", tracer.getPropagationTagsFactory().empty(), DATADOG)
       .withRequestContextDataAppSec("dummy")
 
     def top = tracer.buildSpan("top").asChildOf((AgentSpan.Context) extracted).start()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanTest.groovy
@@ -18,6 +18,7 @@ import spock.lang.Shared
 
 import java.util.concurrent.TimeUnit
 
+import static datadog.trace.api.TracePropagationStyle.DATADOG
 import static datadog.trace.api.sampling.PrioritySampling.UNSET
 import static datadog.trace.api.sampling.SamplingMechanism.SPAN_SAMPLING_RATE
 import static datadog.trace.core.DDSpanContext.SPAN_SAMPLING_MAX_PER_SECOND_TAG
@@ -272,9 +273,9 @@ class DDSpanTest extends DDCoreSpecification {
     child.@origin == null // Access field directly instead of getter.
 
     where:
-    extractedContext                                                                                                                           | _
-    new TagContext("some-origin", [:])                                                                                                         | _
-    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, "some-origin", propagationTagsFactory.empty()) | _
+    extractedContext                                                                                                              | _
+    new TagContext("some-origin", [:])                                                                                            | _
+    new ExtractedContext(DDTraceId.ONE, 2, PrioritySampling.SAMPLER_DROP, "some-origin", propagationTagsFactory.empty(), DATADOG) | _
   }
 
   def "isRootSpan() in and not in the context of distributed tracing"() {
@@ -291,9 +292,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                                                                                        | isTraceRootSpan
-    null                                                                                                                                    | true
-    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", propagationTagsFactory.empty()) | false
+    extractedContext                                                                                                              | isTraceRootSpan
+    null                                                                                                                          | true
+    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", propagationTagsFactory.empty(), DATADOG) | false
   }
 
   def "getApplicationRootSpan() in and not in the context of distributed tracing"() {
@@ -313,9 +314,9 @@ class DDSpanTest extends DDCoreSpecification {
     root.finish()
 
     where:
-    extractedContext                                                                                                                          | isTraceRootSpan
-    null                                                                                                                                      | true
-    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", propagationTagsFactory.empty()) | false
+    extractedContext                                                                                                              | isTraceRootSpan
+    null                                                                                                                          | true
+    new ExtractedContext(DDTraceId.from(123), 456, PrioritySampling.SAMPLER_KEEP, "789", propagationTagsFactory.empty(), DATADOG) | false
   }
 
   def 'publishing of root span closes the request context data'() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/DefaultPathwayContextTest.groovy
@@ -16,6 +16,7 @@ import datadog.trace.core.test.DDCoreSpecification
 
 import java.util.function.Consumer
 
+import static datadog.trace.api.TracePropagationStyle.DATADOG
 import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG
 import static datadog.trace.core.datastreams.DefaultDataStreamsMonitoring.DEFAULT_BUCKET_DURATION_NANOS
 import static java.util.concurrent.TimeUnit.MILLISECONDS
@@ -717,7 +718,7 @@ class DefaultPathwayContextTest extends DDCoreSpecification {
 
     @Override
     <C> TagContext extract(C carrier, AgentPropagation.ContextVisitor<C> getter) {
-      return new ExtractedContext(DDTraceId.ONE, 1, 0, null, 0, null, null, null, null, traceConfig )
+      return new ExtractedContext(DDTraceId.ONE, 1, 0, null, 0, null, null, null, null, traceConfig, DATADOG)
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/B3HttpExtractorTest.groovy
@@ -293,7 +293,8 @@ class B3HttpExtractorTest extends DDSpecification {
     TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
 
     then:
-    context == null
+    !(context instanceof ExtractedContext)
+    context.getTags() == ["some-tag": "my-interesting-info"]
   }
 
   def "extract http headers with out of range span ID"() {
@@ -304,12 +305,12 @@ class B3HttpExtractorTest extends DDSpecification {
       SOME_HEADER                 : "my-interesting-info",
     ]
 
-
     when:
     TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
 
     then:
-    context == null
+    !(context instanceof ExtractedContext)
+    context.getTags() == ["some-tag": "my-interesting-info"]
   }
 
   def "extract ids while retaining the original string"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CHttpInjectorTest.groovy
@@ -47,17 +47,15 @@ class W3CHttpInjectorTest extends DDCoreSpecification {
       null,
       NoopPathwayContext.INSTANCE,
       false,
-      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, tracestate ? "_dd.p.usr=123" : ""))
+      PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.usr=123"))
     final Map<String, String> carrier = [:]
     Map<String, String> expected = [
-      (TRACE_PARENT_KEY): buildTraceParent(traceId, spanId, samplingPriority),
+      (TRACE_PARENT_KEY)        : buildTraceParent(traceId, spanId, samplingPriority),
       (OT_BAGGAGE_PREFIX + "k1"): "v1",
       (OT_BAGGAGE_PREFIX + "k2"): "v2",
-      "SOME_CUSTOM_HEADER": "some-value"
+      "SOME_CUSTOM_HEADER"      : "some-value",
+      (TRACE_STATE_KEY)         : tracestate
     ]
-    if (tracestate) {
-      expected.put(TRACE_STATE_KEY, tracestate)
-    }
 
     when:
     injector.inject(mockedContext, carrier, MapSetter.INSTANCE)
@@ -70,11 +68,11 @@ class W3CHttpInjectorTest extends DDCoreSpecification {
 
     where:
     traceId               | spanId                | samplingPriority | origin   | tracestate
-    "1"                   | "2"                   | UNSET            | null     | null
-    "1"                   | "2"                   | SAMPLER_KEEP     | "saipan" | "dd=s:1;o:saipan;t.usr:123"
-    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | UNSET            | "saipan" | "dd=o:saipan;t.usr:123"
-    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_KEEP     | null     | "dd=s:1;t.usr:123"
-    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_DROP     | null     | "dd=s:0;t.usr:123"
+    "1"                   | "2"                   | UNSET            | null     | "dd=p:2;t.usr:123"
+    "1"                   | "2"                   | SAMPLER_KEEP     | "saipan" | "dd=s:1;o:saipan;p:2;t.usr:123"
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | UNSET            | "saipan" | "dd=o:saipan;p:fffffffffffffffe;t.usr:123"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_KEEP     | null     | "dd=s:1;p:ffffffffffffffff;t.usr:123"
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | SAMPLER_DROP     | null     | "dd=s:0;p:ffffffffffffffff;t.usr:123"
   }
 
   def "inject http headers with end-to-end"() {
@@ -113,7 +111,7 @@ class W3CHttpInjectorTest extends DDCoreSpecification {
     then:
     carrier == [
       (TRACE_PARENT_KEY): buildTraceParent('1', '2', UNSET),
-      (TRACE_STATE_KEY): "dd=o:fakeOrigin;t.dm:-4;t.anytag:value",
+      (TRACE_STATE_KEY): "dd=o:fakeOrigin;p:2;t.dm:-4;t.anytag:value",
       (OT_BAGGAGE_PREFIX + "t0"): "${(long) (mockedContext.endToEndStartTime / 1000000L)}",
       (OT_BAGGAGE_PREFIX + "k1"): "v1",
       (OT_BAGGAGE_PREFIX + "k2"): "v2",
@@ -159,7 +157,7 @@ class W3CHttpInjectorTest extends DDCoreSpecification {
     then:
     carrier == [
       (TRACE_PARENT_KEY): buildTraceParent('1', '2', USER_KEEP),
-      (TRACE_STATE_KEY): "dd=s:2;o:fakeOrigin;t.dm:-4",
+      (TRACE_STATE_KEY): "dd=s:2;o:fakeOrigin;p:2;t.dm:-4",
       (OT_BAGGAGE_PREFIX + "k1"): "v1",
       (OT_BAGGAGE_PREFIX + "k2"): "v2",
     ]

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -104,6 +104,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_V05_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANALYTICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_PROPAGATION_EXTRACT_FIRST;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_PROPAGATION_STYLE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_REPORT_HOSTNAME;
@@ -391,6 +392,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOU
 import static datadog.trace.api.config.TracerConfig.TRACE_PEER_SERVICE_COMPONENT_OVERRIDES;
 import static datadog.trace.api.config.TracerConfig.TRACE_PEER_SERVICE_DEFAULTS_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_PEER_SERVICE_MAPPING;
+import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_EXTRACT_FIRST;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT;
 import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_STYLE_INJECT;
@@ -576,6 +578,7 @@ public class Config {
   private final boolean tracePropagationStyleB3PaddingEnabled;
   private final Set<TracePropagationStyle> tracePropagationStylesToExtract;
   private final Set<TracePropagationStyle> tracePropagationStylesToInject;
+  private final boolean tracePropagationExtractFirst;
   private final int clockSyncPeriod;
   private final boolean logsInjectionEnabled;
 
@@ -1250,6 +1253,10 @@ public class Config {
       propagationStylesToInject =
           deprecatedInject.isEmpty() ? DEFAULT_PROPAGATION_STYLE : deprecatedInject;
     }
+
+    tracePropagationExtractFirst =
+        configProvider.getBoolean(
+            TRACE_PROPAGATION_EXTRACT_FIRST, DEFAULT_TRACE_PROPAGATION_EXTRACT_FIRST);
 
     clockSyncPeriod = configProvider.getInteger(CLOCK_SYNC_PERIOD, DEFAULT_CLOCK_SYNC_PERIOD);
 
@@ -2146,6 +2153,10 @@ public class Config {
 
   public Set<TracePropagationStyle> getTracePropagationStylesToInject() {
     return tracePropagationStylesToInject;
+  }
+
+  public boolean isTracePropagationExtractFirst() {
+    return tracePropagationExtractFirst;
   }
 
   public int getClockSyncPeriod() {
@@ -3825,6 +3836,8 @@ public class Config {
         + tracePropagationStylesToExtract
         + ", tracePropagationStylesToInject="
         + tracePropagationStylesToInject
+        + ", tracePropagationExtractFirst="
+        + tracePropagationExtractFirst
         + ", clockSyncPeriod="
         + clockSyncPeriod
         + ", jmxFetchEnabled="

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -6,6 +6,7 @@ import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.sampling.PrioritySampling;
+import java.util.List;
 import java.util.Map;
 
 public interface AgentSpan extends MutableSpan, IGSpanInfo {
@@ -178,6 +179,13 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
     default void mergePathwayContext(PathwayContext pathwayContext) {}
 
     interface Extracted extends Context {
+      /**
+       * Gets the span links related to the other terminated context.
+       *
+       * @return The span links to other extracted contexts found but terminated.
+       */
+      List<AgentSpanLink> getTerminatedContextLinks();
+
       String getForwarded();
 
       String getFastlyClientIp();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
+import static java.util.Collections.emptyList;
 
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
@@ -25,6 +26,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -915,12 +917,17 @@ public class AgentTracer {
 
     @Override
     public Iterable<Map.Entry<String, String>> baggageItems() {
-      return Collections.emptyList();
+      return emptyList();
     }
 
     @Override
     public PathwayContext getPathwayContext() {
       return NoopPathwayContext.INSTANCE;
+    }
+
+    @Override
+    public List<AgentSpanLink> getTerminatedContextLinks() {
+      return emptyList();
     }
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -1,8 +1,11 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
+import static datadog.trace.api.TracePropagationStyle.NONE;
+
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.sampling.PrioritySampling;
 import java.util.Collections;
 import java.util.Map;
@@ -25,13 +28,14 @@ public class TagContext implements AgentSpan.Context.Extracted {
   private final Map<String, String> baggage;
   private final int samplingPriority;
   private final TraceConfig traceConfig;
+  private final TracePropagationStyle propagationStyle;
 
   public TagContext() {
     this(null, null);
   }
 
   public TagContext(final String origin, final Map<String, String> tags) {
-    this(origin, tags, null, null, PrioritySampling.UNSET, null);
+    this(origin, tags, null, null, PrioritySampling.UNSET, null, NONE);
   }
 
   public TagContext(
@@ -40,17 +44,23 @@ public class TagContext implements AgentSpan.Context.Extracted {
       final HttpHeaders httpHeaders,
       final Map<String, String> baggage,
       final int samplingPriority,
-      final TraceConfig traceConfig) {
+      final TraceConfig traceConfig,
+      final TracePropagationStyle propagationStyle) {
     this.origin = origin;
     this.tags = tags;
     this.httpHeaders = httpHeaders == null ? EMPTY_HTTP_HEADERS : httpHeaders;
     this.baggage = baggage == null ? Collections.emptyMap() : baggage;
     this.samplingPriority = samplingPriority;
     this.traceConfig = traceConfig;
+    this.propagationStyle = propagationStyle;
   }
 
   public TraceConfig getTraceConfig() {
     return traceConfig;
+  }
+
+  public TracePropagationStyle getPropagationStyle() {
+    return this.propagationStyle;
   }
 
   public final CharSequence getOrigin() {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/TagContext.java
@@ -1,13 +1,16 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import static datadog.trace.api.TracePropagationStyle.NONE;
+import static java.util.Collections.emptyList;
 
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.sampling.PrioritySampling;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -20,6 +23,7 @@ public class TagContext implements AgentSpan.Context.Extracted {
 
   private final CharSequence origin;
   private final Map<String, String> tags;
+  private List<AgentSpanLink> terminatedContextLinks;
   private Object requestContextDataAppSec;
   private Object requestContextDataIast;
   private Object ciVisibilityContextData;
@@ -48,6 +52,7 @@ public class TagContext implements AgentSpan.Context.Extracted {
       final TracePropagationStyle propagationStyle) {
     this.origin = origin;
     this.tags = tags;
+    this.terminatedContextLinks = null;
     this.httpHeaders = httpHeaders == null ? EMPTY_HTTP_HEADERS : httpHeaders;
     this.baggage = baggage == null ? Collections.emptyMap() : baggage;
     this.samplingPriority = samplingPriority;
@@ -65,6 +70,18 @@ public class TagContext implements AgentSpan.Context.Extracted {
 
   public final CharSequence getOrigin() {
     return origin;
+  }
+
+  @Override
+  public List<AgentSpanLink> getTerminatedContextLinks() {
+    return this.terminatedContextLinks == null ? emptyList() : this.terminatedContextLinks;
+  }
+
+  public void addTerminatedContextLink(AgentSpanLink link) {
+    if (this.terminatedContextLinks == null) {
+      this.terminatedContextLinks = new ArrayList<>();
+    }
+    this.terminatedContextLinks.add(link);
   }
 
   @Override

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -114,6 +114,7 @@ import static datadog.trace.api.config.TracerConfig.SPAN_TAGS
 import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS
 import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PORT
 import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_URL
+import static datadog.trace.api.config.TracerConfig.TRACE_PROPAGATION_EXTRACT_FIRST
 import static datadog.trace.api.config.TracerConfig.TRACE_RATE_LIMIT
 import static datadog.trace.api.config.TracerConfig.TRACE_REPORT_HOSTNAME
 import static datadog.trace.api.config.TracerConfig.TRACE_RESOLVER_ENABLED
@@ -145,6 +146,7 @@ class ConfigTest extends DDSpecification {
   private static final DD_JMX_TAGS_ENV = "DD_TRACE_JMX_TAGS"
   private static final DD_PROPAGATION_STYLE_EXTRACT = "DD_PROPAGATION_STYLE_EXTRACT"
   private static final DD_PROPAGATION_STYLE_INJECT = "DD_PROPAGATION_STYLE_INJECT"
+  private static final DD_TRACE_PROPAGATION_EXTRACT_FIRST = "DD_TRACE_PROPAGATION_EXTRACT_FIRST"
   private static final DD_JMXFETCH_METRICS_CONFIGS_ENV = "DD_JMXFETCH_METRICS_CONFIGS"
   private static final DD_TRACE_AGENT_PORT_ENV = "DD_TRACE_AGENT_PORT"
   private static final DD_AGENT_PORT_LEGACY_ENV = "DD_AGENT_PORT"
@@ -191,6 +193,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(RUNTIME_CONTEXT_FIELD_INJECTION, "false")
     prop.setProperty(PROPAGATION_STYLE_EXTRACT, "Datadog, B3")
     prop.setProperty(PROPAGATION_STYLE_INJECT, "B3, Datadog")
+    prop.setProperty(TRACE_PROPAGATION_EXTRACT_FIRST, "false")
     prop.setProperty(JMX_FETCH_ENABLED, "false")
     prop.setProperty(JMX_FETCH_METRICS_CONFIGS, "/foo.yaml,/bar.yaml")
     prop.setProperty(JMX_FETCH_CHECK_PERIOD, "100")
@@ -279,6 +282,7 @@ class ConfigTest extends DDSpecification {
     config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.tracePropagationStylesToExtract.toList() == [DATADOG, B3SINGLE, B3MULTI]
     config.tracePropagationStylesToInject.toList() == [B3SINGLE, B3MULTI, DATADOG]
+    config.tracePropagationExtractFirst == false
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -368,6 +372,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + RUNTIME_CONTEXT_FIELD_INJECTION, "false")
     System.setProperty(PREFIX + PROPAGATION_STYLE_EXTRACT, "Datadog, B3")
     System.setProperty(PREFIX + PROPAGATION_STYLE_INJECT, "B3, Datadog")
+    System.setProperty(PREFIX + TRACE_PROPAGATION_EXTRACT_FIRST, "false")
     System.setProperty(PREFIX + JMX_FETCH_ENABLED, "false")
     System.setProperty(PREFIX + JMX_FETCH_METRICS_CONFIGS, "/foo.yaml,/bar.yaml")
     System.setProperty(PREFIX + JMX_FETCH_CHECK_PERIOD, "100")
@@ -456,6 +461,7 @@ class ConfigTest extends DDSpecification {
     config.propagationStylesToInject.toList() == [PropagationStyle.B3, PropagationStyle.DATADOG]
     config.tracePropagationStylesToExtract.toList() == [DATADOG, B3SINGLE, B3MULTI]
     config.tracePropagationStylesToInject.toList() == [B3SINGLE, B3MULTI, DATADOG]
+    config.tracePropagationExtractFirst == false
     config.jmxFetchEnabled == false
     config.jmxFetchMetricsConfigs == ["/foo.yaml", "/bar.yaml"]
     config.jmxFetchCheckPeriod == 100
@@ -522,6 +528,7 @@ class ConfigTest extends DDSpecification {
     environmentVariables.set(DD_PRIORITIZATION_TYPE_ENV, "EnsureTrace")
     environmentVariables.set(DD_PROPAGATION_STYLE_EXTRACT, "B3 Datadog")
     environmentVariables.set(DD_PROPAGATION_STYLE_INJECT, "Datadog B3")
+    environmentVariables.set(DD_TRACE_PROPAGATION_EXTRACT_FIRST, "false")
     environmentVariables.set(DD_JMXFETCH_METRICS_CONFIGS_ENV, "some/file")
     environmentVariables.set(DD_TRACE_REPORT_HOSTNAME, "true")
     environmentVariables.set(DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH, "42")
@@ -540,6 +547,7 @@ class ConfigTest extends DDSpecification {
     config.propagationStylesToInject.toList() == [PropagationStyle.DATADOG, PropagationStyle.B3]
     config.tracePropagationStylesToExtract.toList() == [B3SINGLE, B3MULTI, DATADOG]
     config.tracePropagationStylesToInject.toList() == [DATADOG, B3SINGLE, B3MULTI]
+    config.tracePropagationExtractFirst == false
     config.jmxFetchMetricsConfigs == ["some/file"]
     config.reportHostName == true
     config.xDatadogTagsMaxLength == 42


### PR DESCRIPTION
# What Does This Do

* Extract multiple propagated context according the new W3C trace context initiative,
* Add `DD_TRACE_PROPAGATION_EXTRACT_FIRST` configuration to limit to the first valid one,
* Propagate W3C tracestate if matches the extracted context, even if not a Datadog one,
* Add span links of terminated contexts (terminated but not matching).

# Motivation

This will improve W3C tracecontext standard compatibility.
W3C trace state will be extracted from W3C extracted context even using Datadog headers. 

# Additional Notes

An addition PR is coming to documentation repository for the new configuration key and behavior change.

Jira tickets:
* [APMJAVA-1123]
* [APMJAVA-1088]

Few comments that might help reviewing:
* Context interpreters are now aware of the propagation style --> Required to handle specific W3C behavior
* Same for extracted context --> Add a new parameter to constructor. I did not want to create another overloaded constructor as the constructor was not call that often (it mostly impacts tests and I am fine with updating them rather than creating multiple constructors that would make the code harder to read)
* The new extract first trace context logic will only impact the `CompoundExtractor` --> The RFC has a diagram to help understand the expected behavior. I tried to comment it the most possible for futur maintainability. 
* W3C tracestate is added to PTags --> It should now be supported whatever the main propagation style, not only W3C. So `original` from W3CPTags was removed in favor of the new generic field.
* W3CPtagsCodec now supports PTags (not only W3CPTags) for tracestate injection. --> I also add the 32 member limit check, with and without dd member presence. 
* W3CPTagsCodec now use the generic error field for inconsistent trace id --> I removed logic override to rely on the parent field
* B3 extractor test are fixed --> They failed to extract partial tag content when trace id is invalid.  
* Moved propagation tags factory to the parent `ContextInterpreter` and make sure PTags are always defined (empty at least) --> PTags factory was the same for all context interpreter using it. Moving it to parent allow to make empty initialization if not done by the child interpreter. It does not introduce performance overhead as PTags will always be creating when creating a span from an extracted context (even an empty instance). Creating it at `ExtractedContext` level ensure we can propagate `tracestate` in `CompoundExtractor`. 

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1123]: https://datadoghq.atlassian.net/browse/APMJAVA-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APMJAVA-1088]: https://datadoghq.atlassian.net/browse/APMJAVA-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ