### PR TITLE
Dependency collection with telemetry for native image

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -11,6 +11,7 @@ import datadog.trace.agent.tooling.bytebuddy.outline.TypePoolFacade;
 import datadog.trace.agent.tooling.usm.UsmExtractorImpl;
 import datadog.trace.agent.tooling.usm.UsmMessageFactoryImpl;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.Platform;
 import datadog.trace.api.ProductActivation;
 import datadog.trace.api.telemetry.IntegrationsCollector;
 import datadog.trace.bootstrap.FieldBackedContextAccessor;
@@ -198,7 +199,8 @@ public class AgentInstaller {
       log.debug("Installed {} instrumenter(s)", installedCount);
     }
 
-    if (InstrumenterConfig.get().isTelemetryEnabled()) {
+    if (InstrumenterConfig.get().isTelemetryEnabledAtBuildTime()
+        && !Platform.isNativeImageBuilder()) {
       InstrumenterState.setObserver(
           new InstrumenterState.Observer() {
             @Override

--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -49,6 +49,8 @@ dependencies {
   implementation group: 'net.java.dev.jna', name: 'jna-platform', version: '5.8.0'
 
   api project(':dd-trace-core')
+  // TODO: Just for native-image's TracerActivation; we could move this to reflection.
+  compileOnly project(':telemetry')
 
   implementation project(':dd-java-agent:agent-crashtracking')
 

--- a/dd-java-agent/instrumentation/graal/native-image/build.gradle
+++ b/dd-java-agent/instrumentation/graal/native-image/build.gradle
@@ -28,6 +28,7 @@ apply plugin: "idea"
 
 dependencies {
   compileOnly project(':dd-java-agent:agent-logging')
+  compileOnly project(':telemetry')
 
   main_java11CompileOnly group: 'org.graalvm.nativeimage', name: 'svm', version: '20.0.0'
 }

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -21,14 +21,6 @@ public final class NativeImageGeneratorRunnerInstrumentation
   }
 
   @Override
-  public String[] helperClassNames() {
-    return new String[] {
-      "datadog.trace.instrumentation.graal.nativeimage.DatadogFeature",
-      "datadog.trace.instrumentation.graal.nativeimage.TelemetryFeature"
-    };
-  }
-
-  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod().and(named("main")),

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -21,6 +21,14 @@ public final class NativeImageGeneratorRunnerInstrumentation
   }
 
   @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      "datadog.trace.instrumentation.graal.nativeimage.DatadogFeature",
+      "datadog.trace.instrumentation.graal.nativeimage.TelemetryFeature"
+    };
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod().and(named("main")),
@@ -55,6 +63,8 @@ public final class NativeImageGeneratorRunnerInstrumentation
               + "META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json";
       args[oldLength++] =
           "-H:ClassInitialization="
+              + "datadog.telemetry.dependency.Dependency:build_time,"
+              + "datadog.telemetry.dependency.DependencyResolver:build_time,"
               + "datadog.trace.api.Config:rerun,"
               + "datadog.trace.api.Platform:rerun,"
               + "datadog.trace.api.env.CapturedEnvironment:build_time,"

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/ResourcesFeatureInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/ResourcesFeatureInstrumentation.java
@@ -23,6 +23,11 @@ public final class ResourcesFeatureInstrumentation extends AbstractNativeImageIn
   }
 
   @Override
+  public String[] helperClassNames() {
+    return new String[] {"datadog.trace.instrumentation.graal.nativeimage.TelemetryFeature"};
+  }
+
+  @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
         isMethod().and(named("beforeAnalysis")),

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/TelemetryFeature.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/TelemetryFeature.java
@@ -1,0 +1,79 @@
+package datadog.trace.instrumentation.graal.nativeimage;
+
+import datadog.telemetry.dependency.Dependency;
+import datadog.telemetry.dependency.DependencyResolver;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.graalvm.nativeimage.hosted.Feature;
+
+public final class TelemetryFeature implements Feature {
+
+  private static final Set<URI> SEEN_URIS = new HashSet<>();
+
+  public static InputStream getDependenciesFileContent(final DuringAnalysisAccess access) {
+    final Set<Dependency> dependencies = new HashSet<>();
+    final Set<ProtectionDomain> seen = new HashSet<>();
+    for (final Class<?> clazz : access.reachableSubtypes(Object.class)) {
+      final ProtectionDomain protectionDomain = clazz.getProtectionDomain();
+      if (protectionDomain == null) {
+        continue;
+      }
+      if (!seen.add(protectionDomain)) {
+        continue;
+      }
+      final CodeSource codeSource = protectionDomain.getCodeSource();
+      if (codeSource == null) {
+        continue;
+      }
+      final URL location = codeSource.getLocation();
+      if (location == null) {
+        continue;
+      }
+      final URI uri = convertToURI(location);
+      if (uri == null) {
+        continue;
+      }
+      if (!SEEN_URIS.add(uri)) {
+        continue;
+      }
+      dependencies.addAll(DependencyResolver.resolve(uri));
+    }
+    if (dependencies.isEmpty()) {
+      return null;
+    }
+    final List<String> serializedDependencies = new ArrayList<>(dependencies.size());
+    for (final Dependency dependency : dependencies) {
+      serializedDependencies.add(dependency.toSimpleString());
+    }
+    serializedDependencies.sort(String::compareTo);
+    final byte[] content =
+        String.join("\n", serializedDependencies).getBytes(StandardCharsets.UTF_8);
+    return new ByteArrayInputStream(content);
+  }
+
+  private static URI convertToURI(URL location) {
+    if (location == null) {
+      return null;
+    }
+    if (location.getProtocol().equals("vfs")) {
+      // TODO: Ignore JBoss VFS in native image at the moment, since it's not tested.
+      return null;
+    }
+    try {
+      return new URI(location.toString().replace(" ", "%20"));
+    } catch (URISyntaxException e) {
+      // silently ignored
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/TelemetryFeature.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/TelemetryFeature.java
@@ -16,11 +16,11 @@ import java.util.List;
 import java.util.Set;
 import org.graalvm.nativeimage.hosted.Feature;
 
-public final class TelemetryFeature implements Feature {
+public final class TelemetryFeature {
 
   private static final Set<URI> SEEN_URIS = new HashSet<>();
 
-  public static InputStream getDependenciesFileContent(final DuringAnalysisAccess access) {
+  public static InputStream getDependenciesFileContent(final Feature.DuringAnalysisAccess access) {
     final Set<Dependency> dependencies = new HashSet<>();
     final Set<ProtectionDomain> seen = new HashSet<>();
     for (final Class<?> clazz : access.reachableSubtypes(Object.class)) {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1504,11 +1504,9 @@ public class Config {
             : configProvider.getBoolean(GeneralConfig.TELEMETRY_METRICS_ENABLED, true);
 
     isTelemetryDependencyServiceEnabled =
-        Platform.isNativeImageBuilder()
-            ? false
-            : configProvider.getBoolean(
-                TELEMETRY_DEPENDENCY_COLLECTION_ENABLED,
-                DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED);
+        configProvider.getBoolean(
+            TELEMETRY_DEPENDENCY_COLLECTION_ENABLED,
+            DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED);
 
     isTelemetryLogCollectionEnabled =
         Platform.isNativeImageBuilder()

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -157,17 +157,16 @@ public class InstrumenterConfig {
           ProductActivation.fromString(
               configProvider.getStringNotEmpty(IAST_ENABLED, DEFAULT_IAST_ENABLED));
       usmEnabled = configProvider.getBoolean(USM_ENABLED, DEFAULT_USM_ENABLED);
-      telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
     } else {
       // disable these features in native-image
       profilingEnabled = false;
       ciVisibilityEnabled = false;
       appSecActivation = ProductActivation.FULLY_DISABLED;
       iastActivation = ProductActivation.FULLY_DISABLED;
-      telemetryEnabled = false;
       usmEnabled = false;
     }
 
+    telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
     traceExecutorsAll = configProvider.getBoolean(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
     traceExecutors = tryMakeImmutableList(configProvider.getList(TRACE_EXECUTORS));
     traceThreadPoolExecutorsExclude =
@@ -268,7 +267,11 @@ public class InstrumenterConfig {
     return usmEnabled;
   }
 
-  public boolean isTelemetryEnabled() {
+  /**
+   * Checks if telemetry is enabled. In Native Image, this is set at build time. Use Config for run
+   * time.
+   */
+  public boolean isTelemetryEnabledAtBuildTime() {
     return telemetryEnabled;
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricRegistry.java
+++ b/internal-api/src/main/java/datadog/trace/api/metrics/SpanMetricRegistry.java
@@ -1,6 +1,6 @@
 package datadog.trace.api.metrics;
 
-import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.Config;
 
 /** This class holds the {@link SpanMetrics} instances. */
 @FunctionalInterface
@@ -21,7 +21,7 @@ public interface SpanMetricRegistry {
    * @return The registry instance.
    */
   static SpanMetricRegistry getInstance() {
-    return InstrumenterConfig.get().isTelemetryEnabled()
+    return Config.get().isTelemetryEnabled()
         ? SpanMetricRegistryImpl.getInstance()
         : SpanMetricRegistry.NOOP;
   }

--- a/telemetry/build.gradle
+++ b/telemetry/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 
   implementation project(':internal-api')
 
-  compileOnly project(':dd-java-agent:agent-tooling')
   testImplementation project(':dd-java-agent:agent-tooling')
   testImplementation project(':dd-java-agent:agent-logging')
 

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -11,6 +11,7 @@ import datadog.telemetry.metric.CoreMetricsPeriodicAction;
 import datadog.telemetry.metric.IastMetricPeriodicAction;
 import datadog.telemetry.metric.WafMetricPeriodicAction;
 import datadog.trace.api.Config;
+import datadog.trace.api.Platform;
 import datadog.trace.api.iast.telemetry.Verbosity;
 import datadog.trace.util.AgentThreadFactory;
 import java.lang.instrument.Instrumentation;
@@ -47,7 +48,9 @@ public class TelemetrySystem {
     List<TelemetryPeriodicAction> actions = new ArrayList<>();
     if (telemetryMetricsEnabled) {
       actions.add(new CoreMetricsPeriodicAction());
-      actions.add(new IntegrationPeriodicAction());
+      if (!Platform.isNativeImageBuilder()) {
+        actions.add(new IntegrationPeriodicAction());
+      }
       actions.add(new WafMetricPeriodicAction());
       if (Verbosity.OFF != Config.get().getIastTelemetryVerbosity()) {
         actions.add(new IastMetricPeriodicAction());

--- a/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
+import java.util.StringJoiner;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -263,5 +264,26 @@ public final class Dependency {
     }
 
     return null;
+  }
+
+  /** Used for serialization. Must be compatible with {@link #fromSimpleString(String)}. */
+  public String toSimpleString() {
+    final StringJoiner joiner = new StringJoiner("|");
+    joiner.add(name);
+    joiner.add(version);
+    joiner.add(hash == null ? "" : hash);
+    // Could contain `|` or whatever separator we have here, use last.
+    joiner.add(source);
+    return joiner.toString();
+  }
+
+  /** Used for deserialization. Must be compatible with {@link #toSimpleString()}. */
+  public static Dependency fromSimpleString(final String s) {
+    final String[] parts = s.split("\\|", 4);
+    if (parts.length != 4) {
+      log.debug("Invalid dependency string: {}", s);
+      return null;
+    }
+    return new Dependency(parts[0], parts[1], parts[3], parts[2].isEmpty() ? null : parts[2]);
   }
 }


### PR DESCRIPTION
# What Does This Do
Adds support for dependency collection with telemetry on native image.

Dependency collection is done during the native image build (analysis stage), and embedded in the final binary within resource files. These are later read at runtime to send them through telemetry.

# Motivation

# Additional Notes

Depends on:
* https://github.com/DataDog/dd-trace-java/pull/6286 for the initial telemetry support

To do:
* [ ] Check if the scenario of multiple analysis runs with multiple dependencies files is possible and works.