### PR TITLE
Synchronously flush test session finish event

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/DDTestSessionImpl.java
@@ -6,6 +6,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.CIConstants;
 import datadog.trace.api.civisibility.DDTestSession;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.codeowners.Codeowners;
@@ -95,6 +96,11 @@ public class DDTestSessionImpl implements DDTestSession {
     } else {
       span.finish();
     }
+
+    // flushing written traces synchronously:
+    // as soon as build finish event is processed,
+    // the process can be killed by the CI provider
+    AgentTracer.get().flush();
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Adds synchronous flush of pending traces after test session finishes.

# Motivation
When build system is instrumented, it is the build process that handles the session event - Maven or Gradle daemon.
When running a Gradle build inside a CI provider (e.g. Github Actions), the daemon is killed as soon as it reports that the build has been completed.
Depending on the timing, this can happen before pending traces (including the session event) have been flushed.
Flushing the traces synchronously ensures that no events get lost.

Jira ticket: [CIVIS-8453]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8453]: https://datadoghq.atlassian.net/browse/CIVIS-8453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ