### PR TITLE
Use OpenTelemetry SDK context key instead of Datadog proprietary one for local root span

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OtelContext.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OtelContext.java
@@ -15,7 +15,7 @@ public class OtelContext implements Context {
   public static final OtelContext ROOT = new OtelContext(OtelSpan.invalid(), OtelSpan.invalid());
 
   private static final String OTEL_CONTEXT_SPAN_KEY = "opentelemetry-trace-span-key";
-  private static final String DATADOG_CONTEXT_ROOT_SPAN_KEY = "datadog-root-span-key";
+  private static final String OTEL_CONTEXT_ROOT_SPAN_KEY = "opentelemetry-traces-local-root-span";
 
   private final Span currentSpan;
   private final Span rootSpan;
@@ -30,7 +30,7 @@ public class OtelContext implements Context {
   public <V> V get(ContextKey<V> key) {
     if (OTEL_CONTEXT_SPAN_KEY.equals(key.toString())) {
       return (V) this.currentSpan;
-    } else if (DATADOG_CONTEXT_ROOT_SPAN_KEY.equals(key.toString())) {
+    } else if (OTEL_CONTEXT_ROOT_SPAN_KEY.equals(key.toString())) {
       return (V) this.rootSpan;
     }
     return null;
@@ -40,7 +40,7 @@ public class OtelContext implements Context {
   public <V> Context with(ContextKey<V> k1, V v1) {
     if (OTEL_CONTEXT_SPAN_KEY.equals(k1.toString())) {
       return new OtelContext((Span) v1, this.rootSpan);
-    } else if (DATADOG_CONTEXT_ROOT_SPAN_KEY.equals(k1.toString())) {
+    } else if (OTEL_CONTEXT_ROOT_SPAN_KEY.equals(k1.toString())) {
       return new OtelContext(this.currentSpan, (Span) v1);
     }
     return this;

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/opentelemetry14/context/ContextTest.groovy
@@ -10,7 +10,7 @@ import io.opentelemetry.context.ThreadLocalContextStorage
 import spock.lang.Subject
 
 import static datadog.trace.bootstrap.instrumentation.api.ScopeSource.MANUAL
-import static datadog.trace.instrumentation.opentelemetry14.context.OtelContext.DATADOG_CONTEXT_ROOT_SPAN_KEY
+import static datadog.trace.instrumentation.opentelemetry14.context.OtelContext.OTEL_CONTEXT_ROOT_SPAN_KEY
 import static datadog.trace.instrumentation.opentelemetry14.context.OtelContext.OTEL_CONTEXT_SPAN_KEY
 import static datadog.trace.instrumentation.opentelemetry14.trace.OtelConventions.SPAN_KIND_INTERNAL
 
@@ -245,7 +245,7 @@ class ContextTest extends AgentTestRunner {
     def parentSpan = tracer.spanBuilder("some-name").startSpan()
     def parentScope = parentSpan.makeCurrent()
     def currentSpanKey = ContextKey.named(OTEL_CONTEXT_SPAN_KEY)
-    def rootSpanKey = ContextKey.named(DATADOG_CONTEXT_ROOT_SPAN_KEY)
+    def rootSpanKey = ContextKey.named(OTEL_CONTEXT_ROOT_SPAN_KEY)
 
     when:
     def current = Context.current()


### PR DESCRIPTION
# What Does This Do

This PR changes the Context key to retrieve the local root span from OpenTelemetry `Context`.
It will now use the same key as the OpenTelemetry SDK making it compatible with SDK `LocalRootSpan` behavior. 

# Motivation

This will increase compatibility with OTel SDK and OTel instrumenter API. 

# Additional Notes

This behavior change is following the gap analysis of Micronaut Tracing features.

The related documentation update PR: https://github.com/DataDog/documentation/pull/21122

Jira ticket: [APMJAVA-1151]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1151]: https://datadoghq.atlassian.net/browse/APMJAVA-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ