### PR TITLE
Exclude VertX 4.4.+. Fix Java release param issue

### DIFF
--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -21,7 +21,7 @@ java {
 
 tasks.withType(AbstractCompile).configureEach {
   // ensure no APIs beyond JDK8 are used
-  options.compilerArgs.addAll(['--release', '8'])
+  options.release = 8
 }
 
 // First version with Mac M1 support

--- a/dd-java-agent/instrumentation/vertx-mysql-client-4.4.2/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-mysql-client-4.4.2/build.gradle
@@ -5,7 +5,7 @@ muzzle {
   pass {
     group = 'io.vertx'
     module = 'vertx-mysql-client'
-    versions = '[4.4.2,4.5.0)'
+    versions = '[4.4.2,4.6.0)'
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
@@ -44,6 +44,6 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:jackson-core')
   testRuntimeOnly project(':dd-java-agent:instrumentation:netty-buffer-4')
 
-  latestDepTestImplementation group: 'io.vertx', name: 'vertx-web', version: '4.+'
-  latestDepTestImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.+'
+  latestDepTestImplementation group: 'io.vertx', name: 'vertx-web', version: '4.4.+'
+  latestDepTestImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.4.+'
 }


### PR DESCRIPTION
# What Does This Do

Excludes VertX 4.4.+. Fix Java release param issue

# Motivation

Fixes 
```
unable to resolve class io.vertx.core.http.impl.NoStackTraceTimeoutException
```
after Vert.X 4.5.0 release

Fixes
```
Cannot specify --release via `CompileOptions.compilerArgs` when using `JavaCompile.release
```

when building with `OpenJDK Runtime Environment Zulu11.64+19-CA (build 11.0.19+7-LTS)` and the next Java toolchain:

```
❯ ./gradlew -q javaToolchains

 + Options
     | Auto-detection:     Disabled
     | Auto-download:      Disabled

 + AdoptOpenJDK 1.8.0_292-b10
     | Location:           /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
     | Language Version:   8
     | Vendor:             AdoptOpenJDK
     | Architecture:       x86_64
     | Is JDK:             true
     | Detected by:        environment variable 'JAVA_8_HOME'

 + Azul Zulu JDK 11.0.19+7-LTS
     | Location:           /Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
     | Language Version:   11
     | Vendor:             Azul Zulu
     | Architecture:       aarch64
     | Is JDK:             true
     | Detected by:        environment variable 'JAVA_11_HOME'

 + Homebrew JDK 17.0.7+0
     | Location:           /opt/homebrew/Cellar/openjdk@17/17.0.7
     | Language Version:   17
     | Vendor:             Homebrew
     | Architecture:       aarch64
     | Is JDK:             true
     | Detected by:        environment variable 'JAVA_17_HOME'
```

Also fixes:

```
> Task :dd-java-agent:instrumentation:vertx-mysql-client-4.4.2:muzzle-AssertFail-io.vertx-vertx-mysql-client-4.5.0 FAILED
MUZZLE PASSED MySQLConnectionFactoryInstrumentation BUT FAILURE WAS EXPECTED
```

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
