### PR TITLE
lock aerospike to < 8

### DIFF
--- a/dd-java-agent/instrumentation/aerospike-4/build.gradle
+++ b/dd-java-agent/instrumentation/aerospike-4/build.gradle
@@ -6,7 +6,7 @@ muzzle {
   pass {
     group = 'com.aerospike'
     module = 'aerospike-client'
-    versions = "[4,)"
+    versions = "[4,8)"
     skipVersions += "4.4.19" // bad release
   }
 }
@@ -17,7 +17,7 @@ dependencies {
   testImplementation group: 'com.aerospike', name: 'aerospike-client', version: '4.0.0'
   testImplementation deps.testcontainers
 
-  latestDepTestImplementation group: 'com.aerospike', name: 'aerospike-client', version: '+'
+  latestDepTestImplementation group: 'com.aerospike', name: 'aerospike-client', version: '7.+'
 }
 
 tasks.withType(Test).configureEach {


### PR DESCRIPTION
# What Does This Do

Aerospike 8 requires java 21 according to the [release notes](https://download.aerospike.com/download/client/java/notes.html#8.0.0). We lock latestDep and muzzle since a jdk 21 will be officially part of the CI build


# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
