### PR TITLE
Fix race for SymDB enablement

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.regex.Pattern;
@@ -48,6 +49,7 @@ public class SymDBEnablement implements ProductListener {
   private final SymbolAggregator symbolAggregator;
   private SymbolExtractionTransformer symbolExtractionTransformer;
   private volatile long lastUploadTimestamp;
+  private AtomicBoolean starting = new AtomicBoolean();
 
   public SymDBEnablement(
       Instrumentation instrumentation, Config config, SymbolAggregator symbolAggregator) {
@@ -102,25 +104,32 @@ public class SymDBEnablement implements ProductListener {
   }
 
   public void startSymbolExtraction() {
-    LOGGER.debug("Starting symbol extraction...");
-    if (lastUploadTimestamp > 0) {
-      LOGGER.debug(
-          "Last upload was on {}",
-          LocalDateTime.ofInstant(
-              Instant.ofEpochMilli(lastUploadTimestamp), ZoneId.systemDefault()));
+    if (!starting.compareAndSet(false, true)) {
       return;
     }
-    String includes = config.getDebuggerSymbolIncludes();
-    AllowListHelper allowListHelper = new AllowListHelper(buildFilterList(includes));
-    symbolAggregator.startLoadedClasses();
     try {
-      symbolExtractionTransformer =
-          new SymbolExtractionTransformer(allowListHelper, symbolAggregator);
-      instrumentation.addTransformer(symbolExtractionTransformer, true);
-      extractSymbolForLoadedClasses(allowListHelper);
-      lastUploadTimestamp = System.currentTimeMillis();
+      LOGGER.debug("Starting symbol extraction...");
+      if (lastUploadTimestamp > 0) {
+        LOGGER.debug(
+            "Last upload was on {}",
+            LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(lastUploadTimestamp), ZoneId.systemDefault()));
+        return;
+      }
+      String includes = config.getDebuggerSymbolIncludes();
+      AllowListHelper allowListHelper = new AllowListHelper(buildFilterList(includes));
+      symbolAggregator.loadedClassesProcessStarted();
+      try {
+        symbolExtractionTransformer =
+            new SymbolExtractionTransformer(allowListHelper, symbolAggregator);
+        instrumentation.addTransformer(symbolExtractionTransformer);
+        extractSymbolForLoadedClasses(allowListHelper);
+        lastUploadTimestamp = System.currentTimeMillis();
+      } finally {
+        symbolAggregator.loadedClassesProcessEnded();
+      }
     } finally {
-      symbolAggregator.finishLoadedClasses();
+      starting.set(false);
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
@@ -112,11 +112,16 @@ public class SymDBEnablement implements ProductListener {
     }
     String includes = config.getDebuggerSymbolIncludes();
     AllowListHelper allowListHelper = new AllowListHelper(buildFilterList(includes));
-    symbolExtractionTransformer =
-        new SymbolExtractionTransformer(allowListHelper, symbolAggregator);
-    instrumentation.addTransformer(symbolExtractionTransformer, true);
-    extractSymbolForLoadedClasses(allowListHelper);
-    lastUploadTimestamp = System.currentTimeMillis();
+    symbolAggregator.startLoadedClasses();
+    try {
+      symbolExtractionTransformer =
+          new SymbolExtractionTransformer(allowListHelper, symbolAggregator);
+      instrumentation.addTransformer(symbolExtractionTransformer, true);
+      extractSymbolForLoadedClasses(allowListHelper);
+      lastUploadTimestamp = System.currentTimeMillis();
+    } finally {
+      symbolAggregator.finishLoadedClasses();
+    }
   }
 
   private void extractSymbolForLoadedClasses(AllowListHelper allowListHelper) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolAggregator.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolAggregator.java
@@ -111,13 +111,13 @@ public class SymbolAggregator {
     }
   }
 
-  void startLoadedClasses() {
+  void loadedClassesProcessStarted() {
     // to avoid duplicate symbol extraction we keep track of loaded classes
     // during the loaded class extraction phase
     loadedClasses = ConcurrentHashMap.newKeySet();
   }
 
-  void finishLoadedClasses() {
+  void loadedClassesProcessEnded() {
     loadedClasses = null;
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
@@ -54,7 +54,7 @@ class SymDBEnablementTest {
         new SymDBEnablement(instr, config, new SymbolAggregator(symbolSink, 1));
     symDBEnablement.accept(ParsedConfigKey.parse(CONFIG_KEY), UPlOAD_SYMBOL_TRUE, null);
     waitForUpload(symDBEnablement);
-    verify(instr).addTransformer(any(SymbolExtractionTransformer.class), eq(true));
+    verify(instr).addTransformer(any(SymbolExtractionTransformer.class));
     symDBEnablement.accept(ParsedConfigKey.parse(CONFIG_KEY), UPlOAD_SYMBOL_FALSE, null);
     verify(instr).removeTransformer(any(SymbolExtractionTransformer.class));
   }
@@ -77,7 +77,7 @@ class SymDBEnablementTest {
     symDBEnablement.startSymbolExtraction();
     ArgumentCaptor<SymbolExtractionTransformer> captor =
         ArgumentCaptor.forClass(SymbolExtractionTransformer.class);
-    verify(instr).addTransformer(captor.capture(), eq(true));
+    verify(instr).addTransformer(captor.capture());
     SymbolExtractionTransformer transformer = captor.getValue();
     AllowListHelper allowListHelper = transformer.getAllowListHelper();
     assertTrue(allowListHelper.isAllowed("com.datadog.debugger.test.TestClass"));
@@ -98,7 +98,7 @@ class SymDBEnablementTest {
     SymbolAggregator symbolAggregator = mock(SymbolAggregator.class);
     SymDBEnablement symDBEnablement = new SymDBEnablement(instr, config, symbolAggregator);
     symDBEnablement.startSymbolExtraction();
-    verify(instr).addTransformer(any(SymbolExtractionTransformer.class), eq(true));
+    verify(instr).addTransformer(any(SymbolExtractionTransformer.class));
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
     verify(symbolAggregator, times(2))
         .parseClass(captor.capture(), any(), eq(jarFileUrl.getFile()));
@@ -145,7 +145,7 @@ class SymDBEnablementTest {
               return new Class[] {testClass};
             });
     symDBEnablement.startSymbolExtraction();
-    verify(mockSymbolSink).addScope(any());
+    verify(mockSymbolSink, times(1)).addScope(any());
   }
 
   private void waitForUpload(SymDBEnablement symDBEnablement) throws InterruptedException {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,11 +15,16 @@ import com.datadog.debugger.agent.AllowListHelper;
 import com.datadog.debugger.sink.SymbolSink;
 import datadog.remoteconfig.state.ParsedConfigKey;
 import datadog.trace.api.Config;
+import datadog.trace.util.Strings;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.instrument.Instrumentation;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -101,6 +107,45 @@ class SymDBEnablementTest {
     assertEquals(
         "BOOT-INF/classes/org/springframework/samples/petclinic/vet/VetController.class",
         captor.getAllValues().get(1));
+  }
+
+  @Test
+  public void noDuplicateSymbolExtraction() {
+    final String CLASS_NAME_PATH = "com/datadog/debugger/symbol/SymbolExtraction01";
+    SymbolSink mockSymbolSink = mock(SymbolSink.class);
+    SymbolAggregator symbolAggregator = new SymbolAggregator(mockSymbolSink, 1);
+    SymDBEnablement symDBEnablement = new SymDBEnablement(instr, config, symbolAggregator);
+    doAnswer(
+            invocation -> {
+              SymbolExtractionTransformer transformer = invocation.getArgument(0);
+              JarFile jarFile =
+                  new JarFile(getClass().getResource("/debugger-symbol.jar").getFile());
+              JarEntry jarEntry = jarFile.getJarEntry(CLASS_NAME_PATH + ".class");
+              InputStream inputStream = jarFile.getInputStream(jarEntry);
+              byte[] buffer = new byte[4096];
+              ByteArrayOutputStream baos = new ByteArrayOutputStream(4096);
+              int readBytes;
+              baos.reset();
+              while ((readBytes = inputStream.read(buffer)) != -1) {
+                baos.write(buffer, 0, readBytes);
+              }
+              transformer.transform(
+                  getClass().getClassLoader(), CLASS_NAME_PATH, null, null, baos.toByteArray());
+              return null;
+            })
+        .when(instr)
+        .addTransformer(any(SymbolExtractionTransformer.class), eq(true));
+    when(instr.getAllLoadedClasses())
+        .thenAnswer(
+            invocation -> {
+              URL jarFileUrl = getClass().getResource("/debugger-symbol.jar");
+              URL jarUrl = new URL("jar:file:" + jarFileUrl.getFile() + "!/");
+              URLClassLoader urlClassLoader = new URLClassLoader(new URL[] {jarUrl}, null);
+              Class<?> testClass = urlClassLoader.loadClass(Strings.getClassName(CLASS_NAME_PATH));
+              return new Class[] {testClass};
+            });
+    symDBEnablement.startSymbolExtraction();
+    verify(mockSymbolSink).addScope(any());
   }
 
   private void waitForUpload(SymDBEnablement symDBEnablement) throws InterruptedException {


### PR DESCRIPTION
# What Does This Do
When we register the symbol extraction transformer and when we snapshot all loaded classes there is a race where a class can be loaded by a classloader and process by the transformer but can also be part of the loaded classes and then be processed twice. we add a temporary concurrent set to track class names that are parsed by the SymbolAggregator

# Motivation

# Additional Notes

Jira ticket: [DEBUG-1916]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1916]: https://datadoghq.atlassian.net/browse/DEBUG-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ