### PR TITLE
Fix accessing array field by reflection

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -166,7 +166,9 @@ public class ASMHelper {
     String methodName = getReflectiveMethodName(sort);
     // stack: [target_object, string]
     org.objectweb.asm.Type returnType =
-        sort == org.objectweb.asm.Type.OBJECT ? Types.OBJECT_TYPE : fieldType.getMainType();
+        sort == org.objectweb.asm.Type.OBJECT || sort == org.objectweb.asm.Type.ARRAY
+            ? Types.OBJECT_TYPE
+            : fieldType.getMainType();
     invokeStatic(
         insnList,
         REFLECTIVE_FIELD_VALUE_RESOLVER_TYPE,
@@ -174,7 +176,7 @@ public class ASMHelper {
         returnType,
         targetType,
         Types.STRING_TYPE);
-    if (sort == org.objectweb.asm.Type.OBJECT) {
+    if (sort == org.objectweb.asm.Type.OBJECT || sort == org.objectweb.asm.Type.ARRAY) {
       insnList.add(new TypeInsnNode(Opcodes.CHECKCAST, fieldType.getMainType().getInternalName()));
     }
     // stack: [field_value]
@@ -199,6 +201,7 @@ public class ASMHelper {
       case org.objectweb.asm.Type.BOOLEAN:
         return "getFieldValueAsBoolean";
       case org.objectweb.asm.Type.OBJECT:
+      case org.objectweb.asm.Type.ARRAY:
         return "getFieldValue";
       default:
         throw new IllegalArgumentException("Unsupported type sort:" + sort);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1234,10 +1234,11 @@ public class CapturedSnapshotTest {
     Snapshot snapshot = assertOneSnapshot(listener);
     Map<String, CapturedContext.CapturedValue> staticFields =
         snapshot.getCaptures().getReturn().getStaticFields();
-    assertEquals(5, staticFields.size());
+    assertEquals(6, staticFields.size());
     assertEquals("barfoo", getValue(staticFields.get("strValue")));
     assertEquals("48", getValue(staticFields.get("intValue")));
     assertEquals("6.28", getValue(staticFields.get("doubleValue")));
+    assertEquals("[1, 2, 3, 4]", getValue(staticFields.get("longValues")));
   }
 
   @Test
@@ -2140,11 +2141,46 @@ public class CapturedSnapshotTest {
         Assertions.fail("NotCapturedReason: " + valued.getNotCapturedReason());
       }
       Object obj = valued.getValue();
+      if (obj != null && obj.getClass().isArray()) {
+        if (obj.getClass().getComponentType().isPrimitive()) {
+          return primitiveArrayToString(obj);
+        }
+        return Arrays.toString((Object[]) obj);
+      }
       return obj != null ? String.valueOf(obj) : null;
     } catch (IOException e) {
       e.printStackTrace();
       return null;
     }
+  }
+
+  private static String primitiveArrayToString(Object obj) {
+    Class<?> componentType = obj.getClass().getComponentType();
+    if (componentType == long.class) {
+      return Arrays.toString((long[]) obj);
+    }
+    if (componentType == int.class) {
+      return Arrays.toString((int[]) obj);
+    }
+    if (componentType == short.class) {
+      return Arrays.toString((short[]) obj);
+    }
+    if (componentType == char.class) {
+      return Arrays.toString((char[]) obj);
+    }
+    if (componentType == byte.class) {
+      return Arrays.toString((byte[]) obj);
+    }
+    if (componentType == boolean.class) {
+      return Arrays.toString((boolean[]) obj);
+    }
+    if (componentType == float.class) {
+      return Arrays.toString((float[]) obj);
+    }
+    if (componentType == double.class) {
+      return Arrays.toString((double[]) obj);
+    }
+    return null;
   }
 
   public static Map<String, CapturedContext.CapturedValue> getFields(

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot19.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot19.java
@@ -17,6 +17,7 @@ public class CapturedSnapshot19 {
     private static int intValue = 24;
     protected static double doubleValue = 3.14;
     private static Object obj1;
+    private static long[] longValues = new long[] {1, 2, 3, 4};
 
     public Base(Object obj1) {
       this.obj1 = obj1;


### PR DESCRIPTION
# What Does This Do
When some fields are not accessible directly because of the visibility we emit a relfection call to get the value but arrays was not supported

# Motivation

# Additional Notes


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
