### PR TITLE
Reduce per-test code coverage overhead

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/NoopCoverageProbeStore.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/NoopCoverageProbeStore.java
@@ -9,7 +9,7 @@ public class NoopCoverageProbeStore implements CoverageProbeStore {
   private static final CoverageProbeStore INSTANCE = new NoopCoverageProbeStore();
 
   @Override
-  public void record(Class<?> clazz, long classId, String className, int probeId) {}
+  public void record(Class<?> clazz, long classId, int probeId) {}
 
   @Override
   public void recordNonCodeResource(String absolutePath) {}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/TestProbes.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/TestProbes.java
@@ -40,9 +40,9 @@ public class TestProbes implements CoverageProbeStore {
   }
 
   @Override
-  public void record(Class<?> clazz, long classId, String className, int probeId) {
+  public void record(Class<?> clazz, long classId, int probeId) {
     probeActivations
-        .computeIfAbsent(clazz, (ignored) -> new ExecutionDataAdapter(classId, className))
+        .computeIfAbsent(clazz, (ignored) -> new ExecutionDataAdapter(classId, clazz.getName()))
         .record(probeId);
   }
 
@@ -155,7 +155,7 @@ public class TestProbes implements CoverageProbeStore {
 
     @Override
     public void setTotalProbeCount(String className, int totalProbeCount) {
-      totalProbeCounts.put(className, totalProbeCount);
+      totalProbeCounts.put(className.replace('/', '.'), totalProbeCount);
     }
 
     @Override

--- a/dd-java-agent/instrumentation/jacoco/src/main/java/datadog/trace/instrumentation/jacoco/ProbeInserterInstrumentation.java
+++ b/dd-java-agent/instrumentation/jacoco/src/main/java/datadog/trace/instrumentation/jacoco/ProbeInserterInstrumentation.java
@@ -151,16 +151,15 @@ public class ProbeInserterInstrumentation extends Instrumenter.CiVisibility
 
       MethodVisitorWrapper methodVisitor = MethodVisitorWrapper.wrap(mv);
 
-      methodVisitor.visitLdcInsn(classId);
-      methodVisitor.visitLdcInsn(className);
       methodVisitor.pushClass(className);
+      methodVisitor.visitLdcInsn(classId);
       methodVisitor.push(id);
 
       methodVisitor.visitMethodInsn(
           Opcodes.INVOKESTATIC,
           "datadog/trace/api/civisibility/InstrumentationBridge",
           "currentCoverageProbeStoreRecord",
-          "(JLjava/lang/String;Ljava/lang/Class;I)V",
+          "(Ljava/lang/Class;JI)V",
           false);
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/coverage/CoverageProbeStore.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/coverage/CoverageProbeStore.java
@@ -1,7 +1,7 @@
 package datadog.trace.api.civisibility.coverage;
 
 public interface CoverageProbeStore extends TestReportHolder {
-  void record(Class<?> clazz, long classId, String className, int probeId);
+  void record(Class<?> clazz, long classId, int probeId);
 
   void recordNonCodeResource(String absolutePath);
 


### PR DESCRIPTION
# What Does This Do
Reduces the overhead of per-test code coverage in CI Visibility 

Jira ticket: [CIVIS-8357]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8357]: https://datadoghq.atlassian.net/browse/CIVIS-8357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ