### PR TITLE
Support special case of empty catch block

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -53,6 +53,7 @@ import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDSpan;
 import groovy.lang.GroovyClassLoader;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
@@ -785,7 +786,7 @@ public class CapturedSnapshotTest {
         "CapturedSnapshot05$CustomException",
         "oops",
         "CapturedSnapshot05.triggerUncaughtException",
-        7);
+        8);
     Map<String, String> expectedFields = new HashMap<>();
     expectedFields.put("detailMessage", "oops");
     expectedFields.put("additionalMsg", "I did it again");
@@ -834,7 +835,7 @@ public class CapturedSnapshotTest {
         "CapturedSnapshot05$CustomException",
         "oops",
         "CapturedSnapshot05.triggerUncaughtException",
-        7);
+        8);
   }
 
   @Test
@@ -852,7 +853,45 @@ public class CapturedSnapshotTest {
         "java.lang.IllegalStateException",
         "oops",
         "CapturedSnapshot05.triggerCaughtException",
-        12);
+        13);
+  }
+
+  @Test
+  public void lineEmptyCaughtException() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot05";
+    LogProbe probe1 = createProbe(PROBE_ID1, CLASS_NAME, "triggerSwallowedException", null, "26");
+    LogProbe probe2 = createProbe(PROBE_ID2, CLASS_NAME, "triggerSwallowedException", null, "29");
+    LogProbe probe3 = createProbe(PROBE_ID3, CLASS_NAME, "triggerSwallowedException", null, "32");
+    DebuggerTransformerTest.TestSnapshotListener listener =
+        installProbes(CLASS_NAME, probe1, probe2, probe3);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.on(testClass).call("main", "triggerSwallowedException").get();
+    assertEquals(-1, result);
+    List<Snapshot> snapshots = assertSnapshots(listener, 3, PROBE_ID1, PROBE_ID2, PROBE_ID3);
+    Snapshot snapshot0 = snapshots.get(0);
+    Map<String, String> expectedFields0 = new HashMap<>();
+    expectedFields0.put("detailMessage", "oops");
+    assertCaptureLocals(
+        snapshot0.getCaptures().getLines().get(26),
+        "ex0",
+        IllegalStateException.class.getTypeName(),
+        expectedFields0);
+    Snapshot snapshot1 = snapshots.get(1);
+    Map<String, String> expectedFields1 = new HashMap<>();
+    expectedFields1.put("detailMessage", "nope!");
+    assertCaptureLocals(
+        snapshot1.getCaptures().getLines().get(29),
+        "ex",
+        IllegalArgumentException.class.getTypeName(),
+        expectedFields1);
+    Snapshot snapshot2 = snapshots.get(2);
+    Map<String, String> expectedFields2 = new HashMap<>();
+    expectedFields2.put("detailMessage", "not there");
+    assertCaptureLocals(
+        snapshot2.getCaptures().getLines().get(32),
+        "ex",
+        FileNotFoundException.class.getTypeName(),
+        expectedFields2);
   }
 
   @Test
@@ -1618,7 +1657,7 @@ public class CapturedSnapshotTest {
         "CapturedSnapshot05$CustomException",
         "oops",
         "CapturedSnapshot05.triggerUncaughtException",
-        7);
+        8);
     assertEquals(2, snapshot.getEvaluationErrors().size());
     assertEquals("Cannot find symbol: after", snapshot.getEvaluationErrors().get(0).getMessage());
     assertEquals(

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot05.java
@@ -1,3 +1,4 @@
+import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -15,6 +16,24 @@ public class CapturedSnapshot05 {
     }
   }
 
+  int triggerSwallowedException(int arg) {
+    try {
+      if (arg == 0)
+        throw new IllegalStateException("oops");
+      if (arg == 1)
+        throw new IllegalArgumentException("nope!");
+      throw new FileNotFoundException("not there");
+    } catch (IllegalStateException ex) {
+      // swallowed with empty catch block
+    } catch (IllegalArgumentException ex) {
+      ex.printStackTrace();
+      return 0;
+    } catch (Throwable ex) {
+      return -1;
+    }
+    return 42;
+  }
+
   public static int main(String arg) {
     CapturedSnapshot05 cs5 = new CapturedSnapshot05();
     long before = System.currentTimeMillis();
@@ -22,6 +41,10 @@ public class CapturedSnapshot05 {
       cs5.triggerUncaughtException();
     } else if ("triggerCaughtException".equals(arg)) {
       return cs5.triggerCaughtException();
+    } else if ("triggerSwallowedException".equals(arg)) {
+      cs5.triggerSwallowedException(0);
+      cs5.triggerSwallowedException(1);
+      return cs5.triggerSwallowedException(2);
     }
     long after = System.currentTimeMillis();
     System.out.println(after-before);


### PR DESCRIPTION
# What Does This Do
We declare the missing local var if not present and store the exception present on the stack in it. then we collect as usual the local vars and the exception will be then present in the snapshot


# Motivation
if you want to put a line probe in an empty catch block, exception variable is not declared in that special case, so to capture it as local var we need to explicitly add it.
```
try {
  throw new IllegalArgumentException("oops");
} catch (IllegalArgumentException ex) {
}
```
# Additional Notes

Jira ticket: [DEBUG-2045]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2045]: https://datadoghq.atlassian.net/browse/DEBUG-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ