### PR TITLE
Allow Jacoco auto-instrumentation even when ITR is disabled

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
@@ -135,8 +135,11 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
   }
 
   private boolean isCodeCoverageEnabled(CiVisibilitySettings ciVisibilitySettings) {
-    return ciVisibilitySettings.isCodeCoverageEnabled()
-        && config.isCiVisibilityCodeCoverageEnabled();
+    return config.isCiVisibilityCodeCoverageEnabled()
+        && (ciVisibilitySettings.isCodeCoverageEnabled() // coverage enabled via backend settings
+            || config
+                .isCiVisibilityJacocoPluginVersionProvided() // coverage enabled via tracer settings
+        );
   }
 
   private Map<String, String> getPropertiesPropagatedToChildProcess(

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -710,6 +710,7 @@ public class Config {
   private final String ciVisibilityCodeCoverageReportDumpDir;
   private final String ciVisibilityCompilerPluginVersion;
   private final String ciVisibilityJacocoPluginVersion;
+  private final boolean ciVisibilityJacocoPluginVersionProvided;
   private final List<String> ciVisibilityJacocoPluginIncludes;
   private final List<String> ciVisibilityJacocoPluginExcludes;
   private final String[] ciVisibilityJacocoPluginExcludedClassnames;
@@ -1620,6 +1621,8 @@ public class Config {
     ciVisibilityJacocoPluginVersion =
         configProvider.getString(
             CIVISIBILITY_JACOCO_PLUGIN_VERSION, DEFAULT_CIVISIBILITY_JACOCO_PLUGIN_VERSION);
+    ciVisibilityJacocoPluginVersionProvided =
+        configProvider.getString(CIVISIBILITY_JACOCO_PLUGIN_VERSION) != null;
     ciVisibilityJacocoPluginIncludes =
         Arrays.asList(
             COLON.split(configProvider.getString(CIVISIBILITY_JACOCO_PLUGIN_INCLUDES, ":")));
@@ -2711,6 +2714,10 @@ public class Config {
 
   public String getCiVisibilityJacocoPluginVersion() {
     return ciVisibilityJacocoPluginVersion;
+  }
+
+  public boolean isCiVisibilityJacocoPluginVersionProvided() {
+    return ciVisibilityJacocoPluginVersionProvided;
   }
 
   public List<String> getCiVisibilityJacocoPluginIncludes() {


### PR DESCRIPTION
# What Does This Do
Allows to enable automatic Jacoco injection in Maven and Gradle builds even if ITR is disabled for the tested service.
Now automatic injection will happen either if coverage is enabled according to the remote settings or if the user sets `DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION` environment variable.

# Motivation
Done as part of the new Coverage feature in CI Visibility.

Jira ticket: [CIVIS-8160]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8160]: https://datadoghq.atlassian.net/browse/CIVIS-8160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ