### PR TITLE
Add `instanceof` operator in Expression Language

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
@@ -95,6 +95,10 @@ public class DSL {
     return new ComparisonExpression(left, right, ComparisonOperator.EQ);
   }
 
+  public static BooleanExpression instanceOf(ValueExpression<?> left, ValueExpression<?> right) {
+    return new ComparisonExpression(left, right, ComparisonOperator.INSTANCEOF);
+  }
+
   public static BooleanExpression not(BooleanExpression expression) {
     return new NotExpression(expression);
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -157,6 +157,18 @@ public class JsonToExpressionConverter {
           reader.endArray();
           return expr;
         }
+      case "instanceof":
+        {
+          JsonReader.Token token = reader.peek();
+          if (token != BEGIN_ARRAY) {
+            throw new UnsupportedOperationException(
+                "Operation 'instanceof' expects the arguments to be defined as array");
+          }
+          reader.beginArray();
+          BooleanExpression expr = createBinaryValuePredicate(reader, DSL::instanceOf);
+          reader.endArray();
+          return expr;
+        }
       case "or":
         {
           JsonReader.Token token = reader.peek();

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonExpression.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -30,7 +32,11 @@ public class ComparisonExpression implements BooleanExpression {
     if (rightValue.isUndefined()) {
       return Boolean.FALSE;
     }
-    return operator.apply(leftValue, rightValue);
+    try {
+      return operator.apply(leftValue, rightValue);
+    } catch (EvaluationException e) {
+      throw new EvaluationException(e.getMessage(), PrettyPrintVisitor.print(this));
+    }
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonOperator.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ComparisonOperator.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.NumericValue;
@@ -64,6 +65,23 @@ public enum ComparisonOperator {
         return Boolean.FALSE;
       }
       return result < 0;
+    }
+  },
+  INSTANCEOF("instanceof") {
+    @Override
+    public Boolean apply(Value<?> left, Value<?> right) {
+      if (right.getValue() instanceof String) {
+        String typeStr = (String) right.getValue();
+        Class<?> clazz;
+        try {
+          clazz = Class.forName(typeStr, false, left.getValue().getClass().getClassLoader());
+        } catch (ClassNotFoundException e) {
+          throw new EvaluationException("Class not found: " + typeStr, null);
+        }
+        return clazz.isInstance(left.getValue());
+      }
+      throw new EvaluationException(
+          "Right operand of instanceof operator must be a string literal", null);
     }
   };
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -84,11 +84,14 @@ public class ProbeConditionTest {
     ProbeCondition probeCondition = load("/test_conditional_05.json");
     class Obj {
       int intField1 = 42;
+      String strField = "foo";
     }
     Obj obj = new Obj();
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("intField1", obj.intField1);
+    fields.put("strField", obj.strField);
     ValueReferenceResolver ctx =
-        RefResolverHelper.createResolver(
-            singletonMap("this", obj), null, singletonMap("intField1", obj.intField1));
+        RefResolverHelper.createResolver(singletonMap("this", obj), null, fields);
     assertTrue(probeCondition.execute(ctx));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_05.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_05.json
@@ -1,5 +1,5 @@
 {
-  "dsl": "this.intField1 == 42 && (this.intField1 > 0 || intField1 >= 0 || intField1 < 50 || intField1 <= 42) && intField1 != 0",
+  "dsl": "this.intField1 == 42 && (this.intField1 > 0 || intField1 >= 0 || intField1 < 50 || intField1 <= 42) && intField1 != 0 && strField instanceof \"java.lang.String\"",
   "json": {
     "and": [
       { "eq": [{"getmember": [{"ref": "this"}, "intField1"]}, 42] },
@@ -9,7 +9,8 @@
         {"lt": [{"ref": "intField1"}, 50]},
         {"le": [{"ref": "intField1"}, 42]}
       ]},
-      {"ne": [{"ref": "intField1"}, 0]}
+      {"ne": [{"ref": "intField1"}, 0]},
+      {"instanceof":  [{"ref": "strField"}, "java.lang.String"]}
     ]
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -790,10 +790,14 @@ public class CapturedSnapshotTest {
             .when(
                 new ProbeCondition(
                     DSL.when(
-                        DSL.eq(
-                            DSL.getMember(DSL.ref("@exception"), "detailMessage"),
-                            DSL.value("oops"))),
-                    "@exception.detailMessage == 'oops'"))
+                        DSL.and(
+                            DSL.instanceOf(
+                                DSL.ref("@exception"),
+                                DSL.value("java.lang.IllegalStateException")),
+                            DSL.eq(
+                                DSL.getMember(DSL.ref("@exception"), "detailMessage"),
+                                DSL.value("oops")))),
+                    "@exception instanceof \"java.lang.IllegalStateException\" and @exception.detailMessage == 'oops'"))
             .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
             .build();
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);


### PR DESCRIPTION
# What Does This Do
Add comparison operator `instanceof` to test object value against a class type provided as string.
class type is looked up using `Class::forName` and the classloader of the left value.

# Motivation

# Additional Notes

Jira ticket: [DEBUG-1979]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1979]: https://datadoghq.atlassian.net/browse/DEBUG-1979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ