### PR TITLE
Include dynamic_instrumentation product into the app_started telemetry event

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
@@ -8,6 +8,7 @@ import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.Metric;
 import datadog.telemetry.api.RequestType;
 import datadog.telemetry.dependency.Dependency;
+import datadog.trace.api.Config;
 import datadog.trace.api.ConfigSetting;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.InstrumenterConfig;
@@ -86,11 +87,13 @@ public class TelemetryRequest {
 
   public void writeProducts() {
     InstrumenterConfig instrumenterConfig = InstrumenterConfig.get();
+    Config config = Config.get();
     try {
       boolean appsecEnabled =
           instrumenterConfig.getAppSecActivation() != ProductActivation.FULLY_DISABLED;
       boolean profilerEnabled = instrumenterConfig.isProfilingEnabled();
-      requestBody.writeProducts(appsecEnabled, profilerEnabled);
+      boolean dynamicInstrumentationEnabled = config.isDebuggerEnabled();
+      requestBody.writeProducts(appsecEnabled, profilerEnabled, dynamicInstrumentationEnabled);
     } catch (IOException e) {
       throw new TelemetryRequestBody.SerializationException("products", e);
     }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
@@ -263,7 +263,9 @@ public class TelemetryRequestBody extends RequestBody {
     endMessageIfBatch(RequestType.APP_DEPENDENCIES_LOADED);
   }
 
-  public void writeProducts(boolean appsecEnabled, boolean profilerEnabled) throws IOException {
+  public void writeProducts(
+      boolean appsecEnabled, boolean profilerEnabled, boolean dynamicInstrumentationEnabled)
+      throws IOException {
     bodyWriter.name("products");
     bodyWriter.beginObject();
 
@@ -275,6 +277,11 @@ public class TelemetryRequestBody extends RequestBody {
     bodyWriter.name("profiler");
     bodyWriter.beginObject();
     bodyWriter.name("enabled").value(profilerEnabled);
+    bodyWriter.endObject();
+
+    bodyWriter.name("dynamic_instrumentation");
+    bodyWriter.beginObject();
+    bodyWriter.name("enabled").value(dynamicInstrumentationEnabled);
     bodyWriter.endObject();
 
     bodyWriter.endObject();

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -9,7 +9,11 @@ import datadog.telemetry.api.Metric
 import datadog.telemetry.api.RequestType
 import datadog.trace.api.ConfigOrigin
 import datadog.trace.api.ConfigSetting
+import datadog.trace.api.config.AppSecConfig
+import datadog.trace.api.config.DebuggerConfig
+import datadog.trace.api.config.ProfilingConfig
 import datadog.trace.test.util.DDSpecification
+import datadog.trace.util.Strings
 
 class TelemetryServiceSpecification extends DDSpecification {
   def confKeyValue = new ConfigSetting("confkey", "confvalue", ConfigOrigin.DEFAULT)
@@ -435,5 +439,32 @@ class TelemetryServiceSpecification extends DDSpecification {
     "68e75c48-57ca-4a12-adfc-575c4b05bfff" | null              | "1704183412"
     "68e75c55-57ca-4a12-adfc-575c4b05aaaa" | "k8s_single_step" | null
     "68e75c77-57ca-4a12-adfc-575c4b05fc44" | "k8s_single_step" | "1993188215"
+  }
+
+  def 'app-started must include activated products info'() {
+    setup:
+    injectEnvConfig(Strings.toEnvVar(AppSecConfig.APPSEC_ENABLED), appsecConfig)
+    injectEnvConfig(Strings.toEnvVar(ProfilingConfig.PROFILING_ENABLED), profilingConfig)
+    injectEnvConfig(Strings.toEnvVar(DebuggerConfig.DEBUGGER_ENABLED), dynInstrConfig)
+
+    TestTelemetryRouter testHttpClient = new TestTelemetryRouter()
+    TelemetryService telemetryService = new TelemetryService(testHttpClient, 10000, false)
+
+    when: 'first iteration'
+    testHttpClient.expectRequest(TelemetryClient.Result.SUCCESS)
+    telemetryService.sendAppStartedEvent()
+
+    then: 'app-started'
+    testHttpClient.assertRequestBody(RequestType.APP_STARTED).assertPayload().products(appsecEnabled, profilingEnabled, dynInstrEnabled)
+    testHttpClient.assertNoMoreRequests()
+
+    where:
+    appsecConfig | appsecEnabled | profilingConfig | profilingEnabled | dynInstrConfig | dynInstrEnabled
+    "1"          | true          | "1"             | true             | "1"            | true
+    "1"          | true          | "1"             | true             | "0"            | false
+    "1"          | true          | "0"             | false            | "1"            | true
+    "1"          | true          | "0"             | false            | "0"            | false
+    "0"          | false         | "0"             | false            | "0"            | false
+    "inactive"   | true          | "0"             | false            | "0"            | false
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
@@ -240,8 +240,12 @@ class TestTelemetryRouter extends TelemetryRouter {
       return this
     }
 
-    PayloadAssertions products(boolean appsecEnabled = true, boolean profilerEnabled = false) {
-      def expected = [appsec: [enabled: appsecEnabled], profiler: [enabled: profilerEnabled]]
+    PayloadAssertions products(boolean appsecEnabled = true, boolean profilerEnabled = false, boolean dynamicInstrumentationEnabled = false) {
+      def expected = [
+        appsec: [enabled: appsecEnabled],
+        profiler: [enabled: profilerEnabled],
+        dynamic_instrumentation: [enabled: dynamicInstrumentationEnabled]
+      ]
       assert this.payload['products'] == expected
       return this
     }


### PR DESCRIPTION
# What Does This Do

Includes info about Dynamic Instrumentation into the app-started telemetry event.

# Motivation

The Dynamic Instrumentation (also known as Live Debugger) were not included in the app-started telemetry event.

# Additional Notes

[RFC: Dynamic Instrumentation Schema](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/dynamic_instrumentation.md)

