### PR TITLE
Header injection vulnerability detection

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -5,6 +5,7 @@ import com.datadog.iast.propagation.FastCodecModule;
 import com.datadog.iast.propagation.PropagationModuleImpl;
 import com.datadog.iast.propagation.StringModuleImpl;
 import com.datadog.iast.sink.CommandInjectionModuleImpl;
+import com.datadog.iast.sink.HeaderInjectionModuleImpl;
 import com.datadog.iast.sink.HstsMissingHeaderModuleImpl;
 import com.datadog.iast.sink.HttpResponseHeaderModuleImpl;
 import com.datadog.iast.sink.InsecureCookieModuleImpl;
@@ -102,7 +103,8 @@ public class IastSystem {
         new XPathInjectionModuleImpl(dependencies),
         new TrustBoundaryViolationModuleImpl(dependencies),
         new XssModuleImpl(dependencies),
-        new StacktraceLeakModuleImpl(dependencies));
+        new StacktraceLeakModuleImpl(dependencies),
+        new HeaderInjectionModuleImpl(dependencies));
   }
 
   private static void registerRequestStartedCallback(

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -65,6 +65,12 @@ public interface VulnerabilityType {
   InjectionType XSS =
       new InjectionTypeImpl(VulnerabilityTypes.XSS_STRING, VulnerabilityMarks.XSS_MARK, ' ');
 
+  InjectionType HEADER_INJECTION =
+      new InjectionTypeImpl(
+          VulnerabilityTypes.HEADER_INJECTION_STRING,
+          VulnerabilityMarks.HEADER_INJECTION_MARK,
+          ' ');
+
   VulnerabilityType STACKTRACE_LEAK =
       new VulnerabilityTypeImpl(VulnerabilityTypes.STACKTRACE_LEAK_STRING, NOT_MARKED);
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/SensitiveHandlerImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sensitive/SensitiveHandlerImpl.java
@@ -46,6 +46,7 @@ public class SensitiveHandlerImpl implements SensitiveHandler {
     tokenizers.put(VulnerabilityType.SSRF, UrlRegexpTokenizer::new);
     tokenizers.put(VulnerabilityType.UNVALIDATED_REDIRECT, UrlRegexpTokenizer::new);
     tokenizers.put(VulnerabilityType.XSS, TaintedRangeBasedTokenizer::new);
+    tokenizers.put(VulnerabilityType.HEADER_INJECTION, TaintedRangeBasedTokenizer::new);
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
@@ -1,0 +1,102 @@
+package com.datadog.iast.sink;
+
+import com.datadog.iast.Dependencies;
+import com.datadog.iast.IastRequestContext;
+import com.datadog.iast.model.Evidence;
+import com.datadog.iast.model.Range;
+import com.datadog.iast.model.VulnerabilityType;
+import com.datadog.iast.overhead.Operations;
+import com.datadog.iast.taint.Ranges;
+import com.datadog.iast.taint.TaintedObject;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.sink.HeaderInjectionModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class HeaderInjectionModuleImpl extends SinkModuleBase implements HeaderInjectionModule {
+
+  private static final Set<String> headerInjectionExclusions =
+      new HashSet<String>(
+          Arrays.asList(
+              "Sec-WebSocket-Location".toUpperCase(),
+              "Sec-WebSocket-Accept".toUpperCase(),
+              "Upgrade".toUpperCase(),
+              "Connection".toUpperCase(),
+              "location".toUpperCase()));
+
+  public HeaderInjectionModuleImpl(final Dependencies dependencies) {
+    super(dependencies);
+  }
+
+  @Override
+  public void onHeader(@Nonnull final String name, @Nullable final String value) {
+    if (null == value) {
+      return;
+    }
+    boolean headerInjectionExclusion = headerInjectionExclusions.contains(name.toUpperCase());
+
+    if (!headerInjectionExclusion) {
+      final AgentSpan span = AgentTracer.activeSpan();
+      final IastRequestContext ctx = IastRequestContext.get(span);
+      if (ctx == null) {
+        return;
+      }
+
+      final TaintedObject taintedObject = ctx.getTaintedObjects().get(value);
+      if (null == taintedObject) {
+        return;
+      }
+
+      final Range[] ranges =
+          Ranges.getNotMarkedRanges(
+              taintedObject.getRanges(), VulnerabilityType.HEADER_INJECTION.mark());
+      if (ranges == null || ranges.length == 0) {
+        return;
+      }
+
+      if ("Access-Control-Allow-Origin".equalsIgnoreCase(name)) {
+        boolean allRangesFromOrigin = true;
+        for (Range range : ranges) {
+          if (null != range.getSource().getName()
+              && range.getSource().getOrigin() == SourceTypes.REQUEST_HEADER_VALUE
+              && !range.getSource().getName().equalsIgnoreCase("origin")) {
+            allRangesFromOrigin = false;
+          }
+        }
+        if (allRangesFromOrigin) {
+          return;
+        }
+      }
+
+      if ("Set-Cookie".equalsIgnoreCase(name)) {
+        boolean allRangesFromCookie = true;
+        for (Range range : ranges) {
+          if (null != range.getSource().getName()
+              && range.getSource().getOrigin() == SourceTypes.REQUEST_HEADER_VALUE
+              && !range.getSource().getName().equalsIgnoreCase("Set-Cookie")) {
+            allRangesFromCookie = false;
+          }
+        }
+        if (allRangesFromCookie) {
+          return;
+        }
+      }
+
+      if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
+        return;
+      }
+      final String evidenceString = name + ": " + value;
+      final Range[] shiftedRanges = new Range[ranges.length];
+      for (int i = 0; i < ranges.length; i++) {
+        shiftedRanges[i] = ranges[i].shift(name.length() + 2);
+      }
+      final Evidence result = new Evidence(evidenceString, shiftedRanges);
+      report(span, VulnerabilityType.HEADER_INJECTION, result);
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
@@ -40,9 +40,6 @@ public class HeaderInjectionModuleImpl extends SinkModuleBase implements HeaderI
       return;
     }
     HttpHeader header = HttpHeader.from(name);
-    if (null == header) {
-      return;
-    }
     boolean headerInjectionExclusion = headerInjectionExclusions.contains(header);
 
     if (!headerInjectionExclusion) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HttpResponseHeaderModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HttpResponseHeaderModuleImpl.java
@@ -50,6 +50,9 @@ public class HttpResponseHeaderModuleImpl extends SinkModuleBase
         InstrumentationBridge.UNVALIDATED_REDIRECT.onHeader(name, value);
       }
     }
+    if (null != InstrumentationBridge.HEADER_INJECTION) {
+      InstrumentationBridge.HEADER_INJECTION.onHeader(name, value);
+    }
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
@@ -89,7 +89,12 @@ public class HttpHeader {
                   Values.CONTENT_TYPE,
                   Values.X_CONTENT_TYPE_OPTIONS,
                   Values.LOCATION,
-                  Values.REFERER)
+                  Values.REFERER,
+                  Values.SEC_WEBSOCKET_LOCATION,
+                  Values.SEC_WEBSOCKET_ACCEPT,
+                  Values.UPGRADE,
+                  Values.CONNECTION,
+                  Values.ACCESS_CONTROL_ALLOW_ORIGIN)
               .collect(Collectors.toMap(header -> header.name, Function.identity()));
     }
   }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
@@ -66,8 +66,16 @@ public class HttpHeader {
             ctx.setxContentTypeOptions(value);
           }
         };
+
     public static final HttpHeader LOCATION = new HttpHeader("Location");
     public static final HttpHeader REFERER = new HttpHeader("Referer");
+    public static final HttpHeader SEC_WEBSOCKET_LOCATION =
+        new HttpHeader("Sec-WebSocket-Location");
+    public static final HttpHeader SEC_WEBSOCKET_ACCEPT = new HttpHeader("Sec-WebSocket-Accept");
+    public static final HttpHeader UPGRADE = new HttpHeader("Upgrade");
+    public static final HttpHeader CONNECTION = new HttpHeader("Connection");
+    public static final HttpHeader ACCESS_CONTROL_ALLOW_ORIGIN =
+        new HttpHeader("Access-Control-Allow-Origin");
 
     /** Faster lookup for headers */
     static final Map<String, HttpHeader> HEADERS;

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
@@ -9,9 +9,16 @@ import com.datadog.iast.taint.TaintedObjects
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.VulnerabilityMarks
 import datadog.trace.api.iast.telemetry.IastMetricCollector
 import datadog.trace.api.iast.util.Cookie
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
+import static com.datadog.iast.taint.TaintUtils.addFromRangeList
+import static com.datadog.iast.taint.TaintUtils.taintFormat
+import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED
 
 class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
 
@@ -32,6 +39,7 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
     InstrumentationBridge.registerIastModule(new NoSameSiteCookieModuleImpl())
     InstrumentationBridge.registerIastModule(new HstsMissingHeaderModuleImpl(dependencies))
     InstrumentationBridge.registerIastModule(new UnvalidatedRedirectModuleImpl(dependencies))
+    InstrumentationBridge.registerIastModule(new HeaderInjectionModuleImpl(dependencies))
     objectHolder = []
     ctx = new IastRequestContext()
     final reqCtx = Stub(RequestContext) {
@@ -41,6 +49,7 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }
+    tracer.activeSpan() >> span
   }
 
 
@@ -93,7 +102,7 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
     module.onHeader("Strict-Transport-Security", "invalid max age")
 
     then:
-    4 * tracer.activeSpan()
+    8 * tracer.activeSpan()
     1 * overheadController.consumeQuota(_,_)
     0 * _
   }
@@ -125,5 +134,147 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
 
     then:
     0 * _
+  }
+
+  void 'check header value injection'(final String headerName, final int mark, final String headerValue, final String expected) {
+    given:
+    Vulnerability savedVul
+    final taintedHeaderValue = mapTainted(headerValue, mark)
+
+    when:
+    module.onHeader(headerName, taintedHeaderValue)
+
+    then:
+    1 * reporter.report(_, _ as Vulnerability) >> { savedVul = it[1] }
+    assertEvidence(savedVul, expected, VulnerabilityType.HEADER_INJECTION)
+
+    where:
+    headerValue   | mark                                     | headerName               | expected
+    '/==>var<=='  | NOT_MARKED                               | 'headerName'             | "headerName: /==>var<=="
+    '/==>var<=='  | VulnerabilityMarks.XPATH_INJECTION_MARK  | 'headerName'             | "headerName: /==>var<=="
+  }
+
+  void 'check untainted header value injection'(final String headerName, final int mark, final String headerValue, final String expected) {
+    given:
+    final taintedHeaderValue = mapTainted(headerValue, mark)
+
+    when:
+    module.onHeader(headerName, taintedHeaderValue)
+
+    then:
+    0 * reporter.report(_, _ as Vulnerability) >> { savedVul = it[1] }
+
+    where:
+    headerValue   | mark                                      | headerName               | expected
+    'var'         | NOT_MARKED                                | 'headerName'             | null
+    '/==>var<=='  | VulnerabilityMarks.HEADER_INJECTION_MARK  | 'headerName'             | null
+  }
+
+
+  void 'check unvalidated redirect exclusion'(final String headerName, final int mark, final String headerValue, final String expected) {
+    given:
+    Vulnerability savedVul
+    final taintedHeaderValue = mapTainted(headerValue, mark)
+
+    when:
+    module.onHeader(headerName, taintedHeaderValue)
+
+    then:
+    1 * reporter.report(_, _ as Vulnerability) >> { savedVul = it[1] }
+    assertEvidence(savedVul, expected, VulnerabilityType.UNVALIDATED_REDIRECT)
+
+    where:
+    headerValue   | mark                                     | headerName               | expected
+    '/==>var<=='  | NOT_MARKED                               | 'location'               | "/==>var<=="
+  }
+
+  void 'check header exclusions'(final String headerName, final int mark, final String headerValue) {
+    given:
+    final taintedHeaderValue = mapTainted(headerValue, mark)
+
+    when:
+    module.onHeader(headerName, taintedHeaderValue)
+
+    then:
+    0 * reporter.report(_, _ as Vulnerability)
+
+    where:
+    headerValue    | mark                                    | headerName
+    '/==>var<=='  | NOT_MARKED                               | 'Sec-WebSocket-Location'
+    '/==>var<=='  | NOT_MARKED                               | 'Sec-WebSocket-Accept'
+    '/==>var<=='  | NOT_MARKED                               | 'Upgrade'
+    '/==>var<=='  | NOT_MARKED                               | 'Connection'
+  }
+
+  void 'range test'(){
+    given:
+    addFromRangeList(ctx.taintedObjects, headerValue, ranges)
+
+    when:
+    module.onHeader(headerName, headerValue)
+
+    then:
+    0 * reporter.report(_, _ as Vulnerability)
+
+    where:
+    headerValue | headerName                    | ranges
+    'pepito'    | 'Sec-WebSocket-Location'      | [[0, 2, 'sourceName', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]]
+    'pepito'    | 'Access-Control-Allow-Origin' | [[0, 2, 'origin', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]]
+    'pepito'    | 'Access-Control-Allow-Origin' | [
+      [0, 2, 'origin', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE],
+      [2, 2, 'origin', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]
+    ]
+    'pepito'    | 'Set-Cookie'                  | [[0, 2, 'Set-Cookie', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]]
+    'pepito'    | 'Set-Cookie'                  | [
+      [0, 2, 'Set-Cookie', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE],
+      [2, 2, 'Set-Cookie', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]
+    ]
+  }
+
+  void 'range test exclusions'(){
+    given:
+    Vulnerability savedVul
+    addFromRangeList(ctx.taintedObjects, headerValue, ranges)
+
+    when:
+    module.onHeader(headerName, headerValue)
+
+    then:
+    1 * reporter.report(_, _ as Vulnerability) >> { savedVul = it[1] }
+    assertEvidence(savedVul, expected, VulnerabilityType.HEADER_INJECTION)
+
+    where:
+    headerValue | expected                                           | headerName                   | ranges
+    'pepito'    | 'Access-Control-Allow-Origin: ==>pe<==pito'        |'Access-Control-Allow-Origin' | [[0, 2, 'X-Test-Header', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]]
+    'pepito'    | 'Access-Control-Allow-Origin: ==>pe<====>pi<==to'  |'Access-Control-Allow-Origin' | [
+      [0, 2, 'origin', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE],
+      [2, 2, 'X-Test-Header', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]
+    ]
+    'pepito'    | 'Set-Cookie: ==>pe<==pito'                        |'Set-Cookie'                  | [[0, 2, 'X-Test-Header', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]]
+    'pepito'    | 'Set-Cookie: ==>pe<====>pi<==to'                  |'Set-Cookie'                  | [
+      [0, 2, 'Set-Cookie', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE],
+      [2, 2, 'X-Test-Header', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]
+    ]
+  }
+
+
+  private String mapTainted(final String value, final int mark) {
+    final result = addFromTaintFormat(ctx.taintedObjects, value, mark)
+    objectHolder.add(result)
+    return result
+  }
+
+  private static void assertVulnerability(final Vulnerability vuln, final VulnerabilityType type ) {
+    assert vuln != null
+    assert vuln.getType() == type
+    assert vuln.getLocation() != null
+  }
+
+  private static void assertEvidence(final Vulnerability vuln, final String expected, final VulnerabilityType type = VulnerabilityType.HEADER_INJECTION) {
+    assertVulnerability(vuln, type)
+    final evidence = vuln.getEvidence()
+    assert evidence != null
+    final formatted = taintFormat(evidence.getValue(), evidence.getRanges())
+    assert formatted == expected
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintUtils.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintUtils.groovy
@@ -94,6 +94,19 @@ class TaintUtils {
     return resultString
   }
 
+  static void addFromRangeList(final TaintedObjects tos, final String s, final List<List<Object>> spockRangeList) {
+    Vector<Range> rangesVector = new Vector<>()
+    for (List<Object> range : spockRangeList) {
+      int start = (int)range.get(0)
+      int length = (int)range.get(1)
+      byte sourceType = (byte)range.get(4)
+      rangesVector.add(new Range(start, length, new Source(sourceType, (String)range.get(2), (String)range.get(3)), NOT_MARKED))
+    }
+
+    Range[] ranges = (Range[])rangesVector.toArray()
+    tos.taint(s, ranges)
+  }
+
   static StringBuilder addFromTaintFormat(final TaintedObjects tos, final StringBuilder sb) {
     final String s = sb.toString()
     final ranges = fromTaintFormat(s)

--- a/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
+++ b/dd-java-agent/agent-iast/src/test/resources/redaction/evidence-redaction-suite.yml
@@ -2022,4 +2022,44 @@ suite:
           }
         ]
       }
-
+  - type: 'VULNERABILITIES'
+    description: 'Testing header injection redaction'
+    input: >
+      [
+        {
+          "type": "HEADER_INJECTION",
+          "evidence": {
+            "value": "Authorization: bearer 12345644",
+            "ranges": [
+              { "start" : 0, "length" : 30, "source": { "origin": "http.request.header", "name": "X-Test-Header", "value": "Authorization: bearer 12345644" }}
+            ]
+          }
+        }
+      ]
+    expected: >
+     {
+         "vulnerabilities": [
+             {
+                "type": "HEADER_INJECTION",
+                 "evidence": {
+                     "valueParts": [
+                         {
+                             "source": 0,
+                             "redacted": true,
+                             "pattern": "abcdefghijklmnopqrstuvwxyzABCD"
+                         }
+                     ]
+                 },
+                 "hash": 0,
+                 "type": "HEADER_INJECTION"
+             }
+         ],
+         "sources": [
+             {
+                 "origin": "http.request.header",
+                 "name": "X-Test-Header",
+                 "redacted": true,
+                 "pattern": "abcdefghijklmnopqrstuvwxyzABCD"
+             }
+         ]
+     }

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -301,6 +301,10 @@
 0 org.springframework.http.ReadOnlyHttpHeaders
 0 org.springframework.http.codec.json.Jackson2Tokenizer
 0 org.springframework.http.server.reactive.UndertowServerHttpRequest$UndertowDataBuffer
+0 org.springframework.http.server.ServletServerHttpRequest
+0 org.springframework.http.server.reactive.ReactorServerHttpRequest
+0 org.springframework.http.client.reactive.AbstractClientHttpRequest
+0 org.springframework.http.client.reactive.ReactorClientHttpRequest
 0 org.springframework.core.io.buffer.DataBuffer
 0 org.springframework.core.io.buffer.DefaultDataBuffer
 0 org.springframework.core.io.buffer.NettyDataBuffer

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/AbstractServerHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/AbstractServerHttpRequestInstrumentation.java
@@ -1,0 +1,45 @@
+package datadog.trace.instrumentation.springwebflux.server.iast;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class AbstractServerHttpRequestInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  public AbstractServerHttpRequestInstrumentation() {
+    super("spring-webflux");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.springframework.http.server.reactive.AbstractServerHttpRequest";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(isPublic()).and(named("getHeaders")).and(takesArguments(0)),
+        getClass().getName() + "$TaintHeadersAdvice");
+  }
+
+  public static class TaintHeadersAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void after(@Advice.Return Object object) {
+      PropagationModule propagation = InstrumentationBridge.PROPAGATION;
+      if (propagation == null) {
+        return;
+      }
+      propagation.taint(object, SourceTypes.REQUEST_HEADER_VALUE);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HttpHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HttpHeadersInstrumentation.java
@@ -31,5 +31,8 @@ public class HttpHeadersInstrumentation extends Instrumenter.Iast
     transformation.applyAdvice(
         isMethod().and(named("toSingleValueMap")).and(takesArguments(0)),
         packageName + ".TaintHttpHeadersToSingleValueMapAdvice");
+    transformation.applyAdvice(
+        isMethod().and(named("readOnlyHttpHeaders")).and(takesArguments(1)),
+        packageName + ".TaintReadOnlyHttpHeadersAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HttpMessageInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HttpMessageInstrumentation.java
@@ -1,0 +1,53 @@
+package datadog.trace.instrumentation.springwebflux.server.iast;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public class HttpMessageInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+
+  public HttpMessageInstrumentation() {
+    super("spring-webflux");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "org.springframework.http.HttpMessage";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()));
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(isPublic()).and(named("getHeaders")).and(takesArguments(0)),
+        getClass().getName() + "$TaintHeadersAdvice");
+  }
+
+  public static class TaintHeadersAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void after(@Advice.Return Object object) {
+      PropagationModule propagation = InstrumentationBridge.PROPAGATION;
+      if (propagation == null) {
+        return;
+      }
+      propagation.taint(object, SourceTypes.REQUEST_HEADER_VALUE);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ReactorServerHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ReactorServerHttpRequestInstrumentation.java
@@ -1,0 +1,45 @@
+package datadog.trace.instrumentation.springwebflux.server.iast;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class ReactorServerHttpRequestInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  public ReactorServerHttpRequestInstrumentation() {
+    super("spring-webflux");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.springframework.http.server.reactive.ReactorServerHttpRequest";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(isPublic()).and(named("initHeaders")).and(takesArguments(1)),
+        getClass().getName() + "$TaintHeadersAdvice");
+  }
+
+  public static class TaintHeadersAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void after(@Advice.Return Object object) {
+      PropagationModule propagation = InstrumentationBridge.PROPAGATION;
+      if (propagation == null) {
+        return;
+      }
+      propagation.taint(object, SourceTypes.REQUEST_HEADER_VALUE);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ServerServletHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ServerServletHttpRequestInstrumentation.java
@@ -1,0 +1,45 @@
+package datadog.trace.instrumentation.springwebflux.server.iast;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.SourceTypes;
+import datadog.trace.api.iast.propagation.PropagationModule;
+import net.bytebuddy.asm.Advice;
+
+@AutoService(Instrumenter.class)
+public class ServerServletHttpRequestInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForSingleType {
+
+  public ServerServletHttpRequestInstrumentation() {
+    super("spring-webflux");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.springframework.http.server.ServletServerHttpRequest";
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(isPublic()).and(named("getHeaders")).and(takesArguments(0)),
+        getClass().getName() + "$TaintHeadersAdvice");
+  }
+
+  public static class TaintHeadersAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void after(@Advice.Return Object object) {
+      PropagationModule propagation = InstrumentationBridge.PROPAGATION;
+      if (propagation == null) {
+        return;
+      }
+      propagation.taint(object, SourceTypes.REQUEST_HEADER_VALUE);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
@@ -16,7 +16,11 @@ import net.bytebuddy.asm.Advice;
 class TaintHttpHeadersGetAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_HEADER_VALUE)
-  public static void after(@Advice.Argument(0) Object arg, @Advice.Return List<String> values) {
+  public static void after(
+      @Advice.This Object self,
+      @Advice.Argument(0) Object arg,
+      @Advice.Return List<String> values) {
+
     PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || values == null || values.isEmpty()) {
       return;
@@ -27,7 +31,7 @@ class TaintHttpHeadersGetAdvice {
     final IastContext ctx = IastContext.Provider.get();
     String lc = ((String) arg).toLowerCase(Locale.ROOT);
     for (String value : values) {
-      module.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, lc);
+      module.taintIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, lc);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
@@ -16,7 +16,7 @@ import org.springframework.http.HttpHeaders;
 class TaintHttpHeadersToSingleValueMapAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_HEADER_VALUE)
-  public static void after(@Advice.Return Map<String, String> values) {
+  public static void after(@Advice.This Object self, @Advice.Return Map<String, String> values) {
     PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || values == null || values.isEmpty()) {
       return;
@@ -26,8 +26,8 @@ class TaintHttpHeadersToSingleValueMapAdvice {
     for (Map.Entry<String, String> e : values.entrySet()) {
       final String name = e.getKey();
       final String value = e.getValue();
-      module.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
-      module.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+      module.taintIfTainted(ctx, name, self, SourceTypes.REQUEST_HEADER_NAME, name);
+      module.taintIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, name);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintReadOnlyHttpHeadersAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintReadOnlyHttpHeadersAdvice.java
@@ -2,24 +2,26 @@ package datadog.trace.instrumentation.springwebflux.server.iast;
 
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
-/** @see org.springframework.http.HttpHeaders#getFirst(String) */
+/** @see org.springframework.http.HttpHeaders#get(Object) */
 @RequiresRequestContext(RequestContextSlot.IAST)
-class TaintHttpHeadersGetFirstAdvice {
+class TaintReadOnlyHttpHeadersAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_HEADER_VALUE)
-  public static void after(
-      @Advice.This Object self, @Advice.Argument(0) String arg, @Advice.Return String value) {
+  public static void after(@Advice.Argument(0) Object headers, @Advice.Return Object retValue) {
 
     PropagationModule module = InstrumentationBridge.PROPAGATION;
-    if (module == null || arg == null || value == null) {
+    if (module == null || retValue == null) {
       return;
     }
-    module.taintIfTainted(value, self, SourceTypes.REQUEST_HEADER_VALUE, arg);
+    final IastContext ctx = IastContext.Provider.get();
+
+    module.taintIfTainted(ctx, retValue, headers);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/HeadersAdviceForkedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/HeadersAdviceForkedTest.groovy
@@ -1,0 +1,30 @@
+package dd.trace.instrumentation.springwebflux.client
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.propagation.PropagationModule
+import foo.bar.DummyRequest
+import org.springframework.http.server.ServletServerHttpRequest
+
+class HeadersAdviceForkedTest extends AgentTestRunner {
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void 'Headers instrumentation'() {
+    given:
+    final module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+    final ServletServerHttpRequest request = new ServletServerHttpRequest(new DummyRequest())
+
+
+    when:
+    request.getHeaders()
+
+    then:
+    2 * module.taint(_ as Object, SourceTypes.REQUEST_HEADER_VALUE)
+    0 * _
+  }
+}

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/java/foo/bar/DummyRequest.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/java/foo/bar/DummyRequest.java
@@ -1,0 +1,367 @@
+package foo.bar;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
+
+public class DummyRequest implements HttpServletRequest {
+  Map<String, String> headers = Collections.emptyMap();
+
+  @Override
+  public String getAuthType() {
+    return null;
+  }
+
+  @Override
+  public Cookie[] getCookies() {
+    return new Cookie[0];
+  }
+
+  @Override
+  public long getDateHeader(String s) {
+    return 0;
+  }
+
+  @Override
+  public String getHeader(String s) {
+    return headers.get(s);
+  }
+
+  @Override
+  public Enumeration<String> getHeaders(String s) {
+    return Collections.enumeration(Collections.singletonList(headers.get(s)));
+  }
+
+  @Override
+  public Enumeration<String> getHeaderNames() {
+    return Collections.enumeration(headers.keySet());
+  }
+
+  @Override
+  public int getIntHeader(String s) {
+    return 0;
+  }
+
+  @Override
+  public String getMethod() {
+    return null;
+  }
+
+  @Override
+  public String getPathInfo() {
+    return null;
+  }
+
+  @Override
+  public String getPathTranslated() {
+    return null;
+  }
+
+  @Override
+  public String getContextPath() {
+    return null;
+  }
+
+  @Override
+  public String getQueryString() {
+    return null;
+  }
+
+  @Override
+  public String getRemoteUser() {
+    return null;
+  }
+
+  @Override
+  public boolean isUserInRole(String s) {
+    return false;
+  }
+
+  @Override
+  public Principal getUserPrincipal() {
+    return null;
+  }
+
+  @Override
+  public String getRequestedSessionId() {
+    return null;
+  }
+
+  @Override
+  public String getRequestURI() {
+    return null;
+  }
+
+  @Override
+  public StringBuffer getRequestURL() {
+    return null;
+  }
+
+  @Override
+  public String getServletPath() {
+    return null;
+  }
+
+  @Override
+  public HttpSession getSession(boolean b) {
+    return null;
+  }
+
+  @Override
+  public HttpSession getSession() {
+    return null;
+  }
+
+  @Override
+  public String changeSessionId() {
+    return null;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdValid() {
+    return false;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromCookie() {
+    return false;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromURL() {
+    return false;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromUrl() {
+    return false;
+  }
+
+  @Override
+  public boolean authenticate(HttpServletResponse httpServletResponse)
+      throws IOException, ServletException {
+    return false;
+  }
+
+  @Override
+  public void login(String s, String s1) throws ServletException {}
+
+  @Override
+  public void logout() throws ServletException {}
+
+  @Override
+  public Collection<Part> getParts() throws IOException, ServletException {
+    return null;
+  }
+
+  @Override
+  public Part getPart(String s) throws IOException, ServletException {
+    return null;
+  }
+
+  @Override
+  public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass)
+      throws IOException, ServletException {
+    return null;
+  }
+
+  @Override
+  public Object getAttribute(String s) {
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getAttributeNames() {
+    return null;
+  }
+
+  @Override
+  public String getCharacterEncoding() {
+    return null;
+  }
+
+  @Override
+  public void setCharacterEncoding(String s) throws UnsupportedEncodingException {}
+
+  @Override
+  public int getContentLength() {
+    return 0;
+  }
+
+  @Override
+  public long getContentLengthLong() {
+    return 0;
+  }
+
+  @Override
+  public String getContentType() {
+    return null;
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    return null;
+  }
+
+  @Override
+  public String getParameter(String s) {
+    return null;
+  }
+
+  @Override
+  public Enumeration<String> getParameterNames() {
+    return null;
+  }
+
+  @Override
+  public String[] getParameterValues(String s) {
+    return new String[0];
+  }
+
+  @Override
+  public Map<String, String[]> getParameterMap() {
+    return null;
+  }
+
+  @Override
+  public String getProtocol() {
+    return null;
+  }
+
+  @Override
+  public String getScheme() {
+    return null;
+  }
+
+  @Override
+  public String getServerName() {
+    return null;
+  }
+
+  @Override
+  public int getServerPort() {
+    return 0;
+  }
+
+  @Override
+  public BufferedReader getReader() throws IOException {
+    return null;
+  }
+
+  @Override
+  public String getRemoteAddr() {
+    return null;
+  }
+
+  @Override
+  public String getRemoteHost() {
+    return null;
+  }
+
+  @Override
+  public void setAttribute(String s, Object o) {}
+
+  @Override
+  public void removeAttribute(String s) {}
+
+  @Override
+  public Locale getLocale() {
+    return null;
+  }
+
+  @Override
+  public Enumeration<Locale> getLocales() {
+    return null;
+  }
+
+  @Override
+  public boolean isSecure() {
+    return false;
+  }
+
+  @Override
+  public RequestDispatcher getRequestDispatcher(String s) {
+    return null;
+  }
+
+  @Override
+  public String getRealPath(String s) {
+    return null;
+  }
+
+  @Override
+  public int getRemotePort() {
+    return 0;
+  }
+
+  @Override
+  public String getLocalName() {
+    return null;
+  }
+
+  @Override
+  public String getLocalAddr() {
+    return null;
+  }
+
+  @Override
+  public int getLocalPort() {
+    return 0;
+  }
+
+  @Override
+  public ServletContext getServletContext() {
+    return null;
+  }
+
+  @Override
+  public AsyncContext startAsync() throws IllegalStateException {
+    return null;
+  }
+
+  @Override
+  public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+      throws IllegalStateException {
+    return null;
+  }
+
+  @Override
+  public boolean isAsyncStarted() {
+    return false;
+  }
+
+  @Override
+  public boolean isAsyncSupported() {
+    return false;
+  }
+
+  @Override
+  public AsyncContext getAsyncContext() {
+    return null;
+  }
+
+  @Override
+  public DispatcherType getDispatcherType() {
+    return null;
+  }
+}

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -366,6 +366,26 @@ public class IastWebController {
     return "Ok";
   }
 
+  @GetMapping("/header_injection")
+  public String headerInjection(@RequestParam("param") String param, HttpServletResponse response) {
+    response.addHeader("X-Test-Header", param);
+    return "Ok";
+  }
+
+  @GetMapping("/header_injection_exclusion")
+  public String headerInjectionExclusion(
+      @RequestParam("param") String param, HttpServletResponse response) {
+    response.addHeader("Sec-WebSocket-Location", param);
+    return "Ok";
+  }
+
+  @GetMapping("/header_injection_redaction")
+  public String headerInjectionRedaction(
+      @RequestParam("param") String param, HttpServletResponse response) {
+    response.addHeader("X-Test-Header", param);
+    return "Ok";
+  }
+
   private void withProcess(final Operation<Process> op) {
     Process process = null;
     try {

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -9,7 +9,6 @@ import okhttp3.RequestBody
 import static datadog.trace.api.config.IastConfig.IAST_DEBUG_ENABLED
 import static datadog.trace.api.config.IastConfig.IAST_DETECTION_MODE
 import static datadog.trace.api.config.IastConfig.IAST_ENABLED
-import static datadog.trace.api.config.IastConfig.IAST_REDACTION_ENABLED
 
 abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
 
@@ -26,7 +25,6 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
       withSystemProperty(IAST_ENABLED, true),
       withSystemProperty(IAST_DETECTION_MODE, 'FULL'),
       withSystemProperty(IAST_DEBUG_ENABLED, true),
-      withSystemProperty(IAST_REDACTION_ENABLED, false)
     ])
     command.addAll((String[]) ['-jar', springBootShadowJar, "--server.port=${httpPort}"])
     ProcessBuilder processBuilder = new ProcessBuilder(command)
@@ -850,6 +848,43 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
       tainted.value == '/getrequesturi' &&
         tainted.ranges[0].source.origin == 'http.request.path'
     }
+  }
+
+  void 'header injection'(){
+    setup:
+    final url = "http://localhost:${httpPort}/header_injection?param=test"
+    final request = new Request.Builder().url(url).get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    hasVulnerability { vul -> vul.type == 'HEADER_INJECTION' }
+  }
+
+  void 'header injection exclusion'(){
+    setup:
+    final url = "http://localhost:${httpPort}/header_injection_exclusion?param=testExclusion"
+    final request = new Request.Builder().url(url).get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    noVulnerability { vul -> vul.type == 'HEADER_INJECTION'}
+  }
+
+  void 'header injection redaction'(){
+    setup:
+    String bearer = URLEncoder.encode("Authorization: bearer 12345644", "UTF-8")
+    final url = "http://localhost:${httpPort}/header_injection_redaction?param=" + bearer
+    final request = new Request.Builder().url(url).get().build()
+
+    when:
+    client.newCall(request).execute()
+
+    then:
+    hasVulnerability { vul -> vul.type == 'HEADER_INJECTION' && vul.evidence.valueParts[1].redacted == true }
   }
 
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.propagation.CodecModule;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.propagation.StringModule;
 import datadog.trace.api.iast.sink.CommandInjectionModule;
+import datadog.trace.api.iast.sink.HeaderInjectionModule;
 import datadog.trace.api.iast.sink.HstsMissingHeaderModule;
 import datadog.trace.api.iast.sink.HttpResponseHeaderModule;
 import datadog.trace.api.iast.sink.InsecureCookieModule;
@@ -54,6 +55,8 @@ public abstract class InstrumentationBridge {
 
   public static volatile StacktraceLeakModule STACKTRACE_LEAK_MODULE;
 
+  public static volatile HeaderInjectionModule HEADER_INJECTION;
+
   private InstrumentationBridge() {}
 
   public static void registerIastModule(final IastModule module) {
@@ -101,6 +104,8 @@ public abstract class InstrumentationBridge {
       XSS = (XssModule) module;
     } else if (module instanceof StacktraceLeakModule) {
       STACKTRACE_LEAK_MODULE = (StacktraceLeakModule) module;
+    } else if (module instanceof HeaderInjectionModule) {
+      HEADER_INJECTION = (HeaderInjectionModule) module;
     } else {
       throw new UnsupportedOperationException("Module not yet supported: " + module);
     }
@@ -175,6 +180,9 @@ public abstract class InstrumentationBridge {
     if (type == StacktraceLeakModule.class) {
       return (E) STACKTRACE_LEAK_MODULE;
     }
+    if (type == HeaderInjectionModule.class) {
+      return (E) HEADER_INJECTION;
+    }
     throw new UnsupportedOperationException("Module not yet supported: " + type);
   }
 
@@ -202,5 +210,6 @@ public abstract class InstrumentationBridge {
     TRUST_BOUNDARY_VIOLATION = null;
     XSS = null;
     STACKTRACE_LEAK_MODULE = null;
+    HEADER_INJECTION = null;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityMarks.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityMarks.java
@@ -17,4 +17,5 @@ public class VulnerabilityMarks {
   public static final int XSS_MARK = 1 << 7;
 
   public static final int TRUST_BOUNDARY_VIOLATION = 1 << 8;
+  public static final int HEADER_INJECTION_MARK = 1 << 9;
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -40,6 +40,8 @@ public abstract class VulnerabilityTypes {
   public static final String XSS_STRING = "XSS";
   public static final byte STACKTRACE_LEAK = 17;
   public static final String STACKTRACE_LEAK_STRING = "STACKTRACE_LEAK";
+  public static final byte HEADER_INJECTION = 18;
+  public static final String HEADER_INJECTION_STRING = "HEADER_INJECTION";
 
   /**
    * Use for telemetry only, this is a special vulnerability type that is not reported, reported
@@ -81,7 +83,8 @@ public abstract class VulnerabilityTypes {
     XCONTENTTYPE_HEADER_MISSING,
     NO_SAMESITE_COOKIE,
     XSS,
-    STACKTRACE_LEAK
+    STACKTRACE_LEAK,
+    HEADER_INJECTION
   };
 
   public static byte[] values() {
@@ -126,6 +129,8 @@ public abstract class VulnerabilityTypes {
         return VulnerabilityTypes.XSS_STRING;
       case VulnerabilityTypes.STACKTRACE_LEAK:
         return VulnerabilityTypes.STACKTRACE_LEAK_STRING;
+      case VulnerabilityTypes.HEADER_INJECTION:
+        return VulnerabilityTypes.HEADER_INJECTION_STRING;
       default:
         return null;
     }

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -54,7 +54,8 @@ public abstract class VulnerabilityTypes {
     INSECURE_COOKIE,
     NO_SAMESITE_COOKIE,
     XCONTENTTYPE_HEADER_MISSING,
-    HSTS_HEADER_MISSING
+    HSTS_HEADER_MISSING,
+    HEADER_INJECTION
   };
 
   /**

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/HeaderInjectionModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/HeaderInjectionModule.java
@@ -1,0 +1,9 @@
+package datadog.trace.api.iast.sink;
+
+import datadog.trace.api.iast.IastModule;
+import javax.annotation.Nonnull;
+
+public interface HeaderInjectionModule extends IastModule {
+
+  void onHeader(@Nonnull String name, String value);
+}


### PR DESCRIPTION
# What Does This Do
Implements detection of header injection vulnerabilities

# Motivation
To increase the scope of the security vulnerability detection functionality

# Additional Notes
Please note that there is instrumentation for webflux so we can separate the cases where the headers come from the request from the cases where the headers come from the response. Previously all headers were tainted even if they were response headers, this would cause false header injection positives.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
