### PR TITLE
Do not change JFR repo location if cleanup not required

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -96,8 +96,14 @@ public final class OpenJdkController implements Controller {
       // this will allow emitting the settings event with the current stack depth
       JfrProfilerSettings.instance().markJfrStackDepthApplied();
     }
-    String jfrRepositoryBase = getJfrRepositoryBase(configProvider);
-    JFRAccess.instance().setBaseLocation(jfrRepositoryBase + "/pid_" + PidHelper.getPid());
+    boolean shouldCleanupJfrRepository =
+        configProvider.getBoolean(
+            PROFILING_DEBUG_CLEANUP_REPO, PROFILING_DEBUG_CLEANUP_REPO_DEFAULT);
+    String jfrRepositoryBase = null;
+    if (shouldCleanupJfrRepository) {
+      jfrRepositoryBase = getJfrRepositoryBase(configProvider);
+      JFRAccess.instance().setBaseLocation(jfrRepositoryBase + "/pid_" + PidHelper.getPid());
+    }
     // Make sure we can load JFR classes before declaring that we have successfully created
     // factory and can use it.
     Class.forName("jdk.jfr.Recording");
@@ -110,8 +116,7 @@ public final class OpenJdkController implements Controller {
     Map<String, String> recordingSettings;
 
     try {
-      if (configProvider.getBoolean(
-          PROFILING_DEBUG_CLEANUP_REPO, PROFILING_DEBUG_CLEANUP_REPO_DEFAULT)) {
+      if (shouldCleanupJfrRepository) {
         cleanupJfrRepositories(Paths.get(jfrRepositoryBase));
       }
 


### PR DESCRIPTION
# What Does This Do
Adds a guard not to change the JFR repository location unless the cleanup-on-startup is required.

# Motivation
Changing the JFR repo location behind-the-scenes may be confusing
