### PR TITLE
Remove warning about unknown graphql.server.all_resolvers

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -98,6 +98,9 @@ public interface KnownAddresses {
   // XXX: Not really used yet, but it's a known address and we should not treat it as unknown.
   Address<Object> GRPC_SERVER_REQUEST_METADATA = new Address<>("grpc.server.request.metadata");
 
+  // XXX: Not really used yet, but it's a known address and we should not treat it as unknown.
+  Address<Object> GRAPHQL_SERVER_ALL_RESOLVERS = new Address<>("graphql.server.all_resolvers");
+
   Address<String> USER_ID = new Address<>("usr.id");
 
   Address<Map<String, Object>> WAF_CONTEXT_PROCESSOR = new Address<>("waf.context.processor");
@@ -148,6 +151,8 @@ public interface KnownAddresses {
         return GRPC_SERVER_REQUEST_MESSAGE;
       case "grpc.server.request.metadata":
         return GRPC_SERVER_REQUEST_METADATA;
+      case "graphql.server.all_resolvers":
+        return GRAPHQL_SERVER_ALL_RESOLVERS;
       case "usr.id":
         return USER_ID;
       case "waf.context.processor":

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -30,6 +30,7 @@ class KnownAddressesSpecification extends Specification {
       'server.request.headers.no_cookies',
       'grpc.server.request.message',
       'grpc.server.request.metadata',
+      'graphql.server.all_resolvers',
       'usr.id',
       'waf.context.processor',
     ]
@@ -37,7 +38,7 @@ class KnownAddressesSpecification extends Specification {
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 24
+    Address.instanceCount() == 25
     KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }


### PR DESCRIPTION
# What Does This Do
Avoid the following warning:
> WAF has rule against unknown address graphql.server.all_resolvers
# Motivation

# Additional Notes

Jira ticket: [APPSEC-16696](https://datadoghq.atlassian.net/browse/APPSEC-16696)



[APPSEC-16696]: https://datadoghq.atlassian.net/browse/APPSEC-16696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ