### PR TITLE
Enforce new ingestion reason for spark traces

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatabricksParentContext.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/DatabricksParentContext.java
@@ -81,7 +81,7 @@ public class DatabricksParentContext implements AgentSpan.Context {
 
   @Override
   public int getSamplingPriority() {
-    return PrioritySampling.SAMPLER_KEEP;
+    return PrioritySampling.UNSET;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkStructuredStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkStructuredStreamingTest.groovy
@@ -2,6 +2,8 @@ package datadog.trace.instrumentation.spark
 
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Platform
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
 import org.apache.spark.sql.Encoders
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.SparkSession
@@ -69,6 +71,8 @@ class AbstractSparkStructuredStreamingTest extends AgentTestRunner {
           resourceName "test-query"
           spanType "spark"
           parent()
+          assert span.context().getSamplingPriority() == PrioritySampling.USER_KEEP
+          assert span.context().getPropagationTags().createTagMap()["_dd.p.dm"] == (-SamplingMechanism.DATA_JOBS).toString()
           tags {
             defaultTags()
             // Streaming tags
@@ -174,6 +178,8 @@ class AbstractSparkStructuredStreamingTest extends AgentTestRunner {
           operationName "spark.streaming_batch"
           spanType "spark"
           assert span.tags["streaming_query.batch_id"] == 1
+          assert span.context().getSamplingPriority() == PrioritySampling.USER_KEEP
+          assert span.context().getPropagationTags().createTagMap()["_dd.p.dm"] == (-SamplingMechanism.DATA_JOBS).toString()
           parent()
         }
         span {

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkTest.groovy
@@ -4,6 +4,8 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.Platform
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.test.util.Flaky
 import org.apache.hadoop.yarn.api.records.FinalApplicationStatus
 import org.apache.hadoop.yarn.conf.YarnConfiguration
@@ -51,6 +53,8 @@ abstract class AbstractSparkTest extends AgentTestRunner {
           resourceName "spark.application"
           spanType "spark"
           errored false
+          assert span.context().getSamplingPriority() == PrioritySampling.USER_KEEP
+          assert span.context().getPropagationTags().createTagMap()["_dd.p.dm"] == (-SamplingMechanism.DATA_JOBS).toString()
           parent()
         }
         span {
@@ -254,6 +258,8 @@ abstract class AbstractSparkTest extends AgentTestRunner {
           spanType "spark"
           traceId 8944764253919609482G
           parentSpanId 15104224823446433673G
+          assert span.context().getSamplingPriority() == PrioritySampling.USER_KEEP
+          assert span.context().getPropagationTags().createTagMap()["_dd.p.dm"] == (-SamplingMechanism.DATA_JOBS).toString()
           assert span.tags["databricks_job_id"] == "1234"
           assert span.tags["databricks_job_run_id"] == "5678"
           assert span.tags["databricks_task_run_id"] == "9012"
@@ -275,6 +281,8 @@ abstract class AbstractSparkTest extends AgentTestRunner {
           spanType "spark"
           traceId 5240384461065211484G
           parentSpanId 14128229261586201946G
+          assert span.context().getSamplingPriority() == PrioritySampling.USER_KEEP
+          assert span.context().getPropagationTags().createTagMap()["_dd.p.dm"] == (-SamplingMechanism.DATA_JOBS).toString()
           assert span.tags["databricks_job_id"] == "3456"
           assert span.tags["databricks_job_run_id"] == "901"
           assert span.tags["databricks_task_run_id"] == "7890"
@@ -296,6 +304,8 @@ abstract class AbstractSparkTest extends AgentTestRunner {
           spanType "spark"
           traceId 2235374731114184741G
           parentSpanId 8956125882166502063G
+          assert span.context().getSamplingPriority() == PrioritySampling.USER_KEEP
+          assert span.context().getPropagationTags().createTagMap()["_dd.p.dm"] == (-SamplingMechanism.DATA_JOBS).toString()
           assert span.tags["databricks_job_id"] == "123"
           assert span.tags["databricks_job_run_id"] == "8765"
           assert span.tags["databricks_task_run_id"] == "456"
@@ -316,6 +326,8 @@ abstract class AbstractSparkTest extends AgentTestRunner {
           operationName "spark.job"
           spanType "spark"
           parent()
+          assert span.context().getSamplingPriority() == PrioritySampling.USER_KEEP
+          assert span.context().getPropagationTags().createTagMap()["_dd.p.dm"] == (-SamplingMechanism.DATA_JOBS).toString()
           assert span.tags["databricks_job_id"] == null
           assert span.tags["databricks_job_run_id"] == "8765"
           assert span.tags["databricks_task_run_id"] == null
@@ -429,6 +441,8 @@ abstract class AbstractSparkTest extends AgentTestRunner {
           spanType "spark"
           traceId 8944764253919609482G
           parentSpanId 15104224823446433673G
+          assert span.context().getSamplingPriority() == PrioritySampling.USER_KEEP
+          assert span.context().getPropagationTags().createTagMap()["_dd.p.dm"] == (-SamplingMechanism.DATA_JOBS).toString()
         }
         span {
           operationName "spark.job"

--- a/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
@@ -42,6 +42,7 @@ public class SamplingMechanism {
         return priority == USER_DROP || priority == USER_KEEP;
 
       case APPSEC:
+      case DATA_JOBS:
         return priority == PrioritySampling.USER_KEEP;
 
       case EXTERNAL_OVERRIDE:

--- a/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
@@ -21,6 +21,8 @@ public class SamplingMechanism {
   public static final byte REMOTE_USER_RATE = 6;
   /** Span Sampling Rate (single span sampled on account of a span sampling rule) */
   public static final byte SPAN_SAMPLING_RATE = 8;
+  /** Data Jobs */
+  public static final byte DATA_JOBS = 10;
   /** Force override sampling decision from external source, like W3C traceparent. */
   public static final byte EXTERNAL_OVERRIDE = Byte.MIN_VALUE;
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -135,6 +135,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
 
   Integer forceSamplingDecision();
 
+  AgentSpan setSamplingPriority(final int newPriority, int samplingMechanism);
+
   TraceConfig traceConfig();
 
   void addLink(AgentSpanLink link);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -658,6 +658,11 @@ public class AgentTracer {
     }
 
     @Override
+    public AgentSpan setSamplingPriority(int newPriority, int samplingMechanism) {
+      return this;
+    }
+
+    @Override
     public Integer getSamplingPriority() {
       return (int) PrioritySampling.UNSET;
     }

--- a/internal-api/src/test/groovy/datadog/trace/api/sampling/SamplingMechanismTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/sampling/SamplingMechanismTest.groovy
@@ -79,6 +79,14 @@ class SamplingMechanismTest extends Specification {
     APPSEC            | userDropX    | false
     APPSEC            | userKeepX    | false
 
+    DATA_JOBS         | UNSET        | false
+    DATA_JOBS         | SAMPLER_DROP | false
+    DATA_JOBS         | SAMPLER_KEEP | false
+    DATA_JOBS         | USER_DROP    | false
+    DATA_JOBS         | USER_KEEP    | true
+    DATA_JOBS         | userDropX    | false
+    DATA_JOBS         | userKeepX    | false
+
     EXTERNAL_OVERRIDE | UNSET        | false
     EXTERNAL_OVERRIDE | SAMPLER_DROP | false
     EXTERNAL_OVERRIDE | SAMPLER_KEEP | false


### PR DESCRIPTION
# What Does This Do

Enforce new ingestion reason for spark traces

# Motivation

It is critical to keep all spark traces as customers closely monitor job runs. The new ingestion reason will allow tracking of ingested bytes for billing. Analysis on ingested bytes can be found in [here](https://docs.google.com/document/d/1uIG4zlgism09V6u4nhXl8F5IXj7eX1o8H4yqoJrSK7w/edit)

# Additional Notes

Added the method `AgentSpan setSamplingPriority(final int newPriority, int samplingMechanism)` in the `AgentSpan` interface so that it can be called from an instrumentation