### PR TITLE
MongoDB 4.10-11 instrumentation fix

### DIFF
--- a/dd-java-agent/instrumentation/mongo/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/build.gradle
@@ -1,6 +1,5 @@
 apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+  testImplementation "org.testcontainers:mongodb:${versions.testcontainers}"
 }

--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/build.gradle
@@ -4,8 +4,7 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+  testImplementation "org.testcontainers:mongodb:${versions.testcontainers}"
 
   // We need to pull in this dependency to get the 'suspend span' instrumentation for spock tests
   // as well as to test the instrumentaiton 'layering' (3.4 instrumentation should take precedence

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/build.gradle
@@ -30,9 +30,7 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
-
+  testImplementation "org.testcontainers:mongodb:${versions.testcontainers}"
 
   testImplementation project(':dd-java-agent:instrumentation:mongo:bson-document')
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/build.gradle
@@ -15,8 +15,7 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+  testImplementation "org.testcontainers:mongodb:${versions.testcontainers}"
 
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '3.10.0'
   latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '3.+'

--- a/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/build.gradle
@@ -12,8 +12,7 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+  testImplementation "org.testcontainers:mongodb:${versions.testcontainers}"
 
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-async', version: '3.3.0'
   latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-async', version: '+'

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/build.gradle
@@ -38,9 +38,7 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
-
+  testImplementation "org.testcontainers:mongodb:${versions.testcontainers}"
 
   // We need to pull in this dependency to get the 'suspend span' instrumentation for spock tests
   // as well as to test the instrumentaiton 'layering' (3.4 instrumentation should take precedence

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/build.gradle
@@ -4,8 +4,7 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+  testImplementation "org.testcontainers:mongodb:${versions.testcontainers}"
 
   // We need to pull in this dependency to get the 'suspend span' instrumentation for spock tests
   // as well as to test the instrumentaiton 'layering' (3.4 instrumentation should take precedence

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/build.gradle
@@ -33,8 +33,7 @@ dependencies {
   }
 
   testImplementation project(':dd-java-agent:instrumentation:mongo').sourceSets.test.output
-  testImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '4.5.1'
-  testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+  testImplementation "org.testcontainers:mongodb:${versions.testcontainers}"
 
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.0.1'
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.0.1'  // race condition bug in 4.0.0

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/build.gradle
@@ -17,6 +17,10 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('mongo43Test', 'test')
+addTestSuiteForDir('mongo43ForkedTest', 'test')
+addTestSuiteForDir('mongo410Test', 'test')
+addTestSuiteForDir('mongo410ForkedTest', 'test')
 
 dependencies {
   compileOnly group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.0.0'
@@ -37,6 +41,19 @@ dependencies {
 
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.0.1'
   testImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.0.1'  // race condition bug in 4.0.0
-  latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.2+'
-  latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.2+'
+
+  mongo43TestImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.3.+'
+  mongo43TestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.3.+'
+
+  mongo43ForkedTestImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.3.+'
+  mongo43ForkedTestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.3.+'
+
+  mongo410TestImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.10.+'
+  mongo410TestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.10.+'
+
+  mongo410ForkedTestImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '4.10.+'
+  mongo410ForkedTestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.10.+'
+
+  latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-reactivestreams', version: '+'
+  latestDepTestImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '+'
 }

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/main/java/datadog/trace/instrumentation/mongo/Arg2Advice.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/main/java/datadog/trace/instrumentation/mongo/Arg2Advice.java
@@ -1,0 +1,12 @@
+package datadog.trace.instrumentation.mongo;
+
+import com.mongodb.internal.async.SingleResultCallback;
+import net.bytebuddy.asm.Advice;
+
+public class Arg2Advice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void wrap(
+      @Advice.Argument(value = 2, readOnly = false) SingleResultCallback<Object> callback) {
+    callback = CallbackWrapper.wrapIfRequired(callback);
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/main/java/datadog/trace/instrumentation/mongo/BaseClusterInstrumentation410.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/main/java/datadog/trace/instrumentation/mongo/BaseClusterInstrumentation410.java
@@ -1,0 +1,35 @@
+package datadog.trace.instrumentation.mongo;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+
+@AutoService(Instrumenter.class)
+public class BaseClusterInstrumentation410 extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+  public BaseClusterInstrumentation410() {
+    super("mongo", "mongo-reactivestreams");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.mongodb.internal.connection.BaseCluster";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".CallbackWrapper"};
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("selectServerAsync"))
+            .and(takesArgument(2, named("com.mongodb.internal.async.SingleResultCallback"))),
+        packageName + ".Arg2Advice");
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/main/java/datadog/trace/instrumentation/mongo/DefaultConnectionPoolInstrumentation410.java
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/main/java/datadog/trace/instrumentation/mongo/DefaultConnectionPoolInstrumentation410.java
@@ -1,0 +1,35 @@
+package datadog.trace.instrumentation.mongo;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+
+@AutoService(Instrumenter.class)
+public class DefaultConnectionPoolInstrumentation410 extends Instrumenter.Tracing
+    implements Instrumenter.ForSingleType {
+  public DefaultConnectionPoolInstrumentation410() {
+    super("mongo", "mongo-reactivestreams");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.mongodb.internal.connection.DefaultConnectionPool";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".CallbackWrapper"};
+  }
+
+  @Override
+  public void adviceTransformations(AdviceTransformation transformation) {
+    transformation.applyAdvice(
+        isMethod()
+            .and(named("getAsync"))
+            .and(takesArgument(1, named("com.mongodb.internal.async.SingleResultCallback"))),
+        packageName + ".Arg1Advice");
+  }
+}

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
@@ -3,6 +3,7 @@ import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
+import com.mongodb.internal.build.MongoDriverVersion
 import datadog.trace.core.DDSpan
 import org.bson.BsonDocument
 import org.bson.BsonString
@@ -27,6 +28,19 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
     client?.close()
     client = null
   }
+
+  @Shared
+  String query = {
+    def parts = MongoDriverVersion.VERSION.split('\\.')
+    switch (parts[1]) {
+      case '0':
+      case '1':
+      case '2':
+        return ',"query":{}'
+      default:
+        return ''
+    }
+  }.call()
 
   def "test create collection"() {
     setup:
@@ -78,7 +92,7 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
     count == 0
     assertTraces(1) {
       trace(1) {
-        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
 
@@ -110,7 +124,7 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}")
       }
       trace(1) {
-        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
 
@@ -147,7 +161,7 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}")
       }
       trace(1) {
-        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
 
@@ -182,7 +196,7 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}")
       }
       trace(1) {
-        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
 

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
@@ -1,5 +1,6 @@
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
+import com.mongodb.internal.build.MongoDriverVersion
 import com.mongodb.reactivestreams.client.MongoClient
 import com.mongodb.reactivestreams.client.MongoClients
 import com.mongodb.reactivestreams.client.MongoCollection
@@ -32,6 +33,19 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
     client?.close()
     client = null
   }
+
+  @Shared
+  String query = {
+    def parts = MongoDriverVersion.VERSION.split('\\.')
+    switch (parts[1]) {
+      case '0':
+      case '1':
+      case '2':
+        return ',"query":{}'
+      default:
+        return ''
+    }
+  }.call()
 
   MongoCollection<Document> setupCollection(String collectionName) {
     DDSpan setupSpan = null
@@ -158,7 +172,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
     count.get() == 0
     assertTraces(1) {
       trace(1) {
-        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
 
@@ -182,7 +196,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
       trace(2) {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
-        mongoSpan(it, 1, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-description", span(0))
+        mongoSpan(it, 1, "count", "{\"count\":\"$collectionName\"$query}", false, "some-description", span(0))
       }
     }
 
@@ -207,7 +221,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}")
       }
       trace(1) {
-        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
 
@@ -234,7 +248,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
         mongoSpan(it, 1, "insert", "{\"insert\":\"$collectionName\",\"ordered\":true,\"documents\":[]}", false, "some-description", span(0))
-        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-description", span(0))
+        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\"$query}", false, "some-description", span(0))
       }
     }
 
@@ -265,7 +279,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}")
       }
       trace(1) {
-        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
 
@@ -298,7 +312,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
         mongoSpan(it, 1, "update", "{\"update\":\"$collectionName\",\"ordered\":true,\"updates\":[]}", false, "some-description", span(0))
-        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-description", span(0))
+        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\"$query}", false, "some-description", span(0))
       }
     }
 
@@ -327,7 +341,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}")
       }
       trace(1) {
-        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
+        mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
 
@@ -358,7 +372,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         sortSpansByStart()
         basicSpan(it, 0,"parent")
         mongoSpan(it, 1, "delete", "{\"delete\":\"$collectionName\",\"ordered\":true,\"deletes\":[]}", false, "some-description", span(0))
-        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-description", span(0))
+        mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\"$query}", false, "some-description", span(0))
       }
     }
 

--- a/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
@@ -1,32 +1,13 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
-import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
-import datadog.trace.test.util.Flaky
-import de.flapdoodle.embed.mongo.config.Net
-import de.flapdoodle.embed.mongo.distribution.Version
-import de.flapdoodle.embed.mongo.transitions.Mongod
-import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess
-import de.flapdoodle.embed.process.io.ProcessOutput
-import de.flapdoodle.embed.process.io.Processors
-import de.flapdoodle.embed.process.io.Slf4jLevel
-import de.flapdoodle.embed.process.runtime.Network
-import de.flapdoodle.reverse.transitions.Start
-import org.apache.commons.io.FileUtils
 import org.slf4j.LoggerFactory
+import org.testcontainers.containers.MongoDBContainer
 import spock.lang.Shared
-import spock.util.concurrent.PollingConditions
 
-import java.nio.channels.FileChannel
-import java.nio.file.StandardOpenOption
-
-/**
- * Testing needs to be in a centralized project.
- */
-@Flaky("Fails sometimes with java.io.IOException https://github.com/DataDog/dd-trace-java/issues/3884")
 abstract class MongoBaseTest extends VersionedNamingTestBase {
   public static final String V0_DB_TYPE = "mongo"
   public static final String V0_SERVICE = "mongo"
@@ -44,53 +25,26 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
 
   @Shared
   int port
+
   @Shared
-  RunningMongodProcess mongodProcess
+  MongoDBContainer mongoDbContainer
 
   abstract String dbType()
 
-  def setupSpec() throws Exception {
-    // The embedded MongoDB library will fail if it starts preparing the
-    // distribution and then finds that one of the files already exists.
-    // Since we usually execute multiple test modules in parallel, we use
-    // an exclusive file lock.
-    final mongoHome = new File(FileUtils.getUserDirectory(), ".embedmongo")
-    mongoHome.mkdirs()
+  def mongodbImageName() {
+    return "mongo:3.6.23"
+  }
 
-    final lockFile = new File(mongoHome, "dd-trace-java.lock")
-    final conditions = new PollingConditions(timeout: 60, delay: 0.5)
-    // pre download and extract
-    conditions.eventually {
-      final lockChannel = FileChannel.open(lockFile.toPath(), StandardOpenOption.CREATE, StandardOpenOption.APPEND)
-      mongodProcess = lockChannel.withCloseable {
-        final lock = it.tryLock()
-        assert lock != null
-        try {
-          // Create the MongodConfig here, including the allocation of the port.
-          // If we allocate the port before acquiring the lock, some other process
-          // might bind to the same port, resulting in a port conflict.
-          port = PortUtils.randomOpenPort()
-          return Mongod.builder()
-            .processOutput(Start.to(ProcessOutput)
-            .initializedWith(ProcessOutput.builder()
-            .output(Processors.logTo(logger, Slf4jLevel.INFO))
-            .error(Processors.logTo(logger, Slf4jLevel.ERROR))
-            .commands(Processors.named("[console>]", Processors.logTo(logger, Slf4jLevel.DEBUG)))
-            .build()))
-            .net(Start.to(Net).initializedWith(Net.of("localhost", port, Network.localhostIsIPv6())))
-            .build()
-            //force a old mongodb version to be compatible with driver version we test
-            .start(Version.Main.V3_2).current()
-        } finally {
-          lock.release()
-        }
-      }
-    }
+  def setupSpec() throws Exception {
+    mongoDbContainer = new MongoDBContainer(mongodbImageName())
+    mongoDbContainer.start()
+    port = mongoDbContainer.getMappedPort(27017)
+    logger.info("MongoDB started on port {}", port)
   }
 
   def cleanupSpec() throws Exception {
-    mongodProcess?.stop()
-    mongodProcess = null
+    mongoDbContainer.stop()
+    mongoDbContainer = null
   }
 
   def randomCollectionName() {
@@ -99,7 +53,14 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
 
   def matchesStatement(statement) {
     return {
-      assert it.replace(" ", "").replace(",\"\$db\":\"$databaseName\"", "").replace(',"lsid":{"id":"?"}', '').replace(',"readPreference":{"node":"?"}', '').replace(',"autoIndexId":"?"', '').replace(',"$readPreference":{"mode":"?"}', '') == statement
+      assert it.replace(" ", "").
+      replace(",\"\$db\":\"$databaseName\"", "").
+      replace(',"lsid":{"id":"?"}', '').
+      replace(',"readPreference":{"node":"?"}', '').
+      replace(',"autoIndexId":"?"', '').
+      replace(',"$readPreference":{"mode":"?"}', '').
+      replace(',"txnNumber":"?"', '').
+      replace(',"$clusterTime":{"clusterTime":"?","signature":{"hash":"?","keyId":"?"}}', '') == statement
       return true
     }
   }

--- a/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/src/test/groovy/MongoBaseTest.groovy
@@ -91,12 +91,4 @@ abstract class MongoBaseTest extends VersionedNamingTestBase {
       }
     }
   }
-
-  def "test port open"() {
-    when:
-    new Socket("localhost", port)
-
-    then:
-    noExceptionThrown()
-  }
 }


### PR DESCRIPTION
# What Does This Do

MongoDB 4.10-11 instrumentation fix

# Motivation

In mongo-java-driver starting from 4.10 some instrumented classes has changed method signatures.
Specifically, the `BaseCluster` and `DefaultConnectionPool` classes have changed the `selectServerAsync` and `getAsync` method signatures:

`BaseCluster` class:
4.9 - `public void selectServerAsync(final ServerSelector serverSelector, final SingleResultCallback<ServerTuple> callback)`
4.10 - `public void selectServerAsync(final ServerSelector serverSelector, final OperationContext operationContext, final SingleResultCallback<ServerTuple> callback)`

`DefaultConnectionPool` class:
4.9 - `public void getAsync(final SingleResultCallback<InternalConnection> callback)`
4.10 - `public void getAsync(final OperationContext operationContext, final SingleResultCallback<InternalConnection> callback)`

# Additional Notes

Reproducer: https://github.com/DataDog/trace-java-examples/pull/1

- [x] Implement unit tests to cover all versions `4.3`..`4.11`


Jira ticket: [APMJAVA-1014] [APMS-11035]
GitHub ticket: #5702 


[APMJAVA-1014]: https://datadoghq.atlassian.net/browse/APMJAVA-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APMS-11035]: https://datadoghq.atlassian.net/browse/APMS-11035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ