### PR TITLE
remove suffix from tag in gh workflow

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -19,15 +19,18 @@ jobs:
             const milestoneTitle = '${{github.event.ref}}'.startsWith('v') ?
                 '${{github.event.ref}}'.substring(1) :
                 '${{github.event.ref}}'
+                
+            // get X.Y.Z from X.Y.Z-RC1
+            const milestoneShortTitle = milestoneTitle.split("-")[0]
 
             // Look for the milestone
             const milestone = (await github.paginate('GET /repos/{owner}/{repo}/milestones', {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'all'
-            })).find(m => m.title == milestoneTitle)
+            })).find(m => m.title == milestoneShortTitle)
             if (!milestone) {
-              core.setFailed('Failed to find milestone: ${milestoneTitle}')
+              core.setFailed('Failed to find milestone: ${milestoneShortTitle}')
               return
             }
 

--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -30,7 +30,7 @@ jobs:
               state: 'all'
             })).find(m => m.title == milestoneShortTitle)
             if (!milestone) {
-              core.setFailed('Failed to find milestone: ${milestoneShortTitle}')
+              core.setFailed('Failed to find milestone: ' + milestoneShortTitle')
               return
             }
 

--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -30,7 +30,7 @@ jobs:
               state: 'all'
             })).find(m => m.title == milestoneShortTitle)
             if (!milestone) {
-              core.setFailed('Failed to find milestone: ' + milestoneShortTitle')
+              core.setFailed('Failed to find milestone: ' + milestoneShortTitle)
               return
             }
 


### PR DESCRIPTION
# What Does This Do

Retains only the portion of a release tag before any "-" in the tag.  Gets "1.2.3" from "1.2.3-RC" to lookup the milestone.