### PR TITLE
Use connection pool for http communications with extension.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -15,6 +15,7 @@ import datadog.trace.core.propagation.PropagationTags;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import okhttp3.ConnectionPool;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -49,6 +50,8 @@ public class LambdaHandler {
   private static final String END_INVOCATION = "/lambda/end-invocation";
 
   private static final Long REQUEST_TIMEOUT_IN_S = 1L;
+  private static final int MAX_IDLE_CONNECTIONS = 5;
+  private static final Long KEEP_ALIVE_DURATION = 300L;
 
   private static OkHttpClient HTTP_CLIENT =
       new OkHttpClient.Builder()
@@ -57,6 +60,7 @@ public class LambdaHandler {
           .writeTimeout(REQUEST_TIMEOUT_IN_S, SECONDS)
           .readTimeout(REQUEST_TIMEOUT_IN_S, SECONDS)
           .callTimeout(REQUEST_TIMEOUT_IN_S, SECONDS)
+          .connectionPool(new ConnectionPool(MAX_IDLE_CONNECTIONS, KEEP_ALIVE_DURATION, SECONDS))
           .build();
 
   private static final MediaType jsonMediaType = MediaType.parse("application/json");


### PR DESCRIPTION
# What Does This Do

Instead of creating a new tcp connection with each call to the extension (ie start and end invocation), use a pool of available connections.

# Motivation

This change reduces `aws.lambda.enhanced.runtime_duration` by approximately 2%.

<img width="366" alt="Screenshot 2023-12-26 at 2 00 50 PM" src="https://github.com/DataDog/dd-trace-java/assets/1383216/5eefe348-484d-47c6-8c30-976f0ccb3bad">

See https://ddserverless.datadoghq.com/notebook/2987494/reys-purple-notebook?range=3600000&view=view-mode&start=1703617009962&live=false

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
