### PR TITLE
Fix incorrect cloudfoundry url to 1.23.0

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -90,4 +90,4 @@
 1.20.1: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/1.20.1/dd-java-agent-1.20.1.jar
 1.21.0: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/1.21.0/dd-java-agent-1.21.0.jar
 1.22.0: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/1.22.0/dd-java-agent-1.22.0.jar
-1.23.0: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/1.22.0/dd-java-agent-1.23.0.jar
+1.23.0: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/1.23.0/dd-java-agent-1.23.0.jar


### PR DESCRIPTION
The updated URL in the cloudfoundry index.yml is incorrect
