### PR TITLE
Track Kafka Avro schemas using Data Streams

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/AvroSchemaExtractor.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/AvroSchemaExtractor.java
@@ -9,7 +9,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 
 public class AvroSchemaExtractor {
   public static void tryExtractProducer(ProducerRecord record, AgentSpan span) {
-    Integer prio = span.forceSamplingDecision();
+    Integer prio = span.getSamplingPriority();
     if (prio == null || prio <= 0) {
       // don't extract schema if span is not sampled
       return;

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/AvroSchemaExtractor.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/AvroSchemaExtractor.java
@@ -1,12 +1,14 @@
 package datadog.trace.instrumentation.kafka_clients;
 
+import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.util.FNV64Hash;
 import java.lang.reflect.Field;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
 public class AvroSchemaExtractor {
-  public static void tryExtract(ProducerRecord record, AgentSpan span) {
+  public static void tryExtractProducer(ProducerRecord record, AgentSpan span) {
     Integer prio = span.forceSamplingDecision();
     if (prio == null || prio <= 0) {
       // don't extract schema if span is not sampled
@@ -18,10 +20,13 @@ public class AvroSchemaExtractor {
     }
     String schema = extract(record.value());
     if (schema != null) {
-      span.setTag("messaging.kafka.value_schema.definition", schema);
-      span.setTag("messaging.kafka.value_schema.weight", weight);
-      span.setTag("messaging.kafka.value_schema.type", "avro");
-      span.setTag("messaging.kafka.value_schema.id", schema.hashCode());
+      span.setTag(DDTags.SCHEMA_DEFINITION, schema);
+      span.setTag(DDTags.SCHEMA_WEIGHT, weight);
+      span.setTag(DDTags.SCHEMA_TYPE, "avro");
+      span.setTag(DDTags.SCHEMA_OPERATION, "serialization");
+      span.setTag(
+          DDTags.SCHEMA_ID,
+          Long.toUnsignedString(FNV64Hash.generateHash(schema, FNV64Hash.Version.v1A)));
     }
   }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/AvroSchemaExtractor.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/AvroSchemaExtractor.java
@@ -1,0 +1,41 @@
+package datadog.trace.instrumentation.kafka_clients;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.lang.reflect.Field;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+public class AvroSchemaExtractor {
+  public static void tryExtract(ProducerRecord record, AgentSpan span) {
+    Integer prio = span.forceSamplingDecision();
+    if (prio == null || prio <= 0) {
+      // don't extract schema if span is not sampled
+      return;
+    }
+    int weight = AgentTracer.get().getDataStreamsMonitoring().shouldSampleSchema(record.topic());
+    if (weight == 0) {
+      return;
+    }
+    String schema = extract(record.value());
+    if (schema != null) {
+      span.setTag("messaging.kafka.value_schema.definition", schema);
+      span.setTag("messaging.kafka.value_schema.weight", weight);
+      span.setTag("messaging.kafka.value_schema.type", "avro");
+      span.setTag("messaging.kafka.value_schema.id", schema.hashCode());
+    }
+  }
+
+  public static String extract(Object value) {
+    if (value == null) {
+      return null;
+    }
+    try {
+      Class<?> clazz = value.getClass();
+      Field field = clazz.getDeclaredField("schema");
+      field.setAccessible(true);
+      return field.get(value).toString();
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      return null;
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -58,6 +58,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
       packageName + ".TextMapInjectAdapter",
       packageName + ".KafkaProducerCallback",
       "datadog.trace.instrumentation.kafka_common.StreamingContext",
+      packageName + ".AvroSchemaExtractor",
     };
   }
 
@@ -121,6 +122,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
           propagate().inject(span, record.headers(), SETTER);
           if (STREAMING_CONTEXT.empty() || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
             propagate().injectPathwayContext(span, record.headers(), SETTER, sortedTags);
+            AvroSchemaExtractor.tryExtract(record, span);
           }
         } catch (final IllegalStateException e) {
           // headers must be read-only from reused record. try again with new one.
@@ -136,6 +138,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
           propagate().inject(span, record.headers(), SETTER);
           if (STREAMING_CONTEXT.empty() || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
             propagate().injectPathwayContext(span, record.headers(), SETTER, sortedTags);
+            AvroSchemaExtractor.tryExtract(record, span);
           }
         }
         if (TIME_IN_QUEUE_ENABLED) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -122,7 +122,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
           propagate().inject(span, record.headers(), SETTER);
           if (STREAMING_CONTEXT.empty() || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
             propagate().injectPathwayContext(span, record.headers(), SETTER, sortedTags);
-            AvroSchemaExtractor.tryExtract(record, span);
+            AvroSchemaExtractor.tryExtractProducer(record, span);
           }
         } catch (final IllegalStateException e) {
           // headers must be read-only from reused record. try again with new one.
@@ -138,7 +138,7 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Tracing
           propagate().inject(span, record.headers(), SETTER);
           if (STREAMING_CONTEXT.empty() || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
             propagate().injectPathwayContext(span, record.headers(), SETTER, sortedTags);
-            AvroSchemaExtractor.tryExtract(record, span);
+            AvroSchemaExtractor.tryExtractProducer(record, span);
           }
         }
         if (TIME_IN_QUEUE_ENABLED) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/AvroMock.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/AvroMock.java
@@ -1,0 +1,7 @@
+public class AvroMock {
+  private final String schema;
+
+  AvroMock(String schema) {
+    this.schema = schema;
+  }
+}

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/AvroMockSerializer.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/AvroMockSerializer.java
@@ -1,0 +1,15 @@
+import java.util.Map;
+import org.apache.kafka.common.serialization.Serializer;
+
+class AvroMockSerializer implements Serializer<AvroMock> {
+  @Override
+  public void configure(Map configs, boolean isKey) {}
+
+  @Override
+  public byte[] serialize(String topic, AvroMock data) {
+    return new byte[0];
+  }
+
+  @Override
+  public void close() {}
+}

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -989,12 +989,13 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         }
         if ({isDataStreamsEnabled()}) {
           "$DDTags.PATHWAY_HASH" { String }
-        }
-        if ({isDataStreamsEnabled() && schema != null}) {
-          "messaging.kafka.value_schema.definition" schema
-          "messaging.kafka.value_schema.weight" 1
-          "messaging.kafka.value_schema.type" "avro"
-          "messaging.kafka.value_schema.id" 1698511397
+          if (schema != null) {
+            "$DDTags.SCHEMA_DEFINITION" schema
+            "$DDTags.SCHEMA_WEIGHT" 1
+            "$DDTags.SCHEMA_TYPE" "avro"
+            "$DDTags.SCHEMA_OPERATION" "serialization"
+            "$DDTags.SCHEMA_ID" "10810872322569724838"
+          }
         }
         peerServiceFrom(InstrumentationTags.KAFKA_BOOTSTRAP_SERVERS)
         defaultTags()

--- a/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
+++ b/dd-smoke-tests/datastreams/kafkaschemaregistry/build.gradle
@@ -1,0 +1,42 @@
+plugins {
+  id "com.github.johnrengelman.shadow"
+  id 'java'
+  id 'org.springframework.boot' version '2.6.3'
+}
+
+repositories {
+  mavenCentral()
+  maven {
+    url 'https://packages.confluent.io/maven/'
+  }
+  maven { url 'https://repo.spring.io/libs-milestone' }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+description = 'Kafka Smoke Tests.'
+
+jar {
+  manifest {
+    attributes('Main-Class': 'datadog.smoketest.datastreams.kafkaschemaregistry.KafkaProducerWithSchemaRegistry')
+  }
+}
+
+dependencies {
+  implementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0')
+  implementation 'io.confluent:kafka-schema-registry-client:7.5.2'
+  implementation 'io.confluent:kafka-avro-serializer:7.5.2'
+  implementation('org.apache.avro:avro:1.11.0')
+  // Add SLF4J binding (Logback in this case)
+  implementation 'ch.qos.logback:logback-classic:1.2.6'
+}
+
+tasks.withType(Test).configureEach {
+  dependsOn "shadowJar"
+
+  jvmArgs "-Ddatadog.smoketest.datastreams.kafkaschemaregistry.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
+}
+
+task testRuntimeActivation(type: Test) {
+  jvmArgs "-Ddatadog.smoketest.datastreams.kafkaschemaregistry.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
+}
+tasks['check'].dependsOn(testRuntimeActivation)

--- a/dd-smoke-tests/datastreams/kafkaschemaregistry/src/main/java/datadog/smoketest/datastreamskafka/KafkaProducerWithSchemaRegistry.java
+++ b/dd-smoke-tests/datastreams/kafkaschemaregistry/src/main/java/datadog/smoketest/datastreamskafka/KafkaProducerWithSchemaRegistry.java
@@ -1,0 +1,90 @@
+package datadog.smoketest.datastreams.kafkaschemaregistry;
+
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import java.util.Properties;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+public class KafkaProducerWithSchemaRegistry {
+  public static void main(String[] args) {
+    String schemaRegistryUrl = System.getenv("SCHEMA_REGISTRY_URL");
+    String topicName = "test_topic";
+    String apiKey = System.getenv("CONFLUENT_API_KEY");
+    String apiSecret = System.getenv("CONFLUENT_API_SECRET");
+    String bootstrapServers = System.getenv("CONFLUENT_SERVERS");
+
+    Properties properties = new Properties();
+    properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    properties.setProperty(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    properties.setProperty(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
+    properties.setProperty("schema.registry.url", schemaRegistryUrl);
+    properties.setProperty(
+        "sasl.jaas.config",
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\""
+            + apiKey
+            + "\" password=\""
+            + apiSecret
+            + "\";");
+    properties.setProperty("sasl.mechanism", "PLAIN");
+    properties.setProperty("security.protocol", "SASL_SSL");
+    properties.setProperty("basic.auth.credentials.source", "USER_INFO");
+    properties.setProperty("basic.auth.user.info", System.getenv("CONFLUENT_REGISTRY_AUTH"));
+
+    String avroSchema =
+        "{ "
+            + "\"type\": \"record\", "
+            + "\"name\": \"Person\", "
+            + "\"fields\": ["
+            + "   {\"name\": \"name\", \"type\": \"string\"}, "
+            + "   {\"name\": \"age\", \"type\": \"int\"}, "
+            + "   {\"name\": \"address\", \"type\": {"
+            + "       \"type\": \"record\","
+            + "       \"name\": \"Address\","
+            + "       \"fields\": ["
+            + "           {\"name\": \"city\", \"type\": \"string\"},"
+            + "           {\"name\": \"zipCode\", \"type\": \"string\"}"
+            + "       ]"
+            + "   }}"
+            + " ]}";
+
+    // Avro record
+    Schema schema = new Schema.Parser().parse(avroSchema);
+
+    Producer<String, GenericRecord> producer =
+        new org.apache.kafka.clients.producer.KafkaProducer<>(properties);
+
+    try {
+      for (int i = 1; i <= 20; i++) {
+        GenericRecord avroRecord = new GenericData.Record(schema);
+
+        // Set values for the fields
+        avroRecord.put("name", "John Doe");
+        avroRecord.put("age", 25);
+
+        // Create a nested record for the "address" field
+        GenericData.Record addressRecord =
+            new GenericData.Record(schema.getField("address").schema());
+        addressRecord.put("city", "Anytown");
+        addressRecord.put("zipCode", "12345");
+        avroRecord.put("address", addressRecord);
+
+        Schema parsedSchema = avroRecord.getSchema();
+        ProducerRecord<String, GenericRecord> producerRecord =
+            new ProducerRecord<>(topicName, avroRecord);
+        producer.send(producerRecord);
+        Thread.sleep(1500);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      producer.close();
+    }
+  }
+}

--- a/dd-smoke-tests/datastreams/kafkaschemaregistry/src/main/java/datadog/smoketest/datastreamskafka/KafkaProducerWithSchemaRegistry.java
+++ b/dd-smoke-tests/datastreams/kafkaschemaregistry/src/main/java/datadog/smoketest/datastreamskafka/KafkaProducerWithSchemaRegistry.java
@@ -35,7 +35,7 @@ public class KafkaProducerWithSchemaRegistry {
     properties.setProperty("sasl.mechanism", "PLAIN");
     properties.setProperty("security.protocol", "SASL_SSL");
     properties.setProperty("basic.auth.credentials.source", "USER_INFO");
-    properties.setProperty("basic.auth.user.info", System.getenv("CONFLUENT_REGISTRY_AUTH"));
+    properties.setProperty("basic.auth.user.info", System.getenv("SCHEMA_REGISTRY_AUTH"));
 
     String avroSchema =
         "{ "

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -9,6 +9,12 @@ public class DDTags {
   public static final String THREAD_ID = "thread.id";
   public static final String DB_STATEMENT = "sql.query";
   public static final String PATHWAY_HASH = "pathway.hash";
+  public static final String SCHEMA_DEFINITION = "schema.definition";
+  public static final String SCHEMA_WEIGHT = "schema.weight";
+  public static final String SCHEMA_TYPE = "schema.type";
+  public static final String SCHEMA_ID = "schema.id";
+  public static final String SCHEMA_TOPIC = "schema.topic";
+  public static final String SCHEMA_OPERATION = "schema.operation";
 
   public static final String HTTP_QUERY = "http.query.string";
   public static final String HTTP_FRAGMENT = "http.fragment.string";

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -71,6 +71,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
   private volatile boolean supportsDataStreams = false;
   private volatile boolean agentSupportsDataStreams = false;
   private volatile boolean configSupportsDataStreams = false;
+  private final HashMap<String, SchemaSampler> schemaSamplers;
 
   public DefaultDataStreamsMonitoring(
       Config config,
@@ -126,6 +127,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
 
     thread = newAgentThread(DATA_STREAMS_MONITORING, new InboxProcessor());
     sink.register(this);
+    schemaSamplers = new HashMap<>();
   }
 
   @Override
@@ -156,6 +158,16 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
     if (thread.isAlive()) {
       inbox.offer(statsPoint);
     }
+  }
+
+  @Override
+  public int shouldSampleSchema(String topic) {
+    SchemaSampler sampler = schemaSamplers.get(topic);
+    if (sampler == null) {
+      sampler = new SchemaSampler();
+      schemaSamplers.put(topic, sampler);
+    }
+    return sampler.shouldSample(timeSource.getCurrentTimeMillis());
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/SchemaSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/SchemaSampler.java
@@ -1,24 +1,29 @@
 package datadog.trace.core.datastreams;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class SchemaSampler {
   private static final int SAMPLE_INTERVAL_MILLIS = 30 * 1000;
-  private int weight;
-  private long lastSampleMillis;
+  private final AtomicInteger weight;
+  private volatile long lastSampleMillis;
 
   public SchemaSampler() {
-    this.weight = 0;
+    this.weight = new AtomicInteger(0);
     this.lastSampleMillis = 0;
   }
 
   public int shouldSample(long currentTimeMillis) {
-    this.weight += 1;
-    if (currentTimeMillis >= this.lastSampleMillis + SAMPLE_INTERVAL_MILLIS) {
-      int weight = this.weight;
-      this.lastSampleMillis = currentTimeMillis;
-      this.weight = 0;
-      return weight;
-    } else {
-      return 0;
+    weight.incrementAndGet();
+    if (currentTimeMillis >= lastSampleMillis + SAMPLE_INTERVAL_MILLIS) {
+      synchronized (this) {
+        if (currentTimeMillis >= lastSampleMillis + SAMPLE_INTERVAL_MILLIS) {
+          lastSampleMillis = currentTimeMillis;
+          int currentWeight = weight.get();
+          weight.set(0);
+          return currentWeight;
+        }
+      }
     }
+    return 0;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/SchemaSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/SchemaSampler.java
@@ -1,0 +1,24 @@
+package datadog.trace.core.datastreams;
+
+public class SchemaSampler {
+  private static final int SAMPLE_INTERVAL_MILLIS = 30 * 1000;
+  private int weight;
+  private long lastSampleMillis;
+
+  public SchemaSampler() {
+    this.weight = 0;
+    this.lastSampleMillis = 0;
+  }
+
+  public int shouldSample(long currentTimeMillis) {
+    this.weight += 1;
+    if (currentTimeMillis >= this.lastSampleMillis + SAMPLE_INTERVAL_MILLIS) {
+      int weight = this.weight;
+      this.lastSampleMillis = currentTimeMillis;
+      this.weight = 0;
+      return weight;
+    } else {
+      return 0;
+    }
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/SchemaSamplerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/SchemaSamplerTest.groovy
@@ -1,0 +1,26 @@
+package datadog.trace.core.datastreams
+
+import datadog.trace.core.test.DDCoreSpecification
+
+class SchemaSamplerTest  extends DDCoreSpecification {
+
+  def "schema sampler samples with correct weights"() {
+    given:
+    long currentTimeMillis = 100000
+    SchemaSampler sampler = new SchemaSampler()
+
+    when:
+    int weight1 = sampler.shouldSample(currentTimeMillis)
+    int weight2 = sampler.shouldSample(currentTimeMillis + 1000)
+    int weight3 = sampler.shouldSample(currentTimeMillis + 2000)
+    int weight4 = sampler.shouldSample(currentTimeMillis + 30000)
+    int weight5 = sampler.shouldSample(currentTimeMillis + 30001)
+
+    then:
+    weight1 == 1
+    weight2 == 0
+    weight3 == 0
+    weight4 == 3
+    weight5 == 0
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentDataStreamsMonitoring.java
@@ -27,4 +27,13 @@ public interface AgentDataStreamsMonitoring extends DataStreamsCheckpointer {
   PathwayContext newPathwayContext();
 
   void add(StatsPoint statsPoint);
+
+  /**
+   * shouldSampleSchema is used to determine if we should extract schema from the message or not.
+   *
+   * @param topic Kafka topic
+   * @return the weight of the schema, indicating how many messages have been sent to the topic
+   *     without having been sampled.
+   */
+  int shouldSampleSchema(String topic);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1059,6 +1059,11 @@ public class AgentTracer {
     public void add(StatsPoint statsPoint) {}
 
     @Override
+    public int shouldSampleSchema(String topic) {
+      return 0;
+    }
+
+    @Override
     public void setConsumeCheckpoint(
         String type, String source, DataStreamsContextCarrier carrier) {}
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -147,6 +147,7 @@ include ':dd-smoke-tests:appsec:springboot'
 include ':dd-smoke-tests:appsec:springboot-grpc'
 include ':dd-smoke-tests:appsec:springboot-security'
 include ':dd-smoke-tests:debugger-integration-tests'
+include ':dd-smoke-tests:datastreams:kafkaschemaregistry'
 include ':dd-smoke-tests:iast-util'
 // TODO this fails too often with a jgit failure, so disable until fixed
 //include ':dd-smoke-tests:debugger-integration-tests:latest-jdk-app'


### PR DESCRIPTION
# What Does This Do

This PR adds the Avro schema definition as a tag on the span if the schema can be found in the schema field of the sent object.
This is only done if data streams is enabled.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
