### PR TITLE
Update repo indexer to not follow symlinks that point inside the repo

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -128,7 +128,23 @@ public class RepoIndexBuilder implements RepoIndexProvider {
 
     @Override
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+      if (Files.isSymbolicLink(dir) && readSymbolicLink(dir).startsWith(repoRoot)) {
+        // The path is a symlink that points inside the repo.
+        // We'll visit the folder that it points to anyway,
+        // moreover, we don't want two different results for one file
+        // (one containing the symlink, the other - the actual folder).
+        return FileVisitResult.SKIP_SUBTREE;
+      }
       return FileVisitResult.CONTINUE;
+    }
+
+    private static Path readSymbolicLink(Path path) {
+      try {
+        return Files.readSymbolicLink(path);
+      } catch (Exception e) {
+        log.debug("Could not read symbolic link {}", path, e);
+        return path;
+      }
     }
 
     @Override


### PR DESCRIPTION
# What Does This Do
Updates repository indexing logic: if the repository contains a symlink that points inside the repository, this symlink will not be indexed.

# Motivation
The folder/file that the symlink points to will be indexed anyway, since it is located inside the repository.
Moreover, if we do index the symlink, the index will contain two paths for the same file - one containing the symlink, the other containing the actual folder path. This can lead to errors, since depending on the indexing order the source path for a class can be resolved into either of the two paths.

Jira ticket: [CIVIS-8403]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8403]: https://datadoghq.atlassian.net/browse/CIVIS-8403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ