### PR TITLE
Add finally block for `@duration` metric

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -63,7 +63,6 @@ public class CapturedContextInstrumentor extends Instrumentor {
   private int exitContextVar = -1;
   private int timestampStartVar = -1;
   private int throwableListVar = -1;
-  private final List<FinallyBlock> finallyBlocks = new ArrayList<>();
 
   public CapturedContextInstrumentor(
       ProbeDefinition definition,
@@ -95,14 +94,6 @@ public class CapturedContextInstrumentor extends Instrumentor {
     addFinallyHandler(returnHandlerLabel);
     installFinallyBlocks();
     return InstrumentationResult.Status.INSTALLED;
-  }
-
-  private void installFinallyBlocks() {
-    for (FinallyBlock finallyBlock : finallyBlocks) {
-      methodNode.tryCatchBlocks.add(
-          new TryCatchBlockNode(
-              finallyBlock.startLabel, finallyBlock.endLabel, finallyBlock.handlerLabel, null));
-    }
   }
 
   private boolean addLineCaptures(LineMap lineMap) {
@@ -1044,17 +1035,5 @@ public class CapturedContextInstrumentor extends Instrumentor {
         INT_TYPE,
         INT_TYPE);
     // stack: [captured_value]
-  }
-
-  private static class FinallyBlock {
-    final LabelNode startLabel;
-    final LabelNode endLabel;
-    final LabelNode handlerLabel;
-
-    public FinallyBlock(LabelNode startLabel, LabelNode endLabel, LabelNode handlerLabel) {
-      this.startLabel = startLabel;
-      this.endLabel = endLabel;
-      this.handlerLabel = handlerLabel;
-    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -10,8 +10,11 @@ import com.datadog.debugger.instrumentation.DiagnosticMessage.Kind;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.Where;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -24,6 +27,7 @@ import org.objectweb.asm.tree.LineNumberNode;
 import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TryCatchBlockNode;
 import org.objectweb.asm.tree.TypeInsnNode;
 
 /** Common class for generating instrumentation */
@@ -45,6 +49,7 @@ public abstract class Instrumentor {
   protected int argOffset;
   protected final LocalVariableNode[] localVarsBySlot;
   protected LabelNode returnHandlerLabel;
+  protected final List<CapturedContextInstrumentor.FinallyBlock> finallyBlocks = new ArrayList<>();
 
   public Instrumentor(
       ProbeDefinition definition,
@@ -269,5 +274,39 @@ public abstract class Instrumentor {
     ProbeDefinition.Tag[] newTags = Arrays.copyOf(tags, tags.length + 1);
     newTags[newTags.length - 1] = new ProbeDefinition.Tag(PROBEID_TAG_NAME, probeId);
     return newTags;
+  }
+
+  protected InsnList clone(InsnList insnList) {
+    InsnList result = new InsnList();
+    Map<LabelNode, LabelNode> labels = new HashMap<>();
+    for (AbstractInsnNode node : insnList) {
+      if (node instanceof LabelNode) {
+        labels.put((LabelNode) node, new LabelNode());
+      }
+    }
+    for (AbstractInsnNode node : insnList) {
+      result.add(node.clone(labels));
+    }
+    return result;
+  }
+
+  protected void installFinallyBlocks() {
+    for (FinallyBlock finallyBlock : finallyBlocks) {
+      methodNode.tryCatchBlocks.add(
+          new TryCatchBlockNode(
+              finallyBlock.startLabel, finallyBlock.endLabel, finallyBlock.handlerLabel, null));
+    }
+  }
+
+  protected static class FinallyBlock {
+    final LabelNode startLabel;
+    final LabelNode endLabel;
+    final LabelNode handlerLabel;
+
+    public FinallyBlock(LabelNode startLabel, LabelNode endLabel, LabelNode handlerLabel) {
+      this.startLabel = startLabel;
+      this.endLabel = endLabel;
+      this.handlerLabel = handlerLabel;
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do
To make sure we measure the duration of method using `@duration` metric value in case of exception, we add a finally block with the metric call

# Motivation

# Additional Notes

Jira ticket: [DEBUG-1946]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1946]: https://datadoghq.atlassian.net/browse/DEBUG-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ