### PR TITLE
Provide summary of JMXFetch for tracer-flare

### DIFF
--- a/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
+++ b/dd-java-agent/agent-jmxfetch/src/main/java/datadog/trace/agent/jmxfetch/JMXFetch.java
@@ -8,6 +8,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.StatsDClient;
 import datadog.trace.api.StatsDClientManager;
+import datadog.trace.api.flare.TracerFlare;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
 import java.io.InputStream;
@@ -88,6 +89,9 @@ public class JMXFetch {
     }
 
     final StatsDClient statsd = statsDClientManager.statsDClient(host, port, namedPipe, null, null);
+    final AgentStatsdReporter reporter = new AgentStatsdReporter(statsd);
+
+    TracerFlare.addReporter(reporter);
 
     final AppConfig.AppConfigBuilder configBuilder =
         AppConfig.builder()
@@ -104,7 +108,7 @@ public class JMXFetch {
             .initialRefreshBeansPeriod(initialRefreshBeansPeriod)
             .refreshBeansPeriod(refreshBeansPeriod)
             .globalTags(globalTags)
-            .reporter(new AgentStatsdReporter(statsd));
+            .reporter(reporter);
 
     if (config.isJmxFetchMultipleRuntimeServicesEnabled()) {
       ServiceNameCollectingTraceInterceptor serviceNameProvider =
@@ -117,6 +121,7 @@ public class JMXFetch {
     if (checkPeriod != null) {
       configBuilder.checkPeriod(checkPeriod);
     }
+
     final AppConfig appConfig = configBuilder.build();
 
     final Thread thread =


### PR DESCRIPTION
This PR temporarily records JMXFetch metrics sent between preparing for the tracer-flare and capturing the flare.

It's expected that several minutes will elapse between the remote-config events to prepare for the flare and capture it, which is more than enough time to cover at least one JMXFetch report cycle.

Jira ticket: [APMJAVA-1078]

[APMJAVA-1078]: https://datadoghq.atlassian.net/browse/APMJAVA-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ