### PR TITLE
Revert setting dd.internal.card:none for UDS

### DIFF
--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
@@ -115,7 +115,6 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
         // when using UDS, set "entity-id" to "none" to avoid having the DogStatsD
         // server add origin tags (see https://github.com/DataDog/jmxfetch/pull/264)
         if (this.port == 0) {
-          clientBuilder.constantTags("dd.internal.card:none");
           clientBuilder.entityID("none");
         } else {
           clientBuilder.entityID(null);


### PR DESCRIPTION
# What Does This Do

Reverts this line from PR #6043 which went into 1.22.0: https://github.com/DataDog/dd-trace-java/pull/6043/files#diff-4ecbbf0b0217d0bda56d4038d2e12220a5989e971174ad50dd3074969a273a29R118

This line was brought over from https://github.com/DataDog/jmxfetch/commit/bf68517fd94f4f4d22344dd915ca92c46fa04f89

# Motivation

We've had a report that this might affect some metrics tagging in certain situations - while we investigate this further it is prudent to remove it for now and revert back to the behaviour in 1.21.0.