### PR TITLE
Remove @Deprecated from Config

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -477,7 +477,6 @@ import org.slf4j.LoggerFactory;
  * @see InstrumenterConfig for pre-instrumentation configurations
  * @see DynamicConfig for configuration that can be dynamically updated via remote-config
  */
-@Deprecated
 public class Config {
 
   private static final Logger log = LoggerFactory.getLogger(Config.class);


### PR DESCRIPTION
# What Does This Do

Removes the `@Deprecated` annotation from `Config`

# Motivation
The annotation was added back when `Config` was part of the public api (#1577). The purpose was to discourage its use so that we could make internal changes to how config is handled. As the class is now in the `internal-api` module, and is the de facto config management class for the whole library, the annotation just leads to confusion, extra warnings on the command line, and extra warnings in IDEs.
