### PR TITLE
Enable diagnostics on debugger track

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -54,9 +54,7 @@ public class DebuggerAgent {
     String diagnosticEndpoint = getDiagnosticEndpoint(config, ddAgentFeaturesDiscovery);
     ProbeStatusSink probeStatusSink =
         new ProbeStatusSink(
-            config,
-            diagnosticEndpoint, /*ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics()*/
-            false);
+            config, diagnosticEndpoint, ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics());
     DebuggerSink debuggerSink = new DebuggerSink(config, probeStatusSink);
     debuggerSink.start();
     ConfigurationUpdater configurationUpdater =
@@ -116,10 +114,9 @@ public class DebuggerAgent {
 
   private static String getDiagnosticEndpoint(
       Config config, DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery) {
-    //    if (ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics()) {
-    //      return config.getAgentUrl() + "/" +
-    // DDAgentFeaturesDiscovery.DEBUGGER_DIAGNOSTICS_ENDPOINT;
-    //    }
+    if (ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics()) {
+      return config.getAgentUrl() + "/" + DDAgentFeaturesDiscovery.DEBUGGER_DIAGNOSTICS_ENDPOINT;
+    }
     return config.getFinalDebuggerSnapshotUrl();
   }
 


### PR DESCRIPTION
Manually reverts https://github.com/DataDog/dd-trace-java/pull/6367

# Motivation
Enable diagnostics to be sent to DEBUGGER track if datadog agent supports it.

# Additional Notes


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
