### PR TITLE
Fix NPE in @setup calls when tracing Karate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@ dd-java-agent/instrumentation/cucumber/    @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/jacoco/      @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/junit-4.10/  @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/junit-5.3/   @DataDog/ci-app-libraries-java
+dd-java-agent/instrumentation/karate/      @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/testng/      @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/gradle/      @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/maven-3.2.1/ @DataDog/ci-app-libraries-java

--- a/dd-java-agent/instrumentation/karate/src/test/groovy/KarateTest.groovy
+++ b/dd-java-agent/instrumentation/karate/src/test/groovy/KarateTest.groovy
@@ -53,7 +53,7 @@ class KarateTest extends CiVisibilityTest {
 
   def "test scenarios with setup generate spans"() {
     given:
-    Assumptions.assumeTrue(FileUtils.KARATE_VERSION >= "1.3.0","Current Karate version is ${FileUtils.KARATE_VERSION}, while @setup tags are supported starting with 1.3.0")
+    Assumptions.assumeTrue(isSetupTagSupported(FileUtils.KARATE_VERSION),"Current Karate version is ${FileUtils.KARATE_VERSION}, while @setup tags are supported starting with 1.3.0")
 
     when:
     runTests(TestWithSetupKarate)
@@ -333,5 +333,9 @@ class KarateTest extends CiVisibilityTest {
   boolean isSkippingSupported(String frameworkVersion) {
     // earlier Karate version contain a bug that does not allow skipping scenarios
     frameworkVersion >= "1.2.0"
+  }
+
+  boolean isSetupTagSupported(String frameworkVersion) {
+    frameworkVersion >= "1.3.0"
   }
 }

--- a/dd-java-agent/instrumentation/karate/src/test/java/org/example/TestWithSetupKarate.java
+++ b/dd-java-agent/instrumentation/karate/src/test/java/org/example/TestWithSetupKarate.java
@@ -1,0 +1,11 @@
+package org.example;
+
+import com.intuit.karate.junit5.Karate;
+
+public class TestWithSetupKarate {
+
+  @Karate.Test
+  public Karate testSucceed() {
+    return Karate.run("classpath:org/example/test_with_setup.feature");
+  }
+}

--- a/dd-java-agent/instrumentation/karate/src/test/java/org/example/karate-config.js
+++ b/dd-java-agent/instrumentation/karate/src/test/java/org/example/karate-config.js
@@ -1,0 +1,2 @@
+function fn() {
+}

--- a/dd-java-agent/instrumentation/karate/src/test/java/org/example/test_with_setup.feature
+++ b/dd-java-agent/instrumentation/karate/src/test/java/org/example/test_with_setup.feature
@@ -1,0 +1,27 @@
+Feature: test with setup
+
+  @setup
+  Scenario: setup scenario
+    * call read('@setupStep')
+    * def data =
+    """
+    [
+     {foo: "bar"}
+    ]
+    """
+
+  @withSetup
+  Scenario Outline: first scenario
+    * print foo
+    Examples:
+      | karate.setup().data |
+
+  @withSetupOnce
+  Scenario Outline: second scenario
+    * print foo
+    Examples:
+      | karate.setupOnce().data |
+
+  @ignore @setupStep
+  Scenario: setup step
+    * print 'test'


### PR DESCRIPTION
# What Does This Do
Fixes `NullPointerException` when Karate tests with `@setup` blocks are instrumented.

# Motivation
This is a bug that breaks test runs.

# Additional Notes
`@setup` is a special tag in Karate that can be used to mark a scenario that is a part of another scenario's setup.
The problem for CI Visibility is that `beforeScenario` and `afterScenario` events for these setup blocks are fired before events that demarcate the start of their "parent" scenario and feature.

"Manually" reconstructing feature starts for these setup scenarios is error-prone, besides we do not want to report them as separate tests (given that they aren't tests), so for now the decision is to not track them.

Jira ticket: [CIVIS-7898]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-7898]: https://datadoghq.atlassian.net/browse/CIVIS-7898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ