### PR TITLE
Test that HTTP headers with commas should be truncated at the first comma

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -123,19 +123,19 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
   def setupSpec() {
     List<Proxy> proxyList = Collections.singletonList(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxy.port)))
     proxySelector = new ProxySelector() {
-      @Override
-      List<Proxy> select(URI uri) {
-        if (uri.fragment == "proxy") {
-          return proxyList
+        @Override
+        List<Proxy> select(URI uri) {
+          if (uri.fragment == "proxy") {
+            return proxyList
+          }
+          return getDefault().select(uri)
         }
-        return getDefault().select(uri)
-      }
 
-      @Override
-      void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
-        getDefault().connectFailed(uri, sa, ioe)
+        @Override
+        void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+          getDefault().connectFailed(uri, sa, ioe)
+        }
       }
-    }
   }
 
   /**


### PR DESCRIPTION
# What Does This Do
Adds a new test that confirms that we truncate headers at the first comma
This also applies our default auto-formatting to the updated file

# Motivation
Codifies expected behavior via additional testing

# Additional Notes

Jira ticket: APMS-10909

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
