### PR TITLE
Capture relationships between spark SQL stages

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkSQLUtils.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkSQLUtils.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -30,7 +29,7 @@ public class SparkSQLUtils {
     SparkPlanInfoForStage planForStage =
         computeStageInfoForStage(plan, accumulators, stageId, parentStageIds, false);
 
-    span.setTag("_dd.spark.sql_parent_stage_ids", Arrays.toString(parentStageIds.toArray()));
+    span.setTag("_dd.spark.sql_parent_stage_ids", parentStageIds.toString());
 
     if (planForStage != null) {
       String json = planForStage.toJson(accumulators);

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSpark32SqlTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSpark32SqlTest.groovy
@@ -30,10 +30,10 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
     """).show()
     sparkSession.stop()
 
-    def firstStagePlan = """{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":3,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"WholeStageCodegen (1)","metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","metrics":[{"number of output rows":3,"type":"sum"},{"peak memory":"any","type":"size"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"LocalTableScan","metrics":[{"number of output rows":3,"type":"sum"}]}]}]}]}"""
-    def secondStagePlan = """{"node":"WholeStageCodegen (2)","metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","metrics":[{"avg hash probe bucket list iters":"any","type":"average"},{"number of output rows":2,"type":"sum"},{"peak memory":"any","type":"size"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"InputAdapter","children":[{"node":"AQEShuffleRead","metrics":[],"children":[{"node":"ShuffleQueryStage","children":[{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":3,"type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":3,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}"""
-    def thirdStagePlan = """{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":2,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"WholeStageCodegen (2)","metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","metrics":[{"avg hash probe bucket list iters":"any","type":"average"},{"number of output rows":"any","type":"sum"},{"peak memory":"any","type":"size"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"InputAdapter","children":[{"node":"AQEShuffleRead","metrics":[],"children":[{"node":"ShuffleQueryStage","children":[{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":"any","type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}]}"""
-    def fourthStagePlan = """{"node":"WholeStageCodegen (3)","metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"Project","children":[{"node":"Sort","metrics":[{"peak memory":"any","type":"size"},{"sort time":"any","type":"timing"},{"spill size":"any","type":"size"}],"children":[{"node":"InputAdapter","children":[{"node":"AQEShuffleRead","metrics":[],"children":[{"node":"ShuffleQueryStage","children":[{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":2,"type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":2,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}]}"""
+    def firstStagePlan = """{"node":"Exchange","nodeId":-1478732333,"metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":3,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"WholeStageCodegen (1)","nodeId":-2095665476,"metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","nodeId":1128016273,"metrics":[{"number of output rows":3,"type":"sum"},{"peak memory":"any","type":"size"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"LocalTableScan","nodeId":1632930767,"metrics":[{"number of output rows":3,"type":"sum"}]}]}]}]}"""
+    def secondStagePlan = """{"node":"WholeStageCodegen (2)","nodeId":-2095665445,"metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","nodeId":126020943,"metrics":[{"avg hash probe bucket list iters":"any","type":"average"},{"number of output rows":2,"type":"sum"},{"peak memory":"any","type":"size"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"InputAdapter","nodeId":180293,"children":[{"node":"AQEShuffleRead","nodeId":859212759,"metrics":[],"children":[{"node":"ShuffleQueryStage","nodeId":1722565407,"children":[{"node":"Exchange","nodeId":-1478732333,"metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":3,"type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":3,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}"""
+    def thirdStagePlan = """{"node":"Exchange","nodeId":1918740223,"metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":2,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"WholeStageCodegen (2)","nodeId":-2095665445,"metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","nodeId":126020943,"metrics":[{"avg hash probe bucket list iters":"any","type":"average"},{"number of output rows":"any","type":"sum"},{"peak memory":"any","type":"size"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"InputAdapter","nodeId":180293,"children":[{"node":"AQEShuffleRead","nodeId":859212759,"metrics":[],"children":[{"node":"ShuffleQueryStage","nodeId":1722565407,"children":[{"node":"Exchange","nodeId":-1478732333,"metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":"any","type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}]}"""
+    def fourthStagePlan = """{"node":"WholeStageCodegen (3)","nodeId":-2095665414,"metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"Project","nodeId":-437821613,"children":[{"node":"Sort","nodeId":-1103360848,"metrics":[{"peak memory":"any","type":"size"},{"sort time":"any","type":"timing"},{"spill size":"any","type":"size"}],"children":[{"node":"InputAdapter","nodeId":180293,"children":[{"node":"AQEShuffleRead","nodeId":859212759,"metrics":[],"children":[{"node":"ShuffleQueryStage","nodeId":1722565408,"children":[{"node":"Exchange","nodeId":1918740223,"metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":2,"type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":2,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}]}"""
 
     expect:
     assertTraces(1) {
@@ -57,6 +57,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
           spanType "spark"
           childOf(span(2))
           AbstractSpark24SqlTest.assertStringSQLPlanEquals(fourthStagePlan, span.tags["_dd.spark.sql_plan"].toString())
+          assert span.tags["_dd.spark.sql_parent_stage_ids"] == "[4]"
         }
         span {
           operationName "spark.job"
@@ -68,6 +69,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
           spanType "spark"
           childOf(span(4))
           AbstractSpark24SqlTest.assertStringSQLPlanEquals(thirdStagePlan, span.tags["_dd.spark.sql_plan"].toString())
+          assert span.tags["_dd.spark.sql_parent_stage_ids"] == "[0]"
         }
         span {
           operationName "spark.job"
@@ -79,6 +81,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
           spanType "spark"
           childOf(span(6))
           AbstractSpark24SqlTest.assertStringSQLPlanEquals(secondStagePlan, span.tags["_dd.spark.sql_plan"].toString())
+          assert span.tags["_dd.spark.sql_parent_stage_ids"] == "[0]"
         }
         span {
           operationName "spark.job"
@@ -90,6 +93,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
           spanType "spark"
           childOf(span(8))
           AbstractSpark24SqlTest.assertStringSQLPlanEquals(firstStagePlan, span.tags["_dd.spark.sql_plan"].toString())
+          assert span.tags["_dd.spark.sql_parent_stage_ids"] == "[]"
         }
       }
     }
@@ -114,10 +118,10 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
 
     sparkSession.stop()
 
-    def firstStagePlan = """{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"LocalTableScan","metrics":[{"number of output rows":"any","type":"sum"}]}]}"""
-    def secondStagePlan = """{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"LocalTableScan","metrics":[{"number of output rows":"any","type":"sum"}]}]}"""
-    def thirdStagePlan = """{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":1,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"WholeStageCodegen (3)","metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","metrics":[{"number of output rows":1,"type":"sum"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"Project","children":[{"node":"SortMergeJoin","metrics":[{"number of output rows":"any","type":"sum"}],"children":[{"node":"InputAdapter","children":[{"node":"WholeStageCodegen (1)","metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"Sort","metrics":[{"peak memory":"any","type":"size"},{"sort time":"any","type":"timing"},{"spill size":"any","type":"size"}],"children":[{"node":"InputAdapter","children":[{"node":"AQEShuffleRead","metrics":[],"children":[{"node":"ShuffleQueryStage","children":[{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":"any","type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}]},{"node":"InputAdapter","children":[{"node":"WholeStageCodegen (2)","metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"Sort","metrics":[{"peak memory":"any","type":"size"},{"sort time":"any","type":"timing"},{"spill size":"any","type":"size"}],"children":[{"node":"InputAdapter","children":[{"node":"AQEShuffleRead","metrics":[],"children":[{"node":"ShuffleQueryStage","children":[{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":"any","type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}]}]}]}]}]}]}"""
-    def fourthStagePlan = """{"node":"WholeStageCodegen (4)","metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","metrics":[{"number of output rows":"any","type":"sum"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"InputAdapter","children":[{"node":"ShuffleQueryStage","children":[{"node":"Exchange","metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":"any","type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}"""
+    def firstStagePlan = """{"node":"Exchange","nodeId":"any","metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"LocalTableScan","nodeId":"any","metrics":[{"number of output rows":"any","type":"sum"}]}]}"""
+    def secondStagePlan = """{"node":"Exchange","nodeId":"any","metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"LocalTableScan","nodeId":"any","metrics":[{"number of output rows":"any","type":"sum"}]}]}"""
+    def thirdStagePlan = """{"node":"Exchange","nodeId":-178148375,"metrics":[{"data size":"any","type":"size"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":1,"type":"sum"},{"shuffle write time":"any","type":"nsTiming"}],"children":[{"node":"WholeStageCodegen (3)","nodeId":-2095665414,"metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","nodeId":-879128980,"metrics":[{"number of output rows":1,"type":"sum"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"Project","nodeId":1355342585,"children":[{"node":"SortMergeJoin","nodeId":-827855373,"metrics":[{"number of output rows":"any","type":"sum"}],"children":[{"node":"InputAdapter","nodeId":180293,"children":[{"node":"WholeStageCodegen (1)","nodeId":-2095665476,"metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"Sort","nodeId":-1716348417,"metrics":[{"peak memory":"any","type":"size"},{"sort time":"any","type":"timing"},{"spill size":"any","type":"size"}],"children":[{"node":"InputAdapter","nodeId":180293,"children":[{"node":"AQEShuffleRead","nodeId":859212759,"metrics":[],"children":[{"node":"ShuffleQueryStage","nodeId":1722565407,"children":[{"node":"Exchange","nodeId":1119987703,"metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":"any","type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}]},{"node":"InputAdapter","nodeId":180293,"children":[{"node":"WholeStageCodegen (2)","nodeId":-2095665445,"metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"Sort","nodeId":505172550,"metrics":[{"peak memory":"any","type":"size"},{"sort time":"any","type":"timing"},{"spill size":"any","type":"size"}],"children":[{"node":"InputAdapter","nodeId":180293,"children":[{"node":"AQEShuffleRead","nodeId":859212759,"metrics":[],"children":[{"node":"ShuffleQueryStage","nodeId":1722565408,"children":[{"node":"Exchange","nodeId":-26878534,"metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":"any","type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}]}]}]}]}]}]}]}"""
+    def fourthStagePlan = """{"node":"WholeStageCodegen (4)","nodeId":-2095665383,"metrics":[{"duration":"any","type":"timing"}],"children":[{"node":"HashAggregate","nodeId":724815342,"metrics":[{"number of output rows":"any","type":"sum"},{"time in aggregation build":"any","type":"timing"}],"children":[{"node":"InputAdapter","nodeId":180293,"children":[{"node":"ShuffleQueryStage","nodeId":1722565409,"children":[{"node":"Exchange","nodeId":-178148375,"metrics":[{"data size":"any","type":"size"},{"fetch wait time":"any","type":"timing"},{"local blocks read":"any","type":"sum"},{"local bytes read":"any","type":"size"},{"records read":"any","type":"sum"},{"shuffle bytes written":"any","type":"size"},{"shuffle records written":"any","type":"sum"},{"shuffle write time":"any","type":"nsTiming"}]}]}]}]}]}"""
 
     expect:
     assertTraces(1) {
@@ -141,6 +145,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
           spanType "spark"
           childOf(span(2))
           AbstractSpark24SqlTest.assertStringSQLPlanEquals(fourthStagePlan, span.tags["_dd.spark.sql_plan"].toString())
+          assert span.tags["_dd.spark.sql_parent_stage_ids"] == "[4]"
         }
         span {
           operationName "spark.job"
@@ -152,6 +157,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
           spanType "spark"
           childOf(span(4))
           AbstractSpark24SqlTest.assertStringSQLPlanEquals(thirdStagePlan, span.tags["_dd.spark.sql_plan"].toString())
+          assert ["[0, 1]", "[1, 0]"].contains(span.tags["_dd.spark.sql_parent_stage_ids"])
         }
         span {
           operationName "spark.job"
@@ -163,6 +169,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
           spanType "spark"
           childOf(span(6))
           AbstractSpark24SqlTest.assertStringSQLPlanEquals(secondStagePlan, span.tags["_dd.spark.sql_plan"].toString())
+          assert span.tags["_dd.spark.sql_parent_stage_ids"] == "[]"
         }
         span {
           operationName "spark.job"
@@ -174,6 +181,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
           spanType "spark"
           childOf(span(8))
           AbstractSpark24SqlTest.assertStringSQLPlanEquals(firstStagePlan, span.tags["_dd.spark.sql_plan"].toString())
+          assert span.tags["_dd.spark.sql_parent_stage_ids"] == "[]"
         }
       }
     }


### PR DESCRIPTION
# What Does This Do

Relationships are captured with the two new fields
- `_dd.spark.sql_parent_stage_ids`, the list of stageIds that the current stage is dependant on
- `nodeId` for each node of the existing JSON plan in `_dd.spark.sql_plan`. It allows to capture which SQL nodes are used by multiple stages

# Motivation

Capture relationships between spark SQL stages so that they can be displayed linked together

# Additional Notes

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
