### PR TITLE
Detect servlet configuration vulnerabilities with IAST

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -4,6 +4,7 @@ import com.datadog.iast.overhead.OverheadController;
 import com.datadog.iast.propagation.FastCodecModule;
 import com.datadog.iast.propagation.PropagationModuleImpl;
 import com.datadog.iast.propagation.StringModuleImpl;
+import com.datadog.iast.sink.ApplicationModuleImpl;
 import com.datadog.iast.sink.CommandInjectionModuleImpl;
 import com.datadog.iast.sink.HeaderInjectionModuleImpl;
 import com.datadog.iast.sink.HstsMissingHeaderModuleImpl;
@@ -104,7 +105,8 @@ public class IastSystem {
         new TrustBoundaryViolationModuleImpl(dependencies),
         new XssModuleImpl(dependencies),
         new StacktraceLeakModuleImpl(dependencies),
-        new HeaderInjectionModuleImpl(dependencies));
+        new HeaderInjectionModuleImpl(dependencies),
+        new ApplicationModuleImpl(dependencies));
   }
 
   private static void registerRequestStartedCallback(

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -74,6 +74,23 @@ public interface VulnerabilityType {
   VulnerabilityType STACKTRACE_LEAK =
       new VulnerabilityTypeImpl(VulnerabilityTypes.STACKTRACE_LEAK_STRING, NOT_MARKED);
 
+  VulnerabilityType VERB_TAMPERING =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.VERB_TAMPERING_STRING, NOT_MARKED);
+
+  VulnerabilityType ADMIN_CONSOLE_ACTIVE =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE_STRING, NOT_MARKED);
+
+  VulnerabilityType DEFAULT_HTML_ESCAPE_INVALID =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID_STRING, NOT_MARKED);
+
+  VulnerabilityType SESSION_TIMEOUT =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.SESSION_TIMEOUT_STRING, NOT_MARKED);
+
+  VulnerabilityType DIRECTORY_LISTING_LEAK =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.DIRECTORY_LISTING_LEAK_STRING, NOT_MARKED);
+  VulnerabilityType INSECURE_JSP_LAYOUT =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_JSP_LAYOUT_STRING, NOT_MARKED);;
+
   String name();
 
   /** A bit flag to ignore tainted ranges for this vulnerability. Set to 0 if none. */

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 public class ApplicationModuleImpl extends SinkModuleBase implements ApplicationModule {
@@ -139,16 +140,16 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     if (jspPaths.isEmpty()) {
       return;
     }
-    StringBuilder sb = new StringBuilder();
-    for (String jsp : jspPaths) {
-      sb.append(File.separatorChar).append(jsp).append('\n');
-    }
+    String result =
+        jspPaths.stream()
+            .map(s -> File.separatorChar + s)
+            .collect(Collectors.joining(System.lineSeparator()));
     reporter.report(
         span,
         new Vulnerability(
             VulnerabilityType.INSECURE_JSP_LAYOUT,
             Location.forSpanAndFileAndLine(span, "web.xml", -1),
-            new Evidence(sb.toString())));
+            new Evidence(result)));
   }
 
   @Nullable

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -1,0 +1,247 @@
+package com.datadog.iast.sink;
+
+import com.datadog.iast.Dependencies;
+import com.datadog.iast.model.Evidence;
+import com.datadog.iast.model.Location;
+import com.datadog.iast.model.Vulnerability;
+import com.datadog.iast.model.VulnerabilityType;
+import datadog.trace.api.iast.sink.ApplicationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class ApplicationModuleImpl extends SinkModuleBase implements ApplicationModule {
+
+  public ApplicationModuleImpl(final Dependencies dependencies) {
+    super(dependencies);
+  }
+
+  @Override
+  public void onRealPath(final @Nullable String realPath) {
+
+    if (realPath == null) {
+      return;
+    }
+
+    final AgentSpan span = AgentTracer.activeSpan();
+
+    checkInsecureJSPLayout(realPath, span);
+
+    String webXmlContent = webXmlContent(realPath);
+    if (webXmlContent == null) {
+      return;
+    }
+
+    checkVerbTampering(webXmlContent, span);
+    checkSessionTimeOut(webXmlContent, span);
+    checkDirectoryListingLeak(webXmlContent, span);
+    checkAdminConsoleActive(webXmlContent, span);
+  }
+
+  private void checkAdminConsoleActive(String webXmlContent, AgentSpan span) {
+    if (webXmlContent != null && webXmlContent.contains("Tomcat Manager Application")) {
+      reporter.report(
+          span,
+          new Vulnerability(
+              VulnerabilityType.ADMIN_CONSOLE_ACTIVE,
+              Location.forSpanAndFileAndLine(span, "web.xml", -1),
+              new Evidence("Tomcat Manager Application")));
+    }
+  }
+
+  private void checkDirectoryListingLeak(final String webXmlContent, final AgentSpan span) {
+    if (webXmlContent != null && webXmlContent.contains("<param-name>listings</param-name>")) {
+      int index = webXmlContent.indexOf("<param-name>listings</param-name>");
+      int valueIndex = webXmlContent.indexOf("<param-value>", index);
+      int valueLast = webXmlContent.indexOf("</param-value>", index);
+      String data = webXmlContent.substring(valueIndex, valueLast);
+      if (data.trim().toLowerCase().contains("true")) {
+        reporter.report(
+            span,
+            new Vulnerability(
+                VulnerabilityType.DIRECTORY_LISTING_LEAK,
+                Location.forSpanAndFileAndLine(span, "web.xml", -1),
+                new Evidence("Directory listings configured")));
+      }
+    }
+  }
+
+  private void checkSessionTimeOut(final String webXmlContent, final AgentSpan span) {
+    if (webXmlContent != null && webXmlContent.contains("session-timeout")) {
+      Clue clue = getFirstClue(webXmlContent, "<session-timeout>", "</session-timeout>");
+      String innerText = clue.getValue();
+      if (innerText != null) {
+        innerText = innerText.trim();
+        try {
+          int timeoutValue = Integer.parseInt(innerText);
+          if (timeoutValue > 30 || timeoutValue == -1) {
+            reporter.report(
+                span,
+                new Vulnerability(
+                    VulnerabilityType.SESSION_TIMEOUT,
+                    Location.forSpanAndFileAndLine(span, "web.xml", clue.getLine()),
+                    new Evidence("Found vulnerable timeout value: " + timeoutValue)));
+          }
+        } catch (NumberFormatException e) {
+          // Nothing to do
+        }
+      }
+    }
+  }
+
+  private void checkVerbTampering(final String webXmlContent, final AgentSpan span) {
+    Clue clue = getFirstClue(webXmlContent, "<security-constraint>", "</security-constraint>");
+    if (clue.getValue() != null && !clue.getValue().contains("<http-method>")) {
+      reporter.report(
+          span,
+          new Vulnerability(
+              VulnerabilityType.VERB_TAMPERING,
+              Location.forSpanAndFileAndLine(span, "web.xml", clue.getLine()),
+              new Evidence("http-method not defined in web.xml")));
+    }
+  }
+
+  private void checkInsecureJSPLayout(String realPath, AgentSpan span) {
+    List<String> jspPaths = findRecursively(new File(realPath));
+    if (jspPaths.isEmpty()) {
+      return;
+    }
+    StringBuilder sb = new StringBuilder();
+    for (String jsp : jspPaths) {
+      sb.append(File.separatorChar).append(jsp).append('\n');
+    }
+    reporter.report(
+        span,
+        new Vulnerability(
+            VulnerabilityType.INSECURE_JSP_LAYOUT,
+            Location.forSpanAndFileAndLine(span, "web.xml", -1),
+            new Evidence(sb.toString())));
+  }
+
+  @Nullable
+  private String webXmlContent(final String realPath) {
+    if (realPath != null) {
+      Path path =
+          Paths.get(realPath + File.separatorChar + "WEB-INF" + File.separatorChar + "web.xml");
+      if (path.toFile().exists()) {
+        try {
+          return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }
+    }
+    return null;
+  }
+
+  private Clue getFirstClue(final String text, final String startToken, final String endToken) {
+    Clue match = new Clue();
+    if (text == null) {
+      return match;
+    }
+
+    BufferedReader br = new BufferedReader(new StringReader(text));
+
+    try {
+      int startLine = -1;
+      int endLine = -1;
+      int currentLine = 0;
+      StringBuilder innerText = new StringBuilder();
+      String buff;
+      while ((buff = br.readLine()) != null) {
+        if (startLine == -1 && buff.contains(startToken)) {
+          startLine = currentLine;
+          int idx = buff.indexOf(startToken);
+
+          int endIdx = buff.indexOf(endToken);
+          if (endIdx != -1) {
+            innerText.append(buff.substring(idx + startToken.length(), endIdx));
+            endLine = currentLine;
+            match.setLine(startLine);
+            match.setInnerText(innerText.toString());
+            return match;
+          }
+        } else if (endLine == -1 && buff.contains(endToken)) {
+          int idx = buff.indexOf(endToken);
+          innerText.append(buff.substring(0, idx));
+          endLine = currentLine;
+          match.setLine(startLine);
+          match.setInnerText(innerText.toString());
+          return match;
+        } else if (startLine != -1 && endLine == -1) {
+          innerText.append(buff);
+        }
+        currentLine++;
+      }
+    } catch (IOException e) {
+      // Ignore
+    }
+    return match;
+  }
+
+  private List<String> findRecursively(final File root) {
+    List<String> jspPaths = new ArrayList<>();
+    if (root.listFiles() != null) {
+      for (File file : root.listFiles()) {
+        if (file.isFile() && isJsp(file.getName().toLowerCase())) {
+          jspPaths.add(file.getName());
+        } else if (file.isDirectory() && !"WEB-INF".equals(file.getName())) {
+          addDirectoryJSPs("", file, jspPaths);
+        }
+      }
+    }
+    return jspPaths;
+  }
+
+  private void addDirectoryJSPs(final String path, final File dir, final List<String> jspPaths) {
+    String currentPath = path + dir.getName() + File.separatorChar;
+    if (dir.listFiles() != null) {
+      for (File file : dir.listFiles()) {
+        if (file.isFile() && isJsp(file.getName().toLowerCase())) {
+          jspPaths.add(currentPath + file.getName());
+        } else if (file.isDirectory()) {
+          addDirectoryJSPs(currentPath, file, jspPaths);
+        }
+      }
+    }
+  }
+
+  private boolean isJsp(final String name) {
+    return name.endsWith(".jsp") || name.endsWith(".jspx");
+  }
+
+  class Clue {
+    @Nullable private String innerText;
+
+    private int line;
+
+    Clue() {}
+
+    @Nullable
+    String getValue() {
+      return innerText;
+    }
+
+    void setInnerText(final String txt) {
+      innerText = txt;
+    }
+
+    int getLine() {
+      return line;
+    }
+
+    void setLine(final int line) {
+      this.line = line;
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -118,6 +118,8 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
         case SECURITY_CONSTRAINT_START_TAG:
           checkVerbTampering(webXmlContent, matcher.start(), span);
           break;
+        default:
+          break;
       }
     }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -8,10 +8,8 @@ import com.datadog.iast.model.VulnerabilityType;
 import datadog.trace.api.iast.sink.ApplicationModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,26 +35,38 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
   private static final String DISPATCHER_SERVLET_VALUE =
       "org.springframework.web.servlet.DispatcherServlet";
 
-  private static final String DEFAULT_HTML_ESCAPE_PATTERN = "defaultHtmlEscape";
+  private static final String DEFAULT_HTML_ESCAPE = "defaultHtmlEscape";
 
-  private static final String TOMCAT_MANAGER_APPLICATION_PATTERN = "Tomcat Manager Application";
+  private static final String TOMCAT_MANAGER_APPLICATION = "Tomcat Manager Application";
 
   private static final String LISTINGS_PATTERN = "<param-name>listings</param-name>";
 
-  private static final String SESSION_TIMEOUT_PATTERN = "<session-timeout>";
+  private static final String SESSION_TIMEOUT_START_TAG = "<session-timeout>";
 
-  private static final String SECURITY_CONSTRAINT_PATTERN = "<security-constraint>";
+  private static final String SESSION_TIMEOUT_END_TAG = "</session-timeout>";
+
+  private static final String SECURITY_CONSTRAINT_START_TAG = "<security-constraint>";
+
+  private static final String SECURITY_CONSTRAINT_END_TAG = "</security-constraint>";
+
+  public static final String PARAM_VALUE_START_TAG = "<param-value>";
+
+  public static final String PARAM_VALUE_END_TAG = "</param-value>";
+
+  public static final String WEB_INF = "WEB-INF";
+
+  public static final String WEB_XML = "web.xml";
 
   private static final String REGEX =
       String.join(
           "|",
           CONTEXT_LOADER_LISTENER_PATTERN,
           DISPATCHER_SERVLET_PATTERN,
-          DEFAULT_HTML_ESCAPE_PATTERN,
-          TOMCAT_MANAGER_APPLICATION_PATTERN,
+          DEFAULT_HTML_ESCAPE,
+          TOMCAT_MANAGER_APPLICATION,
           LISTINGS_PATTERN,
-          SESSION_TIMEOUT_PATTERN,
-          SECURITY_CONSTRAINT_PATTERN);
+          SESSION_TIMEOUT_START_TAG,
+          SECURITY_CONSTRAINT_START_TAG);
 
   private static final Pattern PATTERN = Pattern.compile(REGEX);
 
@@ -91,19 +101,19 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
         case CONTEXT_LOADER_LISTENER_VALUE:
           isSpring = true;
           break;
-        case DEFAULT_HTML_ESCAPE_PATTERN:
+        case DEFAULT_HTML_ESCAPE:
           defaultHtmlEscapeIndex = matcher.start();
           break;
-        case TOMCAT_MANAGER_APPLICATION_PATTERN:
+        case TOMCAT_MANAGER_APPLICATION:
           reportAdminConsoleActive(span);
           break;
         case LISTINGS_PATTERN:
           checkDirectoryListingLeak(webXmlContent, matcher.start(), span);
           break;
-        case SESSION_TIMEOUT_PATTERN:
+        case SESSION_TIMEOUT_START_TAG:
           checkSessionTimeOut(webXmlContent, matcher.start(), span);
           break;
-        case SECURITY_CONSTRAINT_PATTERN:
+        case SECURITY_CONSTRAINT_START_TAG:
           checkVerbTampering(webXmlContent, matcher.start(), span);
           break;
       }
@@ -119,77 +129,70 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     String value = "false";
     if (defaultHtmlEscapeIndex != -1) {
       int start =
-          webXmlContent.indexOf("<param-value>", defaultHtmlEscapeIndex) + "<param-value>".length();
-      value = webXmlContent.substring(start, webXmlContent.indexOf("</param-value>", start));
+          webXmlContent.indexOf(PARAM_VALUE_START_TAG, defaultHtmlEscapeIndex)
+              + PARAM_VALUE_START_TAG.length();
+      value = webXmlContent.substring(start, webXmlContent.indexOf(PARAM_VALUE_END_TAG, start));
     }
     if (defaultHtmlEscapeIndex == -1 || !Boolean.parseBoolean(value)) {
-      reporter.report(
+      report(
           span,
-          new Vulnerability(
-              VulnerabilityType.DEFAULT_HTML_ESCAPE_INVALID,
-              Location.forSpanAndFileAndLine(span, "web.xml", -1),
-              new Evidence("defaultHtmlEscape tag should be set")));
+          VulnerabilityType.DEFAULT_HTML_ESCAPE_INVALID,
+          "defaultHtmlEscape tag should be set");
     }
   }
 
   private void reportAdminConsoleActive(AgentSpan span) {
-    reporter.report(
-        span,
-        new Vulnerability(
-            VulnerabilityType.ADMIN_CONSOLE_ACTIVE,
-            Location.forSpanAndFileAndLine(span, "web.xml", -1),
-            new Evidence("Tomcat Manager Application")));
+    report(span, VulnerabilityType.ADMIN_CONSOLE_ACTIVE, "Tomcat Manager Application");
   }
 
   private void checkDirectoryListingLeak(
       final String webXmlContent, int index, final AgentSpan span) {
-    int valueIndex = webXmlContent.indexOf("<param-value>", index);
-    int valueLast = webXmlContent.indexOf("</param-value>", valueIndex);
+    int valueIndex =
+        webXmlContent.indexOf(PARAM_VALUE_START_TAG, index) + PARAM_VALUE_START_TAG.length();
+    int valueLast = webXmlContent.indexOf(PARAM_VALUE_END_TAG, valueIndex);
     String data = webXmlContent.substring(valueIndex, valueLast);
-    if (data.trim().toLowerCase().contains("true")) {
-      reporter.report(
-          span,
-          new Vulnerability(
-              VulnerabilityType.DIRECTORY_LISTING_LEAK,
-              Location.forSpanAndFileAndLine(span, "web.xml", -1),
-              new Evidence("Directory listings configured")));
+    if (data.trim().toLowerCase().equals("true")) {
+      report(span, VulnerabilityType.DIRECTORY_LISTING_LEAK, "Directory listings configured");
     }
   }
 
   private void checkSessionTimeOut(final String webXmlContent, int index, final AgentSpan span) {
-    Clue clue =
-        getFirstClue(webXmlContent.substring(index), "<session-timeout>", "</session-timeout>");
-    String innerText = clue.getValue();
-    if (innerText != null) {
-      innerText = innerText.trim();
-      try {
-        int timeoutValue = Integer.parseInt(innerText);
-        if (timeoutValue > 30 || timeoutValue == -1) {
-          reporter.report(
-              span,
-              new Vulnerability(
-                  VulnerabilityType.SESSION_TIMEOUT,
-                  Location.forSpanAndFileAndLine(span, "web.xml", clue.getLine()),
-                  new Evidence("Found vulnerable timeout value: " + timeoutValue)));
-        }
-      } catch (NumberFormatException e) {
-        // Nothing to do
+    try {
+      String innerText =
+          webXmlContent
+              .substring(
+                  index + SESSION_TIMEOUT_START_TAG.length(),
+                  webXmlContent.indexOf(SESSION_TIMEOUT_END_TAG, index))
+              .trim();
+      int timeoutValue = Integer.parseInt(innerText);
+      if (timeoutValue > 30 || timeoutValue == -1) {
+        report(
+            span,
+            VulnerabilityType.SESSION_TIMEOUT,
+            "Found vulnerable timeout value: " + timeoutValue);
       }
+    } catch (NumberFormatException e) {
+      // Nothing to do
     }
   }
 
   private void checkVerbTampering(final String webXmlContent, int index, final AgentSpan span) {
-    Clue clue =
-        getFirstClue(
-            webXmlContent.substring(index), "<security-constraint>", "</security-constraint>");
-    if (clue.getValue() != null && !clue.getValue().contains("<http-method>")) {
-      reporter.report(
-          span,
-          new Vulnerability(
-              VulnerabilityType.VERB_TAMPERING,
-              Location.forSpanAndFileAndLine(span, "web.xml", clue.getLine()),
-              new Evidence("http-method not defined in web.xml")));
+    String innerText =
+        webXmlContent
+            .substring(
+                index + SECURITY_CONSTRAINT_START_TAG.length(),
+                webXmlContent.indexOf(SECURITY_CONSTRAINT_END_TAG, index))
+            .trim();
+    if (!innerText.contains("<http-method>")) {
+      report(span, VulnerabilityType.VERB_TAMPERING, "http-method not defined in web.xml");
     }
+  }
+
+  private void report(AgentSpan span, VulnerabilityType verbTampering, String value) {
+    reporter.report(
+        span,
+        new Vulnerability(
+            verbTampering, Location.forSpanAndFileAndLine(span, WEB_XML, -1), new Evidence(value)));
   }
 
   private void checkInsecureJSPLayout(String realPath, AgentSpan span) {
@@ -204,16 +207,13 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     reporter.report(
         span,
         new Vulnerability(
-            VulnerabilityType.INSECURE_JSP_LAYOUT,
-            Location.forSpanAndFileAndLine(span, "web.xml", -1),
-            new Evidence(result)));
+            VulnerabilityType.INSECURE_JSP_LAYOUT, Location.forSpan(span), new Evidence(result)));
   }
 
   @Nullable
   private String webXmlContent(final String realPath) {
     if (realPath != null) {
-      Path path =
-          Paths.get(realPath + File.separatorChar + "WEB-INF" + File.separatorChar + "web.xml");
+      Path path = Paths.get(realPath + File.separatorChar + WEB_INF + File.separatorChar + WEB_XML);
       if (path.toFile().exists()) {
         try {
           return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
@@ -225,58 +225,13 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     return null;
   }
 
-  private Clue getFirstClue(final String text, final String startToken, final String endToken) {
-    Clue match = new Clue();
-    if (text == null) {
-      return match;
-    }
-
-    BufferedReader br = new BufferedReader(new StringReader(text));
-
-    try {
-      int startLine = -1;
-      int endLine = -1;
-      int currentLine = 0;
-      StringBuilder innerText = new StringBuilder();
-      String buff;
-      while ((buff = br.readLine()) != null) {
-        if (startLine == -1 && buff.contains(startToken)) {
-          startLine = currentLine;
-          int idx = buff.indexOf(startToken);
-
-          int endIdx = buff.indexOf(endToken);
-          if (endIdx != -1) {
-            innerText.append(buff.substring(idx + startToken.length(), endIdx));
-            endLine = currentLine;
-            match.setLine(startLine);
-            match.setInnerText(innerText.toString());
-            return match;
-          }
-        } else if (endLine == -1 && buff.contains(endToken)) {
-          int idx = buff.indexOf(endToken);
-          innerText.append(buff.substring(0, idx));
-          endLine = currentLine;
-          match.setLine(startLine);
-          match.setInnerText(innerText.toString());
-          return match;
-        } else if (startLine != -1 && endLine == -1) {
-          innerText.append(buff);
-        }
-        currentLine++;
-      }
-    } catch (IOException e) {
-      // Ignore
-    }
-    return match;
-  }
-
   private List<String> findRecursively(final File root) {
     List<String> jspPaths = new ArrayList<>();
     if (root.listFiles() != null) {
       for (File file : root.listFiles()) {
         if (file.isFile() && isJsp(file.getName().toLowerCase())) {
           jspPaths.add(file.getName());
-        } else if (file.isDirectory() && !"WEB-INF".equals(file.getName())) {
+        } else if (file.isDirectory() && !WEB_INF.equals(file.getName())) {
           addDirectoryJSPs("", file, jspPaths);
         }
       }
@@ -299,30 +254,5 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
 
   private boolean isJsp(final String name) {
     return name.endsWith(".jsp") || name.endsWith(".jspx");
-  }
-
-  class Clue {
-    @Nullable private String innerText;
-
-    private int line;
-
-    Clue() {}
-
-    @Nullable
-    String getValue() {
-      return innerText;
-    }
-
-    void setInnerText(final String txt) {
-      innerText = txt;
-    }
-
-    int getLine() {
-      return line;
-    }
-
-    void setLine(final int line) {
-      this.line = line;
-    }
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -188,11 +188,11 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     }
   }
 
-  private void report(AgentSpan span, VulnerabilityType verbTampering, String value) {
+  private void report(AgentSpan span, VulnerabilityType type, String value) {
     reporter.report(
         span,
         new Vulnerability(
-            verbTampering, Location.forSpanAndFileAndLine(span, WEB_XML, -1), new Evidence(value)));
+            type, Location.forSpanAndFileAndLine(span, WEB_XML, -1), new Evidence(value)));
   }
 
   private void checkInsecureJSPLayout(String realPath, AgentSpan span) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -242,7 +242,6 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
 
   private boolean isSpring(final String web) {
     return web != null
-        && web.contains(ORG_SPRINGFRAMEWORK + ".web.")
         && (web.contains(ORG_SPRINGFRAMEWORK + ".web.context.ContextLoaderListener")
             || web.contains(ORG_SPRINGFRAMEWORK + ".web.servlet.DispatcherServlet"));
   }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -71,9 +71,6 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
   }
 
   void 'in deep checkVulns methods test'(){
-
-
-
   }
 
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -2,21 +2,14 @@ package com.datadog.iast.sink
 
 import com.datadog.iast.IastModuleImplTestBase
 import com.datadog.iast.IastRequestContext
-import com.datadog.iast.model.Source
 import com.datadog.iast.model.Vulnerability
 import com.datadog.iast.model.VulnerabilityType
-import com.datadog.iast.taint.Ranges
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
-import datadog.trace.api.iast.SourceTypes
-import datadog.trace.api.iast.VulnerabilityMarks
 import datadog.trace.api.iast.sink.ApplicationModule
-import datadog.trace.api.iast.sink.XssModule
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 
-import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
 import static com.datadog.iast.taint.TaintUtils.taintFormat
-import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED
 
 class ApplicationModuleTest extends IastModuleImplTestBase {
 
@@ -75,6 +68,12 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
     'application/adminconsoleactive/insecure' | VulnerabilityType.ADMIN_CONSOLE_ACTIVE | 'Tomcat Manager Application'
     'application/defaulthtmlescapeinvalid/secure' | null | null
     'application/defaulthtmlescapeinvalid/insecure' | VulnerabilityType.DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'
+  }
+
+  void 'in deep checkVulns methods test'(){
+
+
+
   }
 
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -1,0 +1,95 @@
+package com.datadog.iast.sink
+
+import com.datadog.iast.IastModuleImplTestBase
+import com.datadog.iast.IastRequestContext
+import com.datadog.iast.model.Source
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityType
+import com.datadog.iast.taint.Ranges
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.VulnerabilityMarks
+import datadog.trace.api.iast.sink.ApplicationModule
+import datadog.trace.api.iast.sink.XssModule
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+
+import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
+import static com.datadog.iast.taint.TaintUtils.taintFormat
+import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED
+
+class ApplicationModuleTest extends IastModuleImplTestBase {
+
+  private ApplicationModule module
+
+  private IastRequestContext ctx
+
+  def setup() {
+    module = new ApplicationModuleImpl(dependencies)
+    ctx = new IastRequestContext()
+    final reqCtx = Mock(RequestContext) {
+      getData(RequestContextSlot.IAST) >> ctx
+    }
+    final span = Mock(AgentSpan) {
+      getSpanId() >> 123456
+      getRequestContext() >> reqCtx
+    }
+    tracer.activeSpan() >> span
+  }
+
+  void 'if realPath is null do nothing'() {
+
+    when:
+    module.onRealPath(null)
+
+    then:
+    0 * reporter._
+  }
+
+  void 'check vulnerabilities'() {
+    given:
+    final file  = ClassLoader.getSystemResource(path)
+    final realPath = file.path
+
+    when:
+    module.onRealPath(realPath)
+
+    then:
+    if (expectedVulnType != null) {
+      1 * reporter.report(_, _) >> { assertEvidence(it[1], expectedVulnType, expectedEvidence) }
+    } else {
+      0 * reporter._
+    }
+
+    where:
+    path | expectedVulnType | expectedEvidence
+    'application/insecurejsplayout/secure' | null | null
+    'application/insecurejsplayout/insecure' | VulnerabilityType.INSECURE_JSP_LAYOUT |  '/nestedinsecure/insecure2.jsp'+System.lineSeparator()+'/insecure.jsp'
+    'application/verbtampering/secure' | null | null
+    'application/verbtampering/insecure' | VulnerabilityType.VERB_TAMPERING | 'http-method not defined in web.xml'
+    'application/sessiontimeout/secure' | null | null
+    'application/sessiontimeout/insecure' | VulnerabilityType.SESSION_TIMEOUT | 'Found vulnerable timeout value: 80'
+    'application/directorylistingleak/secure' | null | null
+    'application/directorylistingleak/insecure' | VulnerabilityType.DIRECTORY_LISTING_LEAK | 'Directory listings configured'
+    'application/adminconsoleactive/secure' | null | null
+    'application/adminconsoleactive/insecure' | VulnerabilityType.ADMIN_CONSOLE_ACTIVE | 'Tomcat Manager Application'
+    'application/defaulthtmlescapeinvalid/secure' | null | null
+    'application/defaulthtmlescapeinvalid/insecure' | VulnerabilityType.DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'
+  }
+
+
+
+  private static void assertVulnerability(final Vulnerability vuln, final VulnerabilityType expectedVulnType) {
+    assert vuln != null
+    assert vuln.getType() == expectedVulnType
+    assert vuln.getLocation() != null
+  }
+
+  private static void assertEvidence(final Vulnerability vuln, final VulnerabilityType expectedVulnType, final String expectedEvidence) {
+    assertVulnerability(vuln, expectedVulnType)
+    final evidence = vuln.getEvidence()
+    assert evidence != null
+    final formatted = taintFormat(evidence.getValue(), evidence.getRanges())
+    assert formatted == expectedEvidence
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -2,14 +2,12 @@ package com.datadog.iast.sink
 
 import com.datadog.iast.IastModuleImplTestBase
 import com.datadog.iast.IastRequestContext
-import com.datadog.iast.model.Vulnerability
 import com.datadog.iast.model.VulnerabilityType
 import datadog.trace.api.gateway.RequestContext
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.iast.sink.ApplicationModule
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 
-import static com.datadog.iast.taint.TaintUtils.taintFormat
 
 class ApplicationModuleTest extends IastModuleImplTestBase {
 
@@ -57,7 +55,7 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
     where:
     path | expectedVulnType | expectedEvidence
     'application/insecurejsplayout/secure' | null | null
-    'application/insecurejsplayout/insecure' | VulnerabilityType.INSECURE_JSP_LAYOUT |  '/nestedinsecure/insecure2.jsp'+System.lineSeparator()+'/insecure.jsp'
+    'application/insecurejsplayout/insecure' | VulnerabilityType.INSECURE_JSP_LAYOUT |  ['/nestedinsecure/insecure2.jsp', '/insecure.jsp'] as String []
     'application/verbtampering/secure' | null | null
     'application/verbtampering/insecure' | VulnerabilityType.VERB_TAMPERING | 'http-method not defined in web.xml'
     'application/sessiontimeout/secure' | null | null
@@ -70,22 +68,22 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
     'application/defaulthtmlescapeinvalid/insecure' | VulnerabilityType.DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'
   }
 
-  void 'in deep checkVulns methods test'(){
-  }
-
-
-
-  private static void assertVulnerability(final Vulnerability vuln, final VulnerabilityType expectedVulnType) {
+  private static void assertVulnerability(final  vuln, final  expectedVulnType) {
     assert vuln != null
     assert vuln.getType() == expectedVulnType
     assert vuln.getLocation() != null
   }
 
-  private static void assertEvidence(final Vulnerability vuln, final VulnerabilityType expectedVulnType, final String expectedEvidence) {
+  private static void assertEvidence(final  vuln, final  expectedVulnType, final  expectedEvidence) {
     assertVulnerability(vuln, expectedVulnType)
-    final evidence = vuln.getEvidence()
+    final evidence = vuln.evidence
     assert evidence != null
-    final formatted = taintFormat(evidence.getValue(), evidence.getRanges())
-    assert formatted == expectedEvidence
+    if(expectedEvidence instanceof String[]) {
+      for (String s : expectedEvidence) {
+        assert evidence.value.contains(s)
+      }
+    } else {
+      assert evidence.value == expectedEvidence
+    }
   }
 }

--- a/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/insecure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/insecure/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <display-name>Tomcat Manager Application</display-name>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/secure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/secure/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <display-name>Test app</display-name>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/false_tag/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/false_tag/WEB-INF/web.xml
@@ -3,4 +3,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
          version="4.0">
+  <context-param>
+    <param-name>defaultHtmlEscape</param-name>
+    <param-value>false</param-value>
+  </context-param>
+  <listener>
+    <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+  </listener>
 </web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/insecure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/insecure/WEB-INF/web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <!-- Spring Context Loader -->
+  <context-param>
+    <param-name>contextConfigLocation</param-name>
+    <param-value>
+      /WEB-INF/dataAccess-config.xml
+      /WEB-INF/security-config.xml
+      /WEB-INF/hdiv-config.xml
+    </param-value>
+  </context-param>
+  <context-param>
+    <param-name>defaultHtmlEscape</param-name>
+    <param-value>false</param-value>
+  </context-param>
+  <listener>
+    <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+  </listener>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/no_tag_1/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/no_tag_1/WEB-INF/web.xml
@@ -3,19 +3,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
          version="4.0">
-  <!-- Spring Context Loader -->
-  <context-param>
-    <param-name>contextConfigLocation</param-name>
-    <param-value>
-      /WEB-INF/dataAccess-config.xml
-      /WEB-INF/security-config.xml
-      /WEB-INF/hdiv-config.xml
-    </param-value>
-  </context-param>
-  <context-param>
-    <param-name>defaultHtmlEscape</param-name>
-    <param-value>false</param-value>
-  </context-param>
   <listener>
     <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
   </listener>

--- a/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/no_tag_2/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/no_tag_2/WEB-INF/web.xml
@@ -3,4 +3,15 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
          version="4.0">
+  <servlet>
+    <servlet-name>dispatcher</servlet-name>
+    <servlet-class>
+      org.springframework.web.servlet.DispatcherServlet
+    </servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>dispatcher</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
 </web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/secure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/secure/WEB-INF/web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <!-- Spring Context Loader -->
+  <context-param>
+    <param-name>contextConfigLocation</param-name>
+    <param-value>
+      /WEB-INF/dataAccess-config.xml
+      /WEB-INF/security-config.xml
+      /WEB-INF/hdiv-config.xml
+    </param-value>
+  </context-param>
+  <context-param>
+    <param-name>defaultHtmlEscape</param-name>
+    <param-value>true</param-value>
+  </context-param>
+  <listener>
+    <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+  </listener>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/secure_tag/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/defaulthtmlescapeinvalid/secure_tag/WEB-INF/web.xml
@@ -3,4 +3,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
          version="4.0">
+  <context-param>
+    <param-name>defaultHtmlEscape</param-name>
+    <param-value>true</param-value>
+  </context-param>
+  <listener>
+    <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+  </listener>
 </web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/directorylistingleak/insecure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/directorylistingleak/insecure/WEB-INF/web.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <servlet>
+    <servlet-name>default</servlet-name>
+    <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>listings</param-name>
+      <param-value>true</param-value>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/directorylistingleak/secure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/directorylistingleak/secure/WEB-INF/web.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <servlet>
+    <servlet-name>default</servlet-name>
+    <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>
+    <init-param>
+      <param-name>debug</param-name>
+      <param-value>0</param-value>
+    </init-param>
+    <init-param>
+      <param-name>listings</param-name>
+      <param-value>false</param-value>
+    </init-param>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/WEB-INF/secure.jsp
+++ b/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/WEB-INF/secure.jsp
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/insecure.jsp
+++ b/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/insecure.jsp
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/insecure.jspx
+++ b/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/insecure.jspx
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/nestedinsecure/insecure2.jsp
+++ b/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/nestedinsecure/insecure2.jsp
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/nestedinsecure/nestedinsecure/insecure3.jsp
+++ b/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/insecure/nestedinsecure/nestedinsecure/insecure3.jsp
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/secure/WEB-INF/secure.jsp
+++ b/dd-java-agent/agent-iast/src/test/resources/application/insecurejsplayout/secure/WEB-INF/secure.jsp
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/dd-java-agent/agent-iast/src/test/resources/application/sessiontimeout/insecure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/sessiontimeout/insecure/WEB-INF/web.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <session-config>
+    <session-timeout>80</session-timeout>
+  </session-config>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/sessiontimeout/secure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/sessiontimeout/secure/WEB-INF/web.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <session-config>
+    <session-timeout>3</session-timeout>
+  </session-config>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/verbtampering/insecure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/verbtampering/insecure/WEB-INF/web.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <security-constraint>
+    <display-name>
+      Protect GET only, leave all other methods unprotected
+    </display-name>
+  </security-constraint>
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/verbtampering/secure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/verbtampering/secure/WEB-INF/web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <security-constraint>
+    <display-name>
+      Protect GET only, leave all other methods unprotected
+    </display-name>
+    <http-method>GET</http-method>
+  </security-constraint>
+</web-app>

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/IastServletContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/IastServletContextInstrumentation.java
@@ -1,0 +1,69 @@
+package datadog.trace.instrumentation.servlet.dispatcher;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedNoneOf;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.sink.ApplicationModule;
+import datadog.trace.bootstrap.InstrumentationContext;
+import java.util.Collections;
+import java.util.Map;
+import javax.servlet.ServletContext;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(Instrumenter.class)
+public final class IastServletContextInstrumentation extends Instrumenter.Iast
+    implements Instrumenter.ForTypeHierarchy {
+
+  private static final String TYPE = "javax.servlet.ServletContext";
+
+  public IastServletContextInstrumentation() {
+    super("servlet", "servlet-dispatcher");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return TYPE;
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named(hierarchyMarkerType()))
+        .and(namedNoneOf("org.apache.catalina.core.ApplicationContext")); // Tomcat has
+    // org.apache.catalina.core.ApplicationContextFacade which implements ServletContext and calls
+    // internally org.apache.catalina.core.ApplicationContext
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap(TYPE, String.class.getName());
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod().and(isPublic()).and(named("getRealPath")).and(takesArguments(String.class)),
+        IastServletContextInstrumentation.class.getName() + "$IastContextAdvice");
+  }
+
+  public static class IastContextAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void getRealPath(
+        @Advice.This final ServletContext context, @Advice.Return final String realPath) {
+      final ApplicationModule applicationModule = InstrumentationBridge.APPLICATION;
+      if (applicationModule != null
+          && InstrumentationContext.get(ServletContext.class, String.class).get(context) == null) {
+        InstrumentationContext.get(ServletContext.class, String.class).put(context, realPath);
+        applicationModule.onRealPath(realPath);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/IastServletContextInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/IastServletContextInstrumentationTest.groovy
@@ -1,0 +1,26 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.sink.ApplicationModule
+
+
+class IastServletContextInstrumentationTest extends AgentTestRunner{
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig("dd.iast.enabled", "true")
+  }
+
+  void 'test'() {
+    given:
+    final module = Mock(ApplicationModule)
+    InstrumentationBridge.registerIastModule(module)
+    final dispatcher = new RequestDispatcherUtils()
+
+    when:
+    dispatcher.getRealPath("/")
+
+    then:
+    1 *  module.onRealPath(_)
+    0 * _
+  }
+}

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherUtils.java
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/RequestDispatcherUtils.java
@@ -32,6 +32,12 @@ public class RequestDispatcherUtils {
     this.toThrow = toThrow;
   }
 
+  public RequestDispatcherUtils() {
+    this.req = null;
+    this.resp = null;
+    this.toThrow = null;
+  }
+
   /* RequestDispatcher can't be visible to groovy otherwise things break, so everything is
    * encapsulated in here where groovy doesn't need to access it.
    */
@@ -50,6 +56,10 @@ public class RequestDispatcherUtils {
 
   void includeNamed(final String target) throws ServletException, IOException {
     new TestContext().getNamedDispatcher(target).include(req, resp);
+  }
+
+  void getRealPath(final String target) {
+    new TestContext().getRealPath(target);
   }
 
   class TestContext implements ServletContext {

--- a/dd-smoke-tests/springboot/src/main/resources/WEB-INF/web.xml
+++ b/dd-smoke-tests/springboot/src/main/resources/WEB-INF/web.xml
@@ -1,6 +1,0 @@
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
-         version="3.1">
-</web-app>

--- a/dd-smoke-tests/springboot/src/main/resources/WEB-INF/web.xml
+++ b/dd-smoke-tests/springboot/src/main/resources/WEB-INF/web.xml
@@ -1,0 +1,6 @@
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+</web-app>

--- a/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/InstrumentationBridge.java
@@ -3,6 +3,7 @@ package datadog.trace.api.iast;
 import datadog.trace.api.iast.propagation.CodecModule;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.propagation.StringModule;
+import datadog.trace.api.iast.sink.ApplicationModule;
 import datadog.trace.api.iast.sink.CommandInjectionModule;
 import datadog.trace.api.iast.sink.HeaderInjectionModule;
 import datadog.trace.api.iast.sink.HstsMissingHeaderModule;
@@ -55,6 +56,8 @@ public abstract class InstrumentationBridge {
 
   public static volatile StacktraceLeakModule STACKTRACE_LEAK_MODULE;
 
+  public static volatile ApplicationModule APPLICATION;
+
   public static volatile HeaderInjectionModule HEADER_INJECTION;
 
   private InstrumentationBridge() {}
@@ -106,6 +109,8 @@ public abstract class InstrumentationBridge {
       STACKTRACE_LEAK_MODULE = (StacktraceLeakModule) module;
     } else if (module instanceof HeaderInjectionModule) {
       HEADER_INJECTION = (HeaderInjectionModule) module;
+    } else if (module instanceof ApplicationModule) {
+      APPLICATION = (ApplicationModule) module;
     } else {
       throw new UnsupportedOperationException("Module not yet supported: " + module);
     }
@@ -180,6 +185,9 @@ public abstract class InstrumentationBridge {
     if (type == StacktraceLeakModule.class) {
       return (E) STACKTRACE_LEAK_MODULE;
     }
+    if (type == ApplicationModule.class) {
+      return (E) APPLICATION;
+    }
     if (type == HeaderInjectionModule.class) {
       return (E) HEADER_INJECTION;
     }
@@ -210,6 +218,7 @@ public abstract class InstrumentationBridge {
     TRUST_BOUNDARY_VIOLATION = null;
     XSS = null;
     STACKTRACE_LEAK_MODULE = null;
+    APPLICATION = null;
     HEADER_INJECTION = null;
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -61,7 +61,6 @@ public abstract class VulnerabilityTypes {
   public static final byte ADMIN_CONSOLE_ACTIVE = 24;
   public static final String ADMIN_CONSOLE_ACTIVE_STRING = "ADMIN_CONSOLE_ACTIVE";
 
-
   /**
    * Use for telemetry only, this is a special vulnerability type that is not reported, reported
    * values will be {@link #RESPONSE_HEADER_TYPES}

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -43,6 +43,25 @@ public abstract class VulnerabilityTypes {
   public static final byte HEADER_INJECTION = 18;
   public static final String HEADER_INJECTION_STRING = "HEADER_INJECTION";
 
+  public static final byte VERB_TAMPERING = 19;
+  public static final String VERB_TAMPERING_STRING = "VERB_TAMPERING";
+
+  public static final byte DEFAULT_HTML_ESCAPE_INVALID = 20;
+  public static final String DEFAULT_HTML_ESCAPE_INVALID_STRING = "DEFAULT_HTML_ESCAPE_INVALID";
+
+  public static final byte SESSION_TIMEOUT = 21;
+  public static final String SESSION_TIMEOUT_STRING = "SESSION_TIMEOUT";
+
+  public static final byte DIRECTORY_LISTING_LEAK = 22;
+  public static final String DIRECTORY_LISTING_LEAK_STRING = "DIRECTORY_LISTING_LEAK";
+
+  public static final byte INSECURE_JSP_LAYOUT = 23;
+  public static final String INSECURE_JSP_LAYOUT_STRING = "INSECURE_JSP_LAYOUT";
+
+  public static final byte ADMIN_CONSOLE_ACTIVE = 24;
+  public static final String ADMIN_CONSOLE_ACTIVE_STRING = "ADMIN_CONSOLE_ACTIVE";
+
+
   /**
    * Use for telemetry only, this is a special vulnerability type that is not reported, reported
    * values will be {@link #RESPONSE_HEADER_TYPES}
@@ -85,7 +104,13 @@ public abstract class VulnerabilityTypes {
     NO_SAMESITE_COOKIE,
     XSS,
     STACKTRACE_LEAK,
-    HEADER_INJECTION
+    HEADER_INJECTION,
+    ADMIN_CONSOLE_ACTIVE,
+    VERB_TAMPERING,
+    DEFAULT_HTML_ESCAPE_INVALID,
+    SESSION_TIMEOUT,
+    DIRECTORY_LISTING_LEAK,
+    INSECURE_JSP_LAYOUT
   };
 
   public static byte[] values() {
@@ -132,6 +157,18 @@ public abstract class VulnerabilityTypes {
         return VulnerabilityTypes.STACKTRACE_LEAK_STRING;
       case VulnerabilityTypes.HEADER_INJECTION:
         return VulnerabilityTypes.HEADER_INJECTION_STRING;
+      case VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE:
+        return VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE_STRING;
+      case VulnerabilityTypes.VERB_TAMPERING:
+        return VulnerabilityTypes.VERB_TAMPERING_STRING;
+      case VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID:
+        return VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID_STRING;
+      case VulnerabilityTypes.SESSION_TIMEOUT:
+        return VulnerabilityTypes.SESSION_TIMEOUT_STRING;
+      case VulnerabilityTypes.DIRECTORY_LISTING_LEAK:
+        return VulnerabilityTypes.DIRECTORY_LISTING_LEAK_STRING;
+      case VulnerabilityTypes.INSECURE_JSP_LAYOUT:
+        return VulnerabilityTypes.INSECURE_JSP_LAYOUT_STRING;
       default:
         return null;
     }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/ApplicationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/ApplicationModule.java
@@ -1,0 +1,9 @@
+package datadog.trace.api.iast.sink;
+
+import datadog.trace.api.iast.IastModule;
+import javax.annotation.Nullable;
+
+public interface ApplicationModule extends IastModule {
+
+  void onRealPath(@Nullable String realPath);
+}


### PR DESCRIPTION
# What Does This Do

Add 6 new vulnerabilities:

VERB_TAMPERING
ADMIN_CONSOLE_ACTIVE
DEFAULT_HTML_ESCAPE_INVALID
SESSION_TIMEOUT
DIRECTORY_LISTING_LEAK
INSECURE_JSP_LAYOUT

These vulnerabilities rely on the web.xml analysis or checking the jsp files location

We instrument the javax.servlet.ServletContext#getRealPath to be able to check the web.xml and the jsp files using the instrumentation context to call the module only once per context

# Motivation

Innovation week project

# Additional Notes

As we run it once per application there is no overheadController check

This PR aims to cover tomcat server

Jira ticket: [APPSEC-17025]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-17025]: https://datadoghq.atlassian.net/browse/APPSEC-17025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ