### PR TITLE
Tidy up tracer health metrics

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/HealthMetrics.java
@@ -51,8 +51,6 @@ public abstract class HealthMetrics implements AutoCloseable {
 
   public void onCreateTrace() {}
 
-  public void onCreateManualTrace() {}
-
   public void onScopeCloseError(int scopeSource) {}
 
   public void onCaptureContinuation() {}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -378,7 +378,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
     private static final String[] UNSET_TAG = new String[] {"priority:unset"};
     private static final String[] SINGLE_SPAN_SAMPLER = new String[] {"sampler:single-span"};
 
-    private final long[] previousCounts = new long[41];
+    private final long[] previousCounts = new long[43];
     private int countIndex;
 
     @Override
@@ -454,6 +454,11 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         reportIfChanged(
             target.statsd,
             "queue.dropped.spans",
+            target.serialFailedDroppedSpans,
+            SERIAL_FAILED_TAG);
+        reportIfChanged(
+            target.statsd,
+            "queue.dropped.spans",
             target.unsetPriorityFailedPublishSpanCount,
             UNSET_TAG);
 
@@ -477,6 +482,8 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
             target.singleSpanUnsampled,
             SINGLE_SPAN_SAMPLER);
 
+        reportIfChanged(
+            target.statsd, "span.continuations.captured", target.capturedContinuations, NO_TAGS);
         reportIfChanged(
             target.statsd, "span.continuations.canceled", target.cancelledContinuations, NO_TAGS);
         reportIfChanged(

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -38,6 +38,13 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   private final AtomicBoolean started = new AtomicBoolean(false);
   private volatile AgentTaskScheduler.Scheduled<TracerHealthMetrics> cancellation;
 
+  private final FixedSizeStripedLongCounter apiRequests =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter apiErrors =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter apiResponsesOK =
+      CountersFactory.createFixedSizeStripedCounter(8);
+
   private final FixedSizeStripedLongCounter userDropEnqueuedTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter userKeepEnqueuedTraces =
@@ -59,48 +66,35 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter serialFailedDroppedTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter unsetPriorityDroppedTraces =
+      CountersFactory.createFixedSizeStripedCounter(8);
+
+  private final FixedSizeStripedLongCounter userDropFailedPublishSpanCount =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter userKeepFailedPublishSpanCount =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter samplerDropFailedPublishSpanCount =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter samplerKeepFailedPublishSpanCount =
+      CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter serialFailedDroppedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter unsetPriorityDroppedTraces =
+  private final FixedSizeStripedLongCounter unsetPriorityFailedPublishSpanCount =
       CountersFactory.createFixedSizeStripedCounter(8);
 
   private final FixedSizeStripedLongCounter enqueuedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter enqueuedBytes =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter singleSpanSampled =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter singleSpanUnsampled =
-      CountersFactory.createFixedSizeStripedCounter(8);
-
   private final FixedSizeStripedLongCounter createdTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
-
   private final FixedSizeStripedLongCounter createdSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter finishedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter samplerKeepFailedPublishSpanCount =
+  private final FixedSizeStripedLongCounter flushedTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter userKeepFailedPublishSpanCount =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter userDropFailedPublishSpanCount =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter samplerDropFailedPublishSpanCount =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter unsetPriorityFailedPublishSpanCount =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter capturedContinuations =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter cancelledContinuations =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter finishedContinuations =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter activatedScopes =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter closedScopes =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter scopeStackOverflow =
+  private final FixedSizeStripedLongCounter flushedBytes =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter partialTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
@@ -108,26 +102,35 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter clientSpansWithoutContext =
       CountersFactory.createFixedSizeStripedCounter(8);
+
+  private final FixedSizeStripedLongCounter singleSpanSampled =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter singleSpanUnsampled =
+      CountersFactory.createFixedSizeStripedCounter(8);
+
+  private final FixedSizeStripedLongCounter capturedContinuations =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter cancelledContinuations =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter finishedContinuations =
+      CountersFactory.createFixedSizeStripedCounter(8);
+
+  private final FixedSizeStripedLongCounter activatedScopes =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter closedScopes =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter scopeStackOverflow =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter scopeCloseErrors =
+      CountersFactory.createFixedSizeStripedCounter(8);
+  private final FixedSizeStripedLongCounter userScopeCloseErrors =
+      CountersFactory.createFixedSizeStripedCounter(8);
+
   private final FixedSizeStripedLongCounter longRunningTracesWrite =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter longRunningTracesDropped =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter longRunningTracesExpired =
-      CountersFactory.createFixedSizeStripedCounter(8);
-
-  private final FixedSizeStripedLongCounter apiRequests =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter apiResponsesOK =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter apiErrors =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter flushedTraces =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter flushedBytes =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter scopeCloseErrors =
-      CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter userScopeCloseErrors =
       CountersFactory.createFixedSizeStripedCounter(8);
 
   private final StatsDClient statsd;
@@ -382,6 +385,13 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
     public void run(TracerHealthMetrics target) {
       countIndex = -1; // reposition so _next_ value is 0
       try {
+
+        reportIfChanged(target.statsd, "api.requests.total", target.apiRequests, NO_TAGS);
+        reportIfChanged(target.statsd, "api.errors.total", target.apiErrors, NO_TAGS);
+        // non-OK responses are reported immediately in onSendAttempt with different status tags
+        reportIfChanged(
+            target.statsd, "api.responses.total", target.apiResponsesOK, STATUS_OK_TAGS);
+
         reportIfChanged(
             target.statsd, "queue.enqueued.traces", target.userDropEnqueuedTraces, USER_DROP_TAG);
         reportIfChanged(
@@ -398,6 +408,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
             SAMPLER_KEEP_TAG);
         reportIfChanged(
             target.statsd, "queue.enqueued.traces", target.unsetPriorityEnqueuedTraces, UNSET_TAG);
+
         reportIfChanged(
             target.statsd, "queue.dropped.traces", target.userDropDroppedTraces, USER_DROP_TAG);
         reportIfChanged(
@@ -419,21 +430,12 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
             SERIAL_FAILED_TAG);
         reportIfChanged(
             target.statsd, "queue.dropped.traces", target.unsetPriorityDroppedTraces, UNSET_TAG);
+
         reportIfChanged(
             target.statsd,
             "queue.dropped.spans",
-            target.unsetPriorityFailedPublishSpanCount,
-            UNSET_TAG);
-        reportIfChanged(
-            target.statsd,
-            "queue.dropped.spans",
-            target.samplerKeepFailedPublishSpanCount,
-            SAMPLER_KEEP_TAG);
-        reportIfChanged(
-            target.statsd,
-            "queue.dropped.spans",
-            target.samplerDropFailedPublishSpanCount,
-            SAMPLER_DROP_TAG);
+            target.userDropFailedPublishSpanCount,
+            USER_DROP_TAG);
         reportIfChanged(
             target.statsd,
             "queue.dropped.spans",
@@ -442,22 +444,31 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         reportIfChanged(
             target.statsd,
             "queue.dropped.spans",
-            target.userDropFailedPublishSpanCount,
-            USER_DROP_TAG);
+            target.samplerDropFailedPublishSpanCount,
+            SAMPLER_DROP_TAG);
+        reportIfChanged(
+            target.statsd,
+            "queue.dropped.spans",
+            target.samplerKeepFailedPublishSpanCount,
+            SAMPLER_KEEP_TAG);
+        reportIfChanged(
+            target.statsd,
+            "queue.dropped.spans",
+            target.unsetPriorityFailedPublishSpanCount,
+            UNSET_TAG);
+
         reportIfChanged(target.statsd, "queue.enqueued.spans", target.enqueuedSpans, NO_TAGS);
         reportIfChanged(target.statsd, "queue.enqueued.bytes", target.enqueuedBytes, NO_TAGS);
         reportIfChanged(target.statsd, "trace.pending.created", target.createdTraces, NO_TAGS);
         reportIfChanged(target.statsd, "span.pending.created", target.createdSpans, NO_TAGS);
         reportIfChanged(target.statsd, "span.pending.finished", target.finishedSpans, NO_TAGS);
-
-        reportIfChanged(
-            target.statsd, "span.continuations.canceled", target.cancelledContinuations, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "span.continuations.finished", target.finishedContinuations, NO_TAGS);
+        reportIfChanged(target.statsd, "flush.traces.total", target.flushedTraces, NO_TAGS);
+        reportIfChanged(target.statsd, "flush.bytes.total", target.flushedBytes, NO_TAGS);
         reportIfChanged(target.statsd, "queue.partial.traces", target.partialTraces, NO_TAGS);
         reportIfChanged(target.statsd, "span.flushed.partial", target.partialBytes, NO_TAGS);
         reportIfChanged(
             target.statsd, "span.client.no-context", target.clientSpansWithoutContext, NO_TAGS);
+
         reportIfChanged(
             target.statsd, "span.sampling.sampled", target.singleSpanSampled, SINGLE_SPAN_SAMPLER);
         reportIfChanged(
@@ -465,10 +476,20 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
             "span.sampling.unsampled",
             target.singleSpanUnsampled,
             SINGLE_SPAN_SAMPLER);
+
+        reportIfChanged(
+            target.statsd, "span.continuations.canceled", target.cancelledContinuations, NO_TAGS);
+        reportIfChanged(
+            target.statsd, "span.continuations.finished", target.finishedContinuations, NO_TAGS);
+
         reportIfChanged(target.statsd, "scope.activate.count", target.activatedScopes, NO_TAGS);
         reportIfChanged(target.statsd, "scope.close.count", target.closedScopes, NO_TAGS);
         reportIfChanged(
             target.statsd, "scope.error.stack-overflow", target.scopeStackOverflow, NO_TAGS);
+        reportIfChanged(target.statsd, "scope.close.error", target.scopeCloseErrors, NO_TAGS);
+        reportIfChanged(
+            target.statsd, "scope.user.close.error", target.userScopeCloseErrors, NO_TAGS);
+
         reportIfChanged(
             target.statsd, "long-running.write", target.longRunningTracesWrite, NO_TAGS);
         reportIfChanged(
@@ -476,16 +497,6 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
         reportIfChanged(
             target.statsd, "long-running.expired", target.longRunningTracesExpired, NO_TAGS);
 
-        reportIfChanged(target.statsd, "api.requests.total", target.apiRequests, NO_TAGS);
-        reportIfChanged(target.statsd, "api.errors.total", target.apiErrors, NO_TAGS);
-        // non-OK responses are reported immediately in onSendAttempt with different status tags
-        reportIfChanged(
-            target.statsd, "api.responses.total", target.apiResponsesOK, STATUS_OK_TAGS);
-        reportIfChanged(target.statsd, "flush.traces.total", target.flushedTraces, NO_TAGS);
-        reportIfChanged(target.statsd, "flush.bytes.total", target.flushedBytes, NO_TAGS);
-        reportIfChanged(target.statsd, "scope.close.error", target.scopeCloseErrors, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "scope.user.close.error", target.userScopeCloseErrors, NO_TAGS);
       } catch (ArrayIndexOutOfBoundsException e) {
         log.warn(
             "previousCounts array needs resizing to at least {}, was {}",

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -69,17 +69,17 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   private final FixedSizeStripedLongCounter unsetPriorityDroppedTraces =
       CountersFactory.createFixedSizeStripedCounter(8);
 
-  private final FixedSizeStripedLongCounter userDropFailedPublishSpanCount =
+  private final FixedSizeStripedLongCounter userDropDroppedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter userKeepFailedPublishSpanCount =
+  private final FixedSizeStripedLongCounter userKeepDroppedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter samplerDropFailedPublishSpanCount =
+  private final FixedSizeStripedLongCounter samplerDropDroppedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter samplerKeepFailedPublishSpanCount =
+  private final FixedSizeStripedLongCounter samplerKeepDroppedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter serialFailedDroppedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter unsetPriorityFailedPublishSpanCount =
+  private final FixedSizeStripedLongCounter unsetPriorityDroppedSpans =
       CountersFactory.createFixedSizeStripedCounter(8);
 
   private final FixedSizeStripedLongCounter enqueuedSpans =
@@ -201,23 +201,23 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   public void onFailedPublish(final int samplingPriority, final int spanCount) {
     switch (samplingPriority) {
       case USER_DROP:
-        userDropFailedPublishSpanCount.inc(spanCount);
+        userDropDroppedSpans.inc(spanCount);
         userDropDroppedTraces.inc();
         break;
       case USER_KEEP:
-        userKeepFailedPublishSpanCount.inc(spanCount);
+        userKeepDroppedSpans.inc(spanCount);
         userKeepDroppedTraces.inc();
         break;
       case SAMPLER_DROP:
-        samplerDropFailedPublishSpanCount.inc(spanCount);
+        samplerDropDroppedSpans.inc(spanCount);
         samplerDropDroppedTraces.inc();
         break;
       case SAMPLER_KEEP:
-        samplerKeepFailedPublishSpanCount.inc(spanCount);
+        samplerKeepDroppedSpans.inc(spanCount);
         samplerKeepDroppedTraces.inc();
         break;
       default:
-        unsetPriorityFailedPublishSpanCount.inc(spanCount);
+        unsetPriorityDroppedSpans.inc(spanCount);
         unsetPriorityDroppedTraces.inc();
     }
   }
@@ -225,7 +225,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   @Override
   public void onPartialPublish(final int numberOfDroppedSpans) {
     partialTraces.inc();
-    samplerDropFailedPublishSpanCount.inc(numberOfDroppedSpans);
+    samplerDropDroppedSpans.inc(numberOfDroppedSpans);
   }
 
   @Override
@@ -432,35 +432,20 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
             target.statsd, "queue.dropped.traces", target.unsetPriorityDroppedTraces, UNSET_TAG);
 
         reportIfChanged(
-            target.statsd,
-            "queue.dropped.spans",
-            target.userDropFailedPublishSpanCount,
-            USER_DROP_TAG);
+            target.statsd, "queue.dropped.spans", target.userDropDroppedSpans, USER_DROP_TAG);
         reportIfChanged(
-            target.statsd,
-            "queue.dropped.spans",
-            target.userKeepFailedPublishSpanCount,
-            USER_KEEP_TAG);
+            target.statsd, "queue.dropped.spans", target.userKeepDroppedSpans, USER_KEEP_TAG);
         reportIfChanged(
-            target.statsd,
-            "queue.dropped.spans",
-            target.samplerDropFailedPublishSpanCount,
-            SAMPLER_DROP_TAG);
+            target.statsd, "queue.dropped.spans", target.samplerDropDroppedSpans, SAMPLER_DROP_TAG);
         reportIfChanged(
-            target.statsd,
-            "queue.dropped.spans",
-            target.samplerKeepFailedPublishSpanCount,
-            SAMPLER_KEEP_TAG);
+            target.statsd, "queue.dropped.spans", target.samplerKeepDroppedSpans, SAMPLER_KEEP_TAG);
         reportIfChanged(
             target.statsd,
             "queue.dropped.spans",
             target.serialFailedDroppedSpans,
             SERIAL_FAILED_TAG);
         reportIfChanged(
-            target.statsd,
-            "queue.dropped.spans",
-            target.unsetPriorityFailedPublishSpanCount,
-            UNSET_TAG);
+            target.statsd, "queue.dropped.spans", target.unsetPriorityDroppedSpans, UNSET_TAG);
 
         reportIfChanged(target.statsd, "queue.enqueued.spans", target.enqueuedSpans, NO_TAGS);
         reportIfChanged(target.statsd, "queue.enqueued.bytes", target.enqueuedBytes, NO_TAGS);

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -90,8 +90,6 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter unsetPriorityFailedPublishSpanCount =
       CountersFactory.createFixedSizeStripedCounter(8);
-  private final FixedSizeStripedLongCounter manualTraces =
-      CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter capturedContinuations =
       CountersFactory.createFixedSizeStripedCounter(8);
   private final FixedSizeStripedLongCounter cancelledContinuations =
@@ -278,11 +276,6 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   @Override
   public void onCreateTrace() {
     createdTraces.inc();
-  }
-
-  @Override
-  public void onCreateManualTrace() {
-    manualTraces.inc();
   }
 
   @Override


### PR DESCRIPTION
Minor cleanup:

* Arrange metrics into groupings in the code
* Remove unused `manualTraces` metric, was never called
* Publish metrics that were collected but never submitted:
  * `serialFailedDroppedSpans` and `capturedContinuations`
* Consistent naming

Jira ticket: [APMJAVA-1078]


[APMJAVA-1077]: https://datadoghq.atlassian.net/browse/APMJAVA-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APMJAVA-1078]: https://datadoghq.atlassian.net/browse/APMJAVA-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ