### PR TITLE
avoid extra time due to telemetry for jmx tests

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
@@ -20,6 +20,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Ddd.jmxfetch.start-delay=0",
         "-Ddd.jmxfetch.refresh-beans-period=1",
         "-Ddd.profiling.enabled=true",
+        "-Ddd.instrumentation.telemetry.enabled=false",
         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"
       ] as String[]
       , "" as String[]
@@ -35,6 +36,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Ddd.jmxfetch.start-delay=0",
         "-Ddd.jmxfetch.refresh-beans-period=1",
         "-Ddd.profiling.enabled=true",
+        "-Ddd.instrumentation.telemetry.enabled=false",
         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
         "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"
       ] as String[]
@@ -51,6 +53,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Ddd.jmxfetch.start-delay=0",
         "-Ddd.jmxfetch.refresh-beans-period=1",
         "-Ddd.profiling.enabled=true",
+        "-Ddd.instrumentation.telemetry.enabled=false",
         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
         "-Djavax.management.builder.initial=jvmbootstraptest.MissingMBeanServerBuilder"
       ] as String[]
@@ -67,6 +70,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Ddd.jmxfetch.start-delay=0",
         "-Ddd.jmxfetch.refresh-beans-period=1",
         "-Ddd.profiling.enabled=true",
+        "-Ddd.instrumentation.telemetry.enabled=false",
         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
         "-Ddd.app.customjmxbuilder=true"
       ] as String[]
@@ -83,6 +87,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Ddd.jmxfetch.start-delay=0",
         "-Ddd.jmxfetch.refresh-beans-period=1",
         "-Ddd.profiling.enabled=true",
+        "-Ddd.instrumentation.telemetry.enabled=false",
         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL",
         "-Ddd.app.customjmxbuilder=false",
         "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"


### PR DESCRIPTION
# What Does This Do

According to some failed test logs, telemetry thread termination can take some additional time (also because retries before deciding to directly send things to intake). In the scope of this test, telemetry is not required hence disabled in order to let the test pass easier

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
