### PR TITLE
Fix Maven instrumentation following the latest release. Disable Maven smoke tests for alpha versions

### DIFF
--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
@@ -289,9 +289,10 @@ public abstract class MavenUtils {
       new MethodHandles(PlexusContainer.class.getClassLoader());
   private static final MethodHandle SESSION_FIELD =
       METHOD_HANDLES.privateFieldGetter(MavenSession.class, "session");
-  private static final MethodHandle CONTAINER_FIELD =
-      METHOD_HANDLES.privateFieldGetter(
-          "org.apache.maven.internal.impl.DefaultSession", "container");
+  private static final MethodHandle LOOKUP_FIELD =
+      METHOD_HANDLES.privateFieldGetter("org.apache.maven.internal.impl.DefaultSession", "lookup");
+  private static final MethodHandle LOOKUP_METHOD =
+      METHOD_HANDLES.method("org.apache.maven.api.services.Lookup", "lookup", Class.class);
 
   public static PlexusContainer getContainer(MavenSession mavenSession) {
     PlexusContainer container = mavenSession.getContainer();
@@ -300,6 +301,8 @@ public abstract class MavenUtils {
     }
     Object /* org.apache.maven.internal.impl.DefaultSession */ session =
         METHOD_HANDLES.invoke(SESSION_FIELD, mavenSession);
-    return METHOD_HANDLES.invoke(CONTAINER_FIELD, session);
+    Object /* org.apache.maven.api.services.Lookup */ lookup =
+        METHOD_HANDLES.invoke(LOOKUP_FIELD, session);
+    return METHOD_HANDLES.invoke(LOOKUP_METHOD, lookup, PlexusContainer.class);
   }
 }

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -274,11 +274,9 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
         NodeList versionList = doc.getElementsByTagName("latest")
         if (versionList.getLength() > 0) {
           def version = versionList.item(0).getTextContent()
-          if (!['4.0.0-alpha-12'].contains(version)) {
+          if (!version.contains('alpha')) {
             LOGGER.info("Will run the 'latest' tests with version ${version}")
-            return version
           }
-          LOGGER.warn("Skipping failing maven version ${version}")
         }
       } else {
         LOGGER.warn("Could not get latest maven version, response from repo.maven.apache.org is ${response.code()}: ${response.body().string()}")
@@ -286,8 +284,8 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
     } catch (Exception e) {
       LOGGER.warn("Could not get latest maven version", e)
     }
-    def hardcodedLatestVersion = "4.0.0-alpha-8"
-    LOGGER.warn("Will run the 'latest' tests with hard-coded version ${hardcodedLatestVersion}")
+    def hardcodedLatestVersion = "4.0.0-alpha-12" // latest alpha that is known to work
+    LOGGER.info("Will run the 'latest' tests with hard-coded version ${hardcodedLatestVersion}")
     return hardcodedLatestVersion
   }
 }

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -276,6 +276,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
           def version = versionList.item(0).getTextContent()
           if (!version.contains('alpha')) {
             LOGGER.info("Will run the 'latest' tests with version ${version}")
+            return version
           }
         }
       } else {


### PR DESCRIPTION
# What Does This Do
- Fixes Maven smoke tests following release `4.0.0-alpha-12`
- Disables Maven smoke tests for "alpha" versions

# Motivation
Alpha versions are unstable and lately have been released frequently.
Maven instrumentation will be updated (if needed), when 4.0 is officially released.

Jira ticket: [CIVIS-8583]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8583]: https://datadoghq.atlassian.net/browse/CIVIS-8583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ