### PR TITLE
Update system-tests to 268c7ddfba2c45085dc29434e677ff13307445ef

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 4e82927b4c93b78339a3e9d89b41b6dce7790075
+default_system_tests_commit: &default_system_tests_commit 268c7ddfba2c45085dc29434e677ff13307445ef
 
 parameters:
   nightly:


### PR DESCRIPTION
# What Does This Do

Enables tracer-flare system tests for the development version of the Java tracer (1.25.0)

```
[gw2] [ 98%] PASSED tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_flare_log_level_order[library_env0] 
[gw0] [ 98%] PASSED tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_telemetry_app_started[library_env0] 
tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_no_tracer_flare_for_other_task_types[library_env0] 
[gw1] [ 99%] PASSED tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_tracer_flare_with_debug[library_env0] 
[gw3] [ 99%] PASSED tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_tracer_flare[library_env0] 
[gw0] [100%] PASSED tests/parametric/test_tracer_flare.py::TestTracerFlareV1::test_no_tracer_flare_for_other_task_types[library_env0] 
```

# Additional Notes

Jira ticket: [APMJAVA-1125]

[APMJAVA-1125]: https://datadoghq.atlassian.net/browse/APMJAVA-1125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ