### PR TITLE
add new javaassist proxy separator to ignores

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyClassIgnores.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ProxyClassIgnores.java
@@ -12,7 +12,8 @@ public class ProxyClassIgnores {
           || name.contains("$$EnhancerByGuice$$")
           || name.contains("$$EnhancerByProxool$$")
           || name.contains("$$$view")
-          || name.contains("$$_Weld")) {
+          || name.contains("$$_Weld")
+          || name.contains("_$$_jvst")) {
         return true;
       }
     }


### PR DESCRIPTION
# What Does This Do

Javassist proxy separator changed in https://github.com/jboss-javassist/javassist/commit/3358dc269352383eb5e9c186d24ff4a292eeb637

Not sure about the order if we can optimize some checks

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
