### PR TITLE
Add basic telemetry support for native image

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 706b4eb3ff053068e961a684d21dfe2ff4487d37
+default_system_tests_commit: &default_system_tests_commit f5409dee787e1758c77d067188b20a2705a679a2
 
 parameters:
   nightly:

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -140,7 +140,6 @@ public class Agent {
   private static boolean cwsEnabled = false;
   private static boolean ciVisibilityEnabled = false;
   private static boolean usmEnabled = false;
-  private static boolean telemetryEnabled = true;
   private static boolean debuggerEnabled = false;
 
   public static void start(final Instrumentation inst, final URL agentJarURL, String agentArgs) {
@@ -153,7 +152,6 @@ public class Agent {
       // these default services are not used during native-image builds
       jmxFetchEnabled = false;
       remoteConfigEnabled = false;
-      telemetryEnabled = false;
       // apply trace instrumentation, but skip starting other services
       startDatadogAgent(inst);
       StaticEventLogger.end("Agent.start");
@@ -211,7 +209,6 @@ public class Agent {
     appSecFullyDisabled = isAppSecFullyDisabled();
     remoteConfigEnabled = isFeatureEnabled(AgentFeature.REMOTE_CONFIG);
     cwsEnabled = isFeatureEnabled(AgentFeature.CWS);
-    telemetryEnabled = isFeatureEnabled(AgentFeature.TELEMETRY);
     debuggerEnabled = isFeatureEnabled(AgentFeature.DEBUGGER);
 
     if (profilingEnabled) {
@@ -341,7 +338,7 @@ public class Agent {
     if (profilingEnabled) {
       shutdownProfilingAgent(sync);
     }
-    if (telemetryEnabled) {
+    if (Config.get().isTelemetryEnabled()) {
       stopTelemetry();
     }
   }
@@ -472,10 +469,7 @@ public class Agent {
       // start debugger before remote config to subscribe to it before starting to poll
       maybeStartDebugger(instrumentation, scoClass, sco);
       maybeStartRemoteConfig(scoClass, sco);
-
-      if (telemetryEnabled) {
-        startTelemetry(instrumentation, scoClass, sco);
-      }
+      maybeStartTelemetry(instrumentation, scoClass, sco);
     }
   }
 
@@ -780,6 +774,13 @@ public class Agent {
     }
   }
 
+  private static void maybeStartTelemetry(Instrumentation inst, Class<?> scoClass, Object sco) {
+    if (!Config.get().isTelemetryEnabled()) {
+      return;
+    }
+    startTelemetry(inst, scoClass, sco);
+  }
+
   private static void startTelemetry(Instrumentation inst, Class<?> scoClass, Object sco) {
     StaticEventLogger.begin("Telemetry");
 
@@ -803,7 +804,7 @@ public class Agent {
 
     try {
       final Class<?> telemetrySystem =
-          AGENT_CLASSLOADER.loadClass("datadog.telemetry.TelemetrySystem");
+          Class.forName("datadog.telemetry.TelemetrySystem", true, AGENT_CLASSLOADER);
       final Method stopTelemetry = telemetrySystem.getMethod("stop");
       stopTelemetry.invoke(null);
     } catch (final Throwable ex) {

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -203,7 +203,7 @@ public class AgentInstaller {
       InstrumenterFlare.register();
     }
 
-    if (InstrumenterConfig.get().isTelemetryEnabled()) {
+    if (InstrumenterConfig.get().isTelemetryEnabledAtBuildTime() && !Platform.isNativeImage()) {
       InstrumenterState.setObserver(
           new InstrumenterState.Observer() {
             @Override

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -50,6 +50,8 @@ dependencies {
   implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.8.0'
 
   api project(':dd-trace-core')
+  // Just for native-image's TracerActivation.
+  compileOnly project(':telemetry')
 
   implementation project(':dd-java-agent:agent-crashtracking')
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/nativeimage/TracerActivation.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/nativeimage/TracerActivation.java
@@ -2,8 +2,10 @@ package datadog.trace.agent.tooling.nativeimage;
 
 import com.datadog.profiling.controller.openjdk.JFREventContextIntegration;
 import datadog.communication.ddagent.SharedCommunicationObjects;
+import datadog.telemetry.TelemetrySystem;
 import datadog.trace.agent.tooling.ProfilerInstaller;
 import datadog.trace.agent.tooling.TracerInstaller;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,15 +15,29 @@ public final class TracerActivation {
   private static final Logger log = LoggerFactory.getLogger(TracerActivation.class);
 
   public static void activate() {
+    SharedCommunicationObjects sco;
+    try {
+      sco = new SharedCommunicationObjects();
+    } catch (Throwable e) {
+      log.warn("Problem creating shared communication objects", e);
+      return;
+    }
     try {
       boolean withProfiler = ProfilerInstaller.installProfiler();
       TracerInstaller.installGlobalTracer(
-          new SharedCommunicationObjects(),
+          sco,
           withProfiler
               ? new JFREventContextIntegration()
               : ProfilingContextIntegration.NoOp.INSTANCE);
     } catch (Throwable e) {
       log.warn("Problem activating datadog tracer", e);
+    }
+    if (Config.get().isTelemetryEnabled()) {
+      try {
+        TelemetrySystem.startTelemetry(null, sco);
+      } catch (final Throwable ex) {
+        log.warn("Unable start telemetry", ex);
+      }
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -161,16 +161,15 @@ public class InstrumenterConfig {
           ProductActivation.fromString(
               configProvider.getStringNotEmpty(IAST_ENABLED, DEFAULT_IAST_ENABLED));
       usmEnabled = configProvider.getBoolean(USM_ENABLED, DEFAULT_USM_ENABLED);
-      telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
     } else {
       // disable these features in native-image
       ciVisibilityEnabled = false;
       appSecActivation = ProductActivation.FULLY_DISABLED;
       iastActivation = ProductActivation.FULLY_DISABLED;
-      telemetryEnabled = false;
       usmEnabled = false;
     }
 
+    telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
     traceExecutorsAll = configProvider.getBoolean(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
     traceExecutors = tryMakeImmutableList(configProvider.getList(TRACE_EXECUTORS));
     traceThreadPoolExecutorsExclude =
@@ -273,7 +272,11 @@ public class InstrumenterConfig {
     return usmEnabled;
   }
 
-  public boolean isTelemetryEnabled() {
+  /**
+   * Checks if telemetry is enabled. In Native Image, this is set at build time. Use Config for run
+   * time.
+   */
+  public boolean isTelemetryEnabledAtBuildTime() {
     return telemetryEnabled;
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricRegistry.java
+++ b/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricRegistry.java
@@ -1,6 +1,6 @@
 package datadog.trace.api.metrics;
 
-import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.Config;
 
 /** This class holds the {@link SpanMetrics} instances. */
 @FunctionalInterface
@@ -26,7 +26,7 @@ public interface SpanMetricRegistry {
    * @return The registry instance.
    */
   static SpanMetricRegistry getInstance() {
-    return InstrumenterConfig.get().isTelemetryEnabled()
+    return Config.get().isTelemetryEnabled()
         ? SpanMetricRegistryImpl.getInstance()
         : SpanMetricRegistry.NOOP;
   }

--- a/telemetry/build.gradle
+++ b/telemetry/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 
   implementation project(':internal-api')
 
-  compileOnly project(':dd-java-agent:agent-tooling')
   testImplementation project(':dd-java-agent:agent-tooling')
   testImplementation project(':dd-java-agent:agent-logging')
 


### PR DESCRIPTION
# What Does This Do
* Adds basic telemetry support for native image.
* Only supports app started/closed, heartbeats, extended heartbeats, and config.

# Motivation

# Additional Notes

Other PRs will follow for:
* Dependencies: https://github.com/DataDog/dd-trace-java/pull/6302
* Integrations
* Metrics
* Logs

