### PR TITLE
Add support for tracestate extraction from OpenTelemetry API

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
+++ b/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
@@ -72,6 +72,19 @@
     ]
   },
   {
+    "name" : "io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator",
+    "methods": [
+      {"name": "extractTraceState", "parameterTypes": ["io.opentelemetry.api.trace.TraceState", "java.lang.String"] }
+    ]
+  },
+  {
+    "name" : "io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding",
+    "methods": [
+      {"name": "decodeTraceState", "parameterTypes": ["io.opentelemetry.api.trace.TraceState", "java.lang.String"] },
+      {"name": "encodeTraceState", "parameterTypes": ["java.lang.String", "io.opentelemetry.api.trace.TraceState"] }
+    ]
+  },
+  {
     "name" : "org.jctools.queues.MpscBlockingConsumerArrayQueueColdProducerFields",
     "fields": [
       {"name": "producerLimit", "allowUnsafeAccess": true}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
@@ -63,6 +63,7 @@ public class OpenTelemetryInstrumentation extends Instrumenter.Tracing
       packageName + ".context.OtelScope",
       packageName + ".context.propagation.AgentTextMapPropagator",
       packageName + ".context.propagation.OtelContextPropagators",
+      packageName + ".context.propagation.TraceStateHelper",
       packageName + ".trace.OtelExtractedContext",
       packageName + ".trace.OtelConventions",
       packageName + ".trace.OtelConventions$1",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/propagation/TraceStateHelper.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/propagation/TraceStateHelper.java
@@ -1,0 +1,158 @@
+package datadog.trace.instrumentation.opentelemetry14.context.propagation;
+
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class helps to decode W3C tracestate header into a {@link TraceState} instance using OTel
+ * API.
+ */
+public class TraceStateHelper {
+  private static final int TRACESTATE_MAX_SIZE = 512;
+  private static final char TRACESTATE_ENTRY_DELIMITER = ',';
+  private static final char TRACESTATE_KEY_VALUE_DELIMITER = '=';
+
+  private static final Function<String, TraceState> DECODER;
+  private static final Function<TraceState, String> ENCODER;
+  private static final Logger LOGGER = LoggerFactory.getLogger(TraceStateHelper.class);
+
+  static {
+    DECODER = lookForDecoder();
+    ENCODER = lookForEncoder();
+  }
+
+  /**
+   * Looks for a {@link TraceState} decoder function. Tries to use:
+   *
+   * <ul>
+   *   <li>W3CTraceContextEncoding.decodeTraceState(String):TraceState static helper if available,
+   *   <li>W3CTraceContextPropagator.extractTraceState(String):TraceState private method otherwise,
+   *   <li>A default trace state provider if none of the above solution worked.
+   * </ul>
+   *
+   * @return The {@link TraceState} decoder function
+   */
+  private static Function<String, TraceState> lookForDecoder() {
+    Function<String, TraceState> decoder = header -> TraceState.getDefault();
+    try {
+      try {
+        Class<?> encodingClass =
+            Class.forName(
+                "io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding",
+                false,
+                W3CTraceContextPropagator.class.getClassLoader());
+        MethodHandle decodeTraceStateHandle =
+            MethodHandles.lookup()
+                .findStatic(
+                    encodingClass,
+                    "decodeTraceState",
+                    MethodType.methodType(TraceState.class, String.class));
+        decoder =
+            header -> {
+              try {
+                return (TraceState) decodeTraceStateHandle.invokeExact(header);
+              } catch (Throwable t) {
+                return TraceState.getDefault();
+              }
+            };
+      } catch (ClassNotFoundException e) {
+        // The W3CTraceContextEncoding class is not available is older versions of OTel
+        // Try to use W3CTraceContextPropagator.extractTraceState(String):String instead
+        Class<W3CTraceContextPropagator> propagatorClass = W3CTraceContextPropagator.class;
+        Method extractTraceStateMethod =
+            propagatorClass.getDeclaredMethod("extractTraceState", String.class);
+        extractTraceStateMethod.setAccessible(true);
+        MethodHandle extractTraceStateHandle =
+            MethodHandles.lookup()
+                .unreflect(extractTraceStateMethod)
+                .asType(MethodType.methodType(TraceState.class, String.class));
+        decoder =
+            header -> {
+              try {
+                return (TraceState) extractTraceStateHandle.invokeExact(header);
+              } catch (Throwable t) {
+                return TraceState.getDefault();
+              }
+            };
+      }
+    } catch (Throwable t) {
+      // Failed to find a tracestate decoder
+      LOGGER.debug("Unable to setup OpenTelemetry instrumentation tracestate decoder", t);
+    }
+    return decoder;
+  }
+
+  /**
+   * Looks for a {@link TraceState} encoder function. Tries to use:
+   *
+   * <ul>
+   *   <li>W3CTraceContextEncoding.encodeTraceStace(TraceStace):String static helper if available,
+   *   <li>A basic vendor implementation if none of the above solution worked.
+   * </ul>
+   *
+   * @return The {@link TraceState} decoder function
+   */
+  private static Function<TraceState, String> lookForEncoder() {
+    Function<TraceState, String> encoder = tracestate -> "";
+    try {
+      try {
+        Class<?> encodingClass =
+            Class.forName(
+                "io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding",
+                false,
+                W3CTraceContextPropagator.class.getClassLoader());
+        MethodHandle encodeTraceStateHandle =
+            MethodHandles.lookup()
+                .findStatic(
+                    encodingClass,
+                    "encodeTraceState",
+                    MethodType.methodType(String.class, TraceState.class));
+        encoder =
+            tracestate -> {
+              try {
+                return (String) encodeTraceStateHandle.invokeExact(tracestate);
+              } catch (Throwable t) {
+                return "";
+              }
+            };
+      } catch (final ClassNotFoundException e) {
+        encoder = TraceStateHelper::encodeTraceState;
+      }
+    } catch (Throwable t) {
+      // Failed to find a tracestate encoder
+      LOGGER.debug("Unable to setup OpenTelemetry instrumentation tracestate decoder", t);
+    }
+    return encoder;
+  }
+
+  // Inspired from W3CTraceContextEncoding.encodeTraceState only available in API later versions.
+  private static String encodeTraceState(TraceState traceState) {
+    if (traceState.isEmpty()) {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder(TRACESTATE_MAX_SIZE);
+    traceState.forEach(
+        (key, value) -> {
+          if (builder.length() != 0) {
+            builder.append(TRACESTATE_ENTRY_DELIMITER);
+          }
+          builder.append(key).append(TRACESTATE_KEY_VALUE_DELIMITER).append(value);
+        });
+    return builder.toString();
+  }
+
+  public static TraceState decodeHeader(String header) {
+    return DECODER.apply(header);
+  }
+
+  public static String encodeHeader(TraceState tracestate) {
+    return ENCODER.apply(tracestate);
+  }
+}

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/propagation/TraceStateHelper.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/propagation/TraceStateHelper.java
@@ -1,139 +1,51 @@
 package datadog.trace.instrumentation.opentelemetry14.context.propagation;
 
 import io.opentelemetry.api.trace.TraceState;
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.Method;
-import java.util.function.Function;
+import io.opentelemetry.api.trace.TraceStateBuilder;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * This class helps to decode W3C tracestate header into a {@link TraceState} instance using OTel
- * API.
- */
-public class TraceStateHelper {
+/** This class helps to decode W3C tracestate header into a {@link TraceState} instance. */
+public final class TraceStateHelper {
   private static final int TRACESTATE_MAX_SIZE = 512;
   private static final char TRACESTATE_ENTRY_DELIMITER = ',';
   private static final char TRACESTATE_KEY_VALUE_DELIMITER = '=';
-
-  private static final Function<String, TraceState> DECODER;
-  private static final Function<TraceState, String> ENCODER;
+  private static final Pattern TRACESTATE_ENTRY_DELIMITER_SPLIT_PATTERN =
+      Pattern.compile("[ \t]*,[ \t]*");
   private static final Logger LOGGER = LoggerFactory.getLogger(TraceStateHelper.class);
 
-  static {
-    DECODER = lookForDecoder();
-    ENCODER = lookForEncoder();
-  }
+  private TraceStateHelper() {}
 
-  /**
-   * Looks for a {@link TraceState} decoder function. Tries to use:
-   *
-   * <ul>
-   *   <li>W3CTraceContextEncoding.decodeTraceState(String):TraceState static helper if available,
-   *   <li>W3CTraceContextPropagator.extractTraceState(String):TraceState private method otherwise,
-   *   <li>A default trace state provider if none of the above solution worked.
-   * </ul>
-   *
-   * @return The {@link TraceState} decoder function
-   */
-  private static Function<String, TraceState> lookForDecoder() {
-    Function<String, TraceState> decoder = header -> TraceState.getDefault();
-    try {
-      try {
-        Class<?> encodingClass =
-            Class.forName(
-                "io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding",
-                false,
-                W3CTraceContextPropagator.class.getClassLoader());
-        MethodHandle decodeTraceStateHandle =
-            MethodHandles.lookup()
-                .findStatic(
-                    encodingClass,
-                    "decodeTraceState",
-                    MethodType.methodType(TraceState.class, String.class));
-        decoder =
-            header -> {
-              try {
-                return (TraceState) decodeTraceStateHandle.invokeExact(header);
-              } catch (Throwable t) {
-                return TraceState.getDefault();
-              }
-            };
-      } catch (ClassNotFoundException e) {
-        // The W3CTraceContextEncoding class is not available is older versions of OTel
-        // Try to use W3CTraceContextPropagator.extractTraceState(String):String instead
-        Class<W3CTraceContextPropagator> propagatorClass = W3CTraceContextPropagator.class;
-        Method extractTraceStateMethod =
-            propagatorClass.getDeclaredMethod("extractTraceState", String.class);
-        extractTraceStateMethod.setAccessible(true);
-        MethodHandle extractTraceStateHandle =
-            MethodHandles.lookup()
-                .unreflect(extractTraceStateMethod)
-                .asType(MethodType.methodType(TraceState.class, String.class));
-        decoder =
-            header -> {
-              try {
-                return (TraceState) extractTraceStateHandle.invokeExact(header);
-              } catch (Throwable t) {
-                return TraceState.getDefault();
-              }
-            };
-      }
-    } catch (Throwable t) {
-      // Failed to find a tracestate decoder
-      LOGGER.debug("Unable to setup OpenTelemetry instrumentation tracestate decoder", t);
+  // Inspired from W3CTraceContextEncoding.decodeTraceState only available in API later versions.
+  public static TraceState decodeHeader(String header) {
+    TraceStateBuilder traceStateBuilder = TraceState.builder();
+    String[] listMembers = TRACESTATE_ENTRY_DELIMITER_SPLIT_PATTERN.split(header);
+    if (listMembers.length > 32) {
+      LOGGER.warn("TraceState has too many elements: {}", header);
+      return TraceState.getDefault();
     }
-    return decoder;
-  }
 
-  /**
-   * Looks for a {@link TraceState} encoder function. Tries to use:
-   *
-   * <ul>
-   *   <li>W3CTraceContextEncoding.encodeTraceStace(TraceStace):String static helper if available,
-   *   <li>A basic vendor implementation if none of the above solution worked.
-   * </ul>
-   *
-   * @return The {@link TraceState} decoder function
-   */
-  private static Function<TraceState, String> lookForEncoder() {
-    Function<TraceState, String> encoder = tracestate -> "";
-    try {
-      try {
-        Class<?> encodingClass =
-            Class.forName(
-                "io.opentelemetry.api.trace.propagation.internal.W3CTraceContextEncoding",
-                false,
-                W3CTraceContextPropagator.class.getClassLoader());
-        MethodHandle encodeTraceStateHandle =
-            MethodHandles.lookup()
-                .findStatic(
-                    encodingClass,
-                    "encodeTraceState",
-                    MethodType.methodType(String.class, TraceState.class));
-        encoder =
-            tracestate -> {
-              try {
-                return (String) encodeTraceStateHandle.invokeExact(tracestate);
-              } catch (Throwable t) {
-                return "";
-              }
-            };
-      } catch (final ClassNotFoundException e) {
-        encoder = TraceStateHelper::encodeTraceState;
+    for (int i = listMembers.length - 1; i >= 0; --i) {
+      String listMember = listMembers[i];
+      int index = listMember.indexOf(61);
+      if (index == -1) {
+        LOGGER.warn("Invalid TraceState list-member format: {}", listMember);
+        return TraceState.getDefault();
       }
-    } catch (Throwable t) {
-      // Failed to find a tracestate encoder
-      LOGGER.debug("Unable to setup OpenTelemetry instrumentation tracestate decoder", t);
+      traceStateBuilder.put(listMember.substring(0, index), listMember.substring(index + 1));
     }
-    return encoder;
+
+    TraceState traceState = traceStateBuilder.build();
+    if (traceState.size() != listMembers.length) {
+      return TraceState.getDefault();
+    } else {
+      return traceState;
+    }
   }
 
   // Inspired from W3CTraceContextEncoding.encodeTraceState only available in API later versions.
-  private static String encodeTraceState(TraceState traceState) {
+  public static String encodeHeader(TraceState traceState) {
     if (traceState.isEmpty()) {
       return "";
     }
@@ -146,13 +58,5 @@ public class TraceStateHelper {
           builder.append(key).append(TRACESTATE_KEY_VALUE_DELIMITER).append(value);
         });
     return builder.toString();
-  }
-
-  public static TraceState decodeHeader(String header) {
-    return DECODER.apply(header);
-  }
-
-  public static String encodeHeader(TraceState tracestate) {
-    return ENCODER.apply(tracestate);
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanLink.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/trace/OtelSpanLink.java
@@ -4,15 +4,11 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.bootstrap.instrumentation.api.SpanLink;
 import datadog.trace.bootstrap.instrumentation.api.SpanLinkAttributes;
+import datadog.trace.instrumentation.opentelemetry14.context.propagation.TraceStateHelper;
 import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.TraceState;
 import java.util.List;
 
 public class OtelSpanLink extends SpanLink {
-  private static final int TRACESTATE_MAX_SIZE = 512;
-  private static final char TRACESTATE_ENTRY_DELIMITER = ',';
-  private static final char TRACESTATE_KEY_VALUE_DELIMITER = '=';
-
   public OtelSpanLink(SpanContext spanContext) {
     this(spanContext, io.opentelemetry.api.common.Attributes.empty());
   }
@@ -22,24 +18,8 @@ public class OtelSpanLink extends SpanLink {
         DDTraceId.fromHex(spanContext.getTraceId()),
         DDSpanId.fromHex(spanContext.getSpanId()),
         spanContext.isSampled() ? SAMPLED_FLAG : DEFAULT_FLAGS,
-        encodeTraceState(spanContext.getTraceState()),
+        TraceStateHelper.encodeHeader(spanContext.getTraceState()),
         convertAttributes(attributes));
-  }
-
-  // Inspired from W3CTraceContextEncoding.encodeTraceState only available in API later versions.
-  private static String encodeTraceState(TraceState traceState) {
-    if (traceState.isEmpty()) {
-      return "";
-    }
-    StringBuilder builder = new StringBuilder(TRACESTATE_MAX_SIZE);
-    traceState.forEach(
-        (key, value) -> {
-          if (builder.length() != 0) {
-            builder.append(TRACESTATE_ENTRY_DELIMITER);
-          }
-          builder.append(key).append(TRACESTATE_KEY_VALUE_DELIMITER).append(value);
-        });
-    return builder.toString();
   }
 
   private static Attributes convertAttributes(io.opentelemetry.api.common.Attributes attributes) {

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
@@ -1,8 +1,8 @@
 package opentelemetry14.context.propagation
 
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.DD128bTraceId
 import datadog.trace.api.DDSpanId
+import datadog.trace.api.DDTraceId
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ThreadLocalContextStorage
@@ -12,6 +12,8 @@ import io.opentelemetry.context.propagation.TextMapSetter
 import spock.lang.Subject
 
 import javax.annotation.Nullable
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
 
 abstract class AbstractPropagatorTest extends AgentTestRunner {
   static int testInstance
@@ -57,13 +59,14 @@ abstract class AbstractPropagatorTest extends AgentTestRunner {
    * @param headers The injected headers.
    * @param traceId The continued trace identifier.
    * @param spanId The child span identifier.
-   * @param sampled Whether the child span is sampled.
+   * @param sampling The sampling decision.
    */
-  abstract void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled)
+  abstract void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, byte sampling)
 
   def "test context extraction and injection"() {
     setup:
     def propagator = propagator()
+    def expectedSampled = sampling == SAMPLER_KEEP
 
     when:
     def context = propagator.extract(Context.root(), headers, new TextMap())
@@ -90,17 +93,21 @@ abstract class AbstractPropagatorTest extends AgentTestRunner {
         span {
           operationName "internal"
           resourceName "some-name"
-          traceDDId(DD128bTraceId.fromHex(traceId))
+          traceDDId(expectedTraceId(traceId))
           parentSpanId(DDSpanId.fromHex(spanId).toLong() as BigInteger)
         }
       }
     }
-    spanSampled == sampled
-    assertInjectedHeaders(injectedHeaders, traceId, localSpanId, sampled)
+    spanSampled == expectedSampled
+    assertInjectedHeaders(injectedHeaders, traceId, localSpanId, sampling)
 
     where:
     values << values()
-    (headers, traceId, spanId, sampled) = values
+    (headers, traceId, spanId, sampling) = values
+  }
+
+  def expectedTraceId(String traceId) {
+    return DDTraceId.fromHex(traceId)
   }
 
   @Override

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/AbstractPropagatorTest.groovy
@@ -14,8 +14,10 @@ import spock.lang.Subject
 import javax.annotation.Nullable
 
 abstract class AbstractPropagatorTest extends AgentTestRunner {
+  static int testInstance
+
   @Subject
-  def tracer = GlobalOpenTelemetry.get().tracerProvider.get("propagator" + Math.random()) // TODO FIX LATER
+  def tracer = GlobalOpenTelemetry.get().tracerProvider.get("propagator" + testInstance++)
 
   @Override
   void configurePreAgent() {

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/B3MultiPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/B3MultiPropagatorTest.groovy
@@ -1,5 +1,10 @@
 package opentelemetry14.context.propagation
 
+import datadog.trace.core.propagation.B3TraceId
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.UNSET
 import static datadog.trace.core.propagation.B3HttpCodec.SAMPLING_PRIORITY_KEY
 import static datadog.trace.core.propagation.B3HttpCodec.SPAN_ID_KEY
 import static datadog.trace.core.propagation.B3HttpCodec.TRACE_ID_KEY
@@ -14,19 +19,25 @@ class B3MultiPropagatorTest extends AgentPropagatorTest {
   def values() {
     // spotless:off
     return [
-      [[(TRACE_ID_KEY): '1', (SPAN_ID_KEY):'2'],                                                                             '1' ,                               '2' ,               false],
-      [[(TRACE_ID_KEY): '1111111111111111', (SPAN_ID_KEY):'2222222222222222'],                                               '1111111111111111'                , '2222222222222222', false],
-      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222'],                               '11111111111111111111111111111111', '2222222222222222', false],
-      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222', (SAMPLING_PRIORITY_KEY): '0'], '11111111111111111111111111111111', '2222222222222222', false],
-      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222', (SAMPLING_PRIORITY_KEY): '1'], '11111111111111111111111111111111', '2222222222222222', true],
+      [[(TRACE_ID_KEY): '1', (SPAN_ID_KEY):'2'],                                                                             '1' ,                               '2' ,               UNSET],
+      [[(TRACE_ID_KEY): '1111111111111111', (SPAN_ID_KEY):'2222222222222222'],                                               '1111111111111111'                , '2222222222222222', UNSET],
+      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222'],                               '11111111111111111111111111111111', '2222222222222222', UNSET],
+      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222', (SAMPLING_PRIORITY_KEY): '0'], '11111111111111111111111111111111', '2222222222222222', SAMPLER_DROP],
+      [[(TRACE_ID_KEY): '11111111111111111111111111111111', (SPAN_ID_KEY):'2222222222222222', (SAMPLING_PRIORITY_KEY): '1'], '11111111111111111111111111111111', '2222222222222222', SAMPLER_KEEP],
     ]
     // spotless:on
   }
 
   @Override
-  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
+  def expectedTraceId(String traceId) {
+    return B3TraceId.fromHex(traceId)
+  }
+
+  @Override
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, byte sampling) {
+    def priorityKey = sampling == SAMPLER_DROP ? '0' : '1' // Deterministic sampler with rate to 1 if not explicitly dropped
     assert headers[TRACE_ID_KEY] == traceId.padLeft(32, '0')
     assert headers[SPAN_ID_KEY] == spanId.padLeft(8, '0')
-    assert headers[SAMPLING_PRIORITY_KEY] == "1" // Deterministic sampler with rate to 1
+    assert headers[SAMPLING_PRIORITY_KEY] == priorityKey
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/B3SinglePropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/B3SinglePropagatorTest.groovy
@@ -1,5 +1,11 @@
 package opentelemetry14.context.propagation
 
+
+import datadog.trace.core.propagation.B3TraceId
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.UNSET
 import static datadog.trace.core.propagation.B3HttpCodec.B3_KEY
 
 class B3SinglePropagatorTest extends AgentPropagatorTest {
@@ -12,18 +18,23 @@ class B3SinglePropagatorTest extends AgentPropagatorTest {
   def values() {
     // spotless:off
     return [
-      [[(B3_KEY): '1-2'], '1' , '2' , false],
-      [[(B3_KEY): '1111111111111111-2222222222222222'],                   '1111111111111111',                 '2222222222222222', false],
-      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222'],   '11111111111111111111111111111111', '2222222222222222', false],
-      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222-0'], '11111111111111111111111111111111', '2222222222222222', false],
-      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222-1'], '11111111111111111111111111111111', '2222222222222222', true],
+      [[(B3_KEY): '1-2'],                                                 '1',                                '2',                UNSET],
+      [[(B3_KEY): '1111111111111111-2222222222222222'],                   '1111111111111111',                 '2222222222222222', UNSET],
+      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222'],   '11111111111111111111111111111111', '2222222222222222', UNSET],
+      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222-0'], '11111111111111111111111111111111', '2222222222222222', SAMPLER_DROP],
+      [[(B3_KEY): '11111111111111111111111111111111-2222222222222222-1'], '11111111111111111111111111111111', '2222222222222222', SAMPLER_KEEP],
     ]
     // spotless:on
   }
 
   @Override
-  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
-    def sampledValue = "1" // Deterministic sampler with rate to 1
+  def expectedTraceId(String traceId) {
+    return B3TraceId.fromHex(traceId)
+  }
+
+  @Override
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, byte sampling) {
+    def sampledValue = sampling == SAMPLER_DROP ? '0' : '1' // Deterministic sampler with rate to 1 if not explicitly dropped
     assert headers[B3_KEY] == "${traceId.padLeft(32, '0')}-${spanId.padLeft(8, '0')}-$sampledValue"
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/DatadogPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/DatadogPropagatorTest.groovy
@@ -3,6 +3,7 @@ package opentelemetry14.context.propagation
 
 import datadog.trace.api.DDTraceId
 
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
 import static datadog.trace.api.sampling.PrioritySampling.UNSET
 import static java.lang.Long.parseLong
@@ -16,26 +17,27 @@ class DatadogPropagatorTest extends AgentPropagatorTest {
   def values() {
     // spotless:off
     return [
-      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}"],                                                                                                 '00000000000000001111111111111111', '2222222222222222', false],
-      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-tags': '_dd.p.tid=1111111111111111'],                                                 '11111111111111111111111111111111', '2222222222222222', false],
-      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-sampling-priority': "$SAMPLER_KEEP", 'x-datadog-tags': '_dd.p.tid=1111111111111111'], '11111111111111111111111111111111', '2222222222222222', true],
-      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-sampling-priority': "$UNSET", 'x-datadog-tags': '_dd.p.tid=1111111111111111'],        '11111111111111111111111111111111', '2222222222222222', false],
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}"],                                                                                                                 '1111111111111111', '2222222222222222', UNSET],
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-tags': '_dd.p.tid=1111111111111111'],                                                 '11111111111111111111111111111111', '2222222222222222', UNSET],
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-sampling-priority': "$SAMPLER_KEEP", 'x-datadog-tags': '_dd.p.tid=1111111111111111'], '11111111111111111111111111111111', '2222222222222222', SAMPLER_KEEP],
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-sampling-priority': "$UNSET", 'x-datadog-tags': '_dd.p.tid=1111111111111111'],        '11111111111111111111111111111111', '2222222222222222', UNSET],
+      [['x-datadog-trace-id': "${parseLong('1111111111111111', 16)}", 'x-datadog-parent-id': "${parseLong('2222222222222222', 16)}", 'x-datadog-sampling-priority': "$SAMPLER_DROP", 'x-datadog-tags': '_dd.p.tid=1111111111111111'], '11111111111111111111111111111111', '2222222222222222', SAMPLER_DROP],
     ]
     // spotless:on
   }
 
-  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, byte sampling) {
     assert headers['x-datadog-trace-id'] == Long.toString(DDTraceId.fromHex(traceId).toLong())
     assert headers['x-datadog-parent-id'] == spanId.replaceAll('^0+(?!$)', '')
     def tags = []
-    if (!sampled) {
+    def samplingPriority = sampling == SAMPLER_DROP ? '0' : '1' // Deterministic sampler with rate to 1 if not explicitly dropped
+    if (sampling == UNSET) {
       tags+= '_dd.p.dm=-1'
     }
-    def highOrderBits = traceId.substring(0, 16)
-    if (highOrderBits != '0000000000000000') {
-      tags+= '_dd.p.tid='+highOrderBits
+    if (traceId.length() == 32) {
+      tags+= '_dd.p.tid='+ traceId.substring(0, 16)
     }
     assert headers['x-datadog-tags'] == tags.join(',')
-    assert headers['x-datadog-sampling-priority'] == '1' // Deterministic sampler with rate to 1
+    assert headers['x-datadog-sampling-priority'] == samplingPriority
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/OtelW3cPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/OtelW3cPropagatorTest.groovy
@@ -1,8 +1,10 @@
 package opentelemetry14.context.propagation
 
-
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.TextMapPropagator
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.UNSET
 
 class OtelW3cPropagatorTest extends AbstractPropagatorTest {
   @Override
@@ -20,15 +22,15 @@ class OtelW3cPropagatorTest extends AbstractPropagatorTest {
   def values() {
     // spotless:off
     return [
-      [['traceparent': '00-00000000000000001111111111111111-2222222222222222-00'], '00000000000000001111111111111111', '2222222222222222', false],
-      [['traceparent': '00-00000000000000001111111111111111-2222222222222222-01'], '00000000000000001111111111111111', '2222222222222222', true],
+      [['traceparent': '00-00000000000000001111111111111111-2222222222222222-00'], '00000000000000001111111111111111', '2222222222222222', UNSET],
+      [['traceparent': '00-00000000000000001111111111111111-2222222222222222-01'], '00000000000000001111111111111111', '2222222222222222', SAMPLER_KEEP],
     ]
     // spotless:on
   }
 
   @Override
-  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
-    def sampleFlag = sampled ? '01' : '00'
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, byte sampling) {
+    def sampleFlag = sampling == SAMPLER_KEEP ? '01' : '00'
     assert headers['traceparent'] ==  "00-$traceId-$spanId-$sampleFlag"
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/W3cPropagatorTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/W3cPropagatorTest.groovy
@@ -1,5 +1,8 @@
 package opentelemetry14.context.propagation
 
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP
+import static datadog.trace.api.sampling.PrioritySampling.UNSET
+
 class W3cPropagatorTest extends AgentPropagatorTest {
   @Override
   String style() {
@@ -10,15 +13,15 @@ class W3cPropagatorTest extends AgentPropagatorTest {
   def values() {
     // spotless:off
     return [
-      [['traceparent': '00-11111111111111111111111111111111-2222222222222222-00'], '11111111111111111111111111111111', '2222222222222222', false],
-      [['traceparent': '00-11111111111111111111111111111111-2222222222222222-01'], '11111111111111111111111111111111', '2222222222222222', true],
+      [['traceparent': '00-11111111111111111111111111111111-2222222222222222-00'], '11111111111111111111111111111111', '2222222222222222', UNSET],
+      [['traceparent': '00-11111111111111111111111111111111-2222222222222222-01'], '11111111111111111111111111111111', '2222222222222222', SAMPLER_KEEP],
     ]
     // spotless:on
   }
 
   @Override
-  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, boolean sampled) {
-    def traceFlags = "01" // Deterministic sampler with rate to 1
+  void assertInjectedHeaders(Map<String, String> headers, String traceId, String spanId, byte sampling) {
+    def traceFlags = sampling == SAMPLER_KEEP ? '01' : '00'
     assert headers['traceparent'] == "00-$traceId-$spanId-$traceFlags"
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/W3cPropagatorTracestateTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/propagation/W3cPropagatorTracestateTest.groovy
@@ -1,0 +1,72 @@
+package opentelemetry14.context.propagation
+
+import datadog.trace.agent.test.AgentTestRunner
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.context.Context
+import spock.lang.Subject
+
+class W3cPropagatorTracestateTest extends AgentTestRunner {
+  @Subject
+  def tracer = GlobalOpenTelemetry.get().tracerProvider.get("tracecontext-propagator-tracestate")
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig("dd.integration.opentelemetry.experimental.enabled", "true")
+    injectSysConfig("dd.trace.propagation.style", "tracecontext")
+  }
+
+  def "test tracestate propagation"() {
+    setup:
+    // Get agent propagator injected by instrumentation
+    def propagator = GlobalOpenTelemetry.get().getPropagators().getTextMapPropagator()
+    def headers = [
+      'traceparent': '00-11111111111111111111111111111111-2222222222222222-00'
+    ]
+    def members = new String[0]
+    if (tracestate) {
+      headers['tracestate'] = tracestate
+      members = Arrays.stream(tracestate.split(','))
+      .filter { !it.startsWith("dd=")}
+      .toArray(String[]::new)
+    }
+
+    when:
+    def context = propagator.extract(Context.root(), headers, new AbstractPropagatorTest.TextMap())
+
+    then:
+    context != Context.root()
+
+    when:
+    def localSpan = tracer.spanBuilder("some-name")
+      .setParent(context)
+      .startSpan()
+    def scope = localSpan.makeCurrent()
+    Map<String, String> injectedHeaders = [:]
+    propagator.inject(Context.current(), injectedHeaders, new AbstractPropagatorTest.TextMap())
+    scope.close()
+    localSpan.end()
+
+    then:
+    // Check tracestate was injected
+    def injectedTracestate = injectedHeaders['tracestate']
+    injectedTracestate != null
+    // Check tracestate contains extracted members plus the Datadog one in first position
+    def injectedMembers = injectedTracestate.split(',')
+    injectedMembers.length == Math.min(1 + members.length, 32)
+    injectedMembers[0] == "dd=s:0;t.tid:1111111111111111"
+    for (int i = 0; i< Math.min(members.length, 31); i++) {
+      assert injectedMembers[i+1] == members[i]
+    }
+
+    where:
+    // spotless:off
+    tracestate << [
+      "foo=1,bar=2",
+      "dd=s:0,foo=1,bar=2",
+      "foo=1,dd=s:0,bar=2",
+    ]
+    // spotless:on
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR will ensure that extracted context from OpenTelemetry API will respect W3C tracestate if any.
Such context can then be used as parent span or span links.

# Motivation

This will improve OpenTelemetry interoperability.

# Additional Notes

Previously, the W3C tracestate was dropped and not propagated to any downstream service.

Jira ticket: [APMJAVA-1060]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1060]: https://datadoghq.atlassian.net/browse/APMJAVA-1060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ