### PR TITLE
Exclude OAuth from Spring Security instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/SpringSecurityUserEventDecorator.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/SpringSecurityUserEventDecorator.java
@@ -40,18 +40,28 @@ public class SpringSecurityUserEventDecorator extends AppSecUserEventDecorator {
   }
 
   public void onLogin(Authentication authentication, Throwable throwable, Authentication result) {
+    if (authentication == null) {
+      return;
+    }
     UserEventTrackingMode mode = Config.get().getAppSecUserEventsTrackingMode();
+    if (mode == DISABLED) {
+      return;
+    }
+
+    // For now, exclude all OAuth events. See APPSEC-12547.
+    if (authentication.getClass().getName().contains("OAuth")) {
+      return;
+    }
 
     String userId = null;
-    Map<String, String> metadata = null;
 
-    if (mode == EXTENDED && authentication != null) {
+    if (mode == EXTENDED) {
       userId = authentication.getName();
     }
 
     if (mode != DISABLED) {
       if (throwable == null && result != null && result.isAuthenticated()) {
-
+        Map<String, String> metadata = null;
         Object principal = result.getPrincipal();
         if (principal instanceof User) {
           User user = (User) principal;


### PR DESCRIPTION

# What Does This Do
Our Spring Security instrumentation is detecting all OAuth events as login attempts, which is incorrect. This can lead to a high volume of kept traces for Spring Security oauth-authorization-server.

These events might be captured in the future once we define which events need to be emitted for OAuth.

# Motivation

# Additional Notes

Jira ticket: [APPSEC-12547](https://datadoghq.atlassian.net/browse/APPSEC-12547)


[APPSEC-12547]: https://datadoghq.atlassian.net/browse/APPSEC-12547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ