### PR TITLE
Allow comma in request header tag values

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -790,9 +790,11 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
     }
 
     where:
-    method | header                           | value | tags
-    'GET'  | 'X-Datadog-Test-Both-Header'     | 'foo' | [ 'both_header_tag': 'foo' ]
-    'GET'  | 'X-Datadog-Test-Request-Header'  | 'bar' | [ 'request_header_tag': 'bar' ]
+    method | header                           | value     | tags
+    'GET'  | 'X-Datadog-Test-Both-Header'     | 'foo'     | [ 'both_header_tag': 'foo' ]
+    'GET'  | 'X-Datadog-Test-Request-Header'  | 'bar'     | [ 'request_header_tag': 'bar' ]
+    'GET'  | 'X-Datadog-Test-Both-Header'     | 'bar,baz' | [ 'both_header_tag': 'bar,baz' ]
+    'GET'  | 'X-Datadog-Test-Request-Header'  | 'foo,bar' | [ 'request_header_tag': 'foo,bar' ]
   }
 
   def "test response header #header tag mapping"() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -54,6 +54,8 @@ public final class TracerConfig {
   public static final String TRACE_CLIENT_IP_RESOLVER_ENABLED = "trace.client-ip.resolver.enabled";
   public static final String TRACE_GIT_METADATA_ENABLED = "trace.git.metadata.enabled";
   public static final String HEADER_TAGS = "trace.header.tags";
+  public static final String REQUEST_HEADER_TAGS_COMMA_ALLOWED =
+      "trace.request_header.tags.comma.allowed";
   public static final String REQUEST_HEADER_TAGS = "trace.request_header.tags";
   public static final String RESPONSE_HEADER_TAGS = "trace.response_header.tags";
   public static final String BAGGAGE_MAPPING = "trace.header.baggage";

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -29,6 +29,8 @@ excludedClassesCoverage += [
   'datadog.trace.core.DDSpan.1',
   'datadog.trace.core.tagprocessor.QueryObfuscator.1',
   'datadog.trace.common.writer.TraceProcessingWorker.NonDaemonTraceSerializingHandler',
+  // Interface with an empty defender method
+  'datadog.trace.core.propagation.HttpCodec.Extractor',
   'datadog.trace.core.flare.*',
   // FIXME(DSM): test coverage needed
   'datadog.trace.core.datastreams.DataStreamContextInjector'

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -56,6 +56,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
   private final boolean clientIpResolutionEnabled;
   private final boolean clientIpWithoutAppSec;
   private boolean collectIpHeaders;
+  private final boolean requestHeaderTagsCommaAllowed;
 
   protected static final boolean LOG_EXTRACT_HEADER_NAMES = Config.get().isLogExtractHeaderNames();
   private static final DDCache<String, String> CACHE = DDCaches.newFixedSizeCache(64);
@@ -69,6 +70,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
     this.clientIpResolutionEnabled = config.isTraceClientIpResolverEnabled();
     this.clientIpWithoutAppSec = config.isClientIpEnabled();
     this.propagationTagsFactory = PropagationTags.factory(config);
+    this.requestHeaderTagsCommaAllowed = config.isRequestHeaderTagsCommaAllowed();
   }
 
   /**
@@ -190,7 +192,10 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
       if (tags.isEmpty()) {
         tags = new TreeMap<>();
       }
-      tags.put(mappedKey, HttpCodec.decode(HttpCodec.firstHeaderValue(value)));
+      tags.put(
+          mappedKey,
+          HttpCodec.decode(
+              requestHeaderTagsCommaAllowed ? value : HttpCodec.firstHeaderValue(value)));
       return true;
     }
     return false;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -64,6 +64,15 @@ public class HttpCodec {
      *     context extraction or an {@link ExtractedContext} for complete context extraction.
      */
     <C> TagContext extract(final C carrier, final AgentPropagation.ContextVisitor<C> getter);
+
+    /**
+     * Cleans up any thread local resources associated with this extractor.
+     *
+     * <p>Implementations should override this method if they need to clean up any resources.
+     *
+     * <p><i>Currently only used from tests.</i>
+     */
+    default void cleanup() {}
   }
 
   public static Injector createInjector(

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/TagContextExtractor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/TagContextExtractor.java
@@ -22,4 +22,9 @@ public class TagContextExtractor implements HttpCodec.Extractor {
     getter.forEachKey(carrier, interpreter);
     return interpreter.build();
   }
+
+  @Override
+  public void cleanup() {
+    ctxInterpreter.remove();
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -382,6 +382,7 @@ import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_EXTRACT;
 import static datadog.trace.api.config.TracerConfig.PROPAGATION_STYLE_INJECT;
 import static datadog.trace.api.config.TracerConfig.PROXY_NO_PROXY;
 import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS;
+import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS_COMMA_ALLOWED;
 import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.SCOPE_DEPTH_LIMIT;
 import static datadog.trace.api.config.TracerConfig.SCOPE_INHERIT_ASYNC_PROPAGATION;
@@ -567,6 +568,7 @@ public class Config {
   private final Map<String, String> requestHeaderTags;
   private final Map<String, String> responseHeaderTags;
   private final Map<String, String> baggageMapping;
+  private final boolean requestHeaderTagsCommaAllowed;
   private final BitSet httpServerErrorStatuses;
   private final BitSet httpClientErrorStatuses;
   private final boolean httpServerTagQueryString;
@@ -1096,6 +1098,8 @@ public class Config {
           configProvider.getMergedMapWithOptionalMappings(
               "http.response.headers.", true, HEADER_TAGS, RESPONSE_HEADER_TAGS);
     }
+    requestHeaderTagsCommaAllowed =
+        configProvider.getBoolean(REQUEST_HEADER_TAGS_COMMA_ALLOWED, true);
 
     baggageMapping = configProvider.getMergedMap(BAGGAGE_MAPPING);
 
@@ -2115,6 +2119,10 @@ public class Config {
 
   public Map<String, String> getResponseHeaderTags() {
     return responseHeaderTags;
+  }
+
+  public boolean isRequestHeaderTagsCommaAllowed() {
+    return requestHeaderTagsCommaAllowed;
   }
 
   public Map<String, String> getBaggageMapping() {


### PR DESCRIPTION
# What Does This Do

Allows the trace header tags values to contain commas (previously the value was split at the first comma, and only the first part was used).

It is possible to switch to the old behavior by setting the Java property `-Ddd.trace.request_header.tags.comma.allowed=false` or the environment variable `DD_TRACE_REQUEST_HEADER_TAGS_COMMA_ALLOWED=false`

# Motivation

Splitting at the first value breaks some encodings that use commas in the values. This was also the default behavior for some propagators up until `v1.4.0`.

# Additional Notes

Although it's not possible in HTTP to distinguish between multiple instances of the same header being combined into a comma separate list of the values, and a single header with a value with comma in it, we could be lenient here since the header names to read are user supplied.

Jira ticket: [APMJAVA-1140]
GitHub Ticket: #6148 


[APMJAVA-1140]: https://datadoghq.atlassian.net/browse/APMJAVA-1140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ