### PR TITLE
Don't run debugger tests twice in CI

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1030,7 +1030,7 @@ build_test_jobs: &build_test_jobs
       name: z_test_<< matrix.testJvm >>_base
       triggeredBy: *core_modules
       gradleTarget: ":baseTest"
-      gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests"
+      gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests -PskipDebuggerTests"
       stage: core
       cacheType: base
       parallelism: 4
@@ -1044,7 +1044,7 @@ build_test_jobs: &build_test_jobs
       name: z_test_8_base
       triggeredBy: *core_modules
       gradleTarget: :baseTest jacocoTestReport jacocoTestCoverageVerification
-      gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests"
+      gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests -PskipDebuggerTests"
       stage: core
       cacheType: base
       parallelism: 4

--- a/build.gradle
+++ b/build.gradle
@@ -184,4 +184,9 @@ testAggregate("smoke", [":dd-smoke-tests"], [])
 testAggregate("instrumentation", [":dd-java-agent:instrumentation"], [])
 testAggregate("profiling", [":dd-java-agent:agent-profiling"], [])
 testAggregate("debugger", [":dd-java-agent:agent-debugger"], [])
-testAggregate("base", [":"], [":dd-java-agent:instrumentation", ":dd-smoke-tests", ":dd-java-agent:agent-profiling"])
+testAggregate("base", [":"], [
+  ":dd-java-agent:instrumentation",
+  ":dd-smoke-tests",
+  ":dd-java-agent:agent-profiling",
+  ":dd-java-agent:agent-debugger"
+])

--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -70,6 +70,7 @@ jar {
 }
 
 tasks.withType(Test).configureEach {
+  onlyIf { !project.rootProject.hasProperty("skipDebuggerTests") }
   // DebuggerTransformerTest made some Reflective calls on java.lang package
   // needs to open it since jdk16
   def matcher = it.name =~ /testJava(\d+)Generated/
@@ -78,5 +79,11 @@ tasks.withType(Test).configureEach {
     if (javaVersion >= 16) {
       jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
     }
+  }
+}
+
+subprojects { Project subProj ->
+  subProj.tasks.withType(Test).configureEach { subTask ->
+    onlyIf { !project.rootProject.hasProperty("skipDebuggerTests") }
   }
 }

--- a/dd-java-agent/agent-profiling/build.gradle
+++ b/dd-java-agent/agent-profiling/build.gradle
@@ -31,7 +31,6 @@ dependencies {
   testImplementation deps.mockito
 }
 
-Project parent_project = project
 subprojects { Project subProj ->
   subProj.tasks.withType(Test).configureEach { subTask ->
     onlyIf { !project.rootProject.hasProperty("skipProfilingTests") }


### PR DESCRIPTION
# What Does This Do

Skips the `debugger` tests in the `base` configuration to avoid running them twice.

# Motivation

While looking at upgrading some test dependencies I noticed that it seem like the `debugger` tests run as part of the `base` tests https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/33016/workflows/da5dc872-792f-4c99-ba27-27a2c6e22726/jobs/1149959/tests
