### PR TITLE
Fix kinesis dsm flaky tests

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/kinesisDsmTest/groovy/AWS1KinesisClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/kinesisDsmTest/groovy/AWS1KinesisClientTest.groovy
@@ -20,6 +20,7 @@ import spock.util.concurrent.PollingConditions
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
@@ -65,6 +66,13 @@ abstract class AWS1KinesisClientTest extends VersionedNamingTestBase {
   protected boolean isDataStreamsEnabled() {
     return true
   }
+
+  @Override
+  protected long dataStreamsBucketDuration() {
+    TimeUnit.MILLISECONDS.toNanos(250)
+  }
+
+
 
   @Override
   String operation() {

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/kinesisDsmTest/groovy/Aws2KinesisDataStreamsTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/kinesisDsmTest/groovy/Aws2KinesisDataStreamsTest.groovy
@@ -30,6 +30,7 @@ import spock.lang.Unroll
 
 import java.time.Instant
 import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
@@ -98,6 +99,11 @@ abstract class Aws2KinesisDataStreamsTest extends VersionedNamingTestBase {
   @Override
   protected boolean isDataStreamsEnabled() {
     true
+  }
+
+  @Override
+  protected long dataStreamsBucketDuration() {
+    TimeUnit.MILLISECONDS.toNanos(250)
   }
 
   abstract String expectedOperation(String awsService, String awsOperation)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -256,6 +256,10 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     return false
   }
 
+  protected long dataStreamsBucketDuration() {
+    TimeUnit.MILLISECONDS.toNanos(50)
+  }
+
   protected boolean isTestAgentEnabled() {
     return System.getenv("CI_USE_TEST_AGENT").equals("true")
   }
@@ -302,7 +306,7 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
       }
 
     // Fast enough so tests don't take forever
-    long bucketDuration = TimeUnit.MILLISECONDS.toNanos(50)
+    long bucketDuration = dataStreamsBucketDuration()
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "my-env", "service", "version", "language")
     TEST_DATA_STREAMS_MONITORING = new DefaultDataStreamsMonitoring(sink, features, SystemTimeSource.INSTANCE, { MOCK_DSM_TRACE_CONFIG }, wellKnownTags, TEST_DATA_STREAMS_WRITER, bucketDuration)
 


### PR DESCRIPTION
# What Does This Do

Increase the bucket duration to be sure that the number of stats that are assumed to be collected fits in one bucket duration.

Note: I could not increase the bucket duration for all the tests since that caused other issues on other kafka related dsm tests. Hence limiting only to kinesis

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
