### PR TITLE
guard operation and resource name encoding properly when encoding is disabled

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
@@ -37,6 +37,22 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
   }
 
   @Override
+  public int encodeOperationName(CharSequence constant) {
+    if (SPAN_NAME_INDEX >= 0) {
+      return DDPROF.encode(constant);
+    }
+    return 0;
+  }
+
+  @Override
+  public int encodeResourceName(CharSequence constant) {
+    if (RESOURCE_NAME_INDEX >= 0) {
+      return DDPROF.encode(constant);
+    }
+    return 0;
+  }
+
+  @Override
   public void setContext(ProfilerContext profilerContext) {
     DDPROF.setSpanContext(profilerContext.getSpanId(), profilerContext.getRootSpanId());
     DDPROF.setContextValue(SPAN_NAME_INDEX, profilerContext.getEncodedOperationName());

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -333,7 +333,7 @@ public class DDSpanContext
     // as fast as we can try to make this operation, we still might need to activate/deactivate
     // contexts at alarming rates in unpredictable async applications, so we'll try
     // to get away with doing this just once per span
-    this.encodedOperationName = profilingContextIntegration.encode(operationName);
+    this.encodedOperationName = profilingContextIntegration.encodeOperationName(operationName);
 
     setServiceName(serviceName);
     this.operationName = operationName;
@@ -419,7 +419,7 @@ public class DDSpanContext
     if (priority >= this.resourceNamePriority) {
       this.resourceNamePriority = priority;
       this.resourceName = resourceName;
-      this.encodedResourceName = profilingContextIntegration.encode(resourceName);
+      this.encodedResourceName = profilingContextIntegration.encodeResourceName(resourceName);
     }
   }
 
@@ -433,7 +433,7 @@ public class DDSpanContext
 
   public void setOperationName(final CharSequence operationName) {
     this.operationName = operationName;
-    this.encodedOperationName = profilingContextIntegration.encode(operationName);
+    this.encodedOperationName = profilingContextIntegration.encodeOperationName(operationName);
   }
 
   public boolean getErrorFlag() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -264,8 +264,8 @@ class DDSpanContextTest extends DDCoreSpecification {
       .start()
 
     then: "encoded operation name matches operation name"
-    1 * profilingContextIntegration.encode("fakeOperation") >> 1
-    1 * profilingContextIntegration.encode("fakeResource") >> -1
+    1 * profilingContextIntegration.encodeOperationName("fakeOperation") >> 1
+    1 * profilingContextIntegration.encodeResourceName("fakeResource") >> -1
     span.context.encodedOperationName == 1
     span.context.encodedResourceName == -1
 
@@ -273,14 +273,14 @@ class DDSpanContextTest extends DDCoreSpecification {
     span.setOperationName("newOperationName")
 
     then:
-    1 * profilingContextIntegration.encode("newOperationName") >> 2
+    1 * profilingContextIntegration.encodeOperationName("newOperationName") >> 2
     span.context.encodedOperationName == 2
 
     when:
     span.setResourceName("newResourceName")
 
     then:
-    1 * profilingContextIntegration.encode("newResourceName") >> -2
+    1 * profilingContextIntegration.encodeResourceName("newResourceName") >> -2
     span.context.encodedResourceName == -2
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -554,8 +554,8 @@ class ScopeManagerTest extends DDCoreSpecification {
     1 * rootSpanCheckpointer.onRootSpanStarted(_)
     3 * profilingContext.setContext(_)
     1 * profilingContext.onAttach()
-    1 * profilingContext.encode("foo")
-    1 * profilingContext.encode("bar")
+    1 * profilingContext.encodeOperationName("foo")
+    1 * profilingContext.encodeOperationName("bar")
     _ * profilingContext._
     0 * _
 
@@ -596,7 +596,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     1 * rootSpanCheckpointer.onRootSpanStarted(_)
     1 * profilingContext.onAttach()
     1 * profilingContext.setContext(_)
-    1 * profilingContext.encode("foo")
+    1 * profilingContext.encodeOperationName("foo")
     _ * profilingContext._
     0 * _
 
@@ -610,7 +610,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeScope() == secondScope
     assertEvents([ACTIVATE, ACTIVATE])
     1 * profilingContext.setContext(_)
-    1 * profilingContext.encode("bar")
+    1 * profilingContext.encodeOperationName("bar")
     _ * profilingContext._
     0 * _
 
@@ -624,7 +624,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeScope() == thirdScope
     assertEvents([ACTIVATE, ACTIVATE, ACTIVATE])
     1 * profilingContext.setContext(_)
-    1 * profilingContext.encode("quux")
+    1 * profilingContext.encodeOperationName("quux")
     _ * profilingContext._
     0 * _
 
@@ -709,7 +709,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.activeScope() == thirdScope
     assertEvents([ACTIVATE, ACTIVATE])
     1 * profilingContext.setContext(_)
-    1 * profilingContext.encode("quux")
+    1 * profilingContext.encodeOperationName("quux")
     _ * profilingContext._
     0 * _
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ProfilingContextIntegration.java
@@ -21,6 +21,14 @@ public interface ProfilingContextIntegration extends Profiling {
     return 0;
   }
 
+  default int encodeOperationName(CharSequence constant) {
+    return 0;
+  }
+
+  default int encodeResourceName(CharSequence constant) {
+    return 0;
+  }
+
   final class NoOp implements ProfilingContextIntegration {
 
     public static final ProfilingContextIntegration INSTANCE =


### PR DESCRIPTION
# What Does This Do

Without this change we would encode operation and resource names even if attaching them to profile samples was disabled.

# Motivation

# Additional Notes

Jira ticket: [PROF-8531]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8531]: https://datadoghq.atlassian.net/browse/PROF-8531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ