### PR TITLE
Fix source path detection in multi-project repos

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -177,17 +177,15 @@ public class CiVisibilitySystem {
       ResourceResolver resourceResolver =
           new ConventionBasedResourceResolver(
               fileSystem, config.getCiVisibilityResourceFolderNames());
-
-      // scanning only the project folder and not the entire repo to
-      // save time and to properly determine root packages for coverage instrumentation
-      // (when there are multiple projects in the repo, root package resolution cannot establish
-      // common roots)
-      String sourcePathResolutionRoot = projectRoot.toString();
       RepoIndexBuilder indexBuilder =
           new RepoIndexBuilder(
-              config, sourcePathResolutionRoot, packageResolver, resourceResolver, fileSystem);
-      SourcePathResolver sourcePathResolver =
-          getSourcePathResolver(sourcePathResolutionRoot, indexBuilder);
+              config,
+              repoRoot,
+              projectRoot.toString(),
+              packageResolver,
+              resourceResolver,
+              fileSystem);
+      SourcePathResolver sourcePathResolver = getSourcePathResolver(repoRoot, indexBuilder);
       Codeowners codeowners = getCodeowners(repoRoot);
 
       MethodLinesResolver methodLinesResolver =
@@ -314,7 +312,8 @@ public class CiVisibilitySystem {
             new ConventionBasedResourceResolver(
                 fileSystem, config.getCiVisibilityResourceFolderNames());
         RepoIndexProvider indexProvider =
-            new RepoIndexBuilder(config, repoRoot, packageResolver, resourceResolver, fileSystem);
+            new RepoIndexBuilder(
+                config, repoRoot, repoRoot, packageResolver, resourceResolver, fileSystem);
 
         BackendApi backendApi = backendApiFactory.createBackendApi();
         GitDataUploader gitDataUploader =
@@ -396,7 +395,8 @@ public class CiVisibilitySystem {
           new ConventionBasedResourceResolver(
               fileSystem, config.getCiVisibilityResourceFolderNames());
       RepoIndexProvider indexProvider =
-          new RepoIndexBuilder(config, repoRoot, packageResolver, resourceResolver, fileSystem);
+          new RepoIndexBuilder(
+              config, repoRoot, repoRoot, packageResolver, resourceResolver, fileSystem);
       SourcePathResolver sourcePathResolver = getSourcePathResolver(repoRoot, indexProvider);
 
       return new DDTestSessionImpl(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -23,6 +23,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
   private final Config config;
   private final String repoRoot;
+  private final String scanRoot;
   private final PackageResolver packageResolver;
   private final ResourceResolver resourceResolver;
   private final FileSystem fileSystem;
@@ -33,11 +34,13 @@ public class RepoIndexBuilder implements RepoIndexProvider {
   public RepoIndexBuilder(
       Config config,
       String repoRoot,
+      String scanRoot,
       PackageResolver packageResolver,
       ResourceResolver resourceResolver,
       FileSystem fileSystem) {
     this.config = config;
     this.repoRoot = repoRoot;
+    this.scanRoot = scanRoot;
     this.packageResolver = packageResolver;
     this.resourceResolver = resourceResolver;
     this.fileSystem = fileSystem;
@@ -57,24 +60,26 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
   private RepoIndex doGetIndex() {
     log.warn(
-        "Building index of source files in {}. "
+        "Building index of source files in {}, repo root is {}. "
             + "This operation can be slow, "
             + "please consider using Datadog Java compiler plugin to avoid indexing",
+        scanRoot,
         repoRoot);
 
     Path repoRootPath = fileSystem.getPath(repoRoot);
+    Path scanRootPath = fileSystem.getPath(scanRoot);
     RepoIndexingFileVisitor repoIndexingFileVisitor =
         new RepoIndexingFileVisitor(config, packageResolver, resourceResolver, repoRootPath);
 
     long startTime = System.currentTimeMillis();
     try {
       Files.walkFileTree(
-          repoRootPath,
+          scanRootPath,
           EnumSet.of(FileVisitOption.FOLLOW_LINKS),
           Integer.MAX_VALUE,
           repoIndexingFileVisitor);
     } catch (Exception e) {
-      log.error("Failed to build index repo of {}", repoRoot, e);
+      log.error("Failed to build index of {}", scanRootPath, e);
     }
 
     long duration = System.currentTimeMillis() - startTime;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolver.java
@@ -27,7 +27,8 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
       FileSystem fileSystem) {
     this.repoRoot = repoRoot;
     this.indexProvider =
-        new RepoIndexBuilder(config, repoRoot, packageResolver, resourceResolver, fileSystem);
+        new RepoIndexBuilder(
+            config, repoRoot, repoRoot, packageResolver, resourceResolver, fileSystem);
   }
 
   @Nullable


### PR DESCRIPTION
# What Does This Do
Fixes source path detection in projects where repo root is not the same as project root.

# Motivation
Repo indexer only scans the project root (to save time and to work around some issues with calculating root packages), however all the source code paths submitted to the backend should be relative to the repo root.

Jira ticket: [CIVIS-8234]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8234]: https://datadoghq.atlassian.net/browse/CIVIS-8234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ