### PR TITLE
RC config poller with multiple listeners per product

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -244,8 +244,8 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
    */
   private class TransactionalAppSecModuleConfigurerImpl
       implements TransactionalAppSecModuleConfigurer {
-    private Map<String, SubconfigListener> listenerMap = new HashMap<>();
-    private List<TraceSegmentPostProcessor> postProcessors = new ArrayList<>();
+    private final Map<String, SubconfigListener> listenerMap = new HashMap<>();
+    private final List<TraceSegmentPostProcessor> postProcessors = new ArrayList<>();
 
     @Override
     public Optional<Object> addSubConfigListener(String key, SubconfigListener listener) {
@@ -332,10 +332,10 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_CUSTOM_RULES
             | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
             | CAPABILITY_ASM_TRUSTED_IPS);
-    this.configurationPoller.removeListener(Product.ASM_DD);
-    this.configurationPoller.removeListener(Product.ASM_DATA);
-    this.configurationPoller.removeListener(Product.ASM);
-    this.configurationPoller.removeListener(Product.ASM_FEATURES);
+    this.configurationPoller.removeListeners(Product.ASM_DD);
+    this.configurationPoller.removeListeners(Product.ASM_DATA);
+    this.configurationPoller.removeListeners(Product.ASM);
+    this.configurationPoller.removeListeners(Product.ASM_FEATURES);
     this.configurationPoller.removeConfigurationEndListener(applyWAFChangesAsListener);
     this.configurationPoller.stop();
   }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -407,7 +407,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
 
     then:
     1 * poller.removeCapabilities(1982L)
-    4 * poller.removeListener(_)
+    4 * poller.removeListeners(_)
     1 * poller.removeConfigurationEndListener(_)
     1 * poller.stop()
   }

--- a/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
@@ -129,7 +129,9 @@ public class ConfigurationPoller
   }
 
   public synchronized <T> void addListener(Product product, ProductListener listener) {
-    this.productStates.put(product, new ProductState(product, listener));
+    ProductState productState =
+        this.productStates.computeIfAbsent(product, p -> new ProductState(product));
+    productState.addProductListener(listener);
   }
 
   public synchronized <T> void addListener(

--- a/remote-config/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
@@ -62,6 +62,7 @@ public class RemoteConfigRequest {
     public static final long CAPABILITY_ASM_CUSTOM_RULES = 1 << 8;
     public static final long CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE = 1 << 9;
     public static final long CAPABILITY_ASM_TRUSTED_IPS = 1 << 10;
+    public static final long CAPABILITY_ASM_API_SECURITY_SAMPLE_RATE = 1 << 11;
 
     @Json(name = "state")
     private final ClientState clientState;

--- a/remote-config/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/tuf/RemoteConfigRequest.java
@@ -62,7 +62,6 @@ public class RemoteConfigRequest {
     public static final long CAPABILITY_ASM_CUSTOM_RULES = 1 << 8;
     public static final long CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE = 1 << 9;
     public static final long CAPABILITY_ASM_TRUSTED_IPS = 1 << 10;
-    public static final long CAPABILITY_ASM_API_SECURITY_SAMPLE_RATE = 1 << 11;
 
     @Json(name = "state")
     private final ClientState clientState;

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -101,7 +101,7 @@ class ConfigurationPollerSpecification extends DDSpecification {
     poller.addListener(Product.ASM_DD,
       {throw new RuntimeException('should not be called') } as ConfigurationDeserializer,
       { cfg, hinter -> true } as ConfigurationChangesTypedListener)
-    poller.removeListener(Product.ASM_DD)
+    poller.removeListeners(Product.ASM_DD)
     task.run(poller)
 
     then:
@@ -1262,7 +1262,7 @@ class ConfigurationPollerSpecification extends DDSpecification {
     1 * scheduler.scheduleAtFixedRate(_, poller, 0, DEFAULT_POLL_PERIOD, TimeUnit.MILLISECONDS) >> { task = it[0]; scheduled }
 
     and:
-    poller.removeListener(Product.ASM_FEATURES)
+    poller.removeListeners(Product.ASM_FEATURES)
 
     when:
     poller.addListener(Product.ASM_FEATURES,
@@ -1346,7 +1346,7 @@ class ConfigurationPollerSpecification extends DDSpecification {
     poller.addListener(Product.ASM_FEATURES,
       {} as ConfigurationDeserializer<Boolean>,
       listener)
-    poller.removeListener(Product.ASM_FEATURES)
+    poller.removeListeners(Product.ASM_FEATURES)
     poller.start()
 
     then:
@@ -1361,7 +1361,7 @@ class ConfigurationPollerSpecification extends DDSpecification {
     0 * _._ // in particular, listener is not called
 
     when:
-    poller.removeListener(Product._UNKNOWN)
+    poller.removeListeners(Product._UNKNOWN)
     task.run(poller)
 
     then:


### PR DESCRIPTION
# What Does This Do
Improved Configuration poller to support multiple listeners per product.

# Motivation
The changes needed to follow implementation of Api Security Sample Rate configuration via remote config.

# Additional Notes
This is preparation for https://github.com/DataDog/dd-trace-java/pull/6340

<!-- Jira ticket: [PROJ-IDENT] -->

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
