### PR TITLE
Fix root coverage packages calculation in large repositories

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -177,10 +177,17 @@ public class CiVisibilitySystem {
       ResourceResolver resourceResolver =
           new ConventionBasedResourceResolver(
               fileSystem, config.getCiVisibilityResourceFolderNames());
-      RepoIndexBuilder indexBuilder =
-          new RepoIndexBuilder(repoRoot, packageResolver, resourceResolver, fileSystem);
 
-      SourcePathResolver sourcePathResolver = getSourcePathResolver(repoRoot, indexBuilder);
+      // scanning only the project folder and not the entire repo to
+      // save time and to properly determine root packages for coverage instrumentation
+      // (when there are multiple projects in the repo, root package resolution cannot establish
+      // common roots)
+      String sourcePathResolutionRoot = projectRoot.toString();
+      RepoIndexBuilder indexBuilder =
+          new RepoIndexBuilder(
+              config, sourcePathResolutionRoot, packageResolver, resourceResolver, fileSystem);
+      SourcePathResolver sourcePathResolver =
+          getSourcePathResolver(sourcePathResolutionRoot, indexBuilder);
       Codeowners codeowners = getCodeowners(repoRoot);
 
       MethodLinesResolver methodLinesResolver =
@@ -307,7 +314,7 @@ public class CiVisibilitySystem {
             new ConventionBasedResourceResolver(
                 fileSystem, config.getCiVisibilityResourceFolderNames());
         RepoIndexProvider indexProvider =
-            new RepoIndexBuilder(repoRoot, packageResolver, resourceResolver, fileSystem);
+            new RepoIndexBuilder(config, repoRoot, packageResolver, resourceResolver, fileSystem);
 
         BackendApi backendApi = backendApiFactory.createBackendApi();
         GitDataUploader gitDataUploader =
@@ -389,7 +396,7 @@ public class CiVisibilitySystem {
           new ConventionBasedResourceResolver(
               fileSystem, config.getCiVisibilityResourceFolderNames());
       RepoIndexProvider indexProvider =
-          new RepoIndexBuilder(repoRoot, packageResolver, resourceResolver, fileSystem);
+          new RepoIndexBuilder(config, repoRoot, packageResolver, resourceResolver, fileSystem);
       SourcePathResolver sourcePathResolver = getSourcePathResolver(repoRoot, indexProvider);
 
       return new DDTestSessionImpl(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.source.index;
 
+import datadog.trace.api.Config;
 import datadog.trace.util.ClassNameTrie;
 import java.io.File;
 import java.io.IOException;
@@ -20,6 +21,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
   private static final Logger log = LoggerFactory.getLogger(RepoIndexBuilder.class);
 
+  private final Config config;
   private final String repoRoot;
   private final PackageResolver packageResolver;
   private final ResourceResolver resourceResolver;
@@ -29,10 +31,12 @@ public class RepoIndexBuilder implements RepoIndexProvider {
   private volatile RepoIndex index;
 
   public RepoIndexBuilder(
+      Config config,
       String repoRoot,
       PackageResolver packageResolver,
       ResourceResolver resourceResolver,
       FileSystem fileSystem) {
+    this.config = config;
     this.repoRoot = repoRoot;
     this.packageResolver = packageResolver;
     this.resourceResolver = resourceResolver;
@@ -60,7 +64,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
     Path repoRootPath = fileSystem.getPath(repoRoot);
     RepoIndexingFileVisitor repoIndexingFileVisitor =
-        new RepoIndexingFileVisitor(packageResolver, resourceResolver, repoRootPath);
+        new RepoIndexingFileVisitor(config, packageResolver, resourceResolver, repoRootPath);
 
     long startTime = System.currentTimeMillis();
     try {
@@ -100,13 +104,16 @@ public class RepoIndexBuilder implements RepoIndexProvider {
     private final Path repoRoot;
 
     private RepoIndexingFileVisitor(
-        PackageResolver packageResolver, ResourceResolver resourceResolver, Path repoRoot) {
+        Config config,
+        PackageResolver packageResolver,
+        ResourceResolver resourceResolver,
+        Path repoRoot) {
       this.packageResolver = packageResolver;
       this.resourceResolver = resourceResolver;
       this.repoRoot = repoRoot;
       trieBuilder = new ClassNameTrie.Builder();
       sourceRoots = new LinkedHashSet<>();
-      packageTree = new PackageTree();
+      packageTree = new PackageTree(config);
       indexingStats = new RepoIndexingStats();
     }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolver.java
@@ -20,13 +20,14 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
   }
 
   RepoIndexSourcePathResolver(
+      Config config,
       String repoRoot,
       PackageResolver packageResolver,
       ResourceResolver resourceResolver,
       FileSystem fileSystem) {
     this.repoRoot = repoRoot;
     this.indexProvider =
-        new RepoIndexBuilder(repoRoot, packageResolver, resourceResolver, fileSystem);
+        new RepoIndexBuilder(config, repoRoot, packageResolver, resourceResolver, fileSystem);
   }
 
   @Nullable

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolverTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolverTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.civisibility.source.index
 
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
+import datadog.trace.api.Config
 import groovy.transform.PackageScope
 import spock.lang.Specification
 
@@ -10,6 +11,7 @@ import java.nio.file.Path
 
 class RepoIndexSourcePathResolverTest extends Specification {
 
+  def config = Stub(Config)
   def packageResolver = Stub(PackageResolver)
   def resourceResolver = Stub(ResourceResolver)
   def fileSystem = Jimfs.newFileSystem(Configuration.unix())
@@ -20,7 +22,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     def expectedSourcePath = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(RepoIndexSourcePathResolverTest) == expectedSourcePath
@@ -31,7 +33,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     def expectedSourcePath = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(InnerClass) == expectedSourcePath
@@ -42,7 +44,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     def expectedSourcePath = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(InnerClass.NestedInnerClass) == expectedSourcePath
@@ -53,7 +55,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     def expectedSourcePath = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
     def r = new Runnable() {
         void run() {}
       }
@@ -67,7 +69,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     def expectedSourcePath = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(PackagePrivateClass) == expectedSourcePath
@@ -78,7 +80,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     def expectedSourcePath = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(PackagePrivateClass.NestedIntoPackagePrivateClass) == expectedSourcePath
@@ -89,7 +91,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     def expectedSourcePath = givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src")
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(PublicClassWhoseNameDoesNotCorrespondToFileName) == expectedSourcePath
@@ -99,7 +101,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     setup:
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(RepoIndexSourcePathResolver) == null
@@ -109,7 +111,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     setup:
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(PackagePrivateClass) == null
@@ -124,7 +126,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     Files.write(classPath, "STUB CLASS BODY".getBytes())
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(RepoIndexSourcePathResolverTest) == null
@@ -138,7 +140,7 @@ class RepoIndexSourcePathResolverTest extends Specification {
     givenRepoFile(fileSystem.getPath(repoRoot, "README.md"))
 
     when:
-    def sourcePathResolver = new RepoIndexSourcePathResolver(repoRoot, packageResolver, resourceResolver, fileSystem)
+    def sourcePathResolver = new RepoIndexSourcePathResolver(config, repoRoot, packageResolver, resourceResolver, fileSystem)
 
     then:
     sourcePathResolver.getSourcePath(RepoIndexSourcePathResolverTest) == expectedSourcePathOne

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -62,6 +62,8 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_JVM_INFO_CACHE_SIZE = "civisibility.jvm.info.cache.size";
   public static final String CIVISIBILITY_COVERAGE_SEGMENTS_ENABLED =
       "civisibility.coverage.segments.enabled";
+  public static final String CIVISIBILITY_COVERAGE_ROOT_PACKAGES_LIMIT =
+      "civisibility.coverage.root.packages.limit";
   public static final String CIVISIBILITY_INJECTED_TRACER_VERSION =
       "civisibility.injected.tracer.version";
   public static final String CIVISIBILITY_RESOURCE_FOLDER_NAMES =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -153,6 +153,7 @@ import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_CODE_COVE
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_REPORT_DUMP_DIR;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_COMPILER_PLUGIN_AUTO_CONFIGURATION_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_COMPILER_PLUGIN_VERSION;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_COVERAGE_ROOT_PACKAGES_LIMIT;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_COVERAGE_SEGMENTS_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_DEBUG_PORT;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_GIT_COMMAND_TIMEOUT_MILLIS;
@@ -736,6 +737,7 @@ public class Config {
   private final int ciVisibilityModuleExecutionSettingsCacheSize;
   private final int ciVisibilityJvmInfoCacheSize;
   private final boolean ciVisibilityCoverageSegmentsEnabled;
+  private final int ciVisibilityCoverageRootPackagesLimit;
   private final String ciVisibilityInjectedTracerVersion;
   private final List<String> ciVisibilityResourceFolderNames;
 
@@ -1690,6 +1692,8 @@ public class Config {
     ciVisibilityJvmInfoCacheSize = configProvider.getInteger(CIVISIBILITY_JVM_INFO_CACHE_SIZE, 8);
     ciVisibilityCoverageSegmentsEnabled =
         configProvider.getBoolean(CIVISIBILITY_COVERAGE_SEGMENTS_ENABLED, false);
+    ciVisibilityCoverageRootPackagesLimit =
+        configProvider.getInteger(CIVISIBILITY_COVERAGE_ROOT_PACKAGES_LIMIT, 30);
     ciVisibilityInjectedTracerVersion =
         configProvider.getString(CIVISIBILITY_INJECTED_TRACER_VERSION);
     ciVisibilityResourceFolderNames =
@@ -2832,6 +2836,10 @@ public class Config {
 
   public boolean isCiVisibilityCoverageSegmentsEnabled() {
     return ciVisibilityCoverageSegmentsEnabled;
+  }
+
+  public int getCiVisibilityCoverageRootPackagesLimit() {
+    return ciVisibilityCoverageRootPackagesLimit;
   }
 
   public String getCiVisibilityInjectedTracerVersion() {


### PR DESCRIPTION
# What Does This Do
1. Updates repository indexer to only scan the project folder (and not the entire repository).
2. Adds a new config property that sets the limit on the number of root packages calculated by the indexed.

# Motivation
Both changes are needed to handle builds in repositories that contain multiple projects.

One of the things that the repository indexer does is determining the set of packages that should be instrumented with code coverage (limiting the set of packages is needed to reduce coverage overhead, as instrumenting 3rd party dependencies and core JDK classes adds a lot of overhead and serves no purpose).
The set of packages determined by the indexer is passed to Jacoco agent via the command line.
The length of the command line is finite (exact max length is OS-dependant), so the number of packages added to the command line has to be limited.

The new config property allows to manually increase the limit for those projects that might need it.
Indexing only the project folder allows to exclude packages that are known to be irrelevant.

The problem with the previous version of the code was that in a large repository (for example, CI Visibility test environment repo) the total number of packages was too big to fit the hard-coded limit, so the coverage logic degraded to instrumenting all the classes, which caused huge performance overhead.

# Additional Notes

Jira ticket: [CIVIS-8227]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8227]: https://datadoghq.atlassian.net/browse/CIVIS-8227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ