### PR TITLE
Add specific support for Optional

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -129,10 +129,10 @@ public class CapturedContext implements ValueReferenceResolver {
         }
       }
     } else {
-      Function<Object, WellKnownClasses.SpecialField> specialFieldAccess =
+      Function<Object, CapturedValue> specialFieldAccess =
           WellKnownClasses.getSpecialFieldAccess(target.getClass().getTypeName());
       if (specialFieldAccess != null) {
-        WellKnownClasses.SpecialField specialField = specialFieldAccess.apply(target);
+        CapturedValue specialField = specialFieldAccess.apply(target);
         if (specialField != null && specialField.getName().equals(memberName)) {
           return specialField.getValue();
         } else {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.debugger.util;
 
+import datadog.trace.bootstrap.debugger.CapturedContext;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -58,7 +59,8 @@ public class WellKnownClasses {
               "java.time.LocalDateTime",
               "java.util.UUID"));
 
-  private static Map<String, Function<Object, SpecialField>> specialFields = new HashMap<>();
+  private static Map<String, Function<Object, CapturedContext.CapturedValue>> specialFields =
+      new HashMap<>();
 
   static {
     specialFields.put("java.util.Optional", WellKnownClasses::optionalSpecialField);
@@ -119,35 +121,12 @@ public class WellKnownClasses {
    * @return a function to access special field of a type, or null if type is not supported. This is
    *     used to avoid using reflection to access fields on well known types
    */
-  public static Function<Object, SpecialField> getSpecialFieldAccess(String type) {
+  public static Function<Object, CapturedContext.CapturedValue> getSpecialFieldAccess(String type) {
     return specialFields.get(type);
   }
 
-  private static SpecialField optionalSpecialField(Object o) {
-    return new SpecialField("value", Object.class.getTypeName(), ((Optional<?>) o).orElse(null));
-  }
-
-  public static class SpecialField {
-    private final String name;
-    private final String type;
-    private final Object value;
-
-    public SpecialField(String name, String type, Object value) {
-      this.name = name;
-      this.type = type;
-      this.value = value;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public String getType() {
-      return type;
-    }
-
-    public Object getValue() {
-      return value;
-    }
+  private static CapturedContext.CapturedValue optionalSpecialField(Object o) {
+    return CapturedContext.CapturedValue.of(
+        "value", Object.class.getTypeName(), ((Optional<?>) o).orElse(null));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_12.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_12.json
@@ -1,0 +1,14 @@
+{
+  "dsl": "isEmpty(emptyStr) && isEmpty(emptyList) && isEmpty(emptyMap) && isEmpty(emptyArray) && isUndefined(@exception)",
+  "json": {
+    "and": [
+      {"isEmpty": {"ref": "emptyStr"}},
+      {"isEmpty": {"ref": "emptyList"}},
+      {"isEmpty": {"ref": "emptyMap"}},
+      {"isEmpty": {"ref": "emptyArray"}},
+      {"isUndefined":  {"ref": "@exception"}}
+    ]
+  }
+}
+
+

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -413,8 +413,9 @@ public class MoshiSnapshotHelper {
       }
 
       @Override
-      public void objectFieldPrologue(Field field, Object value, int maxDepth) throws Exception {
-        jsonWriter.name(field.getName());
+      public void objectFieldPrologue(String fieldName, Object value, int maxDepth)
+          throws Exception {
+        jsonWriter.name(fieldName);
       }
 
       @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +98,7 @@ public class SerializerWithLimits {
       return true;
     }
 
-    void objectFieldPrologue(Field field, Object value, int maxDepth) throws Exception;
+    void objectFieldPrologue(String fieldName, Object value, int maxDepth) throws Exception;
 
     void handleFieldException(Exception ex, Field field);
 
@@ -256,6 +257,14 @@ public class SerializerWithLimits {
 
   private void serializeObjectValue(Object value, Limits limits) throws Exception {
     tokenWriter.objectPrologue(value);
+    Function<Object, WellKnownClasses.SpecialField> specialFieldAccess =
+        WellKnownClasses.getSpecialFieldAccess(value.getClass().getTypeName());
+    if (specialFieldAccess != null) {
+      WellKnownClasses.SpecialField specialField = specialFieldAccess.apply(value);
+      onSpecialField(specialField, limits);
+      tokenWriter.objectEpilogue(value);
+      return;
+    }
     Class<?> currentClass = value.getClass();
     int processedFieldCount = 0;
     NotCapturedReason reason = null;
@@ -287,15 +296,24 @@ public class SerializerWithLimits {
   }
 
   private void onField(Field field, Object value, Limits limits) throws Exception {
-    tokenWriter.objectFieldPrologue(field, value, limits.maxReferenceDepth);
+    internalOnField(field.getName(), field.getType().getTypeName(), value, limits);
+  }
+
+  private void onSpecialField(WellKnownClasses.SpecialField field, Limits limits) throws Exception {
+    internalOnField(field.getName(), field.getType(), field.getValue(), limits);
+  }
+
+  private void internalOnField(String fieldName, String fieldType, Object value, Limits limits)
+      throws Exception {
+    tokenWriter.objectFieldPrologue(fieldName, value, limits.maxReferenceDepth);
     Limits newLimits = Limits.decDepthLimits(limits);
     String typeName;
-    if (SerializerWithLimits.isPrimitive(field.getType().getTypeName())) {
-      typeName = field.getType().getTypeName();
+    if (SerializerWithLimits.isPrimitive(fieldType)) {
+      typeName = fieldType;
     } else {
-      typeName = value != null ? value.getClass().getTypeName() : field.getType().getTypeName();
+      typeName = value != null ? value.getClass().getTypeName() : fieldType;
     }
-    if (Redaction.isRedactedKeyword(field.getName())) {
+    if (Redaction.isRedactedKeyword(fieldName)) {
       value = REDACTED_VALUE;
     }
     serialize(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -257,10 +257,10 @@ public class SerializerWithLimits {
 
   private void serializeObjectValue(Object value, Limits limits) throws Exception {
     tokenWriter.objectPrologue(value);
-    Function<Object, WellKnownClasses.SpecialField> specialFieldAccess =
+    Function<Object, CapturedContext.CapturedValue> specialFieldAccess =
         WellKnownClasses.getSpecialFieldAccess(value.getClass().getTypeName());
     if (specialFieldAccess != null) {
-      WellKnownClasses.SpecialField specialField = specialFieldAccess.apply(value);
+      CapturedContext.CapturedValue specialField = specialFieldAccess.apply(value);
       onSpecialField(specialField, limits);
       tokenWriter.objectEpilogue(value);
       return;
@@ -299,7 +299,7 @@ public class SerializerWithLimits {
     internalOnField(field.getName(), field.getType().getTypeName(), value, limits);
   }
 
-  private void onSpecialField(WellKnownClasses.SpecialField field, Limits limits) throws Exception {
+  private void onSpecialField(CapturedContext.CapturedValue field, Limits limits) throws Exception {
     internalOnField(field.getName(), field.getType(), field.getValue(), limits);
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
@@ -125,12 +125,12 @@ public class StringTokenWriter implements SerializerWithLimits.TokenWriter {
   }
 
   @Override
-  public void objectFieldPrologue(Field field, Object value, int maxDepth) {
+  public void objectFieldPrologue(String fieldName, Object value, int maxDepth) {
     if (!initial) {
       sb.append(", ");
     }
     initial = false;
-    sb.append(field.getName()).append("=");
+    sb.append(fieldName).append("=");
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -296,7 +296,7 @@ public class SnapshotSerializationTest {
     UUID uuid = UUID.nameUUIDFromBytes("foobar".getBytes());
     AtomicLong atomicLong = new AtomicLong(123);
     URI uri = URI.create("https://www.datadoghq.com");
-    Optional<Date> maybeUiid = Optional.of(new Date());
+    Optional<Date> maybeDate = Optional.of(new Date());
     Optional<Object> empty = Optional.empty();
   }
 
@@ -332,9 +332,9 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(objLocalFields, "atomicLong", AtomicLong.class.getTypeName(), "123");
     assertPrimitiveValue(
         objLocalFields, "uri", URI.class.getTypeName(), "https://www.datadoghq.com");
-    Map<String, Object> maybeUiid = (Map<String, Object>) objLocalFields.get("maybeUiid");
-    assertComplexClass(maybeUiid, Optional.class.getTypeName());
-    Map<String, Object> maybeUiidFields = (Map<String, Object>) maybeUiid.get(FIELDS);
+    Map<String, Object> maybeDate = (Map<String, Object>) objLocalFields.get("maybeDate");
+    assertComplexClass(maybeDate, Optional.class.getTypeName());
+    Map<String, Object> maybeUiidFields = (Map<String, Object>) maybeDate.get(FIELDS);
     Map<String, Object> value = (Map<String, Object>) maybeUiidFields.get("value");
     assertComplexClass(value, Date.class.getTypeName());
     Map<String, Object> empty = (Map<String, Object>) objLocalFields.get("empty");

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -50,9 +50,11 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -294,6 +296,8 @@ public class SnapshotSerializationTest {
     UUID uuid = UUID.nameUUIDFromBytes("foobar".getBytes());
     AtomicLong atomicLong = new AtomicLong(123);
     URI uri = URI.create("https://www.datadoghq.com");
+    Optional<Date> maybeUiid = Optional.of(new Date());
+    Optional<Object> empty = Optional.empty();
   }
 
   @Test
@@ -328,6 +332,17 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(objLocalFields, "atomicLong", AtomicLong.class.getTypeName(), "123");
     assertPrimitiveValue(
         objLocalFields, "uri", URI.class.getTypeName(), "https://www.datadoghq.com");
+    Map<String, Object> maybeUiid = (Map<String, Object>) objLocalFields.get("maybeUiid");
+    assertComplexClass(maybeUiid, Optional.class.getTypeName());
+    Map<String, Object> maybeUiidFields = (Map<String, Object>) maybeUiid.get(FIELDS);
+    Map<String, Object> value = (Map<String, Object>) maybeUiidFields.get("value");
+    assertComplexClass(value, Date.class.getTypeName());
+    Map<String, Object> empty = (Map<String, Object>) objLocalFields.get("empty");
+    assertComplexClass(empty, Optional.class.getTypeName());
+    Map<String, Object> emptyFields = (Map<String, Object>) empty.get(FIELDS);
+    value = (Map<String, Object>) emptyFields.get("value");
+    assertEquals(Object.class.getTypeName(), value.get(TYPE));
+    assertTrue((Boolean) value.get(IS_NULL));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot08.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot08.java
@@ -1,4 +1,20 @@
+import java.util.Optional;
+
 public class CapturedSnapshot08 {
+  public static int main(String arg) {
+    return INSTANCE.doit(arg);
+  }
+
+  private int doit(String arg) {
+    int var1 = 1;
+    if (Integer.parseInt(arg) == 2) {
+      var1 = 2;
+      return var1;
+    }
+    var1 = 3;
+    return var1;
+  }
+
   static class Type3 {
     final String msg;
     Type3(String msg) {
@@ -23,20 +39,7 @@ public class CapturedSnapshot08 {
   private int fld = 11;
   private Type1 typed = new Type1(new Type2(new Type3("hello")));
   private Type1 nullTyped = new Type1(null);
+  private Optional<String> maybeStr = Optional.of("maybe foo");
 
   private static final CapturedSnapshot08 INSTANCE = new CapturedSnapshot08();
-
-  public static int main(String arg) {
-    return INSTANCE.doit(arg);
-  }
-
-  private int doit(String arg) {
-    int var1 = 1;
-    if (Integer.parseInt(arg) == 2) {
-      var1 = 2;
-      return var1;
-    }
-    var1 = 3;
-    return var1;
-  }
 }


### PR DESCRIPTION
# What Does This Do
We access directly to the value of an Optional through the `java.util.Optional` API rather than using the reflection as since JDK 16 it will be prohibited.

# Motivation
Avoid using reflection on some JDK classes that is prohibited since JDK 16

# Additional Notes

Jira ticket: [DEBUG-1980]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1980]: https://datadoghq.atlassian.net/browse/DEBUG-1980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ