### PR TITLE
Make timeout error explicit on log serialization

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.util;
 
 import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_IDENT_REASON;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_TYPE_REASON;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.TIMEOUT_REASON;
 
 import com.datadog.debugger.el.Value;
 import datadog.trace.bootstrap.debugger.EvaluationError;
@@ -152,8 +153,10 @@ public class StringTokenWriter implements SerializerWithLimits.TokenWriter {
   public void notCaptured(SerializerWithLimits.NotCapturedReason reason) {
     switch (reason) {
       case MAX_DEPTH:
-      case TIMEOUT:
         sb.append("...");
+        break;
+      case TIMEOUT:
+        sb.append("{").append(TIMEOUT_REASON).append("}");
         break;
       case FIELD_COUNT:
         sb.append(", ...");

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -151,7 +151,9 @@ public abstract class BaseIntegrationTest {
             "-Ddd.dynamic.instrumentation.classfile.dump.enabled=true",
             "-Ddd.dynamic.instrumentation.upload.batch.size=" + batchSize,
             // flush uploads every 100ms to have quick tests
-            "-Ddd.dynamic.instrumentation.upload.flush.interval=100"));
+            "-Ddd.dynamic.instrumentation.upload.flush.interval=100",
+            // increase timeout for serialization
+            "-Ddd.dynamic.instrumentation.capture.timeout=200"));
   }
 
   protected RecordedRequest retrieveSnapshotRequest() throws Exception {


### PR DESCRIPTION
# What Does This Do
Instead of using ellipsis to indicate timeout happened, use `{timeout}`
Boost timeout for smoke tests

# Motivation
Flaky smoke tests

# Additional Notes

Jira ticket: [DEBUG-1931]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1931]: https://datadoghq.atlassian.net/browse/DEBUG-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ