### PR TITLE
byte-buddy 1.14.9

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.8")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.9")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.8' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.9' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.9.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.14.8",
+    bytebuddy     : "1.14.9",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
Updates byte-buddy to a version compiled with ASM 9.6 (we previously upgraded ASM in #5992)