### PR TITLE
Update the enablement logic for allocation and liveheap

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -6,7 +6,6 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBU
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_RESOURCE_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED;
-import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_ENABLED;
@@ -49,12 +48,16 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_STACKDEPTH_DEFA
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ULTRA_MINIMAL;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
 
+import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatadogProfilerConfig {
+  private static final Logger log = LoggerFactory.getLogger(DatadogProfilerConfig.class);
 
   public static boolean isCpuProfilerEnabled(ConfigProvider configProvider) {
     return getBoolean(
@@ -139,14 +142,42 @@ public class DatadogProfilerConfig {
         PROFILING_DATADOG_PROFILER_WALL_CONTEXT_FILTER_DEFAULT);
   }
 
-  public static boolean isAllocationProfilingEnabled(ConfigProvider configProvider) {
-    boolean userOptedIn =
-        getBoolean(configProvider, PROFILING_DATADOG_PROFILER_ALLOC_ENABLED, false);
-    // once DD allocation profiling is GA use the longstanding allocation flag to toggle it
-    if (PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT) {
-      return getBoolean(configProvider, PROFILING_ALLOCATION_ENABLED, userOptedIn);
+  private static boolean isJmethodIDSafe() {
+    // see https://bugs.openjdk.org/browse/JDK-8313816
+    if (Platform.isJavaVersionAtLeast(22)) {
+      // any version after 22 should be safe
+      return true;
     }
-    return userOptedIn;
+    switch (Platform.getLangVersion()) {
+      case "8":
+        // Java 8 is not affected by the jmethodID issue
+        return true;
+      case "11":
+        return Platform.isJavaVersionAtLeast(11, 0, 23);
+      case "17":
+        return Platform.isJavaVersionAtLeast(17, 0, 11);
+      case "21":
+        return Platform.isJavaVersionAtLeast(21, 0, 3);
+      default:
+        // any other non-LTS version should be considered unsafe
+        return false;
+    }
+  }
+
+  public static boolean isAllocationProfilingEnabled(ConfigProvider configProvider) {
+    boolean dflt = isJmethodIDSafe();
+    boolean enableDdprofAlloc =
+        getBoolean(
+            configProvider,
+            PROFILING_ALLOCATION_ENABLED,
+            dflt,
+            PROFILING_DATADOG_PROFILER_ALLOC_ENABLED);
+
+    if (!dflt && enableDdprofAlloc) {
+      log.warn(
+          "Allocation profiling was enabled although it is not considered stable on this JVM version.");
+    }
+    return enableDdprofAlloc;
   }
 
   public static boolean isAllocationProfilingEnabled() {
@@ -165,11 +196,18 @@ public class DatadogProfilerConfig {
   }
 
   public static boolean isMemoryLeakProfilingEnabled(ConfigProvider configProvider) {
-    return getBoolean(
-        configProvider,
-        PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED,
-        PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT,
-        PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED);
+    boolean isSafe = isJmethodIDSafe();
+    boolean enableDdprofMemleak =
+        getBoolean(
+            configProvider,
+            PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED,
+            PROFILING_DATADOG_PROFILER_LIVEHEAP_ENABLED_DEFAULT,
+            PROFILING_DATADOG_PROFILER_MEMLEAK_ENABLED);
+    if (!isSafe && enableDdprofMemleak) {
+      log.warn(
+          "Memory leak profiling was enabled although it is not considered stable on this JVM version.");
+    }
+    return enableDdprofMemleak;
   }
 
   public static boolean isMemoryLeakProfilingEnabled() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -78,7 +78,6 @@ public final class ProfilingConfig {
   public static final String PROFILING_DATADOG_PROFILER_LIBPATH = "profiling.ddprof.debug.lib";
   public static final String PROFILING_DATADOG_PROFILER_ALLOC_ENABLED =
       "profiling.ddprof.alloc.enabled";
-  public static final boolean PROFILING_DATADOG_PROFILER_ALLOC_ENABLED_DEFAULT = false;
   public static final String PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL =
       "profiling.ddprof.alloc.interval";
   public static final int PROFILING_DATADOG_PROFILER_ALLOC_INTERVAL_DEFAULT = 256 * 1024;


### PR DESCRIPTION
# What Does This Do
It adjusts the enablement logic for allocation and liveheap profiling when using ddprof-java

# Motivation
In the anticipation of [JDK-8313816](https://bugs.openjdk.org/browse/JDK-8313816) it will become completely safe to enable allocation and liveheap profiling on the latest updates of LTS Java versions.
The liveheap will not be enabled by default, however, since it is still not considered GA, but rather will log a warning when explicitly enabled on an inherently unsafe JDK version.


# Additional Notes

Jira ticket: [PROF-8839]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-8839]: https://datadoghq.atlassian.net/browse/PROF-8839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ