### PR TITLE
Scoped context API

### DIFF
--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -53,6 +53,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.Tags",
   "datadog.trace.bootstrap.instrumentation.api.CommonTagValues",
   // Caused by empty 'default' interface method
+  "datadog.trace.bootstrap.instrumentation.api.AgentSpan",
   "datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentPropagation",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer",
@@ -80,6 +81,9 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.ForwardedTagContext",
   "datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities",
   "datadog.trace.bootstrap.instrumentation.api.ErrorPriorities",
+  "datadog.trace.bootstrap.instrumentation.api.ScopedContext",
+  "datadog.trace.bootstrap.instrumentation.api.ScopedContextKey",
+  "datadog.trace.bootstrap.instrumentation.api.Baggage",
   'datadog.trace.api.civisibility.config.Configurations',
   "datadog.trace.api.civisibility.config.ModuleExecutionSettings",
   "datadog.trace.api.civisibility.config.TestIdentifier",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -9,7 +9,7 @@ import datadog.trace.api.sampling.PrioritySampling;
 import java.util.List;
 import java.util.Map;
 
-public interface AgentSpan extends MutableSpan, IGSpanInfo {
+public interface AgentSpan extends MutableSpan, IGSpanInfo, ImplicitContextKeyed {
 
   DDTraceId getTraceId();
 
@@ -140,6 +140,11 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo {
   TraceConfig traceConfig();
 
   void addLink(AgentSpanLink link);
+
+  @Override
+  default ScopedContext storeInto(ScopedContext context) {
+    return context.with(ScopedContextKey.SPAN_KEY, this);
+  }
 
   interface Context {
     /**

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Baggage.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/Baggage.java
@@ -1,0 +1,46 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/** Immutable key-value store for contextual information shared between spans. */
+public interface Baggage extends ImplicitContextKeyed {
+
+  /** Returns the item associated with the key; {@code null} if there's no value. */
+  String get(String key);
+
+  /** Iterates over the items in this baggage. */
+  void forEach(BiConsumer<String, String> consumer);
+
+  /** Returns a read-only {@link Map} view of this baggage. */
+  Map<String, String> asMap();
+
+  /** Returns the number of baggage items. */
+  int size();
+
+  /** Returns whether this baggage contains any items. */
+  default boolean isEmpty() {
+    return size() == 0;
+  }
+
+  @Override
+  default ScopedContext storeInto(ScopedContext context) {
+    return context.with(ScopedContextKey.BAGGAGE_KEY, this);
+  }
+
+  /** Returns a builder that includes all the items in this baggage. */
+  Builder toBuilder();
+
+  /** A mutable builder of {@link Baggage}. */
+  interface Builder {
+
+    /** Adds a new item to the baggage. */
+    Builder put(String key, String value);
+
+    /** Removes an item from the baggage. */
+    Builder remove(String key);
+
+    /** Creates immutable {@link Baggage} containing the items currently in this builder. */
+    Baggage build();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ImplicitContextKeyed.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ImplicitContextKeyed.java
@@ -1,0 +1,8 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+/** A {@link ScopedContext} value that defines its own implicit {@link ScopedContextKey}. */
+public interface ImplicitContextKeyed {
+
+  /** Creates a new context based on the current context with this value. */
+  ScopedContext storeInto(ScopedContext context);
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopedContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopedContext.java
@@ -1,0 +1,33 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import javax.annotation.Nullable;
+
+/** Immutable context scoped to an execution unit. */
+public interface ScopedContext {
+
+  /** Returns the value stored in this context for the key; {@code null} if there's no value. */
+  @Nullable
+  <T> T get(ScopedContextKey<T> key);
+
+  /** Creates a new context based on the current context with the additional key-value. */
+  <T> ScopedContext with(ScopedContextKey<T> key, T value);
+
+  /**
+   * Creates a new context based on the current context with the additional value. The value
+   * contains an implicit key which it will use to store itself.
+   */
+  default ScopedContext with(ImplicitContextKeyed value) {
+    return value.storeInto(this);
+  }
+
+  /** The span associated with this context; {@code null} if there is no span. */
+  @Nullable
+  default AgentSpan span() {
+    return get(ScopedContextKey.SPAN_KEY);
+  }
+
+  /** The baggage to be shared between spans created from the same context. */
+  default Baggage baggage() {
+    return get(ScopedContextKey.BAGGAGE_KEY);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopedContextKey.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/ScopedContextKey.java
@@ -1,0 +1,54 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Key for indexing values of type {@link T} stored in a {@link ScopedContext}. Keys are compared by
+ * identity rather than by name. Each stored type should share its context key somewhere for re-use.
+ */
+public final class ScopedContextKey<T> {
+  private static final AtomicInteger INDEX_GENERATOR = new AtomicInteger(0);
+
+  // internal context keys
+  static final ScopedContextKey<AgentSpan> SPAN_KEY = named("dd-span-key");
+  static final ScopedContextKey<Baggage> BAGGAGE_KEY = named("dd-baggage-key");
+
+  private final String name;
+  private final int index;
+
+  private ScopedContextKey(String name) {
+    this.name = name;
+    this.index = INDEX_GENERATOR.getAndIncrement();
+  }
+
+  /** Creates a new key with the given name. */
+  public static <T> ScopedContextKey<T> named(String name) {
+    return new ScopedContextKey<>(name);
+  }
+
+  /** Returns the index allocated to this key. */
+  public int index() {
+    return index;
+  }
+
+  @Override
+  public int hashCode() {
+    return index;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    } else if (o == null || getClass() != o.getClass()) {
+      return false;
+    } else {
+      return index == ((ScopedContextKey<?>) o).index;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return name + '@' + index;
+  }
+}


### PR DESCRIPTION
# What Does This Do

Draft API for supporting arbitrary context propagated across APIs, threads, etc.

# Motivation

We'd like to minimise the gap between our current context propagation model and OpeTelemetry's model.

# Additional Notes

This is the initial API, which follows the same semantics as OpenTelemetry - namely that each update results in an immutable context. We also introduce a specific interface to represent `Baggage` which should be propagated to child spans in the same context.

Jira ticket: [AIT-9455]

[AIT-9455]: https://datadoghq.atlassian.net/browse/AIT-9455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ