### PR TITLE
Jsantos/header injection improvement

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
@@ -61,6 +61,14 @@ public class HeaderInjectionModuleImpl extends SinkModuleBase implements HeaderI
         return;
       }
 
+      if (1 == ranges.length){
+        if (ranges[0].getSource().getOrigin() == SourceTypes.REQUEST_HEADER_VALUE){
+          if (name.equalsIgnoreCase(ranges[0].getSource().getName())) {
+            return;
+          }
+        }
+
+      }
       if (header == HttpHeader.Values.ACCESS_CONTROL_ALLOW_ORIGIN) {
         boolean allRangesFromOrigin = true;
         for (Range range : ranges) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
@@ -61,13 +61,12 @@ public class HeaderInjectionModuleImpl extends SinkModuleBase implements HeaderI
         return;
       }
 
-      if (1 == ranges.length){
-        if (ranges[0].getSource().getOrigin() == SourceTypes.REQUEST_HEADER_VALUE){
+      if (1 == ranges.length) {
+        if (ranges[0].getSource().getOrigin() == SourceTypes.REQUEST_HEADER_VALUE) {
           if (name.equalsIgnoreCase(ranges[0].getSource().getName())) {
             return;
           }
         }
-
       }
       if (header == HttpHeader.Values.ACCESS_CONTROL_ALLOW_ORIGIN) {
         boolean allRangesFromOrigin = true;

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
@@ -247,6 +247,23 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
     ]
   }
 
+  void 'passing header down exclusions'(){
+    given:
+    Vulnerability savedVul
+    addFromRangeList(ctx.taintedObjects, headerValue, ranges)
+
+    when:
+    module.onHeader(headerName, headerValue)
+
+    then:
+    1 * tracer.activeSpan()
+    0 * _
+
+    where:
+    headerValue | expected                                           | headerName             | ranges
+    'pepito'    | 'X-Test-Header: ==>pepito<=='        |'X-Test-Header'         | [[0, 6, 'X-Test-Header', 'pepito', SourceTypes.REQUEST_HEADER_VALUE]]
+  }
+
 
   private String mapTainted(final String value, final int mark) {
     final result = addFromTaintFormat(ctx.taintedObjects, value, mark)


### PR DESCRIPTION
# What Does This Do
Modify Header Injection vulnerability detection so when a header value is set that comes from a header with the same name as the header we are setting, it will not be reported as a vulnerability.

# Motivation
Don't report this common use case as a vulnerability

# Additional Notes

Jira ticket: [APPSEC-45949]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->



[APPSEC-45949]: https://datadoghq.atlassian.net/browse/APPSEC-45949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ