### PR TITLE
Add graphql.server.resolver to known WAF addresses

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -101,6 +101,9 @@ public interface KnownAddresses {
   // XXX: Not really used yet, but it's a known address and we should not treat it as unknown.
   Address<Object> GRAPHQL_SERVER_ALL_RESOLVERS = new Address<>("graphql.server.all_resolvers");
 
+  // XXX: Not really used yet, but it's a known address and we should not treat it as unknown.
+  Address<Object> GRAPHQL_SERVER_RESOLVER = new Address<>("graphql.server.resolver");
+
   Address<String> USER_ID = new Address<>("usr.id");
 
   Address<Map<String, Object>> WAF_CONTEXT_PROCESSOR = new Address<>("waf.context.processor");
@@ -153,6 +156,8 @@ public interface KnownAddresses {
         return GRPC_SERVER_REQUEST_METADATA;
       case "graphql.server.all_resolvers":
         return GRAPHQL_SERVER_ALL_RESOLVERS;
+      case "graphql.server.resolver":
+        return GRAPHQL_SERVER_RESOLVER;
       case "usr.id":
         return USER_ID;
       case "waf.context.processor":

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -31,6 +31,7 @@ class KnownAddressesSpecification extends Specification {
       'grpc.server.request.message',
       'grpc.server.request.metadata',
       'graphql.server.all_resolvers',
+      'graphql.server.resolver',
       'usr.id',
       'waf.context.processor',
     ]
@@ -38,7 +39,7 @@ class KnownAddressesSpecification extends Specification {
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 25
+    Address.instanceCount() == 26
     KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }


### PR DESCRIPTION
# What Does This Do
Add the upcoming `graphql.server.resolver` WAF address to known addresses to avoid warnings. 

# Motivation

# Additional Notes

* Similar PR: https://github.com/DataDog/dd-trace-java/pull/6344
* Rules update using this address: https://github.com/DataDog/dd-trace-java/pull/6349