### PR TITLE
Add field parent_stage_ids to `spark.stage` spans

### DIFF
--- a/dd-java-agent/instrumentation/spark/spark_2.12/src/main/java/datadog/trace/instrumentation/spark/DatadogSpark212Listener.java
+++ b/dd-java-agent/instrumentation/spark/spark_2.12/src/main/java/datadog/trace/instrumentation/spark/DatadogSpark212Listener.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.spark;
 import java.util.ArrayList;
 import org.apache.spark.SparkConf;
 import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.StageInfo;
 
 /**
  * DatadogSparkListener compiled for Scala 2.12
@@ -35,5 +36,15 @@ public class DatadogSpark212Listener extends AbstractDatadogSparkListener {
   @Override
   protected int getStageCount(SparkListenerJobStart jobStart) {
     return jobStart.stageInfos().length();
+  }
+
+  @Override
+  protected int[] getStageParentIds(StageInfo info) {
+    int[] parentIds = new int[info.parentIds().length()];
+    for (int i = 0; i < parentIds.length; i++) {
+      parentIds[i] = (int) info.parentIds().apply(i);
+    }
+
+    return parentIds;
   }
 }

--- a/dd-java-agent/instrumentation/spark/spark_2.13/src/main/java/datadog/trace/instrumentation/spark/DatadogSpark213Listener.java
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/src/main/java/datadog/trace/instrumentation/spark/DatadogSpark213Listener.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.spark;
 import java.util.ArrayList;
 import org.apache.spark.SparkConf;
 import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.scheduler.StageInfo;
 
 /**
  * DatadogSparkListener compiled for Scala 2.13
@@ -35,5 +36,15 @@ public class DatadogSpark213Listener extends AbstractDatadogSparkListener {
   @Override
   protected int getStageCount(SparkListenerJobStart jobStart) {
     return jobStart.stageInfos().length();
+  }
+
+  @Override
+  protected int[] getStageParentIds(StageInfo info) {
+    int[] parentIds = new int[info.parentIds().length()];
+    for (int i = 0; i < parentIds.length; i++) {
+      parentIds[i] = (int) info.parentIds().apply(i);
+    }
+
+    return parentIds;
   }
 }

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -13,6 +13,7 @@ import java.io.StringWriter;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -108,6 +109,9 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
 
   /** Stage count of the spark job. Provide an implementation based on a specific scala version */
   protected abstract int getStageCount(SparkListenerJobStart jobStart);
+
+  /** Parent Ids of a Stage. Provide an implementation based on a specific scala version */
+  protected abstract int[] getStageParentIds(StageInfo info);
 
   @Override
   public synchronized void onApplicationStart(SparkListenerApplicationStart applicationStart) {
@@ -398,6 +402,8 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
             .asChildOf(jobSpan.context())
             .withStartTimestamp(submissionTimeMs * 1000)
             .withTag("stage_id", stageId)
+            .withTag(
+                "parent_stage_ids", Arrays.toString(getStageParentIds(stageSubmitted.stageInfo())))
             .withTag("task_count", stageSubmitted.stageInfo().numTasks())
             .withTag("attempt_id", stageAttemptId)
             .withTag("details", stageSubmitted.stageInfo().details())

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkTest.groovy
@@ -65,6 +65,7 @@ abstract class AbstractSparkTest extends AgentTestRunner {
           resourceName "count at TestSparkComputation.java:19"
           spanType "spark"
           errored false
+          assert span.tags["parent_stage_ids"] == "[0]"
           childOf(span(1))
         }
         span {
@@ -72,6 +73,7 @@ abstract class AbstractSparkTest extends AgentTestRunner {
           resourceName "distinct at TestSparkComputation.java:19"
           spanType "spark"
           errored false
+          assert span.tags["parent_stage_ids"] == "[]"
           childOf(span(1))
         }
       }


### PR DESCRIPTION
# What Does This Do

Add field `parent_stage_ids` to `spark.stage` spans

# Motivation

In a spark job, input of a stage can be the output of a previous stage. This new fields parent_stage_ids will capture the dependency between stage to display it in the UI

# Additional Notes

Specific implementation based on the scala version because the signature of scala.Seq changed in scala 2.13
