### PR TITLE
Reduce ITR overhead on default branches

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/CiVisibilitySettings.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/CiVisibilitySettings.java
@@ -6,10 +6,12 @@ public class CiVisibilitySettings {
 
   private final boolean code_coverage;
   private final boolean tests_skipping;
+  private final boolean require_git;
 
-  public CiVisibilitySettings(boolean code_coverage, boolean tests_skipping) {
+  public CiVisibilitySettings(boolean code_coverage, boolean tests_skipping, boolean require_git) {
     this.code_coverage = code_coverage;
     this.tests_skipping = tests_skipping;
+    this.require_git = require_git;
   }
 
   public boolean isCodeCoverageEnabled() {
@@ -18,6 +20,10 @@ public class CiVisibilitySettings {
 
   public boolean isTestsSkippingEnabled() {
     return tests_skipping;
+  }
+
+  public boolean isGitUploadRequired() {
+    return require_git;
   }
 
   public interface Factory {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApi.java
@@ -11,7 +11,7 @@ public interface ConfigurationApi {
       new ConfigurationApi() {
         @Override
         public CiVisibilitySettings getSettings(TracerEnvironment tracerEnvironment) {
-          return new CiVisibilitySettings(false, false);
+          return new CiVisibilitySettings(false, false, false);
         }
 
         @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
@@ -121,12 +121,23 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
 
   private CiVisibilitySettings getCiVisibilitySettings(TracerEnvironment tracerEnvironment) {
     try {
-      return configurationApi.getSettings(tracerEnvironment);
+      CiVisibilitySettings settings = configurationApi.getSettings(tracerEnvironment);
+      if (settings.isGitUploadRequired()) {
+        LOGGER.info("Git data upload needs to finish before remote settings can be retrieved");
+        gitDataUploader
+            .startOrObserveGitDataUpload()
+            .get(config.getCiVisibilityGitUploadTimeoutMillis(), TimeUnit.MILLISECONDS);
+
+        return configurationApi.getSettings(tracerEnvironment);
+      } else {
+        return settings;
+      }
+
     } catch (Exception e) {
       LOGGER.warn(
           "Could not obtain CI Visibility settings, will default to disabled code coverage and tests skipping");
       LOGGER.debug("Error while obtaining CI Visibility settings", e);
-      return new CiVisibilitySettings(false, false);
+      return new CiVisibilitySettings(false, false, false);
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TracerEnvironment.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/TracerEnvironment.java
@@ -15,6 +15,10 @@ public class TracerEnvironment {
 
   private final String branch;
   private final String sha;
+
+  @Json(name = "test_level")
+  private final String testLevel = "test";
+
   private final Configurations configurations;
 
   private TracerEnvironment(

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
@@ -39,6 +39,7 @@ class ConfigurationApiImplTest extends Specification {
               "repository_url": "https://github.com/DataDog/foo",
               "branch"        : "prod",
               "sha"           : "d64185e45d1722ab3a53c45be47accae",
+              "test_level"    : "test",
               "configurations": [
                 "os.platform"         : "linux",
                 "os.architecture"     : "amd64",
@@ -57,7 +58,7 @@ class ConfigurationApiImplTest extends Specification {
         ]
 
         if (expectedRequest) {
-          response.status(200).send('{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { "code_coverage": true, "tests_skipping": true } } }')
+          response.status(200).send('{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { "code_coverage": true, "tests_skipping": true, "require_git": true } } }')
         } else {
           response.status(400).send()
         }
@@ -75,6 +76,7 @@ class ConfigurationApiImplTest extends Specification {
               "repository_url": "https://github.com/DataDog/foo",
               "branch"        : "prod",
               "sha"           : "d64185e45d1722ab3a53c45be47accae",
+              "test_level"    : "test",
               "configurations": [
                 "os.platform"         : "linux",
                 "os.architecture"     : "amd64",
@@ -118,6 +120,7 @@ class ConfigurationApiImplTest extends Specification {
     then:
     settings.codeCoverageEnabled
     settings.testsSkippingEnabled
+    settings.gitUploadRequired
   }
 
   def "test skippable tests request"() {


### PR DESCRIPTION
# What Does This Do
Updates ITR logic to reduce overhead on default branches.
Remote settings returned by the backend now include new boolean field `require_git`.
If the new field is set to true, the tracer should wait until Git data upload finishes and retry the settings request.

# Motivation
Most of the overhead when using ITR comes from having to run test with code coverage on default branches.
Based on the git data contents, the backend might decide to disable code coverage for a specific run.

Jira ticket: [CIVIS-8068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8068]: https://datadoghq.atlassian.net/browse/CIVIS-8068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ