### PR TITLE
Rate limit Datadog tags decoding warnings

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/DatadogPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/DatadogPTagsCodec.java
@@ -3,15 +3,17 @@ package datadog.trace.core.propagation.ptags;
 import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.propagation.ptags.PTagsFactory.PTags;
 import datadog.trace.core.propagation.ptags.TagElement.Encoding;
+import datadog.trace.relocate.api.RatelimitedLogger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.IntPredicate;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Captures configuration required for PropagationTags logic */
 final class DatadogPTagsCodec extends PTagsCodec {
-  private static final Logger log = LoggerFactory.getLogger(DatadogPTagsCodec.class);
+  private static final RatelimitedLogger log =
+      new RatelimitedLogger(LoggerFactory.getLogger(DatadogPTagsCodec.class), 5, TimeUnit.MINUTES);
   private static final String PROPAGATION_ERROR_EXTRACT_MAX_SIZE = "extract_max_size";
   private static final String PROPAGATION_ERROR_DECODING_ERROR = "decoding_error";
   private static final char TAGS_SEPARATOR = ',';

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -6,14 +6,16 @@ import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.propagation.ptags.PTagsFactory.PTags;
 import datadog.trace.core.propagation.ptags.TagElement.Encoding;
+import datadog.trace.relocate.api.RatelimitedLogger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.IntPredicate;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class W3CPTagsCodec extends PTagsCodec {
-  private static final Logger log = LoggerFactory.getLogger(W3CPTagsCodec.class);
+  private static final RatelimitedLogger log =
+      new RatelimitedLogger(LoggerFactory.getLogger(W3CPTagsCodec.class), 5, TimeUnit.MINUTES);
 
   private static final int MAX_HEADER_SIZE = 256;
   private static final String DATADOG_MEMBER_KEY = "dd=";

--- a/internal-api/src/main/java/datadog/trace/relocate/api/RatelimitedLogger.java
+++ b/internal-api/src/main/java/datadog/trace/relocate/api/RatelimitedLogger.java
@@ -29,7 +29,7 @@ public class RatelimitedLogger {
       final Logger log, final int delay, final TimeUnit timeUnit, final TimeSource timeSource) {
     this.log = log;
     this.delayNanos = timeUnit.toNanos(delay);
-    this.noLogMessage = createNoLogMessage(" (Will not log errors for ", ")", delay, timeUnit);
+    this.noLogMessage = createNoLogMessage(" (Will not log warnings for ", ")", delay, timeUnit);
     this.timeSource = timeSource;
     nextLogNanos = new AtomicLong(timeSource.getNanoTicks());
   }

--- a/internal-api/src/test/groovy/datadog/trace/relocate/api/RateLimitedLoggerTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/relocate/api/RateLimitedLoggerTest.groovy
@@ -38,7 +38,7 @@ class RateLimitedLoggerTest extends DDSpecification {
     def secondLog = defaultRateLimitedLog.warn("test {} {}", "message", exception)
 
     then:
-    1 * log.warn("test {} {} (Will not log errors for 5 minutes)", "message", exception)
+    1 * log.warn("test {} {} (Will not log warnings for 5 minutes)", "message", exception)
     firstLog
     !secondLog
   }
@@ -56,7 +56,7 @@ class RateLimitedLoggerTest extends DDSpecification {
     def firstLog = rateLimitedLog.warn("test {} {}", "message", exception)
 
     then:
-    1 * log.warn("test {} {} (Will not log errors for 1 minute)", "message", exception)
+    1 * log.warn("test {} {} (Will not log warnings for 1 minute)", "message", exception)
     firstLog
 
     when:
@@ -80,7 +80,7 @@ class RateLimitedLoggerTest extends DDSpecification {
     def firstLog = rateLimitedLog.warn("test {} {}", "message", exception)
 
     then:
-    1 * log.warn("test {} {} (Will not log errors for 5 nanoseconds)", "message", exception)
+    1 * log.warn("test {} {} (Will not log warnings for 5 nanoseconds)", "message", exception)
     firstLog
 
     when:
@@ -105,7 +105,7 @@ class RateLimitedLoggerTest extends DDSpecification {
     def firstLog = rateLimitedLog.warn("test {} {}", "message", exception)
 
     then:
-    1 * log.warn("test {} {} (Will not log errors for 5 nanoseconds)", "message", exception)
+    1 * log.warn("test {} {} (Will not log warnings for 5 nanoseconds)", "message", exception)
     firstLog
 
     when:
@@ -128,7 +128,7 @@ class RateLimitedLoggerTest extends DDSpecification {
     def firstLog = rateLimitedLog.warn("test {} {}", "message", exception)
 
     then:
-    1 * log.warn("test {} {} (Will not log errors for 7 nanoseconds)", "message", exception)
+    1 * log.warn("test {} {} (Will not log warnings for 7 nanoseconds)", "message", exception)
     firstLog
 
     when:
@@ -136,7 +136,7 @@ class RateLimitedLoggerTest extends DDSpecification {
     def secondLog = rateLimitedLog.warn("test {} {}", "message", exception)
 
     then:
-    1 * log.warn("test {} {} (Will not log errors for 7 nanoseconds)", "message", exception)
+    1 * log.warn("test {} {} (Will not log warnings for 7 nanoseconds)", "message", exception)
     secondLog
   }
 
@@ -152,6 +152,6 @@ class RateLimitedLoggerTest extends DDSpecification {
     rateLimitedLog.warn("test")
 
     then:
-    1 * log.warn("test (Will not log errors for 1 millisecond)")
+    1 * log.warn("test (Will not log warnings for 1 millisecond)")
   }
 }


### PR DESCRIPTION
# What Does This Do

This rate limits the warnings for illegal Datadog tags for both W3C and Datadog headers.

# Motivation

Other language tracers in mixed language systems that keep sending traces with broken headers are filling up the logs with these warnings.

# Additional Notes

Jira ticket: [APMJAVA-1042]
GitHub ticket: #5930


[APMJAVA-1042]: https://datadoghq.atlassian.net/browse/APMJAVA-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ