### PR TITLE
Remove retransformation on failed resolution

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -24,7 +24,7 @@ public class DebuggerContext {
   }
 
   public interface ProbeResolver {
-    ProbeImplementation resolve(String encodedProbeId, Class<?> callingClass);
+    ProbeImplementation resolve(String encodedProbeId);
   }
 
   public interface ClassFilter {
@@ -89,12 +89,12 @@ public class DebuggerContext {
    * Returns the probe details based on the probe id provided. If no probe is found, try to
    * re-transform the class using the callingClass parameter No-op if no implementation available
    */
-  public static ProbeImplementation resolveProbe(String id, Class<?> callingClass) {
+  public static ProbeImplementation resolveProbe(String id) {
     ProbeResolver resolver = probeResolver;
     if (resolver == null) {
       return null;
     }
-    return resolver.resolve(id, callingClass);
+    return resolver.resolve(id);
   }
 
   /**
@@ -231,7 +231,7 @@ public class DebuggerContext {
     try {
       boolean needFreeze = false;
       for (String encodedProbeId : encodedProbeIds) {
-        ProbeImplementation probeImplementation = resolveProbe(encodedProbeId, callingClass);
+        ProbeImplementation probeImplementation = resolveProbe(encodedProbeId);
         if (probeImplementation == null) {
           continue;
         }
@@ -264,7 +264,7 @@ public class DebuggerContext {
     try {
       List<ProbeImplementation> probeImplementations = new ArrayList<>();
       for (String encodedProbeId : encodedProbeIds) {
-        ProbeImplementation probeImplementation = resolveProbe(encodedProbeId, callingClass);
+        ProbeImplementation probeImplementation = resolveProbe(encodedProbeId);
         if (probeImplementation == null) {
           continue;
         }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.agent;
 
+import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
+
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
@@ -240,15 +242,10 @@ public class ConfigurationUpdater
 
   // /!\ This is called potentially by multiple threads from the instrumented code /!\
   @Override
-  public ProbeImplementation resolve(String encodedProbeId, Class<?> callingClass) {
+  public ProbeImplementation resolve(String encodedProbeId) {
     ProbeDefinition definition = appliedDefinitions.get(encodedProbeId);
-    if (definition == null && callingClass != null) {
-      LOGGER.info(
-          "Cannot resolve probe id={}, re-transforming calling class: {}",
-          encodedProbeId,
-          callingClass.getName());
-      retransformClasses(Collections.singletonList(callingClass));
-      return null;
+    if (definition == null) {
+      LOGGER.warn(SEND_TELEMETRY, "Cannot resolve probe id=" + encodedProbeId);
     }
     return definition;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -282,7 +282,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
     }
   }
 
-  public ProbeImplementation instrumentTheWorldResolver(String id, Class<?> callingClass) {
+  public ProbeImplementation instrumentTheWorldResolver(String id) {
     if (instrumentTheWorldProbes == null) {
       return null;
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -171,7 +171,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)", "8");
     DebuggerAgentHelper.injectSink(listener);
-    DebuggerContext.init((encodedProbeId, clazz) -> null, null);
+    DebuggerContext.init((encodedProbeId) -> null, null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -187,7 +187,7 @@ public class CapturedSnapshotTest {
         installProbes(CLASS_NAME, lineProbe, methodProbe);
     DebuggerAgentHelper.injectSink(listener);
     DebuggerContext.init(
-        (encodedProbeId, clazz) -> {
+        (encodedProbeId) -> {
           throw new IllegalArgumentException("oops");
         },
         null);
@@ -2109,10 +2109,7 @@ public class CapturedSnapshotTest {
         new DebuggerTransformer(config, configuration, instrumentationListener, listener);
     instr.addTransformer(currentTransformer);
     DebuggerAgentHelper.injectSink(listener);
-    DebuggerContext.init(
-        (encodedId, callingClass) ->
-            resolver(encodedId, callingClass, expectedClassName, logProbes),
-        null);
+    DebuggerContext.init((encodedId) -> resolver(encodedId, logProbes), null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
     for (LogProbe probe : logProbes) {
@@ -2127,12 +2124,7 @@ public class CapturedSnapshotTest {
     return listener;
   }
 
-  private ProbeImplementation resolver(
-      String encodedId,
-      Class<?> callingClass,
-      String expectedClassName,
-      Collection<LogProbe> logProbes) {
-    assertEquals(expectedClassName, callingClass.getName());
+  private ProbeImplementation resolver(String encodedId, Collection<LogProbe> logProbes) {
     for (LogProbe probe : logProbes) {
       if (probe.getProbeId().getEncodedId().equals(encodedId)) {
         return probe;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -454,8 +454,7 @@ public class ConfigurationUpdaterTest {
                 .build());
     logProbes.get(0).buildLocation(null);
     configurationUpdater.accept(createApp(logProbes));
-    ProbeImplementation probeImplementation =
-        configurationUpdater.resolve(PROBE_ID.getEncodedId(), String.class);
+    ProbeImplementation probeImplementation = configurationUpdater.resolve(PROBE_ID.getEncodedId());
     Assertions.assertEquals(
         PROBE_ID.getEncodedId(), probeImplementation.getProbeId().getEncodedId());
     Assertions.assertEquals("java.lang.String", probeImplementation.getLocation().getType());
@@ -476,9 +475,8 @@ public class ConfigurationUpdaterTest {
     verify(inst).retransformClasses(eq(String.class));
     // simulate that there is a snapshot probe instrumentation left in HashMap class
     ProbeImplementation probeImplementation =
-        configurationUpdater.resolve(PROBE_ID2.getEncodedId(), HashMap.class);
+        configurationUpdater.resolve(PROBE_ID2.getEncodedId());
     Assertions.assertNull(probeImplementation);
-    verify(inst).retransformClasses(eq(HashMap.class));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -147,7 +147,7 @@ public class LogProbesInstrumentationTest {
                 "int (java.lang.String)")
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -173,8 +173,7 @@ public class LogProbesInstrumentationTest {
             CLASS_NAME,
             "main",
             "int (java.lang.String)");
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, logProbe1, logProbe2);
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -238,8 +237,7 @@ public class LogProbesInstrumentationTest {
                 "int (java.lang.String)")
             .captureSnapshot(additionalCapture)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, logProbe1, logProbe2);
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -393,7 +391,7 @@ public class LogProbesInstrumentationTest {
             .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
             .captureSnapshot(true)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "5").get();
     Assertions.assertEquals(3, result);
@@ -490,8 +488,7 @@ public class LogProbesInstrumentationTest {
                 LOG_ID2, additionalTemplate, CLASS_NAME, "main", "int (java.lang.String)")
             .captureSnapshot(true)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, logProbe1, logProbe2);
+    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -502,14 +499,11 @@ public class LogProbesInstrumentationTest {
   private DebuggerTransformerTest.TestSnapshotListener installSingleProbe(
       String template, String typeName, String methodName, String signature, String... lines) {
     LogProbe logProbe = createProbe(LOG_ID, template, typeName, methodName, signature, lines);
-    return installProbes(
-        typeName, Configuration.builder().setService(SERVICE_NAME).add(logProbe).build());
+    return installProbes(Configuration.builder().setService(SERVICE_NAME).add(logProbe).build());
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installProbes(
-      String expectedClassName, LogProbe... logProbes) {
+  private DebuggerTransformerTest.TestSnapshotListener installProbes(LogProbe... logProbes) {
     return installProbes(
-        expectedClassName,
         Configuration.builder()
             .setService(SERVICE_NAME)
             .addLogProbes(Arrays.asList(logProbes))
@@ -540,8 +534,7 @@ public class LogProbesInstrumentationTest {
     return createProbeBuilder(id, template, typeName, methodName, signature, lines).build();
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installProbes(
-      String expectedClassName, Configuration configuration) {
+  private DebuggerTransformerTest.TestSnapshotListener installProbes(Configuration configuration) {
     Config config = mock(Config.class);
     when(config.isDebuggerEnabled()).thenReturn(true);
     when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
@@ -550,8 +543,7 @@ public class LogProbesInstrumentationTest {
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     DebuggerContext.ProbeResolver resolver =
-        (encodedProbeId, callingClass) ->
-            resolver(encodedProbeId, callingClass, expectedClassName, configuration.getLogProbes());
+        (encodedProbeId) -> resolver(encodedProbeId, configuration.getLogProbes());
     currentTransformer = new DebuggerTransformer(config, configuration);
     instr.addTransformer(currentTransformer);
     DebuggerTransformerTest.TestSnapshotListener listener =
@@ -563,12 +555,7 @@ public class LogProbesInstrumentationTest {
     return listener;
   }
 
-  private ProbeImplementation resolver(
-      String encodedProbeId,
-      Class<?> callingClass,
-      String expectedClassName,
-      Collection<LogProbe> logProbes) {
-    Assertions.assertEquals(expectedClassName, callingClass.getName());
+  private ProbeImplementation resolver(String encodedProbeId, Collection<LogProbe> logProbes) {
     for (LogProbe probe : logProbes) {
       if (probe.getProbeId().getEncodedId().equals(encodedProbeId)) {
         return probe;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -649,19 +649,11 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     instr.addTransformer(currentTransformer);
     mockSink = new MockSink(config, probeStatusSink);
     DebuggerAgentHelper.injectSink(mockSink);
-    DebuggerContext.init(
-        (encodedProbeId, callingClass) ->
-            resolver(encodedProbeId, callingClass, expectedClassName, configuration),
-        null);
+    DebuggerContext.init((encodedProbeId) -> resolver(encodedProbeId, configuration), null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
   }
 
-  private ProbeImplementation resolver(
-      String encodedProbeId,
-      Class<?> callingClass,
-      String expectedClassName,
-      Configuration configuration) {
-    Assertions.assertEquals(expectedClassName, callingClass.getName());
+  private ProbeImplementation resolver(String encodedProbeId, Configuration configuration) {
     for (SpanDecorationProbe probe : configuration.getSpanDecorationProbes()) {
       if (probe.getProbeId().getEncodedId().equals(encodedProbeId)) {
         return probe;


### PR DESCRIPTION

# What Does This Do
Previously, in case of failed resolution from probe id we retransformed the current class to make sure the code is in sync with probe definitions. if a loop was still executing instrumented code, this can lead to a storm of retransformation which can hurt significantly performance of the application (retransform is STW). we now do nothing except log a warning and send it as telemetry.

# Motivation
avoid performance issue in rare cases

# Additional Notes

Jira ticket: [DEBUG-2022]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2022]: https://datadoghq.atlassian.net/browse/DEBUG-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ