### PR TITLE
Don't create a process span for agent internal threads

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.java.lang;
 
+import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
+
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
@@ -16,6 +18,11 @@ class ProcessImplStartAdvice {
     }
 
     if (command.length == 0) {
+      return null;
+    }
+
+    // Don't create spans for agent threads
+    if (AGENT_THREAD_GROUP.equals(Thread.currentThread().getThreadGroup())) {
       return null;
     }
 


### PR DESCRIPTION
# What Does This Do

Skips creating a process span for process execution that is initialized from one of the agent internal threads.

# Motivation

Internal calls to `hostname` and other commands from the agent during setup runs at various times and pollute smoke tests with unrelated traces.
