### PR TITLE
Reduce the memory footprint of IAST sources

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Range.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Range.java
@@ -16,7 +16,7 @@ public final class Range implements Ranged {
   private final @Nonnull @SourceIndex Source source;
   private final int marks;
 
-  public Range(final int start, final int length, final Source source, final int marks) {
+  public Range(final int start, final int length, @Nonnull final Source source, final int marks) {
     this.start = start;
     this.length = length;
     this.source = source;
@@ -33,6 +33,7 @@ public final class Range implements Ranged {
     return length;
   }
 
+  @Nonnull
   public Source getSource() {
     return source;
   }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Source.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Source.java
@@ -3,21 +3,21 @@ package com.datadog.iast.model;
 import com.datadog.iast.model.json.SourceTypeString;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.Taintable;
+import java.lang.ref.Reference;
 import java.util.Objects;
 import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 public final class Source implements Taintable.Source {
+
+  // value to send in the rare case that the name/value have been garbage collected
+  private static final String GARBAGE_COLLECTED_REF = "[GCed]";
+
   private final @SourceTypeString byte origin;
-  @Nullable private final String name;
-  @Nullable private final String value;
+  @Nullable private final Object name;
+  @Nullable private final Object value;
 
-  public Source(
-      final byte origin, @Nullable final CharSequence name, @Nullable final CharSequence value) {
-    this(origin, name == null ? null : name.toString(), value == null ? null : value.toString());
-  }
-
-  public Source(final byte origin, @Nullable final String name, @Nullable final String value) {
+  public Source(final byte origin, @Nullable final Object name, @Nullable final Object value) {
     this.origin = origin;
     this.name = name;
     this.value = value;
@@ -31,21 +31,33 @@ public final class Source implements Taintable.Source {
   @Override
   @Nullable
   public String getName() {
-    return name;
+    return asString(name);
   }
 
   @Override
   @Nullable
   public String getValue() {
-    return value;
+    return asString(value);
+  }
+
+  @Nullable
+  private String asString(@Nullable final Object target) {
+    Object value = target;
+    if (value instanceof Reference) {
+      value = ((Reference<?>) value).get();
+      if (value == null) {
+        value = GARBAGE_COLLECTED_REF;
+      }
+    }
+    return value instanceof String ? (String) value : null;
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", Source.class.getSimpleName() + "[", "]")
         .add("origin=" + SourceTypes.toString(origin))
-        .add("name='" + name + "'")
-        .add("value='" + value + "'")
+        .add("name='" + getName() + "'")
+        .add("value='" + getValue() + "'")
         .toString();
   }
 
@@ -55,12 +67,12 @@ public final class Source implements Taintable.Source {
     if (o == null || getClass() != o.getClass()) return false;
     Source source = (Source) o;
     return origin == source.origin
-        && Objects.equals(name, source.name)
-        && Objects.equals(value, source.value);
+        && Objects.equals(getName(), source.getName())
+        && Objects.equals(getValue(), source.getValue());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(origin, name, value);
+    return Objects.hash(origin, getName(), getValue());
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
@@ -212,44 +212,6 @@ class VulnerabilityEncodingTest extends DDSpecification {
     }''', result, true)
   }
 
-  void 'one vulnerability with null source'() {
-    given:
-    final span = Stub(AgentSpan)
-    final spanId = 123456
-    span.getSpanId() >> spanId
-    final value = new VulnerabilityBatch()
-    value.add(new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(span, new StackTraceElement("foo", "fooMethod", "foo", 1)),
-      new Evidence("BAD", [new Range(0, 1, null, NOT_MARKED)] as Range[])
-      ))
-
-    when:
-    final result = VulnerabilityEncoding.toJson(value)
-
-    then:
-    JSONAssert.assertEquals('''{
-      "vulnerabilities": [
-        {
-          "type": "WEAK_HASH",
-          "evidence": {
-            "valueParts": [
-              {"value": "B"},
-              {"value": "AD"}
-            ]
-          },
-          "hash":1042880134,
-          "location": {
-            "spanId": 123456,
-            "line": 1,
-            "method": "fooMethod",
-            "path": "foo"
-          }
-        }
-      ]
-    }''', result, true)
-  }
-
   void 'one vulnerability with no source type'() {
     given:
     final span = Stub(AgentSpan)

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -29,12 +29,9 @@ public interface PropagationModule extends IastModule {
   void taint(
       @Nullable IastContext ctx, @Nullable Object target, byte origin, @Nullable CharSequence name);
 
-  /** @see #taint(IastContext, Object, byte, CharSequence, CharSequence) */
+  /** @see #taint(IastContext, Object, byte, CharSequence, Object) */
   void taint(
-      @Nullable Object target,
-      byte origin,
-      @Nullable CharSequence name,
-      @Nullable CharSequence value);
+      @Nullable Object target, byte origin, @Nullable CharSequence name, @Nullable Object value);
 
   /** Taints the object with a source with the selected origin, name and value */
   void taint(
@@ -42,7 +39,7 @@ public interface PropagationModule extends IastModule {
       @Nullable Object target,
       byte origin,
       @Nullable CharSequence name,
-      @Nullable CharSequence value);
+      @Nullable Object value);
 
   /** @see #taintIfTainted(IastContext, Object, Object) */
   void taintIfTainted(@Nullable Object target, @Nullable Object input);
@@ -100,13 +97,13 @@ public interface PropagationModule extends IastModule {
       byte origin,
       @Nullable CharSequence name);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence, CharSequence) */
+  /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence, Object) */
   void taintIfTainted(
       @Nullable Object target,
       @Nullable Object input,
       byte origin,
       @Nullable CharSequence name,
-      @Nullable CharSequence value);
+      @Nullable Object value);
 
   /**
    * Taints the object only if the input value is tainted, the resulting value will be tainted using
@@ -118,7 +115,7 @@ public interface PropagationModule extends IastModule {
       @Nullable Object input,
       byte origin,
       @Nullable CharSequence name,
-      @Nullable CharSequence value);
+      @Nullable Object value);
 
   /** @see #taintIfAnyTainted(IastContext, Object, Object[]) */
   void taintIfAnyTainted(@Nullable Object target, @Nullable Object[] inputs);


### PR DESCRIPTION
# What Does This Do
Removes the string copies used for the `Source`'s name and values and replaces them with weak references to the original value. Once a vulnerability is found, the values are consolidated using copies.

# Motivation
The number of tainted objects present at runtime can vary quite a lot so we have to ensure we consume the minimum amount of memory.
