### PR TITLE
zio: fix context propagation

### DIFF
--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/FiberContext.java
@@ -41,7 +41,7 @@ public class FiberContext {
   }
 
   public void onSuspend() {
-    if (this.scope != null) {
+    if (this.scope != null && continuation != null) {
       this.scope.close();
       this.scope = null;
     }

--- a/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/ZioRuntimeInstrumentation.java
+++ b/dd-java-agent/instrumentation/zio/zio-2.0/src/main/java/datadog/trace/instrumentation/zio/v2_0/ZioRuntimeInstrumentation.java
@@ -5,9 +5,13 @@ import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import zio.Fiber;
@@ -15,7 +19,7 @@ import zio.Supervisor;
 
 @AutoService(Instrumenter.class)
 public class ZioRuntimeInstrumentation extends Instrumenter.Tracing
-    implements Instrumenter.ForSingleType {
+    implements Instrumenter.ForSingleType, ExcludeFilterProvider {
 
   public ZioRuntimeInstrumentation() {
     super("zio.experimental");
@@ -45,6 +49,12 @@ public class ZioRuntimeInstrumentation extends Instrumenter.Tracing
   @Override
   public Map<String, String> contextStore() {
     return singletonMap("zio.Fiber$Runtime", packageName + ".FiberContext");
+  }
+
+  @Override
+  public Map<ExcludeFilter.ExcludeType, ? extends Collection<String>> excludedClasses() {
+    return Collections.singletonMap(
+        ExcludeFilter.ExcludeType.RUNNABLE, Collections.singletonList("zio.internal.FiberRuntime"));
   }
 
   public static final class DefaultSupervisor {


### PR DESCRIPTION
# What Does This Do

Provides several fixes to the zio instrumentation hence resolving as well the flakiness of tests.
* Excludes `zio.internal.FiberRuntime` from context propagation since this is done via the instrumentation itself (supervisor)

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
