### PR TITLE
exclude spring-kafka runnables from spring scheduling wrapping

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExcludeFilter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExcludeFilter.java
@@ -110,6 +110,9 @@ public class ExcludeFilter {
     SKIP_TYPE_PREFIXES
         .get(ExcludeType.RUNNABLE)
         .add("com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap");
+    SKIP_TYPE_PREFIXES
+        .get(ExcludeType.RUNNABLE)
+        .add("org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer$");
   }
 
   /**

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   testImplementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.2.3'
   testImplementation group: 'org.assertj', name: 'assertj-core', version: '2.9.+'
   testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.19.0'
+  testRuntimeOnly project(':dd-java-agent:instrumentation:spring-scheduling-3.1')
 
   // Include latest version of kafka itself along with latest version of client libs.
   // This seems to help with jar compatibility hell.


### PR DESCRIPTION
# What Does This Do

Do not wrap `org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer$...` (inner class and lambdas) when advice spring scheduling `schdule(atFixedRate)`

# Motivation

# Additional Notes

Jira ticket: [APMS-10946]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-10946]: https://datadoghq.atlassian.net/browse/APMS-10946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ