### PR TITLE
Skip Scalatest alpha and beta versions

### DIFF
--- a/dd-java-agent/instrumentation/scalatest/build.gradle
+++ b/dd-java-agent/instrumentation/scalatest/build.gradle
@@ -27,7 +27,17 @@ compileTestGroovy {
   dependsOn compileTestScala
   classpath += files(sourceSets.test.scala.destinationDirectory)
 }
+
 compileLatestDepTestGroovy {
   dependsOn compileLatestDepTestScala
   classpath += files(sourceSets.latestDepTest.scala.destinationDirectory)
+}
+
+configurations.configureEach {
+  resolutionStrategy.componentSelection.all { ComponentSelection selection ->
+    def version = selection.candidate.version.toLowerCase()
+    if (version.contains('alpha') || version.contains('beta')) {
+      reject("Early Access Version: ${selection.candidate.version}")
+    }
+  }
 }


### PR DESCRIPTION
# What Does This Do

Skips scalatest alpha and beta versions since there are half-published versions that breaks the build.
