### PR TITLE
Accept any config id from Remote Config

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
@@ -17,8 +17,13 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import okio.Okio;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DebuggerProductChangesListener implements ProductListener {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DebuggerProductChangesListener.class);
+
   public interface ConfigurationAcceptor {
     void accept(Configuration configuration);
   }
@@ -110,7 +115,7 @@ public class DebuggerProductChangesListener implements ProductListener {
             "got config.serviceName = " + newConfig.getService() + ", ignoring configuration");
       }
     } else {
-      throw new IOException("unsupported configuration id " + configId);
+      LOGGER.debug("Unsupported configuration id: {}, ignoring configuration", configId);
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.agent;
 import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.lenient;
 
 import com.datadog.debugger.probe.LogProbe;
@@ -193,15 +194,12 @@ public class DebuggerProductChangesListenerTest {
   }
 
   @Test
-  public void badConfigIDFailsToAccept() {
+  public void badConfigIDFailsToAccept() throws IOException {
     SimpleAcceptor acceptor = new SimpleAcceptor();
-
     DebuggerProductChangesListener listener =
         new DebuggerProductChangesListener(tracerConfig, acceptor);
-
-    Assertions.assertThrows(
-        IOException.class,
-        () -> listener.accept(createConfigKey("bad-config-id"), null, pollingHinter));
+    listener.accept(createConfigKey("bad-config-id"), null, pollingHinter);
+    assertNull(acceptor.configuration);
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
For supporting compatibility with new config ids, don't throw exception of an actual non supporting id format.

# Motivation
Compatibility

# Additional Notes

Jira ticket: [DEBUG-1793]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1793]: https://datadoghq.atlassian.net/browse/DEBUG-1793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ