### PR TITLE
Store OpenTelemetry span kind as tag instead of span type and drop reserved attributes from span tags

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpan.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpan.java
@@ -1,7 +1,8 @@
 package datadog.trace.instrumentation.opentelemetry14.trace;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.applyConventions;
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.applyNamingConvention;
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.applyReservedAttribute;
 import static io.opentelemetry.api.trace.StatusCode.ERROR;
 import static io.opentelemetry.api.trace.StatusCode.OK;
 import static io.opentelemetry.api.trace.StatusCode.UNSET;
@@ -42,7 +43,7 @@ public class OtelSpan implements Span {
 
   @Override
   public <T> Span setAttribute(AttributeKey<T> key, T value) {
-    if (this.recording) {
+    if (this.recording && !applyReservedAttribute(this.delegate, key, value)) {
       switch (key.getType()) {
         case STRING_ARRAY:
         case BOOLEAN_ARRAY:
@@ -115,14 +116,14 @@ public class OtelSpan implements Span {
   @Override
   public void end() {
     this.recording = false;
-    applyConventions(this.delegate);
+    applyNamingConvention(this.delegate);
     this.delegate.finish();
   }
 
   @Override
   public void end(long timestamp, TimeUnit unit) {
     this.recording = false;
-    applyConventions(this.delegate);
+    applyNamingConvention(this.delegate);
     this.delegate.finish(unit.toMicros(timestamp));
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanBuilder.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanBuilder.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.opentelemetry14.trace;
 
-import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.toSpanType;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.toSpanKindTagValue;
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelExtractedContext.extract;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
 
@@ -113,7 +114,7 @@ public class OtelSpanBuilder implements SpanBuilder {
   @Override
   public SpanBuilder setSpanKind(SpanKind spanKind) {
     if (spanKind != null) {
-      this.delegate.withSpanType(toSpanType(spanKind));
+      this.delegate.withTag(SPAN_KIND, toSpanKindTagValue(spanKind));
       this.spanKindSet = true;
     }
     return this;

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanBuilder.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanBuilder.java
@@ -1,9 +1,14 @@
 package datadog.trace.instrumentation.opentelemetry14.trace;
 
+import static datadog.trace.api.DDTags.ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES;
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.OPERATION_NAME_SPECIFIC_ATTRIBUTE;
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.toSpanKindTagValue;
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelExtractedContext.extract;
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL;
+import static java.lang.Boolean.parseBoolean;
+import static java.util.Locale.ROOT;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -22,10 +27,23 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public class OtelSpanBuilder implements SpanBuilder {
   private final AgentTracer.SpanBuilder delegate;
   private boolean spanKindSet;
+  /**
+   * Operation name overridden value by {@link OtelConventions#OPERATION_NAME_SPECIFIC_ATTRIBUTE}
+   * reserved attribute ({@code null} if not set).
+   */
+  private String overriddenOperationName;
+  /**
+   * Analytics sample rate metric value from {@link
+   * OtelConventions#ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES} reserved attribute ({@code -1} if not
+   * set).
+   */
+  private int overriddenAnalyticsSampleRate;
 
   public OtelSpanBuilder(AgentTracer.SpanBuilder delegate) {
     this.delegate = delegate;
     this.spanKindSet = false;
+    this.overriddenOperationName = null;
+    this.overriddenAnalyticsSampleRate = -1;
   }
 
   @Override
@@ -62,6 +80,14 @@ public class OtelSpanBuilder implements SpanBuilder {
 
   @Override
   public SpanBuilder setAttribute(String key, String value) {
+    // Check reserved attributes
+    if (OPERATION_NAME_SPECIFIC_ATTRIBUTE.equals(key) && value != null) {
+      this.overriddenOperationName = value.toLowerCase(ROOT);
+      return this;
+    } else if (ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES.equals(key) && value != null) {
+      this.overriddenAnalyticsSampleRate = parseBoolean(value) ? 1 : 0;
+      return this;
+    }
     // Store as object to prevent delegate to remove tag when value is empty
     this.delegate.withTag(key, (Object) value);
     return this;
@@ -81,6 +107,11 @@ public class OtelSpanBuilder implements SpanBuilder {
 
   @Override
   public SpanBuilder setAttribute(String key, boolean value) {
+    // Check reserved attributes
+    if (ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES.equals(key)) {
+      this.overriddenAnalyticsSampleRate = value ? 1 : 0;
+      return this;
+    }
     this.delegate.withTag(key, value);
     return this;
   }
@@ -133,6 +164,13 @@ public class OtelSpanBuilder implements SpanBuilder {
       setSpanKind(INTERNAL);
     }
     AgentSpan delegate = this.delegate.start();
+    // Apply overrides
+    if (this.overriddenOperationName != null) {
+      delegate.setOperationName(this.overriddenOperationName);
+    }
+    if (this.overriddenAnalyticsSampleRate != -1) {
+      delegate.setMetric(ANALYTICS_SAMPLE_RATE, this.overriddenAnalyticsSampleRate);
+    }
     return new OtelSpan(delegate);
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ConventionsTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ConventionsTest.groovy
@@ -6,6 +6,7 @@ import io.opentelemetry.context.ThreadLocalContextStorage
 import spock.lang.Subject
 
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND
+import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.OPERATION_NAME_SPECIFIC_ATTRIBUTE
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.SPAN_KIND_INTERNAL
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.toSpanKindTagValue
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
@@ -43,8 +44,10 @@ class OpenTelemetry14ConventionsTest extends AgentTestRunner {
           tags {
             defaultTags()
             "$SPAN_KIND" "${toSpanKindTagValue(kind == null ? INTERNAL : kind)}"
-            attributes.forEach { key, value->
-              tag(key, value)
+            attributes.forEach { key, value ->
+              if (!OPERATION_NAME_SPECIFIC_ATTRIBUTE.equals(key)) {
+                tag(key, value)
+              }
             }
           }
         }
@@ -93,20 +96,31 @@ class OpenTelemetry14ConventionsTest extends AgentTestRunner {
   }
 
   def "test span specific tags"() {
+    setup:
+    def builder = tracer.spanBuilder("some-name")
+
     when:
-    tracer.spanBuilder("some-name")
-      .setAttribute("service.name", "my-service")
-      .setAttribute("resource.name", "/my-resource")
-      .setAttribute("span.type", "http")
-      .startSpan()
-      .end()
+    if (setInBuilder) {
+      builder.setAttribute("operation.name", "my-operation")
+        .setAttribute("service.name", "my-service")
+        .setAttribute("resource.name", "/my-resource")
+        .setAttribute("span.type", "http")
+    }
+    def result = builder.startSpan()
+    if (!setInBuilder) {
+      result.setAttribute("operation.name", "my-operation")
+        .setAttribute("service.name", "my-service")
+        .setAttribute("resource.name", "/my-resource")
+        .setAttribute("span.type", "http")
+    }
+    result.end()
 
     then:
     assertTraces(1) {
       trace(1) {
         span {
           parent()
-          operationName "internal"
+          operationName "my-operation"
           resourceName "/my-resource"
           serviceName "my-service"
           spanType "http"
@@ -117,15 +131,24 @@ class OpenTelemetry14ConventionsTest extends AgentTestRunner {
         }
       }
     }
+
+    where:
+    setInBuilder << [true, false]
   }
 
   def "test span analytics.event specific tag"() {
-    when:
-    tracer.spanBuilder("some-name")
-      .setAttribute("analytics.event", value)
-      .startSpan()
-      .end()
+    setup:
+    def builder = tracer.spanBuilder("some-name")
 
+    when:
+    if (setInBuilder) {
+      builder.setAttribute("analytics.event", value)
+    }
+    def result = builder.startSpan()
+    if (!setInBuilder) {
+      result.setAttribute("analytics.event", value)
+    }
+    result.end()
 
     then:
     assertTraces(1) {
@@ -137,7 +160,6 @@ class OpenTelemetry14ConventionsTest extends AgentTestRunner {
             defaultTags()
             "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             if (value != null) {
-              "analytics.event" value
               "$DDTags.ANALYTICS_SAMPLE_RATE" expectedMetric
             }
           }
@@ -146,17 +168,27 @@ class OpenTelemetry14ConventionsTest extends AgentTestRunner {
     }
 
     where:
-    value            | expectedMetric
-    true             | 1
-    Boolean.TRUE     | 1
-    false            | 0
-    Boolean.FALSE    | 0
-    null             | 0 // Not used
-    "true"           | 1
-    "false"          | 0
-    "TRUE"           | 1
-    "something-else" | 0
-    ""               | 0
+    setInBuilder | value            | expectedMetric
+    true         | true             | 1
+    true         | Boolean.TRUE     | 1
+    true         | false            | 0
+    true         | Boolean.FALSE    | 0
+    true         | null             | 0 // Not used
+    true         | "true"           | 1
+    true         | "false"          | 0
+    true         | "TRUE"           | 1
+    true         | "something-else" | 0
+    true         | ""               | 0
+    false        | true             | 1
+    false        | Boolean.TRUE     | 1
+    false        | false            | 0
+    false        | Boolean.FALSE    | 0
+    false        | null             | 0 // Not used
+    false        | "true"           | 1
+    false        | "false"          | 0
+    false        | "TRUE"           | 1
+    false        | "something-else" | 0
+    false        | ""               | 0
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -1,11 +1,9 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
-import datadog.trace.bootstrap.instrumentation.api.Tags
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.TraceFlags
 import io.opentelemetry.api.trace.TraceState
 import io.opentelemetry.context.Context
@@ -15,8 +13,17 @@ import spock.lang.Subject
 
 import java.security.InvalidParameterException
 
+import static datadog.trace.api.DDTags.ERROR_MSG
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CLIENT
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUMER
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_PRODUCER
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.SPAN_KIND_INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.CLIENT
+import static io.opentelemetry.api.trace.SpanKind.CONSUMER
+import static io.opentelemetry.api.trace.SpanKind.INTERNAL
+import static io.opentelemetry.api.trace.SpanKind.PRODUCER
 import static io.opentelemetry.api.trace.SpanKind.SERVER
 import static io.opentelemetry.api.trace.StatusCode.ERROR
 import static io.opentelemetry.api.trace.StatusCode.OK
@@ -51,13 +58,11 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
         }
         span {
           childOfPrevious()
           operationName "internal"
           resourceName "other-name"
-          spanType "internal"
         }
       }
     }
@@ -81,13 +86,11 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
         }
         span {
           childOfPrevious()
           operationName "internal"
           resourceName "other-name"
-          spanType "internal"
         }
       }
     }
@@ -129,7 +132,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName"some-name"
-          spanType "internal"
         }
       }
       trace(1) {
@@ -137,7 +139,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName"other-name"
-          spanType "internal"
         }
       }
     }
@@ -158,14 +159,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
     then:
     assertTraces(2) {
       trace(1) {
-        span {
-          spanType "internal"
-        }
+        span {}
       }
       trace(1) {
-        span {
-          spanType "internal"
-        }
+        span {}
       }
     }
   }
@@ -195,9 +192,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType "internal"
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
           }
         }
@@ -229,9 +226,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType "internal"
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
           }
         }
@@ -264,9 +261,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType "internal"
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
           }
         }
@@ -305,9 +302,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType "internal"
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             tag("_dd.span_links", { JSONAssert.assertEquals(expectedLinksTag, it as String, true); return true })
           }
         }
@@ -366,7 +363,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
         span {
           parent()
           operationName "internal"
-          spanType "internal"
           if (tagSpan) {
             resourceName "other-resource"
           } else if (tagBuilder) {
@@ -376,6 +372,8 @@ class OpenTelemetry14Test extends AgentTestRunner {
           }
           errored false
           tags {
+            defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             if (tagSpan) {
               "string" "b"
               "empty_string" ""
@@ -413,7 +411,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
               "double-array.1" 4.56D
               "empty-array" ""
             }
-            defaultTags()
           }
         }
       }
@@ -429,9 +426,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span kinds"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    builder.setSpanKind(otelSpanKind)
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name")
+      .setSpanKind(otelSpanKind)
+      .startSpan()
 
     when:
     result.end()
@@ -440,24 +437,26 @@ class OpenTelemetry14Test extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          spanType(tagSpanKind)
+          tags {
+            defaultTags()
+            "$SPAN_KIND" "$tagSpanKind"
+          }
         }
       }
     }
 
     where:
     otelSpanKind | tagSpanKind
-    SpanKind.CLIENT | Tags.SPAN_KIND_CLIENT
-    SpanKind.CONSUMER | Tags.SPAN_KIND_CONSUMER
-    SpanKind.INTERNAL | "internal"
-    SpanKind.PRODUCER | Tags.SPAN_KIND_PRODUCER
-    SERVER | Tags.SPAN_KIND_SERVER
+    INTERNAL     | SPAN_KIND_INTERNAL
+    SERVER       | SPAN_KIND_SERVER
+    CLIENT       | SPAN_KIND_CLIENT
+    PRODUCER     | SPAN_KIND_PRODUCER
+    CONSUMER     | SPAN_KIND_CONSUMER
   }
 
   def "test span error status"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name").startSpan()
 
     when:
     result.setStatus(ERROR, "some-error")
@@ -470,12 +469,11 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
           errored true
-
           tags {
-            "$DDTags.ERROR_MSG" "some-error"
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
+            "$ERROR_MSG" "some-error"
           }
         }
       }
@@ -484,34 +482,35 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span status transition"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name").startSpan()
+
+    when:
     result.setStatus(UNSET)
 
-    expect:
+    then:
     !result.delegate.isError()
-    result.delegate.getTag(DDTags.ERROR_MSG) == null
+    result.delegate.getTag(ERROR_MSG) == null
 
     when:
     result.setStatus(ERROR, "some error")
 
     then:
     result.delegate.isError()
-    result.delegate.getTag(DDTags.ERROR_MSG) == "some error"
+    result.delegate.getTag(ERROR_MSG) == "some error"
 
     when:
     result.setStatus(UNSET)
 
     then:
     result.delegate.isError()
-    result.delegate.getTag(DDTags.ERROR_MSG) == "some error"
+    result.delegate.getTag(ERROR_MSG) == "some error"
 
     when:
     result.setStatus(OK)
 
     then:
     !result.delegate.isError()
-    result.delegate.getTag(DDTags.ERROR_MSG) == null
+    result.delegate.getTag(ERROR_MSG) == null
 
     when:
     result.end()
@@ -523,10 +522,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
           errored false
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
           }
         }
       }
@@ -535,13 +534,12 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span record exception"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name").startSpan()
     def message = "input can't be null"
     def exception = new InvalidParameterException(message)
 
     expect:
-    result.delegate.getTag(DDTags.ERROR_MSG) == null
+    result.delegate.getTag(ERROR_MSG) == null
     result.delegate.getTag(DDTags.ERROR_TYPE) == null
     result.delegate.getTag(DDTags.ERROR_STACK) == null
     !result.delegate.isError()
@@ -550,7 +548,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     result.recordException(exception)
 
     then:
-    result.delegate.getTag(DDTags.ERROR_MSG) == message
+    result.delegate.getTag(ERROR_MSG) == message
     result.delegate.getTag(DDTags.ERROR_TYPE) == InvalidParameterException.name
     result.delegate.getTag(DDTags.ERROR_STACK) != null
     !result.delegate.isError()
@@ -565,10 +563,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
           errored false
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             errorTags(exception)
           }
         }
@@ -578,8 +576,9 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span name update"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.setSpanKind(SERVER).startSpan()
+    def result = tracer.spanBuilder("some-name")
+      .setSpanKind(SERVER)
+      .startSpan()
 
     expect:
     result.delegate.operationName == SPAN_KIND_INTERNAL
@@ -600,7 +599,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
       trace(1) {
         span {
           parent()
-          spanType SPAN_KIND_SERVER
           operationName "server.request"
           resourceName "other-name"
         }
@@ -610,8 +608,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
 
   def "test span update after end"() {
     setup:
-    def builder = tracer.spanBuilder("some-name")
-    def result = builder.startSpan()
+    def result = tracer.spanBuilder("some-name").startSpan()
 
     when:
     result.setAttribute("string", "value")
@@ -628,10 +625,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName"some-name"
-          spanType "internal"
           errored true
           tags {
             defaultTags()
+            "$SPAN_KIND" "$SPAN_KIND_INTERNAL"
             "string" "value"
           }
         }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
@@ -226,7 +226,6 @@ class ContextTest extends AgentTestRunner {
           parent()
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
         }
         span {
           childOfPrevious()
@@ -236,7 +235,6 @@ class ContextTest extends AgentTestRunner {
           childOfPrevious()
           operationName "internal"
           resourceName "another-name"
-          spanType "internal"
         }
       }
     }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
@@ -88,7 +88,6 @@ abstract class AbstractPropagatorTest extends AgentTestRunner {
         span {
           operationName "internal"
           resourceName "some-name"
-          spanType "internal"
           traceDDId(DD128bTraceId.fromHex(traceId))
           parentSpanId(DDSpanId.fromHex(spanId).toLong() as BigInteger)
         }


### PR DESCRIPTION
# What Does This Do

This PR is a port of #6232 bug fix.
It also prevents reserved attributes being sent as span tags.

> [!WARNING]  
> This will change the span type for span issued from OpenTelemetry instrumentations.
As the OpenTelemetry instrumentation is currently in beta and the past behavior was not the one expected, no feature flag was introduce to revert to the past behavior.

# Motivation

This behavior was recently describes in the OTel API support RFC. 

# Additional Notes

Jira ticket: [APMJAVA-1062]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1062]: https://datadoghq.atlassian.net/browse/APMJAVA-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ