### PR TITLE
Refactor http headers to reduce memory allocations

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestHeaderHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestHeaderHandler.java
@@ -1,7 +1,6 @@
 package com.datadog.iast;
 
 import com.datadog.iast.util.HttpHeader;
-import com.datadog.iast.util.HttpHeader.ContextAwareHeader;
 import datadog.trace.api.function.TriConsumer;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
@@ -13,8 +12,8 @@ public class RequestHeaderHandler implements TriConsumer<RequestContext, String,
     final IastRequestContext ctx = requestContext.getData(RequestContextSlot.IAST);
     if (null != ctx && key != null) {
       final HttpHeader header = HttpHeader.from(key);
-      if (header instanceof ContextAwareHeader) {
-        ((ContextAwareHeader) header).onHeader(ctx, value);
+      if (header != null) {
+        header.addToContext(ctx, value);
       }
     }
   }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
@@ -1,5 +1,15 @@
 package com.datadog.iast.sink;
 
+import static com.datadog.iast.taint.Ranges.allRangesFromHeader;
+import static com.datadog.iast.util.HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static com.datadog.iast.util.HttpHeader.CONNECTION;
+import static com.datadog.iast.util.HttpHeader.LOCATION;
+import static com.datadog.iast.util.HttpHeader.ORIGIN;
+import static com.datadog.iast.util.HttpHeader.SEC_WEBSOCKET_ACCEPT;
+import static com.datadog.iast.util.HttpHeader.SEC_WEBSOCKET_LOCATION;
+import static com.datadog.iast.util.HttpHeader.SET_COOKIE;
+import static com.datadog.iast.util.HttpHeader.UPGRADE;
+
 import com.datadog.iast.Dependencies;
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.Range;
@@ -10,12 +20,10 @@ import com.datadog.iast.taint.TaintedObject;
 import com.datadog.iast.taint.TaintedObjects;
 import com.datadog.iast.util.HttpHeader;
 import datadog.trace.api.iast.IastContext;
-import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.sink.HeaderInjectionModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -23,13 +31,7 @@ import javax.annotation.Nullable;
 public class HeaderInjectionModuleImpl extends SinkModuleBase implements HeaderInjectionModule {
 
   private static final Set<HttpHeader> headerInjectionExclusions =
-      new HashSet<HttpHeader>(
-          Arrays.asList(
-              HttpHeader.Values.SEC_WEBSOCKET_LOCATION,
-              HttpHeader.Values.SEC_WEBSOCKET_ACCEPT,
-              HttpHeader.Values.UPGRADE,
-              HttpHeader.Values.CONNECTION,
-              HttpHeader.Values.LOCATION));
+      EnumSet.of(SEC_WEBSOCKET_LOCATION, SEC_WEBSOCKET_ACCEPT, UPGRADE, CONNECTION, LOCATION);
 
   public HeaderInjectionModuleImpl(final Dependencies dependencies) {
     super(dependencies);
@@ -41,65 +43,49 @@ public class HeaderInjectionModuleImpl extends SinkModuleBase implements HeaderI
       return;
     }
     HttpHeader header = HttpHeader.from(name);
-    boolean headerInjectionExclusion = headerInjectionExclusions.contains(header);
-
-    if (!headerInjectionExclusion) {
-      final IastContext ctx = IastContext.Provider.get();
-      if (ctx == null) {
-        return;
-      }
-      final TaintedObjects to = ctx.getTaintedObjects();
-      final TaintedObject taintedObject = to.get(value);
-      if (null == taintedObject) {
-        return;
-      }
-
-      final Range[] ranges =
-          Ranges.getNotMarkedRanges(
-              taintedObject.getRanges(), VulnerabilityType.HEADER_INJECTION.mark());
-      if (ranges == null || ranges.length == 0) {
-        return;
-      }
-
-      if (header == HttpHeader.Values.ACCESS_CONTROL_ALLOW_ORIGIN) {
-        boolean allRangesFromOrigin = true;
-        for (Range range : ranges) {
-          if (null != range.getSource().getName()
-              && range.getSource().getOrigin() == SourceTypes.REQUEST_HEADER_VALUE
-              && !range.getSource().getName().equalsIgnoreCase("origin")) {
-            allRangesFromOrigin = false;
-          }
-        }
-        if (allRangesFromOrigin) {
-          return;
-        }
-      }
-
-      if (header == HttpHeader.Values.SET_COOKIE) {
-        boolean allRangesFromCookie = true;
-        for (Range range : ranges) {
-          if (null != range.getSource().getName()
-              && range.getSource().getOrigin() == SourceTypes.REQUEST_HEADER_VALUE
-              && !range.getSource().getName().equalsIgnoreCase("Set-Cookie")) {
-            allRangesFromCookie = false;
-          }
-        }
-        if (allRangesFromCookie) {
-          return;
-        }
-      }
-
-      final AgentSpan span = AgentTracer.activeSpan();
-      if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
-        return;
-      }
-      final String evidenceString = name + ": " + value;
-      final Range[] shiftedRanges = new Range[ranges.length];
-      for (int i = 0; i < ranges.length; i++) {
-        shiftedRanges[i] = ranges[i].shift(name.length() + 2);
-      }
-      final Evidence result = new Evidence(evidenceString, shiftedRanges);
-      report(span, VulnerabilityType.HEADER_INJECTION, result);
+    if (headerInjectionExclusions.contains(header)) {
+      return;
     }
+
+    final IastContext ctx = IastContext.Provider.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects to = ctx.getTaintedObjects();
+    final TaintedObject taintedObject = to.get(value);
+    if (null == taintedObject) {
+      return;
+    }
+
+    final Range[] ranges =
+        Ranges.getNotMarkedRanges(
+            taintedObject.getRanges(), VulnerabilityType.HEADER_INJECTION.mark());
+    if (ranges == null || ranges.length == 0) {
+      return;
+    }
+
+    // TODO (spec) we should fix this as it's not a 100% accurate
+    if (header == ACCESS_CONTROL_ALLOW_ORIGIN && allRangesFromHeader(ORIGIN, ranges)) {
+      return;
+    }
+
+    // TODO (spec): we should fix this, the source header should be 'Cookie' not 'Set-Cookie'
+    if ((header == SET_COOKIE) && allRangesFromHeader(SET_COOKIE, ranges)) {
+      return;
+    }
+
+    // TODO (spec): we are missing the case where the header is reflected from the request
+
+    final AgentSpan span = AgentTracer.activeSpan();
+    if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
+      return;
+    }
+    final String evidenceString = name + ": " + value;
+    final Range[] shiftedRanges = new Range[ranges.length];
+    for (int i = 0; i < ranges.length; i++) {
+      shiftedRanges[i] = ranges[i].shift(name.length() + 2);
+    }
+    final Evidence result = new Evidence(evidenceString, shiftedRanges);
+    report(span, VulnerabilityType.HEADER_INJECTION, result);
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HttpResponseHeaderModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HttpResponseHeaderModuleImpl.java
@@ -1,6 +1,6 @@
 package com.datadog.iast.sink;
 
-import static com.datadog.iast.util.HttpHeader.Values.SET_COOKIE;
+import static com.datadog.iast.util.HttpHeader.SET_COOKIE;
 import static java.util.Collections.singletonList;
 
 import com.datadog.iast.Dependencies;
@@ -12,7 +12,6 @@ import com.datadog.iast.model.VulnerabilityType;
 import com.datadog.iast.overhead.Operations;
 import com.datadog.iast.util.CookieSecurityParser;
 import com.datadog.iast.util.HttpHeader;
-import com.datadog.iast.util.HttpHeader.ContextAwareHeader;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.sink.HttpCookieModule;
@@ -37,14 +36,10 @@ public class HttpResponseHeaderModuleImpl extends SinkModuleBase
   public void onHeader(@Nonnull final String name, final String value) {
     final HttpHeader header = HttpHeader.from(name);
     if (header != null) {
-      if (header instanceof ContextAwareHeader) {
-        final AgentSpan span = AgentTracer.activeSpan();
-        final IastContext ctx = IastContext.Provider.get(span);
-        if (ctx instanceof IastRequestContext) {
-          final ContextAwareHeader ctxHeader = (ContextAwareHeader) header;
-          final IastRequestContext iastCtx = (IastRequestContext) ctx;
-          ctxHeader.onHeader(iastCtx, value);
-        }
+      final AgentSpan span = AgentTracer.activeSpan();
+      final IastContext ctx = IastContext.Provider.get(span);
+      if (ctx instanceof IastRequestContext) {
+        header.addToContext((IastRequestContext) ctx, value);
       }
       if (header == SET_COOKIE) {
         onCookies(CookieSecurityParser.parse(value));

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -5,6 +5,8 @@ import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED;
 
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.Source;
+import com.datadog.iast.util.HttpHeader;
+import datadog.trace.api.iast.SourceTypes;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -213,6 +215,30 @@ public final class Ranges {
       }
     }
     return ranges[0];
+  }
+
+  /**
+   * Checks if all ranges are coming from the header, in case no ranges are provided it will return
+   * {@code true}
+   */
+  public static boolean allRangesFromHeader(
+      @Nonnull final String header, @Nonnull final Range[] ranges) {
+    for (Range range : ranges) {
+      final Source source = range.getSource();
+      if (source.getOrigin() != SourceTypes.REQUEST_HEADER_VALUE) {
+        return false;
+      }
+      if (!header.equalsIgnoreCase(source.getName())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** @see #allRangesFromHeader(String, Range[]) */
+  public static boolean allRangesFromHeader(
+      @Nonnull final HttpHeader header, @Nonnull final Range[] ranges) {
+    return allRangesFromHeader(header.name, ranges);
   }
 
   public static Range[] newArray(final long size) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
@@ -1,101 +1,67 @@
 package com.datadog.iast.util;
 
 import com.datadog.iast.IastRequestContext;
-import java.util.Locale;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
-public class HttpHeader {
+public enum HttpHeader {
+  X_FORWARDED_PROTO("X-Forwarded-Proto") {
+    @Override
+    public void addToContext(final IastRequestContext ctx, final String value) {
+      ctx.setxForwardedProto(value);
+    }
+  },
+  STRICT_TRANSPORT_SECURITY("Strict-Transport-Security") {
+    @Override
+    public void addToContext(final IastRequestContext ctx, final String value) {
+      ctx.setStrictTransportSecurity(value);
+    }
+  },
+  CONTENT_TYPE("Content-Type") {
+    @Override
+    public void addToContext(final IastRequestContext ctx, final String value) {
+      ctx.setContentType(value);
+    }
+  },
+  X_CONTENT_TYPE_OPTIONS("X-Content-Type-Options") {
+    @Override
+    public void addToContext(final IastRequestContext ctx, final String value) {
+      ctx.setxContentTypeOptions(value);
+    }
+  },
+  SET_COOKIE("Set-Cookie"),
+  LOCATION("Location"),
+  REFERER("Referer"),
+  SEC_WEBSOCKET_LOCATION("Sec-WebSocket-Location"),
+  SEC_WEBSOCKET_ACCEPT("Sec-WebSocket-Accept"),
+  UPGRADE("Upgrade"),
+  CONNECTION("Connection"),
+  ACCESS_CONTROL_ALLOW_ORIGIN("Access-Control-Allow-Origin"),
+  ORIGIN("Origin");
 
-  final String name;
+  /** Faster lookup for headers */
+  private static final HttpHeaderMap<HttpHeader> HEADERS;
 
-  HttpHeader(final String name) {
-    this.name = name.toLowerCase(Locale.ROOT);
+  static {
+    HEADERS = new HttpHeaderMap<>();
+    for (final HttpHeader header : values()) {
+      HEADERS.put(header.name, header);
+    }
   }
 
-  public boolean matches(final String name) {
+  public final String name;
+
+  HttpHeader(final String name) {
+    this.name = name;
+  }
+
+  public void addToContext(final IastRequestContext ctx, final String value) {}
+
+  public boolean matches(@Nullable final String name) {
     return this.name.equalsIgnoreCase(name);
   }
 
   @Nullable
   public static HttpHeader from(final String name) {
-    return Values.HEADERS.get(name.toLowerCase(Locale.ROOT));
-  }
-
-  public abstract static class ContextAwareHeader extends HttpHeader {
-
-    ContextAwareHeader(final String name) {
-      super(name);
-    }
-
-    public abstract void onHeader(final IastRequestContext ctx, final String value);
-  }
-
-  public static final class Values {
-
-    public static final HttpHeader X_FORWARDED_PROTO =
-        new ContextAwareHeader("X-Forwarded-Proto") {
-
-          @Override
-          public void onHeader(final IastRequestContext ctx, final String value) {
-            ctx.setxForwardedProto(value);
-          }
-        };
-    public static final HttpHeader SET_COOKIE = new HttpHeader("Set-Cookie");
-    public static final HttpHeader STRICT_TRANSPORT_SECURITY =
-        new ContextAwareHeader("Strict-Transport-Security") {
-          @Override
-          public void onHeader(final IastRequestContext ctx, final String value) {
-            ctx.setStrictTransportSecurity(value);
-          }
-        };
-    public static final HttpHeader CONTENT_TYPE =
-        new ContextAwareHeader("Content-Type") {
-          @Override
-          public void onHeader(final IastRequestContext ctx, final String value) {
-            ctx.setContentType(value);
-          }
-        };
-    public static final HttpHeader X_CONTENT_TYPE_OPTIONS =
-        new ContextAwareHeader("X-Content-Type-Options") {
-          @Override
-          public void onHeader(final IastRequestContext ctx, final String value) {
-            ctx.setxContentTypeOptions(value);
-          }
-        };
-
-    public static final HttpHeader LOCATION = new HttpHeader("Location");
-    public static final HttpHeader REFERER = new HttpHeader("Referer");
-    public static final HttpHeader SEC_WEBSOCKET_LOCATION =
-        new HttpHeader("Sec-WebSocket-Location");
-    public static final HttpHeader SEC_WEBSOCKET_ACCEPT = new HttpHeader("Sec-WebSocket-Accept");
-    public static final HttpHeader UPGRADE = new HttpHeader("Upgrade");
-    public static final HttpHeader CONNECTION = new HttpHeader("Connection");
-    public static final HttpHeader ACCESS_CONTROL_ALLOW_ORIGIN =
-        new HttpHeader("Access-Control-Allow-Origin");
-
-    /** Faster lookup for headers */
-    static final Map<String, HttpHeader> HEADERS;
-
-    static {
-      HEADERS =
-          Stream.of(
-                  Values.X_FORWARDED_PROTO,
-                  Values.SET_COOKIE,
-                  Values.STRICT_TRANSPORT_SECURITY,
-                  Values.CONTENT_TYPE,
-                  Values.X_CONTENT_TYPE_OPTIONS,
-                  Values.LOCATION,
-                  Values.REFERER,
-                  Values.SEC_WEBSOCKET_LOCATION,
-                  Values.SEC_WEBSOCKET_ACCEPT,
-                  Values.UPGRADE,
-                  Values.CONNECTION,
-                  Values.ACCESS_CONTROL_ALLOW_ORIGIN)
-              .collect(Collectors.toMap(header -> header.name, Function.identity()));
-    }
+    return HEADERS.get(name);
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeaderMap.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeaderMap.java
@@ -1,0 +1,160 @@
+package com.datadog.iast.util;
+
+import java.lang.reflect.Array;
+import javax.annotation.Nullable;
+
+/**
+ * Naive implementation of an HTTP header in a case-insensitive way.
+ *
+ * <p><b>Warning</b> case insensitive only works for characters in the range [A-Za-z]
+ */
+public class HttpHeaderMap<T> {
+
+  private static final int DEFAULT_BUCKETS = 1 << 4;
+
+  private static final class Entry<T> {
+
+    private final String key;
+
+    @Nullable private T value;
+
+    @Nullable private Entry<T> next;
+
+    private Entry(final String key, @Nullable final T value) {
+      this.key = key;
+      this.value = value;
+    }
+  }
+
+  private final Entry<T>[] entries;
+  private final int bucketCount;
+
+  @SuppressWarnings("unchecked")
+  public HttpHeaderMap(int bucketCount) {
+    this.bucketCount = bucketCount;
+    this.entries = (Entry<T>[]) Array.newInstance(Entry.class, bucketCount);
+  }
+
+  public HttpHeaderMap() {
+    this(DEFAULT_BUCKETS);
+  }
+
+  @Nullable
+  public T put(final String header, @Nullable final T value) {
+    if (header == null) {
+      return null;
+    }
+    final int index = index(hash(header));
+    Entry<T> cur = entries[index];
+    if (cur == null) {
+      entries[index] = new Entry<>(header, value);
+    } else {
+      while (true) {
+        if (equals(cur.key, header)) {
+          final T currentValue = cur.value;
+          cur.value = value;
+          return currentValue;
+        }
+        if (cur.next == null) {
+          cur.next = new Entry<>(header, value);
+          return null;
+        }
+        cur = cur.next;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  public T get(final String name) {
+    if (name == null) {
+      return null;
+    }
+    final int index = index(hash(name));
+    Entry<T> entry = entries[index];
+    while (entry != null) {
+      if (equals(entry.key, name)) {
+        return entry.value;
+      }
+      entry = entry.next;
+    }
+    return null;
+  }
+
+  @Nullable
+  public T remove(final String name) {
+    if (name == null) {
+      return null;
+    }
+    final int index = index(hash(name));
+    Entry<T> cur = entries[index], prev = null;
+    while (cur != null) {
+      if (equals(cur.key, name)) {
+        if (prev == null) {
+          entries[index] = cur.next;
+        } else {
+          prev.next = cur.next;
+        }
+        return cur.value;
+      }
+      prev = cur;
+      cur = cur.next;
+    }
+    return null;
+  }
+
+  public int size() {
+    int result = 0;
+    for (Entry<T> cur : entries) {
+      while (cur != null) {
+        result++;
+        cur = cur.next;
+      }
+    }
+    return result;
+  }
+
+  private int index(final int hash) {
+    return hash % bucketCount;
+  }
+
+  /** Case insensitive hash */
+  private static int hash(final String name) {
+    int h = 0;
+    for (int i = 0; i < name.length(); i++) {
+      char c = lowerCase(name, i);
+      h = 31 * h + c;
+    }
+    if (h > 0) {
+      return h;
+    } else if (h == Integer.MIN_VALUE) {
+      return Integer.MAX_VALUE;
+    } else {
+      return -h;
+    }
+  }
+
+  /** Case insensitive equals * */
+  private static boolean equals(final String name1, final String name2) {
+    if (name1.length() != name2.length()) {
+      return false;
+    }
+    for (int i = 0; i < name1.length(); i++) {
+      char c1 = lowerCase(name1, i);
+      char c2 = lowerCase(name2, i);
+      if (c1 != c2) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** It works for our subset of headers */
+  private static char lowerCase(final String string, final int index) {
+    final char c = string.charAt(index);
+    if (c >= 'A' && c <= 'Z') {
+      return (char) (c + 32); // 'a' - 'A'
+    }
+    return c;
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
@@ -87,15 +87,21 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
 
   void 'exercise onHeader'() {
     when:
-    module.onHeader("Set-Cookie", "user-id=7")
-    module.onHeader("X-Content-Type-Options", "nosniff")
-    module.onHeader("Content-Type", "text/html")
-    module.onHeader("Strict-Transport-Security", "invalid max age")
+    module.onHeader(header, value)
 
     then:
     overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span) >> false // do not report in this test
-    8 * tracer.activeSpan() >> span
+    activeSpanCount * tracer.activeSpan() >>  {
+      return span
+    }
     0 * _
+
+    where:
+    header                      | value             | activeSpanCount
+    "Set-Cookie"                | "user-id=7"       | 3
+    "X-Content-Type-Options"    | "nosniff"         | 2
+    "Content-Type"              | "text/html"       | 2
+    "Strict-Transport-Security" | "invalid max age" | 2
   }
 
   void 'exercise IastRequestController'(){

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
@@ -8,6 +8,10 @@ import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.VulnerabilityMarks
 import datadog.trace.test.util.DDSpecification
 
+import static com.datadog.iast.util.HttpHeader.LOCATION
+import static com.datadog.iast.util.HttpHeader.REFERER
+import static datadog.trace.api.iast.SourceTypes.GRPC_BODY
+import static datadog.trace.api.iast.SourceTypes.REQUEST_HEADER_VALUE
 import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED
 import static com.datadog.iast.taint.Ranges.mergeRanges
 import static com.datadog.iast.taint.Ranges.rangesProviderFor
@@ -307,6 +311,26 @@ class RangesTest extends DDSpecification {
     10     | MAX_RANGE_COUNT | MAX_RANGE_COUNT | MAX_RANGE_COUNT
   }
 
+  void 'test all ranges coming from header'() {
+    when:
+    final allRangesFrom = Ranges.allRangesFromHeader(header, ranges as Range[])
+
+    then:
+    allRangesFrom == expected
+
+    where:
+    header  | ranges                                                                                                     | expected
+    REFERER | []                                                                                                         | true
+    REFERER | [rangeWithSource(REQUEST_HEADER_VALUE, header.name)]                                                       | true
+    REFERER | [rangeWithSource(REQUEST_HEADER_VALUE, LOCATION.name)]                                                     | false
+    REFERER | [rangeWithSource(GRPC_BODY)]                                                                               | false
+    REFERER | [rangeWithSource(REQUEST_HEADER_VALUE, header.name), rangeWithSource(GRPC_BODY)]                           | false
+    REFERER | [
+      rangeWithSource(REQUEST_HEADER_VALUE, header.name),
+      rangeWithSource(REQUEST_HEADER_VALUE, LOCATION.name)
+    ] | false
+  }
+
 
   Range[] rangesFromSpec(List<List<Object>> spec) {
     def ranges = new Range[spec.size()]
@@ -334,5 +358,9 @@ class RangesTest extends DDSpecification {
 
   Range rangeFor(final int index) {
     return new Range(index, 1, new Source(REQUEST_HEADER_NAME, 'a', 'b'), NOT_MARKED)
+  }
+
+  Range rangeWithSource(final byte source, final String name = 'name', final String value = 'value') {
+    return new Range(0, 10, new Source(source, name, value), NOT_MARKED)
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/HttpHeaderMapTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/HttpHeaderMapTest.groovy
@@ -1,0 +1,91 @@
+package com.datadog.iast.util
+
+import spock.lang.Specification
+
+class HttpHeaderMapTest extends Specification {
+
+  void 'test adding key'() {
+    given:
+    final map = new HttpHeaderMap<String>()
+    final value = 'hello'
+
+    when:
+    map.put('oRiGiN', value)
+
+    then:
+    map.get('origin') === value
+  }
+
+  void 'test update key'() {
+    given:
+    final map = new HttpHeaderMap<String>()
+    final value = 'hello'
+    final newValue = 'hello world!'
+    map.put('oRiGiN', value)
+
+    when:
+    final result = map.put('origin', newValue)
+
+    then:
+    result === value
+    map.get('OrIgIn') === newValue
+  }
+
+  void 'test remove key'() {
+    given:
+    final map = new HttpHeaderMap<String>()
+    final value = 'hello'
+    map.put('oRiGiN', value)
+
+    when:
+    final result = map.remove('origin')
+
+    then:
+    result === value
+    map.get('origin') === null
+  }
+
+  void 'test with single bucket'() {
+    given:
+    final map = new HttpHeaderMap<String>(1)
+    final items = (1..5).collect { "header-$it" }
+    final first = items.first()
+    final middle = items[items.size() >> 1]
+    final last = items.last()
+    def expectedSize = items.size()
+
+    when:
+    items.each { map.put(it, it) }
+
+    then:
+    items.each { assert map.get(it) === it }
+    map.size() == expectedSize
+
+    when:
+    final firstRemoved = map.remove(first)
+    expectedSize--
+
+    then:
+    firstRemoved === first
+    map.get(first) === null
+    map.size() == expectedSize
+
+    when:
+    final middleRemoved = map.remove(middle)
+    expectedSize--
+
+    then:
+    middleRemoved === middle
+    map.get(middle) === null
+    map.size() == expectedSize
+
+    when:
+    final lastRemoved = map.remove(last)
+    expectedSize--
+
+    then:
+    lastRemoved === last
+    map.get(last) === null
+    map.size() == expectedSize
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/HttpHeaderTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/HttpHeaderTest.groovy
@@ -1,40 +1,63 @@
 package com.datadog.iast.util
 
-import com.datadog.iast.IastRequestContext
 import spock.lang.Specification
-
-import static com.datadog.iast.util.HttpHeader.Values.HEADERS
 
 class HttpHeaderTest extends Specification {
 
-
-  void 'test context headers'() {
-    setup:
-    final iastCtx = Spy(IastRequestContext)
+  void 'test that headers are not case sensitive'() {
+    given:
+    final name = header.name
 
     when:
-    final parsed = HttpHeader.from(header.name)
+    final sameName = HttpHeader.from(name)
 
     then:
-    parsed != null
+    sameName == header
 
     when:
-    final matches = parsed.matches(header.name.toUpperCase(Locale.ROOT))
+    final lowerHeader = HttpHeader.from(name.toLowerCase(Locale.ROOT))
+
+    then:
+    lowerHeader == header
+
+    when:
+    final upperHeader = HttpHeader.from(name.toUpperCase(Locale.ROOT))
+
+    then:
+    upperHeader == header
+
+    when:
+    final mixedChars = name.toCharArray()
+    mixedChars.eachWithIndex { char entry, int i ->
+      if (i % 2 == 0) {
+        mixedChars[i] = Character.toLowerCase(entry)
+      } else {
+        mixedChars[i] = Character.toUpperCase(entry)
+      }
+    }
+    final mixedHeader = HttpHeader.from(new String(mixedChars))
+
+    then:
+    mixedHeader == header
+
+    when:
+    final nonExisting = HttpHeader.from(name + '_')
+
+    then:
+    nonExisting == null
+
+    where:
+    header << HttpHeader.values()
+  }
+
+  void 'ensure headers can be used in the map'() {
+    when:
+    final matches = header.name  ==~ /[a-zA-Z-]+/
 
     then:
     matches
 
-    when:
-    if (header instanceof HttpHeader.ContextAwareHeader) {
-      header.onHeader(iastCtx, "my_value")
-    }
-
-    then:
-    if (header instanceof HttpHeader.ContextAwareHeader) {
-      1 * iastCtx._
-    }
-
     where:
-    header << HEADERS.values()
+    header << HttpHeader.values()
   }
 }


### PR DESCRIPTION
# What Does This Do
Refactors the `HttpHeader` class in order to reduce memory allocations while checking headers.