### PR TITLE
Add emitting status for probes

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -64,7 +64,8 @@ public class CapturedContext implements ValueReferenceResolver {
   // used for EMPTY_CONTEXT
   private CapturedContext(ProbeImplementation probeImplementation) {
     if (probeImplementation != null) {
-      this.statusByProbeId.put(probeImplementation.getId(), probeImplementation.createStatus());
+      this.statusByProbeId.put(
+          probeImplementation.getProbeId().getEncodedId(), probeImplementation.createStatus());
     }
   }
 
@@ -328,13 +329,13 @@ public class CapturedContext implements ValueReferenceResolver {
   }
 
   public Status evaluate(
-      String probeId,
+      String encodedProbeId,
       ProbeImplementation probeImplementation,
       String thisClassName,
       long startTimestamp,
       MethodLocation methodLocation) {
     Status status =
-        statusByProbeId.computeIfAbsent(probeId, key -> probeImplementation.createStatus());
+        statusByProbeId.computeIfAbsent(encodedProbeId, key -> probeImplementation.createStatus());
     if (methodLocation == MethodLocation.EXIT) {
       duration = System.nanoTime() - startTimestamp;
       addExtension(
@@ -349,10 +350,10 @@ public class CapturedContext implements ValueReferenceResolver {
     return status;
   }
 
-  public Status getStatus(String probeId) {
-    Status result = statusByProbeId.get(probeId);
+  public Status getStatus(String encodedProbeId) {
+    Status result = statusByProbeId.get(encodedProbeId);
     if (result == null) {
-      result = statusByProbeId.get(ProbeImplementation.UNKNOWN.getId());
+      result = statusByProbeId.get(ProbeImplementation.UNKNOWN.getProbeId().getEncodedId());
       if (result == null) {
         return Status.EMPTY_STATUS;
       }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -39,23 +39,23 @@ public class DebuggerContext {
   }
 
   public interface MetricForwarder {
-    void count(String name, long delta, String[] tags);
+    void count(String probeId, String name, long delta, String[] tags);
 
-    void gauge(String name, long value, String[] tags);
+    void gauge(String probeId, String name, long value, String[] tags);
 
-    void gauge(String name, double value, String[] tags);
+    void gauge(String probeId, String name, double value, String[] tags);
 
-    void histogram(String name, long value, String[] tags);
+    void histogram(String probeId, String name, long value, String[] tags);
 
-    void histogram(String name, double value, String[] tags);
+    void histogram(String probeId, String name, double value, String[] tags);
 
-    void distribution(String name, long value, String[] tags);
+    void distribution(String probeId, String name, long value, String[] tags);
 
-    void distribution(String name, double value, String[] tags);
+    void distribution(String probeId, String name, double value, String[] tags);
   }
 
   public interface Tracer {
-    DebuggerSpan createSpan(String resourceName, String[] tags);
+    DebuggerSpan createSpan(String probeId, String resourceName, String[] tags);
   }
 
   public interface ValueSerializer {
@@ -111,7 +111,8 @@ public class DebuggerContext {
   }
 
   /** Increments or updates the specified metric No-op if no implementation is available */
-  public static void metric(MetricKind kind, String name, long value, String[] tags) {
+  public static void metric(
+      String probeId, MetricKind kind, String name, long value, String[] tags) {
     try {
       MetricForwarder forwarder = metricForwarder;
       if (forwarder == null) {
@@ -119,16 +120,16 @@ public class DebuggerContext {
       }
       switch (kind) {
         case COUNT:
-          forwarder.count(name, value, tags);
+          forwarder.count(probeId, name, value, tags);
           break;
         case GAUGE:
-          forwarder.gauge(name, value, tags);
+          forwarder.gauge(probeId, name, value, tags);
           break;
         case HISTOGRAM:
-          forwarder.histogram(name, value, tags);
+          forwarder.histogram(probeId, name, value, tags);
           break;
         case DISTRIBUTION:
-          forwarder.distribution(name, value, tags);
+          forwarder.distribution(probeId, name, value, tags);
         default:
           throw new IllegalArgumentException("Unsupported metric kind: " + kind);
       }
@@ -138,7 +139,8 @@ public class DebuggerContext {
   }
 
   /** Updates the specified metric No-op if no implementation is available */
-  public static void metric(MetricKind kind, String name, double value, String[] tags) {
+  public static void metric(
+      String probeId, MetricKind kind, String name, double value, String[] tags) {
     try {
       MetricForwarder forwarder = metricForwarder;
       if (forwarder == null) {
@@ -146,13 +148,13 @@ public class DebuggerContext {
       }
       switch (kind) {
         case GAUGE:
-          forwarder.gauge(name, value, tags);
+          forwarder.gauge(probeId, name, value, tags);
           break;
         case HISTOGRAM:
-          forwarder.histogram(name, value, tags);
+          forwarder.histogram(probeId, name, value, tags);
           break;
         case DISTRIBUTION:
-          forwarder.distribution(name, value, tags);
+          forwarder.distribution(probeId, name, value, tags);
           break;
         default:
           throw new IllegalArgumentException("Unsupported metric kind: " + kind);
@@ -173,13 +175,13 @@ public class DebuggerContext {
   }
 
   /** Creates a span, returns null if no implementation available */
-  public static DebuggerSpan createSpan(String operationName, String[] tags) {
+  public static DebuggerSpan createSpan(String probeId, String operationName, String[] tags) {
     try {
       Tracer localTracer = tracer;
       if (localTracer == null) {
         return DebuggerSpan.NOOP_SPAN;
       }
-      return localTracer.createSpan(operationName, tags);
+      return localTracer.createSpan(probeId, operationName, tags);
     } catch (Exception ex) {
       LOGGER.debug("Error in createSpan: ", ex);
       return DebuggerSpan.NOOP_SPAN;

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeId.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeId.java
@@ -1,12 +1,32 @@
 package datadog.trace.bootstrap.debugger;
 
 public class ProbeId {
+  private static final String ID_SEPARATOR = ":";
+
   private final String id;
   private final int version;
+  private final String encoded; // store as string uuid:version
+
+  // decode a probe id from a string with format uuid:version
+  public static ProbeId from(String encodedId) {
+    int idx = encodedId.indexOf(ID_SEPARATOR);
+    if (idx == -1) {
+      throw new IllegalArgumentException("Invalid probe id: " + encodedId);
+    }
+    return new ProbeId(
+        encodedId.substring(0, idx), Integer.parseInt(encodedId.substring(idx + 1)), encodedId);
+  }
 
   public ProbeId(String id, int version) {
     this.id = id;
     this.version = version;
+    this.encoded = id + ID_SEPARATOR + version;
+  }
+
+  private ProbeId(String id, int version, String encoded) {
+    this.id = id;
+    this.version = version;
+    this.encoded = encoded;
   }
 
   public String getId() {
@@ -15,6 +35,13 @@ public class ProbeId {
 
   public int getVersion() {
     return version;
+  }
+
+  /**
+   * @return the encoded id as a string with format uuid:version
+   */
+  public String getEncodedId() {
+    return encoded;
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeId.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeId.java
@@ -37,9 +37,7 @@ public class ProbeId {
     return version;
   }
 
-  /**
-   * @return the encoded id as a string with format uuid:version
-   */
+  /** @return the encoded id as a string with format uuid:version */
   public String getEncodedId() {
     return encoded;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ClassesToRetransformFinder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ClassesToRetransformFinder.java
@@ -61,7 +61,7 @@ public class ClassesToRetransformFinder {
     Trie changedClasses = new Trie();
     for (ProbeDefinition definition : changedDefinitions) {
       InstrumentationResult instrumentationResult =
-          comparer.getInstrumentationResults().get(definition.getId());
+          comparer.getInstrumentationResults().get(definition.getProbeId().getEncodedId());
       String key = instrumentationResult != null ? instrumentationResult.getTypeName() : null;
       if (key == null || key.equals("")) {
         key = definition.getWhere().getTypeName();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -7,6 +7,7 @@ import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.sink.DebuggerSink;
+import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.util.ExceptionHelper;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
@@ -69,7 +70,8 @@ public class ConfigurationUpdater
         instrumentation,
         transformerSupplier,
         config,
-        new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false),
+        new DebuggerSink(
+            config, new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false)),
         finder);
   }
 
@@ -240,7 +242,7 @@ public class ConfigurationUpdater
   @Override
   public ProbeImplementation resolve(String id, Class<?> callingClass) {
     ProbeDefinition definition = appliedDefinitions.get(id);
-    if (definition == null) {
+    if (definition == null && callingClass != null) {
       LOGGER.info(
           "Cannot resolve probe id={}, re-transforming calling class: {}",
           id,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -195,7 +195,7 @@ public class ConfigurationUpdater
     if (instrumentationResult.isError()) {
       return;
     }
-    instrumentationResults.put(definition.getId(), instrumentationResult);
+    instrumentationResults.put(definition.getProbeId().getEncodedId(), instrumentationResult);
     if (instrumentationResult.isInstalled()) {
       sink.addInstalled(definition.getProbeId());
     } else if (instrumentationResult.isBlocked()) {
@@ -230,22 +230,22 @@ public class ConfigurationUpdater
 
   private void storeDebuggerDefinitions(ConfigurationComparer changes) {
     for (ProbeDefinition definition : changes.getRemovedDefinitions()) {
-      appliedDefinitions.remove(definition.getId());
+      appliedDefinitions.remove(definition.getProbeId().getEncodedId());
     }
     for (ProbeDefinition definition : changes.getAddedDefinitions()) {
-      appliedDefinitions.put(definition.getId(), definition);
+      appliedDefinitions.put(definition.getProbeId().getEncodedId(), definition);
     }
     LOGGER.debug("Stored appliedDefinitions: {}", appliedDefinitions.values());
   }
 
   // /!\ This is called potentially by multiple threads from the instrumented code /!\
   @Override
-  public ProbeImplementation resolve(String id, Class<?> callingClass) {
-    ProbeDefinition definition = appliedDefinitions.get(id);
+  public ProbeImplementation resolve(String encodedProbeId, Class<?> callingClass) {
+    ProbeDefinition definition = appliedDefinitions.get(encodedProbeId);
     if (definition == null && callingClass != null) {
       LOGGER.info(
           "Cannot resolve probe id={}, re-transforming calling class: {}",
-          id,
+          encodedProbeId,
           callingClass.getName());
       retransformClasses(Collections.singletonList(callingClass));
       return null;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -52,11 +52,12 @@ public class DebuggerAgent {
     ddAgentFeaturesDiscovery.discoverIfOutdated();
     agentVersion = ddAgentFeaturesDiscovery.getVersion();
     String diagnosticEndpoint = getDiagnosticEndpoint(config, ddAgentFeaturesDiscovery);
-    DebuggerSink debuggerSink =
-        new DebuggerSink(
+    ProbeStatusSink probeStatusSink =
+        new ProbeStatusSink(
             config,
             diagnosticEndpoint, /*ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics()*/
             false);
+    DebuggerSink debuggerSink = new DebuggerSink(config, probeStatusSink);
     debuggerSink.start();
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -67,13 +67,12 @@ public class DebuggerAgent {
             classesToRetransformFinder);
     sink = debuggerSink;
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(config, configurationUpdater, probeStatusSink);
+        new StatsdMetricForwarder(config, probeStatusSink);
     DebuggerContext.init(configurationUpdater, statsdMetricForwarder);
     DebuggerContext.initClassFilter(new DenyListHelper(null)); // default hard coded deny list
     snapshotSerializer = new JsonSnapshotSerializer();
     DebuggerContext.initValueSerializer(snapshotSerializer);
-    DebuggerContext.initTracer(
-        new DebuggerTracer(configurationUpdater, debuggerSink.getProbeStatusSink()));
+    DebuggerContext.initTracer(new DebuggerTracer(debuggerSink.getProbeStatusSink()));
     if (config.isDebuggerInstrumentTheWorld()) {
       setupInstrumentTheWorldTransformer(
           config, instrumentation, debuggerSink, statsdMetricForwarder);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.agent;
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 
 import com.datadog.debugger.sink.DebuggerSink;
+import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.symbol.SymDBEnablement;
 import com.datadog.debugger.symbol.SymbolAggregator;
 import com.datadog.debugger.uploader.BatchUploader;
@@ -65,12 +66,14 @@ public class DebuggerAgent {
             debuggerSink,
             classesToRetransformFinder);
     sink = debuggerSink;
-    StatsdMetricForwarder statsdMetricForwarder = new StatsdMetricForwarder(config);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(config, configurationUpdater, probeStatusSink);
     DebuggerContext.init(configurationUpdater, statsdMetricForwarder);
     DebuggerContext.initClassFilter(new DenyListHelper(null)); // default hard coded deny list
     snapshotSerializer = new JsonSnapshotSerializer();
     DebuggerContext.initValueSerializer(snapshotSerializer);
-    DebuggerContext.initTracer(new DebuggerTracer());
+    DebuggerContext.initTracer(
+        new DebuggerTracer(configurationUpdater, debuggerSink.getProbeStatusSink()));
     if (config.isDebuggerInstrumentTheWorld()) {
       setupInstrumentTheWorldTransformer(
           config, instrumentation, debuggerSink, statsdMetricForwarder);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTracer.java
@@ -2,8 +2,11 @@ package com.datadog.debugger.agent;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.NOOP_TRACER;
 
+import com.datadog.debugger.sink.ProbeStatusSink;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.DebuggerSpan;
+import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.bootstrap.debugger.ProbeImplementation;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -12,8 +15,17 @@ import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 public class DebuggerTracer implements DebuggerContext.Tracer {
   public static final String OPERATION_NAME = "dd.dynamic.span";
 
+  private final DebuggerContext.ProbeResolver probeResolver;
+  private final ProbeStatusSink probeStatusSink;
+
+  public DebuggerTracer(
+      DebuggerContext.ProbeResolver probeResolver, ProbeStatusSink probeStatusSink) {
+    this.probeResolver = probeResolver;
+    this.probeStatusSink = probeStatusSink;
+  }
+
   @Override
-  public DebuggerSpan createSpan(String resourceName, String[] tags) {
+  public DebuggerSpan createSpan(String probeId, String resourceName, String[] tags) {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     if (tracerAPI == null || tracerAPI == NOOP_TRACER) {
       return DebuggerSpan.NOOP_SPAN;
@@ -30,22 +42,36 @@ public class DebuggerTracer implements DebuggerContext.Tracer {
       }
     }
     AgentScope scope = tracerAPI.activateSpan(dynamicSpan, ScopeSource.MANUAL);
-    return new DebuggerSpanImpl(dynamicSpan, scope);
+    ProbeImplementation probeImplementation = probeResolver.resolve(probeId, null);
+    if (probeImplementation == null) {
+      return DebuggerSpan.NOOP_SPAN;
+    }
+    return new DebuggerSpanImpl(
+        dynamicSpan, scope, probeStatusSink, probeImplementation.getProbeId());
   }
 
   static class DebuggerSpanImpl implements DebuggerSpan {
     final AgentSpan underlyingSpan;
     final AgentScope currentScope;
+    final ProbeStatusSink probeStatusSink;
+    final ProbeId probeId;
 
-    public DebuggerSpanImpl(AgentSpan underlyingSpan, AgentScope currentScope) {
+    public DebuggerSpanImpl(
+        AgentSpan underlyingSpan,
+        AgentScope currentScope,
+        ProbeStatusSink probeStatusSink,
+        ProbeId probeId) {
       this.underlyingSpan = underlyingSpan;
       this.currentScope = currentScope;
+      this.probeStatusSink = probeStatusSink;
+      this.probeId = probeId;
     }
 
     @Override
     public void finish() {
       currentScope.close();
       underlyingSpan.finish();
+      probeStatusSink.addEmitting(probeId);
     }
 
     @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -10,6 +10,7 @@ import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.sink.DebuggerSink;
+import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.util.ExceptionHelper;
 import datadog.trace.agent.tooling.AgentStrategies;
 import datadog.trace.api.Config;
@@ -107,7 +108,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
         config,
         configuration,
         null,
-        new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false));
+        new DebuggerSink(
+            config, new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false)));
   }
 
   private void readExcludeFiles(String commaSeparatedFileNames) {
@@ -515,8 +517,8 @@ public class DebuggerTransformer implements ClassFileTransformer {
           }
         }
         if (capturedContextProbes.size() > 0) {
-          List<String> probesIds =
-              capturedContextProbes.stream().map(ProbeDefinition::getId).collect(toList());
+          List<ProbeId> probesIds =
+              capturedContextProbes.stream().map(ProbeDefinition::getProbeId).collect(toList());
           ProbeDefinition referenceDefinition = selectReferenceDefinition(capturedContextProbes);
           List<DiagnosticMessage> probeDiagnostics =
               diagnostics.get(referenceDefinition.getProbeId());

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -258,7 +258,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
                   .captureSnapshot(true)
                   .build();
           probes.add(probe);
-          instrumentTheWorldProbes.put(probe.getId(), probe);
+          instrumentTheWorldProbes.put(probe.getProbeId().getEncodedId(), probe);
         }
       }
       Map<Where, List<ProbeDefinition>> defByLocation = mergeLocations(probes);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
@@ -232,6 +232,7 @@ public class ProbeStatus {
   public enum Status {
     RECEIVED,
     INSTALLED,
+    EMITTING,
     BLOCKED,
     ERROR
   }
@@ -259,6 +260,13 @@ public class ProbeStatus {
           this.serviceName,
           "Installed probe " + probeId + ".",
           new Diagnostics(probeId, runtimeId, Status.INSTALLED, null));
+    }
+
+    public ProbeStatus emittingMessage(ProbeId probeId) {
+      return new ProbeStatus(
+          this.serviceName,
+          "Probe " + probeId + "is emitting.",
+          new Diagnostics(probeId, runtimeId, Status.EMITTING, null));
     }
 
     public ProbeStatus blockedMessage(ProbeId probeId) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
@@ -115,6 +115,15 @@ public class ProbeStatus {
 
     private final ProbeException exception;
 
+    public Diagnostics(String probeId, String runtimeId, Status status, ProbeException exception) {
+      ProbeId id = ProbeId.from(probeId);
+      this.probeId = id.getId();
+      this.probeVersion = id.getVersion();
+      this.runtimeId = runtimeId;
+      this.status = status;
+      this.exception = exception;
+    }
+
     public Diagnostics(ProbeId probeId, String runtimeId, Status status, ProbeException exception) {
       this.probeId = probeId != null ? probeId.getId() : null;
       this.probeVersion = probeId != null ? probeId.getVersion() : 0;
@@ -262,7 +271,7 @@ public class ProbeStatus {
           new Diagnostics(probeId, runtimeId, Status.INSTALLED, null));
     }
 
-    public ProbeStatus emittingMessage(ProbeId probeId) {
+    public ProbeStatus emittingMessage(String probeId) {
       return new ProbeStatus(
           this.serviceName,
           "Probe " + probeId + "is emitting.",

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
@@ -1,10 +1,12 @@
 package com.datadog.debugger.agent;
 
+import com.datadog.debugger.sink.ProbeStatusSink;
 import com.timgroup.statsd.StatsDClientErrorHandler;
 import datadog.communication.monitor.DDAgentStatsDClientManager;
 import datadog.trace.api.Config;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.debugger.ProbeImplementation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,8 +17,11 @@ public class StatsdMetricForwarder
   private static final String METRICPROBE_PREFIX = "dynamic.instrumentation.metric.probe";
 
   private final StatsDClient statsd;
+  private final DebuggerContext.ProbeResolver probeResolver;
+  private final ProbeStatusSink probeStatusSink;
 
-  public StatsdMetricForwarder(Config config) {
+  public StatsdMetricForwarder(
+      Config config, DebuggerContext.ProbeResolver probeResolver, ProbeStatusSink probeStatusSink) {
     statsd =
         DDAgentStatsDClientManager.statsDClientManager()
             .statsDClient(
@@ -25,45 +30,63 @@ public class StatsdMetricForwarder
                 config.getDogStatsDNamedPipe(),
                 METRICPROBE_PREFIX,
                 new String[0]);
+    this.probeResolver = probeResolver;
+    this.probeStatusSink = probeStatusSink;
   }
 
   @Override
-  public void count(String name, long delta, String[] tags) {
+  public void count(String probeId, String name, long delta, String[] tags) {
     statsd.count(name, delta, tags);
+    sendEmittingStatus(probeId);
   }
 
   @Override
-  public void gauge(String name, long value, String[] tags) {
+  public void gauge(String probeId, String name, long value, String[] tags) {
     statsd.gauge(name, value, tags);
+    sendEmittingStatus(probeId);
   }
 
   @Override
-  public void gauge(String name, double value, String[] tags) {
+  public void gauge(String probeId, String name, double value, String[] tags) {
     statsd.gauge(name, value, tags);
+    sendEmittingStatus(probeId);
   }
 
   @Override
-  public void histogram(String name, long value, String[] tags) {
+  public void histogram(String probeId, String name, long value, String[] tags) {
     statsd.histogram(name, value, tags);
+    sendEmittingStatus(probeId);
   }
 
   @Override
-  public void histogram(String name, double value, String[] tags) {
+  public void histogram(String probeId, String name, double value, String[] tags) {
     statsd.histogram(name, value, tags);
+    sendEmittingStatus(probeId);
   }
 
   @Override
-  public void distribution(String name, long value, String[] tags) {
+  public void distribution(String probeId, String name, long value, String[] tags) {
     statsd.distribution(name, value, tags);
+    sendEmittingStatus(probeId);
   }
 
   @Override
-  public void distribution(String name, double value, String[] tags) {
+  public void distribution(String probeId, String name, double value, String[] tags) {
     statsd.distribution(name, value, tags);
+    sendEmittingStatus(probeId);
   }
 
   @Override
   public void handle(Exception exception) {
     LOGGER.warn("Error when sending metrics: ", exception);
+  }
+
+  private void sendEmittingStatus(String probeId) {
+    ProbeImplementation probeImplementation = probeResolver.resolve(probeId, null);
+    if (probeImplementation == null) {
+      LOGGER.debug("Cannot resolve probe id: {}", probeId);
+      return;
+    }
+    probeStatusSink.addEmitting(probeImplementation.getProbeId());
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
@@ -6,7 +6,6 @@ import datadog.communication.monitor.DDAgentStatsDClientManager;
 import datadog.trace.api.Config;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
-import datadog.trace.bootstrap.debugger.ProbeImplementation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,11 +16,9 @@ public class StatsdMetricForwarder
   private static final String METRICPROBE_PREFIX = "dynamic.instrumentation.metric.probe";
 
   private final StatsDClient statsd;
-  private final DebuggerContext.ProbeResolver probeResolver;
   private final ProbeStatusSink probeStatusSink;
 
-  public StatsdMetricForwarder(
-      Config config, DebuggerContext.ProbeResolver probeResolver, ProbeStatusSink probeStatusSink) {
+  public StatsdMetricForwarder(Config config, ProbeStatusSink probeStatusSink) {
     statsd =
         DDAgentStatsDClientManager.statsDClientManager()
             .statsDClient(
@@ -30,50 +27,49 @@ public class StatsdMetricForwarder
                 config.getDogStatsDNamedPipe(),
                 METRICPROBE_PREFIX,
                 new String[0]);
-    this.probeResolver = probeResolver;
     this.probeStatusSink = probeStatusSink;
   }
 
   @Override
-  public void count(String probeId, String name, long delta, String[] tags) {
+  public void count(String encodedProbeId, String name, long delta, String[] tags) {
     statsd.count(name, delta, tags);
-    sendEmittingStatus(probeId);
+    sendEmittingStatus(encodedProbeId);
   }
 
   @Override
-  public void gauge(String probeId, String name, long value, String[] tags) {
+  public void gauge(String encodedProbeId, String name, long value, String[] tags) {
     statsd.gauge(name, value, tags);
-    sendEmittingStatus(probeId);
+    sendEmittingStatus(encodedProbeId);
   }
 
   @Override
-  public void gauge(String probeId, String name, double value, String[] tags) {
+  public void gauge(String encodedProbeId, String name, double value, String[] tags) {
     statsd.gauge(name, value, tags);
-    sendEmittingStatus(probeId);
+    sendEmittingStatus(encodedProbeId);
   }
 
   @Override
-  public void histogram(String probeId, String name, long value, String[] tags) {
+  public void histogram(String encodedProbeId, String name, long value, String[] tags) {
     statsd.histogram(name, value, tags);
-    sendEmittingStatus(probeId);
+    sendEmittingStatus(encodedProbeId);
   }
 
   @Override
-  public void histogram(String probeId, String name, double value, String[] tags) {
+  public void histogram(String encodedProbeId, String name, double value, String[] tags) {
     statsd.histogram(name, value, tags);
-    sendEmittingStatus(probeId);
+    sendEmittingStatus(encodedProbeId);
   }
 
   @Override
-  public void distribution(String probeId, String name, long value, String[] tags) {
+  public void distribution(String encodedProbeId, String name, long value, String[] tags) {
     statsd.distribution(name, value, tags);
-    sendEmittingStatus(probeId);
+    sendEmittingStatus(encodedProbeId);
   }
 
   @Override
-  public void distribution(String probeId, String name, double value, String[] tags) {
+  public void distribution(String encodedProbeId, String name, double value, String[] tags) {
     statsd.distribution(name, value, tags);
-    sendEmittingStatus(probeId);
+    sendEmittingStatus(encodedProbeId);
   }
 
   @Override
@@ -82,11 +78,6 @@ public class StatsdMetricForwarder
   }
 
   private void sendEmittingStatus(String probeId) {
-    ProbeImplementation probeImplementation = probeResolver.resolve(probeId, null);
-    if (probeImplementation == null) {
-      LOGGER.debug("Cannot resolve probe id: {}", probeId);
-      return;
-    }
-    probeStatusSink.addEmitting(probeImplementation.getProbeId());
+    probeStatusSink.addEmitting(probeId);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StatsdMetricForwarder.java
@@ -77,7 +77,7 @@ public class StatsdMetricForwarder
     LOGGER.warn("Error when sending metrics: ", exception);
   }
 
-  private void sendEmittingStatus(String probeId) {
-    probeStatusSink.addEmitting(probeId);
+  private void sendEmittingStatus(String encodedProbeId) {
+    probeStatusSink.addEmitting(encodedProbeId);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -116,6 +116,16 @@ public class ASMHelper {
             Opcodes.GETSTATIC, owner.getInternalName(), fieldName, owner.getDescriptor()));
   }
 
+  public static void getStatic(
+      InsnList insnList,
+      org.objectweb.asm.Type owner,
+      String fieldName,
+      org.objectweb.asm.Type fieldType) {
+    insnList.add(
+        new FieldInsnNode(
+            Opcodes.GETSTATIC, owner.getInternalName(), fieldName, fieldType.getDescriptor()));
+  }
+
   public static Type decodeSignature(String signature) {
     SignatureReader sigReader = new SignatureReader(signature);
     FieldSignatureVisitor fieldSignatureVisitor = new FieldSignatureVisitor();
@@ -243,6 +253,23 @@ public class ASMHelper {
         localVarTableIdx++;
       }
     }
+  }
+
+  public static void newInstance(InsnList insnList, org.objectweb.asm.Type type) {
+    insnList.add(new TypeInsnNode(Opcodes.NEW, type.getInternalName()));
+  }
+
+  public static void invokeConstructor(
+      InsnList insnList, org.objectweb.asm.Type owner, org.objectweb.asm.Type... argTypes) {
+    // expected stack: [instance, arg_type_1 ... arg_type_N]
+    insnList.add(
+        new MethodInsnNode(
+            Opcodes.INVOKESPECIAL,
+            owner.getInternalName(),
+            Types.CONSTRUCTOR,
+            org.objectweb.asm.Type.getMethodDescriptor(org.objectweb.asm.Type.VOID_TYPE, argTypes),
+            false));
+    // stack: []
   }
 
   /** Wraps ASM's {@link org.objectweb.asm.Type} with associated generic types */

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -399,7 +399,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
       // stack [array, array]
       ldc(insnList, i); // index
       // stack [array, array, int]
-      ldc(insnList, probeIds.get(i).getId());
+      ldc(insnList, probeIds.get(i).getEncodedId());
       // stack [array, array, int, string]
       insnList.add(new InsnNode(Opcodes.AASTORE));
       // stack [array]

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -41,7 +41,6 @@ public abstract class Instrumentor {
   protected final boolean isLineProbe;
   protected final LineMap lineMap = new LineMap();
   protected final LabelNode methodEnterLabel;
-  protected final String probeIdFieldName;
   protected int localVarBaseOffset;
   protected int argOffset;
   protected final LocalVariableNode[] localVarsBySlot;
@@ -70,8 +69,6 @@ public abstract class Instrumentor {
       argOffset += t.getSize();
     }
     localVarsBySlot = extractLocalVariables(argTypes);
-    this.probeIdFieldName =
-        "PROBE_ID_" + definition.getId(); // TODO sanitize id for fieldname Java identifier
   }
 
   public abstract InstrumentationResult.Status instrument();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -9,6 +9,7 @@ import static com.datadog.debugger.instrumentation.Types.STRING_TYPE;
 import com.datadog.debugger.instrumentation.DiagnosticMessage.Kind;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Where;
+import datadog.trace.bootstrap.debugger.ProbeId;
 import java.util.Arrays;
 import java.util.List;
 import org.objectweb.asm.Opcodes;
@@ -35,11 +36,12 @@ public abstract class Instrumentor {
   protected final ClassNode classNode;
   protected final MethodNode methodNode;
   protected final List<DiagnosticMessage> diagnostics;
-  protected final List<String> probeIds;
+  protected final List<ProbeId> probeIds;
   protected final boolean isStatic;
   protected final boolean isLineProbe;
   protected final LineMap lineMap = new LineMap();
   protected final LabelNode methodEnterLabel;
+  protected final String probeIdFieldName;
   protected int localVarBaseOffset;
   protected int argOffset;
   protected final LocalVariableNode[] localVarsBySlot;
@@ -51,7 +53,7 @@ public abstract class Instrumentor {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
-      List<String> probeIds) {
+      List<ProbeId> probeIds) {
     this.definition = definition;
     this.classLoader = classLoader;
     this.classNode = classNode;
@@ -68,6 +70,8 @@ public abstract class Instrumentor {
       argOffset += t.getSize();
     }
     localVarsBySlot = extractLocalVariables(argTypes);
+    this.probeIdFieldName =
+        "PROBE_ID_" + definition.getId(); // TODO sanitize id for fieldname Java identifier
   }
 
   public abstract InstrumentationResult.Status instrument();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -193,7 +193,7 @@ public class MetricInstrumentor extends Instrumentor {
   private InsnList callCount(MetricProbe metricProbe, ReturnContext returnContext) {
     if (metricProbe.getValue() == null) {
       InsnList insnList = new InsnList();
-      ldc(insnList, metricProbe.getId());
+      ldc(insnList, metricProbe.getProbeId().getEncodedId());
       // stack [ProbeId]
       getStatic(insnList, METRICKIND_TYPE, metricProbe.getKind().name());
       // stack [string, MetricKind]
@@ -249,7 +249,7 @@ public class MetricInstrumentor extends Instrumentor {
       return EMPTY_INSN_LIST;
     }
     resultType = convertIfRequired(resultType, result.insnList);
-    ldc(insnList, metricProbe.getId());
+    ldc(insnList, metricProbe.getProbeId().getEncodedId());
     // stack [string]
     getStatic(insnList, METRICKIND_TYPE, metricProbe.getKind().name());
     // stack [string, MetricKind]

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
@@ -76,7 +76,7 @@ public class SpanInstrumentor extends Instrumentor {
 
   private InsnList createSpan(LabelNode initSpanLabel) {
     InsnList insnList = new InsnList();
-    ldc(insnList, definition.getId());
+    ldc(insnList, definition.getProbeId().getEncodedId());
     // stack: [string]
     ldc(insnList, buildResourceName());
     // stack: [string, string]

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
@@ -11,6 +11,7 @@ import static com.datadog.debugger.util.ClassFileHelper.stripPackagePath;
 
 import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.probe.Where;
+import datadog.trace.bootstrap.debugger.ProbeId;
 import java.util.List;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
@@ -31,7 +32,7 @@ public class SpanInstrumentor extends Instrumentor {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
-      List<String> probeIds) {
+      List<ProbeId> probeIds) {
     super(spanProbe, classLoader, classNode, methodNode, diagnostics, probeIds);
   }
 
@@ -75,15 +76,18 @@ public class SpanInstrumentor extends Instrumentor {
 
   private InsnList createSpan(LabelNode initSpanLabel) {
     InsnList insnList = new InsnList();
-    ldc(insnList, buildResourceName());
+    ldc(insnList, definition.getId());
     // stack: [string]
+    ldc(insnList, buildResourceName());
+    // stack: [string, string]
     pushTags(insnList, addProbeIdWithTags(definition.getId(), definition.getTags()));
-    // stack: [string, tags]
+    // stack: [string, string, tags]
     invokeStatic(
         insnList,
         DEBUGGER_CONTEXT_TYPE,
         "createSpan",
         DEBUGGER_SPAN_TYPE,
+        STRING_TYPE,
         STRING_TYPE,
         Types.asArray(STRING_TYPE, 1)); // tags
     // stack: [span]

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Types.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Types.java
@@ -22,6 +22,7 @@ import datadog.trace.bootstrap.debugger.CorrelationAccess;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.DebuggerSpan;
 import datadog.trace.bootstrap.debugger.MethodLocation;
+import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.el.ReflectiveFieldValueResolver;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -68,6 +69,7 @@ public final class Types {
   public static final Type REFLECTIVE_FIELD_VALUE_RESOLVER_TYPE =
       Type.getType(ReflectiveFieldValueResolver.class);
   public static final Type METRICKIND_TYPE = Type.getType(DebuggerContext.MetricKind.class);
+  public static final Type PROBE_ID_TYPE = Type.getType(ProbeId.class);
 
   // special initialization methods
   public static final String CONSTRUCTOR = "<init>";

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -439,8 +439,8 @@ public class LogProbe extends ProbeDefinition {
       CapturedContext entryContext,
       CapturedContext exitContext,
       List<CapturedContext.CapturedThrowable> caughtExceptions) {
-    LogStatus entryStatus = convertStatus(entryContext.getStatus(id));
-    LogStatus exitStatus = convertStatus(exitContext.getStatus(id));
+    LogStatus entryStatus = convertStatus(entryContext.getStatus(probeId.getEncodedId()));
+    LogStatus exitStatus = convertStatus(exitContext.getStatus(probeId.getEncodedId()));
     String message = null;
     String traceId = null;
     String spanId = null;
@@ -522,7 +522,7 @@ public class LogProbe extends ProbeDefinition {
 
   @Override
   public void commit(CapturedContext lineContext, int line) {
-    LogStatus status = (LogStatus) lineContext.getStatus(id);
+    LogStatus status = (LogStatus) lineContext.getStatus(probeId.getEncodedId());
     if (status == null) {
       return;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -351,7 +351,7 @@ public class LogProbe extends ProbeDefinition {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
-      List<String> probeIds) {
+      List<ProbeId> probeIds) {
     return new CapturedContextInstrumentor(
             this,
             classLoader,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/MetricProbe.java
@@ -141,7 +141,7 @@ public class MetricProbe extends ProbeDefinition {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
-      List<String> probeIds) {
+      List<ProbeId> probeIds) {
     return new MetricInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
         .instrument();
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -31,6 +31,7 @@ public abstract class ProbeDefinition implements ProbeImplementation {
   protected final String language;
   protected final String id;
   protected final int version;
+  protected transient ProbeId probeId;
   protected final Tag[] tags;
   protected final Map<String, String> tagMap = new HashMap<>();
   protected final Where where;
@@ -47,6 +48,7 @@ public abstract class ProbeDefinition implements ProbeImplementation {
     this.language = language;
     this.id = probeId != null ? probeId.getId() : null;
     this.version = probeId != null ? probeId.getVersion() : 0;
+    this.probeId = probeId;
     this.tags = tags;
     initTagMap(tagMap, tags);
     this.where = where;
@@ -60,7 +62,10 @@ public abstract class ProbeDefinition implements ProbeImplementation {
 
   @Override
   public ProbeId getProbeId() {
-    return new ProbeId(id, version);
+    if (probeId == null) {
+      probeId = new ProbeId(id, version);
+    }
+    return probeId;
   }
 
   public String getLanguage() {
@@ -127,7 +132,7 @@ public abstract class ProbeDefinition implements ProbeImplementation {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics) {
-    return instrument(classLoader, classNode, methodNode, diagnostics, singletonList(getId()));
+    return instrument(classLoader, classNode, methodNode, diagnostics, singletonList(getProbeId()));
   }
 
   public abstract InstrumentationResult.Status instrument(
@@ -135,7 +140,7 @@ public abstract class ProbeDefinition implements ProbeImplementation {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
-      List<String> probeIds);
+      List<ProbeId> probeIds);
 
   @Override
   public ProbeLocation getLocation() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -139,7 +139,7 @@ public class SpanDecorationProbe extends ProbeDefinition {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
-      List<String> probeIds) {
+      List<ProbeId> probeIds) {
     return new CapturedContextInstrumentor(
             this, classLoader, classNode, methodNode, diagnostics, probeIds, false, Limits.DEFAULT)
         .instrument();
@@ -236,6 +236,7 @@ public class SpanDecorationProbe extends ProbeDefinition {
     for (Pair<String, String> tag : tagsToDecorate) {
       agentSpan.setTag(tag.getLeft(), tag.getRight());
     }
+    DebuggerAgent.getSink().getProbeStatusSink().addEmitting(probeId);
   }
 
   private void handleEvaluationErrors(SpanDecorationStatus status) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -195,7 +195,9 @@ public class SpanDecorationProbe extends ProbeDefinition {
       CapturedContext exitContext,
       List<CapturedContext.CapturedThrowable> caughtExceptions) {
     CapturedContext.Status status =
-        evaluateAt == MethodLocation.EXIT ? exitContext.getStatus(id) : entryContext.getStatus(id);
+        evaluateAt == MethodLocation.EXIT
+            ? exitContext.getStatus(probeId.getEncodedId())
+            : entryContext.getStatus(probeId.getEncodedId());
     if (status == null) {
       return;
     }
@@ -206,7 +208,7 @@ public class SpanDecorationProbe extends ProbeDefinition {
 
   @Override
   public void commit(CapturedContext lineContext, int line) {
-    CapturedContext.Status status = lineContext.getStatus(id);
+    CapturedContext.Status status = lineContext.getStatus(probeId.getEncodedId());
     if (status == null) {
       return;
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanProbe.java
@@ -29,7 +29,7 @@ public class SpanProbe extends ProbeDefinition {
       ClassNode classNode,
       MethodNode methodNode,
       List<DiagnosticMessage> diagnostics,
-      List<String> probeIds) {
+      List<ProbeId> probeIds) {
     return new SpanInstrumentor(this, classLoader, classNode, methodNode, diagnostics, probeIds)
         .instrument();
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -59,13 +59,17 @@ public class ProbeStatusSink {
   }
 
   public void addEmitting(ProbeId probeId) {
-    TimedMessage timedMessage = probeStatuses.get(probeId.getId());
+    addEmitting(probeId.getEncodedId());
+  }
+
+  public void addEmitting(String encodedProbeId) {
+    TimedMessage timedMessage = probeStatuses.get(encodedProbeId);
     if (timedMessage != null
         && timedMessage.getMessage().getDiagnostics().getStatus() == Status.EMITTING) {
       // if we already have a message for this probe, don't build the message again
       return;
     }
-    addDiagnostics(messageBuilder.emittingMessage(probeId));
+    addDiagnostics(messageBuilder.emittingMessage(encodedProbeId));
   }
 
   public void addBlocked(ProbeId probeId) {
@@ -142,7 +146,7 @@ public class ProbeStatusSink {
   }
 
   public void removeDiagnostics(ProbeId probeId) {
-    probeStatuses.remove(probeId.getId());
+    probeStatuses.remove(probeId.getEncodedId());
   }
 
   private void addDiagnostics(ProbeStatus message) {
@@ -154,7 +158,7 @@ public class ProbeStatusSink {
     TimedMessage current = probeStatuses.get(probeId.getId());
     if (current == null || shouldOverwrite(current.getMessage(), message)) {
       TimedMessage newMessage = new TimedMessage(message);
-      probeStatuses.put(probeId.getId(), newMessage);
+      probeStatuses.put(probeId.getEncodedId(), newMessage);
       enqueueTimedMessage(newMessage, Instant.now(Clock.systemDefaultZone()));
     }
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -36,7 +36,7 @@ public class ProbeStatusSink {
   private final boolean isInstrumentTheWorld;
   private final boolean useMultiPart;
 
-  ProbeStatusSink(Config config, String diagnosticsEndpoint, boolean useMultiPart) {
+  public ProbeStatusSink(Config config, String diagnosticsEndpoint, boolean useMultiPart) {
     this(config, new BatchUploader(config, diagnosticsEndpoint), useMultiPart);
   }
 
@@ -56,6 +56,16 @@ public class ProbeStatusSink {
 
   public void addInstalled(ProbeId probeId) {
     addDiagnostics(messageBuilder.installedMessage(probeId));
+  }
+
+  public void addEmitting(ProbeId probeId) {
+    TimedMessage timedMessage = probeStatuses.get(probeId.getId());
+    if (timedMessage != null
+        && timedMessage.getMessage().getDiagnostics().getStatus() == Status.EMITTING) {
+      // if we already have a message for this probe, don't build the message again
+      return;
+    }
+    addDiagnostics(messageBuilder.emittingMessage(probeId));
   }
 
   public void addBlocked(ProbeId probeId) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -2051,7 +2051,8 @@ public class CapturedSnapshotTest {
         DebuggerAgent.setupInstrumentTheWorldTransformer(
             config,
             instr,
-            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false),
+            new DebuggerSink(
+                config, new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false)),
             null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     return listener;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -171,7 +171,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)", "8");
     DebuggerAgentHelper.injectSink(listener);
-    DebuggerContext.init((id, clazz) -> null, null);
+    DebuggerContext.init((encodedProbeId, clazz) -> null, null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -187,7 +187,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, lineProbe, methodProbe);
     DebuggerAgentHelper.injectSink(listener);
     DebuggerContext.init(
-        (id, clazz) -> {
+        (encodedProbeId, clazz) -> {
           throw new IllegalArgumentException("oops");
         },
         null);
@@ -2110,7 +2110,9 @@ public class CapturedSnapshotTest {
     instr.addTransformer(currentTransformer);
     DebuggerAgentHelper.injectSink(listener);
     DebuggerContext.init(
-        (id, callingClass) -> resolver(id, callingClass, expectedClassName, logProbes), null);
+        (encodedId, callingClass) ->
+            resolver(encodedId, callingClass, expectedClassName, logProbes),
+        null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
     for (LogProbe probe : logProbes) {
@@ -2126,10 +2128,13 @@ public class CapturedSnapshotTest {
   }
 
   private ProbeImplementation resolver(
-      String id, Class<?> callingClass, String expectedClassName, Collection<LogProbe> logProbes) {
+      String encodedId,
+      Class<?> callingClass,
+      String expectedClassName,
+      Collection<LogProbe> logProbes) {
     assertEquals(expectedClassName, callingClass.getName());
     for (LogProbe probe : logProbes) {
-      if (probe.getId().equals(id)) {
+      if (probe.getProbeId().getEncodedId().equals(encodedId)) {
         return probe;
       }
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationComparerTest.java
@@ -179,7 +179,8 @@ class ConfigurationComparerTest {
 
     Map<String, InstrumentationResult> instrumentationResults = new HashMap<>();
     instrumentationResults.put(
-        probe.getId(), InstrumentationResult.Factory.blocked(probe.getWhere().getTypeName()));
+        probe.getProbeId().getEncodedId(),
+        InstrumentationResult.Factory.blocked(probe.getWhere().getTypeName()));
     Configuration noFilterConfig = createConfig(Collections.singletonList(probe));
     Configuration config =
         Configuration.builder()

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -97,7 +97,7 @@ public class ConfigurationUpdaterTest {
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
   }
 
@@ -154,8 +154,8 @@ public class ConfigurationUpdaterTest {
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(2, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getEncodedId()));
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(PROBE_ID2));
   }
@@ -179,7 +179,7 @@ public class ConfigurationUpdaterTest {
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
     // phase 2: add duplicated probe definitions
     logProbes =
         Arrays.asList(
@@ -188,7 +188,7 @@ public class ConfigurationUpdaterTest {
     configurationUpdater.accept(createApp(logProbes));
     appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(2, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getEncodedId()));
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(PROBE_ID2));
   }
@@ -213,8 +213,8 @@ public class ConfigurationUpdaterTest {
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(2, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getEncodedId()));
     // phase 2: remove duplicated probe definitions
     logProbes =
         Arrays.asList(
@@ -222,7 +222,7 @@ public class ConfigurationUpdaterTest {
     configurationUpdater.accept(createApp(logProbes));
     appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(PROBE_ID2));
     verify(probeStatusSink).removeDiagnostics(eq(PROBE_ID2));
@@ -249,8 +249,8 @@ public class ConfigurationUpdaterTest {
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(2, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
-    assertTrue(appliedDefinitions.containsKey(METRIC_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
+    assertTrue(appliedDefinitions.containsKey(METRIC_ID.getEncodedId()));
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(METRIC_ID));
   }
@@ -273,7 +273,7 @@ public class ConfigurationUpdaterTest {
     verify(inst).retransformClasses(eq(String.class));
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
   }
 
   @Test
@@ -300,7 +300,7 @@ public class ConfigurationUpdaterTest {
     verify(inst).retransformClasses(eq(String.class));
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
   }
 
   @Test
@@ -326,7 +326,7 @@ public class ConfigurationUpdaterTest {
     verify(inst).retransformClasses(eq(runnable.getClass()));
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
   }
 
   @Test
@@ -367,7 +367,7 @@ public class ConfigurationUpdaterTest {
     assertEquals(HashMap.class, allValues.get(2)); // for removing instrumentation
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     Assertions.assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(probe1.getId()));
+    assertTrue(appliedDefinitions.containsKey(probe1.getProbeId().getEncodedId()));
   }
 
   @Test
@@ -412,7 +412,7 @@ public class ConfigurationUpdaterTest {
     assertEquals(String.class, allValues.get(1));
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     Assertions.assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(probe1.getId()));
+    assertTrue(appliedDefinitions.containsKey(probe1.getProbeId().getEncodedId()));
   }
 
   @Test
@@ -455,8 +455,9 @@ public class ConfigurationUpdaterTest {
     logProbes.get(0).buildLocation(null);
     configurationUpdater.accept(createApp(logProbes));
     ProbeImplementation probeImplementation =
-        configurationUpdater.resolve(PROBE_ID.getId(), String.class);
-    Assertions.assertEquals(PROBE_ID.getId(), probeImplementation.getId());
+        configurationUpdater.resolve(PROBE_ID.getEncodedId(), String.class);
+    Assertions.assertEquals(
+        PROBE_ID.getEncodedId(), probeImplementation.getProbeId().getEncodedId());
     Assertions.assertEquals("java.lang.String", probeImplementation.getLocation().getType());
     Assertions.assertEquals("concat", probeImplementation.getLocation().getMethod());
     Assertions.assertNotNull(((LogProbe) probeImplementation).getProbeCondition());
@@ -475,7 +476,7 @@ public class ConfigurationUpdaterTest {
     verify(inst).retransformClasses(eq(String.class));
     // simulate that there is a snapshot probe instrumentation left in HashMap class
     ProbeImplementation probeImplementation =
-        configurationUpdater.resolve(PROBE_ID2.getId(), HashMap.class);
+        configurationUpdater.resolve(PROBE_ID2.getEncodedId(), HashMap.class);
     Assertions.assertNull(probeImplementation);
     verify(inst).retransformClasses(eq(HashMap.class));
   }
@@ -508,16 +509,13 @@ public class ConfigurationUpdaterTest {
             inst, this::createTransformer, tracerConfig, new ClassesToRetransformFinder());
     List<MetricProbe> metricProbes =
         Collections.singletonList(
-            MetricProbe.builder()
-                .probeId(METRIC_ID.getId(), 0)
-                .where("java.lang.String", "concat")
-                .build());
+            MetricProbe.builder().probeId(METRIC_ID).where("java.lang.String", "concat").build());
     configurationUpdater.accept(createAppMetrics(metricProbes));
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(METRIC_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(METRIC_ID.getEncodedId()));
   }
 
   @Test
@@ -534,7 +532,7 @@ public class ConfigurationUpdaterTest {
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(LOG_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(LOG_ID.getEncodedId()));
   }
 
   @Test
@@ -568,7 +566,7 @@ public class ConfigurationUpdaterTest {
     assertEquals(HashMap.class, allValues.get(2)); // for removing instrumentation
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(metricProbe1.getId()));
+    assertTrue(appliedDefinitions.containsKey(metricProbe1.getProbeId().getEncodedId()));
   }
 
   @Test
@@ -602,7 +600,7 @@ public class ConfigurationUpdaterTest {
     assertEquals(HashMap.class, allValues.get(2)); // for removing instrumentation
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(logProbe1.getId()));
+    assertTrue(appliedDefinitions.containsKey(logProbe1.getProbeId().getEncodedId()));
   }
 
   @Test
@@ -676,7 +674,7 @@ public class ConfigurationUpdaterTest {
     assertEquals(StringBuilder.class, allValues.get(4));
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
-    assertTrue(appliedDefinitions.containsKey(METRIC_ID.getId()));
+    assertTrue(appliedDefinitions.containsKey(METRIC_ID.getEncodedId()));
   }
 
   private static Configuration createApp(List<LogProbe> logProbes) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
@@ -1,20 +1,38 @@
 package com.datadog.debugger.agent;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import com.datadog.debugger.sink.ProbeStatusSink;
 import datadog.trace.bootstrap.debugger.DebuggerSpan;
+import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import datadog.trace.bootstrap.debugger.ProbeLocation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.core.CoreTracer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class DebuggerTracerTest {
 
+  private static final ProbeId SPAN_ID = new ProbeId("spanProbe-id", 1);
+
+  @AfterEach
+  public void after() {
+    AgentTracer.forceRegister(null);
+  }
+
   @Test
   public void createSpan() {
     AgentTracer.forceRegister(CoreTracer.builder().build());
-    DebuggerTracer debuggerTracer = new DebuggerTracer();
-    DebuggerSpan span = debuggerTracer.createSpan("a-span", new String[] {"foo:bar"});
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    DebuggerTracer debuggerTracer =
+        new DebuggerTracer(DebuggerTracerTest::resolver, probeStatusSink);
+    DebuggerSpan span =
+        debuggerTracer.createSpan(SPAN_ID.getId(), "a-span", new String[] {"foo:bar"});
     AgentSpan underlyingSpan = ((DebuggerTracer.DebuggerSpanImpl) span).underlyingSpan;
     assertEquals("dd.dynamic.span", underlyingSpan.getSpanName());
     assertEquals("a-span", underlyingSpan.getResourceName());
@@ -26,15 +44,48 @@ class DebuggerTracerTest {
         "a-span", ((DebuggerTracer.DebuggerSpanImpl) span).currentScope.span().getResourceName());
     span.finish();
     assertNotEquals(0, underlyingSpan.getDurationNano());
+    verify(probeStatusSink).addEmitting(eq(SPAN_ID));
   }
 
   @Test
   public void setError() {
     AgentTracer.forceRegister(CoreTracer.builder().build());
-    DebuggerTracer debuggerTracer = new DebuggerTracer();
-    DebuggerSpan span = debuggerTracer.createSpan("a-span", new String[] {"foo:bar"});
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    DebuggerTracer debuggerTracer =
+        new DebuggerTracer(DebuggerTracerTest::resolver, probeStatusSink);
+    DebuggerSpan span =
+        debuggerTracer.createSpan(SPAN_ID.getId(), "a-span", new String[] {"foo:bar"});
     span.setError(new IllegalArgumentException("oops"));
     AgentSpan underlyingSpan = ((DebuggerTracer.DebuggerSpanImpl) span).underlyingSpan;
     assertTrue(underlyingSpan.isError());
+    span.finish();
+    verify(probeStatusSink).addEmitting(eq(SPAN_ID));
+  }
+
+  @Test
+  public void noApi() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    DebuggerTracer debuggerTracer =
+        new DebuggerTracer(DebuggerTracerTest::resolver, probeStatusSink);
+    DebuggerSpan span =
+        debuggerTracer.createSpan(SPAN_ID.getId(), "a-span", new String[] {"foo:bar"});
+    assertEquals(DebuggerSpan.NOOP_SPAN, span);
+  }
+
+  @Test
+  public void badResolve() {
+    AgentTracer.forceRegister(CoreTracer.builder().build());
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    DebuggerTracer debuggerTracer =
+        new DebuggerTracer(DebuggerTracerTest::resolver, probeStatusSink);
+    DebuggerSpan span = debuggerTracer.createSpan("badId", "a-span", new String[] {"foo:bar"});
+    assertEquals(DebuggerSpan.NOOP_SPAN, span);
+  }
+
+  private static ProbeImplementation resolver(String probeId, Class<?> callingClass) {
+    if (probeId.equals(SPAN_ID.getId())) {
+      return new ProbeImplementation.NoopProbeImplementation(SPAN_ID, ProbeLocation.UNKNOWN);
+    }
+    return null;
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -262,7 +262,8 @@ public class DebuggerTransformerTest {
             config,
             configuration,
             ((definition, result) -> lastResult.set(result)),
-            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false));
+            new DebuggerSink(
+                config, new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false)));
     byte[] newClassBuffer =
         debuggerTransformer.transform(
             ClassLoader.getSystemClassLoader(),
@@ -289,7 +290,8 @@ public class DebuggerTransformerTest {
             config,
             configuration,
             ((definition, result) -> lastResult.set(result)),
-            new DebuggerSink(config, config.getFinalDebuggerSnapshotUrl(), false));
+            new DebuggerSink(
+                config, new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false)));
     byte[] newClassBuffer =
         debuggerTransformer.transform(
             ClassLoader.getSystemClassLoader(),
@@ -370,7 +372,7 @@ public class DebuggerTransformerTest {
         ClassNode classNode,
         MethodNode methodNode,
         List<DiagnosticMessage> diagnostics,
-        List<String> probeIds) {
+        List<ProbeId> probeIds) {
       methodNode.instructions.insert(
           new VarInsnNode(Opcodes.ASTORE, methodNode.localVariables.size()));
       return InstrumentationResult.Status.INSTALLED;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -549,15 +549,15 @@ public class LogProbesInstrumentationTest {
         .thenReturn("http://localhost:8126/debugger/v1/input");
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
+    DebuggerContext.ProbeResolver resolver =
+        (id, callingClass) ->
+            resolver(id, callingClass, expectedClassName, configuration.getLogProbes());
     currentTransformer = new DebuggerTransformer(config, configuration);
     instr.addTransformer(currentTransformer);
     DebuggerTransformerTest.TestSnapshotListener listener =
         new DebuggerTransformerTest.TestSnapshotListener(config, mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
-    DebuggerContext.init(
-        (id, callingClass) ->
-            resolver(id, callingClass, expectedClassName, configuration.getLogProbes()),
-        null);
+    DebuggerContext.init(resolver, null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
     return listener;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -550,8 +550,8 @@ public class LogProbesInstrumentationTest {
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     DebuggerContext.ProbeResolver resolver =
-        (id, callingClass) ->
-            resolver(id, callingClass, expectedClassName, configuration.getLogProbes());
+        (encodedProbeId, callingClass) ->
+            resolver(encodedProbeId, callingClass, expectedClassName, configuration.getLogProbes());
     currentTransformer = new DebuggerTransformer(config, configuration);
     instr.addTransformer(currentTransformer);
     DebuggerTransformerTest.TestSnapshotListener listener =
@@ -564,10 +564,13 @@ public class LogProbesInstrumentationTest {
   }
 
   private ProbeImplementation resolver(
-      String id, Class<?> callingClass, String expectedClassName, Collection<LogProbe> logProbes) {
+      String encodedProbeId,
+      Class<?> callingClass,
+      String expectedClassName,
+      Collection<LogProbe> logProbes) {
     Assertions.assertEquals(expectedClassName, callingClass.getName());
     for (LogProbe probe : logProbes) {
-      if (probe.getId().equals(id)) {
+      if (probe.getProbeId().getEncodedId().equals(encodedProbeId)) {
         return probe;
       }
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -1283,7 +1283,7 @@ public class MetricProbesInstrumentationTest {
     boolean throwing;
 
     @Override
-    public void count(String probeId, String name, long delta, String[] tags) {
+    public void count(String encodedProbeId, String name, long delta, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1292,7 +1292,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void gauge(String probeId, String name, long value, String[] tags) {
+    public void gauge(String encodedProbeId, String name, long value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1301,7 +1301,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void gauge(String probeId, String name, double value, String[] tags) {
+    public void gauge(String encodedProbeId, String name, double value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1310,7 +1310,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void histogram(String probeId, String name, long value, String[] tags) {
+    public void histogram(String encodedProbeId, String name, long value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1319,7 +1319,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void histogram(String probeId, String name, double value, String[] tags) {
+    public void histogram(String encodedProbeId, String name, double value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1328,7 +1328,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void distribution(String probeId, String name, long value, String[] tags) {
+    public void distribution(String encodedProbeId, String name, long value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1337,7 +1337,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void distribution(String probeId, String name, double value, String[] tags) {
+    public void distribution(String encodedProbeId, String name, double value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -4,6 +4,10 @@ import static com.datadog.debugger.probe.MetricProbe.MetricKind.COUNT;
 import static com.datadog.debugger.probe.MetricProbe.MetricKind.DISTRIBUTION;
 import static com.datadog.debugger.probe.MetricProbe.MetricKind.GAUGE;
 import static com.datadog.debugger.probe.MetricProbe.MetricKind.HISTOGRAM;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -35,7 +39,6 @@ import java.util.Map;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.joor.Reflect;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -69,10 +72,10 @@ public class MetricProbesInstrumentationTest {
         installSingleMetric(METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(3, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -90,10 +93,10 @@ public class MetricProbesInstrumentationTest {
             new String[] {"tag1:foo1", "tag2:foo2"});
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
-    Assertions.assertArrayEquals(
+    assertEquals(3, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
+    assertArrayEquals(
         new String[] {"tag1:foo1", "tag2:foo2", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
@@ -111,9 +114,9 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.value(42L), "42"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(42, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(3, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(42, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -130,8 +133,8 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.value(42.0), "42.0"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(3, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink)
         .addError(eq(METRIC_ID), eq("Unsupported constant value: 42.0 type: java.lang.Double"));
   }
@@ -150,8 +153,8 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(3, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink).addError(eq(METRIC_ID), eq("Cannot resolve symbol value"));
   }
 
@@ -178,12 +181,12 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metric1, metric2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertEquals(0, listener.counters.size());
+    assertEquals(3, result);
+    assertEquals(0, listener.counters.size());
     ArgumentCaptor<String> msgCaptor = ArgumentCaptor.forClass(String.class);
     verify(probeStatusSink, times(2)).addError(any(), msgCaptor.capture());
-    Assertions.assertEquals("Cannot resolve symbol value", msgCaptor.getAllValues().get(0));
-    Assertions.assertEquals("Cannot resolve symbol invalid", msgCaptor.getAllValues().get(1));
+    assertEquals("Cannot resolve symbol value", msgCaptor.getAllValues().get(0));
+    assertEquals("Cannot resolve symbol invalid", msgCaptor.getAllValues().get(1));
   }
 
   @Test
@@ -200,9 +203,9 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(48, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(48, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -219,10 +222,10 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(48, result);
-    Assertions.assertTrue(listener.gauges.containsKey(METRIC_NAME));
-    Assertions.assertEquals(31, listener.gauges.get(METRIC_NAME).longValue());
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(48, result);
+    assertTrue(listener.gauges.containsKey(METRIC_NAME));
+    assertEquals(31, listener.gauges.get(METRIC_NAME).longValue());
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -239,10 +242,10 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("doubleValue"), "doubleValue"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.doubleGauges.containsKey(METRIC_NAME));
-    Assertions.assertEquals(3.14, listener.doubleGauges.get(METRIC_NAME).doubleValue(), 0.001);
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(42, result);
+    assertTrue(listener.doubleGauges.containsKey(METRIC_NAME));
+    assertEquals(3.14, listener.doubleGauges.get(METRIC_NAME).doubleValue(), 0.001);
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -260,7 +263,7 @@ public class MetricProbesInstrumentationTest {
             new String[] {"tag1:foo1"});
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
+    assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -277,10 +280,10 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(48, result);
-    Assertions.assertTrue(listener.histograms.containsKey(METRIC_NAME));
-    Assertions.assertEquals(31, listener.histograms.get(METRIC_NAME).longValue());
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(48, result);
+    assertTrue(listener.histograms.containsKey(METRIC_NAME));
+    assertEquals(31, listener.histograms.get(METRIC_NAME).longValue());
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -297,10 +300,10 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("doubleValue"), "doubleValue"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.doubleHistograms.containsKey(METRIC_NAME));
-    Assertions.assertEquals(3.14, listener.doubleHistograms.get(METRIC_NAME).doubleValue(), 0.001);
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(42, result);
+    assertTrue(listener.doubleHistograms.containsKey(METRIC_NAME));
+    assertEquals(3.14, listener.doubleHistograms.get(METRIC_NAME).doubleValue(), 0.001);
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -319,10 +322,10 @@ public class MetricProbesInstrumentationTest {
             new String[] {"tag1:foo1"});
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(48, result);
-    Assertions.assertTrue(listener.histograms.containsKey(METRIC_NAME));
-    Assertions.assertEquals(31, listener.histograms.get(METRIC_NAME).longValue());
-    Assertions.assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(48, result);
+    assertTrue(listener.histograms.containsKey(METRIC_NAME));
+    assertEquals(31, listener.histograms.get(METRIC_NAME).longValue());
+    assertArrayEquals(new String[] {"tag1:foo1", METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -339,10 +342,10 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("value"), "value"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(48, result);
-    Assertions.assertTrue(listener.distributions.containsKey(METRIC_NAME));
-    Assertions.assertEquals(31, listener.distributions.get(METRIC_NAME).longValue());
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(48, result);
+    assertTrue(listener.distributions.containsKey(METRIC_NAME));
+    assertEquals(31, listener.distributions.get(METRIC_NAME).longValue());
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -359,11 +362,10 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("doubleValue"), "doubleValue"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.doubleDistributions.containsKey(METRIC_NAME));
-    Assertions.assertEquals(
-        3.14, listener.doubleDistributions.get(METRIC_NAME).doubleValue(), 0.001);
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(42, result);
+    assertTrue(listener.doubleDistributions.containsKey(METRIC_NAME));
+    assertEquals(3.14, listener.doubleDistributions.get(METRIC_NAME).doubleValue(), 0.001);
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -379,10 +381,10 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.gauges.containsKey(METRIC_NAME));
-    Assertions.assertEquals(42, listener.gauges.get(METRIC_NAME).longValue());
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(42, result);
+    assertTrue(listener.gauges.containsKey(METRIC_NAME));
+    assertEquals(42, listener.gauges.get(METRIC_NAME).longValue());
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -399,8 +401,8 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertFalse(listener.gauges.containsKey(METRIC_NAME));
+    assertEquals(42, result);
+    assertFalse(listener.gauges.containsKey(METRIC_NAME));
     verify(probeStatusSink).addError(eq(METRIC_ID), eq("Cannot resolve symbol @return"));
   }
 
@@ -417,10 +419,10 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.doubleGauges.containsKey(METRIC_NAME));
-    Assertions.assertTrue(listener.doubleGauges.get(METRIC_NAME).doubleValue() > 0);
-    Assertions.assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
+    assertEquals(42, result);
+    assertTrue(listener.doubleGauges.containsKey(METRIC_NAME));
+    assertTrue(listener.doubleGauges.get(METRIC_NAME).doubleValue() > 0);
+    assertArrayEquals(new String[] {METRIC_PROBEID_TAG}, listener.lastTags);
   }
 
   @Test
@@ -438,9 +440,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(48, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(48, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(31, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -457,8 +459,8 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("foo"), "foo"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(48, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(48, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink).addError(eq(METRIC_ID), eq("Cannot resolve symbol foo"));
   }
 
@@ -476,8 +478,8 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("arg"), "arg"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(48, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(48, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink)
         .addError(
             eq(METRIC_ID),
@@ -494,9 +496,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(3, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(3, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(3, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -509,8 +511,8 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(3, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink).addError(eq(METRIC_ID), eq("Cannot resolve symbol foo"));
   }
 
@@ -524,8 +526,8 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(3, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink)
         .addError(
             eq(METRIC_ID),
@@ -547,9 +549,9 @@ public class MetricProbesInstrumentationTest {
 
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(42, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -567,9 +569,9 @@ public class MetricProbesInstrumentationTest {
 
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(42, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -587,9 +589,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(48, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(42, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(48, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -618,11 +620,11 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME1));
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME2));
-    Assertions.assertEquals(42, listener.counters.get(METRIC_NAME1).longValue());
-    Assertions.assertEquals(101, listener.counters.get(METRIC_NAME2).longValue());
+    assertEquals(143, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME1));
+    assertTrue(listener.counters.containsKey(METRIC_NAME2));
+    assertEquals(42, listener.counters.get(METRIC_NAME1).longValue());
+    assertEquals(101, listener.counters.get(METRIC_NAME2).longValue());
   }
 
   @Test
@@ -652,9 +654,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME1));
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME2));
+    assertEquals(143, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME1));
+    assertFalse(listener.counters.containsKey(METRIC_NAME2));
     verify(probeStatusSink, times(0)).addError(any(), anyString());
   }
 
@@ -684,13 +686,13 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME1));
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME2));
+    assertEquals(143, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME1));
+    assertFalse(listener.counters.containsKey(METRIC_NAME2));
     ArgumentCaptor<String> strCaptor = ArgumentCaptor.forClass(String.class);
     verify(probeStatusSink, times(2)).addError(any(), strCaptor.capture());
-    Assertions.assertEquals("Cannot resolve field foovalue", strCaptor.getAllValues().get(0));
-    Assertions.assertEquals("Cannot resolve field foovalue", strCaptor.getAllValues().get(1));
+    assertEquals("Cannot resolve field foovalue", strCaptor.getAllValues().get(0));
+    assertEquals("Cannot resolve field foovalue", strCaptor.getAllValues().get(1));
   }
 
   @Test
@@ -719,15 +721,15 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
-    Assertions.assertEquals(143, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME1));
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME2));
+    assertEquals(143, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME1));
+    assertFalse(listener.counters.containsKey(METRIC_NAME2));
     ArgumentCaptor<String> strCaptor = ArgumentCaptor.forClass(String.class);
     verify(probeStatusSink, times(2)).addError(any(), strCaptor.capture());
-    Assertions.assertEquals(
+    assertEquals(
         "Incompatible type for expression: java.lang.String with expected types: [long]",
         strCaptor.getAllValues().get(0));
-    Assertions.assertEquals(
+    assertEquals(
         "Incompatible type for expression: java.lang.String with expected types: [long]",
         strCaptor.getAllValues().get(1));
   }
@@ -747,8 +749,8 @@ public class MetricProbesInstrumentationTest {
 
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(42, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink).addError(eq(METRIC_ID), eq("Cannot resolve symbol fooValue"));
   }
 
@@ -766,8 +768,8 @@ public class MetricProbesInstrumentationTest {
             new ValueScript(DSL.ref("strValue"), "strValue"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertFalse(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(42, result);
+    assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink)
         .addError(
             eq(METRIC_ID),
@@ -790,7 +792,7 @@ public class MetricProbesInstrumentationTest {
     listener.setThrowing(true);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
+    assertEquals(42, result);
   }
 
   @Test
@@ -802,9 +804,9 @@ public class MetricProbesInstrumentationTest {
             METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null, null, "8");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(3, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(1, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -816,11 +818,11 @@ public class MetricProbesInstrumentationTest {
             METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null, null, "4-8");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
-    Assertions.assertEquals(3, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(2, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(3, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(2, listener.counters.get(METRIC_NAME).longValue());
     result = Reflect.on(testClass).call("main", "2").get();
-    Assertions.assertEquals(3, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(3, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -836,9 +838,9 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(42, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(24, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
@@ -854,31 +856,34 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.counters.containsKey(METRIC_NAME));
-    Assertions.assertEquals(48, listener.counters.get(METRIC_NAME).longValue());
+    assertEquals(42, result);
+    assertTrue(listener.counters.containsKey(METRIC_NAME));
+    assertEquals(48, listener.counters.get(METRIC_NAME).longValue());
   }
 
   @Test
   public void lenExpression() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot06";
-    String STRLEN_METRIC = "strlen";
-    String LISTSIZE_METRIC = "listsize";
-    String MAPSIZE_METRIC = "mapsize";
+    final String STRLEN_METRIC = "strlen";
+    final ProbeId STRLEN_METRIC_ID = new ProbeId(STRLEN_METRIC, 1);
+    final String LISTSIZE_METRIC = "listsize";
+    final ProbeId LISTSIZE_METRIC_ID = new ProbeId(LISTSIZE_METRIC, 1);
+    final String MAPSIZE_METRIC = "mapsize";
+    final ProbeId MAPSIZE_METRIC_ID = new ProbeId(MAPSIZE_METRIC, 1);
     MetricProbe metricProbe1 =
-        createMetricBuilder(METRIC_ID, STRLEN_METRIC, GAUGE)
+        createMetricBuilder(STRLEN_METRIC_ID, STRLEN_METRIC, GAUGE)
             .where(CLASS_NAME, "f", "()")
             .valueScript(new ValueScript(DSL.len(DSL.ref("strValue")), "len(strValue)"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbe2 =
-        createMetricBuilder(METRIC_ID, LISTSIZE_METRIC, GAUGE)
+        createMetricBuilder(LISTSIZE_METRIC_ID, LISTSIZE_METRIC, GAUGE)
             .where(CLASS_NAME, "f", "()")
             .valueScript(new ValueScript(DSL.len(DSL.ref("strList")), "len(strList)"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbe3 =
-        createMetricBuilder(METRIC_ID, MAPSIZE_METRIC, GAUGE)
+        createMetricBuilder(MAPSIZE_METRIC_ID, MAPSIZE_METRIC, GAUGE)
             .where(CLASS_NAME, "f", "()")
             .valueScript(new ValueScript(DSL.len(DSL.ref("strMap")), "len(strMap)"))
             .evaluateAt(MethodLocation.EXIT)
@@ -887,16 +892,13 @@ public class MetricProbesInstrumentationTest {
         installMetricProbes(metricProbe1, metricProbe2, metricProbe3);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.gauges.containsKey(STRLEN_METRIC));
-    Assertions.assertEquals(
-        4, listener.gauges.get(STRLEN_METRIC).longValue()); // <=> "done".length()
-    Assertions.assertTrue(listener.gauges.containsKey(LISTSIZE_METRIC));
-    Assertions.assertEquals(
-        3, listener.gauges.get(LISTSIZE_METRIC).longValue()); // <=> strList.size()
-    Assertions.assertTrue(listener.gauges.containsKey(MAPSIZE_METRIC));
-    Assertions.assertEquals(
-        1, listener.gauges.get(MAPSIZE_METRIC).longValue()); // <=> strMap.size()
+    assertEquals(42, result);
+    assertTrue(listener.gauges.containsKey(STRLEN_METRIC));
+    assertEquals(4, listener.gauges.get(STRLEN_METRIC).longValue()); // <=> "done".length()
+    assertTrue(listener.gauges.containsKey(LISTSIZE_METRIC));
+    assertEquals(3, listener.gauges.get(LISTSIZE_METRIC).longValue()); // <=> strList.size()
+    assertTrue(listener.gauges.containsKey(MAPSIZE_METRIC));
+    assertEquals(1, listener.gauges.get(MAPSIZE_METRIC).longValue()); // <=> strMap.size()
   }
 
   @Test
@@ -928,16 +930,16 @@ public class MetricProbesInstrumentationTest {
         installMetricProbes(metricProbe1, metricProbe2, metricProbe3);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(0, listener.gauges.size());
+    assertEquals(42, result);
+    assertEquals(0, listener.gauges.size());
     ArgumentCaptor<String> strCaptor = ArgumentCaptor.forClass(String.class);
     verify(probeStatusSink, times(3)).addError(any(), strCaptor.capture());
-    Assertions.assertEquals(
+    assertEquals(
         "Unsupported type for len operation: java.lang.Object", strCaptor.getAllValues().get(0));
-    Assertions.assertEquals(
+    assertEquals(
         "Incompatible type for expression: java.lang.String with expected types: [long,double]",
         strCaptor.getAllValues().get(1));
-    Assertions.assertEquals(
+    assertEquals(
         "Incompatible type for expression: java.lang.Object with expected types: [long,double]",
         strCaptor.getAllValues().get(2));
   }
@@ -945,18 +947,21 @@ public class MetricProbesInstrumentationTest {
   @Test
   public void indexExpression() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot22";
-    String ARRAYIDX_METRIC = "arrayindex";
-    String LISTIDX_METRIC = "listindex";
-    String MAPIDX_METRIC = "mapindex";
+    final String ARRAYIDX_METRIC = "arrayindex";
+    final ProbeId ARRAYIDX_METRIC_ID = new ProbeId(ARRAYIDX_METRIC, 1);
+    final String LISTIDX_METRIC = "listindex";
+    final ProbeId LISTIDX_METRIC_ID = new ProbeId(LISTIDX_METRIC, 1);
+    final String MAPIDX_METRIC = "mapindex";
+    final ProbeId MAPIDX_METRIC_ID = new ProbeId(MAPIDX_METRIC, 1);
     MetricProbe metricProbe1 =
-        createMetricBuilder(METRIC_ID, ARRAYIDX_METRIC, GAUGE)
+        createMetricBuilder(ARRAYIDX_METRIC_ID, ARRAYIDX_METRIC, GAUGE)
             .where(CLASS_NAME, "doit", "(String)")
             .valueScript(
                 new ValueScript(DSL.index(DSL.ref("intArray"), DSL.value(4)), "intArray[4]"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbe2 =
-        createMetricBuilder(METRIC_ID, LISTIDX_METRIC, GAUGE)
+        createMetricBuilder(LISTIDX_METRIC_ID, LISTIDX_METRIC, GAUGE)
             .where(CLASS_NAME, "doit", "(String)")
             .valueScript(
                 new ValueScript(
@@ -964,7 +969,7 @@ public class MetricProbesInstrumentationTest {
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbe3 =
-        createMetricBuilder(METRIC_ID, MAPIDX_METRIC, GAUGE)
+        createMetricBuilder(MAPIDX_METRIC_ID, MAPIDX_METRIC, GAUGE)
             .where(CLASS_NAME, "doit", "(String)")
             .valueScript(
                 new ValueScript(
@@ -976,22 +981,24 @@ public class MetricProbesInstrumentationTest {
         installMetricProbes(metricProbe1, metricProbe2, metricProbe3);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertTrue(listener.gauges.containsKey(ARRAYIDX_METRIC));
-    Assertions.assertEquals(4, listener.gauges.get(ARRAYIDX_METRIC).longValue());
-    Assertions.assertTrue(listener.gauges.containsKey(LISTIDX_METRIC));
-    Assertions.assertEquals(3, listener.gauges.get(LISTIDX_METRIC).longValue());
-    Assertions.assertTrue(listener.gauges.containsKey(MAPIDX_METRIC));
-    Assertions.assertEquals(4, listener.gauges.get(MAPIDX_METRIC).longValue());
+    assertEquals(42, result);
+    assertTrue(listener.gauges.containsKey(ARRAYIDX_METRIC));
+    assertEquals(4, listener.gauges.get(ARRAYIDX_METRIC).longValue());
+    assertTrue(listener.gauges.containsKey(LISTIDX_METRIC));
+    assertEquals(3, listener.gauges.get(LISTIDX_METRIC).longValue());
+    assertTrue(listener.gauges.containsKey(MAPIDX_METRIC));
+    assertEquals(4, listener.gauges.get(MAPIDX_METRIC).longValue());
   }
 
   @Test
   public void indexInvalidKeyTypeExpression() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot22";
-    String ARRAYSTRIDX_METRIC = "arrayStrIndex";
-    String ARRAYOOBIDX_METRIC = "arrayOutOfBoundsIndex";
+    final String ARRAYSTRIDX_METRIC = "arrayStrIndex";
+    final ProbeId ARRAYSTRIDX_METRIC_ID = new ProbeId(ARRAYSTRIDX_METRIC, 1);
+    final String ARRAYOOBIDX_METRIC = "arrayOutOfBoundsIndex";
+    final ProbeId ARRAYOOBIDX_METRIC_ID = new ProbeId(ARRAYOOBIDX_METRIC, 1);
     MetricProbe metricProbe1 =
-        createMetricBuilder(METRIC_ID, ARRAYSTRIDX_METRIC, GAUGE)
+        createMetricBuilder(ARRAYSTRIDX_METRIC_ID, ARRAYSTRIDX_METRIC, GAUGE)
             .where(CLASS_NAME, "doit", "(String)")
             .valueScript(
                 new ValueScript(
@@ -999,7 +1006,7 @@ public class MetricProbesInstrumentationTest {
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbe2 =
-        createMetricBuilder(METRIC_ID, ARRAYOOBIDX_METRIC, GAUGE)
+        createMetricBuilder(ARRAYOOBIDX_METRIC_ID, ARRAYOOBIDX_METRIC, GAUGE)
             .where(CLASS_NAME, "doit", "(String)")
             // generates ArrayOutOfBoundsException
             .valueScript(
@@ -1009,12 +1016,12 @@ public class MetricProbesInstrumentationTest {
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertFalse(listener.gauges.containsKey(ARRAYSTRIDX_METRIC));
-    Assertions.assertFalse(listener.gauges.containsKey(ARRAYOOBIDX_METRIC));
-    verify(probeStatusSink, times(2))
+    assertEquals(42, result);
+    assertFalse(listener.gauges.containsKey(ARRAYSTRIDX_METRIC));
+    assertFalse(listener.gauges.containsKey(ARRAYOOBIDX_METRIC));
+    verify(probeStatusSink)
         .addError(
-            eq(METRIC_ID),
+            eq(ARRAYSTRIDX_METRIC_ID),
             eq(
                 "Incompatible type for key: Type{mainType=Ljava/lang/String;, genericTypes=[]}, expected int or long"));
   }
@@ -1052,67 +1059,75 @@ public class MetricProbesInstrumentationTest {
         installMetricProbes(metricProbe1, metricProbe2, metricProbe3);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
-    Assertions.assertEquals(143, result);
-    Assertions.assertEquals(3, listener.gauges.get(STRVALUE_METRIC));
-    Assertions.assertEquals(1042, listener.gauges.get(LONGVALUE_METRIC));
-    Assertions.assertEquals(202, listener.gauges.get(INTVALUE_METRIC));
+    assertEquals(143, result);
+    assertEquals(3, listener.gauges.get(STRVALUE_METRIC));
+    assertEquals(1042, listener.gauges.get(LONGVALUE_METRIC));
+    assertEquals(202, listener.gauges.get(INTVALUE_METRIC));
   }
 
   @Test
   public void primitivesFunction() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot25";
     final String METRIC_NAME_INT = "int_arg_count";
+    final ProbeId METRIC_INT_ID = new ProbeId(METRIC_NAME_INT, 1);
     final String METRIC_NAME_LONG = "long_arg_count";
+    final ProbeId METRIC_LONG_ID = new ProbeId(METRIC_NAME_LONG, 1);
     final String METRIC_NAME_FLOAT = "float_arg_count";
+    final ProbeId METRIC_FLOAT_ID = new ProbeId(METRIC_NAME_FLOAT, 1);
     final String METRIC_NAME_DOUBLE = "double_arg_count";
+    final ProbeId METRIC_DOUBLE_ID = new ProbeId(METRIC_NAME_DOUBLE, 1);
     final String METRIC_NAME_BOOLEAN = "boolean_arg_count";
+    final ProbeId METRIC_BOOLEAN_ID = new ProbeId(METRIC_NAME_BOOLEAN, 1);
     final String METRIC_NAME_BYTE = "byte_arg_count";
+    final ProbeId METRIC_BYTE_ID = new ProbeId(METRIC_NAME_BYTE, 1);
     final String METRIC_NAME_SHORT = "short_arg_count";
+    final ProbeId METRIC_SHORT_ID = new ProbeId(METRIC_NAME_SHORT, 1);
     final String METRIC_NAME_CHAR = "char_arg_count";
+    final ProbeId METRIC_CHAR_ID = new ProbeId(METRIC_NAME_CHAR, 1);
     MetricProbe metricProbeInt =
-        createMetricBuilder(METRIC_ID, METRIC_NAME_INT, COUNT)
+        createMetricBuilder(METRIC_INT_ID, METRIC_NAME_INT, COUNT)
             .where(CLASS_NAME, "intFunction")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbeLong =
-        createMetricBuilder(METRIC_ID, METRIC_NAME_LONG, COUNT)
+        createMetricBuilder(METRIC_LONG_ID, METRIC_NAME_LONG, COUNT)
             .where(CLASS_NAME, "longFunction")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbeFloat =
-        createMetricBuilder(METRIC_ID, METRIC_NAME_FLOAT, GAUGE)
+        createMetricBuilder(METRIC_FLOAT_ID, METRIC_NAME_FLOAT, GAUGE)
             .where(CLASS_NAME, "floatFunction")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbeDouble =
-        createMetricBuilder(METRIC_ID, METRIC_NAME_DOUBLE, GAUGE)
+        createMetricBuilder(METRIC_DOUBLE_ID, METRIC_NAME_DOUBLE, GAUGE)
             .where(CLASS_NAME, "doubleFunction")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbeBoolean =
-        createMetricBuilder(METRIC_ID, METRIC_NAME_BOOLEAN, COUNT)
+        createMetricBuilder(METRIC_BOOLEAN_ID, METRIC_NAME_BOOLEAN, COUNT)
             .where(CLASS_NAME, "booleanFunction")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbeByte =
-        createMetricBuilder(METRIC_ID, METRIC_NAME_BYTE, COUNT)
+        createMetricBuilder(METRIC_BYTE_ID, METRIC_NAME_BYTE, COUNT)
             .where(CLASS_NAME, "byteFunction")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbeShort =
-        createMetricBuilder(METRIC_ID, METRIC_NAME_SHORT, COUNT)
+        createMetricBuilder(METRIC_SHORT_ID, METRIC_NAME_SHORT, COUNT)
             .where(CLASS_NAME, "shortFunction")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
     MetricProbe metricProbeChar =
-        createMetricBuilder(METRIC_ID, METRIC_NAME_CHAR, COUNT)
+        createMetricBuilder(METRIC_CHAR_ID, METRIC_NAME_CHAR, COUNT)
             .where(CLASS_NAME, "charFunction")
             .valueScript(new ValueScript(DSL.ref("arg"), "arg"))
             .evaluateAt(MethodLocation.EXIT)
@@ -1130,29 +1145,29 @@ public class MetricProbesInstrumentationTest {
             metricProbeChar);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "int").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(42, listener.counters.get(METRIC_NAME_INT));
+    assertEquals(42, result);
+    assertEquals(42, listener.counters.get(METRIC_NAME_INT));
     result = Reflect.on(testClass).call("main", "long").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(1001, listener.counters.get(METRIC_NAME_LONG));
+    assertEquals(42, result);
+    assertEquals(1001, listener.counters.get(METRIC_NAME_LONG));
     result = Reflect.on(testClass).call("main", "float").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(3.14, listener.doubleGauges.get(METRIC_NAME_FLOAT), 0.001);
+    assertEquals(42, result);
+    assertEquals(3.14, listener.doubleGauges.get(METRIC_NAME_FLOAT), 0.001);
     result = Reflect.on(testClass).call("main", "double").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(Math.E, listener.doubleGauges.get(METRIC_NAME_DOUBLE), 0.001);
+    assertEquals(42, result);
+    assertEquals(Math.E, listener.doubleGauges.get(METRIC_NAME_DOUBLE), 0.001);
     result = Reflect.on(testClass).call("main", "boolean").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(1, listener.counters.get(METRIC_NAME_BOOLEAN));
+    assertEquals(42, result);
+    assertEquals(1, listener.counters.get(METRIC_NAME_BOOLEAN));
     result = Reflect.on(testClass).call("main", "byte").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(0x42, listener.counters.get(METRIC_NAME_BYTE));
+    assertEquals(42, result);
+    assertEquals(0x42, listener.counters.get(METRIC_NAME_BYTE));
     result = Reflect.on(testClass).call("main", "short").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(1001, listener.counters.get(METRIC_NAME_SHORT));
+    assertEquals(42, result);
+    assertEquals(1001, listener.counters.get(METRIC_NAME_SHORT));
     result = Reflect.on(testClass).call("main", "char").get();
-    Assertions.assertEquals(42, result);
-    Assertions.assertEquals(97, listener.counters.get(METRIC_NAME_CHAR));
+    assertEquals(42, result);
+    assertEquals(97, listener.counters.get(METRIC_NAME_CHAR));
   }
 
   private MetricForwarderListener installSingleMetric(
@@ -1268,7 +1283,7 @@ public class MetricProbesInstrumentationTest {
     boolean throwing;
 
     @Override
-    public void count(String name, long delta, String[] tags) {
+    public void count(String probeId, String name, long delta, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1277,7 +1292,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void gauge(String name, long value, String[] tags) {
+    public void gauge(String probeId, String name, long value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1286,7 +1301,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void gauge(String name, double value, String[] tags) {
+    public void gauge(String probeId, String name, double value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1295,7 +1310,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void histogram(String name, long value, String[] tags) {
+    public void histogram(String probeId, String name, long value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1304,7 +1319,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void histogram(String name, double value, String[] tags) {
+    public void histogram(String probeId, String name, double value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1313,7 +1328,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void distribution(String name, long value, String[] tags) {
+    public void distribution(String probeId, String name, long value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }
@@ -1322,7 +1337,7 @@ public class MetricProbesInstrumentationTest {
     }
 
     @Override
-    public void distribution(String name, double value, String[] tags) {
+    public void distribution(String probeId, String name, double value, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -650,20 +650,25 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     mockSink = new MockSink(config, probeStatusSink);
     DebuggerAgentHelper.injectSink(mockSink);
     DebuggerContext.init(
-        (id, callingClass) -> resolver(id, callingClass, expectedClassName, configuration), null);
+        (encodedProbeId, callingClass) ->
+            resolver(encodedProbeId, callingClass, expectedClassName, configuration),
+        null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
   }
 
   private ProbeImplementation resolver(
-      String id, Class<?> callingClass, String expectedClassName, Configuration configuration) {
+      String encodedProbeId,
+      Class<?> callingClass,
+      String expectedClassName,
+      Configuration configuration) {
     Assertions.assertEquals(expectedClassName, callingClass.getName());
     for (SpanDecorationProbe probe : configuration.getSpanDecorationProbes()) {
-      if (probe.getId().equals(id)) {
+      if (probe.getProbeId().getEncodedId().equals(encodedProbeId)) {
         return probe;
       }
     }
     for (LogProbe probe : configuration.getLogProbes()) {
-      if (probe.getId().equals(id)) {
+      if (probe.getProbeId().getEncodedId().equals(encodedProbeId)) {
         return probe;
       }
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static utils.InstrumentationTestHelper.compileAndLoadClass;
 
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 
 public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentationTest {
   private static final String LANGUAGE = "java";
@@ -84,6 +86,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     MutableSpan span = traceInterceptor.getFirstSpan();
     assertEquals("1", span.getTags().get("tag1"));
     assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.di.tag1.probe_id"));
+    verify(probeStatusSink).addEmitting(ArgumentMatchers.eq(PROBE_ID));
   }
 
   @Test
@@ -244,6 +247,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     MutableSpan span = traceInterceptor.getFirstSpan();
     assertEquals("1", span.getTags().get("tag1"));
     assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.di.tag1.probe_id"));
+    verify(probeStatusSink).addEmitting(ArgumentMatchers.eq(PROBE_ID));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
@@ -167,7 +167,7 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
     boolean throwing;
 
     @Override
-    public DebuggerSpan createSpan(String probeId, String resourceName, String[] tags) {
+    public DebuggerSpan createSpan(String encodedProbeId, String resourceName, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
@@ -41,6 +41,7 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
     assertEquals(CLASS_NAME + ".main", span.resourceName);
     assertTrue(span.isFinished());
     assertArrayEquals(new String[] {SPAN_PROBEID_TAG}, span.tags);
+    probeStatusSink.addEmitting(eq(SPAN_ID));
   }
 
   @Test
@@ -83,6 +84,7 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
     assertEquals(CLASS_NAME + ".main:L4-8", span.resourceName);
     assertTrue(span.isFinished());
     assertArrayEquals(new String[] {SPAN_PROBEID_TAG}, span.tags);
+    probeStatusSink.addEmitting(eq(SPAN_ID));
   }
 
   @Test
@@ -165,7 +167,7 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
     boolean throwing;
 
     @Override
-    public DebuggerSpan createSpan(String resourceName, String[] tags) {
+    public DebuggerSpan createSpan(String probeId, String resourceName, String[] tags) {
       if (throwing) {
         throw new IllegalArgumentException("oops");
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/StatsdMetricForwarderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/StatsdMetricForwarderTest.java
@@ -1,0 +1,105 @@
+package com.datadog.debugger.agent;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.datadog.debugger.sink.ProbeStatusSink;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import datadog.trace.bootstrap.debugger.ProbeLocation;
+import org.junit.jupiter.api.Test;
+
+class StatsdMetricForwarderTest {
+  private static final ProbeId METRIC_ID = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f8", 0);
+
+  @Test
+  void emittingCountMetric() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(
+            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
+    statsdMetricForwarder.count(METRIC_ID.getId(), "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+  }
+
+  @Test
+  void emittingGaugeLongMetric() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(
+            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
+    statsdMetricForwarder.gauge(METRIC_ID.getId(), "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+  }
+
+  @Test
+  void emittingGaugeDoubleMetric() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(
+            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
+    statsdMetricForwarder.gauge(METRIC_ID.getId(), "name", 1.0, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+  }
+
+  @Test
+  void emittingHistogramLongMetric() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(
+            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
+    statsdMetricForwarder.histogram(METRIC_ID.getId(), "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+  }
+
+  @Test
+  void emittingHistogramDoubleMetric() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(
+            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
+    statsdMetricForwarder.histogram(METRIC_ID.getId(), "name", 1.0, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+  }
+
+  @Test
+  void emittingDistributionLongMetric() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(
+            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
+    statsdMetricForwarder.distribution(METRIC_ID.getId(), "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+  }
+
+  @Test
+  void emittingDistributionDoubleMetric() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(
+            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
+    statsdMetricForwarder.distribution(METRIC_ID.getId(), "name", 1.0, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+  }
+
+  @Test
+  void badResolution() {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    StatsdMetricForwarder statsdMetricForwarder =
+        new StatsdMetricForwarder(
+            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
+    statsdMetricForwarder.count("badId", "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink, times(0)).addEmitting(eq(METRIC_ID));
+  }
+
+  private static ProbeImplementation resolver(String probeId, Class<?> callingClass) {
+    if (probeId.equals(METRIC_ID.getId())) {
+      return new ProbeImplementation.NoopProbeImplementation(METRIC_ID, ProbeLocation.UNKNOWN);
+    }
+    return null;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/StatsdMetricForwarderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/StatsdMetricForwarderTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.verify;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.ProbeId;
-import datadog.trace.bootstrap.debugger.ProbeImplementation;
-import datadog.trace.bootstrap.debugger.ProbeLocation;
 import org.junit.jupiter.api.Test;
 
 class StatsdMetricForwarderTest {
@@ -20,86 +18,74 @@ class StatsdMetricForwarderTest {
   void emittingCountMetric() {
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(
-            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
-    statsdMetricForwarder.count(METRIC_ID.getId(), "name", 1, new String[] {"foo:bar"});
-    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+        new StatsdMetricForwarder(Config.get(), probeStatusSink);
+    statsdMetricForwarder.count(METRIC_ID.getEncodedId(), "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID.getEncodedId()));
   }
 
   @Test
   void emittingGaugeLongMetric() {
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(
-            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
-    statsdMetricForwarder.gauge(METRIC_ID.getId(), "name", 1, new String[] {"foo:bar"});
-    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+        new StatsdMetricForwarder(Config.get(), probeStatusSink);
+    statsdMetricForwarder.gauge(METRIC_ID.getEncodedId(), "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID.getEncodedId()));
   }
 
   @Test
   void emittingGaugeDoubleMetric() {
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(
-            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
-    statsdMetricForwarder.gauge(METRIC_ID.getId(), "name", 1.0, new String[] {"foo:bar"});
-    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+        new StatsdMetricForwarder(Config.get(), probeStatusSink);
+    statsdMetricForwarder.gauge(METRIC_ID.getEncodedId(), "name", 1.0, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID.getEncodedId()));
   }
 
   @Test
   void emittingHistogramLongMetric() {
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(
-            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
-    statsdMetricForwarder.histogram(METRIC_ID.getId(), "name", 1, new String[] {"foo:bar"});
-    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+        new StatsdMetricForwarder(Config.get(), probeStatusSink);
+    statsdMetricForwarder.histogram(METRIC_ID.getEncodedId(), "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID.getEncodedId()));
   }
 
   @Test
   void emittingHistogramDoubleMetric() {
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(
-            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
-    statsdMetricForwarder.histogram(METRIC_ID.getId(), "name", 1.0, new String[] {"foo:bar"});
-    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+        new StatsdMetricForwarder(Config.get(), probeStatusSink);
+    statsdMetricForwarder.histogram(
+        METRIC_ID.getEncodedId(), "name", 1.0, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID.getEncodedId()));
   }
 
   @Test
   void emittingDistributionLongMetric() {
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(
-            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
-    statsdMetricForwarder.distribution(METRIC_ID.getId(), "name", 1, new String[] {"foo:bar"});
-    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+        new StatsdMetricForwarder(Config.get(), probeStatusSink);
+    statsdMetricForwarder.distribution(
+        METRIC_ID.getEncodedId(), "name", 1, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID.getEncodedId()));
   }
 
   @Test
   void emittingDistributionDoubleMetric() {
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(
-            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
-    statsdMetricForwarder.distribution(METRIC_ID.getId(), "name", 1.0, new String[] {"foo:bar"});
-    verify(probeStatusSink).addEmitting(eq(METRIC_ID));
+        new StatsdMetricForwarder(Config.get(), probeStatusSink);
+    statsdMetricForwarder.distribution(
+        METRIC_ID.getEncodedId(), "name", 1.0, new String[] {"foo:bar"});
+    verify(probeStatusSink).addEmitting(eq(METRIC_ID.getEncodedId()));
   }
 
   @Test
   void badResolution() {
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     StatsdMetricForwarder statsdMetricForwarder =
-        new StatsdMetricForwarder(
-            Config.get(), StatsdMetricForwarderTest::resolver, probeStatusSink);
-    statsdMetricForwarder.count("badId", "name", 1, new String[] {"foo:bar"});
+        new StatsdMetricForwarder(Config.get(), probeStatusSink);
+    statsdMetricForwarder.count("badId:0", "name", 1, new String[] {"foo:bar"});
     verify(probeStatusSink, times(0)).addEmitting(eq(METRIC_ID));
-  }
-
-  private static ProbeImplementation resolver(String probeId, Class<?> callingClass) {
-    if (probeId.equals(METRIC_ID.getId())) {
-      return new ProbeImplementation.NoopProbeImplementation(METRIC_ID, ProbeLocation.UNKNOWN);
-    }
-    return null;
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
@@ -89,7 +89,8 @@ class ProbeStatusSinkTest {
   void addEmitting() {
     probeStatusSink.addEmitting(PROBE_ID);
     assertEquals(
-        Arrays.asList(builder.emittingMessage(PROBE_ID)), probeStatusSink.getDiagnostics());
+        Arrays.asList(builder.emittingMessage(PROBE_ID.getEncodedId())),
+        probeStatusSink.getDiagnostics());
   }
 
   @Test
@@ -138,6 +139,7 @@ class ProbeStatusSinkTest {
     probeStatusSink.addInstalled(PROBE_ID);
     probeStatusSink.addReceived(PROBE_ID_NEW_VERSION);
     probeStatusSink.addInstalled(PROBE_ID_NEW_VERSION);
+    probeStatusSink.removeDiagnostics(PROBE_ID);
     assertEquals(
         Arrays.asList(
             builder.receivedMessage(PROBE_ID),

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/ProbeStatusSinkTest.java
@@ -86,6 +86,13 @@ class ProbeStatusSinkTest {
   }
 
   @Test
+  void addEmitting() {
+    probeStatusSink.addEmitting(PROBE_ID);
+    assertEquals(
+        Arrays.asList(builder.emittingMessage(PROBE_ID)), probeStatusSink.getDiagnostics());
+  }
+
+  @Test
   void addReceivedThenInstalled() {
     probeStatusSink.addReceived(PROBE_ID);
     probeStatusSink.addInstalled(PROBE_ID);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -38,6 +38,9 @@ import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import okhttp3.HttpUrl;
@@ -89,9 +92,11 @@ public abstract class BaseIntegrationTest {
   private Configuration currentConfiguration;
   private boolean configProvided;
   protected final Object configLock = new Object();
-  protected final List<Predicate<Snapshot>> snapshotListeners = new ArrayList<>();
-  protected final List<Predicate<DecodedTrace>> traceListeners = new ArrayList<>();
-  protected final List<Predicate<ProbeStatus>> probeStatusListeners = new ArrayList<>();
+  protected final List<Consumer<JsonSnapshotSerializer.IntakeRequest>> intakeRequestListeners =
+      new ArrayList<>();
+  protected final List<Consumer<Snapshot>> snapshotListeners = new ArrayList<>();
+  protected final List<Consumer<DecodedTrace>> traceListeners = new ArrayList<>();
+  protected final List<Consumer<ProbeStatus>> probeStatusListeners = new ArrayList<>();
   protected int batchSize = 1; // to verify each snapshot upload one by one
 
   @BeforeAll
@@ -208,13 +213,13 @@ public abstract class BaseIntegrationTest {
   protected enum RequestType {
     SNAPSHOT {
       @Override
-      public boolean process(BaseIntegrationTest baseIntegrationTest, RecordedRequest request) {
+      public void process(BaseIntegrationTest baseIntegrationTest, RecordedRequest request) {
         if (!request.getPath().startsWith(SNAPSHOT_URL_PATH)) {
-          return false;
+          return;
         }
         try {
           if (request.getBody().indexOf(DIAGNOSTICS_STR) > -1) {
-            return false;
+            return;
           }
         } catch (IOException ex) {
           ex.printStackTrace();
@@ -226,46 +231,44 @@ public abstract class BaseIntegrationTest {
         try {
           List<JsonSnapshotSerializer.IntakeRequest> intakeRequests = adapter.fromJson(bodyStr);
           for (JsonSnapshotSerializer.IntakeRequest intakeRequest : intakeRequests) {
+            for (Consumer<JsonSnapshotSerializer.IntakeRequest> listener :
+                baseIntegrationTest.intakeRequestListeners) {
+              listener.accept(intakeRequest);
+            }
             Snapshot snapshot = intakeRequest.getDebugger().getSnapshot();
-            for (Predicate<Snapshot> listener : baseIntegrationTest.snapshotListeners) {
-              if (listener.test(snapshot)) {
-                return true;
-              }
+            for (Consumer<Snapshot> listener : baseIntegrationTest.snapshotListeners) {
+              listener.accept(snapshot);
             }
           }
         } catch (IOException ex) {
           ex.printStackTrace();
         }
-        return false;
       }
     },
     SPAN {
       @Override
-      public boolean process(BaseIntegrationTest baseIntegrationTest, RecordedRequest request) {
+      public void process(BaseIntegrationTest baseIntegrationTest, RecordedRequest request) {
         if (!request.getPath().equals(TRACE_URL_PATH)) {
-          return false;
+          return;
         }
         DecodedMessage decodedMessage = Decoder.decodeV04(request.getBody().readByteArray());
         LOG.info("got traces: {}", decodedMessage.getTraces().size());
-        for (Predicate<DecodedTrace> listener : baseIntegrationTest.traceListeners) {
+        for (Consumer<DecodedTrace> listener : baseIntegrationTest.traceListeners) {
           for (DecodedTrace trace : decodedMessage.getTraces()) {
-            if (listener.test(trace)) {
-              return true;
-            }
+            listener.accept(trace);
           }
         }
-        return false;
       }
     },
     PROBE_STATUS {
       @Override
-      public boolean process(BaseIntegrationTest baseIntegrationTest, RecordedRequest request) {
+      public void process(BaseIntegrationTest baseIntegrationTest, RecordedRequest request) {
         if (!request.getPath().startsWith(SNAPSHOT_URL_PATH)) {
-          return false;
+          return;
         }
         try {
           if (request.getBody().indexOf(DIAGNOSTICS_STR) == -1) {
-            return false;
+            return;
           }
         } catch (IOException ex) {
           ex.printStackTrace();
@@ -277,56 +280,79 @@ public abstract class BaseIntegrationTest {
         LOG.info("got probe status: {}", bodyStr);
         try {
           List<ProbeStatus> probeStatuses = adapter.fromJson(bodyStr);
-          for (Predicate<ProbeStatus> listener : baseIntegrationTest.probeStatusListeners) {
+          for (Consumer<ProbeStatus> listener : baseIntegrationTest.probeStatusListeners) {
             for (ProbeStatus probeStatus : probeStatuses) {
-              if (listener.test(probeStatus)) {
-                return true;
-              }
+              listener.accept(probeStatus);
             }
           }
         } catch (IOException ex) {
           ex.printStackTrace();
         }
-        return false;
       }
     };
 
-    public abstract boolean process(
-        BaseIntegrationTest baseIntegrationTest, RecordedRequest request);
+    public abstract void process(BaseIntegrationTest baseIntegrationTest, RecordedRequest request);
   }
 
-  protected void registerSnapshotListener(Predicate<Snapshot> listener) {
+  protected void registerIntakeRequestListener(
+      Consumer<JsonSnapshotSerializer.IntakeRequest> listener) {
+    intakeRequestListeners.add(listener);
+  }
+
+  protected void registerSnapshotListener(Consumer<Snapshot> listener) {
     snapshotListeners.add(listener);
   }
 
-  protected void registerTraceListener(Predicate<DecodedTrace> listener) {
+  protected void registerTraceListener(Consumer<DecodedTrace> listener) {
     traceListeners.add(listener);
   }
 
-  protected void registerProbeStatusListener(Predicate<ProbeStatus> listener) {
+  protected void registerProbeStatusListener(Consumer<ProbeStatus> listener) {
     probeStatusListeners.add(listener);
   }
 
-  protected void clearProbeStatusListener() {
-    probeStatusListeners.clear();
+  protected AtomicBoolean registerCheckReceivedInstalledEmitting() {
+    AtomicBoolean received = new AtomicBoolean();
+    AtomicBoolean installed = new AtomicBoolean();
+    AtomicBoolean emitting = new AtomicBoolean();
+    AtomicBoolean result = new AtomicBoolean();
+    registerProbeStatusListener(
+        probeStatus -> {
+          if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.RECEIVED) {
+            received.set(true);
+          }
+          if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.INSTALLED) {
+            installed.set(true);
+          }
+          if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.EMITTING) {
+            emitting.set(true);
+          }
+          result.set(received.get() && installed.get() && emitting.get());
+        });
+    return result;
   }
 
-  protected void processRequests() throws InterruptedException {
+  protected void processRequests(BooleanSupplier conditionOfDone) throws InterruptedException {
     long start = System.currentTimeMillis();
-    RecordedRequest request;
-    do {
-      request = datadogAgentServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
-      if (request == null) {
-        throw new RuntimeException("timeout!");
-      }
-      LOG.info("processRequests path={}", request.getPath());
-      for (RequestType requestType : RequestType.values()) {
-        if (requestType.process(this, request)) {
-          return;
+    try {
+      RecordedRequest request;
+      do {
+        request = datadogAgentServer.takeRequest(REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+        if (request == null) {
+          throw new RuntimeException("timeout!");
         }
-      }
-    } while (request != null && (System.currentTimeMillis() - start < 30_000));
-    throw new RuntimeException("timeout!");
+        LOG.info("processRequests path={}", request.getPath());
+        for (RequestType requestType : RequestType.values()) {
+          requestType.process(this, request);
+          if (conditionOfDone.getAsBoolean()) {
+            return;
+          }
+        }
+      } while (request != null && (System.currentTimeMillis() - start < 30_000));
+      throw new RuntimeException("timeout!");
+    } finally {
+      probeStatusListeners.clear();
+    }
   }
 
   protected void processRemainingRequests() throws InterruptedException {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
@@ -130,8 +130,8 @@ public class ProbeStateIntegrationTest extends ServerAppDebuggerIntegrationTest 
             .where(TEST_APP_CLASS_NAME, "unknownMethodName")
             .build();
     addProbe(logProbe);
-    AtomicBoolean received = new AtomicBoolean(false);
-    AtomicBoolean error = new AtomicBoolean(false);
+    AtomicBoolean received = new AtomicBoolean();
+    AtomicBoolean error = new AtomicBoolean();
     registerProbeStatusListener(
         probeStatus -> {
           if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.RECEIVED) {
@@ -143,8 +143,7 @@ public class ProbeStateIntegrationTest extends ServerAppDebuggerIntegrationTest 
                 probeStatus.getDiagnostics().getException().getMessage());
             error.set(true);
           }
-          return received.get() && error.get();
         });
-    processRequests();
+    processRequests(() -> received.get() && error.get());
   }
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
@@ -2,7 +2,6 @@ package datadog.smoketest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.datadog.debugger.agent.DebuggerTracer;
 import com.datadog.debugger.agent.ProbeStatus;
 import com.datadog.debugger.probe.SpanProbe;
 import datadog.trace.test.agent.decoder.DecodedSpan;
@@ -32,8 +31,16 @@ public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest 
         SpanProbe.builder().probeId(PROBE_ID).where(MAIN_CLASS_NAME, METHOD_NAME).build();
     setCurrentConfiguration(createSpanConfig(spanProbe));
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
-    DecodedSpan decodedSpan = retrieveSpanRequest(DebuggerTracer.OPERATION_NAME);
-    assertEquals("Main.fullMethod", decodedSpan.getResource());
+
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean traceReceived = new AtomicBoolean();
+    registerTraceListener(
+        decodedTrace -> {
+          DecodedSpan decodedSpan = decodedTrace.getSpans().get(0);
+          assertEquals("Main.fullMethod", decodedSpan.getResource());
+          traceReceived.set(true);
+        });
+    processRequests(() -> statusResult.get() && traceReceived.get());
   }
 
   @Test
@@ -50,8 +57,15 @@ public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest 
             .build();
     setCurrentConfiguration(createSpanConfig(spanProbe));
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
-    DecodedSpan decodedSpan = retrieveSpanRequest(DebuggerTracer.OPERATION_NAME);
-    assertEquals("Main.fullMethod:L88-97", decodedSpan.getResource());
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean traceReceived = new AtomicBoolean();
+    registerTraceListener(
+        decodedTrace -> {
+          DecodedSpan decodedSpan = decodedTrace.getSpans().get(0);
+          assertEquals("Main.fullMethod:L88-97", decodedSpan.getResource());
+          traceReceived.set(true);
+        });
+    processRequests(() -> statusResult.get() && traceReceived.get());
   }
 
   @Test
@@ -81,8 +95,7 @@ public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest 
                 probeStatus.getDiagnostics().getException().getMessage());
             error.set(true);
           }
-          return received.get() && error.get();
         });
-    processRequests();
+    processRequests(() -> received.get() && error.get());
   }
 }


### PR DESCRIPTION
# What Does This Do
Add a new status for probes to indicate the fact that they are sending data. a new EMITTING status is added and for each probe implementation we send this status.
- Log probes: when snapshot is sent
- metric probes: when we sent the metric to statsd
- span probes: when the span finishes
- span decoration probes: when all tags were added.

The status is set and sent only the first time.
Refactoring was done for providing full probe id (uuid + version) inside the probe evaluation as encoded string `uuid:version`. 

Refactored also smoke tests to test the status is reached when data are sent.

# Motivation
Indicate when a probe is emitting data

# Additional Notes

Jira ticket: [DEBUG-1893]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1893]: https://datadoghq.atlassian.net/browse/DEBUG-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ