### PR TITLE
Fix module name calculation for test executions whose working dir is outside of project repository

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -227,7 +227,9 @@ public class CiVisibilitySystem {
       CIInfo ciInfo = ciProviderInfo.buildCIInfo();
       String repoRoot = ciInfo.getCiWorkspace();
       String moduleName =
-          (repoRoot != null) ? Paths.get(repoRoot).relativize(path).toString() : path.toString();
+          repoRoot != null && path.startsWith(repoRoot)
+              ? Paths.get(repoRoot).relativize(path).toString()
+              : config.getServiceName();
 
       DDTestFrameworkSession testSession =
           sessionFactory.startSession(moduleName, path, component, null);


### PR DESCRIPTION
# What Does This Do
Changes logic that calculates module names for CI Visibility executions that run without build system instrumentation.
A check is added: if current folder of the JVM running the tests is outside of the project's repository, service name is used to populate module name. Otherwise, module name is the path to the current folder relative to the project root (previous behaviour).

# Motivation
Bazel, whose instrumentation is not supported, runs tests in temporary folders with randomly generated names.
As the result, with the previous logic module name is randomised.
Since module name is a part of the test fingerprint, the fingerprints change with every run, which breaks certain features (execution history, ITR, etc.).

The motivation to use service name as the module name is to avoid adding another configuration parameter that the customers would have to set.
If the build system is not instrumented, then each individual module must be instrumented manually, which means that a different service name can be manually set for each module.

Jira ticket: [CIVIS-8038]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->

[CIVIS-8038]: https://datadoghq.atlassian.net/browse/CIVIS-8038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ