### PR TITLE
Update docker builder image

### DIFF
--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -28,7 +28,7 @@ MASTER_ONLY_JDKS = {
 }
 # Version to use for all the base Docker images, see
 # https://github.com/DataDog/dd-trace-java-docker-build/pkgs/container/dd-trace-java-docker-build
-DOCKER_IMAGE_VERSION="v23.09"
+DOCKER_IMAGE_VERSION="v23.10"
 
 # Get labels from pull requests to override some defaults for jobs to run.
 # `run-tests: all` will run all tests.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ cache: &default_cache
 
 .gradle_build: &gradle_build
   <<: *common
-  image: ghcr.io/datadog/dd-trace-java-docker-build:base
+  image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
 


### PR DESCRIPTION
# What Does This Do

This PR update the docker builder image.

# Motivation

This will bring Temurin 21 and GraalVM native-image 21 as long as patch updates for the existing JDK.

# Additional Notes

This PR also changes the behavior for the GitLab CI.
It moves from latest to a stable version, the same as Circle CI.

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
