### PR TITLE
Avoid calculate Kafka message size when DSM is not enabled

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -90,10 +90,11 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
           sortedTags.put(GROUP_TAG, group);
           sortedTags.put(TOPIC_TAG, val.topic());
           sortedTags.put(TYPE_TAG, "kafka");
-
+          final long payloadSize =
+              span.traceConfig().isDataStreamsEnabled() ? computePayloadSizeBytes(val) : 0;
           AgentTracer.get()
               .getDataStreamsMonitoring()
-              .setCheckpoint(span, sortedTags, val.timestamp(), computePayloadSizeBytes(val));
+              .setCheckpoint(span, sortedTags, val.timestamp(), payloadSize);
         } else {
           span = startSpan(operationName, null);
         }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/Utils.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/Utils.java
@@ -6,7 +6,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 
 public final class Utils {
-  private Utils() {} // prevent instanciation
+  private Utils() {} // prevent instantiation
 
   // this method is used in kafka-clients and kafka-streams instrumentations
   public static long computePayloadSizeBytes(ConsumerRecord<?, ?> val) {

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -245,10 +245,11 @@ public class KafkaStreamTaskInstrumentation extends Instrumenter.Tracing
         }
         sortedTags.put(TOPIC_TAG, record.topic());
         sortedTags.put(TYPE_TAG, "kafka");
+        final long payloadSize =
+            span.traceConfig().isDataStreamsEnabled() ? computePayloadSizeBytes(record.value) : 0;
         AgentTracer.get()
             .getDataStreamsMonitoring()
-            .setCheckpoint(
-                span, sortedTags, record.timestamp, computePayloadSizeBytes(record.value));
+            .setCheckpoint(span, sortedTags, record.timestamp, payloadSize);
       } else {
         span = startSpan(KAFKA_CONSUME, null);
       }


### PR DESCRIPTION
# What Does This Do

Skip costly message size calculation for kafka when DSM is off

Note: I could directly shortcut the whole checkpointing but I preferred to keep code changes minimal

# Motivation

# Additional Notes


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
