### PR TITLE
Fix error when serializing skippable tests whose names contain non-ASCII characters

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/SkippableTestsSerializer.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/SkippableTestsSerializer.java
@@ -26,10 +26,10 @@ public abstract class SkippableTestsSerializer {
       String name = test.getName();
       String parameters = test.getParameters();
 
-      length += suite.length();
-      length += name.length();
+      length += suite.getBytes(CHARSET).length;
+      length += name.getBytes(CHARSET).length;
       if (parameters != null) {
-        length += parameters.length();
+        length += parameters.getBytes(CHARSET).length;
       }
     }
 
@@ -41,14 +41,18 @@ public abstract class SkippableTestsSerializer {
       String name = test.getName();
       String parameters = test.getParameters();
 
-      buffer.putInt(suite.length());
-      buffer.put(suite.getBytes(CHARSET));
-      buffer.putInt(name.length());
-      buffer.put(name.getBytes(CHARSET));
+      byte[] suiteBytes = suite.getBytes(CHARSET);
+      buffer.putInt(suiteBytes.length);
+      buffer.put(suiteBytes);
+
+      byte[] nameBytes = name.getBytes(CHARSET);
+      buffer.putInt(nameBytes.length);
+      buffer.put(nameBytes);
 
       if (parameters != null) {
-        buffer.putInt(parameters.length());
-        buffer.put(parameters.getBytes(CHARSET));
+        byte[] parametersBytes = parameters.getBytes(CHARSET);
+        buffer.putInt(parametersBytes.length);
+        buffer.put(parametersBytes);
       } else {
         buffer.putInt(-1);
       }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/SkippableTestsSerializerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/SkippableTestsSerializerTest.groovy
@@ -22,6 +22,8 @@ class SkippableTestsSerializerTest extends Specification {
     tests << [
       // single test
       [["suite", "name", null]],
+      [["suite", "𝕄 add user properties 𝕎 addUserProperties()", null]],
+      // non-ASCII characters
       [["suite", "name", "parameters"]],
       [["suite", "name", "{\"metadata\":{\"test_name\":\"test display name with #a #b #c\"}}"]],
       // multiple tests


### PR DESCRIPTION
# What Does This Do
Fixes serialisation of `SkippableTest` objects whose suite or test case names contain non-ASCII characters.

# Motivation
Such tests are valid, exist and should be supported.

# Additional Notes
Skippable tests are serialised when sent from the parent process (build system) to the children processes (JVMs forked for tests execution). 

Jira ticket: [CIVIS-7964]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-7964]: https://datadoghq.atlassian.net/browse/CIVIS-7964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ