### PR TITLE
Enforce ordering of probe instrumentation

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -68,8 +68,11 @@ public class DebuggerContext {
   private static volatile Tracer tracer;
   private static volatile ValueSerializer valueSerializer;
 
-  public static void init(ProbeResolver probeResolver, MetricForwarder metricForwarder) {
+  public static void initProbeResolver(ProbeResolver probeResolver) {
     DebuggerContext.probeResolver = probeResolver;
+  }
+
+  public static void initMetricForwarder(MetricForwarder metricForwarder) {
     DebuggerContext.metricForwarder = metricForwarder;
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -69,7 +69,8 @@ public class DebuggerAgent {
     sink = debuggerSink;
     StatsdMetricForwarder statsdMetricForwarder =
         new StatsdMetricForwarder(config, probeStatusSink);
-    DebuggerContext.init(configurationUpdater, statsdMetricForwarder);
+    DebuggerContext.initProbeResolver(configurationUpdater);
+    DebuggerContext.initMetricForwarder(statsdMetricForwarder);
     DebuggerContext.initClassFilter(new DenyListHelper(null)); // default hard coded deny list
     snapshotSerializer = new JsonSnapshotSerializer();
     DebuggerContext.initValueSerializer(snapshotSerializer);
@@ -171,7 +172,8 @@ public class DebuggerAgent {
     LOGGER.info("install Instrument-The-World transformer");
     DebuggerTransformer transformer =
         createTransformer(config, Configuration.builder().build(), null, debuggerSink);
-    DebuggerContext.init(transformer::instrumentTheWorldResolver, statsdMetricForwarder);
+    DebuggerContext.initProbeResolver(transformer::instrumentTheWorldResolver);
+    DebuggerContext.initMetricForwarder(statsdMetricForwarder);
     instrumentation.addTransformer(transformer);
     return transformer;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -1,7 +1,5 @@
 package com.datadog.debugger.probe;
 
-import static java.util.Collections.singletonList;
-
 import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
@@ -125,14 +123,6 @@ public abstract class ProbeDefinition implements ProbeImplementation {
         tagMap.put(tag.getKey(), tag.getValue());
       }
     }
-  }
-
-  public InstrumentationResult.Status instrument(
-      ClassLoader classLoader,
-      ClassNode classNode,
-      MethodNode methodNode,
-      List<DiagnosticMessage> diagnostics) {
-    return instrument(classLoader, classNode, methodNode, diagnostics, singletonList(getProbeId()));
   }
 
   public abstract InstrumentationResult.Status instrument(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -8,6 +8,7 @@ import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_IDENT_REASO
 import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_TYPE_REASON;
 import static com.datadog.debugger.util.TestHelper.setFieldInConfig;
 import static datadog.trace.bootstrap.debugger.util.Redaction.REDACTED_VALUE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -29,7 +30,11 @@ import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.el.values.StringValue;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.probe.LogProbe;
+import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SpanDecorationProbe;
+import com.datadog.debugger.probe.SpanProbe;
+import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.sink.Snapshot;
@@ -37,11 +42,15 @@ import com.datadog.debugger.util.MoshiHelper;
 import com.datadog.debugger.util.MoshiSnapshotTestHelper;
 import com.datadog.debugger.util.SerializerWithLimits;
 import com.squareup.moshi.JsonAdapter;
+import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
+import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.api.sampling.Sampler;
 import datadog.trace.bootstrap.debugger.*;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import datadog.trace.bootstrap.debugger.util.Redaction;
+import datadog.trace.core.CoreTracer;
+import datadog.trace.core.DDSpan;
 import groovy.lang.GroovyClassLoader;
 import java.io.File;
 import java.io.IOException;
@@ -87,7 +96,7 @@ import utils.SourceCompiler;
 
 public class CapturedSnapshotTest {
   private static final String LANGUAGE = "java";
-  private static final ProbeId PROBE_ID = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f8", 0);
+  private static final ProbeId PROBE_ID = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f5", 0);
   private static final ProbeId PROBE_ID1 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f6", 0);
   private static final ProbeId PROBE_ID2 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f7", 0);
   private static final ProbeId PROBE_ID3 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f8", 0);
@@ -171,7 +180,7 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)", "8");
     DebuggerAgentHelper.injectSink(listener);
-    DebuggerContext.init((encodedProbeId) -> null, null);
+    DebuggerContext.initProbeResolver((encodedProbeId) -> null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -186,11 +195,10 @@ public class CapturedSnapshotTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         installProbes(CLASS_NAME, lineProbe, methodProbe);
     DebuggerAgentHelper.injectSink(listener);
-    DebuggerContext.init(
+    DebuggerContext.initProbeResolver(
         (encodedProbeId) -> {
           throw new IllegalArgumentException("oops");
-        },
-        null);
+        });
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -2037,6 +2045,75 @@ public class CapturedSnapshotTest {
     assertCaptureFields(capturedContext, "age", Integer.TYPE.getTypeName(), "0");
   }
 
+  @Test
+  public void allProbesSameMethod() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot01";
+    final String METRIC_NAME = "count";
+    Where where = new Where().typeName(CLASS_NAME).methodName("main");
+    Configuration configuration =
+        Configuration.builder()
+            .add(
+                SpanDecorationProbe.builder()
+                    .probeId(PROBE_ID)
+                    .where(where)
+                    .targetSpan(SpanDecorationProbe.TargetSpan.ACTIVE)
+                    .decorate(
+                        new SpanDecorationProbe.Decoration(
+                            null,
+                            Arrays.asList(
+                                new SpanDecorationProbe.Tag(
+                                    "tag1",
+                                    new SpanDecorationProbe.TagValue(
+                                        "value1", parseTemplate("value1"))))))
+                    .build())
+            .add(SpanProbe.builder().probeId(PROBE_ID1).where(where).build())
+            .add(
+                MetricProbe.builder()
+                    .probeId(PROBE_ID2)
+                    .metricName(METRIC_NAME)
+                    .kind(MetricProbe.MetricKind.COUNT)
+                    .where(where)
+                    .build())
+            .add(LogProbe.builder().probeId(PROBE_ID3).where(where).build())
+            .build();
+
+    CoreTracer tracer = CoreTracer.builder().build();
+    TracerInstaller.forceInstallGlobalTracer(tracer);
+    SpanDecorationProbeInstrumentationTest.TestTraceInterceptor traceInterceptor =
+        new SpanDecorationProbeInstrumentationTest.TestTraceInterceptor();
+    tracer.addTraceInterceptor(traceInterceptor);
+    try {
+      DebuggerTransformerTest.TestSnapshotListener snapshotListener =
+          installProbes(CLASS_NAME, configuration);
+      DebuggerContext.initTracer(new DebuggerTracer(mock(ProbeStatusSink.class)));
+      MetricProbesInstrumentationTest.MetricForwarderListener metricListener =
+          new MetricProbesInstrumentationTest.MetricForwarderListener();
+      DebuggerContext.initMetricForwarder(metricListener);
+      Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+      int result = Reflect.on(testClass).call("main", "1").get();
+      // log probe
+      assertEquals(3, result);
+      assertEquals(1, snapshotListener.snapshots.size());
+      Snapshot snapshot = snapshotListener.snapshots.get(0);
+      assertEquals(PROBE_ID3.getId(), snapshot.getProbe().getId());
+      // span (deco) probe
+      assertEquals(1, traceInterceptor.getTrace().size());
+      MutableSpan span = traceInterceptor.getFirstSpan();
+      assertEquals(CLASS_NAME + ".main", span.getResourceName());
+      assertEquals(PROBE_ID1.getId(), span.getTag("debugger.probeid"));
+      assertEquals("value1", span.getTag("tag1"));
+      // correlation between log and created span
+      assertEquals(snapshot.getSpanId(), String.valueOf(((DDSpan) span).getSpanId()));
+      // metric probe
+      assertTrue(metricListener.counters.containsKey(METRIC_NAME));
+      assertEquals(1, metricListener.counters.get(METRIC_NAME).longValue());
+      assertArrayEquals(
+          new String[] {"debugger.probeid:" + PROBE_ID2.getId()}, metricListener.lastTags);
+    } finally {
+      TracerInstaller.forceInstallGlobalTracer(null);
+    }
+  }
+
   private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(
       String excludeFileName) {
     Config config = mock(Config.class);
@@ -2113,13 +2190,18 @@ public class CapturedSnapshotTest {
         new DebuggerTransformer(config, configuration, instrumentationListener, listener);
     instr.addTransformer(currentTransformer);
     DebuggerAgentHelper.injectSink(listener);
-    DebuggerContext.init((encodedId) -> resolver(encodedId, logProbes), null);
+    DebuggerContext.initProbeResolver(
+        (encodedId) -> resolver(encodedId, logProbes, configuration.getSpanDecorationProbes()));
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
-    for (LogProbe probe : logProbes) {
-      if (probe.getSampling() != null) {
-        ProbeRateLimiter.setRate(
-            probe.getId(), probe.getSampling().getSnapshotsPerSecond(), probe.isCaptureSnapshot());
+    if (logProbes != null) {
+      for (LogProbe probe : logProbes) {
+        if (probe.getSampling() != null) {
+          ProbeRateLimiter.setRate(
+              probe.getId(),
+              probe.getSampling().getSnapshotsPerSecond(),
+              probe.isCaptureSnapshot());
+        }
       }
     }
     if (configuration.getSampling() != null) {
@@ -2128,8 +2210,16 @@ public class CapturedSnapshotTest {
     return listener;
   }
 
-  private ProbeImplementation resolver(String encodedId, Collection<LogProbe> logProbes) {
+  private ProbeImplementation resolver(
+      String encodedId,
+      Collection<LogProbe> logProbes,
+      Collection<SpanDecorationProbe> spanDecorationProbes) {
     for (LogProbe probe : logProbes) {
+      if (probe.getProbeId().getEncodedId().equals(encodedId)) {
+        return probe;
+      }
+    }
+    for (SpanDecorationProbe probe : spanDecorationProbes) {
       if (probe.getProbeId().getEncodedId().equals(encodedId)) {
         return probe;
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTracerTest.java
@@ -60,6 +60,7 @@ class DebuggerTracerTest {
 
   @Test
   public void noApi() {
+    AgentTracer.forceRegister(null);
     ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
     DebuggerTracer debuggerTracer = new DebuggerTracer(probeStatusSink);
     DebuggerSpan span =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -549,7 +549,7 @@ public class LogProbesInstrumentationTest {
     DebuggerTransformerTest.TestSnapshotListener listener =
         new DebuggerTransformerTest.TestSnapshotListener(config, mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
-    DebuggerContext.init(resolver, null);
+    DebuggerContext.initProbeResolver(resolver);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
     return listener;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -1282,7 +1282,7 @@ public class MetricProbesInstrumentationTest {
             config, configuration, null, new DebuggerSink(config, probeStatusSink));
     instr.addTransformer(currentTransformer);
     MetricForwarderListener listener = new MetricForwarderListener();
-    DebuggerContext.init(null, listener);
+    DebuggerContext.initMetricForwarder(listener);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     return listener;
   }
@@ -1295,7 +1295,7 @@ public class MetricProbesInstrumentationTest {
             .build());
   }
 
-  private static class MetricForwarderListener implements DebuggerContext.MetricForwarder {
+  static class MetricForwarderListener implements DebuggerContext.MetricForwarder {
     Map<String, Long> counters = new HashMap<>();
     Map<String, Long> gauges = new HashMap<>();
     Map<String, Double> doubleGauges = new HashMap<>();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -649,7 +649,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     instr.addTransformer(currentTransformer);
     mockSink = new MockSink(config, probeStatusSink);
     DebuggerAgentHelper.injectSink(mockSink);
-    DebuggerContext.init((encodedProbeId) -> resolver(encodedProbeId, configuration), null);
+    DebuggerContext.initProbeResolver((encodedProbeId) -> resolver(encodedProbeId, configuration));
     DebuggerContext.initClassFilter(new DenyListHelper(null));
   }
 
@@ -667,7 +667,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     return null;
   }
 
-  private static class TestTraceInterceptor implements TraceInterceptor {
+  static class TestTraceInterceptor implements TraceInterceptor {
     private Collection<? extends MutableSpan> currentTrace;
     private List<List<? extends MutableSpan>> allTraces = new ArrayList<>();
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanProbeInstrumentationTest.java
@@ -155,7 +155,7 @@ public class SpanProbeInstrumentationTest extends ProbeInstrumentationTest {
     instr.addTransformer(currentTransformer);
     mockSink = new MockSink(config, probeStatusSink);
     DebuggerAgentHelper.injectSink(mockSink);
-    DebuggerContext.init(null, null);
+    DebuggerContext.initProbeResolver(null);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     MockTracer mockTracer = new MockTracer();
     DebuggerContext.initTracer(mockTracer);


### PR DESCRIPTION
# What Does This Do
To make sure on a same method all probe defined on this location are instrumented in right order to interact each other. Order of instrumentation is:
 - metric probes
 - log probes
 - span decoration probes
 - span probes 
 
This way the last probe wraps method body and all other instrumented code.
Span should be first to be executed to create a span for the current method then span decoration should add tags for this new span. Logs should be decorated with trace/span ids for the current method. Finally metric are last because no dependency.



# Motivation

# Additional Notes

Jira ticket: [DEBUG-1752]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-1752]: https://datadoghq.atlassian.net/browse/DEBUG-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ