### PR TITLE
Add TriageReport for Dynamic Instrumentation

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -295,4 +295,8 @@ public class ConfigurationUpdater
   Map<String, ProbeDefinition> getAppliedDefinitions() {
     return appliedDefinitions;
   }
+
+  Map<String, InstrumentationResult> getInstrumentationResults() {
+    return instrumentationResults;
+  }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ProbeStatus.java
@@ -95,6 +95,9 @@ public class ProbeStatus {
         + ", service='"
         + service
         + '\''
+        + ", timestamp='"
+        + Instant.ofEpochMilli(timestamp)
+        + '\''
         + ", message='"
         + message
         + '\''
@@ -274,7 +277,7 @@ public class ProbeStatus {
     public ProbeStatus emittingMessage(String probeId) {
       return new ProbeStatus(
           this.serviceName,
-          "Probe " + probeId + "is emitting.",
+          "Probe " + probeId + " is emitting.",
           new Diagnostics(probeId, runtimeId, Status.EMITTING, null));
     }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/InstrumentationResult.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/InstrumentationResult.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.instrumentation;
 
+import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.probe.ProbeDefinition;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import java.util.Arrays;
@@ -78,5 +79,22 @@ public class InstrumentationResult {
 
   public String getMethodName() {
     return methodName;
+  }
+
+  @Generated
+  @Override
+  public String toString() {
+    return "InstrumentationResult{"
+        + "status="
+        + status
+        + ", diagnostics="
+        + diagnostics
+        + ", typeName='"
+        + typeName
+        + '\''
+        + ", methodName='"
+        + methodName
+        + '\''
+        + '}';
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -186,6 +186,21 @@ public class LogProbe extends ProbeDefinition {
       return Objects.hash(maxReferenceDepth, maxCollectionSize, maxLength, maxFieldCount);
     }
 
+    @Generated
+    @Override
+    public String toString() {
+      return "Capture{"
+          + "maxReferenceDepth="
+          + maxReferenceDepth
+          + ", maxCollectionSize="
+          + maxCollectionSize
+          + ", maxLength="
+          + maxLength
+          + ", maxFieldCount="
+          + maxFieldCount
+          + '}';
+    }
+
     public static Limits toLimits(Capture capture) {
       if (capture == null) {
         return Limits.DEFAULT;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -13,10 +13,12 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import okhttp3.HttpUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,6 +114,18 @@ public class ProbeStatusSink {
       }
     }
     return serializedDiagnostics;
+  }
+
+  public HttpUrl getUrl() {
+    return diagnosticUploader.getUrl();
+  }
+
+  public Map<String, String> getProbeStatuses() {
+    Map<String, String> result = new HashMap<>();
+    for (Map.Entry<String, TimedMessage> entry : probeStatuses.entrySet()) {
+      result.put(entry.getKey(), entry.getValue().getMessage().toString());
+    }
+    return result;
   }
 
   List<ProbeStatus> getDiagnostics() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import okhttp3.HttpUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,7 @@ public class SymbolSink {
   private final BatchUploader symbolUploader;
   private final BatchUploader.MultiPartContent event;
   private final BlockingQueue<ServiceVersion> scopes = new ArrayBlockingQueue<>(CAPACITY);
+  private final Stats stats = new Stats();
 
   public SymbolSink(Config config) {
     this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl()));
@@ -73,6 +75,9 @@ public class SymbolSink {
             "Sending scope: {}, size={}",
             serviceVersion.getScopes().get(0).getName(),
             json.length());
+        List<Scope> classScopes = serviceVersion.getScopes().get(0).getScopes();
+        int classScopeCount = classScopes != null ? classScopes.size() : 0;
+        stats.updateStats(classScopeCount, json.length());
         symbolUploader.uploadAsMultipart(
             "",
             event,
@@ -81,6 +86,37 @@ public class SymbolSink {
       } catch (Exception e) {
         ExceptionHelper.logException(LOGGER, e, "Error during scope serialization:");
       }
+    }
+  }
+
+  public HttpUrl getUrl() {
+    return symbolUploader.getUrl();
+  }
+
+  public Stats getStats() {
+    return stats;
+  }
+
+  public static class Stats {
+    private long totalClassScopes;
+    private long totalSize;
+
+    public long getTotalClassScopes() {
+      return totalClassScopes;
+    }
+
+    public long getTotalSize() {
+      return totalSize;
+    }
+
+    void updateStats(long classScopes, long size) {
+      totalClassScopes += classScopes;
+      totalSize += size;
+    }
+
+    @Override
+    public String toString() {
+      return "Stats{" + "totalClassScopes=" + totalClassScopes + ", totalSize=" + totalSize + '}';
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -178,6 +178,10 @@ public class BatchUploader {
     return client;
   }
 
+  public HttpUrl getUrl() {
+    return urlBase;
+  }
+
   private void makeUploadRequest(byte[] json, String tags) {
     int contentLength = json.length;
     // use RequestBody.create(MediaType, byte[]) to avoid changing Content-Type to


### PR DESCRIPTION
# What Does This Do
When a Java Tracer Flare is triggered we will collect some specific Dynamic Instrumentation information:
- Snapshot url
- Diagnostic url
- SymbolDB url
- Probe definitions
- Instrumentation done
- probe statuses
- SymbolDB stats

```
Snapshot url: http://localhost:8126/debugger/v1/input
Diagnostic url: http://localhost:8126/debugger/v1/diagnostics
SymbolDB url: http://localhost:8126/symdb/v1/input
Probe definitions:
{a73eb042-fd9f-4973-8fe2-7ca79d40ba7e:0=LogProbe{language='java', id='a73eb042-fd9f-4973-8fe2-7ca79d40ba7e', version=0, tags=[], tagMap={}, where=Where{typeName='null', methodName='null', sourceFile='CrashController.java', signature='null', lines=[57]}, evaluateAt=EXIT, template='In CrashController.java, line 57', segments=[Segment{str='In CrashController.java, line 57', parsedExr=null}], captureSnapshot=true, when=null, capture=Capture{maxReferenceDepth=3, maxCollectionSize=100, maxLength=255, maxFieldCount=20}, sampling=Sampling{snapshotsPerSecond=1.0}} , 7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9:0=LogProbe{language='java', id='7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9', version=0, tags=[], tagMap={}, where=Where{typeName='VetController', methodName='showVetList', sourceFile='null', signature='null', lines=null}, evaluateAt=EXIT, template='Executed VetController.showVetList, it took {@duration}ms', segments=[Segment{str='Executed VetController.showVetList, it took ', parsedExr=null}, Segment{str='null', parsedExr=ValueScript{dsl='@duration'}}, Segment{str='ms', parsedExr=null}], captureSnapshot=true, when=ProbeCondition{dslExpression='@duration > 0'}, capture=Capture{maxReferenceDepth=3, maxCollectionSize=100, maxLength=255, maxFieldCount=20}, sampling=Sampling{snapshotsPerSecond=1.0}} , 25c8e861-c7f8-4004-a05f-416380324b2f:3=SpanDecorationProbe{language='java', id='25c8e861-c7f8-4004-a05f-416380324b2f', version=3, tags=[], tagMap={}, where=Where{typeName='VetController', methodName='showVetList', sourceFile='null', signature='null', lines=null}, evaluateAt=EXIT, targetSpan=ROOT, decorations=[Decoration{when=null, tags=[Tag{name='resource.name', value=TagValue{template='this showVetList span', segments=[Segment{str='this showVetList span', parsedExr=null}]}}, Tag{name='tag1', value=TagValue{template='{uuid}', segments=[Segment{str='null', parsedExr=ValueScript{dsl='uuid'}}]}}]}]} , da0c0b91-3e46-4d33-b8b0-c3ce4c565154:0=MetricProbe{language='java', id='da0c0b91-3e46-4d33-b8b0-c3ce4c565154', version=0, tags=[], tagMap={}, where=Where{typeName='VetController', methodName='showVetList', sourceFile='null', signature='null', lines=null}, evaluateAt=EXIT, kind=GAUGE, metricName='callDuration, valueScript='ValueScript{dsl='@duration'}'} , 75ba301c-6f33-4f5b-996c-f799c62f4969:0=LogProbe{language='java', id='75ba301c-6f33-4f5b-996c-f799c62f4969', version=0, tags=[], tagMap={}, where=Where{typeName='VetController', methodName='showVetList', sourceFile='null', signature='null', lines=null}, evaluateAt=EXIT, template='Executed VetController.showVetList, it took {this.foo} ms', segments=[Segment{str='Executed VetController.showVetList, it took ', parsedExr=null}, Segment{str='null', parsedExr=ValueScript{dsl='this.foo'}}, Segment{str=' ms', parsedExr=null}], captureSnapshot=false, when=null, capture=Capture{maxReferenceDepth=3, maxCollectionSize=100, maxLength=255, maxFieldCount=20}, sampling=Sampling{snapshotsPerSecond=5000.0}} , 23976024-216a-448c-84cb-f16aef20b578:0=SpanProbe{language='java', id='23976024-216a-448c-84cb-f16aef20b578', version=0, tags=[], tagMap={}, where=Where{typeName='VetController', methodName='showVetList', sourceFile='null', signature='null', lines=null}, evaluateAt=EXIT} }
Instrumented probes:
{a73eb042-fd9f-4973-8fe2-7ca79d40ba7e:0=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='a73eb042-fd9f-4973-8fe2-7ca79d40ba7e', version=0}=[]}, typeName='org.springframework.samples.petclinic.system.CrashController', methodName='caughtExceptions'}, 7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9:0=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='75ba301c-6f33-4f5b-996c-f799c62f4969', version=0}=[], ProbeId{id='23976024-216a-448c-84cb-f16aef20b578', version=0}=[], ProbeId{id='7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9', version=0}=[], ProbeId{id='25c8e861-c7f8-4004-a05f-416380324b2f', version=3}=[], ProbeId{id='da0c0b91-3e46-4d33-b8b0-c3ce4c565154', version=0}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='showVetList'}, 25c8e861-c7f8-4004-a05f-416380324b2f:3=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='75ba301c-6f33-4f5b-996c-f799c62f4969', version=0}=[], ProbeId{id='23976024-216a-448c-84cb-f16aef20b578', version=0}=[], ProbeId{id='7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9', version=0}=[], ProbeId{id='25c8e861-c7f8-4004-a05f-416380324b2f', version=3}=[], ProbeId{id='da0c0b91-3e46-4d33-b8b0-c3ce4c565154', version=0}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='showVetList'}, da0c0b91-3e46-4d33-b8b0-c3ce4c565154:0=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='75ba301c-6f33-4f5b-996c-f799c62f4969', version=0}=[], ProbeId{id='23976024-216a-448c-84cb-f16aef20b578', version=0}=[], ProbeId{id='7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9', version=0}=[], ProbeId{id='25c8e861-c7f8-4004-a05f-416380324b2f', version=3}=[], ProbeId{id='da0c0b91-3e46-4d33-b8b0-c3ce4c565154', version=0}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='showVetList'}, 75ba301c-6f33-4f5b-996c-f799c62f4969:0=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='75ba301c-6f33-4f5b-996c-f799c62f4969', version=0}=[], ProbeId{id='23976024-216a-448c-84cb-f16aef20b578', version=0}=[], ProbeId{id='7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9', version=0}=[], ProbeId{id='25c8e861-c7f8-4004-a05f-416380324b2f', version=3}=[], ProbeId{id='da0c0b91-3e46-4d33-b8b0-c3ce4c565154', version=0}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='showVetList'}, 23976024-216a-448c-84cb-f16aef20b578:0=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='75ba301c-6f33-4f5b-996c-f799c62f4969', version=0}=[], ProbeId{id='23976024-216a-448c-84cb-f16aef20b578', version=0}=[], ProbeId{id='7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9', version=0}=[], ProbeId{id='25c8e861-c7f8-4004-a05f-416380324b2f', version=3}=[], ProbeId{id='da0c0b91-3e46-4d33-b8b0-c3ce4c565154', version=0}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='showVetList'}}
Probe statuses:
{a73eb042-fd9f-4973-8fe2-7ca79d40ba7e:0=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-01-18T17:29:13.841Z', message='Installed probe ProbeId{id='a73eb042-fd9f-4973-8fe2-7ca79d40ba7e', version=0}.', debugger=Diagnostics{probeId='a73eb042-fd9f-4973-8fe2-7ca79d40ba7e', probeVersion=0, runtimeId='189c31f8-5816-4e74-8bde-3fb2aa8484ff', status=INSTALLED, exception=null}}, 7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9:0=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-01-18T17:29:29.164Z', message='Probe 7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9:0 is emitting.', debugger=Diagnostics{probeId='7c7a98ef-0bc3-4f24-a7bb-13754b7b40f9', probeVersion=0, runtimeId='189c31f8-5816-4e74-8bde-3fb2aa8484ff', status=EMITTING, exception=null}}, 25c8e861-c7f8-4004-a05f-416380324b2f:3=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-01-18T17:29:29.165Z', message='Probe 25c8e861-c7f8-4004-a05f-416380324b2f:3 is emitting.', debugger=Diagnostics{probeId='25c8e861-c7f8-4004-a05f-416380324b2f', probeVersion=3, runtimeId='189c31f8-5816-4e74-8bde-3fb2aa8484ff', status=EMITTING, exception=null}}, da0c0b91-3e46-4d33-b8b0-c3ce4c565154:0=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-01-18T17:29:29.137Z', message='Probe da0c0b91-3e46-4d33-b8b0-c3ce4c565154:0 is emitting.', debugger=Diagnostics{probeId='da0c0b91-3e46-4d33-b8b0-c3ce4c565154', probeVersion=0, runtimeId='189c31f8-5816-4e74-8bde-3fb2aa8484ff', status=EMITTING, exception=null}}, 75ba301c-6f33-4f5b-996c-f799c62f4969:0=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-01-18T17:29:29.165Z', message='Probe 75ba301c-6f33-4f5b-996c-f799c62f4969:0 is emitting.', debugger=Diagnostics{probeId='75ba301c-6f33-4f5b-996c-f799c62f4969', probeVersion=0, runtimeId='189c31f8-5816-4e74-8bde-3fb2aa8484ff', status=EMITTING, exception=null}}, 23976024-216a-448c-84cb-f16aef20b578:0=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-01-18T17:29:29.165Z', message='Probe 23976024-216a-448c-84cb-f16aef20b578:0 is emitting.', debugger=Diagnostics{probeId='23976024-216a-448c-84cb-f16aef20b578', probeVersion=0, runtimeId='189c31f8-5816-4e74-8bde-3fb2aa8484ff', status=EMITTING, exception=null}}}
SymbolDB stats:
Stats{totalClassScopes=28, totalSize=79969}
```

# Motivation
Add additional information for troubleshooting using Java Tracer Flare that can be triggered with Datadog agent flare

# Additional Notes

Jira ticket: [DEBUG-2062]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2062]: https://datadoghq.atlassian.net/browse/DEBUG-2062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ