### PR TITLE
Handle WellKnown classes as primitives in EL

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -43,6 +43,18 @@ public class WellKnownClasses {
             "java.util.concurrent.atomic.AtomicLong"));
   }
 
+  private static Set<String> stringPrimitives =
+      new HashSet<>(
+          Arrays.asList(
+              "java.lang.Class",
+              "java.lang.String",
+              "java.time.Duration",
+              "java.time.Instant",
+              "java.time.LocalTime",
+              "java.time.LocalDate",
+              "java.time.LocalDateTime",
+              "java.util.UUID"));
+
   /**
    * @return true if type is a final class and toString implementation is well known and side effect
    *     free
@@ -84,5 +96,9 @@ public class WellKnownClasses {
       return true;
     }
     return false;
+  }
+
+  public static boolean isStringPrimitive(String type) {
+    return stringPrimitives.contains(type);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -13,12 +13,14 @@ import com.squareup.moshi.Moshi;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import okio.Okio;
 import org.junit.jupiter.api.Test;
 
@@ -191,6 +193,17 @@ public class ProbeConditionTest {
     assertEquals(
         "Could not evaluate the expression because 'password' was redacted",
         evaluationException.getMessage());
+  }
+
+  @Test
+  void stringPrimitives() throws IOException {
+    ProbeCondition probeCondition = load("/test_conditional_10.json");
+    Map<String, Object> args = new HashMap<>();
+    args.put("uuid", UUID.fromString("a3cbe9e7-edd3-4bef-8e5b-59bfcb04cf91"));
+    args.put("duration", Duration.ofSeconds(42));
+    args.put("clazz", "foo".getClass());
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(args, null, null);
+    assertTrue(probeCondition.execute(ctx));
   }
 
   private static ProbeCondition load(String resourcePath) throws IOException {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_10.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_10.json
@@ -1,0 +1,21 @@
+{
+  "dsl": "uuid == 'a3cbe9e7-edd3-4bef-8e5b-59bfcb04cf91' && duration == 'PT42S' && clazz == 'class java.lang.String'",
+  "json": {
+    "and": [{
+        "eq": [
+          {
+            "ref": "uuid"
+          },
+          "a3cbe9e7-edd3-4bef-8e5b-59bfcb04cf91"]
+      }, {
+        "eq": [
+          {"ref": "duration"},
+          "PT42S"]
+      }, {
+      "eq": [
+        {"ref": "clazz"},
+        "class java.lang.String"]
+    }
+    ]
+  }
+}


### PR DESCRIPTION
# What Does This Do
WellKnown classes (like `UUID`) need to be treated as string primitives to be use in Expression Language and conditions
Add a list of string primitives

# Motivation
coherency with serialization behavior

# Additional Notes

Jira ticket: [DEBUG-1689]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1689]: https://datadoghq.atlassian.net/browse/DEBUG-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ