### PR TITLE
Add missing error tags to process spans

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
@@ -43,8 +43,7 @@ class ProcessImplStartAdvice {
       return;
     }
     if (t != null) {
-      span.setError(true);
-      span.setErrorMessage(t.getMessage());
+      span.addThrowable(t);
       span.finish();
       return;
     }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/ProcessImplInstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/ProcessImplInstrumentationSpecification.groovy
@@ -172,7 +172,7 @@ class ProcessImplInstrumentationSpecification extends AgentTestRunner {
           tags {
             tag 'cmd.exec', '["/bin/does-not-exist"]'
             // The captured exception in ProcessImpl is in the cause
-            tag 'error.message', ex.cause.message
+            errorTags(ex.cause)
             defaultTags(false, false)
           }
         }
@@ -248,7 +248,7 @@ class ProcessImplInstrumentationSpecification extends AgentTestRunner {
           errored(true)
           tags {
             tag 'cmd.exec', expected
-            tag 'error.message', ex.cause.message
+            errorTags(ex.cause)
             defaultTags(false, false)
           }
         }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/java/lang/ProcessImplInstrumentationHelpers.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/java/lang/ProcessImplInstrumentationHelpers.java
@@ -154,8 +154,7 @@ public class ProcessImplInstrumentationHelpers {
       future.whenComplete(
           (process, thr) -> {
             if (thr != null) {
-              span.setError(true);
-              span.setErrorMessage(thr.getMessage());
+              span.addThrowable(thr);
             } else {
               span.setTag("cmd.exit_code", process.exitValue());
             }
@@ -168,8 +167,7 @@ public class ProcessImplInstrumentationHelpers {
               int exitCode = p.waitFor();
               span.setTag("cmd.exit_code", exitCode);
             } catch (InterruptedException e) {
-              span.setError(true);
-              span.setErrorMessage(e.getMessage());
+              span.addThrowable(e);
             }
             span.finish();
           });


### PR DESCRIPTION


# What Does This Do
Process spans for failed process executions had `error.message`, but not `error.type` and `error.stack`.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
