### PR TITLE
log4j: preserve mdc when copied and injection is disabled

### DIFF
--- a/dd-java-agent/instrumentation/log4j1/build.gradle
+++ b/dd-java-agent/instrumentation/log4j1/build.gradle
@@ -1,5 +1,3 @@
-apply from: "$rootDir/gradle/java.gradle"
-
 muzzle {
   pass {
     group = 'log4j'
@@ -8,6 +6,17 @@ muzzle {
   }
 }
 
+configurations {
+  testImplementation.exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
+  testCompile.exclude group: 'org.slf4j', module: 'log4j-over-slf4j'
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+addTestSuiteForDir('latestDepTest', 'test')
+
 dependencies {
   compileOnly group: 'log4j', name: 'log4j', version: '1.2.4'
+  testImplementation group: 'log4j', name: 'log4j', version: '1.2.4'
+  latestDepTestImplementation group: 'log4j', name: 'log4j', version: '+'
 }

--- a/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
+++ b/dd-java-agent/instrumentation/log4j1/src/main/java/datadog/trace/instrumentation/log4j1/LoggingEventInstrumentation.java
@@ -20,7 +20,6 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.util.Hashtable;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
-import org.apache.log4j.MDC;
 import org.apache.log4j.spi.LoggingEvent;
 
 @AutoService(Instrumenter.class)
@@ -115,54 +114,53 @@ public class LoggingEventInstrumentation extends Instrumenter.Tracing
 
   public static class GetMdcCopyAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static void onEnter(
+    public static boolean onEnter(
         @Advice.This LoggingEvent event,
-        @Advice.FieldValue(value = "mdcCopyLookupRequired", readOnly = false) boolean copyRequired,
-        @Advice.FieldValue(value = "mdcCopy", readOnly = false) Hashtable mdcCopy) {
-      // this advice basically replaces the original method
-      // since copyRequired will be false when the original method is executed
-      if (copyRequired) {
-        copyRequired = false;
+        @Advice.FieldValue(value = "mdcCopyLookupRequired", readOnly = false)
+            boolean copyRequired) {
+      if (!copyRequired) {
+        return false;
+      }
+      AgentSpan.Context context =
+          InstrumentationContext.get(LoggingEvent.class, AgentSpan.Context.class).get(event);
 
-        Hashtable mdc = new Hashtable();
+      return (context != null || AgentTracer.traceConfig().isLogsInjectionEnabled());
+    }
 
-        AgentSpan.Context context =
-            InstrumentationContext.get(LoggingEvent.class, AgentSpan.Context.class).get(event);
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit(
+        @Advice.This LoggingEvent event,
+        @Advice.Enter() boolean injectionRequired,
+        @Advice.FieldValue(value = "mdcCopy") Hashtable mdc) {
+      if (!injectionRequired) {
+        return;
+      }
+      // at this point the mdc has been shallow copied. No need to replace with a new hashtable.
+      // Just add our info
+      String serviceName = Config.get().getServiceName();
+      if (null != serviceName && !serviceName.isEmpty()) {
+        mdc.put(Tags.DD_SERVICE, serviceName);
+      }
+      String env = Config.get().getEnv();
+      if (null != env && !env.isEmpty()) {
+        mdc.put(Tags.DD_ENV, env);
+      }
+      String version = Config.get().getVersion();
+      if (null != version && !version.isEmpty()) {
+        mdc.put(Tags.DD_VERSION, version);
+      }
 
-        // Nothing to add so return early
-        if (context == null && !AgentTracer.traceConfig().isLogsInjectionEnabled()) {
-          return;
-        }
+      AgentSpan.Context context =
+          InstrumentationContext.get(LoggingEvent.class, AgentSpan.Context.class).get(event);
 
-        String serviceName = Config.get().getServiceName();
-        if (null != serviceName && !serviceName.isEmpty()) {
-          mdc.put(Tags.DD_SERVICE, serviceName);
-        }
-        String env = Config.get().getEnv();
-        if (null != env && !env.isEmpty()) {
-          mdc.put(Tags.DD_ENV, env);
-        }
-        String version = Config.get().getVersion();
-        if (null != version && !version.isEmpty()) {
-          mdc.put(Tags.DD_VERSION, version);
-        }
-
-        if (context != null) {
-          DDTraceId traceId = context.getTraceId();
-          String traceIdValue =
-              InstrumenterConfig.get().isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
-                  ? traceId.toHexString()
-                  : traceId.toString();
-          mdc.put(CorrelationIdentifier.getTraceIdKey(), traceIdValue);
-          mdc.put(CorrelationIdentifier.getSpanIdKey(), DDSpanId.toString(context.getSpanId()));
-        }
-
-        Hashtable originalMdc = MDC.getContext();
-        if (originalMdc != null) {
-          mdc.putAll(originalMdc);
-        }
-
-        mdcCopy = mdc;
+      if (context != null) {
+        DDTraceId traceId = context.getTraceId();
+        String traceIdValue =
+            InstrumenterConfig.get().isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0
+                ? traceId.toHexString()
+                : traceId.toString();
+        mdc.put(CorrelationIdentifier.getTraceIdKey(), traceIdValue);
+        mdc.put(CorrelationIdentifier.getSpanIdKey(), DDSpanId.toString(context.getSpanId()));
       }
     }
   }

--- a/dd-java-agent/instrumentation/log4j1/src/test/groovy/MdcTest.groovy
+++ b/dd-java-agent/instrumentation/log4j1/src/test/groovy/MdcTest.groovy
@@ -1,0 +1,25 @@
+import datadog.trace.agent.test.AgentTestRunner
+import org.apache.log4j.Category
+import org.apache.log4j.MDC
+import org.apache.log4j.Priority
+import org.apache.log4j.spi.LoggingEvent
+import spock.lang.Unroll
+
+@Unroll
+class MdcTest extends AgentTestRunner {
+  def "should preserve mdc when logging injection is #injectionEnabled"() {
+    setup:
+    injectSysConfig("logs.injection", injectionEnabled)
+    def event = new LoggingEvent("test", Category.getRoot(), Priority.INFO, "hello world", null)
+    when:
+    MDC.put("data", "dog")
+    event.getMDCCopy()
+    MDC.remove("data")
+    then:
+    assert event.getMDC("data") == "dog"
+    where:
+    injectionEnabled | _
+    "true"           | _
+    "false"          | _
+  }
+}


### PR DESCRIPTION
# What Does This Do

Recently the log4j1 instrumentation has been changed to be compatible with dynamic config but a regression has been introduced. The copyMdcMethod is returning without effectively copying the mdc when the injection is disabled.

The MDC copy is especially used on asynchronous loggers when the logged event should carry contextual information since logged after on another thread.  So, potentially, customers using async appenders and explicitly disabling log injection could experience in this situation having the mdc wiped out

This PR fixes this behaviour and adds a test for both logs injection enabled and disabled. Also, shunting methods is quite dangerous so I preferred not to skip the original `getMdcCopy` method. I put also some simplifications by not copying the mdc hashtable, since, after the copyMdcMethod, it has already been shallowed copied 

# Motivation

Relates to #6477 

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
