### PR TITLE
Avoid submitting multiple identical coverage reports when test span has children that are top-level spans

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCovMapperV2Test.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCovMapperV2Test.groovy
@@ -7,6 +7,7 @@ import datadog.trace.api.civisibility.coverage.TestReport
 import datadog.trace.api.civisibility.coverage.TestReportFileEntry
 import datadog.trace.api.civisibility.coverage.TestReportHolder
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes
 import datadog.trace.core.CoreSpan
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.core.test.DDCoreSpecification
@@ -187,11 +188,42 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
     ]
   }
 
+  def "skips duplicate reports"() {
+    given:
+    def trace = new ArrayList()
+
+    def report = new TestReport(1, 2, 3, [new TestReportFileEntry("source", [new TestReportFileEntry.Segment(4, -1, 4, -1, 11)])])
+
+    trace.add(buildSpan(0, InternalSpanTypes.TEST, PropagationTags.factory().empty(), [:], PrioritySampling.SAMPLER_KEEP, new DummyReportHolder(report)))
+    trace.add(buildSpan(0, "testChild", PropagationTags.factory().empty(), [:], PrioritySampling.SAMPLER_KEEP, new DummyReportHolder(report)))
+
+    when:
+    def message = getMappedMessage(trace)
+
+    then:
+    message == [
+      version  : 2,
+      coverages: [
+        [
+          test_session_id: 1,
+          test_suite_id  : 2,
+          span_id        : 3,
+          files          : [
+            [
+              filename: "source",
+              segments: [[4, -1, 4, -1, 11]]
+            ]
+          ]
+        ]
+      ]
+    ]
+  }
+
   private List<? extends CoreSpan<?>> givenTrace(TestReport... testReports) {
     def trace = new ArrayList()
     for (TestReport testReport : testReports) {
       def testReportHolder = new DummyReportHolder(testReport)
-      trace.add(buildSpan(0, "spanType", PropagationTags.factory().empty(), [:], PrioritySampling.SAMPLER_KEEP, testReportHolder))
+      trace.add(buildSpan(0, InternalSpanTypes.TEST, PropagationTags.factory().empty(), [:], PrioritySampling.SAMPLER_KEEP, testReportHolder))
     }
     return trace
   }


### PR DESCRIPTION
# What Does This Do
Fixes test coverage reporter to avoid submitting multiple identical coverage reports for test traces that contain children spans that are "top-level".

# Motivation
Code coverage logic obtains coverage probes store by examining the currently active span.
If the active span is a child of a test span (e.g. if coverage probe is triggered inside a database request inside a test), it refers to the same coverage store as its parent test.
Therefore, when coverage reporter receives a trace, it may contain multiple spans that refer to the same coverage store.
All of such spans except for the test spans (that are trace roots) should be ignored, when obtaining test coverage reports for submission.

# Additional Notes
Submitting multiple identical report does not break anything in the backend but is a waste of computational resources.

Jira ticket: [CIVIS-8425]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8425]: https://datadoghq.atlassian.net/browse/CIVIS-8425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ