### PR TITLE
Send probe statuses to new debugger track

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -46,6 +46,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   public static final String DATADOG_AGENT_STATE = "Datadog-Agent-State";
 
   public static final String DEBUGGER_ENDPOINT = "debugger/v1/input";
+  public static final String DEBUGGER_DIAGNOSTICS_ENDPOINT = "debugger/v1/diagnostics";
 
   public static final String TELEMETRY_PROXY_ENDPOINT = "telemetry/proxy/";
 
@@ -70,6 +71,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   private volatile String state;
   private volatile String configEndpoint;
   private volatile String debuggerEndpoint;
+  private volatile String debuggerDiagnosticsEndpoint;
   private volatile String evpProxyEndpoint;
   private volatile String version;
   private volatile String telemetryProxyEndpoint;
@@ -100,6 +102,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
     state = null;
     configEndpoint = null;
     debuggerEndpoint = null;
+    debuggerDiagnosticsEndpoint = null;
     dataStreamsEndpoint = null;
     evpProxyEndpoint = null;
     version = null;
@@ -211,7 +214,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
       String foundMetricsEndpoint = null;
       if (metricsEnabled) {
         for (String endpoint : metricsEndpoints) {
-          if (endpoints.contains(endpoint) || endpoints.contains("/" + endpoint)) {
+          if (containsEndpoint(endpoints, endpoint)) {
             foundMetricsEndpoint = endpoint;
             break;
           }
@@ -222,39 +225,42 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
       metricsEndpoint = foundMetricsEndpoint;
 
       for (String endpoint : traceEndpoints) {
-        if (endpoints.contains(endpoint) || endpoints.contains("/" + endpoint)) {
+        if (containsEndpoint(endpoints, endpoint)) {
           traceEndpoint = endpoint;
           break;
         }
       }
 
       for (String endpoint : configEndpoints) {
-        if (endpoints.contains(endpoint) || endpoints.contains("/" + endpoint)) {
+        if (containsEndpoint(endpoints, endpoint)) {
           configEndpoint = endpoint;
           break;
         }
       }
 
-      if (endpoints.contains(DEBUGGER_ENDPOINT) || endpoints.contains("/" + DEBUGGER_ENDPOINT)) {
+      if (containsEndpoint(endpoints, DEBUGGER_ENDPOINT)) {
         debuggerEndpoint = DEBUGGER_ENDPOINT;
+      }
+      if (containsEndpoint(endpoints, DEBUGGER_DIAGNOSTICS_ENDPOINT)) {
+        debuggerDiagnosticsEndpoint = DEBUGGER_DIAGNOSTICS_ENDPOINT;
       }
 
       for (String endpoint : dataStreamsEndpoints) {
-        if (endpoints.contains(endpoint) || endpoints.contains("/" + endpoint)) {
+        if (containsEndpoint(endpoints, endpoint)) {
           dataStreamsEndpoint = endpoint;
           break;
         }
       }
 
       for (String endpoint : evpProxyEndpoints) {
-        if (endpoints.contains(endpoint) || endpoints.contains("/" + endpoint)) {
+        if (containsEndpoint(endpoints, endpoint)) {
           evpProxyEndpoint = endpoint;
           break;
         }
       }
 
       for (String endpoint : telemetryProxyEndpoints) {
-        if (endpoints.contains(endpoint) || endpoints.contains("/" + endpoint)) {
+        if (containsEndpoint(endpoints, endpoint)) {
           telemetryProxyEndpoint = endpoint;
           break;
         }
@@ -279,6 +285,10 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
       log.debug("Error parsing trace agent /info response", error);
     }
     return false;
+  }
+
+  private static boolean containsEndpoint(Set<String> endpoints, String endpoint) {
+    return endpoints.contains(endpoint) || endpoints.contains("/" + endpoint);
   }
 
   @SuppressWarnings("unchecked")
@@ -307,6 +317,10 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
   public boolean supportsDebugger() {
     return debuggerEndpoint != null;
+  }
+
+  public boolean supportsDebuggerDiagnostics() {
+    return debuggerDiagnosticsEndpoint != null;
   }
 
   boolean supportsDropping() {

--- a/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -59,6 +59,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.state() == INFO_STATE
     features.getConfigEndpoint() == V7_CONFIG_ENDPOINT
     features.supportsDebugger()
+    features.supportsDebuggerDiagnostics()
     features.supportsEvpProxy()
     features.getVersion() == "0.99.0"
     !features.supportsLongRunning()
@@ -87,6 +88,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.state() == INFO_STATE
     features.getConfigEndpoint() == V7_CONFIG_ENDPOINT
     features.supportsDebugger()
+    features.supportsDebuggerDiagnostics()
     features.supportsEvpProxy()
     features.getVersion() == "0.99.0"
     !features.supportsLongRunning()

--- a/communication/src/test/resources/agent-features/agent-info.json
+++ b/communication/src/test/resources/agent-features/agent-info.json
@@ -14,6 +14,7 @@
     "/evp_proxy/v1/",
     "/evp_proxy/v2/",
     "/debugger/v1/input",
+    "/debugger/v1/diagnostics",
     "/v0.7/config"
   ],
   "feature_flags": [

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -69,7 +69,7 @@ public class ConfigurationUpdater
         instrumentation,
         transformerSupplier,
         config,
-        new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()),
+        new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false),
         finder);
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -59,12 +59,18 @@ public class ConfigurationUpdater
 
   private Configuration currentConfiguration;
 
-  public ConfigurationUpdater(
+  // used only for tests
+  ConfigurationUpdater(
       Instrumentation instrumentation,
       TransformerSupplier transformerSupplier,
       Config config,
       ClassesToRetransformFinder finder) {
-    this(instrumentation, transformerSupplier, config, new DebuggerSink(config), finder);
+    this(
+        instrumentation,
+        transformerSupplier,
+        config,
+        new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()),
+        finder);
   }
 
   public ConfigurationUpdater(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -50,7 +50,8 @@ public class DebuggerAgent {
     DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery = sco.featuresDiscovery(config);
     ddAgentFeaturesDiscovery.discoverIfOutdated();
     agentVersion = ddAgentFeaturesDiscovery.getVersion();
-    DebuggerSink debuggerSink = new DebuggerSink(config);
+    String diagnosticEndpoint = getDiagnosticEndpoint(config, ddAgentFeaturesDiscovery);
+    DebuggerSink debuggerSink = new DebuggerSink(config, diagnosticEndpoint);
     debuggerSink.start();
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
@@ -104,6 +105,14 @@ public class DebuggerAgent {
     } else {
       LOGGER.debug("No configuration poller available from SharedCommunicationObjects");
     }
+  }
+
+  private static String getDiagnosticEndpoint(
+      Config config, DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery) {
+    if (ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics()) {
+      return config.getAgentUrl() + "/" + DDAgentFeaturesDiscovery.DEBUGGER_DIAGNOSTICS_ENDPOINT;
+    }
+    return config.getFinalDebuggerSnapshotUrl();
   }
 
   private static void setupSourceFileTracking(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -51,7 +51,9 @@ public class DebuggerAgent {
     ddAgentFeaturesDiscovery.discoverIfOutdated();
     agentVersion = ddAgentFeaturesDiscovery.getVersion();
     String diagnosticEndpoint = getDiagnosticEndpoint(config, ddAgentFeaturesDiscovery);
-    DebuggerSink debuggerSink = new DebuggerSink(config, diagnosticEndpoint);
+    DebuggerSink debuggerSink =
+        new DebuggerSink(
+            config, diagnosticEndpoint, ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics());
     debuggerSink.start();
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -107,7 +107,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
         config,
         configuration,
         null,
-        new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()));
+        new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false));
   }
 
   private void readExcludeFiles(String commaSeparatedFileNames) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -103,7 +103,11 @@ public class DebuggerTransformer implements ClassFileTransformer {
 
   // Used only for tests
   DebuggerTransformer(Config config, Configuration configuration) {
-    this(config, configuration, null, new DebuggerSink(config));
+    this(
+        config,
+        configuration,
+        null,
+        new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()));
   }
 
   private void readExcludeFiles(String commaSeparatedFileNames) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -40,12 +40,12 @@ public class DebuggerSink {
   private volatile AgentTaskScheduler.Scheduled<DebuggerSink> flushIntervalScheduled;
   private volatile long currentFlushInterval = INITIAL_FLUSH_INTERVAL;
 
-  public DebuggerSink(Config config, String diagnosticsEndpoint) {
+  public DebuggerSink(Config config, String diagnosticsEndpoint, boolean useMultiPart) {
     this(
         config,
         new BatchUploader(config, config.getFinalDebuggerSnapshotUrl()),
         DebuggerMetrics.getInstance(config),
-        new ProbeStatusSink(config, diagnosticsEndpoint),
+        new ProbeStatusSink(config, diagnosticsEndpoint, useMultiPart),
         new SnapshotSink(config),
         new SymbolSink(config));
   }
@@ -56,7 +56,7 @@ public class DebuggerSink {
         config,
         snapshotUploader,
         DebuggerMetrics.getInstance(config),
-        new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl()),
+        new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false),
         new SnapshotSink(config),
         new SymbolSink(config));
   }
@@ -76,7 +76,7 @@ public class DebuggerSink {
         config,
         snapshotUploader,
         debuggerMetrics,
-        new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl()),
+        new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false),
         new SnapshotSink(config),
         new SymbolSink(config));
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -35,7 +35,7 @@ public class ProbeStatusSink {
   private final Duration interval;
   private final int batchSize;
   private final boolean isInstrumentTheWorld;
-  private final boolean useDebuggerTracker;
+  private final boolean useDebuggerTrack;
 
   ProbeStatusSink(Config config, String diagnosticsEndpoint) {
     this(
@@ -44,9 +44,9 @@ public class ProbeStatusSink {
         isUsingDebuggerTrack(diagnosticsEndpoint));
   }
 
-  ProbeStatusSink(Config config, BatchUploader diagnosticUploader, boolean useDebuggerTracker) {
+  ProbeStatusSink(Config config, BatchUploader diagnosticUploader, boolean useDebuggerTrack) {
     this.diagnosticUploader = diagnosticUploader;
-    this.useDebuggerTracker = useDebuggerTracker;
+    this.useDebuggerTrack = useDebuggerTrack;
     this.messageBuilder = new Builder(config);
     this.interval = Duration.ofSeconds(config.getDebuggerDiagnosticsInterval());
     this.batchSize = config.getDebuggerUploadBatchSize();
@@ -83,9 +83,9 @@ public class ProbeStatusSink {
     List<String> serializedDiagnostics = getSerializedDiagnostics();
     List<byte[]> batches = IntakeBatchHelper.createBatches(serializedDiagnostics);
     for (byte[] batch : batches) {
-      if (useDebuggerTracker) {
+      if (useDebuggerTrack) {
         diagnosticUploader.uploadAsMultipart(
-            "", new BatchUploader.MultiPartContent(batch, "file", "file.json"));
+            "", new BatchUploader.MultiPartContent(batch, "event", "event.json"));
       } else {
         diagnosticUploader.upload(batch, tags);
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -23,19 +23,11 @@ public class SymbolSink {
   private static final int CAPACITY = 1024;
   private static final JsonAdapter<ServiceVersion> SERVICE_VERSION_ADAPTER =
       MoshiHelper.createMoshiSymbol().adapter(ServiceVersion.class);
-  private static final String EVENT_FORMAT =
-      "{%n"
-          + "\"ddsource\": \"dd_debugger\",%n"
-          + "\"service\": \"%s\",%n"
-          + "\"runtimeId\": \"%s\"%n"
-          + "}";
-
   private final String serviceName;
   private final String env;
   private final String version;
   private final BatchUploader symbolUploader;
   private final BlockingQueue<ServiceVersion> scopes = new ArrayBlockingQueue<>(CAPACITY);
-  private final BatchUploader.MultiPartContent event;
 
   public SymbolSink(Config config) {
     this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl()));
@@ -46,10 +38,6 @@ public class SymbolSink {
     this.env = config.getEnv();
     this.version = config.getVersion();
     this.symbolUploader = symbolUploader;
-    byte[] eventContent =
-        String.format(EVENT_FORMAT, serviceName, config.getRuntimeId())
-            .getBytes(StandardCharsets.UTF_8);
-    this.event = new BatchUploader.MultiPartContent(eventContent, "event", "event.json");
   }
 
   public boolean addScope(Scope jarScope) {
@@ -74,7 +62,6 @@ public class SymbolSink {
             json.length());
         symbolUploader.uploadAsMultipart(
             "",
-            event,
             new BatchUploader.MultiPartContent(
                 json.getBytes(StandardCharsets.UTF_8), "file", "file.json"));
       } catch (Exception e) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -30,6 +30,7 @@ import com.datadog.debugger.el.values.StringValue;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.sink.Snapshot;
 import com.datadog.debugger.util.MoshiHelper;
@@ -1979,7 +1980,10 @@ public class CapturedSnapshotTest {
     DebuggerAgentHelper.injectSink(listener);
     currentTransformer =
         DebuggerAgent.setupInstrumentTheWorldTransformer(
-            config, instr, new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()), null);
+            config,
+            instr,
+            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false),
+            null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     return listener;
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1978,7 +1978,8 @@ public class CapturedSnapshotTest {
         new DebuggerTransformerTest.TestSnapshotListener(config, mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
     currentTransformer =
-        DebuggerAgent.setupInstrumentTheWorldTransformer(config, instr, listener, null);
+        DebuggerAgent.setupInstrumentTheWorldTransformer(
+            config, instr, new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()), null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     return listener;
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -262,7 +262,7 @@ public class DebuggerTransformerTest {
             config,
             configuration,
             ((definition, result) -> lastResult.set(result)),
-            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()));
+            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false));
     byte[] newClassBuffer =
         debuggerTransformer.transform(
             ClassLoader.getSystemClassLoader(),
@@ -289,7 +289,7 @@ public class DebuggerTransformerTest {
             config,
             configuration,
             ((definition, result) -> lastResult.set(result)),
-            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()));
+            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false));
     byte[] newClassBuffer =
         debuggerTransformer.transform(
             ClassLoader.getSystemClassLoader(),

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -262,7 +262,7 @@ public class DebuggerTransformerTest {
             config,
             configuration,
             ((definition, result) -> lastResult.set(result)),
-            new DebuggerSink(config));
+            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()));
     byte[] newClassBuffer =
         debuggerTransformer.transform(
             ClassLoader.getSystemClassLoader(),
@@ -289,7 +289,7 @@ public class DebuggerTransformerTest {
             config,
             configuration,
             ((definition, result) -> lastResult.set(result)),
-            new DebuggerSink(config));
+            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl()));
     byte[] newClassBuffer =
         debuggerTransformer.transform(
             ClassLoader.getSystemClassLoader(),

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
@@ -50,7 +50,7 @@ class ProbeStatusSinkTest {
     when(config.getDebuggerDiagnosticsInterval()).thenReturn(DIAGNOSTICS_INTERVAL);
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     builder = new Builder(config);
-    probeStatusSink = new ProbeStatusSink(config);
+    probeStatusSink = new ProbeStatusSink(config, "http://localhost:8126/debugger/v1/input");
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
@@ -50,7 +50,7 @@ class ProbeStatusSinkTest {
     when(config.getDebuggerDiagnosticsInterval()).thenReturn(DIAGNOSTICS_INTERVAL);
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     builder = new Builder(config);
-    probeStatusSink = new ProbeStatusSink(config, "http://localhost:8126/debugger/v1/input");
+    probeStatusSink = new ProbeStatusSink(config, "http://localhost:8126/debugger/v1/input", true);
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -23,14 +23,8 @@ class SymbolSinkTest {
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock);
     symbolSink.addScope(Scope.builder(ScopeType.JAR, null, 0, 0).build());
     symbolSink.flush();
-    assertEquals(2, symbolUploaderMock.multiPartContents.size());
-    BatchUploader.MultiPartContent eventContent = symbolUploaderMock.multiPartContents.get(0);
-    assertEquals("event", eventContent.getPartName());
-    assertEquals("event.json", eventContent.getFileName());
-    String strEventContent = new String(eventContent.getContent());
-    assertTrue(strEventContent.contains("\"ddsource\": \"dd_debugger\""));
-    assertTrue(strEventContent.contains("\"service\": \"service1\""));
-    BatchUploader.MultiPartContent symbolContent = symbolUploaderMock.multiPartContents.get(1);
+    assertEquals(1, symbolUploaderMock.multiPartContents.size());
+    BatchUploader.MultiPartContent symbolContent = symbolUploaderMock.multiPartContents.get(0);
     assertEquals("file", symbolContent.getPartName());
     assertEquals("file.json", symbolContent.getFileName());
     assertEquals(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -23,8 +23,14 @@ class SymbolSinkTest {
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock);
     symbolSink.addScope(Scope.builder(ScopeType.JAR, null, 0, 0).build());
     symbolSink.flush();
-    assertEquals(1, symbolUploaderMock.multiPartContents.size());
-    BatchUploader.MultiPartContent symbolContent = symbolUploaderMock.multiPartContents.get(0);
+    assertEquals(2, symbolUploaderMock.multiPartContents.size());
+    BatchUploader.MultiPartContent eventContent = symbolUploaderMock.multiPartContents.get(0);
+    assertEquals("event", eventContent.getPartName());
+    assertEquals("event.json", eventContent.getFileName());
+    String strEventContent = new String(eventContent.getContent());
+    assertTrue(strEventContent.contains("\"ddsource\": \"dd_debugger\""));
+    assertTrue(strEventContent.contains("\"service\": \"service1\""));
+    BatchUploader.MultiPartContent symbolContent = symbolUploaderMock.multiPartContents.get(1);
     assertEquals("file", symbolContent.getPartName());
     assertEquals("file.json", symbolContent.getFileName());
     assertEquals(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
@@ -57,8 +57,6 @@ public class BatchUploaderTest {
     url = server.url(URL_PATH);
 
     when(config.getDebuggerUploadTimeout()).thenReturn((int) REQUEST_TIMEOUT.getSeconds());
-    when(config.getServiceName()).thenReturn("myservice");
-    when(config.getRuntimeId()).thenReturn("myruntimeid");
 
     uploader = new BatchUploader(config, url.toString(), ratelimitedLogger);
   }
@@ -262,9 +260,6 @@ public class BatchUploaderTest {
     RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
     assertNotNull(recordedRequest);
     String strBody = recordedRequest.getBody().readUtf8();
-    assertTrue(strBody.contains("\"ddsource\": \"dd_debugger\","));
-    assertTrue(strBody.contains("\"service\": \"myservice\","));
-    assertTrue(strBody.contains("\"runtimeId\": \"myruntimeid\""));
     assertTrue(strBody.contains(new String(SNAPSHOT_BUFFER)));
   }
 }


### PR DESCRIPTION
# What Does This Do
datadog agent is now exposing a new endpoint: /debugger/v1/diagnostics This endpoint is used to send probe statuses to a dedicated debugger track.
we add detection o this new endpoint and create a dedicated BatchUploader to this endpoint using attachment.
if the endpoint is not available (old datadog agent) we send to the previous url as before.

# Motivation

# Additional Notes

Jira ticket: [DEBUG-1853]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1853]: https://datadoghq.atlassian.net/browse/DEBUG-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ