### PR TITLE
Switch some unused Mocks to Stubs to avoid recording actions

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
@@ -59,7 +59,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def createTestSpanContext() {
-    def trace = Mock(PendingTrace)
+    def trace = Stub(PendingTrace)
     return new DDSpanContext(
       DDTraceId.ONE,
       1,

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
@@ -67,7 +67,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def createTestSpanContext() {
-    def trace = Mock(PendingTrace)
+    def trace = Stub(PendingTrace)
     return new DDSpanContext(
       DDTraceId.ONE,
       1,

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
@@ -67,7 +67,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def createTestSpanContext() {
-    def trace = Mock(PendingTrace)
+    def trace = Stub(PendingTrace)
     return new DDSpanContext(
       DDTraceId.ONE,
       1,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterCombinedTest.groovy
@@ -262,8 +262,8 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
   }
 
   def createMinimalContext() {
-    def tracer = Mock(CoreTracer)
-    def trace = Mock(PendingTrace)
+    def tracer = Stub(CoreTracer)
+    def trace = Stub(PendingTrace)
     trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
     return new DDSpanContext(
@@ -413,7 +413,7 @@ class DDAgentWriterCombinedTest extends DDCoreSpecification {
     def healthMetrics = Mock(HealthMetrics)
     def minimalTrace = createMinimalTrace()
     def version = agentVersion
-    def discovery = Mock(DDAgentFeaturesDiscovery) {
+    def discovery = Stub(DDAgentFeaturesDiscovery) {
       it.getTraceEndpoint() >> version
     }
     def api = Mock(DDAgentApi) {

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -193,8 +193,8 @@ class DDAgentWriterTest extends DDCoreSpecification {
   }
 
   def newSpan() {
-    CoreTracer tracer = Mock(CoreTracer)
-    PendingTrace trace = Mock(PendingTrace)
+    CoreTracer tracer = Stub(CoreTracer)
+    PendingTrace trace = Stub(PendingTrace)
     trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
     def context = new DDSpanContext(

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -717,8 +717,8 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
   }
 
   def createMinimalContext() {
-    def tracer = Mock(CoreTracer)
-    def trace = Mock(PendingTrace)
+    def tracer = Stub(CoreTracer)
+    def trace = Stub(PendingTrace)
     trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
     return new DDSpanContext(

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterTest.groovy
@@ -186,8 +186,8 @@ class DDIntakeWriterTest extends DDCoreSpecification {
   }
 
   def newSpan() {
-    CoreTracer tracer = Mock(CoreTracer)
-    PendingTrace trace = Mock(PendingTrace)
+    CoreTracer tracer = Stub(CoreTracer)
+    PendingTrace trace = Stub(PendingTrace)
     trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
     def context = new DDSpanContext(

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherImplTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/PayloadDispatcherImplTest.groovy
@@ -28,14 +28,14 @@ class PayloadDispatcherImplTest extends DDSpecification {
   @Shared
   MonitoringImpl monitoring = new MonitoringImpl(StatsDClient.NO_OP, 1, TimeUnit.SECONDS)
 
-  @Timeout(5)
+  @Timeout(10)
   def "flush automatically when data limit is breached"() {
     setup:
     AtomicBoolean flushed = new AtomicBoolean()
-    HealthMetrics healthMetrics = Mock(HealthMetrics)
-    DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery)
+    HealthMetrics healthMetrics = Stub(HealthMetrics)
+    DDAgentFeaturesDiscovery discovery = Stub(DDAgentFeaturesDiscovery)
     discovery.getTraceEndpoint() >> traceEndpoint
-    DDAgentApi api = Mock(DDAgentApi)
+    DDAgentApi api = Stub(DDAgentApi)
     api.sendSerializedTraces(_) >> {
       flushed.set(true)
       return RemoteApi.Response.success(200)
@@ -124,8 +124,8 @@ class PayloadDispatcherImplTest extends DDSpecification {
 
   def "trace and span counts are reset after access"() {
     setup:
-    HealthMetrics healthMetrics = Mock(HealthMetrics)
-    DDAgentApi api = Mock(DDAgentApi)
+    HealthMetrics healthMetrics = Stub(HealthMetrics)
+    DDAgentApi api = Stub(DDAgentApi)
     DDAgentFeaturesDiscovery discovery = Mock(DDAgentFeaturesDiscovery) {
       it.getTraceEndpoint() >> "v0.4/traces"
     }
@@ -148,8 +148,8 @@ class PayloadDispatcherImplTest extends DDSpecification {
 
 
   def realSpan() {
-    CoreTracer tracer = Mock(CoreTracer)
-    PendingTrace trace = Mock(PendingTrace)
+    CoreTracer tracer = Stub(CoreTracer)
+    PendingTrace trace = Stub(PendingTrace)
     trace.getTracer() >> tracer
     trace.mapServiceName(_) >> { String serviceName -> serviceName }
     def context = new DDSpanContext(

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
@@ -16,8 +16,8 @@ class LongRunningTracesTrackerTest extends DDSpecification {
   def sharedCommunicationObjects = Mock(SharedCommunicationObjects)
   DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(null, Monitoring.DISABLED, null, false, false)
   LongRunningTracesTracker tracker
-  def tracer = Mock(CoreTracer)
-  def traceConfig = Mock(CoreTracer.ConfigSnapshot)
+  def tracer = Stub(CoreTracer)
+  def traceConfig = Stub(CoreTracer.ConfigSnapshot)
   PendingTraceBuffer.DelayingPendingTraceBuffer buffer
   PendingTrace.Factory factory = null
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -70,31 +70,34 @@ class PendingTraceTest extends PendingTraceTestBase {
   }
   def "verify healthmetrics called"() {
     setup:
-    def tracer = Mock(CoreTracer)
-    def traceConfig = Mock(CoreTracer.ConfigSnapshot)
-    def buffer = Mock(PendingTraceBuffer)
+    def tracer = Stub(CoreTracer)
+    def traceConfig = Stub(CoreTracer.ConfigSnapshot)
+    def buffer = Stub(PendingTraceBuffer)
     def healthMetrics = Mock(HealthMetrics)
     tracer.captureTraceConfig() >> traceConfig
     traceConfig.getServiceMapping() >> [:]
     PendingTrace trace = new PendingTrace(tracer, DDTraceId.from(0), buffer, Mock(TimeSource), null, false, healthMetrics)
+
     when:
     rootSpan = createSimpleSpan(trace)
     trace.registerSpan(rootSpan)
+
     then:
     1 * healthMetrics.onCreateSpan()
 
     when:
     rootSpan.finish()
+
     then:
     1 * healthMetrics.onCreateTrace()
   }
 
   def "write when writeRunningSpans is disabled: only completed spans are written"() {
     setup:
-    def tracer = Mock(CoreTracer)
-    def traceConfig = Mock(CoreTracer.ConfigSnapshot)
-    def buffer = Mock(PendingTraceBuffer)
-    def healthMetrics = Mock(HealthMetrics)
+    def tracer = Stub(CoreTracer)
+    def traceConfig = Stub(CoreTracer.ConfigSnapshot)
+    def buffer = Stub(PendingTraceBuffer)
+    def healthMetrics = Stub(HealthMetrics)
     tracer.captureTraceConfig() >> traceConfig
     traceConfig.getServiceMapping() >> [:]
     PendingTrace trace = new PendingTrace(tracer, DDTraceId.from(0), buffer, Mock(TimeSource), null, false, healthMetrics)
@@ -126,10 +129,10 @@ class PendingTraceTest extends PendingTraceTestBase {
 
   def "write when writeRunningSpans is enabled: complete and running spans are written"() {
     setup:
-    def tracer = Mock(CoreTracer)
-    def traceConfig = Mock(CoreTracer.ConfigSnapshot)
-    def buffer = Mock(PendingTraceBuffer)
-    def healthMetrics = Mock(HealthMetrics)
+    def tracer = Stub(CoreTracer)
+    def traceConfig = Stub(CoreTracer.ConfigSnapshot)
+    def buffer = Stub(PendingTraceBuffer)
+    def healthMetrics = Stub(HealthMetrics)
     tracer.captureTraceConfig() >> traceConfig
     traceConfig.getServiceMapping() >> [:]
     PendingTrace trace = new PendingTrace(tracer, DDTraceId.from(0), buffer, Mock(TimeSource), null, false, healthMetrics)

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
@@ -69,8 +69,8 @@ class TypeConverterTest extends DDSpecification {
   }
 
   def createTestSpanContext() {
-    def tracer = Mock(CoreTracer)
-    def trace = Mock(PendingTrace)
+    def tracer = Stub(CoreTracer)
+    def trace = Stub(PendingTrace)
     trace.mapServiceName(_) >> { String serviceName -> serviceName }
     trace.getTracer() >> tracer
 


### PR DESCRIPTION
# What Does This Do

Changes some `Mock` instances to `Stub` instances when the interactions are not validated. 

# Motivation

Had an OOM failure locally when running `:dd-trace-core:test`, and the heap dump showed `org.spockframework.mock.runtime.InteractionScope` holding on to 190 MB in `DDAgentWriterCombinedTest`.

# Additional Notes

Changed all applicable `Mock` calls of `CoreTracer` and `PendingTrace` in all tests, since those where the culprits in `DDAgentWriterCombinedTest`.
