### PR TITLE
Test native-image builds have no ClassNotFoundException

### DIFF
--- a/dd-smoke-tests/spring-boot-3.0-native/src/test/groovy/SpringBootNativeInstrumentationTest.groovy
+++ b/dd-smoke-tests/spring-boot-3.0-native/src/test/groovy/SpringBootNativeInstrumentationTest.groovy
@@ -44,5 +44,17 @@ class SpringBootNativeInstrumentationTest extends AbstractServerSmokeTest {
     responseBodyStr != null
     responseBodyStr.contains("Hello world")
     waitForTraceCount(1)
+
+    when:
+    checkLogPostExit {
+      // Check that there are no ClassNotFound errors printed from bad reflect-config.json
+      if (it.contains("ClassNotFoundException")) {
+        println "Found ClassNotFoundException in log: ${it}"
+        logHasErrors = true
+      }
+    }
+
+    then:
+    !logHasErrors
   }
 }


### PR DESCRIPTION


# What Does This Do
ClassNotFoundException is common in native-image when reflection is used. Add a check in smoke tests to ensure there is no ClassNotFoundException printed at runtime when native-image is used.
# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
