### PR TITLE
Fix maven tests for 4.0.0-alpha-10

### DIFF
--- a/dd-java-agent/instrumentation/maven-3.2.1/build.gradle
+++ b/dd-java-agent/instrumentation/maven-3.2.1/build.gradle
@@ -26,4 +26,11 @@ dependencies {
   latestDepTestImplementation group: 'org.apache.maven.resolver', name: 'maven-resolver-connector-basic', version: '+'
   latestDepTestImplementation group: 'org.apache.maven.resolver', name: 'maven-resolver-transport-http', version: '+'
   latestDepTestImplementation group: 'org.fusesource.jansi', name: 'jansi', version: '+'
+
+  // latest maven-embedder declares these container dependencies as provided (non-transitive)
+  latestDepTestImplementation group: 'javax.inject', name: 'javax.inject', version: '1'
+  latestDepTestImplementation group: 'com.google.inject', name: 'guice', version: '6.0.0'
+  latestDepTestImplementation group: 'org.eclipse.sisu', name: 'org.eclipse.sisu.inject', version: '0.9.0.M2'
+  latestDepTestImplementation group: 'org.codehaus.plexus', name: 'plexus-xml', version: '4.0.1'
+  latestDepTestImplementation group: 'org.eclipse.sisu', name: 'org.eclipse.sisu.plexus', version: '0.9.0.M2'
 }


### PR DESCRIPTION
maven-embedder 4.0.0-alpha-10 made these dependencies provided (ie non-transitive), so we now need to declare them for testing purposes