### PR TITLE
Update the OpenTelemtry default operation name

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelConventions.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelConventions.java
@@ -19,16 +19,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class OtelConventions {
-  /** The Datadog span default operation name. */
-  public static final String DEFAULT_OPERATION_NAME = "otel_unknown";
-
+  static final String SPAN_KIND_INTERNAL = "internal";
   private static final Logger LOGGER = LoggerFactory.getLogger(OtelConventions.class);
   private static final String OPERATION_NAME_SPECIFIC_ATTRIBUTE = "operation.name";
   private static final String SERVICE_NAME_SPECIFIC_ATTRIBUTE = "service.name";
   private static final String RESOURCE_NAME_SPECIFIC_ATTRIBUTE = "resource.name";
   private static final String SPAN_TYPE_SPECIFIC_ATTRIBUTES = "span.type";
   private static final String ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES = "analytics.event";
-  private static final String SPAN_KIND_INTERNAL = "internal";
 
   private OtelConventions() {}
 
@@ -193,11 +190,7 @@ public final class OtelConventions {
           : networkProtocolName + ".client.request";
     }
     // Fallback if no convention match
-    if (span.getSpanType() != null) {
-      return spanKind.name();
-    } else {
-      return DEFAULT_OPERATION_NAME;
-    }
+    return spanKind.name();
   }
 
   @Nullable

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelTracer.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelTracer.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.opentelemetry14.trace;
 
-import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.DEFAULT_OPERATION_NAME;
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.SPAN_KIND_INTERNAL;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -21,9 +21,7 @@ class OtelTracer implements Tracer {
   @Override
   public SpanBuilder spanBuilder(String spanName) {
     AgentTracer.SpanBuilder delegate =
-        this.tracer
-            .buildSpan(INSTRUMENTATION_NAME, DEFAULT_OPERATION_NAME)
-            .withResourceName(spanName);
+        this.tracer.buildSpan(INSTRUMENTATION_NAME, SPAN_KIND_INTERNAL).withResourceName(spanName);
     return new OtelSpanBuilder(delegate);
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -16,7 +16,7 @@ import spock.lang.Subject
 import java.security.InvalidParameterException
 
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER
-import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.DEFAULT_OPERATION_NAME
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.SPAN_KIND_INTERNAL
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.api.trace.StatusCode.OK
@@ -159,7 +159,8 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(2) {
       trace(1) {
         span {
-          spanType "internal"}
+          spanType "internal"
+        }
       }
       trace(1) {
         span {
@@ -194,6 +195,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
+          spanType "internal"
           tags {
             defaultTags()
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
@@ -227,6 +229,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
+          spanType "internal"
           tags {
             defaultTags()
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
@@ -261,6 +264,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
+          spanType "internal"
           tags {
             defaultTags()
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
@@ -301,6 +305,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
+          spanType "internal"
           tags {
             defaultTags()
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
@@ -577,14 +582,14 @@ class OpenTelemetry14Test extends AgentTestRunner {
     def result = builder.setSpanKind(SERVER).startSpan()
 
     expect:
-    result.delegate.operationName == DEFAULT_OPERATION_NAME
+    result.delegate.operationName == SPAN_KIND_INTERNAL
     result.delegate.resourceName == "some-name"
 
     when:
     result.updateName("other-name")
 
     then:
-    result.delegate.operationName == DEFAULT_OPERATION_NAME
+    result.delegate.operationName == SPAN_KIND_INTERNAL
     result.delegate.resourceName == "other-name"
 
     when:

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
@@ -12,7 +12,7 @@ import spock.lang.Subject
 import static datadog.trace.bootstrap.instrumentation.api.ScopeSource.MANUAL
 import static datadog.trace.instrumentation.opentelemetry14.context.OtelContext.DATADOG_CONTEXT_ROOT_SPAN_KEY
 import static datadog.trace.instrumentation.opentelemetry14.context.OtelContext.OTEL_CONTEXT_SPAN_KEY
-import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.DEFAULT_OPERATION_NAME
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.SPAN_KIND_INTERNAL
 
 class ContextTest extends AgentTestRunner {
   @Subject
@@ -189,7 +189,7 @@ class ContextTest extends AgentTestRunner {
     def activeSpan = TEST_TRACER.activeSpan()
 
     then:
-    activeSpan.operationName == DEFAULT_OPERATION_NAME
+    activeSpan.operationName == SPAN_KIND_INTERNAL
     activeSpan.resourceName == "some-name"
     DDSpanId.toHexStringPadded(activeSpan.spanId) == otelParentSpan.getSpanContext().spanId
 
@@ -207,7 +207,7 @@ class ContextTest extends AgentTestRunner {
     activeSpan = TEST_TRACER.activeSpan()
 
     then:
-    activeSpan.operationName == DEFAULT_OPERATION_NAME
+    activeSpan.operationName == SPAN_KIND_INTERNAL
     activeSpan.resourceName == "another-name"
     DDSpanId.toHexStringPadded(activeSpan.spanId) == otelGrandChildSpan.getSpanContext().spanId
 


### PR DESCRIPTION
# What Does This Do

This PR will remove the default operation name that should never be used has OpenTelemetry spans are supposed to always have a kind (`internal` by default).

# Motivation

This change will comply with the latest specification update.

# Additional Notes

Jira ticket: [APMJAVA-1062]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1062]: https://datadoghq.atlassian.net/browse/APMJAVA-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ