### PR TITLE
Replaced unused Mocks with Stubs in IAST

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/LocationTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/LocationTest.groovy
@@ -7,7 +7,7 @@ class LocationTest extends DDSpecification {
 
   void 'forStack'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final stack = new StackTraceElement("declaringClass", "methodName", "fileName", 42)
@@ -24,7 +24,7 @@ class LocationTest extends DDSpecification {
 
   void 'forSpanAndClassAndMethod'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final declaringClass = "declaringClass"

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/VulnerabilityTypeTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/VulnerabilityTypeTest.groovy
@@ -45,19 +45,19 @@ class VulnerabilityTypeTest extends DDSpecification {
   }
 
   private Location getSpanAndStackLocation(final long spanId) {
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     span.getSpanId() >> spanId
     return Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1))
   }
 
   private Location getSpanAndClassAndMethodLocation(final long spanId) {
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     span.getSpanId() >> spanId
     return Location.forSpanAndClassAndMethod(span, "foo", "foo")
   }
 
   private Location getSpanLocation(final long spanId, final String serviceName) {
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     span.getSpanId() >> spanId
     span.getServiceName() >> serviceName
     return Location.forSpan(span)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/EvidenceRedactionTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/EvidenceRedactionTest.groovy
@@ -56,7 +56,7 @@ class EvidenceRedactionTest extends DDSpecification {
 
   void 'test empty value parts'() {
     given:
-    final writer = Mock(JsonWriter)
+    final writer = Stub(JsonWriter)
     final ctx = new AdapterFactory.Context()
 
     when:
@@ -70,8 +70,8 @@ class EvidenceRedactionTest extends DDSpecification {
     new StringValuePart(null)                                  | _
     new StringValuePart('')                                    | _
     new RedactedValuePart(null)                                | _
-    new TaintedValuePart(Mock(JsonAdapter), null, null, true)  | _
-    new TaintedValuePart(Mock(JsonAdapter), null, null, false) | _
+    new TaintedValuePart(Stub(JsonAdapter), null, null, true)  | _
+    new TaintedValuePart(Stub(JsonAdapter), null, null, false) | _
   }
 
   void 'test #suite'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
@@ -49,7 +49,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'one vulnerability'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -115,7 +115,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'one vulnerability with one source'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -160,7 +160,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'one vulnerability with two sources'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -214,7 +214,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'one vulnerability with null source'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -252,7 +252,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'one vulnerability with no source type'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -296,7 +296,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'two vulnerabilities with one shared source'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -363,7 +363,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'two vulnerability with no shared sources'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -434,7 +434,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'one truncated vulnerability'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -469,7 +469,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'two truncated vulnerabilities'() {
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -522,7 +522,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'when json is greater than 25kb VulnerabilityEncoding#getExceededTagSizeJson is called'(){
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
     final value = new VulnerabilityBatch()
@@ -542,7 +542,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
   void 'exception during serialization is caught'() {
     given:
     final value = new VulnerabilityBatch()
-    final type = Mock(VulnerabilityType) {
+    final type = Stub(VulnerabilityType) {
       name() >> { throw new RuntimeException("ERROR") }
     }
     final vuln = new Vulnerability(type, null, null)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/overhead/OverheadControllerTest.groovy
@@ -141,7 +141,7 @@ class OverheadControllerTest extends DDSpecification {
     given:
     def taskSchedler = Stub(AgentTaskScheduler)
     def overheadController = OverheadController.build(Config.get(), taskSchedler)
-    def overheadContext = Mock(OverheadContext)
+    def overheadContext = Stub(OverheadContext)
     def iastRequestContext = Stub(IastRequestContext)
     iastRequestContext.getOverheadContext() >> overheadContext
     def requestContext = Stub(RequestContext)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/AbstractSinkModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/AbstractSinkModuleTest.groovy
@@ -24,10 +24,10 @@ class AbstractSinkModuleTest extends IastModuleImplTestBase {
 
   void setup() {
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getRequestContext() >> reqCtx
     }
     tracer.activeSpan() >> span

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/CommandInjectionModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/CommandInjectionModuleTest.groovy
@@ -30,10 +30,10 @@ class CommandInjectionModuleTest extends IastModuleImplTestBase {
     module = new CommandInjectionModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HstsMissingHeaderModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HstsMissingHeaderModuleTest.groovy
@@ -29,10 +29,10 @@ class HstsMissingHeaderModuleTest extends IastModuleImplTestBase {
     InstrumentationBridge.registerIastModule(module)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
@@ -34,7 +34,7 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
     InstrumentationBridge.registerIastModule(new UnvalidatedRedirectModuleImpl(dependencies))
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
     span = Mock(AgentSpan) {
@@ -100,7 +100,7 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
 
   void 'exercise IastRequestController'(){
     given:
-    final taintedObjects = Mock(TaintedObjects)
+    final taintedObjects = Stub(TaintedObjects)
     IastRequestContext ctx = new IastRequestContext(taintedObjects)
 
     when:
@@ -112,8 +112,8 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
 
   void 'exercise IastRequestContext'(){
     given:
-    final taintedObjects = Mock(TaintedObjects)
-    final iastMetricsCollector = Mock(IastMetricCollector)
+    final taintedObjects = Stub(TaintedObjects)
+    final iastMetricsCollector = Stub(IastMetricCollector)
 
     when:
     IastRequestContext ctx = new IastRequestContext(taintedObjects, iastMetricsCollector)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/InsecureCookieModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/InsecureCookieModuleTest.groovy
@@ -28,10 +28,10 @@ class InsecureCookieModuleTest extends IastModuleImplTestBase {
     InstrumentationBridge.registerIastModule(new InsecureCookieModuleImpl())
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/LdapInjectionModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/LdapInjectionModuleTest.groovy
@@ -30,10 +30,10 @@ class LdapInjectionModuleTest extends IastModuleImplTestBase {
     module = new LdapInjectionModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/NoHttpCookieModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/NoHttpCookieModuleTest.groovy
@@ -28,10 +28,10 @@ class NoHttpCookieModuleTest extends IastModuleImplTestBase {
     InstrumentationBridge.registerIastModule(new NoHttpOnlyCookieModuleImpl())
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/NoSameSiteCookieModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/NoSameSiteCookieModuleTest.groovy
@@ -28,10 +28,10 @@ class NoSameSiteCookieModuleTest extends IastModuleImplTestBase {
     InstrumentationBridge.registerIastModule(new NoSameSiteCookieModuleImpl())
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/PathTraversalModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/PathTraversalModuleTest.groovy
@@ -30,10 +30,10 @@ class PathTraversalModuleTest extends IastModuleImplTestBase {
     module = new PathTraversalModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    final span = Mock(AgentSpan) {
+    final span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/SqlInjectionModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/SqlInjectionModuleTest.groovy
@@ -27,10 +27,10 @@ class SqlInjectionModuleTest extends IastModuleImplTestBase {
     module = new SqlInjectionModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    final span = Mock(AgentSpan) {
+    final span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/SsrfModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/SsrfModuleTest.groovy
@@ -28,10 +28,10 @@ class SsrfModuleTest extends IastModuleImplTestBase {
     module = new SsrfModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/TrustBoundaryViolationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/TrustBoundaryViolationModuleTest.groovy
@@ -28,10 +28,10 @@ class TrustBoundaryViolationModuleTest extends IastModuleImplTestBase {
     module = new TrustBoundaryViolationModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UnvalidatedRedirectModuleTest.groovy
@@ -31,10 +31,10 @@ class UnvalidatedRedirectModuleTest extends IastModuleImplTestBase {
     module = new UnvalidatedRedirectModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    final span = Mock(AgentSpan) {
+    final span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/WeakCipherModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/WeakCipherModuleTest.groovy
@@ -68,7 +68,7 @@ class WeakCipherModuleTest extends IastModuleImplTestBase {
 
   void 'iast module not blocklisted cipher algorithm'(){
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     tracer.activeSpan() >> span
 
     when:

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/WeakHashModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/WeakHashModuleTest.groovy
@@ -49,7 +49,7 @@ class WeakHashModuleTest extends IastModuleImplTestBase {
 
   void 'iast module secure hash algorithm'(){
     given:
-    final span = Mock(AgentSpan)
+    final span = Stub(AgentSpan)
     tracer.activeSpan() >> span
 
     when:

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/WeakRandomnessModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/WeakRandomnessModuleTest.groovy
@@ -15,7 +15,7 @@ class WeakRandomnessModuleTest extends IastModuleImplTestBase {
 
   def setup() {
     module = new WeakRandomnessModuleImpl(dependencies)
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
     }
   }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/XContentTypeOptionsModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/XContentTypeOptionsModuleTest.groovy
@@ -29,10 +29,10 @@ public class XContentTypeOptionsModuleTest extends IastModuleImplTestBase {
     InstrumentationBridge.registerIastModule(module)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    span = Mock(AgentSpan) {
+    span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/XPathInjectionModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/XPathInjectionModuleTest.groovy
@@ -26,10 +26,10 @@ class XPathInjectionModuleTest extends IastModuleImplTestBase {
     module = new XPathInjectionModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    final span = Mock(AgentSpan) {
+    final span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/XssModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/XssModuleTest.groovy
@@ -29,10 +29,10 @@ class XssModuleTest extends IastModuleImplTestBase {
     module = new XssModuleImpl(dependencies)
     objectHolder = []
     ctx = new IastRequestContext()
-    final reqCtx = Mock(RequestContext) {
+    final reqCtx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> ctx
     }
-    final span = Mock(AgentSpan) {
+    final span = Stub(AgentSpan) {
       getSpanId() >> 123456
       getRequestContext() >> reqCtx
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
@@ -73,7 +73,7 @@ class RangesTest extends DDSpecification {
 
   void 'test range provider'(final Object values, final List<TaintedObject> tainted, final int size, final int rangeCount) {
     setup:
-    final to = Mock(TaintedObjects)
+    final to = Stub(TaintedObjects)
     values.eachWithIndex { Object entry, int i ->
       to.get(entry) >> tainted.get(i)
     }
@@ -100,7 +100,7 @@ class RangesTest extends DDSpecification {
 
   void 'test empty range provider'() {
     setup:
-    final to = Mock(TaintedObjects)
+    final to = Stub(TaintedObjects)
     final provider = rangesProviderFor(to, items)
 
     when:

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/taint/TaintedObjectsWithTelemetryTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/taint/TaintedObjectsWithTelemetryTest.groovy
@@ -26,16 +26,16 @@ class TaintedObjectsWithTelemetryTest extends DDSpecification {
 
   void setup() {
     mockCollector = Mock(IastMetricCollector)
-    final iastCtx = Mock(IastRequestContext) {
+    final iastCtx = Stub(IastRequestContext) {
       getMetricCollector() >> mockCollector
     }
-    final ctx = Mock(RequestContext) {
+    final ctx = Stub(RequestContext) {
       getData(RequestContextSlot.IAST) >> iastCtx
     }
-    final span = Mock(AgentSpan) {
+    final span = Stub(AgentSpan) {
       getRequestContext() >> ctx
     }
-    final api = Mock(AgentTracer.TracerAPI) {
+    final api = Stub(AgentTracer.TracerAPI) {
       activeSpan() >> span
     }
     AgentTracer.forceRegister(api)

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/RangedDequeueTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/RangedDequeueTest.groovy
@@ -54,7 +54,7 @@ class RangedDequeueTest extends Specification {
 
   void 'test array based deque'() {
     given:
-    final ranged = Mock(Ranged)
+    final ranged = Stub(Ranged)
     final array = [ranged] as Ranged[]
 
     when:


### PR DESCRIPTION
# What Does This Do
Changes some Mock instances to Stub instances when the interactions are not validated.

# Motivation
Inspired by initial improvement done for core tracer in https://github.com/DataDog/dd-trace-java/pull/6372

# Additional Notes

<!-- Jira ticket: [PROJ-IDENT] -->

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
