### PR TITLE
Allow disabling JFR profiler manually via configuration

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -168,6 +168,7 @@ public final class ProfilingConfig {
   public static final String PROFILING_ENABLED_EVENTS = "profiling.enabled.events";
 
   public static final String PROFILING_DEBUG_DUMP_PATH = "profiling.debug.dump_path";
+  public static final String PROFILING_DEBUG_JFR_DISABLED = "profiling.debug.jfr.disabled";
 
   public static final String PROFILING_CONTEXT_ATTRIBUTES = "profiling.context.attributes";
 


### PR DESCRIPTION
# What Does This Do
Adds a debug config option to allow manually disabling the JFR profiler

# Motivation
Debugging weird issues with JFR repository we are seeing at some customers

# Additional Notes

Jira ticket: [PROF-8843]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8843]: https://datadoghq.atlassian.net/browse/PROF-8843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ