### PR TITLE
dbm connection: do not access contextstore with null key

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DBMCompatibleConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DBMCompatibleConnectionInstrumentation.java
@@ -116,7 +116,7 @@ public class DBMCompatibleConnectionInstrumentation extends AbstractConnectionIn
       }
       ContextStore<Statement, DBQueryInfo> contextStore =
           InstrumentationContext.get(Statement.class, DBQueryInfo.class);
-      if (null == contextStore.get(statement)) {
+      if (null != statement && null == contextStore.get(statement)) {
         DBQueryInfo info = DBQueryInfo.ofPreparedStatement(inputSql);
         contextStore.put(statement, info);
         logQueryInfoInjection(connection, statement, info);


### PR DESCRIPTION
# What Does This Do

Seen on a recent ticket: if the `prepareCall` is throwing exception, the return value will be null hence the WeakHashMap that's backing the context store will throw a NPE because does not support null keys

```
DEBUG datadog.trace.bootstrap.ExceptionLogger - Failed to handle exception in instrumentation for org.postgresql.jdbc.PgConnection
java.lang.NullPointerException
	at com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap.get(WeakConcurrentMap.java:109)
	at datadog.trace.agent.tooling.WeakMaps$Adapter.get(WeakMaps.java:68)
	at datadog.trace.bootstrap.WeakMapContextStore.get(WeakMapContextStore.java:25)
	at datadog.trace.bootstrap.FieldBackedContextStore.get(FieldBackedContextStore.java:19)
	at org.postgresql.jdbc.PgConnection.prepareCall(PgConnection.java:459)
	at com.zaxxer.hikari.pool.ProxyConnection.prepareCall(ProxyConnection.java:295)
	at com.zaxxer.hikari.pool.HikariProxyConnection.prepareCall(HikariProxyConnection.java)
```

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
