### PR TITLE
Add support of `@exception` for uncaught exception

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -211,7 +211,8 @@ public class CapturedContext implements ValueReferenceResolver {
   }
 
   public void addThrowable(Throwable t) {
-    this.throwable = new CapturedThrowable(t);
+    addThrowable(new CapturedThrowable(t));
+    extensions.put(ValueReferences.EXCEPTION_EXTENSION_NAME, t);
   }
 
   public void addThrowable(CapturedThrowable capturedThrowable) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferences.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ValueReferences.java
@@ -13,9 +13,11 @@ public final class ValueReferences {
   public static String DURATION_EXTENSION_NAME = "duration";
   public static String RETURN_EXTENSION_NAME = "return";
   public static String ITERATOR_EXTENSION_NAME = "it";
+  public static String EXCEPTION_EXTENSION_NAME = "exception";
   public static String DURATION_REF = SYNTHETIC_PREFIX + DURATION_EXTENSION_NAME;
   public static String RETURN_REF = SYNTHETIC_PREFIX + RETURN_EXTENSION_NAME;
   public static String ITERATOR_REF = SYNTHETIC_PREFIX + ITERATOR_EXTENSION_NAME;
+  public static String EXCEPTION_REF = SYNTHETIC_PREFIX + EXCEPTION_EXTENSION_NAME;
 
   public static String synthetic(String name) {
     return SYNTHETIC_PREFIX + name;

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
@@ -15,6 +15,7 @@ import com.datadog.debugger.el.expressions.IfElseExpression;
 import com.datadog.debugger.el.expressions.IfExpression;
 import com.datadog.debugger.el.expressions.IndexExpression;
 import com.datadog.debugger.el.expressions.IsEmptyExpression;
+import com.datadog.debugger.el.expressions.IsUndefinedExpression;
 import com.datadog.debugger.el.expressions.LenExpression;
 import com.datadog.debugger.el.expressions.MatchesExpression;
 import com.datadog.debugger.el.expressions.NotExpression;
@@ -204,5 +205,9 @@ public class DSL {
 
   public static BooleanValueExpressionAdapter bool(BooleanExpression expression) {
     return new BooleanValueExpressionAdapter(expression);
+  }
+
+  public static IsUndefinedExpression isUndefined(ValueExpression<?> valueExpression) {
+    return new IsUndefinedExpression(valueExpression);
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -214,6 +214,15 @@ public class JsonToExpressionConverter {
           }
           return DSL.isEmpty(asValueExpression(reader));
         }
+      case "isUndefined":
+        {
+          JsonReader.Token token = reader.peek();
+          if (token == BEGIN_ARRAY) {
+            throw new UnsupportedOperationException(
+                "Operation 'isUndefined' expects exactly one value argument");
+          }
+          return DSL.isUndefined(asValueExpression(reader));
+        }
       case "startsWith":
         {
           return createStringPredicateExpression(reader, DSL::startsWith);

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IsUndefinedExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IsUndefinedExpression.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -21,8 +22,12 @@ public final class IsUndefinedExpression implements BooleanExpression {
     if (valueExpression == null) {
       return Boolean.FALSE;
     }
-    Value<?> value = valueExpression.evaluate(valueRefResolver);
-    return value.isUndefined() ? Boolean.TRUE : Boolean.FALSE;
+    try {
+      Value<?> value = valueExpression.evaluate(valueRefResolver);
+      return value.isUndefined() ? Boolean.TRUE : Boolean.FALSE;
+    } catch (EvaluationException ex) {
+      return Boolean.TRUE;
+    }
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -206,6 +206,19 @@ public class ProbeConditionTest {
     assertTrue(probeCondition.execute(ctx));
   }
 
+  @Test
+  void testBooleanOperation() throws Exception {
+    ProbeCondition probeCondition = load("/test_conditional_11.json");
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("strField", "foobar");
+    fields.put("emptyStr", "");
+    fields.put("emptyList", new ArrayList<>());
+    fields.put("emptyMap", new HashMap<>());
+    fields.put("emptyArray", new Object[0]);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, fields);
+    assertTrue(probeCondition.execute(ctx));
+  }
+
   private static ProbeCondition load(String resourcePath) throws IOException {
     InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath);
     Moshi moshi =

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsUndefinedExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsUndefinedExpressionTest.java
@@ -41,6 +41,8 @@ class IsUndefinedExpressionTest {
         new IsUndefinedExpression(DSL.value(Values.UNDEFINED_OBJECT));
     assertTrue(expression.evaluate(resolver));
     assertEquals("isUndefined(UNDEFINED)", print(expression));
+    expression = new IsUndefinedExpression(DSL.ref("undefinedvar"));
+    assertTrue(expression.evaluate(resolver));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ValueRefExpressionTest.java
@@ -72,9 +72,11 @@ class ValueRefExpressionTest {
 
     long duration = TimeUnit.NANOSECONDS.convert(680, TimeUnit.MILLISECONDS);
     boolean returnVal = true;
+    Throwable exception = new RuntimeException("oops");
     Map<String, Object> exts = new HashMap<>();
     exts.put(ValueReferences.RETURN_EXTENSION_NAME, returnVal);
     exts.put(ValueReferences.DURATION_EXTENSION_NAME, duration);
+    exts.put(ValueReferences.EXCEPTION_EXTENSION_NAME, exception);
     ValueReferenceResolver resolver =
         RefResolverHelper.createResolver(null, null, values).withExtensions(exts);
 
@@ -84,6 +86,9 @@ class ValueRefExpressionTest {
     expression = DSL.ref(ValueReferences.RETURN_REF);
     assertEquals(returnVal, expression.evaluate(resolver).getValue());
     assertEquals("@return", print(expression));
+    expression = DSL.ref(ValueReferences.EXCEPTION_REF);
+    assertEquals(exception, expression.evaluate(resolver).getValue());
+    assertEquals("@exception", print(expression));
     expression = DSL.ref(limitArg);
     assertEquals(limit, expression.evaluate(resolver).getValue());
     assertEquals("limit", print(expression));

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_10.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_10.json
@@ -19,3 +19,13 @@
     ]
   }
 }
+
+  "dsl": "isEmpty(emptyStr) && isEmpty(emptyList) && isEmpty(emptyMap) && isEmpty(emptyArray) && isUndefined(@exception)",
+  "json": {
+    "and": [
+      {"isEmpty": {"ref": "emptyStr"}},
+      {"isEmpty": {"ref": "emptyList"}},
+      {"isEmpty": {"ref": "emptyMap"}},
+      {"isEmpty": {"ref": "emptyArray"}},
+      {"isUndefined":  {"ref": "@exception"}}
+

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_11.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_11.json
@@ -1,0 +1,14 @@
+{
+  "dsl": "isEmpty(emptyStr) && isEmpty(emptyList) && isEmpty(emptyMap) && isEmpty(emptyArray) && isUndefined(@exception)",
+  "json": {
+    "and": [
+      {"isEmpty": {"ref": "emptyStr"}},
+      {"isEmpty": {"ref": "emptyList"}},
+      {"isEmpty": {"ref": "emptyMap"}},
+      {"isEmpty": {"ref": "emptyArray"}},
+      {"isUndefined":  {"ref": "@exception"}}
+    ]
+  }
+}
+
+

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -830,6 +830,25 @@ public class CapturedSnapshotTest {
   }
 
   @Test
+  public void noUncaughtExceptionCondition() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    final String LOG_TEMPLATE = "exception?: {isUndefined(@exception)}";
+    LogProbe probe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "main", "int (String)")
+            .evaluateAt(MethodLocation.EXIT)
+            .when(
+                new ProbeCondition(
+                    DSL.when(DSL.isUndefined(DSL.ref("@exception"))), "isUndefined(@exception)"))
+            .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "2").get();
+    assertEquals(2, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+  }
+
+  @Test
   public void rateLimitSnapshot() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     LogProbe logProbes =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -778,6 +778,40 @@ public class CapturedSnapshotTest {
   }
 
   @Test
+  public void uncaughtExceptionCondition() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot05";
+    final String LOG_TEMPLATE = "exception msg={@exception.detailMessage}";
+    LogProbe probe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "triggerUncaughtException", "()")
+            .evaluateAt(MethodLocation.EXIT)
+            .when(
+                new ProbeCondition(
+                    DSL.when(
+                        DSL.eq(
+                            DSL.getMember(DSL.ref("@exception"), "detailMessage"),
+                            DSL.value("oops"))),
+                    "@exception.detailMessage == 'oops'"))
+            .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
+            .build();
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    try {
+      Reflect.on(testClass).call("main", "triggerUncaughtException").get();
+      Assertions.fail("should not reach this code");
+    } catch (ReflectException ex) {
+      assertEquals("oops", ex.getCause().getCause().getMessage());
+    }
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals("exception msg=oops", snapshot.getMessage());
+    assertCaptureThrowable(
+        snapshot.getCaptures().getReturn(),
+        "java.lang.IllegalStateException",
+        "oops",
+        "CapturedSnapshot05.triggerUncaughtException",
+        7);
+  }
+
+  @Test
   public void caughtException() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot05";
     DebuggerTransformerTest.TestSnapshotListener listener =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.agent;
 
 import static com.datadog.debugger.el.DSL.eq;
+import static com.datadog.debugger.el.DSL.getMember;
 import static com.datadog.debugger.el.DSL.gt;
 import static com.datadog.debugger.el.DSL.ref;
 import static com.datadog.debugger.el.DSL.value;
@@ -200,7 +201,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   public void methodActiveSpanSynthDuration() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
-        createDecoration(gt(ref("@duration"), value(0)), "@return > '0", "tag1", "{@duration}");
+        createDecoration(gt(ref("@duration"), value(0)), "@return > 0", "tag1", "{@duration}");
     installSingleSpanDecoration(
         CLASS_NAME, ACTIVE, decoration, "process", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
@@ -211,10 +212,32 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   }
 
   @Test
+  public void methodActiveSpanSynthException() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
+    SpanDecorationProbe.Decoration decoration =
+        createDecoration(
+            eq(getMember(ref("@exception"), "detailMessage"), value("oops")),
+            "@exception.detailMessage == 'oops'",
+            "tag1",
+            "{@exception.detailMessage}");
+    installSingleSpanDecoration(
+        CLASS_NAME, ACTIVE, decoration, "processWithException", "int (java.lang.String)");
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    try {
+      Reflect.on(testClass).call("main", "exception").get();
+      Assertions.fail("should not reach this code");
+    } catch (RuntimeException ex) {
+      assertEquals("oops", ex.getCause().getCause().getMessage());
+    }
+    MutableSpan span = traceInterceptor.getFirstSpan();
+    assertEquals("oops", span.getTags().get("tag1"));
+  }
+
+  @Test
   public void lineActiveSpanSimpleTag() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration = createDecoration("tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 38);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 41);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(84, result);
@@ -246,7 +269,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
         createDecoration(eq(ref("arg"), value("5")), "arg == '5'", "tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 38);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 41);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 10; i++) {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
@@ -262,7 +285,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
         createDecoration(eq(ref("noarg"), value("5")), "arg == '5'", "tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 38);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 41);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "5").get();
     assertEquals(84, result);

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -27,6 +27,9 @@ public class CapturedSnapshot20 {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     AgentSpan span = tracerAPI.buildSpan("process").start();
     try (AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL)) {
+      if (arg.equals("exception")) {
+        return new CapturedSnapshot20().processWithException(arg);
+      }
       return new CapturedSnapshot20().process(arg);
     } finally {
       span.finish();
@@ -36,5 +39,10 @@ public class CapturedSnapshot20 {
   private int process(String arg) {
     int intLocal = intField + 42;
     return intLocal;
+  }
+
+  private int processWithException(String arg) {
+    int intLocal = intField + 42;
+    throw new RuntimeException("oops");
   }
 }


### PR DESCRIPTION
# What Does This Do
Uncaught exception captured by method probe (log, snapshot or span decoration) can be accessed through @exception synthetic variable with expression language in conditions, log template or span tags

# Motivation

# Additional Notes

Jira ticket: [DEBUG-1940]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1940]: https://datadoghq.atlassian.net/browse/DEBUG-1940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ