### PR TITLE
Fix the JFRAccess lookup

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/src/main/java/com/datadog/profiling/controller/jfr/SimpleJFRAccess.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/src/main/java/com/datadog/profiling/controller/jfr/SimpleJFRAccess.java
@@ -8,7 +8,15 @@ public class SimpleJFRAccess extends JFRAccess {
   public static class FactoryImpl implements JFRAccess.Factory {
     @Override
     public JFRAccess create(Instrumentation inst) {
-      return !Platform.isJ9() && Platform.isJavaVersion(8) ? new SimpleJFRAccess() : null;
+      if (Platform.isJavaVersion(8)) {
+        // if running on Java 8 return either SimpleJFRAccess or NOOP
+        // J9 and Oracle JDK 8 do not contain the required classes and methods to set the stackdepth
+        // programmatically
+        return !Platform.isJ9() && !Platform.isOracleJDK8()
+            ? new SimpleJFRAccess()
+            : JFRAccess.NOOP;
+      }
+      return null;
     }
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/src/test/java/com/datadog/profiling/controller/jfr/JFRAccessTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/src/test/java/com/datadog/profiling/controller/jfr/JFRAccessTest.java
@@ -12,7 +12,7 @@ public class JFRAccessTest {
   void testJava8JFRAccess() {
     // For Java 9 and above, the JFR access requires instrumentation in order to patch the module
     // access
-    assumeTrue(Platform.isJavaVersion(8) && !Platform.isJ9());
+    assumeTrue(Platform.isJavaVersion(8) && !Platform.isJ9() && !Platform.isOracleJDK8());
 
     // just do a sanity check that it is possible to instantiate the class and call
     // 'setStackDepth()'


### PR DESCRIPTION
# What Does This Do
It fixes a bug causing exception when running on some non-hotspot JDK 8 versions.

# Motivation
To fix the bug.

# Additional Notes

Jira ticket: [PROF-8805]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8805]: https://datadoghq.atlassian.net/browse/PROF-8805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ