### PR TITLE
Fix ContextStore#putIfAbsent method to not use a lambda

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/ContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/ContextStore.java
@@ -16,10 +16,14 @@ public interface ContextStore<K, C> {
    *
    * @param <C> context type
    */
-  interface Factory<C> {
+  interface Factory<K, C> extends KeyAwareFactory<K, C> {
 
     /** @return new context instance */
     C create();
+
+    default C create(K key) {
+      return create();
+    }
   }
 
   /**
@@ -67,7 +71,7 @@ public interface ContextStore<K, C> {
    * @param contextFactory factory instance to produce new context object
    * @return old instance if it was present, or new instance
    */
-  C putIfAbsent(K key, Factory<C> contextFactory);
+  C putIfAbsent(K key, Factory<K, C> contextFactory);
 
   /**
    * Put new context instance if key is absent. Uses context factory to avoid creating objects if

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/ContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/ContextStore.java
@@ -16,12 +16,12 @@ public interface ContextStore<K, C> {
    *
    * @param <C> context type
    */
-  interface Factory<K, C> extends KeyAwareFactory<K, C> {
+  interface Factory<C> extends KeyAwareFactory<Object, C> {
 
     /** @return new context instance */
     C create();
 
-    default C create(K key) {
+    default C create(Object key) {
       return create();
     }
   }
@@ -71,7 +71,7 @@ public interface ContextStore<K, C> {
    * @param contextFactory factory instance to produce new context object
    * @return old instance if it was present, or new instance
    */
-  C putIfAbsent(K key, Factory<K, C> contextFactory);
+  C putIfAbsent(K key, Factory<C> contextFactory);
 
   /**
    * Put new context instance if key is absent. Uses context factory to avoid creating objects if
@@ -81,7 +81,7 @@ public interface ContextStore<K, C> {
    * @param contextFactory factory instance to produce new context object
    * @return old instance if it was present, or new instance
    */
-  C computeIfAbsent(K key, KeyAwareFactory<K, C> contextFactory);
+  C computeIfAbsent(K key, KeyAwareFactory<? super K, C> contextFactory);
 
   /**
    * Removes the existing value for key and return it.

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
@@ -50,12 +50,13 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
   }
 
   @Override
-  public Object putIfAbsent(final Object key, final Factory<Object, Object> contextFactory) {
+  public Object putIfAbsent(final Object key, final Factory<Object> contextFactory) {
     return computeIfAbsent(key, contextFactory);
   }
 
   @Override
-  public Object computeIfAbsent(Object key, KeyAwareFactory<Object, Object> contextFactory) {
+  public Object computeIfAbsent(
+      Object key, KeyAwareFactory<? super Object, Object> contextFactory) {
     if (key instanceof FieldBackedContextAccessor) {
       final FieldBackedContextAccessor accessor = (FieldBackedContextAccessor) key;
       Object existingContext = accessor.$get$__datadogContext$(storeId);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
@@ -50,8 +50,8 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
   }
 
   @Override
-  public Object putIfAbsent(final Object key, final Factory<Object> contextFactory) {
-    return computeIfAbsent(key, k -> contextFactory.create());
+  public Object putIfAbsent(final Object key, final Factory<Object, Object> contextFactory) {
+    return computeIfAbsent(key, contextFactory);
   }
 
   @Override

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
@@ -54,8 +54,8 @@ final class WeakMapContextStore<K, V> implements ContextStore<K, V> {
   }
 
   @Override
-  public V putIfAbsent(final K key, final Factory<V> contextFactory) {
-    return computeIfAbsent(key, k -> contextFactory.create());
+  public V putIfAbsent(final K key, final Factory<K, V> contextFactory) {
+    return computeIfAbsent(key, contextFactory);
   }
 
   @Override

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapContextStore.java
@@ -54,12 +54,12 @@ final class WeakMapContextStore<K, V> implements ContextStore<K, V> {
   }
 
   @Override
-  public V putIfAbsent(final K key, final Factory<K, V> contextFactory) {
+  public V putIfAbsent(final K key, final Factory<V> contextFactory) {
     return computeIfAbsent(key, contextFactory);
   }
 
   @Override
-  public V computeIfAbsent(K key, KeyAwareFactory<K, V> contextFactory) {
+  public V computeIfAbsent(K key, KeyAwareFactory<? super K, V> contextFactory) {
     V existingContext = get(key);
     if (null == existingContext) {
       // This whole part with using synchronized is only because


### PR DESCRIPTION
# What Does This Do
Fixes `ContextStore#putIfAbsent` implementations following a change introduced in [PR#6332](https://github.com/DataDog/dd-trace-java/pull/6332)

Jira ticket: [CIVIS-8243]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8243]: https://datadoghq.atlassian.net/browse/CIVIS-8243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ