### PR TITLE
Fix spring-boot-3.0-native gradle dependencies

### DIFF
--- a/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
@@ -27,11 +27,15 @@ dependencies {
 }
 
 if (hasProperty('agentPath')) {
+  final agentPath = property('agentPath')
   graalvmNative {
     binaries {
       main {
-        buildArgs.add("-J-javaagent:${property('agentPath')}")
+        buildArgs.add("-J-javaagent:$agentPath")
       }
     }
+  }
+  tasks.named('nativeCompile') {
+    inputs.file(agentPath).withPropertyName('agentJar')
   }
 }

--- a/dd-smoke-tests/spring-boot-3.0-native/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-native/build.gradle
@@ -48,6 +48,8 @@ if (matcher.size() == 1 && Integer.parseInt(matcher[0][1]) >= 17) {
       exclude '.gradle/**'
     }).withPropertyName('application')
     .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.file(project(':dd-trace-api').tasks.jar.archiveFile.get()).withPropertyName('apiJar')
+    inputs.file(project(':dd-java-agent').tasks.shadowJar.archiveFile.get()).withPropertyName('agentJar')
   }
 
   springNativeBuild {


### PR DESCRIPTION

# What Does This Do
This ensures that native image build is triggered whenever source used in the agent changes. No more --rerun-tasks needed.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
