### PR TITLE
Add component and fix cmd.exit_code tag in subprocess instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
@@ -28,6 +28,7 @@ class ProcessImplStartAdvice {
     final AgentSpan span = tracer.startSpan("appsec", "command_execution");
     span.setSpanType("system");
     span.setResourceName(ProcessImplInstrumentationHelpers.determineResource(command));
+    span.setTag("component", "subprocess");
     ProcessImplInstrumentationHelpers.setTags(span, command);
     return span;
   }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/ProcessImplInstrumentationSpecification.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/ProcessImplInstrumentationSpecification.groovy
@@ -53,8 +53,9 @@ class ProcessImplInstrumentationSpecification extends AgentTestRunner {
     it.spanType 'system'
     it.operationName 'command_execution'
     it.tags {
+      tag 'component', 'subprocess'
       tag 'cmd.exec', '[' + command.collect({ "\"${it}\"" }).join(',') + ']'
-      tag 'cmd.exit_code', exitCode
+      tag 'cmd.exit_code', Integer.toString(exitCode)
       defaultTags(false, false)
     }
   }
@@ -237,6 +238,7 @@ class ProcessImplInstrumentationSpecification extends AgentTestRunner {
           operationName 'command_execution'
           errored(true)
           tags {
+            tag 'component', 'subprocess'
             tag 'cmd.exec', '["/bin/does-not-exist"]'
             // The captured exception in ProcessImpl is in the cause
             errorTags(ex.cause)
@@ -287,9 +289,10 @@ class ProcessImplInstrumentationSpecification extends AgentTestRunner {
           spanType 'system'
           operationName 'command_execution'
           tags {
+            tag 'component', 'subprocess'
             tag 'cmd.truncated', 'true'
             tag 'cmd.exec', '["/bin/sh","-c"]'
-            tag 'cmd.exit_code', 0
+            tag 'cmd.exit_code', "0"
             defaultTags(false, false)
           }
         }
@@ -314,6 +317,7 @@ class ProcessImplInstrumentationSpecification extends AgentTestRunner {
           operationName 'command_execution'
           errored(true)
           tags {
+            tag 'component', 'subprocess'
             tag 'cmd.exec', expected
             errorTags(ex.cause)
             defaultTags(false, false)

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/java/lang/ProcessImplInstrumentationHelpers.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/java/lang/ProcessImplInstrumentationHelpers.java
@@ -156,7 +156,7 @@ public class ProcessImplInstrumentationHelpers {
             if (thr != null) {
               span.addThrowable(thr);
             } else {
-              span.setTag("cmd.exit_code", process.exitValue());
+              span.setTag("cmd.exit_code", Integer.toString(process.exitValue()));
             }
             finishSpan(continuation, span);
           });
@@ -166,7 +166,7 @@ public class ProcessImplInstrumentationHelpers {
           () -> {
             try {
               int exitCode = p.waitFor();
-              span.setTag("cmd.exit_code", exitCode);
+              span.setTag("cmd.exit_code", Integer.toString(exitCode));
             } catch (InterruptedException e) {
               span.addThrowable(e);
             } finally {


### PR DESCRIPTION


# What Does This Do

# Motivation
* cmd.exit_code was present but as an integer (metric).
* component tag was missing.
* 
# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
