### PR TITLE
Ignore configuration blocks when comparing skippable test identifiers

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDBuildSystemSessionImpl.java
@@ -130,7 +130,7 @@ public class DDBuildSystemSessionImpl extends DDTestSessionImpl implements DDBui
 
   private SignalResponse onTestDataRequestReceived(TestDataRequest testDataRequest) {
     try {
-      String relativeModulePath = testDataRequest.getRelativeModulePath();
+      String moduleName = testDataRequest.getModuleName();
       JvmInfo jvmInfo = testDataRequest.getJvmInfo();
       ModuleExecutionSettings moduleExecutionSettings = getModuleExecutionSettings(jvmInfo);
 
@@ -138,10 +138,10 @@ public class DDBuildSystemSessionImpl extends DDTestSessionImpl implements DDBui
       TestDataType testDataType = testDataRequest.getTestDataType();
       switch (testDataType) {
         case SKIPPABLE:
-          tests = moduleExecutionSettings.getSkippableTests(relativeModulePath);
+          tests = moduleExecutionSettings.getSkippableTests(moduleName);
           break;
         case FLAKY:
-          tests = moduleExecutionSettings.getFlakyTests(relativeModulePath);
+          tests = moduleExecutionSettings.getFlakyTests(moduleName);
           break;
         default:
           throw new IllegalArgumentException(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
@@ -71,9 +71,9 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
         repositoryRoot,
         jvmInfo);
 
-    Map<String, List<TestIdentifier>> skippableTestsByModulePath =
+    Map<String, List<TestIdentifier>> skippableTestsByModuleName =
         itrEnabled && repositoryRoot != null
-            ? getSkippableTestsByModulePath(Paths.get(repositoryRoot), tracerEnvironment)
+            ? getSkippableTestsByModuleName(Paths.get(repositoryRoot), tracerEnvironment)
             : Collections.emptyMap();
 
     Collection<TestIdentifier> flakyTests =
@@ -86,7 +86,7 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
         codeCoverageEnabled,
         itrEnabled,
         systemProperties,
-        skippableTestsByModulePath,
+        skippableTestsByModuleName,
         flakyTests,
         coverageEnabledPackages);
   }
@@ -196,7 +196,7 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
     return propagatedSystemProperties;
   }
 
-  private Map<String, List<TestIdentifier>> getSkippableTestsByModulePath(
+  private Map<String, List<TestIdentifier>> getSkippableTestsByModuleName(
       Path repositoryRoot, TracerEnvironment tracerEnvironment) {
     try {
       // ensure git data upload is finished before asking for tests

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/TestDataRequest.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/TestDataRequest.java
@@ -8,12 +8,12 @@ import java.util.Objects;
 public class TestDataRequest implements Signal {
 
   private final TestDataType testDataType;
-  private final String relativeModulePath;
+  private final String moduleName;
   private final JvmInfo jvmInfo;
 
-  public TestDataRequest(TestDataType testDataType, String relativeModulePath, JvmInfo jvmInfo) {
+  public TestDataRequest(TestDataType testDataType, String moduleName, JvmInfo jvmInfo) {
     this.testDataType = testDataType;
-    this.relativeModulePath = relativeModulePath;
+    this.moduleName = moduleName;
     this.jvmInfo = jvmInfo;
   }
 
@@ -26,8 +26,8 @@ public class TestDataRequest implements Signal {
     return testDataType;
   }
 
-  public String getRelativeModulePath() {
-    return relativeModulePath;
+  public String getModuleName() {
+    return moduleName;
   }
 
   public JvmInfo getJvmInfo() {
@@ -39,8 +39,8 @@ public class TestDataRequest implements Signal {
     return "SkippableTestsRequest{"
         + "testDataType="
         + testDataType
-        + ",relativeModulePath="
-        + relativeModulePath
+        + ",moduleName="
+        + moduleName
         + ", jvmInfo="
         + jvmInfo
         + '}';
@@ -56,20 +56,20 @@ public class TestDataRequest implements Signal {
     }
     TestDataRequest that = (TestDataRequest) o;
     return testDataType == that.testDataType
-        && Objects.equals(relativeModulePath, that.relativeModulePath)
+        && Objects.equals(moduleName, that.moduleName)
         && Objects.equals(jvmInfo, that.jvmInfo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(testDataType, relativeModulePath, jvmInfo);
+    return Objects.hash(testDataType, moduleName, jvmInfo);
   }
 
   @Override
   public ByteBuffer serialize() {
 
     byte[] modulePathBytes =
-        relativeModulePath != null ? relativeModulePath.getBytes(StandardCharsets.UTF_8) : null;
+        moduleName != null ? moduleName.getBytes(StandardCharsets.UTF_8) : null;
 
     String jvmName = jvmInfo.getName();
     byte[] jvmNameBytes = jvmName != null ? jvmName.getBytes(StandardCharsets.UTF_8) : null;
@@ -114,12 +114,12 @@ public class TestDataRequest implements Signal {
 
   public static TestDataRequest deserialize(ByteBuffer buffer) {
     TestDataType testDataType = TestDataType.byOrdinal(buffer.get());
-    String relativeModulePath = deserializeString(buffer);
+    String moduleName = deserializeString(buffer);
     String jvmName = deserializeString(buffer);
     String jvmVersion = deserializeString(buffer);
     String jvmVendor = deserializeString(buffer);
     JvmInfo jvmInfo = new JvmInfo(jvmName, jvmVersion, jvmVendor);
-    return new TestDataRequest(testDataType, relativeModulePath, jvmInfo);
+    return new TestDataRequest(testDataType, moduleName, jvmInfo);
   }
 
   private static String deserializeString(ByteBuffer buffer) {

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/config/ModuleExecutionSettings.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/config/ModuleExecutionSettings.java
@@ -41,11 +41,11 @@ public class ModuleExecutionSettings {
     return systemProperties;
   }
 
-  public Collection<TestIdentifier> getSkippableTests(String relativeModulePath) {
-    return skippableTestsByModule.getOrDefault(relativeModulePath, Collections.emptyList());
+  public Collection<TestIdentifier> getSkippableTests(String moduleName) {
+    return skippableTestsByModule.getOrDefault(moduleName, Collections.emptyList());
   }
 
-  public Collection<TestIdentifier> getFlakyTests(String relativeModulePath) {
+  public Collection<TestIdentifier> getFlakyTests(String moduleName) {
     // backend does not store module info for flaky tests
     return flakyTests;
   }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/config/TestIdentifier.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/config/TestIdentifier.java
@@ -8,6 +8,15 @@ public class TestIdentifier {
   private final String suite;
   private final String name;
   private @Nullable final String parameters;
+  /**
+   * Configurations field is intentionally excluded from hashCode/equals: the backend does not
+   * return full configuration for a test case, but rather includes only those parts that were not
+   * specified in the client request (for instance, when requesting tests without specifying module
+   * name, each test in the response will have module name present in its config section). Moreover,
+   * in some edge cases the backend may choose to return empty configuration object instead of null.
+   * Therefore, reconstructing on the client side a configuration block that fully corresponds to
+   * the one returned by the backend is non-trivial.
+   */
   private @Nullable final Configurations configurations;
 
   public TestIdentifier(
@@ -50,13 +59,12 @@ public class TestIdentifier {
     TestIdentifier that = (TestIdentifier) o;
     return Objects.equals(suite, that.suite)
         && Objects.equals(name, that.name)
-        && Objects.equals(parameters, that.parameters)
-        && Objects.equals(configurations, that.configurations);
+        && Objects.equals(parameters, that.parameters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(suite, name, parameters, configurations);
+    return Objects.hash(suite, name, parameters);
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Ignores configuration objects when comparing `TestIdentifier` objects.

# Motivation
Test identifiers comparison is done when determining whether to skip a test with ITR, or whether to retry a flaky test.
There are some inconsistencies in how the backend populates test configurations (depending on some conditions it may return a partially filled configuration block, an empty object, or a null).
Rather than trying to replicate the backend's logic in the tracer, it was decided to not use test configurations for comparison: the relevant fields are not be present in the backend's response anyway (since they are provided by the tracer when requesting tests data, the backend does not include them in the response).

Jira ticket: [CIVIS-8358]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8358]: https://datadoghq.atlassian.net/browse/CIVIS-8358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ