### PR TITLE
Add BP trigger for DSM Kafka Benchmark

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -31,7 +31,7 @@ benchmarks:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-java
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
-dsm-kafka-benchmarks:
+.dsm-kafka-benchmarks:
   stage: benchmarks
   when: manual
   tags: ["runner:apm-k8s-same-cpu"]
@@ -49,3 +49,13 @@ dsm-kafka-benchmarks:
     expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+dsm-kafka-producer-benchmark:
+  extends: .benchmarks
+  variables:
+    BP_KAFKA_SCENARIO_DIR: producer-benchmark
+
+dsm-kafka-consumer-benchmark:
+  extends: .benchmarks
+  variables:
+    BP_KAFKA_SCENARIO_DIR: consumer-benchmark

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -39,7 +39,7 @@ benchmarks:
   timeout: 1h
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:java-dsm-kafka
   script:
-    - git clone --branch java/kafka-dsm-overhead https://github.com/DataDog/benchmarking-platform.git platform && cd platform
+    - git clone --branch java/kafka-dsm-overhead https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform.git platform && cd platform
     - ./steps/run-benchmarks.sh
   artifacts:
     name: "artifacts"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -33,7 +33,14 @@ benchmarks:
 
 .dsm-kafka-benchmarks:
   stage: benchmarks
-  when: manual
+  rules:
+    - if: $CI_PIPELINE_SOURCE != "schedule"
+      changes:
+        paths:
+          - dd-java-agent/instrumentation/kafka*/**/*
+        compare_to: "master"
+      when: on_success
+    - when: manual
   tags: ["runner:apm-k8s-same-cpu"]
   interruptible: true
   timeout: 1h

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -51,11 +51,11 @@ benchmarks:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
 dsm-kafka-producer-benchmark:
-  extends: .benchmarks
+  extends: .dsm-kafka-benchmarks
   variables:
     BP_KAFKA_SCENARIO_DIR: producer-benchmark
 
 dsm-kafka-consumer-benchmark:
-  extends: .benchmarks
+  extends: .dsm-kafka-benchmarks
   variables:
     BP_KAFKA_SCENARIO_DIR: consumer-benchmark

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -41,7 +41,7 @@ benchmarks:
         compare_to: "master"
       when: on_success
     - when: manual
-  tags: ["runner:apm-k8s-same-cpu"]
+  tags: ["runner:apm-k8s-tweaked-metal"]
   interruptible: true
   timeout: 1h
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:java-dsm-kafka

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -30,3 +30,22 @@ benchmarks:
 
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-java
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+dsm-kafka-benchmarks:
+  stage: benchmarks
+  when: manual
+  tags: ["runner:apm-k8s-same-cpu"]
+  interruptible: true
+  timeout: 1h
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:java-dsm-kafka
+  script:
+    - git clone --branch java/kafka-dsm-overhead https://github.com/DataDog/benchmarking-platform.git platform && cd platform
+    - ./steps/run-benchmarks.sh
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - platform/artifacts/
+    expire_in: 3 months
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -59,3 +59,4 @@ dsm-kafka-consumer-benchmark:
   extends: .dsm-kafka-benchmarks
   variables:
     BP_KAFKA_SCENARIO_DIR: consumer-benchmark
+


### PR DESCRIPTION
# What Does This Do

This PR adds automatic kafka benchmark runs (benchmarks developed by DSM team, @hokitam) on changes in kafka-clients instrumentation.

Also the benchmark can be run manually.

Regardless if run was manually or automatically triggered, PR comment will be posted in corresponding PR (if PR exists).

More detailed results of benchmark runs (with visualizations) are available in Gitlab artifacts and in BP UI.

# Motivation

Add performance regression testing for Kafka instrumentation to prevent uncontrollable overhead increase.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
