### PR TITLE
Add `@exception` as local var in snapshots

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -193,11 +193,8 @@ public class CapturedContext implements ValueReferenceResolver {
     if (values == null) {
       return;
     }
-    if (arguments == null) {
-      arguments = new HashMap<>();
-    }
     for (CapturedValue value : values) {
-      arguments.put(value.name, value);
+      putInArguments(value.name, value);
     }
   }
 
@@ -205,11 +202,8 @@ public class CapturedContext implements ValueReferenceResolver {
     if (values == null) {
       return;
     }
-    if (locals == null) {
-      locals = new HashMap<>();
-    }
     for (CapturedValue value : values) {
-      locals.put(value.name, value);
+      putInLocals(value.name, value);
     }
   }
 
@@ -217,20 +211,15 @@ public class CapturedContext implements ValueReferenceResolver {
     if (retValue == null) {
       return;
     }
-    if (locals == null) {
-      locals = new HashMap<>();
-    }
-    locals.put(ValueReferences.RETURN_REF, retValue); // special local name for the return value
+    // special local name for the return value
+    putInLocals(ValueReferences.RETURN_REF, retValue);
     extensions.put(ValueReferences.RETURN_EXTENSION_NAME, retValue);
   }
 
   public void addThrowable(Throwable t) {
     addThrowable(new CapturedThrowable(t));
-    if (locals == null) {
-      locals = new HashMap<>();
-    }
     // special local name for throwable
-    locals.put(ValueReferences.EXCEPTION_REF, CapturedValue.of(t.getClass().getTypeName(), t));
+    putInLocals(ValueReferences.EXCEPTION_REF, CapturedValue.of(t.getClass().getTypeName(), t));
     extensions.put(ValueReferences.EXCEPTION_EXTENSION_NAME, t);
   }
 
@@ -242,11 +231,8 @@ public class CapturedContext implements ValueReferenceResolver {
     if (values == null) {
       return;
     }
-    if (staticFields == null) {
-      staticFields = new HashMap<>();
-    }
     for (CapturedValue value : values) {
-      staticFields.put(value.name, value);
+      putInStaticFields(value.name, value);
     }
   }
 
@@ -254,11 +240,8 @@ public class CapturedContext implements ValueReferenceResolver {
     if (values == null) {
       return;
     }
-    if (fields == null) {
-      fields = new HashMap<>();
-    }
     for (CapturedValue value : values) {
-      fields.put(value.name, value);
+      putInFields(value.name, value);
     }
     traceId = extractSpecialId("dd.trace_id");
     spanId = extractSpecialId("dd.span_id");
@@ -394,6 +377,34 @@ public class CapturedContext implements ValueReferenceResolver {
         + ", fields="
         + fields
         + '}';
+  }
+
+  private void putInLocals(String name, CapturedValue value) {
+    if (locals == null) {
+      locals = new HashMap<>();
+    }
+    locals.put(name, value);
+  }
+
+  private void putInArguments(String name, CapturedValue value) {
+    if (arguments == null) {
+      arguments = new HashMap<>();
+    }
+    arguments.put(name, value);
+  }
+
+  private void putInFields(String name, CapturedValue value) {
+    if (fields == null) {
+      fields = new HashMap<>();
+    }
+    fields.put(name, value);
+  }
+
+  private void putInStaticFields(String name, CapturedValue value) {
+    if (staticFields == null) {
+      staticFields = new HashMap<>();
+    }
+    staticFields.put(name, value);
   }
 
   public static class Status {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -248,6 +248,9 @@ public class CapturedContext implements ValueReferenceResolver {
   }
 
   private String extractSpecialId(String idName) {
+    if (fields == null) {
+      return null;
+    }
     CapturedValue capturedValue = fields.get(idName);
     if (capturedValue == null) {
       return null;

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -226,6 +226,11 @@ public class CapturedContext implements ValueReferenceResolver {
 
   public void addThrowable(Throwable t) {
     addThrowable(new CapturedThrowable(t));
+    if (locals == null) {
+      locals = new HashMap<>();
+    }
+    // special local name for throwable
+    locals.put(ValueReferences.EXCEPTION_REF, CapturedValue.of(t.getClass().getTypeName(), t));
     extensions.put(ValueReferences.EXCEPTION_EXTENSION_NAME, t);
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -774,10 +774,18 @@ public class CapturedSnapshotTest {
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureThrowable(
         snapshot.getCaptures().getReturn(),
-        "java.lang.IllegalStateException",
+        "CapturedSnapshot05$CustomException",
         "oops",
         "CapturedSnapshot05.triggerUncaughtException",
         7);
+    Map<String, String> expectedFields = new HashMap<>();
+    expectedFields.put("detailMessage", "oops");
+    expectedFields.put("additionalMsg", "I did it again");
+    assertCaptureLocals(
+        snapshot.getCaptures().getReturn(),
+        "@exception",
+        "CapturedSnapshot05$CustomException",
+        expectedFields);
   }
 
   @Test
@@ -793,11 +801,14 @@ public class CapturedSnapshotTest {
                         DSL.and(
                             DSL.instanceOf(
                                 DSL.ref("@exception"),
-                                DSL.value("java.lang.IllegalStateException")),
+                                DSL.value("CapturedSnapshot05$CustomException")),
                             DSL.eq(
                                 DSL.getMember(DSL.ref("@exception"), "detailMessage"),
-                                DSL.value("oops")))),
-                    "@exception instanceof \"java.lang.IllegalStateException\" and @exception.detailMessage == 'oops'"))
+                                DSL.value("oops")),
+                            DSL.eq(
+                                DSL.getMember(DSL.ref("@exception"), "additionalMsg"),
+                                DSL.value("I did it again")))),
+                    "@exception instanceof \"CapturedSnapshot05$CustomException\" and @exception.detailMessage == 'oops' and @exception.additionalMsg == 'I did it again'"))
             .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
             .build();
     DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
@@ -812,7 +823,7 @@ public class CapturedSnapshotTest {
     assertEquals("exception msg=oops", snapshot.getMessage());
     assertCaptureThrowable(
         snapshot.getCaptures().getReturn(),
-        "java.lang.IllegalStateException",
+        "CapturedSnapshot05$CustomException",
         "oops",
         "CapturedSnapshot05.triggerUncaughtException",
         7);
@@ -1595,14 +1606,14 @@ public class CapturedSnapshotTest {
     Snapshot snapshot = assertOneSnapshot(listener);
     assertCaptureThrowable(
         snapshot.getCaptures().getReturn(),
-        "java.lang.IllegalStateException",
+        "CapturedSnapshot05$CustomException",
         "oops",
         "CapturedSnapshot05.triggerUncaughtException",
         7);
     assertEquals(2, snapshot.getEvaluationErrors().size());
     assertEquals("Cannot find symbol: after", snapshot.getEvaluationErrors().get(0).getMessage());
     assertEquals(
-        "java.lang.IllegalStateException: oops",
+        "CapturedSnapshot05$CustomException: oops",
         snapshot.getEvaluationErrors().get(1).getMessage());
   }
 

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot05.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 public class CapturedSnapshot05 {
 
   void triggerUncaughtException() {
-    throw new IllegalStateException("oops");
+    throw new CustomException("oops", "I did it again");
   }
 
   int triggerCaughtException() {
@@ -28,4 +28,12 @@ public class CapturedSnapshot05 {
     return 0;
   }
 
+  public static class CustomException extends RuntimeException {
+    private final String additionalMsg;
+
+    public CustomException(String message, String additionalMsg) {
+      super(message);
+      this.additionalMsg = additionalMsg;
+    }
+  }
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
@@ -71,7 +71,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
         snapshot -> {
           assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
           assertFullMethodCaptureArgs(snapshot.getCaptures().getEntry());
-          assertEquals(0, snapshot.getCaptures().getEntry().getLocals().size());
+          assertNull(snapshot.getCaptures().getEntry().getLocals());
           assertNull(snapshot.getCaptures().getEntry().getThrowable());
           assertNull(snapshot.getCaptures().getEntry().getFields());
           assertFullMethodCaptureArgs(snapshot.getCaptures().getReturn());


### PR DESCRIPTION
# What Does This Do
When uncaught exceptions are captured we put them as local variables like return values. This way we can explore fields from custom exceptions from snapshots

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2042]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2042]: https://datadoghq.atlassian.net/browse/DEBUG-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ