### PR TITLE
Add smoke test for multiple agents and NoProtectionDomain system loader

### DIFF
--- a/dd-smoke-tests/agent-bootstrap/build.gradle
+++ b/dd-smoke-tests/agent-bootstrap/build.gradle
@@ -1,0 +1,40 @@
+description = "Check agent can be loaded with another agent on a no protection domain system class-loader"
+
+apply from: rootProject.file('gradle/java.gradle')
+
+dependencies {
+  testImplementation(project(':dd-smoke-tests'))
+}
+
+sourceSets {
+  create('another-agent') {
+    java
+  }
+}
+
+tasks.jar {
+  archiveClassifier = 'app'
+  manifest {
+    attributes('Main-Class': 'datadog.smoketest.app.App')
+  }
+}
+
+tasks.register('anotherAgentJar', Jar) {
+  archiveClassifier = 'another-agent'
+  from(sourceSets['another-agent'].output)
+  manifest {
+    attributes('Premain-Class': 'datadog.smoketest.agent.AnotherAgent')
+  }
+}
+
+tasks.withType(Test).configureEach {
+  dependsOn "jar", "anotherAgentJar"
+
+  def toolchain17 = getJavaLauncherFor(17).get()
+
+  systemProperties(
+    'datadog.smoketest.java.home': toolchain17.metadata.installationPath.asFile.absolutePath,
+    'datadog.smoketest.jar.path': jar.archiveFile.get().asFile.absolutePath,
+    'datadog.smoketest.another.agent.path': anotherAgentJar.archiveFile.get().asFile.absolutePath,
+    )
+}

--- a/dd-smoke-tests/agent-bootstrap/src/another-agent/java/datadog/smoketest/agent/AnotherAgent.java
+++ b/dd-smoke-tests/agent-bootstrap/src/another-agent/java/datadog/smoketest/agent/AnotherAgent.java
@@ -1,0 +1,7 @@
+package datadog.smoketest.agent;
+
+public class AnotherAgent {
+  public static void premain(String argString) {
+    System.out.println("Hello from another agent!");
+  }
+}

--- a/dd-smoke-tests/agent-bootstrap/src/main/java/datadog/smoketest/app/App.java
+++ b/dd-smoke-tests/agent-bootstrap/src/main/java/datadog/smoketest/app/App.java
@@ -1,0 +1,15 @@
+package datadog.smoketest.app;
+
+import datadog.smoketest.classloader.NoProtectionDomainClassLoader;
+
+public class App {
+  public static void main(String[] args) {
+    ClassLoader classLoader = App.class.getClassLoader();
+    if (!(classLoader instanceof NoProtectionDomainClassLoader)) {
+      throw new RuntimeException(
+          "You must run JVM with -Djava.system.class.loader=datadog.smoketest.classloader.NoProtectionDomainClassLoader");
+    }
+
+    System.out.println("Hello form app!");
+  }
+}

--- a/dd-smoke-tests/agent-bootstrap/src/main/java/datadog/smoketest/classloader/NoProtectionDomainClassLoader.java
+++ b/dd-smoke-tests/agent-bootstrap/src/main/java/datadog/smoketest/classloader/NoProtectionDomainClassLoader.java
@@ -1,0 +1,156 @@
+package datadog.smoketest.classloader;
+
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple class loader that defines classes without a protection domain (actually without a {@link
+ * java.security.CodeSource CodeSource}, to mimic IntelliJ's class loading behavior).
+ */
+@SuppressWarnings("unused")
+public class NoProtectionDomainClassLoader extends URLClassLoader {
+  private final Path[] classPath;
+
+  private final Map<String, Class<?>> classCache = new HashMap<>();
+
+  /**
+   * Packages that should be loaded by the parent class loader. There's likely more for a proper
+   * implementation like org.w3c. but not necessary for this test.
+   */
+  private final String[] excludedPackages =
+      new String[] {
+        "java.", "javax.", "jdk.", "sun.", "oracle.", "com.sun.", "com.ibm.", "COM.ibm.",
+      };
+
+  /**
+   * Used by system to inject the default class loader.
+   *
+   * @param parent Parent classloader
+   * @see ClassLoader#getSystemClassLoader
+   */
+  @SuppressForbidden
+  public NoProtectionDomainClassLoader(ClassLoader parent) {
+    super(new URL[0], parent);
+    // Stream equivalent is not possible for system classloader for JDK 8
+    List<Path> list = new ArrayList<>();
+    for (String s : System.getProperty("java.class.path").split(File.pathSeparator)) {
+      Path path = Paths.get(s);
+      list.add(path);
+    }
+    classPath = list.toArray(new Path[0]);
+  }
+
+  /**
+   * Loads the class with the specified name. JDK classes are loaded in the parent classloader,
+   * others by this classloader.
+   *
+   * @param name The binary name of the class
+   * @param resolve If true, then resolve the class
+   * @return The loaded class
+   * @throws ClassNotFoundException if the class is not found
+   */
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    for (String excludedPackage : excludedPackages) {
+      if (name.startsWith(excludedPackage)) {
+        return super.loadClass(name, resolve);
+      }
+    }
+    Class<?> cls = classCache.get(name);
+    if (cls != null) {
+      return cls;
+    }
+    return findClass(name);
+  }
+
+  /**
+   * Finds and loads the class with the specified name from the URL search path without {@link
+   * ProtectionDomain}. Any URLs referring to JAR files are loaded and opened as needed until the
+   * class is found.
+   *
+   * @param name the binary name of the class
+   * @return The defined class
+   * @throws ClassNotFoundException Thrown on any IO or if actually not found
+   */
+  public Class<?> findClass(String name) throws ClassNotFoundException {
+
+    String classFile = name.replace('.', '/') + ".class";
+    try (InputStream classData = getResourceAsStream(classFile)) {
+      byte[] array = readClassBytes(name, classData, classFile);
+
+      // Since this class is used as the system class loader, we need to delegate
+      // to the parent class loader, otherwise **this** class maybe loaded by again itself, thus
+      // resulting in defining different classes making `instanceof` checks fail.
+      if (name.equals(getClass().getCanonicalName())) {
+        return getParent().loadClass(name);
+      }
+
+      Class<?> aClass = defineClass(name, array, 0, array.length, (ProtectionDomain) null);
+      classCache.put(name, aClass);
+      return aClass;
+    } catch (IOException io) {
+      throw new ClassNotFoundException("Loading class failed", io);
+    }
+  }
+
+  /**
+   * Reads all bytes from the class file or from an input stream.
+   *
+   * @param name The binary name of the class
+   * @param classData The stream of the class bytes, nullable
+   * @param classFile The relative path to the class file, nullable
+   * @return The class bytes
+   * @throws IOException Thrown on failure to read the class bytes
+   * @throws ClassNotFoundException Thrown if the class file doesn't exist and classFile is null
+   */
+  private byte[] readClassBytes(String name, InputStream classData, String classFile)
+      throws IOException, ClassNotFoundException {
+    if (classData == null) {
+      // try local classpath
+      for (Path path : classPath) {
+        Path resolvedPath = path.resolve(classFile);
+        if (Files.exists(resolvedPath)) {
+          return Files.readAllBytes(resolvedPath);
+        }
+      }
+      throw new ClassNotFoundException("Couldn't find class " + name);
+    }
+
+    return readAllBytes(classData);
+  }
+
+  /** Straw man {@code readAllBytes} for pre-JDK 9. */
+  private static byte[] readAllBytes(final InputStream resource) throws IOException {
+    final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    int bytesRead;
+    final byte[] data = new byte[1024];
+    while ((bytesRead = resource.read(data, 0, data.length)) != -1) {
+      buffer.write(data, 0, bytesRead);
+    }
+    buffer.flush();
+    return buffer.toByteArray();
+  }
+
+  /**
+   * Called by the VM to support dynamic additions to the class path.
+   *
+   * @see java.lang.instrument.Instrumentation#appendToSystemClassLoaderSearch
+   */
+  @SuppressWarnings("unused")
+  final void appendToClassPathForInstrumentation(String jar) throws IOException {
+    addURL(Paths.get(jar).toRealPath().toFile().toURI().toURL());
+  }
+}

--- a/dd-smoke-tests/agent-bootstrap/src/test/groovy/datadog/smoketest/MultiAgentWithNoProtectionDomainSystemLoaderSmokeTest.groovy
+++ b/dd-smoke-tests/agent-bootstrap/src/test/groovy/datadog/smoketest/MultiAgentWithNoProtectionDomainSystemLoaderSmokeTest.groovy
@@ -1,0 +1,63 @@
+package datadog.smoketest
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+class MultiAgentWithNoProtectionDomainSystemLoaderSmokeTest extends AbstractSmokeTest {
+  private static final int TIMEOUT_SECS = 30
+
+  @Override
+  def logLevel() {
+    "debug"
+  }
+
+  @Override
+  String javaHome() {
+    return System.getProperty("datadog.smoketest.java.home")
+  }
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String appJar = System.getProperty("datadog.smoketest.jar.path")
+    assert new File(appJar).isFile()
+    String anotherAgentJar = System.getProperty("datadog.smoketest.another.agent.path")
+    assert new File(anotherAgentJar).isFile()
+
+    List<String> command = new ArrayList<>()
+    command.add(javaPath())
+    command.addAll(defaultJavaProperties)
+    command.add("-Djava.system.class.loader=datadog.smoketest.classloader.NoProtectionDomainClassLoader")
+    command.add("-javaagent:" + anotherAgentJar)
+    command.addAll((String[]) ["-jar", appJar])
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+
+    return processBuilder
+  }
+
+  def "no failure on bootstrap when multiple agent and no ProtectionDomain system class-loader"() {
+    when:
+    testedProcess.waitFor(TIMEOUT_SECS, SECONDS)
+    boolean codeSourceNotAvailable = false
+    boolean multipleJavaagent = false
+    boolean useClassLoaderResource = false
+    checkLogPostExit {
+      if (it =~ /Could not get bootstrap jar from code source, using -javaagent arg/) {
+        codeSourceNotAvailable = true
+      }
+      if (it =~ /Could not get bootstrap jar from -javaagent arg: multiple javaagents specified/) {
+        multipleJavaagent = true
+      }
+      if (it =~ /Could not get agent jar from -javaagent arg, using ClassLoader#getResource/) {
+        useClassLoaderResource = true
+      }
+    }
+
+    then:
+    testedProcess.exitValue() == 0
+    codeSourceNotAvailable
+    multipleJavaagent
+    useClassLoaderResource
+    !logHasErrors
+  }
+}

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -185,7 +185,7 @@ abstract class ProcessManager extends Specification {
       ProcessBuilder processBuilder = createProcessBuilder(idx)
 
 
-      processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"))
+      processBuilder.environment().put("JAVA_HOME", javaHome())
       processBuilder.environment().put("DD_API_KEY", apiKey())
 
       processBuilder.redirectErrorStream(true)
@@ -200,7 +200,11 @@ abstract class ProcessManager extends Specification {
 
   String javaPath() {
     final String separator = System.getProperty("file.separator")
-    return System.getProperty("java.home") + separator + "bin" + separator + "java"
+    return javaHome() + separator + "bin" + separator + "java"
+  }
+
+  String javaHome() {
+    return System.getProperty("java.home")
   }
 
   def cleanupSpec() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -89,6 +89,7 @@ include ':utils:time-utils'
 include ':utils:version-utils'
 
 // smoke tests
+include ':dd-smoke-tests:agent-bootstrap'
 include ':dd-smoke-tests:armeria-grpc'
 include ':dd-smoke-tests:cli'
 include ':dd-smoke-tests:custom-systemloader'


### PR DESCRIPTION
# What Does This Do
Adds a smoke test for 
* #6126

This is basically the same PR #6244 but from Datadog/dd-trace-java instead of my fork bric3/dd-trace-java. As such this PR supersede #6244.

# Motivation
Verify the changes in #6126, where the agent is now able to determine its location when there are other agents and the classloader strips the protection domain.

# Additional Notes

Jira ticket: [CIVIS-7865](https://datadoghq.atlassian.net/browse/CIVIS-7865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

_Note this is the Jira of #6126._

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-7865]: https://datadoghq.atlassian.net/browse/CIVIS-7865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ