### PR TITLE
Added batch RC handler

### DIFF
--- a/remote-config/src/main/java/datadog/remoteconfig/ConfigurationChangesListener.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/ConfigurationChangesListener.java
@@ -2,6 +2,7 @@ package datadog.remoteconfig;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 public interface ConfigurationChangesListener {
@@ -10,6 +11,10 @@ public interface ConfigurationChangesListener {
       @Nullable byte[] content, // null to "unapply" the configuration
       PollingRateHinter pollingRateHinter)
       throws IOException;
+
+  interface Batch {
+    void accept(Map<String, byte[]> configs, PollingRateHinter pollingRateHinter);
+  }
 
   interface PollingRateHinter {
     PollingRateHinter NOOP = new PollingHinterNoop();

--- a/remote-config/src/main/java/datadog/remoteconfig/ConfigurationChangesTypedListener.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/ConfigurationChangesTypedListener.java
@@ -1,5 +1,7 @@
 package datadog.remoteconfig;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 public interface ConfigurationChangesTypedListener<T> {
@@ -7,6 +9,11 @@ public interface ConfigurationChangesTypedListener<T> {
       String configKey,
       @Nullable T configuration, // null to "unapply" the configuration
       ConfigurationChangesListener.PollingRateHinter pollingRateHinter);
+
+  interface Batch<T> {
+    void accept(
+        Map<String, T> configs, ConfigurationChangesListener.PollingRateHinter pollingRateHinter);
+  }
 
   class Builder {
     static <K> ConfigurationChangesListener useDeserializer(
@@ -22,6 +29,30 @@ public interface ConfigurationChangesTypedListener<T> {
           }
         }
         listener.accept(configKey, configuration, pollingRateHinter);
+      };
+    }
+
+    static <K> ConfigurationChangesListener.Batch useBatchDeserializer(
+        ConfigurationDeserializer<K> deserializer,
+        ConfigurationChangesTypedListener.Batch<K> listener) {
+      return (configs, pollingRateHinter) -> {
+        Map<String, K> parsedConfigs = new HashMap<>();
+        configs.forEach(
+            (configKey, content) -> {
+              if (content != null) {
+                try {
+                  K configuration = deserializer.deserialize(content);
+                  // ensure deserializer return a value.
+                  if (configuration == null) {
+                    throw new Exception("Deserializer returned NULL value");
+                  }
+                  parsedConfigs.put(configKey, configuration);
+                } catch (Exception ex) {
+                  throw new ConfigurationPoller.ReportableException(ex.getMessage(), ex);
+                }
+              }
+            });
+        listener.accept(parsedConfigs, pollingRateHinter);
       };
     }
   }

--- a/remote-config/src/main/java/datadog/remoteconfig/state/BatchProductListener.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/BatchProductListener.java
@@ -1,0 +1,47 @@
+package datadog.remoteconfig.state;
+
+import datadog.remoteconfig.ConfigurationChangesListener;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BatchProductListener implements ProductListener.Batch {
+
+  private final ConfigurationChangesListener.Batch listener;
+
+  public BatchProductListener(ConfigurationChangesListener.Batch listener) {
+    this.listener = listener;
+  }
+
+  @Override
+  public void remove(
+      ParsedConfigKey configKey, ConfigurationChangesListener.PollingRateHinter pollingRateHinter)
+      throws IOException {
+    Map<String, byte[]> configs = new HashMap<>();
+    configs.put(configKey.toString(), null);
+
+    listener.accept(configs, pollingRateHinter);
+  }
+
+  @Override
+  public void commit(ConfigurationChangesListener.PollingRateHinter pollingRateHinter) {}
+
+  @Override
+  public Map<ParsedConfigKey, Exception> accept(
+      Map<ParsedConfigKey, byte[]> configs, ConfigurationChangesListener.PollingRateHinter hinter) {
+
+    Map<String, byte[]> preparedConfigs =
+        configs.entrySet().stream()
+            .collect(Collectors.toMap(entry -> entry.getKey().toString(), Map.Entry::getValue));
+
+    listener.accept(preparedConfigs, hinter);
+
+    // We assume that all configs have been successfully applied unless an exception is thrown
+    Map<ParsedConfigKey, Exception> configState = new HashMap<>();
+    for (ParsedConfigKey key : configs.keySet()) {
+      configState.put(key, null);
+    }
+    return configState;
+  }
+}

--- a/remote-config/src/main/java/datadog/remoteconfig/state/ProductListener.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/ProductListener.java
@@ -1,7 +1,10 @@
 package datadog.remoteconfig.state;
 
 import datadog.remoteconfig.ConfigurationChangesListener;
+import datadog.remoteconfig.ConfigurationPoller;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public interface ProductListener {
   void accept(
@@ -15,4 +18,53 @@ public interface ProductListener {
       throws IOException;
 
   void commit(ConfigurationChangesListener.PollingRateHinter pollingRateHinter);
+
+  interface Batch {
+    Map<ParsedConfigKey, Exception> accept(
+        Map<ParsedConfigKey, byte[]> configs,
+        ConfigurationChangesListener.PollingRateHinter hinter);
+
+    void remove(
+        ParsedConfigKey configKey, ConfigurationChangesListener.PollingRateHinter pollingRateHinter)
+        throws IOException;
+
+    void commit(ConfigurationChangesListener.PollingRateHinter pollingRateHinter);
+  }
+
+  class WrapperProductListener implements Batch {
+    private final ProductListener listener;
+
+    public WrapperProductListener(ProductListener listener) {
+      this.listener = listener;
+    }
+
+    @Override
+    public Map<ParsedConfigKey, Exception> accept(
+        Map<ParsedConfigKey, byte[]> configs, ConfigurationChangesListener.PollingRateHinter hinter)
+        throws ConfigurationPoller.ReportableException {
+      Map<ParsedConfigKey, Exception> state = new HashMap<>();
+      configs.forEach(
+          (configKey, content) -> {
+            try {
+              listener.accept(configKey, content, hinter);
+              state.put(configKey, null);
+            } catch (Exception e) {
+              state.put(configKey, e);
+            }
+          });
+      return state;
+    }
+
+    @Override
+    public void remove(
+        ParsedConfigKey configKey, ConfigurationChangesListener.PollingRateHinter pollingRateHinter)
+        throws IOException {
+      listener.remove(configKey, pollingRateHinter);
+    }
+
+    @Override
+    public void commit(ConfigurationChangesListener.PollingRateHinter pollingRateHinter) {
+      listener.commit(pollingRateHinter);
+    }
+  }
 }

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -205,6 +205,80 @@ class ConfigurationPollerSpecification extends DDSpecification {
     0 * _._
   }
 
+  void 'similar configs are handled in batch'() {
+    def deserializer = Mock(ConfigurationDeserializer)
+    ConfigurationChangesTypedListener.Batch listener = Mock(ConfigurationChangesTypedListener.Batch)
+    def respBody = JsonOutput.toJson(
+      client_configs: [
+        'datadog/2/ASM_FEATURES/asm_features_activation/config',
+        'datadog/2/ASM_FEATURES/api_security/sample_rate',
+      ],
+      roots: [],
+      target_files: [
+        [
+          path: 'datadog/2/ASM_FEATURES/asm_features_activation/config',
+          raw: Base64.encoder.encodeToString('{"asm":{"enabled":true}}'.getBytes('UTF-8'))
+        ],
+        [
+          path: 'datadog/2/ASM_FEATURES/api_security/sample_rate',
+          raw: Base64.encoder.encodeToString('{"api_security": {"request_sample_rate": 0.1}'.getBytes('UTF-8'))
+        ]
+      ],
+      targets: signAndBase64EncodeTargets(
+      signed: [
+        expires: '2022-09-17T12:49:15Z',
+        spec_version: '1.0.0',
+        targets: [
+          'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+            custom: [ v: 1 ],
+            hashes: [ sha256: '159658ab85be7207761a4111172b01558394bfc74a1fe1d314f2023f7c656db' ],
+            length : 24,
+          ],
+          'datadog/2/ASM_FEATURES/api_security/sample_rate': [
+            custom: [v:1],
+            hashes: [ sha256: 'bc898b7eb75d9fd0ddee1c1a556bc3c528dd41382950aa86e48816f792d01494' ],
+            length : 45,
+          ]
+        ],
+        version: 1
+      ]
+      ))
+
+    def noConfigs = SLURPER.parse(SAMPLE_RESP_BODY.bytes).with {
+      it['client_configs'] = []
+      JsonOutput.toJson(it)
+    }
+
+    when:
+    poller.addListener(Product.ASM_FEATURES, deserializer, listener)
+    poller.start()
+
+    then:
+    1 * scheduler.scheduleAtFixedRate(_, poller, 0, DEFAULT_POLL_PERIOD, TimeUnit.MILLISECONDS) >> { task = it[0]; scheduled }
+
+    when:
+    task.run(poller)
+
+    then:
+    1 * okHttpClient.newCall(_ as Request) >> { request = it[0]; call }
+    1 * call.execute() >> { buildOKResponse(respBody) }
+
+    then:
+    2 * deserializer.deserialize(_) >> true
+    1 * listener.accept(_, _)
+    0 * _._
+
+    //remove all configurations
+    when:
+    task.run(poller)
+
+    then:
+    1 * okHttpClient.newCall(_ as Request) >> { request = it[0]; call }
+    1 * call.execute() >> { buildOKResponse(noConfigs) }
+    2 * listener.accept(_, _)
+    0 * _._
+  }
+
   void 'processing happens for all listeners'() {
     def deserializer = Mock(ConfigurationDeserializer)
     List<ConfigurationChangesTypedListener> listeners = (1..5).collect { Mock(ConfigurationChangesTypedListener) }


### PR DESCRIPTION
# What Does This Do
Improved remote config. Now we can define remote config product handler that process batch of RC configurations.
Each product in Remote Config can have multiple configuration files, that allows to access all product configuration files at same handler call.

Initially, each product handler was called for each configuration file.
![Untitled-2023-10-25-1647](https://github.com/DataDog/dd-trace-java/assets/7569471/1477642b-d5f3-4b91-b41f-eac182440020)

The extended implementation additionally provides a way to call a product handler with a complete list of configuration files for the selected product.
![Untitled-2023-10-25-1647a](https://github.com/DataDog/dd-trace-java/assets/7569471/29560143-f113-4fd7-acfd-fae097f6cd7f)

# Motivation
This is the changes, required for PR-????

# Additional Notes

Jira ticket: [APPSEC-16674]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-16674]: https://datadoghq.atlassian.net/browse/APPSEC-16674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ