### PR TITLE
Skip milestone and issues gh workflows for Release Candidates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,7 +44,7 @@ _Recovery:_ Manually trigger the action again on the relevant tag.
 
 ## increment-milestones-on-tag [🔗](increment-milestones-on-tag.yaml)
 
-_Trigger:_ When creating a tag. Release Candidate tags (containing "-RC" or "-rc" will skip this)
+_Trigger:_ When creating a tag. Release Candidate tags containing "-RC" or "-rc" will skip this.
 
 _Actions:_
 * Close the milestone related to the tag,

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,7 +44,7 @@ _Recovery:_ Manually trigger the action again on the relevant tag.
 
 ## increment-milestones-on-tag [🔗](increment-milestones-on-tag.yaml)
 
-_Trigger:_ When creating a tag.
+_Trigger:_ When creating a tag. Release Candidate tags (containing "-RC" or "-rc" will skip this)
 
 _Actions:_
 * Close the milestone related to the tag,
@@ -67,7 +67,7 @@ _Notes:_ _Download releases_ are special GitHub releases with fixed URL and tags
 
 ## update-issues-on-release [🔗](update-issues-on-release.yaml)
 
-_Trigger:_ When a release is published.
+_Trigger:_ When a release is published. Releases of type `prereleased` should skip this.
 
 _Action:_
 * Find all issues related to the release by checking the related milestone,

--- a/.github/workflows/increment-milestones-on-tag.yaml
+++ b/.github/workflows/increment-milestones-on-tag.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   increment_milestone:
-    if: github.event.ref_type == 'tag' && contains(github.ref,'-RC') == false && github.event.master_branch == 'master'
+    if: github.event.ref_type == 'tag' && contains(github.ref_name,'-RC') == false && github.event.master_branch == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Get milestone title

--- a/.github/workflows/increment-milestones-on-tag.yaml
+++ b/.github/workflows/increment-milestones-on-tag.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   increment_milestone:
-    if: github.event.ref_type == 'tag' && github.event.master_branch == 'master'
+    if: github.event.ref_type == 'tag' && contains(github.ref,'-RC') == false && github.event.master_branch == 'master'
     runs-on: ubuntu-latest
     steps:
       - name: Get milestone title

--- a/.github/workflows/update-issues-on-release.yaml
+++ b/.github/workflows/update-issues-on-release.yaml
@@ -1,7 +1,7 @@
 name: Update issues on release
 on:
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
     inputs:
       milestone:


### PR DESCRIPTION
# What Does This Do

Skips the GitHub workflow milestone update when tags contain "-RC".  This allows multiple Release Candidates to be published with the same issues in the release notes.  Also does not update & close issues for releases of type `prerelease`. 
