### PR TITLE
Ignore multi agent smoke test on IBM 8

### DIFF
--- a/dd-smoke-tests/agent-bootstrap/src/test/groovy/datadog/smoketest/MultiAgentWithNoProtectionDomainSystemLoaderSmokeTest.groovy
+++ b/dd-smoke-tests/agent-bootstrap/src/test/groovy/datadog/smoketest/MultiAgentWithNoProtectionDomainSystemLoaderSmokeTest.groovy
@@ -1,7 +1,13 @@
 package datadog.smoketest
 
+import datadog.trace.api.Platform
+import spock.lang.IgnoreIf
+
 import static java.util.concurrent.TimeUnit.SECONDS
 
+@IgnoreIf(reason = "Fails on IBM 8", value = {
+  Platform.isIbm8()
+})
 class MultiAgentWithNoProtectionDomainSystemLoaderSmokeTest extends AbstractSmokeTest {
   private static final int TIMEOUT_SECS = 30
 


### PR DESCRIPTION
# What Does This Do
Disables multiple agents smoke test on IBM 8 platform.

# Motivation
The test fails on IBM 8.

Jira ticket: [CIVIS-8235]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8235]: https://datadoghq.atlassian.net/browse/CIVIS-8235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ