### PR TITLE
Update flaky tests endpoint URI and response format

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -21,7 +21,7 @@ public class ConfigurationApiImpl implements ConfigurationApi {
 
   private static final String SETTINGS_URI = "libraries/tests/services/setting";
   private static final String SKIPPABLE_TESTS_URI = "ci/tests/skippable";
-  private static final String FLAKY_TESTS_URI = "libraries/ci/tests/flaky";
+  private static final String FLAKY_TESTS_URI = "ci/libraries/tests/flaky";
 
   private final BackendApi backendApi;
   private final Supplier<String> uuidGenerator;
@@ -74,20 +74,20 @@ public class ConfigurationApiImpl implements ConfigurationApi {
   @Override
   public Collection<TestIdentifier> getSkippableTests(TracerEnvironment tracerEnvironment)
       throws IOException {
-    return getTestsData(SKIPPABLE_TESTS_URI, tracerEnvironment);
+    return getTestsData(SKIPPABLE_TESTS_URI, "test_params", tracerEnvironment);
   }
 
   @Override
   public Collection<TestIdentifier> getFlakyTests(TracerEnvironment tracerEnvironment)
       throws IOException {
-    return getTestsData(FLAKY_TESTS_URI, tracerEnvironment);
+    return getTestsData(FLAKY_TESTS_URI, "flaky_test_from_libraries_params", tracerEnvironment);
   }
 
   private Collection<TestIdentifier> getTestsData(
-      String endpoint, TracerEnvironment tracerEnvironment) throws IOException {
+      String endpoint, String dataType, TracerEnvironment tracerEnvironment) throws IOException {
     String uuid = uuidGenerator.get();
     EnvelopeDto<TracerEnvironment> request =
-        new EnvelopeDto<>(new DataDto<>(uuid, "test_params", tracerEnvironment));
+        new EnvelopeDto<>(new DataDto<>(uuid, dataType, tracerEnvironment));
     String json = requestAdapter.toJson(request);
     RequestBody requestBody = RequestBody.create(JSON, json);
     Collection<DataDto<TestIdentifier>> response =


### PR DESCRIPTION
# What Does This Do
Updates URI and expected response format for the endpoint that provides the list of known flaky tests.

# Motivation
Fetching the list of flaky tests is needed for implementing flaky tests retries.
The backend API was unstable and has changed recently.

# Additional Notes
Flaky tests retries has not been officially released yet.

Jira ticket: [CIVIS-8243]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8243]: https://datadoghq.atlassian.net/browse/CIVIS-8243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ