### PR TITLE
add option to collect heap histogram after GC or periodically

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -20,6 +20,8 @@ import static com.datadog.profiling.controller.ProfilingSupport.isObjectCountPar
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_ENABLED_DEFAULT;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_MODE;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_MODE_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ULTRA_MINIMAL;
 
 import com.datadog.profiling.controller.ConfigurationException;
@@ -110,7 +112,15 @@ public final class OpenJdkController implements Controller {
             "enabling Datadog heap histogram on JVM without an efficient implementation of the jdk.ObjectCount event. "
                 + "This may increase p99 latency. Consider upgrading to JDK 17.0.9+ or 21+ to reduce latency impact.");
       }
-      enableEvent(recordingSettings, "jdk.ObjectCount", "user enabled histogram heap collection");
+      String mode =
+          configProvider.getString(
+              PROFILING_HEAP_HISTOGRAM_MODE, PROFILING_HEAP_HISTOGRAM_MODE_DEFAULT);
+      if ("periodic".equalsIgnoreCase(mode)) {
+        enableEvent(recordingSettings, "jdk.ObjectCount", "user enabled histogram heap collection");
+      } else {
+        enableEvent(
+            recordingSettings, "jdk.ObjectCountAfterGC", "user enabled histogram heap collection");
+      }
     }
 
     // Toggle settings from override file

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -190,5 +190,8 @@ public final class ProfilingConfig {
   public static final String PROFILING_HEAP_HISTOGRAM_ENABLED = "profiling.heap.histogram.enabled";
   public static final boolean PROFILING_HEAP_HISTOGRAM_ENABLED_DEFAULT = false;
 
+  public static final String PROFILING_HEAP_HISTOGRAM_MODE = "profiling.heap.histogram.mode";
+  public static final String PROFILING_HEAP_HISTOGRAM_MODE_DEFAULT = "aftergc";
+
   private ProfilingConfig() {}
 }


### PR DESCRIPTION
# What Does This Do

Currently enabling the heap histogram triggers a GC once every 60s, which has the advantage of frequently collecting data about heap occupancy. This change adds a mode to only collect the histogram when there is a natural GC and makes it the default.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
