### PR TITLE
Be consistent when checking if tasks are excluded from wrapping/injection

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -72,9 +72,11 @@ public final class TPEHelper {
     return Boolean.TRUE.equals(contextStore.get(executor));
   }
 
-  public static void capture(ContextStore<Runnable, State> contextStore, Runnable task) {
+  public static void capture(
+      ContextStore<Runnable, State> contextStore, ThreadPoolExecutor executor, Runnable task) {
     if (task != null && !exclude(RUNNABLE, task)) {
       AdviceUtils.capture(contextStore, task, true);
+      QueueTimerHelper.startQueuingTimer(contextStore, executor.getClass(), task);
     }
   }
 

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinPoolInstrumentation.java
@@ -60,7 +60,7 @@ public class JavaForkJoinPoolInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static <T> void cleanup(
         @Advice.Argument(0) ForkJoinTask<T> task, @Advice.Thrown Throwable thrown) {
-      if (null != thrown) {
+      if (null != thrown && !exclude(FORK_JOIN_TASK, task)) {
         cancelTask(InstrumentationContext.get(ForkJoinTask.class, State.class), task);
       }
     }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaTimerInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaTimerInstrumentation.java
@@ -3,6 +3,8 @@ package datadog.trace.instrumentation.java.concurrent;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.cancelTask;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
+import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.QueueTimerHelper.startQueuingTimer;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -58,15 +60,17 @@ public class JavaTimerInstrumentation extends Instrumenter.Tracing
       if (period != 0) {
         return;
       }
-      ContextStore<Runnable, State> contextStore =
-          InstrumentationContext.get(Runnable.class, State.class);
-      capture(contextStore, task, true);
-      startQueuingTimer(contextStore, Timer.class, task);
+      if (!exclude(RUNNABLE, task)) {
+        ContextStore<Runnable, State> contextStore =
+            InstrumentationContext.get(Runnable.class, State.class);
+        capture(contextStore, task, true);
+        startQueuingTimer(contextStore, Timer.class, task);
+      }
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static void after(@Advice.Argument(0) TimerTask task, @Advice.Thrown Throwable thrown) {
-      if (null != thrown) {
+      if (null != thrown && !exclude(RUNNABLE, task)) {
         cancelTask(InstrumentationContext.get(Runnable.class, State.class), task);
       }
     }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/ThreadPoolExecutorInstrumentation.java
@@ -16,11 +16,9 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.ExcludeFilterProvider;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.api.Platform;
-import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
-import datadog.trace.bootstrap.instrumentation.java.concurrent.QueueTimerHelper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.TPEHelper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.Wrapper;
@@ -150,10 +148,7 @@ public final class ThreadPoolExecutorInstrumentation extends Instrumenter.Tracin
         if (TPEHelper.useWrapping(task)) {
           task = Wrapper.wrap(task);
         } else {
-          ContextStore<Runnable, State> contextStore =
-              InstrumentationContext.get(Runnable.class, State.class);
-          TPEHelper.capture(contextStore, task);
-          QueueTimerHelper.startQueuingTimer(contextStore, tpe.getClass(), task);
+          TPEHelper.capture(InstrumentationContext.get(Runnable.class, State.class), tpe, task);
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

* add missing checks to `JavaForkJoinPoolInstrumentation` and `JavaTimerInstrumentation`
* move `startQueuingTimer` from `ThreadPoolExecutorInstrumentation` to when we know we've captured the task in `TPEHelper`

# Motivation

Avoids attempts to access context-stores of task types that have been explicitly excluded.