### PR TITLE
Make logging the canonical holder of the dynamic debug state

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -181,16 +181,6 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
   @Shared
   TraceConfig MOCK_DSM_TRACE_CONFIG = new TraceConfig() {
     @Override
-    boolean isDebugEnabled() {
-      return true
-    }
-
-    @Override
-    boolean isTriageEnabled() {
-      return true
-    }
-
-    @Override
     boolean isRuntimeMetricsEnabled() {
       return true
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -535,8 +535,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     this.dynamicConfig =
         DynamicConfig.create(ConfigSnapshot::new)
-            .setDebugEnabled(config.isDebugEnabled())
-            .setTriageEnabled(config.isTriageEnabled())
             .setRuntimeMetricsEnabled(config.isRuntimeMetricsEnabled())
             .setLogsInjectionEnabled(config.isLogsInjectionEnabled())
             .setDataStreamsEnabled(config.isDataStreamsEnabled())
@@ -717,8 +715,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   public void rebuildTraceConfig(Config config) {
     dynamicConfig
         .initial()
-        .setDebugEnabled(config.isDebugEnabled())
-        .setTriageEnabled(config.isTriageEnabled())
         .setRuntimeMetricsEnabled(config.isRuntimeMetricsEnabled())
         .setLogsInjectionEnabled(config.isLogsInjectionEnabled())
         .setDataStreamsEnabled(config.isDataStreamsEnabled())

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -25,13 +25,13 @@ import org.slf4j.LoggerFactory;
 final class TracingConfigPoller {
   private static final Logger log = LoggerFactory.getLogger(TracingConfigPoller.class);
 
-  private final DynamicConfig dynamicConfig;
+  private final DynamicConfig<?> dynamicConfig;
 
   private boolean startupLogsEnabled;
 
   private Runnable stopPolling;
 
-  public TracingConfigPoller(DynamicConfig dynamicConfig) {
+  public TracingConfigPoller(DynamicConfig<?> dynamicConfig) {
     this.dynamicConfig = dynamicConfig;
   }
 
@@ -104,11 +104,8 @@ final class TracingConfigPoller {
   void applyConfigOverrides(LibConfig libConfig) {
     DynamicConfig<?>.Builder builder = dynamicConfig.initial();
 
-    maybeOverride(builder::setDebugEnabled, libConfig.debugEnabled);
-
     if (libConfig.debugEnabled != null) {
       if (Boolean.TRUE.equals(libConfig.debugEnabled)) {
-        builder.setTriageEnabled(true); // debug implies triage
         GlobalLogLevelSwitcher.get().switchLevel(LogLevel.DEBUG);
       } else {
         // Disable debugEnabled when it was set to true at startup
@@ -120,6 +117,8 @@ final class TracingConfigPoller {
           GlobalLogLevelSwitcher.get().switchLevel(LogLevel.WARN);
         }
       }
+    } else {
+      GlobalLogLevelSwitcher.get().restore();
     }
 
     maybeOverride(builder::setRuntimeMetricsEnabled, libConfig.runtimeMetricsEnabled);

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -3,7 +3,6 @@ package datadog.trace.api;
 import static datadog.trace.api.config.GeneralConfig.DATA_STREAMS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.TRACE_DEBUG;
-import static datadog.trace.api.config.GeneralConfig.TRACE_TRIAGE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LOGS_INJECTION_ENABLED;
 import static datadog.trace.api.config.TracerConfig.BAGGAGE_MAPPING;
 import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS;
@@ -23,6 +22,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Config that can be dynamically updated via remote-config
@@ -35,6 +36,7 @@ import java.util.function.Function;
  * @see Config for other configurations
  */
 public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
+  static final Logger rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
   static final Function<Map.Entry<String, String>, String> KEY = DynamicConfig::key;
   static final Function<Map.Entry<String, String>, String> VALUE = DynamicConfig::value;
@@ -91,8 +93,6 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
   public final class Builder {
 
-    boolean debugEnabled;
-    boolean triageEnabled;
     boolean runtimeMetricsEnabled;
     boolean logsInjectionEnabled;
     boolean dataStreamsEnabled;
@@ -101,6 +101,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     Map<String, String> requestHeaderTags;
     Map<String, String> responseHeaderTags;
     Map<String, String> baggageMapping;
+
     List<? extends SpanSamplingRule> spanSamplingRules;
     List<? extends TraceSamplingRule> traceSamplingRules;
 
@@ -110,8 +111,6 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     Builder(Snapshot snapshot) {
 
-      this.debugEnabled = snapshot.debugEnabled;
-      this.triageEnabled = snapshot.triageEnabled;
       this.runtimeMetricsEnabled = snapshot.runtimeMetricsEnabled;
       this.logsInjectionEnabled = snapshot.logsInjectionEnabled;
       this.dataStreamsEnabled = snapshot.dataStreamsEnabled;
@@ -122,16 +121,6 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
       this.baggageMapping = snapshot.baggageMapping;
 
       this.traceSampleRate = snapshot.traceSampleRate;
-    }
-
-    public Builder setDebugEnabled(boolean debugEnabled) {
-      this.debugEnabled = debugEnabled;
-      return this;
-    }
-
-    public Builder setTriageEnabled(boolean triageEnabled) {
-      this.triageEnabled = triageEnabled;
-      return this;
     }
 
     public Builder setRuntimeMetricsEnabled(boolean runtimeMetricsEnabled) {
@@ -262,8 +251,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
   static void reportConfigChange(Snapshot newSnapshot) {
     Map<String, Object> update = new HashMap<>();
 
-    update.put(TRACE_DEBUG, newSnapshot.debugEnabled);
-    update.put(TRACE_TRIAGE, newSnapshot.triageEnabled);
+    update.put(TRACE_DEBUG, rootLogger.isDebugEnabled());
     update.put(RUNTIME_METRICS_ENABLED, newSnapshot.runtimeMetricsEnabled);
     update.put(LOGS_INJECTION_ENABLED, newSnapshot.logsInjectionEnabled);
     update.put(DATA_STREAMS_ENABLED, newSnapshot.dataStreamsEnabled);
@@ -287,9 +275,6 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
   /** Immutable snapshot of the configuration. */
   public static class Snapshot implements TraceConfig {
-
-    final boolean debugEnabled;
-    final boolean triageEnabled;
     final boolean runtimeMetricsEnabled;
     final boolean logsInjectionEnabled;
     final boolean dataStreamsEnabled;
@@ -298,6 +283,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     final Map<String, String> requestHeaderTags;
     final Map<String, String> responseHeaderTags;
     final Map<String, String> baggageMapping;
+
     final List<? extends SpanSamplingRule> spanSamplingRules;
     final List<? extends TraceSamplingRule> traceSamplingRules;
 
@@ -305,8 +291,6 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     protected Snapshot(DynamicConfig<?>.Builder builder, Snapshot oldSnapshot) {
 
-      this.debugEnabled = builder.debugEnabled;
-      this.triageEnabled = builder.triageEnabled;
       this.runtimeMetricsEnabled = builder.runtimeMetricsEnabled;
       this.logsInjectionEnabled = builder.logsInjectionEnabled;
       this.dataStreamsEnabled = builder.dataStreamsEnabled;
@@ -324,16 +308,6 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     private static <K, V> Map<K, V> nullToEmpty(Map<K, V> mapping) {
       return null != mapping ? mapping : Collections.emptyMap();
-    }
-
-    @Override
-    public boolean isDebugEnabled() {
-      return debugEnabled;
-    }
-
-    @Override
-    public boolean isTriageEnabled() {
-      return triageEnabled;
     }
 
     @Override
@@ -390,9 +364,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     public String toString() {
       return "DynamicConfig{"
           + "debugEnabled="
-          + debugEnabled
-          + ", triageEnabled="
-          + triageEnabled
+          + rootLogger.isDebugEnabled()
           + ", runtimeMetricsEnabled="
           + runtimeMetricsEnabled
           + ", logsInjectionEnabled="

--- a/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
@@ -8,10 +8,6 @@ import java.util.Map;
 /** Snapshot of dynamic configuration; valid for the duration of a trace. */
 public interface TraceConfig {
 
-  boolean isDebugEnabled();
-
-  boolean isTriageEnabled();
-
   boolean isRuntimeMetricsEnabled();
 
   boolean isLogsInjectionEnabled();

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1156,16 +1156,6 @@ public class AgentTracer {
     public static final NoopTraceConfig INSTANCE = new NoopTraceConfig();
 
     @Override
-    public boolean isDebugEnabled() {
-      return false;
-    }
-
-    @Override
-    public boolean isTriageEnabled() {
-      return false;
-    }
-
-    @Override
     public boolean isRuntimeMetricsEnabled() {
       return false;
     }


### PR DESCRIPTION
# Motivation

Avoids inconsistencies by having a single canonical place to track dynamic debug state. Since all code that checks dynamic debug state currently uses `log.isDebugEnabled()` it makes sense for that to be `GlobalLogLevelSwitcher`.

This also lets us simplify the `TraceConfig` interface.

At the same time also remove the triage flag from `TraceConfig` which is not being used yet. Instead we'll provide `prepare` and `cleanup` methods in `TracerFlare.Reporter` which will let individual reporters decide how best to temporarily collect triage data. 

Jira ticket: [APMJAVA-1078]

[APMJAVA-1078]: https://datadoghq.atlassian.net/browse/APMJAVA-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ