### PR TITLE
Add IAST exclusion for OpenTelemetry SDK package

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -252,6 +252,8 @@
 1 org.objectweb.*
 # Weak randomness false positive on HotspotUnsafe.guessAlignment
 1 org.openjdk.jol.vm.*
+# Weak randomness false positive on RandomIdGenerator.generateTraceId
+1 io.opentelemetry.sdk.trace.*
 1 org.openxmlformats.*
 1 org.osgi.*
 1 org.owasp.*


### PR DESCRIPTION
# What Does This Do

# Motivation

We had a weak randomness false positive here, and there's probably nothing else interesting in the rest of the package.

# Additional Notes

Jira ticket: [APPSEC-18259](https://datadoghq.atlassian.net/browse/APPSEC-18259)


[APPSEC-18259]: https://datadoghq.atlassian.net/browse/APPSEC-18259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ