### PR TITLE
spring sqs listener test: block on send

### DIFF
--- a/dd-java-agent/instrumentation/spring-messaging-4/src/test/groovy/SpringListenerSQSTest.groovy
+++ b/dd-java-agent/instrumentation/spring-messaging-4/src/test/groovy/SpringListenerSQSTest.groovy
@@ -32,17 +32,18 @@ class SpringListenerSQSTest extends AgentTestRunner {
 
     when:
     TraceUtils.runUnderTrace("parent") {
-      template.sendAsync("SpringListenerSQS", "a message")
+      template.sendAsync("SpringListenerSQS", "a message").get()
     }
 
     then:
     def sendingSpan
     assertTraces(4, SORT_TRACES_BY_START) {
+      sortSpansByStart()
       trace(3) {
-        sendMessage(it, address, span(2))
-        getQueueUrl(it, address, span(2))
         basicSpan(it, "parent")
-        sendingSpan = span(0)
+        getQueueUrl(it, address, span(0))
+        sendMessage(it, address, span(0))
+        sendingSpan = span(2)
       }
       trace(1) {
         receiveMessage(it, address, sendingSpan)
@@ -69,15 +70,16 @@ class SpringListenerSQSTest extends AgentTestRunner {
       '_datadog' : "{\"x-datadog-trace-id\": \"4948377316357291421\", \"x-datadog-parent-id\": \"6746998015037429512\", \"x-datadog-sampling-priority\": \"1\"}"
     ])
     TraceUtils.runUnderTrace("parent") {
-      template.sendAsync("SpringListenerSQS", message)
+      template.sendAsync("SpringListenerSQS", message).get()
     }
 
     then:
     assertTraces(4, SORT_TRACES_BY_START) {
+      sortSpansByStart()
       trace(3) {
-        sendMessage(it, address, span(2))
-        getQueueUrl(it, address, span(2))
         basicSpan(it, "parent")
+        getQueueUrl(it, address, span(0))
+        sendMessage(it, address, span(0))
       }
       trace(1) {
         span {


### PR DESCRIPTION
# What Does This Do

Wait for async completion before closing parent span on sqs spring messaging test. Not waiting might cause the parent to finish before the children and have it (the root) buffered (clashing with strict trace writing and make the test fail)

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
