### PR TITLE
Guard the JFR repo cleanup by a debug flag

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -18,6 +18,8 @@ package com.datadog.profiling.controller.openjdk;
 import static com.datadog.profiling.controller.ProfilingSupport.*;
 import static com.datadog.profiling.controller.ProfilingSupport.isObjectCountParallelized;
 import static datadog.trace.api.Platform.isJavaVersionAtLeast;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DEBUG_CLEANUP_REPO;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DEBUG_CLEANUP_REPO_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_HEAP_HISTOGRAM_MODE;
@@ -108,7 +110,10 @@ public final class OpenJdkController implements Controller {
     Map<String, String> recordingSettings;
 
     try {
-      cleanupJfrRepositories(Paths.get(jfrRepositoryBase));
+      if (configProvider.getBoolean(
+          PROFILING_DEBUG_CLEANUP_REPO, PROFILING_DEBUG_CLEANUP_REPO_DEFAULT)) {
+        cleanupJfrRepositories(Paths.get(jfrRepositoryBase));
+      }
 
       recordingSettings =
           JfpUtils.readNamedJfpResource(

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -176,6 +176,9 @@ public final class ProfilingConfig {
   public static final String PROFILING_DEBUG_DUMP_PATH = "profiling.debug.dump_path";
   public static final String PROFILING_DEBUG_JFR_DISABLED = "profiling.debug.jfr.disabled";
 
+  public static final String PROFILING_DEBUG_CLEANUP_REPO = "profiling.debug.cleanup.jfr.repo";
+  public static final boolean PROFILING_DEBUG_CLEANUP_REPO_DEFAULT = false;
+
   public static final String PROFILING_CONTEXT_ATTRIBUTES = "profiling.context.attributes";
 
   public static final String PROFILING_CONTEXT_ATTRIBUTES_SPAN_NAME_ENABLED =


### PR DESCRIPTION
# What Does This Do
Hides the cleanup code behind a debug flag

# Motivation
Do not run the clean up automatically but only as requested because it might cause issues with multiple profiled processes on the same machine when running a non-hotspot JVM.

