### PR TITLE
Upgrade ddprof to 0.90.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.17.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.88.0",
+    ddprof        : "0.90.0",
     asm           : "9.6",
     cafe_crypto   : "0.1.0"
   ]


### PR DESCRIPTION
Avoids calling AsyncGetCallTrace when a runnable thread is at a safepoint https://github.com/DataDog/java-profiler/compare/v_0.88.0...v_0.90.0

# What Does This Do

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
