### PR TITLE
Add call sites in spring ldap template

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -272,8 +272,9 @@
 1 org.slf4j.*
 1 org.springdoc.*
 1 org.springframework.*
-# Update when JdbcTemplate call sites are ready
+# Update when spring template call sites are ready
 2 org.springframework.jdbc.core.JdbcTemplate$*
+2 org.springframework.ldap.core.LdapTemplate$*
 # https://github.com/spring-projects/spring-petclinic
 0 org.springframework.samples.*
 # Used by insecure-bank


### PR DESCRIPTION
# What Does This Do
Enables call site generation for springs `LdapTemplate` (same logic as with `JdbcTemplate`)
