### PR TITLE
fix logging dependencies for spring-messaging tests

### DIFF
--- a/dd-java-agent/instrumentation/spring-messaging-4/build.gradle
+++ b/dd-java-agent/instrumentation/spring-messaging-4/build.gradle
@@ -29,8 +29,12 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:aws-java-sqs-2.0')
 
   testImplementation group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '2.0.0'
-  testImplementation group: 'io.awspring.cloud', name: 'spring-cloud-aws-sqs', version: '3.0.1'
+  testImplementation group: 'io.awspring.cloud', name: 'spring-cloud-aws-sqs', version: '3.0.1', {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
   testImplementation group: 'org.elasticmq', name: 'elasticmq-rest-sqs_2.13', version: '1.2.3'
 
-  latestDepTestImplementation group: 'org.springframework', name: 'spring-messaging', version: '+'
+  latestDepTestImplementation group: 'org.springframework', name: 'spring-messaging', version: '+', {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
 }


### PR DESCRIPTION
# What Does This Do

Help understanding failures of `SpringListenerSQSTest`. It fixes slf4j dependences that today are too recent and fails binding logback factory. 

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
