### PR TITLE
Added RC product listeners per config

### DIFF
--- a/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
@@ -137,6 +137,22 @@ public class ConfigurationPoller
     this.addListener(product, new SimpleProductListener(useDeserializer(deserializer, listener)));
   }
 
+  public synchronized void addListener(
+      Product product, String configKey, ProductListener listener) {
+    ProductState productState =
+        this.productStates.computeIfAbsent(product, p -> new ProductState(product));
+    productState.addProductListener(configKey, listener);
+  }
+
+  public synchronized <T> void addListener(
+      Product product,
+      String configKey,
+      ConfigurationDeserializer<T> deserializer,
+      ConfigurationChangesTypedListener<T> listener) {
+    this.addListener(
+        product, configKey, new SimpleProductListener(useDeserializer(deserializer, listener)));
+  }
+
   public synchronized void removeListeners(Product product) {
     this.productStates.remove(product);
   }

--- a/remote-config/src/main/java/datadog/remoteconfig/state/ProductState.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/state/ProductState.java
@@ -30,20 +30,26 @@ public class ProductState {
       new HashMap<>();
   private final Map<ParsedConfigKey, RemoteConfigRequest.ClientInfo.ClientState.ConfigState>
       configStates = new HashMap<>();
-  private final List<ProductListener> listeners;
+  private final List<ProductListener> productListeners;
+  private final Map<String, ProductListener> configListeners;
 
   List<ConfigurationPoller.ReportableException> errors = null;
 
   public ProductState(Product product) {
     this.product = product;
-    this.listeners = new LinkedList<>();
+    this.productListeners = new LinkedList<>();
+    this.configListeners = new HashMap<>();
 
     this.ratelimitedLogger =
         new RatelimitedLogger(log, MINUTES_BETWEEN_ERROR_LOG, TimeUnit.MINUTES);
   }
 
   public void addProductListener(ProductListener listener) {
-    listeners.add(listener);
+    productListeners.add(listener);
+  }
+
+  public void addProductListener(String configId, ProductListener listener) {
+    configListeners.put(configId, listener);
   }
 
   public boolean apply(
@@ -99,9 +105,14 @@ public class ProductState {
       byte[] content) {
 
     try {
-      for (ProductListener listener : listeners) {
+      for (ProductListener listener : productListeners) {
         listener.accept(configKey, content, hinter);
       }
+      ProductListener listener = configListeners.get(configKey.getConfigId());
+      if (listener != null) {
+        listener.accept(configKey, content, hinter);
+      }
+
       updateConfigState(fleetResponse, configKey, null);
     } catch (ConfigurationPoller.ReportableException e) {
       recordError(e);
@@ -117,7 +128,11 @@ public class ProductState {
   private void callListenerRemoveTarget(
       ConfigurationChangesListener.PollingRateHinter hinter, ParsedConfigKey configKey) {
     try {
-      for (ProductListener listener : listeners) {
+      for (ProductListener listener : productListeners) {
+        listener.remove(configKey, hinter);
+      }
+      ProductListener listener = configListeners.get(configKey.getConfigId());
+      if (listener != null) {
         listener.remove(configKey, hinter);
       }
     } catch (Exception ex) {
@@ -129,7 +144,10 @@ public class ProductState {
 
   private void callListenerCommit(ConfigurationChangesListener.PollingRateHinter hinter) {
     try {
-      for (ProductListener listener : listeners) {
+      for (ProductListener listener : productListeners) {
+        listener.commit(hinter);
+      }
+      for (ProductListener listener : configListeners.values()) {
         listener.commit(hinter);
       }
     } catch (ConfigurationPoller.ReportableException e) {

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -205,6 +205,84 @@ class ConfigurationPollerSpecification extends DDSpecification {
     0 * _._
   }
 
+  void 'handle product listeners per config'() {
+    def deserializer = Mock(ConfigurationDeserializer)
+    ConfigurationChangesTypedListener activationListener = Mock(ConfigurationChangesTypedListener)
+    ConfigurationChangesTypedListener sampleRateListener = Mock(ConfigurationChangesTypedListener)
+    def respBody = JsonOutput.toJson(
+      client_configs: [
+        'datadog/2/ASM_FEATURES/asm_features_activation/config',
+        'datadog/2/ASM_FEATURES/api_security/sample_rate',
+      ],
+      roots: [],
+      target_files: [
+        [
+          path: 'datadog/2/ASM_FEATURES/asm_features_activation/config',
+          raw: Base64.encoder.encodeToString('{"asm":{"enabled":true}}'.getBytes('UTF-8'))
+        ],
+        [
+          path: 'datadog/2/ASM_FEATURES/api_security/sample_rate',
+          raw: Base64.encoder.encodeToString('{"api_security": {"request_sample_rate": 0.1}'.getBytes('UTF-8'))
+        ]
+      ],
+      targets: signAndBase64EncodeTargets(
+      signed: [
+        expires: '2022-09-17T12:49:15Z',
+        spec_version: '1.0.0',
+        targets: [
+          'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+            custom: [ v: 1 ],
+            hashes: [ sha256: '159658ab85be7207761a4111172b01558394bfc74a1fe1d314f2023f7c656db' ],
+            length : 24,
+          ],
+          'datadog/2/ASM_FEATURES/api_security/sample_rate': [
+            custom: [v:1],
+            hashes: [ sha256: 'bc898b7eb75d9fd0ddee1c1a556bc3c528dd41382950aa86e48816f792d01494' ],
+            length : 45,
+          ]
+        ],
+        version: 1
+      ]
+      ))
+
+    def noConfigs = SLURPER.parse(SAMPLE_RESP_BODY.bytes).with {
+      it['client_configs'] = []
+      JsonOutput.toJson(it)
+    }
+
+    when:
+    poller.addListener(Product.ASM_FEATURES, 'asm_features_activation', deserializer, activationListener)
+    poller.addListener(Product.ASM_FEATURES, 'api_security', deserializer, sampleRateListener)
+    poller.start()
+
+    then:
+    1 * scheduler.scheduleAtFixedRate(_, poller, 0, DEFAULT_POLL_PERIOD, TimeUnit.MILLISECONDS) >> { task = it[0]; scheduled }
+
+    when:
+    task.run(poller)
+
+    then:
+    1 * okHttpClient.newCall(_ as Request) >> { request = it[0]; call }
+    1 * call.execute() >> { buildOKResponse(respBody) }
+
+    then:
+    2 * deserializer.deserialize(_) >> true
+    1 * activationListener.accept('datadog/2/ASM_FEATURES/asm_features_activation/config', _, _)
+    1 * sampleRateListener.accept('datadog/2/ASM_FEATURES/api_security/sample_rate', _, _)
+    0 * _._
+
+    //remove all configurations
+    when:
+    task.run(poller)
+
+    then:
+    1 * okHttpClient.newCall(_ as Request) >> { request = it[0]; call }
+    1 * call.execute() >> { buildOKResponse(noConfigs) }
+    1 * activationListener.accept('datadog/2/ASM_FEATURES/asm_features_activation/config', _, _)
+    1 * sampleRateListener.accept('datadog/2/ASM_FEATURES/api_security/sample_rate', _, _)
+    0 * _._
+  }
+
   void 'processing happens for all listeners'() {
     def deserializer = Mock(ConfigurationDeserializer)
     List<ConfigurationChangesTypedListener> listeners = (1..5).collect { Mock(ConfigurationChangesTypedListener) }


### PR DESCRIPTION
# What Does This Do
Improved remote config. Now you can define RC listener for both: _product_ and _product config_
- **product listener** (all configs are handled with the same listener). The legacy approach, and should be used only if remote config provides only one config with single well defined structure. In case if several configs provided, each will be processed by the same listener.
![Untitled-2023-10-25-1647](https://github.com/DataDog/dd-trace-java/assets/7569471/d0550249-1c2f-42f1-befa-046ef048ed2b)

- **config listener** (only certain config will be handled by listener). New approach, created to handle cases when remote config provides multiple configs per product with different structures, so each config will be deserialised and parsed by it's own listener.
![Untitled-2023-10-25-1647a](https://github.com/DataDog/dd-trace-java/assets/7569471/b1f60388-9cee-42b9-b7b6-8301cc446a75)

# Motivation
This PR is preparation work for #6340 

# Additional Notes
### Usage:
To add product listener:
```
ConfigurationPoller.addListener(product, deserialiser, listener)
```
To add config specific listener:
```
ConfigurationPoller.addListener(product, configKey, deserialiser, listener)
```