### PR TITLE
implement ForKnownTypes

### DIFF
--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
@@ -39,7 +39,7 @@ public class CommonsFileuploadInstrumenter extends Instrumenter.Iast
 
   @Override
   public String[] knownMatchingTypes() {
-    return new String[]
+    return new String[] {
       "org.apache.commons.fileupload.ParameterParser",
       "org.apache.tomcat.util.http.fileupload.ParameterParser"
     };

--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
@@ -20,7 +20,7 @@ import net.bytebuddy.asm.Advice;
 
 @AutoService(Instrumenter.class)
 public class CommonsFileuploadInstrumenter extends Instrumenter.Iast
-    implements Instrumenter.ForConfiguredTypes {
+    implements Instrumenter.ForKnownTypes {
 
   public CommonsFileuploadInstrumenter() {
     super("commons-fileupload");
@@ -38,12 +38,11 @@ public class CommonsFileuploadInstrumenter extends Instrumenter.Iast
   }
 
   @Override
-  public Collection<String> configuredMatchingTypes() {
-    return Arrays.asList(
-        new String[] {
+  public String[] knownMatchingTypes() {
+    return new String[] {
           "org.apache.commons.fileupload.ParameterParser",
           "org.apache.tomcat.util.http.fileupload.ParameterParser"
-        });
+    };
   }
 
   public static class ParseAdvice {

--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
@@ -39,9 +39,9 @@ public class CommonsFileuploadInstrumenter extends Instrumenter.Iast
 
   @Override
   public String[] knownMatchingTypes() {
-    return new String[] {
-          "org.apache.commons.fileupload.ParameterParser",
-          "org.apache.tomcat.util.http.fileupload.ParameterParser"
+    return new String[]
+      "org.apache.commons.fileupload.ParameterParser",
+      "org.apache.tomcat.util.http.fileupload.ParameterParser"
     };
   }
 

--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
@@ -13,8 +13,6 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 


### PR DESCRIPTION
# What Does This Do

Replaces `ForConfiguredTypes` with `ForKnownTypes`.  `ForKnownTypes` is preferred because we know we can statically build that into the tracer and optimize it, whereas `ForConfiguredTypes` implies it might change at runtime and therefore shouldn't be optimized.

Jira ticket: [[APPSEC-11821](https://datadoghq.atlassian.net/browse/APPSEC-11821)]

[APPSEC-11821]: https://datadoghq.atlassian.net/browse/APPSEC-11821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ