### PR TITLE
Fix CI Visibility to work with DD Admission Controller

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -39,10 +39,15 @@ public class SharedCommunicationObjects {
       String namedPipe = config.getAgentNamedPipe();
       okHttpClient =
           OkHttpUtils.buildHttpClient(
-              agentUrl,
-              unixDomainSocket,
-              namedPipe,
-              TimeUnit.SECONDS.toMillis(config.getAgentTimeout()));
+              agentUrl, unixDomainSocket, namedPipe, getHttpClientTimeout(config));
+    }
+  }
+
+  private static long getHttpClientTimeout(Config config) {
+    if (!config.isCiVisibilityEnabled() || !config.isCiVisibilityAgentlessEnabled()) {
+      return TimeUnit.SECONDS.toMillis(config.getAgentTimeout());
+    } else {
+      return config.getCiVisibilityBackendApiTimeoutMillis();
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -74,6 +74,8 @@ public class CiVisibilitySystem {
       return;
     }
 
+    sco.createRemaining(config);
+
     GitClient.Factory gitClientFactory = buildGitClientFactory(config);
     CoverageProbeStoreFactory coverageProbeStoreFactory = buildTestProbesFactory(config);
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/EvpProxyApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/EvpProxyApi.java
@@ -26,10 +26,10 @@ public class EvpProxyApi implements BackendApi {
   private final OkHttpClient httpClient;
 
   public EvpProxyApi(
-      HttpUrl evpProxyUrl, long timeoutMillis, HttpRetryPolicy.Factory retryPolicyFactory) {
+      HttpUrl evpProxyUrl, HttpRetryPolicy.Factory retryPolicyFactory, OkHttpClient httpClient) {
     this.evpProxyUrl = evpProxyUrl.resolve(String.format("api/%s/", API_VERSION));
     this.retryPolicyFactory = retryPolicyFactory;
-    httpClient = OkHttpUtils.buildHttpClient(evpProxyUrl, timeoutMillis);
+    this.httpClient = httpClient;
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
@@ -2,12 +2,14 @@ package datadog.trace.civisibility.config
 
 import com.squareup.moshi.Moshi
 import datadog.communication.http.HttpRetryPolicy
+import datadog.communication.http.OkHttpUtils
 import datadog.trace.agent.test.server.http.TestHttpServer
 import datadog.trace.api.civisibility.config.Configurations
 import datadog.trace.api.civisibility.config.SkippableTest
 import datadog.trace.civisibility.communication.BackendApi
 import datadog.trace.civisibility.communication.EvpProxyApi
 import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -135,7 +137,8 @@ class ConfigurationApiImplTest extends Specification {
   private BackendApi givenEvpProxy() {
     HttpUrl proxyUrl = HttpUrl.get(intakeServer.address)
     HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0)
-    return new EvpProxyApi(proxyUrl, REQUEST_TIMEOUT_MILLIS, retryPolicyFactory)
+    OkHttpClient client = OkHttpUtils.buildHttpClient(proxyUrl, REQUEST_TIMEOUT_MILLIS)
+    return new EvpProxyApi(proxyUrl, retryPolicyFactory, client)
   }
 
   private static TracerEnvironment givenTracerEnvironment() {

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataApiTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataApiTest.groovy
@@ -2,11 +2,13 @@ package datadog.trace.civisibility.git.tree
 
 import com.squareup.moshi.Moshi
 import datadog.communication.http.HttpRetryPolicy
+import datadog.communication.http.OkHttpUtils
 import datadog.trace.agent.test.server.http.TestHttpServer
 import datadog.trace.civisibility.communication.BackendApi
 import datadog.trace.civisibility.communication.EvpProxyApi
 import datadog.trace.test.util.MultipartRequestParser
 import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
@@ -114,7 +116,8 @@ class GitDataApiTest extends Specification {
   private BackendApi givenEvpProxy() {
     HttpUrl proxyUrl = HttpUrl.get(intakeServer.address)
     HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0)
-    return new EvpProxyApi(proxyUrl, REQUEST_TIMEOUT_MILLIS, retryPolicyFactory)
+    OkHttpClient client = OkHttpUtils.buildHttpClient(proxyUrl, REQUEST_TIMEOUT_MILLIS)
+    return new EvpProxyApi(proxyUrl, retryPolicyFactory, client)
   }
 
   private Path givenPackFile() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -164,6 +164,7 @@ public class WriterFactory {
       TrackType trackType) {
     if (featuresDiscovery.supportsEvpProxy() && !config.isCiVisibilityAgentlessEnabled()) {
       return DDEvpProxyApi.builder()
+          .httpClient(commObjects.okHttpClient)
           .agentUrl(commObjects.agentUrl)
           .evpProxyEndpoint(featuresDiscovery.getEvpProxyEndpoint())
           .trackType(trackType)

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDEvpProxyApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDEvpProxyApi.java
@@ -64,7 +64,7 @@ public class DDEvpProxyApi extends RemoteApi {
       return this;
     }
 
-    DDEvpProxyApiBuilder httpClient(final OkHttpClient httpClient) {
+    public DDEvpProxyApiBuilder httpClient(final OkHttpClient httpClient) {
       this.httpClient = httpClient;
       return this;
     }


### PR DESCRIPTION
# What Does This Do
Fixes CI Visibility to work correctly in Kubernetes setups where tracer is injected automatically by Datadog Admission Controller.

# Motivation
Using Datadog Admission Controller is much easier for the customers than injecting the tracer manually in a containerised environment.
It should work correctly with CI Visibility.

# Additional Notes
Admission Controller, among other things, creates a volume and mounts it both to the agent containers and to the application containers. In the volume there is a Unix domain socket. Instrumented applications write to this socket, and the agent reads from it.
The tracer logic responsible for discovering the socket is in `datadog.common.socket.SocketUtils#discoverApmSocket`.
`datadog.communication.ddagent.SharedCommunicationObjects` handles socket detection transparently for the rest of the tracer.
Whenever CI Visibility uses EVP Proxy, it should utilise HTTP client created by the `SharedCommunicationObjects`.

Jira ticket: [CIVIS-7888]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-7888]: https://datadoghq.atlassian.net/browse/CIVIS-7888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ