### PR TITLE
Configuration changes to support triage mode

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -185,6 +185,11 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     }
 
     @Override
+    boolean isTriageEnabled() {
+      return true
+    }
+
+    @Override
     boolean isRuntimeMetricsEnabled() {
       return true
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -29,6 +29,7 @@ public final class GeneralConfig {
   public static final String GLOBAL_TAGS = "trace.global.tags";
 
   public static final String TRACE_DEBUG = "trace.debug";
+  public static final String TRACE_TRIAGE = "trace.triage";
 
   public static final String STARTUP_LOGS_ENABLED = "trace.startup.logs";
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -519,6 +519,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.dynamicConfig =
         DynamicConfig.create(ConfigSnapshot::new)
             .setDebugEnabled(config.isDebugEnabled())
+            .setTriageEnabled(config.isTriageEnabled())
             .setRuntimeMetricsEnabled(config.isRuntimeMetricsEnabled())
             .setLogsInjectionEnabled(config.isLogsInjectionEnabled())
             .setDataStreamsEnabled(config.isDataStreamsEnabled())
@@ -698,6 +699,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     dynamicConfig
         .initial()
         .setDebugEnabled(config.isDebugEnabled())
+        .setTriageEnabled(config.isTriageEnabled())
         .setRuntimeMetricsEnabled(config.isRuntimeMetricsEnabled())
         .setLogsInjectionEnabled(config.isLogsInjectionEnabled())
         .setDataStreamsEnabled(config.isDataStreamsEnabled())

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -105,8 +105,10 @@ final class TracingConfigPoller {
     DynamicConfig<?>.Builder builder = dynamicConfig.initial();
 
     maybeOverride(builder::setDebugEnabled, libConfig.debugEnabled);
+
     if (libConfig.debugEnabled != null) {
       if (Boolean.TRUE.equals(libConfig.debugEnabled)) {
+        builder.setTriageEnabled(true); // debug implies triage
         GlobalLogLevelSwitcher.get().switchLevel(LogLevel.DEBUG);
       } else {
         // Disable debugEnabled when it was set to true at startup

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -239,6 +239,7 @@ import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_IGNORED_RESO
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_AGGREGATES;
 import static datadog.trace.api.config.GeneralConfig.TRACER_METRICS_MAX_PENDING;
 import static datadog.trace.api.config.GeneralConfig.TRACE_DEBUG;
+import static datadog.trace.api.config.GeneralConfig.TRACE_TRIAGE;
 import static datadog.trace.api.config.GeneralConfig.VERSION;
 import static datadog.trace.api.config.IastConfig.IAST_DEBUG_ENABLED;
 import static datadog.trace.api.config.IastConfig.IAST_DETECTION_MODE;
@@ -800,6 +801,7 @@ public class Config {
   private final boolean traceAgentV05Enabled;
 
   private final boolean debugEnabled;
+  private final boolean triageEnabled;
   private final boolean startupLogsEnabled;
   private final String configFileStatus;
 
@@ -1809,6 +1811,7 @@ public class Config {
     servletAsyncTimeoutError = configProvider.getBoolean(SERVLET_ASYNC_TIMEOUT_ERROR, true);
 
     debugEnabled = configProvider.getBoolean(TRACE_DEBUG, false);
+    triageEnabled = configProvider.getBoolean(TRACE_TRIAGE, debugEnabled); // debug implies triage
 
     startupLogsEnabled =
         configProvider.getBoolean(STARTUP_LOGS_ENABLED, DEFAULT_STARTUP_LOGS_ENABLED);
@@ -3009,6 +3012,10 @@ public class Config {
     return debugEnabled;
   }
 
+  public boolean isTriageEnabled() {
+    return triageEnabled;
+  }
+
   public boolean isStartupLogsEnabled() {
     return startupLogsEnabled;
   }
@@ -4075,6 +4082,8 @@ public class Config {
         + traceAgentV05Enabled
         + ", debugEnabled="
         + debugEnabled
+        + ", triageEnabled="
+        + triageEnabled
         + ", startLogsEnabled="
         + startupLogsEnabled
         + ", configFile='"

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -3,6 +3,7 @@ package datadog.trace.api;
 import static datadog.trace.api.config.GeneralConfig.DATA_STREAMS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACE_DEBUG;
+import static datadog.trace.api.config.GeneralConfig.TRACE_TRIAGE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TracerConfig.BAGGAGE_MAPPING;
 import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS;
@@ -83,6 +84,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
   public final class Builder {
 
     boolean debugEnabled;
+    boolean triageEnabled;
     boolean runtimeMetricsEnabled;
     boolean logsInjectionEnabled;
     boolean dataStreamsEnabled;
@@ -99,6 +101,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     Builder(Snapshot snapshot) {
 
       this.debugEnabled = snapshot.debugEnabled;
+      this.triageEnabled = snapshot.triageEnabled;
       this.runtimeMetricsEnabled = snapshot.runtimeMetricsEnabled;
       this.logsInjectionEnabled = snapshot.logsInjectionEnabled;
       this.dataStreamsEnabled = snapshot.dataStreamsEnabled;
@@ -113,6 +116,11 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     public Builder setDebugEnabled(boolean debugEnabled) {
       this.debugEnabled = debugEnabled;
+      return this;
+    }
+
+    public Builder setTriageEnabled(boolean triageEnabled) {
+      this.triageEnabled = triageEnabled;
       return this;
     }
 
@@ -235,6 +243,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     Map<String, Object> update = new HashMap<>();
 
     update.put(TRACE_DEBUG, newSnapshot.debugEnabled);
+    update.put(TRACE_TRIAGE, newSnapshot.triageEnabled);
     update.put(RUNTIME_METRICS_ENABLED, newSnapshot.runtimeMetricsEnabled);
     update.put(LOGS_INJECTION_ENABLED, newSnapshot.logsInjectionEnabled);
     update.put(DATA_STREAMS_ENABLED, newSnapshot.dataStreamsEnabled);
@@ -260,6 +269,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
   public static class Snapshot implements TraceConfig {
 
     final boolean debugEnabled;
+    final boolean triageEnabled;
     final boolean runtimeMetricsEnabled;
     final boolean logsInjectionEnabled;
     final boolean dataStreamsEnabled;
@@ -274,6 +284,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     protected Snapshot(DynamicConfig<?>.Builder builder, Snapshot oldSnapshot) {
 
       this.debugEnabled = builder.debugEnabled;
+      this.triageEnabled = builder.triageEnabled;
       this.runtimeMetricsEnabled = builder.runtimeMetricsEnabled;
       this.logsInjectionEnabled = builder.logsInjectionEnabled;
       this.dataStreamsEnabled = builder.dataStreamsEnabled;
@@ -293,6 +304,11 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     @Override
     public boolean isDebugEnabled() {
       return debugEnabled;
+    }
+
+    @Override
+    public boolean isTriageEnabled() {
+      return triageEnabled;
     }
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
@@ -7,6 +7,8 @@ public interface TraceConfig {
 
   boolean isDebugEnabled();
 
+  boolean isTriageEnabled();
+
   boolean isRuntimeMetricsEnabled();
 
   boolean isLogsInjectionEnabled();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1146,6 +1146,11 @@ public class AgentTracer {
     }
 
     @Override
+    public boolean isTriageEnabled() {
+      return false;
+    }
+
+    @Override
     public boolean isRuntimeMetricsEnabled() {
       return false;
     }


### PR DESCRIPTION
# What Does This Do

Adds a triage mode to static and dynamic config. Explicitly enabling full debug implicitly enables triage mode.

# Motivation

Triage mode will enable lightweight checks to help triage common issues without having to enable full debug mode.

# Usage
JVM option:
```
-Ddd.trace.triage=true
```
Environment variable:
```
DD_TRACE_TRIAGE=true
```

Jira ticket: [APMJAVA-1134]


[APMJAVA-1134]: https://datadoghq.atlassian.net/browse/APMJAVA-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ