### PR TITLE
Replaced unused Mocks with Stubs in AppSec

### DIFF
--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecSystemSpecification.groovy
@@ -77,7 +77,7 @@ class AppSecSystemSpecification extends DDSpecification {
     1 * subService.registerCallback(EVENTS.requestEnded(), _) >> { requestEndedCB = it[1]; null }
     1 * requestContext.getData(RequestContextSlot.APPSEC) >> appSecReqCtx
     1 * requestContext.traceSegment >> traceSegment
-    1 * appSecReqCtx.transferCollectedEvents() >> [Mock(AppSecEvent)]
+    1 * appSecReqCtx.transferCollectedEvents() >> [Stub(AppSecEvent)]
     1 * appSecReqCtx.getRequestHeaders() >> ['foo-bar': ['1.1.1.1']]
     1 * appSecReqCtx.getResponseHeaders() >> [:]
     1 * traceSegment.setTagTop('actor.ip', '1.1.1.1')
@@ -105,7 +105,7 @@ class AppSecSystemSpecification extends DDSpecification {
     1 * subService.registerCallback(EVENTS.requestEnded(), _) >> { requestEndedCB = it[1]; null }
     7 * requestContext.getData(RequestContextSlot.APPSEC) >> appSecReqCtx
     7 * requestContext.traceSegment >> traceSegment
-    7 * appSecReqCtx.transferCollectedEvents() >> [Mock(AppSecEvent)]
+    7 * appSecReqCtx.transferCollectedEvents() >> [Stub(AppSecEvent)]
     // allow for one extra in case we move to another second and round down the prev count
     (5..6) * appSecReqCtx.getRequestHeaders() >> [:]
     (5..6) * appSecReqCtx.getResponseHeaders() >> [:]
@@ -189,9 +189,9 @@ class AppSecSystemSpecification extends DDSpecification {
           poller
         }
       }
-    sco.okHttpClient = Mock(OkHttpClient)
+    sco.okHttpClient = Stub(OkHttpClient)
     sco.monitoring = Mock(Monitoring)
-    sco.featuresDiscovery = Mock(DDAgentFeaturesDiscovery)
+    sco.featuresDiscovery = Stub(DDAgentFeaturesDiscovery)
     sco
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/blocking/BlockingServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/blocking/BlockingServiceImplSpecification.groovy
@@ -23,7 +23,6 @@ class BlockingServiceImplSpecification extends DDSpecification {
   EventProducerService eps = new EventDispatcher()
   def bs = new BlockingServiceImpl(eps)
   def origTracer
-  AgentTracer.TracerAPI tracer = Mock()
 
   void setup() {
     origTracer = AgentTracer.get()
@@ -50,7 +49,7 @@ class BlockingServiceImplSpecification extends DDSpecification {
     })
     eps.subscribeDataAvailable set
 
-    AppSecRequestContext appSecRequestContext = Mock()
+    AppSecRequestContext appSecRequestContext = Stub()
     AgentTracer.forceRegister(Stub(AgentTracer.TracerAPI) {
       activeSpan() >> Stub(AgentSpan) {
         getRequestContext() >> Stub(RequestContext) {
@@ -94,9 +93,9 @@ class BlockingServiceImplSpecification extends DDSpecification {
     setup:
     BlockResponseFunction brf = Mock()
     TraceSegment mts = Mock()
-    AgentTracer.forceRegister(Mock(AgentTracer.TracerAPI) {
-      activeSpan() >> Mock(AgentSpan) {
-        getRequestContext() >> Mock(RequestContext) {
+    AgentTracer.forceRegister(Stub(AgentTracer.TracerAPI) {
+      activeSpan() >> Stub(AgentSpan) {
+        getRequestContext() >> Stub(RequestContext) {
           getBlockResponseFunction() >> brf
           getTraceSegment() >> mts
         }
@@ -115,8 +114,8 @@ class BlockingServiceImplSpecification extends DDSpecification {
   void 'tryCommitBlockingResponse without active span'() {
     setup:
     RequestContext reqCtx = Mock(RequestContext)
-    AgentTracer.forceRegister(Mock(AgentTracer.TracerAPI) {
-      activeSpan() >> Mock(AgentSpan) {
+    AgentTracer.forceRegister(Stub(AgentTracer.TracerAPI) {
+      activeSpan() >> Stub(AgentSpan) {
         getRequestContext() >> reqCtx
       }
     })

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -18,7 +18,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
 
   ConfigurationPoller poller = Mock()
   def config = Mock(Class.forName('datadog.trace.api.Config'))
-  AppSecModuleConfigurer.Reconfiguration reconf = Mock()
+  AppSecModuleConfigurer.Reconfiguration reconf = Stub()
   AppSecConfigServiceImpl appSecConfigService = new AppSecConfigServiceImpl(config, poller, reconf)
 
   void cleanup() {
@@ -81,7 +81,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     setup:
     Path p = Files.createTempFile('appsec', '.json')
     p.toFile() << '{"version":"2.0", "rules": []}'
-    AppSecModuleConfigurer.SubconfigListener listener = Mock()
+    AppSecModuleConfigurer.SubconfigListener listener = Stub()
 
     when:
     appSecConfigService.init()
@@ -116,7 +116,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
   }
 
   void 'provides initial subconfiguration upon subscription'() {
-    AppSecModuleConfigurer.SubconfigListener listener = Mock()
+    AppSecModuleConfigurer.SubconfigListener listener = Stub()
 
     setup:
     appSecConfigService.init()

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/EventDispatcherSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/EventDispatcherSpecification.groovy
@@ -140,7 +140,7 @@ class EventDispatcherSpecification extends DDSpecification {
   void 'saves the subscribed to events and addresses'() {
     given:
     def addressSet = new EventDispatcher.DataSubscriptionSet()
-    DataListener dataListener = Mock()
+    DataListener dataListener = Stub()
     dataListener.priority >> OrderedCallback.Priority.DEFAULT
 
     when:
@@ -155,7 +155,7 @@ class EventDispatcherSpecification extends DDSpecification {
     EventDispatcher anotherDispatcher = new EventDispatcher()
     EventProducerService.DataSubscriberInfo subInfo =
       anotherDispatcher.getDataSubscribers(KnownAddresses.REQUEST_CLIENT_IP)
-    dispatcher.publishDataEvent(subInfo, Mock(AppSecRequestContext), Mock(DataBundle), false)
+    dispatcher.publishDataEvent(subInfo, Stub(AppSecRequestContext), Stub(DataBundle), false)
 
     then:
     thrown ExpiredSubscriberInfoException

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -54,7 +54,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     void close() throws IOException {}
   }
   EventProducerService.DataSubscriberInfo nonEmptyDsInfo = {
-    EventProducerService.DataSubscriberInfo i = Mock()
+    EventProducerService.DataSubscriberInfo i = Stub()
     i.empty >> false
     i
   }()
@@ -121,7 +121,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     mockAppSecCtx.responseHeaders >> [
       'some-header': ['123'],
       'content-type':['text/html; charset=UTF-8']]
-    RequestContext mockCtx = Mock(RequestContext) {
+    RequestContext mockCtx = Stub(RequestContext) {
       getData(RequestContextSlot.APPSEC) >> mockAppSecCtx
       getTraceSegment() >> traceSegment
     }
@@ -149,10 +149,10 @@ class GatewayBridgeSpecification extends DDSpecification {
   }
 
   void 'event publishing is rate limited'() {
-    AppSecEvent event = Mock()
+    AppSecEvent event = Stub()
     AppSecRequestContext mockAppSecCtx = Mock(AppSecRequestContext)
     mockAppSecCtx.requestHeaders >> [:]
-    RequestContext mockCtx = Mock(RequestContext) {
+    RequestContext mockCtx = Stub(RequestContext) {
       getData(RequestContextSlot.APPSEC) >> mockAppSecCtx
       getTraceSegment() >> traceSegment
     }
@@ -175,7 +175,7 @@ class GatewayBridgeSpecification extends DDSpecification {
       'x-real-ip': ['10.0.0.1'],
       forwarded: ['for=127.0.0.1', 'for="[::1]", for=8.8.8.8'],
     ]
-    RequestContext mockCtx = Mock(RequestContext) {
+    RequestContext mockCtx = Stub(RequestContext) {
       getData(RequestContextSlot.APPSEC) >> mockAppSecCtx
       getTraceSegment() >> traceSegment
     }
@@ -185,7 +185,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     requestEndedCB.apply(mockCtx, spanInfo)
 
     then:
-    1 * mockAppSecCtx.transferCollectedEvents() >> [Mock(AppSecEvent)]
+    1 * mockAppSecCtx.transferCollectedEvents() >> [Stub(AppSecEvent)]
     1 * spanInfo.getTags() >> ['http.client_ip':'8.8.8.8']
     1 * traceSegment.setTagTop('actor.ip', '8.8.8.8')
   }
@@ -517,7 +517,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   }
 
   void 'forwards request body start events and stores the supplier'() {
-    StoredBodySupplier supplier = Mock()
+    StoredBodySupplier supplier = Stub()
 
     setup:
     supplier.get() >> 'foobar'
@@ -534,7 +534,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
   void 'forwards request body done events and distributes the body contents'() {
     DataBundle bundle
-    StoredBodySupplier supplier = Mock()
+    StoredBodySupplier supplier = Stub()
 
     setup:
     supplier.get() >> 'foobar'
@@ -550,7 +550,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   }
 
   void 'request body does not get published twice'() {
-    StoredBodySupplier supplier = Mock()
+    StoredBodySupplier supplier = Stub()
     Flow flow
 
     given:
@@ -649,7 +649,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   }
 
   void 'request data does not published twice'() {
-    AppSecRequestContext reqCtx = Mock()
+    AppSecRequestContext reqCtx = Stub()
     Flow flow1, flow2, flow3
 
     when:
@@ -704,7 +704,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
   void 'calls trace segment post processor'() {
     setup:
-    AgentSpan span = Mock()
+    AgentSpan span = Stub()
 
     when:
     requestEndedCB.apply(ctx, span)
@@ -732,8 +732,8 @@ class GatewayBridgeSpecification extends DDSpecification {
         void close() throws IOException {}
       }
 
-    StoredBodySupplier supplier = Mock()
-    IGSpanInfo spanInfo = Mock(AgentSpan)
+    StoredBodySupplier supplier = Stub()
+    IGSpanInfo spanInfo = Stub(AgentSpan)
     Object obj = 'obj'
 
     when:

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -104,7 +104,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
         ]
       ]
     ]
-    AppSecModuleConfigurer.Reconfiguration reconf = Mock()
+    AppSecModuleConfigurer.Reconfiguration reconf = Stub()
     service.currentAppSecConfig.with {
       def dirtyStatus = userConfigs.addConfig(
         new AppSecUserConfig('b', [], actions, [], []))
@@ -728,7 +728,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     AppSecEvent event
 
     when:
-    dataListener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
     ctx.closeAdditive()
 
     then:
@@ -760,7 +760,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     when:
     def bundle = MapDataBundle.of(KnownAddresses.HEADERS_NO_COOKIES,
       new CaseInsensitiveMap<List<String>>(['user-agent': [password: 'Arachni/v0']]))
-    dataListener.onDataAvailable(Mock(ChangeableFlow), ctx, bundle, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, bundle, false)
     ctx.closeAdditive()
 
     then:
@@ -787,7 +787,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     when:
     def bundle = MapDataBundle.of(KnownAddresses.HEADERS_NO_COOKIES,
       new CaseInsensitiveMap<List<String>>(['user-agent': [password: 'Arachni/v0']]))
-    dataListener.onDataAvailable(Mock(ChangeableFlow), ctx, bundle, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, bundle, false)
     ctx.closeAdditive()
 
     then:
@@ -813,7 +813,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     AppSecEvent event
 
     when:
-    dataListener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
     ctx.closeAdditive()
 
     then:
@@ -898,7 +898,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     when:
     cfgService.listeners['waf'].onNewSubconfig(defaultConfig['waf'], reconf)
     dataListener = pwafModule.dataSubscriptions.first()
-    dataListener.onDataAvailable(Mock(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
     ctx.closeAdditive()
 
     then:


### PR DESCRIPTION
# What Does This Do
Changes some Mock instances to Stub instances when the interactions are not validated.

# Motivation
Inspired by initial improvement done for core tracer in https://github.com/DataDog/dd-trace-java/pull/6372

# Additional Notes

<!-- Jira ticket: [PROJ-IDENT] -->

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
