### PR TITLE
Fix forked JVM args duplication when auto-configuring Gradle test tasks

### DIFF
--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleProjectConfigurator.groovy
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleProjectConfigurator.groovy
@@ -75,7 +75,9 @@ class GradleProjectConfigurator {
 
     jvmArgs.add("-javaagent:" + config.ciVisibilityAgentJarFile.toPath())
 
-    task.jvmArgs(jvmArgs)
+    // be sure to use setJvmArgs() and not jvmArgs()
+    // as the latter will add the arguments rather than replacing them
+    task.setJvmArgs(jvmArgs)
   }
 
   private static final Pattern PROJECT_PROPERTY_REFERENCE = Pattern.compile("\\\$\\{([^}]+)\\}")


### PR DESCRIPTION
# What Does This Do
Fixes Gradle test tasks configurator: to run the forked JVM with the tracer, it modifies JVM arguments of Gradle test tasks.
It did so by calling `Test.jvmArgs()`,  which appended the new arguments to the existing ones.
Since the compiled list of arguments already contains the existing ones, it should replace rather than be added to the list of existing args.
So the code was updated to call `Test.setJvmArgs()`, which has the desired semantics.

# Motivation
Duplicating some args (e.g. `--patch-module`) can cause the forked JVM to fail.

Jira ticket: [CIVIS-7901]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-7901]: https://datadoghq.atlassian.net/browse/CIVIS-7901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ