### PR TITLE
Revert "google-pubsub temporary disabled by default (#6222)"

### DIFF
--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PublisherInstrumentation.java
@@ -29,12 +29,7 @@ public final class PublisherInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForSingleType, ExcludeFilterProvider {
 
   public PublisherInstrumentation() {
-    super("google-pubsub", "google-pubsub-publisher");
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return false;
+    super("google-pubsub");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/ReceiverInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/ReceiverInstrumentation.java
@@ -14,12 +14,7 @@ public class ReceiverInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForSingleType {
 
   public ReceiverInstrumentation() {
-    super("google-pubsub", "google-pubsub-receiver");
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return false;
+    super("google-pubsub");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/ReceiverWithAckInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/ReceiverWithAckInstrumentation.java
@@ -15,12 +15,7 @@ public final class ReceiverWithAckInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.ForSingleType {
 
   public ReceiverWithAckInstrumentation() {
-    super("google-pubsub", "google-pubsub-receiver");
-  }
-
-  @Override
-  protected boolean defaultEnabled() {
-    return false;
+    super("google-pubsub");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/google-pubsub/src/test/groovy/PubSubTest.groovy
+++ b/dd-java-agent/instrumentation/google-pubsub/src/test/groovy/PubSubTest.groovy
@@ -134,7 +134,6 @@ abstract class PubSubTest extends VersionedNamingTestBase {
   @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
-    injectSysConfig("integration.google-pubsub.enabled", "true")
     injectSysConfig(GeneralConfig.SERVICE_NAME, "A-service")
     injectSysConfig(GeneralConfig.DATA_STREAMS_ENABLED, isDataStreamsEnabled().toString())
     if (!shadowGrpcSpans()) {


### PR DESCRIPTION
# What Does This Do

**PLEASE DO NOT MERGE BEFORE Dec 2**

This reverts commit 4131e509a94db430b47104769800ec14de5f0a0d.


# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
