### PR TITLE
support PATCH and other custom jaxrs annotations

### DIFF
--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsDecorator.java
@@ -122,8 +122,10 @@ public class JakartaRsAnnotationsDecorator extends BaseDecorator {
   private String locateHttpMethod(final Method method) {
     String httpMethod = null;
     for (final Annotation ann : method.getDeclaredAnnotations()) {
-      if (ann.annotationType().getAnnotation(HttpMethod.class) != null) {
-        httpMethod = ann.annotationType().getSimpleName();
+      final HttpMethod annotation = ann.annotationType().getAnnotation(HttpMethod.class);
+      if (annotation != null) {
+        httpMethod = annotation.value();
+        break;
       }
     }
     return httpMethod;

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
@@ -16,13 +16,17 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import jakarta.ws.rs.container.AsyncResponse;
 import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -35,6 +39,20 @@ public final class JakartaRsAnnotationsInstrumentation extends Instrumenter.Trac
 
   public JakartaRsAnnotationsInstrumentation() {
     super("jakarta-rs", "jakartars", "jakarta-rs-annotations");
+  }
+
+  private Collection<String> getJaxRsAnnotations() {
+    final Set<String> ret = new HashSet<>();
+    ret.add("jakarta.ws.rs.Path");
+    ret.add("jakarta.ws.rs.DELETE");
+    ret.add("jakarta.ws.rs.GET");
+    ret.add("jakarta.ws.rs.HEAD");
+    ret.add("jakarta.ws.rs.OPTIONS");
+    ret.add("jakarta.ws.rs.POST");
+    ret.add("jakarta.ws.rs.PUT");
+    ret.add("jakarta.ws.rs.PATCH");
+    ret.addAll(InstrumenterConfig.get().getAdditionalJaxRsAnnotations());
+    return ret;
   }
 
   @Override
@@ -66,18 +84,7 @@ public final class JakartaRsAnnotationsInstrumentation extends Instrumenter.Trac
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        isMethod()
-            .and(
-                hasSuperMethod(
-                    isAnnotatedWith(
-                        namedOneOf(
-                            "jakarta.ws.rs.Path",
-                            "jakarta.ws.rs.DELETE",
-                            "jakarta.ws.rs.GET",
-                            "jakarta.ws.rs.HEAD",
-                            "jakarta.ws.rs.OPTIONS",
-                            "jakarta.ws.rs.POST",
-                            "jakarta.ws.rs.PUT")))),
+        isMethod().and(hasSuperMethod(isAnnotatedWith(namedOneOf(getJaxRsAnnotations())))),
         JakartaRsAnnotationsInstrumentation.class.getName() + "$JakartaRsAnnotationsAdvice");
   }
 

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/test/groovy/JakartaRsAnnotations3InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/test/groovy/JakartaRsAnnotations3InstrumentationTest.groovy
@@ -1,4 +1,5 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.jakarta3.JakartaRsAnnotationsDecorator
 
@@ -6,6 +7,7 @@ import jakarta.ws.rs.DELETE
 import jakarta.ws.rs.GET
 import jakarta.ws.rs.HEAD
 import jakarta.ws.rs.OPTIONS
+import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.PUT
 import jakarta.ws.rs.Path
@@ -42,6 +44,7 @@ class JakartaRsAnnotations3InstrumentationTest extends AgentTestRunner {
 
   def "span named '#name' from annotations on class when is not root span"() {
     setup:
+    injectSysConfig(TraceInstrumentationConfig.JAX_RS_ADDITIONAL_ANNOTATIONS, "CustomMethod")
     runUnderTrace("test") {
       obj.call()
     }
@@ -93,6 +96,16 @@ class JakartaRsAnnotations3InstrumentationTest extends AgentTestRunner {
       }
     "HEAD /interface"    | new InterfaceWithPath() {
         @HEAD
+        void call() {
+        }
+      }
+    "PATCH /interface"    | new InterfaceWithPath() {
+        @PATCH
+        void call() {
+        }
+      }
+    "CUSTOM /interface"    | new InterfaceWithPath() {
+        @CustomMethod
         void call() {
         }
       }

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/test/java/CustomMethod.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/test/java/CustomMethod.java
@@ -1,0 +1,10 @@
+import jakarta.ws.rs.HttpMethod;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@HttpMethod("CUSTOM")
+public @interface CustomMethod {}

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -113,8 +113,10 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   private String locateHttpMethod(final Method method) {
     String httpMethod = null;
     for (final Annotation ann : method.getDeclaredAnnotations()) {
-      if (ann.annotationType().getAnnotation(HttpMethod.class) != null) {
-        httpMethod = ann.annotationType().getSimpleName();
+      final HttpMethod annotation = ann.annotationType().getAnnotation(HttpMethod.class);
+      if (annotation != null) {
+        httpMethod = annotation.value();
+        break;
       }
     }
     return httpMethod;

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -17,9 +17,13 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -32,6 +36,20 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Tracing
 
   public JaxRsAnnotationsInstrumentation() {
     super("jax-rs", "jaxrs", "jax-rs-annotations");
+  }
+
+  private Collection<String> getJaxRsAnnotations() {
+    final Set<String> ret = new HashSet<>();
+    ret.add("javax.ws.rs.Path");
+    ret.add("javax.ws.rs.DELETE");
+    ret.add("javax.ws.rs.GET");
+    ret.add("javax.ws.rs.HEAD");
+    ret.add("javax.ws.rs.OPTIONS");
+    ret.add("javax.ws.rs.POST");
+    ret.add("javax.ws.rs.PUT");
+    ret.add("io.dropwizard.jersey.PATCH");
+    ret.addAll(InstrumenterConfig.get().getAdditionalJaxRsAnnotations());
+    return ret;
   }
 
   @Override
@@ -64,18 +82,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Tracing
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        isMethod()
-            .and(
-                hasSuperMethod(
-                    isAnnotatedWith(
-                        namedOneOf(
-                            "javax.ws.rs.Path",
-                            "javax.ws.rs.DELETE",
-                            "javax.ws.rs.GET",
-                            "javax.ws.rs.HEAD",
-                            "javax.ws.rs.OPTIONS",
-                            "javax.ws.rs.POST",
-                            "javax.ws.rs.PUT")))),
+        isMethod().and(hasSuperMethod(isAnnotatedWith(namedOneOf(getJaxRsAnnotations())))),
         JaxRsAnnotationsInstrumentation.class.getName() + "$JaxRsAnnotationsAdvice");
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -1,6 +1,10 @@
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.jaxrs1.JaxRsAnnotationsDecorator
+import io.dropwizard.jersey.PATCH
 
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
@@ -9,8 +13,6 @@ import javax.ws.rs.OPTIONS
 import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
-
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
 
@@ -42,6 +44,7 @@ class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
 
   def "span named '#name' from annotations on class when is not root span"() {
     setup:
+    injectSysConfig(TraceInstrumentationConfig.JAX_RS_ADDITIONAL_ANNOTATIONS, "CustomMethod")
     runUnderTrace("test") {
       obj.call()
     }
@@ -93,6 +96,16 @@ class JaxRsAnnotations1InstrumentationTest extends AgentTestRunner {
       }
     "HEAD /interface"    | new InterfaceWithPath() {
         @HEAD
+        void call() {
+        }
+      }
+    "PATCH /interface"    | new InterfaceWithPath() {
+        @PATCH
+        void call() {
+        }
+      }
+    "CUSTOM /interface"    | new InterfaceWithPath() {
+        @CustomMethod
         void call() {
         }
       }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/java/CustomMethod.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/test/java/CustomMethod.java
@@ -1,0 +1,10 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.HttpMethod;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@HttpMethod("CUSTOM")
+public @interface CustomMethod {}

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -129,8 +129,10 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   private String locateHttpMethod(final Method method) {
     String httpMethod = null;
     for (final Annotation ann : method.getDeclaredAnnotations()) {
-      if (ann.annotationType().getAnnotation(HttpMethod.class) != null) {
-        httpMethod = ann.annotationType().getSimpleName();
+      final HttpMethod annotation = ann.annotationType().getAnnotation(HttpMethod.class);
+      if (annotation != null) {
+        httpMethod = annotation.value();
+        break;
       }
     }
     return httpMethod;

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -17,12 +17,16 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.container.AsyncResponse;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -36,6 +40,21 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Tracing
 
   public JaxRsAnnotationsInstrumentation() {
     super("jax-rs", "jaxrs", "jax-rs-annotations");
+  }
+
+  private Collection<String> getJaxRsAnnotations() {
+    final Set<String> ret = new HashSet<>();
+    ret.add("javax.ws.rs.Path");
+    ret.add("javax.ws.rs.DELETE");
+    ret.add("javax.ws.rs.GET");
+    ret.add("javax.ws.rs.HEAD");
+    ret.add("javax.ws.rs.OPTIONS");
+    ret.add("javax.ws.rs.POST");
+    ret.add("javax.ws.rs.PUT");
+    ret.add("javax.ws.rs.PATCH"); // come with 2.1 spec
+    ret.add("io.dropwizard.jersey.PATCH");
+    ret.addAll(InstrumenterConfig.get().getAdditionalJaxRsAnnotations());
+    return ret;
   }
 
   @Override
@@ -73,18 +92,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Tracing
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
     transformation.applyAdvice(
-        isMethod()
-            .and(
-                hasSuperMethod(
-                    isAnnotatedWith(
-                        namedOneOf(
-                            "javax.ws.rs.Path",
-                            "javax.ws.rs.DELETE",
-                            "javax.ws.rs.GET",
-                            "javax.ws.rs.HEAD",
-                            "javax.ws.rs.OPTIONS",
-                            "javax.ws.rs.POST",
-                            "javax.ws.rs.PUT")))),
+        isMethod().and(hasSuperMethod(isAnnotatedWith(namedOneOf(getJaxRsAnnotations())))),
         JaxRsAnnotationsInstrumentation.class.getName() + "$JaxRsAnnotationsAdvice");
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
@@ -1,6 +1,8 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.jaxrs2.JaxRsAnnotationsDecorator
+import io.dropwizard.jersey.PATCH
 
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
@@ -42,6 +44,7 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
 
   def "span named '#name' from annotations on class when is not root span"() {
     setup:
+    injectSysConfig(TraceInstrumentationConfig.JAX_RS_ADDITIONAL_ANNOTATIONS, "CustomMethod")
     runUnderTrace("test") {
       obj.call()
     }
@@ -99,6 +102,16 @@ class JaxRsAnnotations2InstrumentationTest extends AgentTestRunner {
     "POST /abstract/d"   | new AbstractClassWithPath() {
         @POST
         @Path("/d")
+        void call() {
+        }
+      }
+    "PATCH /interface"    | new InterfaceWithPath() {
+        @PATCH
+        void call() {
+        }
+      }
+    "CUSTOM /interface"    | new InterfaceWithPath() {
+        @CustomMethod
         void call() {
         }
       }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/java/CustomMethod.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/test/java/CustomMethod.java
@@ -1,0 +1,10 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.HttpMethod;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@HttpMethod("CUSTOM")
+public @interface CustomMethod {}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -134,6 +134,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String JAX_RS_EXCEPTION_AS_ERROR_ENABLED =
       "trace.jax-rs.exception-as-error.enabled";
+  public static final String JAX_RS_ADDITIONAL_ANNOTATIONS = "trace.jax-rs.additional.annotations";
 
   private TraceInstrumentationConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -28,6 +28,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED_DEFAULT;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_URL_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.JAX_RS_ADDITIONAL_ANNOTATIONS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JDBC_PREPARED_STATEMENT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.LEGACY_INSTALLER_ENABLED;
@@ -61,6 +62,7 @@ import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -129,6 +131,8 @@ public class InstrumenterConfig {
   private final boolean internalExitOnFailure;
 
   private final boolean legacyInstallerEnabled;
+
+  private final Collection<String> additionalJaxRsAnnotations;
 
   private InstrumenterConfig() {
     this(ConfigProvider.createDefault());
@@ -218,6 +222,8 @@ public class InstrumenterConfig {
     internalExitOnFailure = configProvider.getBoolean(INTERNAL_EXIT_ON_FAILURE, false);
 
     legacyInstallerEnabled = configProvider.getBoolean(LEGACY_INSTALLER_ENABLED, false);
+    this.additionalJaxRsAnnotations =
+        tryMakeImmutableSet(configProvider.getList(JAX_RS_ADDITIONAL_ANNOTATIONS));
   }
 
   public boolean isIntegrationsEnabled() {
@@ -371,6 +377,10 @@ public class InstrumenterConfig {
     return traceAnnotations;
   }
 
+  public Collection<String> getAdditionalJaxRsAnnotations() {
+    return additionalJaxRsAnnotations;
+  }
+
   /**
    * Check whether asynchronous result types are supported with @Trace annotation.
    *
@@ -494,6 +504,8 @@ public class InstrumenterConfig {
         + internalExitOnFailure
         + ", legacyInstallerEnabled="
         + legacyInstallerEnabled
+        + ", additionalJaxRsAnnotations="
+        + additionalJaxRsAnnotations
         + '}';
   }
 }


### PR DESCRIPTION
# What Does This Do

Supports the following jaxrs annotations:
* `io.dropwizard.jersey.PATCH` (custom for dropwizard)
* `javax.rs.ws.PATCH` (standard from jaxrs 2.1)
* `jakarta.rs.ws.PATCH` (standard)

Also allows including other annotations for method advising by providing comma separed list of annotation classnames on the system property `dd.trace.jax-rs.additional.annotations` or the env `DD_TRACE_JAX_RS_ADDITIONAL_ANNOTATIONS`

Please note that, for simplicity, we do not check that the annotation is complying with the jaxrs spec (i.e. be annotated with `@HttpMethod`). 

Also, the method name on the resource is no more the annotation name (that's conceptually wrong) but the value of the annotation `HttpMethod`. This is not a breaking change since today the annotations have the same name than the http method names declared. However, for custom annotation, this allows for a proper resource name attribution

# Motivation

# Additional Notes

Jira ticket: [APMS-10887]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-10887]: https://datadoghq.atlassian.net/browse/APMS-10887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ