### PR TITLE
Fix inner class signature matching

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
@@ -164,10 +164,17 @@ public class Where {
     }
     String result = targetSignature;
     for (String className : classes) {
-      Pattern classNamePattern = Pattern.compile("L" + className + ";");
-      result = classNamePattern.matcher(result).replaceAll("L" + simplify(className) + ";");
+      Pattern classNamePattern = Pattern.compile("L" + escapeClassName(className) + ";");
+      result =
+          classNamePattern
+              .matcher(result)
+              .replaceAll("L" + escapeClassName(simplify(className)) + ";");
     }
     return result;
+  }
+
+  private static String escapeClassName(String className) {
+    return className.replace("$", "\\$");
   }
 
   private static String simplify(String fqnClass) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/TypesTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/TypesTest.java
@@ -72,6 +72,14 @@ class TypesTest {
   }
 
   @Test
+  void testDescriptorFromSignatureInnerClassArgs() {
+    String expectedDesc = "(Ljava/util/Map$Entry;Ljava/util/Map$Entry;)V";
+    String signature = "void(java.util.Map$Entry, java.util.Map$Entry)";
+    String desc = Types.descriptorFromSignature(signature);
+    assertEquals(expectedDesc, desc);
+  }
+
+  @Test
   void testDescriptorFromSignatureInvalid() {
     assertThrows(IllegalArgumentException.class, () -> Types.descriptorFromSignature("()"));
     assertThrows(IllegalArgumentException.class, () -> Types.descriptorFromSignature("int"));

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.probe;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
 import java.io.IOException;
@@ -12,7 +14,7 @@ public class WhereTest {
     Where where =
         new Where(
             "java.lang.Object", "toString()", "java.lang.String ()", new String[] {"5-7"}, null);
-    Assertions.assertTrue(where.isSignatureMatching("java.lang.String ()"));
+    assertTrue(where.isSignatureMatching("java.lang.String ()"));
     String[] lines = where.getLines();
     Assertions.assertNotNull(lines);
     Assertions.assertEquals(1, lines.length);
@@ -28,7 +30,7 @@ public class WhereTest {
             "java.lang.String ()",
             new String[] {"12-25", "42-45"},
             null);
-    Assertions.assertTrue(where.isSignatureMatching("java.lang.String ()"));
+    assertTrue(where.isSignatureMatching("java.lang.String ()"));
     String[] lines = where.getLines();
     Assertions.assertNotNull(lines);
     Assertions.assertEquals(2, lines.length);
@@ -41,7 +43,7 @@ public class WhereTest {
     Where where =
         new Where(
             "java.lang.Object", "toString()", "java.lang.String ()", new String[] {"12"}, null);
-    Assertions.assertTrue(where.isSignatureMatching("java.lang.String ()"));
+    assertTrue(where.isSignatureMatching("java.lang.String ()"));
     String[] lines = where.getLines();
     Assertions.assertNotNull(lines);
     Assertions.assertEquals(1, lines.length);
@@ -57,7 +59,7 @@ public class WhereTest {
             "java.lang.String ()",
             (Where.SourceLine[]) null,
             null);
-    Assertions.assertTrue(where.isSignatureMatching("java.lang.String ()"));
+    assertTrue(where.isSignatureMatching("java.lang.String ()"));
     String[] lines = where.getLines();
     Assertions.assertNull(lines);
   }
@@ -78,18 +80,30 @@ public class WhereTest {
   @Test
   public void methodMatching() {
     Where where = new Where("String", "substring", "(int,int)", new String[0], null);
-    Assertions.assertTrue(where.isMethodMatching("substring", "(II)Ljava/lang/String;"));
+    assertTrue(where.isMethodMatching("substring", "(II)Ljava/lang/String;"));
     where = new Where("String", "replaceAll", "(String,String)", new String[0], null);
-    Assertions.assertTrue(
+    assertTrue(
         where.isMethodMatching(
             "replaceAll", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"));
     where = new Where("HashMap", "<init>", "(Map)", new String[0], null);
-    Assertions.assertTrue(where.isMethodMatching("<init>", "(Ljava/util/Map;)V"));
+    assertTrue(where.isMethodMatching("<init>", "(Ljava/util/Map;)V"));
     where = new Where("ArrayList", "removeIf", "(Predicate)", new String[0], null);
-    Assertions.assertTrue(where.isMethodMatching("removeIf", "(Ljava/util/function/Predicate;)Z"));
+    assertTrue(where.isMethodMatching("removeIf", "(Ljava/util/function/Predicate;)Z"));
     where = new Where("String", "concat", "", new String[0], null);
-    Assertions.assertTrue(where.isMethodMatching("concat", "String (String)"));
+    assertTrue(where.isMethodMatching("concat", "String (String)"));
     where = new Where("String", "concat", " \t", new String[0], null);
-    Assertions.assertTrue(where.isMethodMatching("concat", "String (String)"));
+    assertTrue(where.isMethodMatching("concat", "String (String)"));
+    where =
+        new Where(
+            "Inner",
+            "innerMethod",
+            "(com.datadog.debugger.probe.Outer$Inner)",
+            new String[0],
+            null);
+    assertTrue(
+        where.isMethodMatching("innerMethod", "(Lcom/datadog/debugger/probe/Outer$Inner;)V"));
+    where = new Where("Inner", "innerMethod", "(Outer$Inner)", new String[0], null);
+    assertTrue(
+        where.isMethodMatching("innerMethod", "(Lcom/datadog/debugger/probe/Outer$Inner;)V"));
   }
 }


### PR DESCRIPTION
# What Does This Do
the dollar character in inner class is interpreted as regex and replacement special character. Need to be escaped.

# Motivation
Supporting inner classes in probe method signature

# Additional Notes

Jira ticket: [DEBUG-1620]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1620]: https://datadoghq.atlassian.net/browse/DEBUG-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ