### PR TITLE
Enable telemetry logs by default

### DIFF
--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
@@ -91,15 +91,10 @@ public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher {
   // DDLoggerFactory can be called at very early stage, before Config is loaded
   // So to get property/env we use this custom function
   private static boolean isLogCollectionEnabled() {
-    // FIXME: For the initial rollout, we default log collection to true for IAST and CI Visibility
-    // users. This should be removed once we default to true.
-    final boolean defaultValue =
-        isFlagEnabled("dd.iast.enabled", "DD_IAST_ENABLED", false)
-            || isFlagEnabled("dd.civisibility.enabled", "DD_CIVISIBILITY_ENABLED", false)
-            || isFlagEnabled(
-                "dd.dynamic.instrumentation.enabled", "DD_DYNAMIC_INSTRUMENTATION_ENABLED", false);
     return isFlagEnabled(
-        "dd.telemetry.log-collection.enabled", "DD_TELEMETRY_LOG_COLLECTION_ENABLED", defaultValue);
+            "dd.instrumentation.telemetry.enabled", "DD_INSTRUMENTATION_TELEMETRY_ENABLED", true)
+        && isFlagEnabled(
+            "dd.telemetry.log-collection.enabled", "DD_TELEMETRY_LOG_COLLECTION_ENABLED", true);
   }
 
   private static boolean isFlagEnabled(

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -206,7 +206,7 @@ public final class ConfigDefaults {
       24 * 60 * 60; // 24 hours in seconds
   static final int DEFAULT_TELEMETRY_METRICS_INTERVAL = 10; // in seconds
   static final boolean DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED = true;
-  static final boolean DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED = false;
+  static final boolean DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED = true;
   static final int DEFAULT_TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE = 100000;
 
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = true;

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1599,6 +1599,11 @@ public class Config {
         configProvider.getInteger(
             TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE,
             DEFAULT_TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE);
+
+    isTelemetryLogCollectionEnabled =
+        configProvider.getBoolean(
+            TELEMETRY_LOG_COLLECTION_ENABLED, DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED);
+
     clientIpEnabled = configProvider.getBoolean(CLIENT_IP_ENABLED, DEFAULT_CLIENT_IP_ENABLED);
 
     appSecReportingInband =
@@ -1905,19 +1910,6 @@ public class Config {
 
     debuggerThirdPartyIncludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_INCLUDES));
     debuggerThirdPartyExcludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_EXCLUDES));
-
-    // FIXME: For the initial rollout, we default log collection to true for IAST and CI Visibility
-    // users. This should be removed once we default to true, and then it can also be moved up
-    // together with the rest of telemetry ocnfig.
-    final boolean telemetryLogCollectionEnabledDefault =
-        instrumenterConfig.isTelemetryEnabled()
-                && (instrumenterConfig.getIastActivation() == ProductActivation.FULLY_ENABLED
-                    || instrumenterConfig.isCiVisibilityEnabled()
-                    || debuggerEnabled)
-            || DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED;
-    isTelemetryLogCollectionEnabled =
-        configProvider.getBoolean(
-            TELEMETRY_LOG_COLLECTION_ENABLED, telemetryLogCollectionEnabledDefault);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");


### PR DESCRIPTION
# What Does This Do
Enable telemetry log collection by default.

# Motivation

# Additional Notes
* Jira ticket: [APPSEC-53432](https://datadoghq.atlassian.net/browse/APPSEC-53432)
* Follow up to https://github.com/DataDog/dd-trace-java/pull/6057



[APPSEC-53432]: https://datadoghq.atlassian.net/browse/APPSEC-53432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ