### PR TITLE
Append DBM trace context comments for SQL Server & Postgres

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DBMCompatibleConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DBMCompatibleConnectionInstrumentation.java
@@ -27,10 +27,7 @@ import net.bytebuddy.asm.Advice;
 public class DBMCompatibleConnectionInstrumentation extends AbstractConnectionInstrumentation
     implements Instrumenter.ForKnownTypes {
 
-  /**
-   * Instrumentation class for connections for SQL Server, which is a Database Monitoring supported
-   * DB *
-   */
+  /** Instrumentation class for connections for Database Monitoring supported DBs * */
   public DBMCompatibleConnectionInstrumentation() {
     super("jdbc", "dbm");
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DBMCompatibleConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DBMCompatibleConnectionInstrumentation.java
@@ -27,7 +27,10 @@ import net.bytebuddy.asm.Advice;
 public class DBMCompatibleConnectionInstrumentation extends AbstractConnectionInstrumentation
     implements Instrumenter.ForKnownTypes {
 
-  /** Instrumentation class for connections for Database Monitoring supported DBs * */
+  /**
+   * Instrumentation class for connections for SQL Server, which is a Database Monitoring supported
+   * DB *
+   */
   public DBMCompatibleConnectionInstrumentation() {
     super("jdbc", "dbm");
   }
@@ -35,21 +38,10 @@ public class DBMCompatibleConnectionInstrumentation extends AbstractConnectionIn
   // Classes to cover all currently supported
   // db types for the Database Monitoring product
   static final String[] CONCRETE_TYPES = {
-    // should cover mysql
-    "com.mysql.jdbc.Connection",
-    "com.mysql.jdbc.jdbc1.Connection",
-    "com.mysql.jdbc.jdbc2.Connection",
-    "com.mysql.jdbc.ConnectionImpl",
-    "com.mysql.jdbc.JDBC4Connection",
-    "com.mysql.cj.jdbc.ConnectionImpl",
-    // should cover Oracle
-    "oracle.jdbc.driver.PhysicalConnection",
-    // complete
-    "org.mariadb.jdbc.MySQLConnection",
-    // MariaDB Connector/J v2.x
-    "org.mariadb.jdbc.MariaDbConnection",
-    // MariaDB Connector/J v3.x
-    "org.mariadb.jdbc.Connection",
+    "com.microsoft.sqlserver.jdbc.SQLServerConnection",
+    // jtds (for SQL Server and Sybase)
+    "net.sourceforge.jtds.jdbc.ConnectionJDBC2", // 1.2
+    "net.sourceforge.jtds.jdbc.JtdsConnection", // 1.3
     // postgresql seems to be complete
     "org.postgresql.jdbc.PgConnection",
     "org.postgresql.jdbc1.Connection",
@@ -62,8 +54,8 @@ public class DBMCompatibleConnectionInstrumentation extends AbstractConnectionIn
     "postgresql.Connection",
     // EDB version of postgresql
     "com.edb.jdbc.PgConnection",
-    // aws-mysql-jdbc
-    "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.jdbc.ConnectionImpl",
+    // should cover Oracle
+    "oracle.jdbc.driver.PhysicalConnection",
   };
 
   @Override
@@ -111,7 +103,7 @@ public class DBMCompatibleConnectionInstrumentation extends AbstractConnectionIn
         final DBInfo dbInfo =
             JDBCDecorator.parseDBInfo(
                 connection, InstrumentationContext.get(Connection.class, DBInfo.class));
-        sql = SQLCommenter.prepend(sql, DECORATE.getDbService(dbInfo));
+        sql = SQLCommenter.append(sql, DECORATE.getDbService(dbInfo));
         return inputSql;
       }
       return sql;

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/MySQLConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/MySQLConnectionInstrumentation.java
@@ -27,7 +27,9 @@ import net.bytebuddy.asm.Advice;
 public class MySQLConnectionInstrumentation extends AbstractConnectionInstrumentation
     implements Instrumenter.ForKnownTypes {
 
-  /** Instrumentation class for connections for Database Monitoring supported DBs * */
+  /**
+   * Instrumentation class for connections for MySQL, which is a Database Monitoring supported DB *
+   */
   public MySQLConnectionInstrumentation() {
     super("jdbc", "dbm-mysql");
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/MySQLConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/MySQLConnectionInstrumentation.java
@@ -24,24 +24,32 @@ import java.util.Map;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
-public class SQLServerConnectionInstrumentation extends AbstractConnectionInstrumentation
+public class MySQLConnectionInstrumentation extends AbstractConnectionInstrumentation
     implements Instrumenter.ForKnownTypes {
 
-  /**
-   * Instrumentation class for connections for SQL Server, which is a Database Monitoring supported
-   * DB *
-   */
-  public SQLServerConnectionInstrumentation() {
-    super("jdbc", "dbm-sqlserver");
+  /** Instrumentation class for connections for Database Monitoring supported DBs * */
+  public MySQLConnectionInstrumentation() {
+    super("jdbc", "dbm-mysql");
   }
 
   // Classes to cover all currently supported
   // db types for the Database Monitoring product
   static final String[] CONCRETE_TYPES = {
-    "com.microsoft.sqlserver.jdbc.SQLServerConnection",
-    // jtds (for SQL Server and Sybase)
-    "net.sourceforge.jtds.jdbc.ConnectionJDBC2", // 1.2
-    "net.sourceforge.jtds.jdbc.JtdsConnection", // 1.3
+    // should cover mysql
+    "com.mysql.jdbc.Connection",
+    "com.mysql.jdbc.jdbc1.Connection",
+    "com.mysql.jdbc.jdbc2.Connection",
+    "com.mysql.jdbc.ConnectionImpl",
+    "com.mysql.jdbc.JDBC4Connection",
+    "com.mysql.cj.jdbc.ConnectionImpl",
+    // complete
+    "org.mariadb.jdbc.MySQLConnection",
+    // MariaDB Connector/J v2.x
+    "org.mariadb.jdbc.MariaDbConnection",
+    // MariaDB Connector/J v3.x
+    "org.mariadb.jdbc.Connection",
+    // aws-mysql-jdbc
+    "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.jdbc.ConnectionImpl",
   };
 
   @Override
@@ -63,7 +71,7 @@ public class SQLServerConnectionInstrumentation extends AbstractConnectionInstru
             .and(takesArgument(0, String.class))
             // Also include CallableStatement, which is a subtype of PreparedStatement
             .and(returns(hasInterface(named("java.sql.PreparedStatement")))),
-        SQLServerConnectionInstrumentation.class.getName() + "$ConnectionAdvice");
+        MySQLConnectionInstrumentation.class.getName() + "$ConnectionAdvice");
   }
 
   @Override
@@ -89,7 +97,7 @@ public class SQLServerConnectionInstrumentation extends AbstractConnectionInstru
         final DBInfo dbInfo =
             JDBCDecorator.parseDBInfo(
                 connection, InstrumentationContext.get(Connection.class, DBInfo.class));
-        sql = SQLCommenter.append(sql, DECORATE.getDbService(dbInfo));
+        sql = SQLCommenter.prepend(sql, DECORATE.getDbService(dbInfo));
         return inputSql;
       }
       return sql;


### PR DESCRIPTION
# What Does This Do

Fix for reported customer issue around calling procedures for `postgresql` while having DBM-APM link enabled 

```
2023-11-10 13:30:52.870 [Thread-66184] [Error] [modifyJdbcCall] [api_call_unique_identifier-2026618091699623052870] [Client_Id-0] [span_id-99074af426ba7b60ccc2] - com.paymentology.payapi.v1.logging.ApiLogger
Malformed function or procedure escape syntax at offset 40.

org.postgresql.util.PSQLException: Malformed function or procedure escape syntax at offset 40.
at org.postgresql.core.Parser.modifyJdbcCall(Parser.java:1146)
at org.postgresql.core.CachedQueryCreateAction.create(CachedQueryCreateAction.java:48)
at org.postgresql.core.CachedQueryCreateAction.create(CachedQueryCreateAction.java:19)
at org.postgresql.util.LruCache.borrow(LruCache.java:123)
at org.postgresql.core.QueryExecutorBase.borrowCallableQuery(QueryExecutorBase.java:301)
at org.postgresql.jdbc.PgConnection.borrowCallableQuery(PgConnection.java:200)
at org.postgresql.jdbc.PgCallableStatement.<init>(PgCallableStatement.java:54)
at org.postgresql.jdbc.PgConnection.prepareCall(PgConnection.java:1333)
at org.postgresql.jdbc.PgConnection.prepareCall(PgConnection.java:1786)
at org.postgresql.jdbc.PgConnection.prepareCall(PgConnection.java:459)
at com.zaxxer.hikari.pool.ProxyConnection.prepareCall(ProxyConnection.java:295)
at com.zaxxer.hikari.pool.HikariProxyConnection.prepareCall(HikariProxyConnection.java)
at com.paymentology.payapi.v1.logging.ApiLogger.lambda$SaveError$7(ApiLogger.java:320)
at java.lang.Thread.run(Thread.java:750)
```

This happens when running prepared callable statements. E.g. This code:

```java
          final String storedProcedureCall = "{call dogshelterProc(?, ?)}";
          CallableStatement callableStmt = con.prepareCall(storedProcedureCall);
```

... results in the following exception 
```
exception running jdbc ERROR: syntax error at or near "{"
  Position: 95
 ```
 
 When being run from our test application with the latest release of the java tracer. By moving comments to be appended, instead of prepended, I no longer see this exception being thrown. Things are therefore correctly instrumented as a result. **Note**, we should not append comments for MySQL driver classes, since this actually causes an exception to be thrown when calling the similar procedure code.**
