### PR TITLE
Fix issue for parsing classes from debugger.symbol

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
@@ -125,6 +125,9 @@ public class SymDBEnablement implements ProductListener {
         instrumentation.addTransformer(symbolExtractionTransformer);
         extractSymbolForLoadedClasses(allowListHelper);
         lastUploadTimestamp = System.currentTimeMillis();
+      } catch (Throwable ex) {
+        // catch all Throwables because LinkageError is possible (duplicate class definition)
+        LOGGER.debug("Error during symbol extraction: ", ex);
       } finally {
         symbolAggregator.loadedClassesProcessEnded();
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractionTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractionTransformer.java
@@ -50,8 +50,15 @@ public class SymbolExtractionTransformer implements ClassFileTransformer {
             || className.startsWith("com/datadog/")) {
           return null;
         }
-      } else if (!allowListHelper.isAllowed(Strings.getClassName(className))) {
-        return null;
+      } else {
+        String javaClassName = Strings.getClassName(className);
+        if (!allowListHelper.isAllowed(javaClassName)) {
+          return null;
+        }
+        if (javaClassName.startsWith("com.datadog.debugger.symbol.")) {
+          // Don't parse our own classes to avoid duplicate class definition
+          return null;
+        }
       }
       symbolAggregator.parseClass(className, classfileBuffer, protectionDomain);
       return null;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.condition.JRE;
 import org.mockito.Mockito;
 
 class SymbolExtractionTransformerTest {
-  private static final String SYMBOL_PACKAGE = "com.datadog.debugger.symbol.";
+  private static final String SYMBOL_PACKAGE = "com.datadog.debugger.symboltest.";
   private static final String SYMBOL_PACKAGE_DIR = SYMBOL_PACKAGE.replace('.', '/');
 
   private Instrumentation instr = ByteBuddyAgent.install();
@@ -558,7 +558,7 @@ class SymbolExtractionTransformerTest {
         mainMethodLocalScope.getSymbols().get(0),
         SymbolType.LOCAL,
         "winner",
-        "com.datadog.debugger.symbol.SymbolExtraction10$Inner",
+        "com.datadog.debugger.symboltest.SymbolExtraction10$Inner",
         5);
     Scope innerClassScope = symbolSinkMock.jarScopes.get(0).getScopes().get(1);
     assertScope(innerClassScope, ScopeType.CLASS, CLASS_NAME + "$Inner", 9, 13, SOURCE_FILE, 2, 1);
@@ -704,7 +704,8 @@ class SymbolExtractionTransformerTest {
         classScope.getLanguageSpecifics(),
         asList("public"),
         asList(
-            "@com.datadog.debugger.symbol.MyAnnotation", "@com.datadog.debugger.symbol.MyMarker"),
+            "@com.datadog.debugger.symboltest.MyAnnotation",
+            "@com.datadog.debugger.symboltest.MyMarker"),
         Object.class.getTypeName(),
         null,
         null);
@@ -712,7 +713,7 @@ class SymbolExtractionTransformerTest {
     assertLangSpecifics(
         mainMethodScope.getLanguageSpecifics(),
         asList("public", "static"),
-        asList("@com.datadog.debugger.symbol.MyAnnotation"),
+        asList("@com.datadog.debugger.symboltest.MyAnnotation"),
         null,
         null,
         Integer.TYPE.getTypeName());
@@ -721,7 +722,7 @@ class SymbolExtractionTransformerTest {
     assertLangSpecifics(
         intField.getLanguageSpecifics(),
         asList("private"),
-        asList("@com.datadog.debugger.symbol.MyAnnotation"),
+        asList("@com.datadog.debugger.symboltest.MyAnnotation"),
         null,
         null,
         null);
@@ -766,7 +767,7 @@ class SymbolExtractionTransformerTest {
         asList("public", "abstract"),
         null,
         Object.class.getTypeName(),
-        asList("com.datadog.debugger.symbol.I1", "com.datadog.debugger.symbol.I2"),
+        asList("com.datadog.debugger.symboltest.I1", "com.datadog.debugger.symboltest.I2"),
         null);
     assertEquals(4, classScope.getScopes().size());
     Scope m1MethodScope = classScope.getScopes().get(2);

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction01.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction01.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 public class SymbolExtraction01 {
   public static int main(String arg) {
     int var1 = 1;

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction02.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction02.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction02 {
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction03.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction03.java
@@ -1,5 +1,5 @@
 
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction03 {
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction04.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction04.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction04 {
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction05.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction05 {
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction06.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction06.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction06 {
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction07.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction07.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction07 {
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction08.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction08.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction08 {
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction09.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction09.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 import java.util.function.Supplier;
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction10.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction10.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction10 {
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction11.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction11.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 public class SymbolExtraction11 {
   private final int field1 = 1;

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction12.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction12.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 import java.util.Arrays;
 import java.util.List;

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction13.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction13.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 import org.junit.jupiter.api.Test;
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction14.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction14.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 import org.junit.jupiter.api.Test;
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction15.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/symboltest/SymbolExtraction15.java
@@ -1,4 +1,4 @@
-package com.datadog.debugger.symbol;
+package com.datadog.debugger.symboltest;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
# What Does This Do
Hard code exclusion of `com.datadog.debugger.symbol` package to avoid duplicate class definition when loading a class from this package that will be transform by SymbolExtractionTransformer

# Motivation

# Additional Notes


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
