### PR TITLE
Fix OpenTracing tests for 128-bit trace identitifer

### DIFF
--- a/dd-trace-ot/src/ot31CompatibilityTest/groovy/OT31ApiTest.groovy
+++ b/dd-trace-ot/src/ot31CompatibilityTest/groovy/OT31ApiTest.groovy
@@ -114,11 +114,10 @@ class OT31ApiTest extends DDSpecification {
     def expectedTraceparent = "00-${traceId.toHexStringPadded(32)}" +
       "-${DDSpanId.toHexStringPadded(spanId)}" +
       "-" + (propagatedPriority > 0 ? "01" : "00")
-    def expectedTracestate = "dd=s:${propagatedPriority}"
     def effectiveSamplingMechanism = contextPriority == UNSET ? AGENT_RATE : samplingMechanism
-    if (propagatedPriority > 0) {
-      expectedTracestate+= ";t.dm:-" + effectiveSamplingMechanism
-    }
+    def expectedTracestate = "dd=s:${propagatedPriority}" +
+      (propagatedPriority > 0 ? ";t.dm:-" + effectiveSamplingMechanism : "") +
+      ";t.tid:${traceId.toHexStringPadded(32).substring(0, 16)}"
     def expectedTextMap = [
       "x-datadog-trace-id"         : context.toTraceId(),
       "x-datadog-parent-id"        : context.toSpanId(),

--- a/dd-trace-ot/src/ot33CompatibilityTest/groovy/OT33ApiTest.groovy
+++ b/dd-trace-ot/src/ot33CompatibilityTest/groovy/OT33ApiTest.groovy
@@ -103,11 +103,10 @@ class OT33ApiTest extends DDSpecification {
     def expectedTraceparent = "00-${traceId.toHexStringPadded(32)}" +
       "-${DDSpanId.toHexStringPadded(spanId)}" +
       "-" + (propagatedPriority > 0 ? "01" : "00")
-    def expectedTracestate = "dd=s:${propagatedPriority}"
     def effectiveSamplingMechanism = contextPriority == UNSET ? AGENT_RATE : samplingMechanism
-    if (propagatedPriority > 0) {
-      expectedTracestate+= ";t.dm:-" + effectiveSamplingMechanism
-    }
+    def expectedTracestate = "dd=s:${propagatedPriority}" +
+      (propagatedPriority > 0 ? ";t.dm:-" + effectiveSamplingMechanism : "") +
+      ";t.tid:${traceId.toHexStringPadded(32).substring(0, 16)}"
     def expectedTextMap = [
       "x-datadog-trace-id"         : context.toTraceId(),
       "x-datadog-parent-id"        : context.toSpanId(),


### PR DESCRIPTION
# What Does This Do

This will fix the OpenTracing module tests.

# Motivation

As 128-bit trace identifier generation is now enabled by default, some tests need update.

# Additional Notes

Jira ticket: [APMJAVA-1085]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1085]: https://datadoghq.atlassian.net/browse/APMJAVA-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ