### PR TITLE
Introduce more local counters for tracer health metrics

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
@@ -215,8 +215,6 @@ class OpenTelemetryTest extends AgentTestRunner {
 
     then:
     tracer.currentSpan.delegate == secondScope.delegate.span()
-    1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
-    1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
     _ * TEST_CHECKPOINTER._
     0 * _
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -255,8 +255,6 @@ class OpenTracing31Test extends AgentTestRunner {
 
     then:
     tracer.scopeManager().active().delegate == secondScope.delegate
-    1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
-    1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
     _ * TEST_CHECKPOINTER._
     0 * _
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -270,8 +270,6 @@ class OpenTracing32Test extends AgentTestRunner {
 
     then:
     tracer.scopeManager().active().delegate == secondScope.delegate
-    1 * STATS_D_CLIENT.incrementCounter("scope.close.error")
-    1 * STATS_D_CLIENT.incrementCounter("scope.user.close.error")
     _ * TEST_CHECKPOINTER._
     0 * _
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -84,8 +84,6 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter unsetPriorityFailedPublishSpanCount =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter sampledSpans =
-      CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter manualTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter capturedContinuations =

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -29,6 +29,7 @@ import spock.lang.Timeout
 import spock.util.concurrent.PollingConditions
 
 import java.nio.ByteBuffer
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Phaser
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
@@ -669,47 +670,41 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
   }
 
   def "statsd comm failure"() {
-    def numRequests = new AtomicInteger(0)
-    def numResponses = new AtomicInteger(0)
-    def numErrors = new AtomicInteger(0)
-
     setup:
     def minimalTrace = createMinimalTrace()
 
     def api = Mock(DDIntakeApi)
     api.sendSerializedTraces(_) >> RemoteApi.Response.failed(new IOException("comm error"))
 
-    def statsd = Stub(StatsDClient)
-    statsd.incrementCounter("api.requests.total") >> { stat ->
-      numRequests.incrementAndGet()
-    }
-    statsd.incrementCounter("api.responses.total", _) >> { stat, tags ->
-      numResponses.incrementAndGet()
-    }
-    statsd.incrementCounter("api.errors.total", _) >> { stat ->
-      numErrors.incrementAndGet()
-    }
-
-    def healthMetrics = new TracerHealthMetrics(statsd)
+    def latch = new CountDownLatch(2)
+    def statsd = Mock(StatsDClient)
+    def healthMetrics = new TracerHealthMetrics(statsd, 100, TimeUnit.MILLISECONDS)
     def writer = DDIntakeWriter.builder()
       .addTrack(trackType, api)
       .monitoring(monitoring)
       .healthMetrics(healthMetrics)
       .alwaysFlush(false)
       .build()
+    healthMetrics.start()
     writer.start()
 
     when:
     writer.write(minimalTrace)
     writer.flush()
+    latch.await(10, TimeUnit.SECONDS)
 
     then:
-    numRequests.get() == 1
-    numResponses.get() == 0
-    numErrors.get() == 1
+    1 * statsd.count("api.requests.total", 1, _) >> {
+      latch.countDown()
+    }
+    0 * statsd.incrementCounter("api.responses.total", _)
+    1 * statsd.count("api.errors.total", 1, _) >> {
+      latch.countDown()
+    }
 
     cleanup:
     writer.close()
+    healthMetrics.close()
 
     where:
     trackType | apiVersion

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -1,7 +1,6 @@
 package datadog.opentracing
 
 import datadog.trace.api.DDTags
-import datadog.trace.api.StatsDClient
 import datadog.trace.api.config.TracerConfig
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.interceptor.TraceInterceptor
@@ -20,9 +19,8 @@ import static datadog.trace.agent.test.asserts.ListWriterAssert.assertTraces
 
 class OpenTracingAPITest extends DDSpecification {
   def writer = new ListWriter()
-  def statsDClient = Mock(StatsDClient)
 
-  def tracer = DDTracer.builder().writer(writer).statsDClient(statsDClient).build()
+  def tracer = DDTracer.builder().writer(writer).build()
 
   def traceInterceptor = Mock(TraceInterceptor)
   def scopeListener = Mock(ScopeListener)
@@ -364,8 +362,6 @@ class OpenTracingAPITest extends DDSpecification {
 
     then:
     2 * scopeListener.afterScopeActivated()
-    1 * statsDClient.incrementCounter("scope.close.error")
-    1 * statsDClient.incrementCounter("scope.user.close.error")
     0 * _
 
     when:
@@ -382,15 +378,13 @@ class OpenTracingAPITest extends DDSpecification {
     firstScope.close()
 
     then:
-    1 * statsDClient.incrementCounter("scope.close.error")
-    1 * statsDClient.incrementCounter("scope.user.close.error")
     0 * _
   }
 
   def "closing scope when not on top in strict mode"() {
     setup:
     injectSysConfig(TracerConfig.SCOPE_STRICT_MODE, "true")
-    DDTracer strictTracer = DDTracer.builder().writer(writer).statsDClient(statsDClient).build()
+    DDTracer strictTracer = DDTracer.builder().writer(writer).build()
     strictTracer.addTraceInterceptor(traceInterceptor)
     strictTracer.tracer.addScopeListener(scopeListener)
 
@@ -411,8 +405,6 @@ class OpenTracingAPITest extends DDSpecification {
 
     then:
     thrown(RuntimeException)
-    1 * statsDClient.incrementCounter("scope.close.error")
-    1 * statsDClient.incrementCounter("scope.user.close.error")
     0 * _
 
     when:


### PR DESCRIPTION
# Motivation

This will help us report these counts to tracer-flare in the near future.

It also reduces the number of immediate statsd requests, by accumulating counts and sending them on a fixed schedule.

# Additional Notes

The remaining immediate statsd requests in `TracerHealthMetrics` are reporting the tracer queue size on startup (which only happens once) and API responses where the status was not OK (where the metrics tag is derived from the status.) 

Note for tracer-flare it is enough to just have the number of OK responses - if that is drastically different to the number of requests then the full set of metrics with their status code tags can be examined in the UI.

Jira ticket: [APMJAVA-1078]

[APMJAVA-1078]: https://datadoghq.atlassian.net/browse/APMJAVA-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ