### PR TITLE
Bump ddprof dep to 0.83.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.82.0",
+    ddprof        : "0.83.0",
     asm           : "9.6",
     cafe_crypto   : "0.1.0"
   ]


### PR DESCRIPTION
# What Does This Do
Bumps the dependency version for ddprof

# Motivation
To bring in the fix for ZGC related crashes on JDK 21 when Live Heap profiling is enabled (https://github.com/DataDog/java-profiler/pull/41)

# Additional Notes

Jira ticket: [PROF-8526]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8526]: https://datadoghq.atlassian.net/browse/PROF-8526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ