### PR TITLE
couchbase tests: ignore errors on cleanup

### DIFF
--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.1/src/test/groovy/CouchbaseClient31Test.groovy
@@ -16,6 +16,9 @@ import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 import java.time.Duration
 import org.testcontainers.couchbase.BucketDefinition
 import org.testcontainers.couchbase.CouchbaseContainer
@@ -26,6 +29,8 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
   static final String BUCKET = 'test-bucket'
+
+  static final Logger LOGGER = LoggerFactory.getLogger(CouchbaseClient31Test)
 
   @Shared
   CouchbaseContainer couchbase
@@ -62,7 +67,11 @@ abstract class CouchbaseClient31Test extends VersionedNamingTestBase {
   }
 
   def cleanupSpec() {
-    cluster?.disconnect()
+    try {
+      cluster?.disconnect()
+    } catch (Throwable t) {
+      LOGGER.debug("Unable to properly disconnect on cleanup", t)
+    }
     couchbase?.stop()
   }
 

--- a/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
+++ b/dd-java-agent/instrumentation/couchbase/couchbase-3.2/src/test/groovy/CouchbaseClient32Test.groovy
@@ -19,6 +19,8 @@ import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.core.DDSpan
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.testcontainers.couchbase.BucketDefinition
 import org.testcontainers.couchbase.CouchbaseContainer
 import spock.lang.Shared
@@ -27,6 +29,7 @@ import java.time.Duration
 
 abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
   static final String BUCKET = 'test-bucket'
+  static final Logger LOGGER = LoggerFactory.getLogger(CouchbaseClient32Test)
 
   @Shared
   CouchbaseContainer couchbase
@@ -63,7 +66,11 @@ abstract class CouchbaseClient32Test extends VersionedNamingTestBase {
   }
 
   def cleanupSpec() {
-    cluster?.disconnect()
+    try {
+      cluster?.disconnect()
+    } catch (Throwable t) {
+      LOGGER.debug("Unable to properly disconnect on cleanup", t)
+    }
     couchbase?.stop()
   }
 


### PR DESCRIPTION
# What Does This Do

Silently ignores `cluster.disconnect()` error on cleanup

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
