### PR TITLE
Support delayed trigger of local triage report

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -11,6 +11,7 @@ import datadog.trace.agent.tooling.bytebuddy.outline.TypePoolFacade;
 import datadog.trace.agent.tooling.usm.UsmExtractorImpl;
 import datadog.trace.agent.tooling.usm.UsmMessageFactoryImpl;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.Platform;
 import datadog.trace.api.ProductActivation;
 import datadog.trace.api.telemetry.IntegrationsCollector;
 import datadog.trace.bootstrap.FieldBackedContextAccessor;
@@ -198,7 +199,9 @@ public class AgentInstaller {
       log.debug("Installed {} instrumenter(s)", installedCount);
     }
 
-    InstrumenterFlare.register();
+    if (!Platform.isNativeImageBuilder()) {
+      InstrumenterFlare.register();
+    }
 
     if (InstrumenterConfig.get().isTelemetryEnabled()) {
       InstrumenterState.setObserver(

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -30,6 +30,8 @@ public final class GeneralConfig {
 
   public static final String TRACE_DEBUG = "trace.debug";
   public static final String TRACE_TRIAGE = "trace.triage";
+  public static final String TRIAGE_REPORT_TRIGGER = "triage.report.trigger";
+  public static final String TRIAGE_REPORT_DIR = "triage.report.dir";
 
   public static final String STARTUP_LOGS_ENABLED = "trace.startup.logs";
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -95,7 +95,8 @@ final class TracerFlareService {
 
   private void scheduleTriageReport(long delayInSeconds) {
     Path triagePath = Paths.get(config.getTriageReportDir());
-    scheduler.schedule(() -> prepareForFlare("triage"), delayInSeconds - 60, TimeUnit.SECONDS);
+    // prepare at most 10 minutes before collection of the report, to match remote flare behaviour
+    scheduler.schedule(() -> prepareForFlare("triage"), delayInSeconds - 600, TimeUnit.SECONDS);
     scheduler.schedule(
         () -> {
           try {

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -17,8 +17,13 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipOutputStream;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -35,7 +40,11 @@ final class TracerFlareService {
 
   private static final String FLARE_ENDPOINT = "tracer_flare/v1";
 
+  private static final String REPORT_PREFIX = "dd-java-flare-";
+
   private static final MediaType OCTET_STREAM = MediaType.get("application/octet-stream");
+
+  private static final Pattern DELAY_TRIGGER = Pattern.compile("(\\d+)([HhMmSs]?)");
 
   private final AgentTaskScheduler scheduler = new AgentTaskScheduler(TRACER_FLARE);
 
@@ -60,6 +69,48 @@ final class TracerFlareService {
     this.okHttpClient = okHttpClient;
     this.flareUrl = agentUrl.newBuilder().addPathSegments(FLARE_ENDPOINT).build();
     this.tracer = tracer;
+
+    applyTriageReportTrigger(config.getTriageReportTrigger());
+  }
+
+  private void applyTriageReportTrigger(String triageTrigger) {
+    if (null != triageTrigger && !triageTrigger.isEmpty()) {
+      Matcher delayMatcher = DELAY_TRIGGER.matcher(triageTrigger);
+      if (delayMatcher.matches()) {
+        long delay = Integer.parseInt(delayMatcher.group(1));
+        String unit = delayMatcher.group(2);
+        if ("H".equalsIgnoreCase(unit)) {
+          delay = TimeUnit.HOURS.toSeconds(delay);
+        } else if ("M".equalsIgnoreCase(unit)) {
+          delay = TimeUnit.MINUTES.toSeconds(delay);
+        } else {
+          // already in seconds
+        }
+        scheduleTriageReport(delay);
+      } else {
+        log.info("Unrecognized triage trigger {}", triageTrigger);
+      }
+    }
+  }
+
+  private void scheduleTriageReport(long delayInSeconds) {
+    Path triagePath = Paths.get(config.getTriageReportDir());
+    scheduler.schedule(() -> prepareForFlare("triage"), delayInSeconds - 60, TimeUnit.SECONDS);
+    scheduler.schedule(
+        () -> {
+          try {
+            String reportName = REPORT_PREFIX + System.currentTimeMillis() + ".zip";
+            Path reportPath = triagePath.resolve(reportName);
+            log.info("Writing triage report to {}", reportPath);
+            Files.write(reportPath, buildFlareZip(true));
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          } finally {
+            cleanupAfterFlare();
+          }
+        },
+        delayInSeconds,
+        TimeUnit.SECONDS);
   }
 
   public synchronized void prepareForFlare(String logLevel) {
@@ -112,7 +163,7 @@ final class TracerFlareService {
   void doSend(String caseId, String email, String hostname, boolean dumpThreads) {
     log.debug("Sending tracer flare");
     try {
-      String flareName = "java-flare-" + caseId + "-" + System.currentTimeMillis() + ".zip";
+      String flareName = REPORT_PREFIX + caseId + "-" + System.currentTimeMillis() + ".zip";
 
       RequestBody report = RequestBody.create(OCTET_STREAM, buildFlareZip(dumpThreads));
 


### PR DESCRIPTION
To schedule a triage report two minutes after startup add this JVM option:
```
-Ddd.triage.report.trigger=2m
```
or set this environment variable:
```
DD_TRIAGE_REPORT_TRIGGER=2m
```
Units of `h` (hours) and `s` (seconds) are also accepted, the default unit when omitted is seconds.

The report will be written to `$TMPDIR` by default, to choose a different location use:
```
-Ddd.triage.report.dir=/example/reports/
```
or
```
DD_TRIAGE_REPORT_DIR=/example/reports/
```
the report zip will be named `dd-java-flare-<epoch-time-in-millis>.zip`

# Motivation

For situations where remote-config or the tracer-flare endpoint is not available but we'd like to capture a triage report.

Jira ticket: [APMJAVA-1078]


[APMJAVA-1078]: https://datadoghq.atlassian.net/browse/APMJAVA-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ