### PR TITLE
Report instrumenter state in tracer-flare

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -198,6 +198,8 @@ public class AgentInstaller {
       log.debug("Installed {} instrumenter(s)", installedCount);
     }
 
+    InstrumenterFlare.register();
+
     if (InstrumenterConfig.get().isTelemetryEnabled()) {
       InstrumenterState.setObserver(
           new InstrumenterState.Observer() {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterFlare.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterFlare.java
@@ -1,0 +1,20 @@
+package datadog.trace.agent.tooling;
+
+import static datadog.trace.api.flare.TracerFlare.addText;
+
+import datadog.trace.api.flare.TracerFlare;
+import java.io.IOException;
+import java.util.zip.ZipOutputStream;
+
+public final class InstrumenterFlare implements TracerFlare.Reporter {
+  private static final InstrumenterFlare INSTANCE = new InstrumenterFlare();
+
+  public static void register() {
+    TracerFlare.addReporter(INSTANCE);
+  }
+
+  @Override
+  public void addReport(ZipOutputStream zip) throws IOException {
+    addText(zip, "instrumenter_state.txt", InstrumenterState.summary());
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterState.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterState.java
@@ -164,4 +164,37 @@ public final class InstrumenterState {
       wordState = state.get(wordIndex);
     }
   }
+
+  public static String summary() {
+    StringBuilder summary = new StringBuilder();
+    classLoaderStates.visit(
+        (loader, state) -> {
+          summary.append(loader.getClass().getName());
+          summarizeState(summary, state);
+          summary.append("\n\n");
+        });
+    return summary.toString();
+  }
+
+  private static void summarizeState(StringBuilder summary, AtomicLongArray state) {
+    for (int wordIndex = 0; wordIndex < state.length(); wordIndex++) {
+      int instrumentationId = wordIndex * (BITS_PER_WORD >> 1); // 2 bits per status
+      long wordState = state.get(wordIndex);
+      while (wordState != 0) {
+        if ((wordState & STATUS_BITS) != 0) {
+          if ((wordState & APPLIED) != 0) {
+            summary.append("\n    APPLIED  ");
+          } else {
+            summary.append("\n    BLOCKED  ");
+          }
+          summary
+              .append(instrumentationClasses[instrumentationId])
+              .append("  ")
+              .append(instrumentationNames[instrumentationId]);
+        }
+        instrumentationId++;
+        wordState >>>= 2; // move onto next 2 status bits
+      }
+    }
+  }
 }


### PR DESCRIPTION
Will end up in `instrumenter_state.txt` in the tracer-flare. Example output:
```
org.springframework.boot.loader.LaunchedURLClassLoader
    APPLIED  datadog.trace.instrumentation.classloading.ClassloadingInstrumentation  [classloading]
    APPLIED  datadog.trace.instrumentation.hibernate.core.v4_0.QueryInstrumentation  [hibernate, hibernate-core]
    APPLIED  datadog.trace.instrumentation.hibernate.core.v4_0.SessionFactoryInstrumentation  [hibernate, hibernate-core]
    APPLIED  datadog.trace.instrumentation.hibernate.core.v4_0.SessionInstrumentation  [hibernate, hibernate-core]
    APPLIED  datadog.trace.instrumentation.hibernate.core.v4_3.SessionInstrumentation  [hibernate, hibernate-core]
    APPLIED  datadog.trace.instrumentation.java.concurrent.AsyncPropagatingDisableInstrumentation  [java_concurrent]
    APPLIED  datadog.trace.instrumentation.java.concurrent.RunnableInstrumentation  [java_concurrent, runnable]
    APPLIED  datadog.trace.instrumentation.java.concurrent.ThreadPoolExecutorInstrumentation  [java_concurrent]
    APPLIED  datadog.trace.instrumentation.jdbc.DefaultConnectionInstrumentation  [jdbc]
    APPLIED  datadog.trace.instrumentation.jdbc.DriverInstrumentation  [jdbc]
    APPLIED  datadog.trace.instrumentation.jdbc.StatementInstrumentation  [jdbc]
    APPLIED  datadog.trace.instrumentation.log4j2.ThreadContextInstrumentation  [log4j, log4j-2]
    APPLIED  datadog.trace.instrumentation.logback.LogbackLoggerInstrumentation  [logback]
    APPLIED  datadog.trace.instrumentation.logback.LoggingEventInstrumentation  [logback]
    APPLIED  datadog.trace.instrumentation.servlet.dispatcher.ServletContextInstrumentation  [servlet, servlet-dispatcher]
    APPLIED  datadog.trace.instrumentation.servlet3.Servlet3Instrumentation  [servlet, servlet-3]
    APPLIED  datadog.trace.instrumentation.springbeans.BeanFactoryInstrumentation  [spring-beans]
    APPLIED  datadog.trace.instrumentation.springdata.SpringRepositoryInstrumentation  [spring-data]
    APPLIED  datadog.trace.instrumentation.springscheduling.SpringSchedulingInstrumentation  [spring-scheduling]
    APPLIED  datadog.trace.instrumentation.springweb.DispatcherServletInstrumentation  [spring-web]
    APPLIED  datadog.trace.instrumentation.springweb.HandlerAdapterInstrumentation  [spring-web]
    APPLIED  datadog.trace.instrumentation.springweb.HttpMessageConverterInstrumentation  [spring-web]
    APPLIED  datadog.trace.instrumentation.springweb.TemplateAndMatrixVariablesInstrumentation  [spring-web]
    APPLIED  datadog.trace.instrumentation.springweb.WebApplicationContextInstrumentation  [spring-web, spring-path-filter]
    APPLIED  datadog.trace.instrumentation.springweb.ServletPathRequestFilterInstrumentation  [spring-web, spring-path-filter]
    BLOCKED  datadog.trace.instrumentation.springweb6.DispatcherServletInstrumentation  [spring-web]
    BLOCKED  datadog.trace.instrumentation.springweb6.HandlerAdapterInstrumentation  [spring-web]
    BLOCKED  datadog.trace.instrumentation.springweb6.TemplateAndMatrixVariablesInstrumentation  [spring-web]
    BLOCKED  datadog.trace.instrumentation.springweb6.WebApplicationContextInstrumentation  [spring-web, spring-path-filter]
    APPLIED  datadog.trace.instrumentation.tomcat.TomcatServerInstrumentation  [tomcat]
```

Jira ticket: [APMJAVA-1136]

[APMJAVA-1136]: https://datadoghq.atlassian.net/browse/APMJAVA-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ