### PR TITLE
fix flaky couchbase test

### DIFF
--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
@@ -333,7 +333,7 @@ abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
         assertCouchbaseCall(it, "cb.query", [
           'db.couchbase.retries'   : { Long },
           'db.couchbase.service'   : 'query',
-        ], query, span(0), false, ex1)
+        ], normalizedQuery, span(0), false, ex1)
         assertCouchbaseCall(it, "prepare", [
           'db.couchbase.retries'   : { Long },
           'db.couchbase.service'   : 'query',
@@ -342,7 +342,7 @@ abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
         assertCouchbaseCall(it, "cb.query", [
           'db.couchbase.retries'   : { Long },
           'db.couchbase.service'   : 'query',
-        ], query, span(0), false, ex2)
+        ], normalizedQuery, span(0), false, ex2)
         assertCouchbaseCall(it, "prepare", [
           'db.couchbase.retries'   : { Long },
           'db.couchbase.service'   : 'query',


### PR DESCRIPTION
# What Does This Do

Fix flakyness of one couchbase test after query normalization

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
