### PR TITLE
Replace string.format calls with regular concatenation

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestEndedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestEndedHandler.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 public class TelemetryRequestEndedHandler
     implements BiFunction<RequestContext, IGSpanInfo, Flow<Void>> {
 
-  static final String TRACE_METRIC_PATTERN = "_dd.iast.telemetry.%s";
+  static final String TRACE_METRIC_PREFIX = "_dd.iast.telemetry.";
 
   private final BiFunction<RequestContext, IGSpanInfo, Flow<Void>> delegate;
 
@@ -58,7 +58,7 @@ public class TelemetryRequestEndedHandler
       final IastMetric metric = data.getMetric();
       if (metric.getScope() == REQUEST) {
         final String tagValue = data.getSpanTag();
-        trace.setTagTop(String.format(TRACE_METRIC_PATTERN, tagValue), data.value);
+        trace.setTagTop(TRACE_METRIC_PREFIX + tagValue, data.value);
       }
     }
   }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/TelemetryRequestEndedHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/TelemetryRequestEndedHandlerTest.groovy
@@ -17,7 +17,7 @@ import datadog.trace.api.internal.TraceSegment
 import groovy.transform.CompileDynamic
 import groovy.transform.ToString
 
-import static com.datadog.iast.telemetry.TelemetryRequestEndedHandler.TRACE_METRIC_PATTERN
+import static com.datadog.iast.telemetry.TelemetryRequestEndedHandler.TRACE_METRIC_PREFIX
 import static datadog.trace.api.iast.telemetry.IastMetric.*
 
 @CompileDynamic
@@ -79,7 +79,7 @@ class TelemetryRequestEndedHandlerTest extends IastModuleImplTestBase {
 
     then:
     1 * delegate.apply(reqCtx, span)
-    1 * traceSegment.setTagTop(String.format(TRACE_METRIC_PATTERN, getSpanTagValue(metric)), 1)
+    1 * traceSegment.setTagTop(TRACE_METRIC_PREFIX + getSpanTagValue(metric), 1)
 
     when:
     globalCollector.prepareMetrics()
@@ -104,7 +104,7 @@ class TelemetryRequestEndedHandlerTest extends IastModuleImplTestBase {
     then: 'request scoped metrics are propagated to the span'
     1 * delegate.apply(reqCtx, span)
     metrics.findAll { it.metric.scope == Scope.REQUEST }.each {
-      1 * traceSegment.setTagTop(String.format(TRACE_METRIC_PATTERN, getSpanTagValue(it.metric, it.tagValue)), it.value)
+      1 * traceSegment.setTagTop(TRACE_METRIC_PREFIX + getSpanTagValue(it.metric, it.tagValue), it.value)
     }
 
     when:

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
@@ -191,14 +191,14 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
       }
       final String tag = metric.getTag().toString(tagValue);
       final String spanTag = tag.toLowerCase(Locale.ROOT).replace('.', '_');
-      return String.format("%s.%s", metric.getName(), spanTag);
+      return metric.getName() + "." + spanTag;
     }
 
     public static String computeTag(final IastMetric metric, final byte tagValue) {
       if (metric.getTag() == null) {
         return null;
       }
-      return String.format("%s:%s", metric.getTag().getName(), metric.getTag().toString(tagValue));
+      return metric.getTag().getName() + ":" + metric.getTag().toString(tagValue);
     }
   }
 


### PR DESCRIPTION
# What Does This Do
Removes costly String.format operations that are not really needed
