### PR TITLE
Store OpenTelemetry span kind as tag instead of span type

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanBuilder.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanBuilder.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.opentelemetry14.trace;
 
-import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.toSpanType;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.toSpanKindTagValue;
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelExtractedContext.extract;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 
@@ -113,7 +114,7 @@ public class OtelSpanBuilder implements SpanBuilder {
   @Override
   public SpanBuilder setSpanKind(SpanKind spanKind) {
     if (spanKind != null) {
-      this.delegate.withSpanType(toSpanType(spanKind));
+      this.delegate.withTag(SPAN_KIND, toSpanKindTagValue(spanKind));
       this.spanKindSet = true;
     }
     return this;

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -1,11 +1,9 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
-import datadog.trace.bootstrap.instrumentation.api.Tags
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.TraceFlags
 import io.opentelemetry.api.trace.TraceState
 import io.opentelemetry.context.Context
@@ -15,8 +13,17 @@ import spock.lang.Subject
 
 import java.security.InvalidParameterException
 
+import static datadog.trace.api.DDTags.ERROR_MSG
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CLIENT
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUMER
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_PRODUCER
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.SPAN_KIND_INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.api.trace.StatusCode.OK
@@ -51,13 +58,11 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
         }
         span {
           childOfPrevious()
           operationName "internal"
           resourceName "other-name"
-          spanType "internal"
         }
       }
     }
@@ -81,13 +86,11 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
         }
         span {
           childOfPrevious()
           operationName "internal"
           resourceName "other-name"
-          spanType "internal"
         }
       }
     }
@@ -129,7 +132,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName"some-name"
-          spanType "internal"
         }
       }
       trace(1) {
@@ -137,7 +139,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName"other-name"
-          spanType "internal"
         }
       }
     }
@@ -158,14 +159,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
     then:
     assertTraces(2) {
       trace(1) {
-        span {
-          spanType "internal"
-        }
+        span {}
       }
       trace(1) {
-        span {
-          spanType "internal"
-        }
+        span {}
       }
     }
   }
@@ -195,9 +192,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType "internal"
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
           }
         }
@@ -229,9 +226,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType "internal"
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
           }
         }
@@ -264,9 +261,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType "internal"
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
           }
         }
@@ -305,9 +302,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType "internal"
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
           }
         }
@@ -366,7 +363,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
         span {
           parent()
           operationName "internal"
-          spanType "internal"
           if (tagSpan) {
             resourceName "other-resource"
           } else if (tagBuilder) {
@@ -376,6 +372,8 @@ class OpenTelemetry14Test extends AgentTestRunner {
           }
           errored false
           tags {
+            defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             if (tagSpan) {
               "string" "b"
               "empty_string" ""
@@ -413,7 +411,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
               "double-array.1" 4.56D
               "empty-array" ""
             }
-            defaultTags()
           }
         }
       }
@@ -429,9 +426,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span kinds"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    builder.setSpanKind(otelSpanKind)
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name")
+      .setSpanKind(otelSpanKind)
+      .startSpan()
 
     when:
     result.end()
@@ -440,24 +437,26 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType(tagSpanKind)
+          tags {
+            defaultTags()
+            "$SPAN_KIND" "$tagSpanKind"
+          }
         }
       }
     }
 
     where:
     otelSpanKind | tagSpanKind
-    SpanKind.CLIENT | Tags.SPAN_KIND_CLIENT
-    SpanKind.CONSUMER | Tags.SPAN_KIND_CONSUMER
-    SpanKind.INTERNAL | "internal"
-    SpanKind.PRODUCER | Tags.SPAN_KIND_PRODUCER
-    SERVER | Tags.SPAN_KIND_SERVER
+    INTERNAL     | SPAN_KIND_INTERNAL
+    SERVER       | SPAN_KIND_SERVER
+    CLIENT       | SPAN_KIND_CLIENT
+    PRODUCER     | SPAN_KIND_PRODUCER
+    CONSUMER     | SPAN_KIND_CONSUMER
   }
 
   def "test span error status"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name").startSpan()
 
     when:
     result.setStatus(ERROR, "some-error")
@@ -470,12 +469,11 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
           errored true
-
           tags {
-            "$DDTags.ERROR_MSG" "some-error"
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
+            "$ERROR_MSG" "some-error"
           }
         }
       }
@@ -484,34 +482,35 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span status transition"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name").startSpan()
+
+    when:
     result.setStatus(UNSET)
 
-    expect:
+    then:
     !result.delegate.isError()
-    result.delegate.getTag(DDTags.ERROR_MSG) == null
+    result.delegate.getTag(ERROR_MSG) == null
 
     when:
     result.setStatus(ERROR, "some error")
 
     then:
     result.delegate.isError()
-    result.delegate.getTag(DDTags.ERROR_MSG) == "some error"
+    result.delegate.getTag(ERROR_MSG) == "some error"
 
     when:
     result.setStatus(UNSET)
 
     then:
     result.delegate.isError()
-    result.delegate.getTag(DDTags.ERROR_MSG) == "some error"
+    result.delegate.getTag(ERROR_MSG) == "some error"
 
     when:
     result.setStatus(OK)
 
     then:
     !result.delegate.isError()
-    result.delegate.getTag(DDTags.ERROR_MSG) == null
+    result.delegate.getTag(ERROR_MSG) == null
 
     when:
     result.end()
@@ -523,10 +522,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
           errored false
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
           }
         }
       }
@@ -535,13 +534,12 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span record exception"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name").startSpan()
     def message = "input can't be null"
     def exception = new InvalidParameterException(message)
 
     expect:
-    result.delegate.getTag(DDTags.ERROR_MSG) == null
+    result.delegate.getTag(ERROR_MSG) == null
     result.delegate.getTag(DDTags.ERROR_TYPE) == null
     result.delegate.getTag(DDTags.ERROR_STACK) == null
     !result.delegate.isError()
@@ -550,7 +548,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     result.recordException(exception)
 
     then:
-    result.delegate.getTag(DDTags.ERROR_MSG) == message
+    result.delegate.getTag(ERROR_MSG) == message
     result.delegate.getTag(DDTags.ERROR_TYPE) == InvalidParameterException.name
     result.delegate.getTag(DDTags.ERROR_STACK) != null
     !result.delegate.isError()
@@ -565,10 +563,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
           errored false
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             errorTags(exception)
           }
         }
@@ -578,8 +576,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span name update"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.setSpanKind(SERVER).startSpan()
+    def result = tracer.spanBuilder("some-name")
+      .setSpanKind(SERVER)
+      .startSpan()
 
     expect:
     result.delegate.operationName == SPAN_KIND_INTERNAL
@@ -600,7 +599,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
       trace(1) {
         span {
           parent()
-          spanType SPAN_KIND_SERVER
           operationName "server.request"
           resourceName "other-name"
         }
@@ -610,8 +608,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span update after end"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name").startSpan()
 
     when:
     result.setAttribute("string", "value")
@@ -628,10 +625,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName"some-name"
-          spanType "internal"
           errored true
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             "string" "value"
           }
         }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
@@ -226,7 +226,6 @@ class ContextTest extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
         }
         span {
           childOfPrevious()
@@ -236,7 +235,6 @@ class ContextTest extends AgentTestRunner {
           childOfPrevious()
           operationName "internal"
           resourceName "another-name"
-          spanType "internal"
         }
       }
     }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
@@ -88,7 +88,6 @@ abstract class AbstractPropagatorTest extends AgentTestRunner {
         span {
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
           traceDDId(DD128bTraceId.fromHex(traceId))
           parentSpanId(DDSpanId.fromHex(spanId).toLong() as BigInteger)
         }


### PR DESCRIPTION
# What Does This Do

This PR changes the OpenTelemetry instrumentation behavior to store the OpenTelemetry span kind to the `span.kind` tag instead of the (underlying Datadog) span type. 

> [!WARNING]  
> This will change the span type for span issued from OpenTelemetry instrumentations.
As the OpenTelemetry instrumentation is currently in beta and the past behavior was not the one expected, no feature flag was introduce to revert to the past behavior.

# Motivation

This is the expected behavior from OpenTelemetry API support RFC.

# Additional Notes

Jira ticket: [APMJAVA-1062]

I run the changes against the latest system-tests with more [some additional tests enabled](https://github.com/DataDog/system-tests/pull/1818).

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1062]: https://datadoghq.atlassian.net/browse/APMJAVA-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ