### PR TITLE
Remove details tag for `spark.stage` and `spark.sql` spans

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -252,7 +252,6 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
             .withStartTimestamp(queryStart.time() * 1000)
             .withTag("query_id", sqlExecutionId)
             .withTag("description", queryStart.description())
-            .withTag("details", queryStart.details())
             .withTag(DDTags.RESOURCE_NAME, queryStart.description());
 
     if (batchKey != null) {
@@ -400,7 +399,6 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
             .withTag("stage_id", stageId)
             .withTag("task_count", stageSubmitted.stageInfo().numTasks())
             .withTag("attempt_id", stageAttemptId)
-            .withTag("details", stageSubmitted.stageInfo().details())
             .withTag(DDTags.RESOURCE_NAME, stageSubmitted.stageInfo().name())
             .start();
 


### PR DESCRIPTION
# What Does This Do

Remove details tag for `spark.stage` and `spark.sql` spans

# Motivation

This field is very heavy, since it contains the full stacktrace that triggered the spark action, and not used within data jobs monitoring

It also has a limited usefulness since most stacktraces only contains internal spark code, not written by the user

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
