### PR TITLE
surface cause when DD profiler can't be instantiated

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -151,7 +151,7 @@ public final class DatadogProfiler {
                   ProfilingConfig.PROFILING_DATADOG_PROFILER_SCRATCH,
                   ProfilingConfig.PROFILING_DATADOG_PROFILER_SCRATCH_DEFAULT));
     } catch (IOException e) {
-      throw new UnsupportedOperationException("Unable to instantiate datadog profiler");
+      throw new UnsupportedOperationException("Unable to instantiate datadog profiler", e);
     }
     if (profiler == null) {
       throw new UnsupportedEnvironmentException("Unable to instantiate datadog profiler");


### PR DESCRIPTION
# What Does This Do

Fixes #6215 

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
