### PR TITLE
Decouple telemetry logs from minimum log level

### DIFF
--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLogger.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLogger.java
@@ -329,7 +329,7 @@ public class DDLogger implements Logger {
     }
 
     FormattingTuple tuple = MessageFormatter.format(format, arg);
-    alwaysLog(level, marker, format, tuple.getMessage(), tuple.getThrowable());
+    alwaysLog(level, marker, tuple.getMessage(), tuple.getThrowable());
   }
 
   public void formatLog(LogLevel level, Marker marker, String format, Object arg1, Object arg2) {
@@ -338,7 +338,7 @@ public class DDLogger implements Logger {
     }
 
     FormattingTuple tuple = MessageFormatter.format(format, arg1, arg2);
-    alwaysLog(level, marker, format, tuple.getMessage(), tuple.getThrowable());
+    alwaysLog(level, marker, tuple.getMessage(), tuple.getThrowable());
   }
 
   public void formatLog(LogLevel level, Marker marker, String format, Object... arguments) {
@@ -347,17 +347,17 @@ public class DDLogger implements Logger {
     }
 
     FormattingTuple tuple = MessageFormatter.arrayFormat(format, arguments);
-    alwaysLog(level, marker, format, tuple.getMessage(), tuple.getThrowable());
+    alwaysLog(level, marker, tuple.getMessage(), tuple.getThrowable());
   }
 
-  private void log(LogLevel level, Marker marker, String msg, Throwable t) {
+  protected void log(LogLevel level, Marker marker, String msg, Throwable t) {
     if (!helper.enabled(level, marker)) {
       return;
     }
-    alwaysLog(level, marker, null, msg, t);
+    helper.log(level, marker, msg, t);
   }
 
-  protected void alwaysLog(LogLevel level, Marker marker, String format, String msg, Throwable t) {
+  private void alwaysLog(LogLevel level, Marker marker, String msg, Throwable t) {
     helper.log(level, marker, msg, t);
   }
 }

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDTelemetryLogger.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDTelemetryLogger.java
@@ -1,6 +1,5 @@
 package datadog.trace.logging.ddlogger;
 
-import datadog.trace.api.Platform;
 import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.logging.LogLevel;
 import datadog.trace.logging.LoggerHelper;
@@ -38,9 +37,6 @@ public class DDTelemetryLogger extends DDLogger {
   }
 
   private void telemetryLog(LogLevel level, Marker marker, String msgOrgFormat, Throwable t) {
-    if (Platform.isNativeImageBuilder()) {
-      return;
-    }
     // Report only messages with Throwable or explicitly marked with SEND_TELEMETRY.
     // This might be extended to error level without throwable.
     if (t == null && marker != LogCollector.SEND_TELEMETRY) {

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDTelemetryLogger.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDTelemetryLogger.java
@@ -5,6 +5,7 @@ import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.logging.LogLevel;
 import datadog.trace.logging.LoggerHelper;
 import org.slf4j.Marker;
+import org.slf4j.helpers.MessageFormatter;
 
 public class DDTelemetryLogger extends DDLogger {
 
@@ -13,19 +14,42 @@ public class DDTelemetryLogger extends DDLogger {
   }
 
   @Override
-  protected void alwaysLog(LogLevel level, Marker marker, String format, String msg, Throwable t) {
-    super.alwaysLog(level, marker, format, msg, t);
-    if (!Platform.isNativeImageBuilder()) {
-      // We report only messages with Throwable or explicitly marked with SEND_TELEMETRY
-      if (t != null || marker == LogCollector.SEND_TELEMETRY) {
-        // We are scrubbing all data from messages, and only send static (compile time)
-        // log messages, plus redacted stack traces.
-        if (format != null) {
-          LogCollector.get().addLogMessage(level.name(), format, t);
-        } else if (msg != null) {
-          LogCollector.get().addLogMessage(level.name(), msg, t);
-        }
-      }
+  public void formatLog(LogLevel level, Marker marker, String format, Object arg) {
+    telemetryLog(level, marker, format, getIfThrowable(arg));
+    super.formatLog(level, marker, format, arg);
+  }
+
+  @Override
+  public void formatLog(LogLevel level, Marker marker, String format, Object arg1, Object arg2) {
+    telemetryLog(level, marker, format, getIfThrowable(arg2));
+    super.formatLog(level, marker, format, arg1, arg2);
+  }
+
+  @Override
+  public void formatLog(LogLevel level, Marker marker, String format, Object... arguments) {
+    telemetryLog(level, marker, format, MessageFormatter.getThrowableCandidate(arguments));
+    super.formatLog(level, marker, format, arguments);
+  }
+
+  @Override
+  protected void log(LogLevel level, Marker marker, String msg, Throwable t) {
+    telemetryLog(level, marker, msg, t);
+    super.log(level, marker, msg, t);
+  }
+
+  private void telemetryLog(LogLevel level, Marker marker, String msgOrgFormat, Throwable t) {
+    if (Platform.isNativeImageBuilder()) {
+      return;
     }
+    // Report only messages with Throwable or explicitly marked with SEND_TELEMETRY.
+    // This might be extended to error level without throwable.
+    if (t == null && marker != LogCollector.SEND_TELEMETRY) {
+      return;
+    }
+    LogCollector.get().addLogMessage(level.name(), msgOrgFormat, t);
+  }
+
+  private Throwable getIfThrowable(final Object obj) {
+    return obj instanceof Throwable ? (Throwable) obj : null;
   }
 }


### PR DESCRIPTION


# What Does This Do
Logs for errors (e.g. exceptions) will be sent to telemetry regardless of minimum log level. This will ensure we receive logged exceptions from instrumentations (debug level) even if debug level is not set.

# Motivation
Our most important use case is detecting instrumentation bugs leading to internal exceptions, which are logged to debug level.

# Additional Notes

* Jira ticket: [APPSEC-17021](https://datadoghq.atlassian.net/browse/APPSEC-17021)
* Initial PR for this feature: #6057


[APPSEC-17021]: https://datadoghq.atlassian.net/browse/APPSEC-17021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ