### PR TITLE
Enable Java 21 in CI

### DIFF
--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -28,7 +28,7 @@ MASTER_ONLY_JDKS = {
 }
 # Version to use for all the base Docker images, see
 # https://github.com/DataDog/dd-trace-java-docker-build/pkgs/container/dd-trace-java-docker-build
-DOCKER_IMAGE_VERSION="v23.10"
+DOCKER_IMAGE_VERSION="v24.01"
 
 # Get labels from pull requests to override some defaults for jobs to run.
 # `run-tests: all` will run all tests.

--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -14,7 +14,7 @@ OUT_FILENAME = "config.continue.yml"
 GENERATED_CONFIG_PATH = os.path.join(SCRIPT_DIR, OUT_FILENAME)
 
 # JDKs that will run on every pipeline.
-ALWAYS_ON_JDKS = {"8", "11", "17"}
+ALWAYS_ON_JDKS = {"8", "11", "17", "21"}
 # And these will run only in master and release/ branches.
 MASTER_ONLY_JDKS = {
     "ibm8",

--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -53,7 +53,7 @@ dependencies {
   testImplementation project(':dd-trace-core')
   testImplementation project(':dd-java-agent:agent-builder')
   testImplementation project(':utils:test-utils')
-  testRuntimeOnly group: 'org.scala-lang', name: 'scala-compiler', version: '2.13.3'
+  testRuntimeOnly group: 'org.scala-lang', name: 'scala-compiler', version: versions.scala213
   testRuntimeOnly group: 'antlr', name: 'antlr', version: '2.7.7'
 }
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/BaseExceptionHandlerTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/BaseExceptionHandlerTest.groovy
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.core.read.ListAppender
 import datadog.trace.agent.tooling.bytebuddy.ExceptionHandlers
+import datadog.trace.api.Platform
 import datadog.trace.bootstrap.ExceptionLogger
 import datadog.trace.test.util.DDSpecification
 import net.bytebuddy.agent.ByteBuddyAgent
@@ -11,6 +12,7 @@ import net.bytebuddy.agent.builder.AgentBuilder
 import net.bytebuddy.agent.builder.ResettableClassFileTransformer
 import net.bytebuddy.dynamic.ClassFileLocator
 import org.slf4j.LoggerFactory
+import spock.lang.IgnoreIf
 import spock.lang.Shared
 
 import java.security.Permission
@@ -20,6 +22,9 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOn
 import static net.bytebuddy.matcher.ElementMatchers.isMethod
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named
 
+@IgnoreIf(reason = "SecurityManager used in the test is marked for removal and throws exceptions", value = {
+  Platform.isJavaVersionAtLeast(21)
+})
 abstract class BaseExceptionHandlerTest extends DDSpecification {
   @Shared
   ListAppender testAppender = new ListAppender()

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ExceptionHandlerExitOnFailureForkedTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ExceptionHandlerExitOnFailureForkedTest.groovy
@@ -1,7 +1,12 @@
 package datadog.trace.agent.test
 
 import ch.qos.logback.classic.Level
+import datadog.trace.api.Platform
+import spock.lang.IgnoreIf
 
+@IgnoreIf(reason = "SecurityManager used in the test is marked for removal and throws exceptions", value = {
+  Platform.isJavaVersionAtLeast(21)
+})
 class ExceptionHandlerExitOnFailureForkedTest extends BaseExceptionHandlerTest {
   @Override
   protected void changeConfig() {

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ExceptionHandlerForkedTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/ExceptionHandlerForkedTest.groovy
@@ -1,7 +1,12 @@
 package datadog.trace.agent.test
 
 import ch.qos.logback.classic.Level
+import datadog.trace.api.Platform
+import spock.lang.IgnoreIf
 
+@IgnoreIf(reason = "SecurityManager used in the test is marked for removal and throws exceptions", value = {
+  Platform.isJavaVersionAtLeast(21)
+})
 class ExceptionHandlerForkedTest extends BaseExceptionHandlerTest {
   @Override
   protected void changeConfig() {

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/JavaForkJoinPoolInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.java.concurrent;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.cancelTask;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils.capture;
@@ -39,9 +40,11 @@ public class JavaForkJoinPoolInstrumentation extends Instrumenter.Tracing
 
   @Override
   public void adviceTransformations(AdviceTransformation transformation) {
+    String name = getClass().getName();
     transformation.applyAdvice(
-        isMethod().and(namedOneOf("externalPush", "externalSubmit")),
-        getClass().getName() + "$ExternalPush");
+        isMethod().and(namedOneOf("externalPush", "externalSubmit")), name + "$ExternalPush");
+    // Java 21 has a new method name and changed signature
+    transformation.applyAdvice(isMethod().and(named("poolSubmit")), name + "$PoolSubmit");
   }
 
   public static final class ExternalPush {
@@ -60,6 +63,27 @@ public class JavaForkJoinPoolInstrumentation extends Instrumenter.Tracing
     @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static <T> void cleanup(
         @Advice.Argument(0) ForkJoinTask<T> task, @Advice.Thrown Throwable thrown) {
+      if (null != thrown && !exclude(FORK_JOIN_TASK, task)) {
+        cancelTask(InstrumentationContext.get(ForkJoinTask.class, State.class), task);
+      }
+    }
+  }
+
+  public static final class PoolSubmit {
+    @Advice.OnMethodEnter
+    public static <T> void poolSubmit(
+        @Advice.This ForkJoinPool pool, @Advice.Argument(1) ForkJoinTask<T> task) {
+      if (!exclude(FORK_JOIN_TASK, task)) {
+        ContextStore<ForkJoinTask, State> contextStore =
+            InstrumentationContext.get(ForkJoinTask.class, State.class);
+        capture(contextStore, task, true);
+        QueueTimerHelper.startQueuingTimer(contextStore, pool.getClass(), task);
+      }
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
+    public static <T> void cleanup(
+        @Advice.Argument(1) ForkJoinTask<T> task, @Advice.Thrown Throwable thrown) {
       if (null != thrown && !exclude(FORK_JOIN_TASK, task)) {
         cancelTask(InstrumentationContext.get(ForkJoinTask.class, State.class), task);
       }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
@@ -78,7 +78,7 @@ class SpringSchedulingTest extends AgentTestRunner {
     assertTraces(1) {
       trace(1) {
         span {
-          resourceNameContains("LambdaTaskConfigurer\$\$Lambda\$")
+          resourceNameContains("LambdaTaskConfigurer\$\$Lambda")
           operationName "scheduled.call"
           parent()
           errored false

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/AdviceUtils.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/AdviceUtils.java
@@ -26,7 +26,7 @@ public final class AdviceUtils {
       GenericClassValue.of(
           type -> {
             String name = type.getName();
-            int lambdaIdx = name.lastIndexOf("$$Lambda$");
+            int lambdaIdx = name.lastIndexOf("$$Lambda");
             if (lambdaIdx > -1) {
               return UTF8BytesString.create(
                   name.substring(name.lastIndexOf('.') + 1, lambdaIdx) + ".lambda");

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
@@ -46,7 +46,7 @@ public class RouteOnSuccessOrError implements Consumer<HandlerFunction<?>> {
     // Router functions containing lambda predicates should not end up in span tags since they are
     // confusing
     if (routerFunctionString.startsWith(
-        "org.springframework.web.reactive.function.server.RequestPredicates$$Lambda$")) {
+        "org.springframework.web.reactive.function.server.RequestPredicates$$Lambda")) {
       return null;
     } else {
       return ROUTER_FUNCTION_REGEX.matcher(routerFunctionString).replaceFirst("");

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -78,7 +78,10 @@ final class CachedData {
     ],
     mockito              : [
       "org.mockito:mockito-core:${versions.mockito}",
-      "org.mockito:mockito-junit-jupiter:${versions.mockito}"
+      "org.mockito:mockito-junit-jupiter:${versions.mockito}",
+      // needed for Java 21 support
+      "net.bytebuddy:byte-buddy:${versions.bytebuddy}",
+      "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
     ],
     testcontainers       : "org.testcontainers:testcontainers:${versions.testcontainers}",
     testLogging          : [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,8 +18,8 @@ final class CachedData {
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",
-    scala212      : "2.12.12",
-    scala213      : "2.13.4",
+    scala212      : "2.12.18",
+    scala213      : "2.13.11",
     truth         : "1.1.3",
     kotlin        : "1.6.21",
     coroutines    : "1.3.0",

--- a/internal-api/src/main/java/datadog/trace/util/MethodHandles.java
+++ b/internal-api/src/main/java/datadog/trace/util/MethodHandles.java
@@ -33,10 +33,14 @@ public class MethodHandles {
         (PrivilegedAction<MethodHandle>)
             () -> {
               try {
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                  String packageName = clazz.getPackage().getName();
-                  sm.checkPackageAccess(packageName);
+                try {
+                  SecurityManager sm = System.getSecurityManager();
+                  if (sm != null) {
+                    String packageName = clazz.getPackage().getName();
+                    sm.checkPackageAccess(packageName);
+                  }
+                } catch (UnsupportedOperationException e) {
+                  // ignore
                 }
 
                 Field field = clazz.getDeclaredField(fieldName);
@@ -64,10 +68,14 @@ public class MethodHandles {
         (PrivilegedAction<MethodHandle>)
             () -> {
               try {
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                  String packageName = clazz.getPackage().getName();
-                  sm.checkPackageAccess(packageName);
+                try {
+                  SecurityManager sm = System.getSecurityManager();
+                  if (sm != null) {
+                    String packageName = clazz.getPackage().getName();
+                    sm.checkPackageAccess(packageName);
+                  }
+                } catch (UnsupportedOperationException e) {
+                  // ignore
                 }
 
                 Field field = clazz.getDeclaredField(fieldName);
@@ -95,10 +103,14 @@ public class MethodHandles {
         (PrivilegedAction<MethodHandle>)
             () -> {
               try {
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                  String packageName = clazz.getPackage().getName();
-                  sm.checkPackageAccess(packageName);
+                try {
+                  SecurityManager sm = System.getSecurityManager();
+                  if (sm != null) {
+                    String packageName = clazz.getPackage().getName();
+                    sm.checkPackageAccess(packageName);
+                  }
+                } catch (UnsupportedOperationException e) {
+                  // ignore
                 }
 
                 Constructor<?> constructor = clazz.getDeclaredConstructor(parameterTypes);
@@ -126,10 +138,14 @@ public class MethodHandles {
         (PrivilegedAction<MethodHandle>)
             () -> {
               try {
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                  String packageName = clazz.getPackage().getName();
-                  sm.checkPackageAccess(packageName);
+                try {
+                  SecurityManager sm = System.getSecurityManager();
+                  if (sm != null) {
+                    String packageName = clazz.getPackage().getName();
+                    sm.checkPackageAccess(packageName);
+                  }
+                } catch (UnsupportedOperationException e) {
+                  // ignore
                 }
 
                 Method method = clazz.getDeclaredMethod(methodName, parameterTypes);
@@ -153,10 +169,14 @@ public class MethodHandles {
         (PrivilegedAction<MethodHandle>)
             () -> {
               try {
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                  String packageName = clazz.getPackage().getName();
-                  sm.checkPackageAccess(packageName);
+                try {
+                  SecurityManager sm = System.getSecurityManager();
+                  if (sm != null) {
+                    String packageName = clazz.getPackage().getName();
+                    sm.checkPackageAccess(packageName);
+                  }
+                } catch (UnsupportedOperationException e) {
+                  // ignore
                 }
 
                 Method[] methods = clazz.getDeclaredMethods();


### PR DESCRIPTION
# What Does This Do

Enables Java 21 as one of the required JVM versions in CircleCI

# Motivation

We need to test on Java 21

# Additional Notes

* Corrects a number of smaller issues that failed some tests
* Does **_not_** add support for virtual threads executors

Jira ticket: [APMJAVA-1202]


[APMJAVA-1202]: https://datadoghq.atlassian.net/browse/APMJAVA-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ