### PR TITLE
Allow tracer-flare reporters to participate in the prepare+cleanup lifecycle

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterFlare.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterFlare.java
@@ -1,7 +1,5 @@
 package datadog.trace.agent.tooling;
 
-import static datadog.trace.api.flare.TracerFlare.addText;
-
 import datadog.trace.api.flare.TracerFlare;
 import java.io.IOException;
 import java.util.zip.ZipOutputStream;
@@ -14,7 +12,7 @@ public final class InstrumenterFlare implements TracerFlare.Reporter {
   }
 
   @Override
-  public void addReport(ZipOutputStream zip) throws IOException {
-    addText(zip, "instrumenter_state.txt", InstrumenterState.summary());
+  public void addReportToFlare(ZipOutputStream zip) throws IOException {
+    TracerFlare.addText(zip, "instrumenter_state.txt", InstrumenterState.summary());
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -1,6 +1,5 @@
 package datadog.trace.core.flare;
 
-import static datadog.trace.api.flare.TracerFlare.addText;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.TRACER_FLARE;
 
 import datadog.communication.http.OkHttpUtils;
@@ -8,11 +7,15 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DynamicConfig;
 import datadog.trace.api.flare.TracerFlare;
 import datadog.trace.core.DDTraceCoreInfo;
+import datadog.trace.logging.GlobalLogLevelSwitcher;
+import datadog.trace.logging.LogLevel;
 import datadog.trace.util.AgentTaskScheduler;
+import datadog.trace.util.AgentTaskScheduler.Scheduled;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipOutputStream;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -33,39 +36,65 @@ final class TracerFlareService {
 
   private final AgentTaskScheduler scheduler = new AgentTaskScheduler(TRACER_FLARE);
 
+  private final CleanupTask cleanupTask = new CleanupTask();
+
   private final Config config;
-  private final DynamicConfig dynamicConfig;
+  private final DynamicConfig<?> dynamicConfig;
   private final OkHttpClient okHttpClient;
   private final HttpUrl flareUrl;
 
-  private AtomicBoolean preparingTracerFlare = new AtomicBoolean();
+  private final AtomicReference<Scheduled<Runnable>> cleanup = new AtomicReference<>();
+
+  private volatile boolean logLevelOverridden;
 
   TracerFlareService(
-      Config config, DynamicConfig dynamicConfig, OkHttpClient okHttpClient, HttpUrl agentUrl) {
+      Config config, DynamicConfig<?> dynamicConfig, OkHttpClient okHttpClient, HttpUrl agentUrl) {
     this.config = config;
     this.dynamicConfig = dynamicConfig;
     this.okHttpClient = okHttpClient;
     this.flareUrl = agentUrl.newBuilder().addPathSegments(FLARE_ENDPOINT).build();
   }
 
-  public void prepareTracerFlare(String logLevel) {
-    if (preparingTracerFlare.compareAndSet(false, true)) {
-      log.debug("Preparing tracer flare, logLevel={}", logLevel);
+  public void prepareForFlare(String logLevel) {
+    // allow turning on debug even part way through preparation
+    if (!log.isDebugEnabled() && "debug".equalsIgnoreCase(logLevel)) {
+      GlobalLogLevelSwitcher.get().switchLevel(LogLevel.DEBUG);
+      logLevelOverridden = true;
+    }
+    // always schedule clean-up 20 minutes from last prepare request
+    Scheduled<Runnable> task =
+        cleanup.getAndSet(scheduler.schedule(cleanupTask, 20, TimeUnit.MINUTES));
+    if (null != task) {
+      task.cancel(); // already preparing, just cancel old schedule in favour of new one
+    } else {
+      log.debug("Preparing for tracer flare, logLevel={}", logLevel);
+      TracerFlare.prepareForFlare();
+    }
+  }
+
+  public void cleanupAfterFlare() {
+    Scheduled<Runnable> task = cleanup.getAndSet(null);
+    if (null != task) {
+      task.cancel();
+      doCleanup();
+    }
+  }
+
+  void doCleanup() {
+    log.debug("Cleaning up after tracer flare");
+    TracerFlare.cleanupAfterFlare();
+    if (logLevelOverridden) {
+      GlobalLogLevelSwitcher.get().restore();
+      logLevelOverridden = false;
     }
   }
 
   public void sendFlare(String caseId, String email, String hostname) {
+    scheduler.execute(() -> doSend(caseId, email, hostname));
+  }
+
+  void doSend(String caseId, String email, String hostname) {
     log.debug("Sending tracer flare");
-    scheduler.execute(() -> doSendFlare(caseId, email, hostname));
-  }
-
-  public void cancelTracerFlare() {
-    if (preparingTracerFlare.compareAndSet(true, false)) {
-      log.debug("Canceling tracer flare");
-    }
-  }
-
-  private void doSendFlare(String caseId, String email, String hostname) {
     try {
       RequestBody report = RequestBody.create(OCTET_STREAM, buildFlareZip());
 
@@ -94,8 +123,6 @@ final class TracerFlareService {
 
     } catch (IOException e) {
       log.warn("Tracer flare failed with exception: {}", e.toString());
-    } finally {
-      preparingTracerFlare.set(false);
     }
   }
 
@@ -104,7 +131,7 @@ final class TracerFlareService {
         ZipOutputStream zip = new ZipOutputStream(bytes)) {
 
       addPrelude(zip);
-      TracerFlare.buildFlare(zip);
+      TracerFlare.addReportsToFlare(zip);
       zip.finish();
 
       return bytes.toByteArray();
@@ -112,9 +139,16 @@ final class TracerFlareService {
   }
 
   private void addPrelude(ZipOutputStream zip) throws IOException {
-    addText(zip, "version.txt", DDTraceCoreInfo.VERSION);
-    addText(zip, "classpath.txt", System.getProperty("java.class.path"));
-    addText(zip, "initial_config.txt", config.toString());
-    addText(zip, "dynamic_config.txt", dynamicConfig.toString());
+    TracerFlare.addText(zip, "version.txt", DDTraceCoreInfo.VERSION);
+    TracerFlare.addText(zip, "classpath.txt", System.getProperty("java.class.path"));
+    TracerFlare.addText(zip, "initial_config.txt", config.toString());
+    TracerFlare.addText(zip, "dynamic_config.txt", dynamicConfig.toString());
+  }
+
+  final class CleanupTask implements Runnable {
+    @Override
+    public void run() {
+      doCleanup();
+    }
   }
 }


### PR DESCRIPTION
Tracer-flare lifecycle:

1. Agent creates an RC config to prepare the tracer for the flare
   * tracer calls `prepareForFlare` for each registered reporter
2. Agent creates an RC task to create and send the tracer flare
   * tracer starts to build a zip and adds basic details (config, etc.)
   * tracer calls `addReportToFlare` for each registered reporter
   * tracer completes the zip and sends it back to the agent
3. Agent removes the previous RC config and task
   * tracer calls `cleanupAfterFlare` for each registered reporter

If the flare RC config sets logging to debug then the tracer temporarily overrides its logging to be debug too.

This logging override is removed as part of cleanup.

If the agent forgets to remove the RC config then the tracer automatically triggers cleanup after 20 minutes.

Jira ticket: [APMJAVA-1076]

[APMJAVA-1076]: https://datadoghq.atlassian.net/browse/APMJAVA-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ