### PR TITLE
Add release not draft support for RC

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -15,10 +15,13 @@ jobs:
         with:
           result-encoding: string
           script: |
-            // Get the milestone title ("X.Y.Z") from tag name ("vX.Y.Z")
-            const milestoneTitle = '${{github.event.ref}}'.startsWith('v') ?
-                '${{github.event.ref}}'.substring(1) :
-                '${{github.event.ref}}'
+            // Get the milestone title ("X.Y.Z") from tag name ("vX.Y.Z(-rc)")
+            const match = '${{github.event.ref}}'.match(/v(\d+\.\d+\.\d+)(?:-rc\d+)?/i)
+            if (!match) {
+              core.setFailed('Failed to parse tag name into milestone name: ${{github.event.ref}}')
+              return
+            }
+            const milestoneTitle = match[1]
 
             // Look for the milestone
             const milestone = (await github.paginate('GET /repos/{owner}/{repo}/milestones', {
@@ -27,7 +30,7 @@ jobs:
               state: 'all'
             })).find(m => m.title == milestoneTitle)
             if (!milestone) {
-              core.setFailed('Failed to find milestone: ${milestoneTitle}')
+              core.setFailed(`Failed to find milestone: ${milestoneTitle}`)
               return
             }
 


### PR DESCRIPTION
# What Does This Do

This PR adds support for RC release to the release note draft generation.

# Motivation

The introduction of RC broke the tag naming conventions, so the milestone lookup.

# Additional Notes

Jira ticket: [APMJAVA-1197]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1197]: https://datadoghq.atlassian.net/browse/APMJAVA-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ