### PR TITLE
Remove obsolete Sink interface

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -3,7 +3,6 @@ package com.datadog.debugger.agent;
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 
 import com.datadog.debugger.sink.DebuggerSink;
-import com.datadog.debugger.sink.Sink;
 import com.datadog.debugger.symbol.SymDBEnablement;
 import com.datadog.debugger.symbol.SymbolAggregator;
 import com.datadog.debugger.uploader.BatchUploader;
@@ -31,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public class DebuggerAgent {
   private static final Logger LOGGER = LoggerFactory.getLogger(DebuggerAgent.class);
   private static ConfigurationPoller configurationPoller;
-  private static Sink sink;
+  private static DebuggerSink sink;
   private static String agentVersion;
   private static JsonSnapshotSerializer snapshotSerializer;
   private static SymDBEnablement symDBEnablement;
@@ -164,7 +163,7 @@ public class DebuggerAgent {
     return agentVersion;
   }
 
-  public static Sink getSink() {
+  public static DebuggerSink getSink() {
     return sink;
   }
 
@@ -180,13 +179,13 @@ public class DebuggerAgent {
     if (configurationPoller != null) {
       configurationPoller.stop();
     }
-    if (sink != null && sink instanceof DebuggerSink) {
-      ((DebuggerSink) sink).stop();
+    if (sink != null) {
+      sink.stop();
     }
   }
 
   // Used only for tests
-  static void initSink(Sink sink) {
+  static void initSink(DebuggerSink sink) {
     DebuggerAgent.sink = sink;
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -11,7 +11,7 @@ import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.instrumentation.CapturedContextInstrumentor;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
-import com.datadog.debugger.sink.Sink;
+import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.Snapshot;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
@@ -457,7 +457,7 @@ public class LogProbe extends ProbeDefinition {
         spanId = exitContext.getSpanId();
         break;
     }
-    Sink sink = DebuggerAgent.getSink();
+    DebuggerSink sink = DebuggerAgent.getSink();
     boolean shouldCommit = false;
     int maxDepth = capture != null ? capture.maxReferenceDepth : -1;
     Snapshot snapshot = new Snapshot(Thread.currentThread(), this, maxDepth);
@@ -506,7 +506,7 @@ public class LogProbe extends ProbeDefinition {
     return (LogStatus) status;
   }
 
-  private void commitSnapshot(Snapshot snapshot, Sink sink) {
+  private void commitSnapshot(Snapshot snapshot, DebuggerSink sink) {
     /*
      * Record stack trace having the caller of this method as 'top' frame.
      * For this it is necessary to discard:
@@ -526,7 +526,7 @@ public class LogProbe extends ProbeDefinition {
     if (status == null) {
       return;
     }
-    Sink sink = DebuggerAgent.getSink();
+    DebuggerSink sink = DebuggerAgent.getSink();
     int maxDepth = capture != null ? capture.maxReferenceDepth : -1;
     Snapshot snapshot = new Snapshot(Thread.currentThread(), this, maxDepth);
     boolean shouldCommit = false;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Collects data that needs to be sent to the backend: Snapshots, metrics and statuses */
-public class DebuggerSink implements Sink {
+public class DebuggerSink {
   private static final Logger log = LoggerFactory.getLogger(DebuggerSink.class);
   private static final double FREE_CAPACITY_LOWER_THRESHOLD = 0.25;
   private static final double FREE_CAPACITY_UPPER_THRESHOLD = 0.75;
@@ -147,7 +147,6 @@ public class DebuggerSink implements Sink {
     return symbolSink;
   }
 
-  @Override
   public void addSnapshot(Snapshot snapshot) {
     boolean added = snapshotSink.offer(snapshot);
     if (!added) {
@@ -260,7 +259,6 @@ public class DebuggerSink implements Sink {
   }
 
   /** Notifies the snapshot was skipped for one of the SkipCause reason */
-  @Override
   public void skipSnapshot(String probeId, DebuggerContext.SkipCause cause) {
     String causeTag;
     switch (cause) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Sink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Sink.java
@@ -1,9 +1,0 @@
-package com.datadog.debugger.sink;
-
-import datadog.trace.bootstrap.debugger.DebuggerContext;
-
-public interface Sink {
-  void addSnapshot(Snapshot snapshot);
-
-  void skipSnapshot(String probeId, DebuggerContext.SkipCause cause);
-}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentHelper.java
@@ -1,9 +1,9 @@
 package com.datadog.debugger.agent;
 
-import com.datadog.debugger.sink.Sink;
+import com.datadog.debugger.sink.DebuggerSink;
 
 public class DebuggerAgentHelper {
-  public static void injectSink(Sink sink) {
+  public static void injectSink(DebuggerSink sink) {
     DebuggerAgent.initSink(sink);
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -11,6 +11,7 @@ import static utils.InstrumentationTestHelper.compileAndLoadClass;
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.probe.LogProbe;
+import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.sink.Snapshot;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
@@ -551,7 +552,7 @@ public class LogProbesInstrumentationTest {
     currentTransformer = new DebuggerTransformer(config, configuration);
     instr.addTransformer(currentTransformer);
     DebuggerTransformerTest.TestSnapshotListener listener =
-        new DebuggerTransformerTest.TestSnapshotListener();
+        new DebuggerTransformerTest.TestSnapshotListener(config, mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
     DebuggerContext.init(
         (id, callingClass) ->

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeInstrumentationTest.java
@@ -1,8 +1,9 @@
 package com.datadog.debugger.agent;
 
+import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
-import com.datadog.debugger.sink.Sink;
 import com.datadog.debugger.sink.Snapshot;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
@@ -26,9 +27,13 @@ public class ProbeInstrumentationTest {
     }
   }
 
-  protected static class MockSink implements Sink {
+  protected static class MockSink extends DebuggerSink {
 
     private final List<Snapshot> snapshots = new ArrayList<>();
+
+    public MockSink(Config config, ProbeStatusSink probeStatusSink) {
+      super(config, probeStatusSink);
+    }
 
     @Override
     public void addSnapshot(Snapshot snapshot) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -643,7 +643,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
         new DebuggerTransformer(
             config, configuration, null, new DebuggerSink(config, probeStatusSink));
     instr.addTransformer(currentTransformer);
-    mockSink = new MockSink();
+    mockSink = new MockSink(config, probeStatusSink);
     DebuggerAgentHelper.injectSink(mockSink);
     DebuggerContext.init(
         (id, callingClass) -> resolver(id, callingClass, expectedClassName, configuration), null);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
@@ -151,7 +151,7 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
         new DebuggerTransformer(
             config, configuration, null, new DebuggerSink(config, probeStatusSink));
     instr.addTransformer(currentTransformer);
-    mockSink = new MockSink();
+    mockSink = new MockSink(config, probeStatusSink);
     DebuggerAgentHelper.injectSink(mockSink);
     DebuggerContext.init(null, null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));


### PR DESCRIPTION
# What Does This Do
Sink interface was introduced because snapshot was created and send to sink from bootstrap classes. This is not the case anymore so the usage of this interface is no more necessary.

# Motivation

# Additional Notes


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
