### PR TITLE
Improve telemetry log deduplication

### DIFF
--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/ddlogger/DDTelemetryLoggerTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/ddlogger/DDTelemetryLoggerTest.groovy
@@ -75,7 +75,7 @@ class DDTelemetryLoggerTest extends LogValidatingSpecification {
 
     then:
     collection.size() == 1
-    collection[0].message() == format
+    collection[0].message == format
 
     where:
     call << allLogLevels
@@ -94,7 +94,7 @@ class DDTelemetryLoggerTest extends LogValidatingSpecification {
 
     then:
     collection.size() == 1
-    collection[0].message() == format
+    collection[0].message == format
 
     where:
     call << allLogLevels
@@ -114,7 +114,7 @@ class DDTelemetryLoggerTest extends LogValidatingSpecification {
 
     then:
     collection.size() == 1
-    collection[0].message() == format
+    collection[0].message == format
 
     where:
     call << allLogLevels
@@ -134,7 +134,7 @@ class DDTelemetryLoggerTest extends LogValidatingSpecification {
 
     then:
     collection.size() == 1
-    collection[0].message() == format
+    collection[0].message == format
 
     where:
     call << allLogLevels

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
@@ -34,13 +34,14 @@ public class LogCollector {
   }
 
   public void addLogMessage(String logLevel, String message, Throwable throwable) {
+    if (rawLogMessages.size() >= maxCapacity) {
+      // TODO: We could emit a metric for dropped logs.
+      return;
+    }
     RawLogMessage rawLogMessage =
         new RawLogMessage(logLevel, message, throwable, System.currentTimeMillis());
-
-    if (rawLogMessages.size() < maxCapacity) {
-      AtomicInteger count = rawLogMessages.computeIfAbsent(rawLogMessage, k -> new AtomicInteger());
-      count.incrementAndGet();
-    }
+    AtomicInteger count = rawLogMessages.computeIfAbsent(rawLogMessage, k -> new AtomicInteger());
+    count.incrementAndGet();
   }
 
   public Collection<RawLogMessage> drain() {
@@ -49,18 +50,18 @@ public class LogCollector {
     }
 
     List<RawLogMessage> list = new ArrayList<>();
-
     Iterator<Map.Entry<RawLogMessage, AtomicInteger>> iterator =
         rawLogMessages.entrySet().iterator();
 
     while (iterator.hasNext()) {
       Map.Entry<RawLogMessage, AtomicInteger> entry = iterator.next();
-
       RawLogMessage logMessage = entry.getKey();
+      // XXX: There might be lost writers to the counters under concurrency if another thread
+      // increments it
+      //      while we are reading it here. At the moment, we are not overdoing this to prevent some
+      // counter losses.
       logMessage.count = entry.getValue().get();
-
       iterator.remove();
-
       list.add(logMessage);
     }
 
@@ -68,7 +69,7 @@ public class LogCollector {
   }
 
   public static class RawLogMessage {
-    public final String messageOriginal;
+    public final String message;
     public final String logLevel;
     public final Throwable throwable;
     public final long timestamp;
@@ -76,16 +77,9 @@ public class LogCollector {
 
     public RawLogMessage(String logLevel, String message, Throwable throwable, long timestamp) {
       this.logLevel = logLevel;
-      this.messageOriginal = message;
+      this.message = message;
       this.throwable = throwable;
       this.timestamp = timestamp;
-    }
-
-    public String message() {
-      if (count > 1) {
-        return messageOriginal + ", {" + count + "} additional messages skipped";
-      }
-      return messageOriginal;
     }
 
     @Override
@@ -94,13 +88,18 @@ public class LogCollector {
       if (o == null || getClass() != o.getClass()) return false;
       RawLogMessage that = (RawLogMessage) o;
       return Objects.equals(logLevel, that.logLevel)
-          && Objects.equals(messageOriginal, that.messageOriginal)
-          && Objects.equals(throwable, that.throwable);
+          && Objects.equals(message, that.message)
+          && Objects.equals(
+              throwable == null ? null : throwable.getClass(),
+              that.throwable == null ? null : that.throwable.getClass())
+          && Objects.deepEquals(
+              throwable == null ? null : throwable.getStackTrace(),
+              that.throwable == null ? null : that.throwable.getStackTrace());
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(logLevel, messageOriginal, throwable);
+      return Objects.hash(logLevel, message, throwable == null ? null : throwable.getClass());
     }
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/LogCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/LogCollectorTest.groovy
@@ -33,15 +33,15 @@ class LogCollectorTest extends DDSpecification {
     then:
     def list = LogCollector.get().drain()
     list.size() == 4
-    listContains(list, 'ERROR', "First Message", null)
-    listContains(list, 'ERROR', "Second Message, {2} additional messages skipped", null)
-    listContains(list, 'ERROR', "Third Message, {3} additional messages skipped", null)
-    listContains(list, 'ERROR', "Forth Message, {4} additional messages skipped", null)
+    listContains(list, 'ERROR', "First Message", null, 1)
+    listContains(list, 'ERROR', "Second Message", null, 2)
+    listContains(list, 'ERROR', "Third Message", null,3)
+    listContains(list, 'ERROR', "Forth Message", null, 4)
   }
 
-  boolean listContains(Collection<LogCollector.RawLogMessage> list, String logLevel, String message, Throwable t) {
+  boolean listContains(Collection<LogCollector.RawLogMessage> list, String logLevel, String message, Throwable t, int count) {
     for (final def logMsg in list) {
-      if (logMsg.logLevel == logLevel && logMsg.message() == message && logMsg.throwable == t) {
+      if (logMsg.logLevel == logLevel && logMsg.message == message && logMsg.throwable == t && logMsg.count == count) {
         return true
       }
     }

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
@@ -200,6 +200,7 @@ public class TelemetryRequestBody extends RequestBody {
     bodyWriter.name("tags").value(m.getTags()); // optional
     bodyWriter.name("stack_trace").value(m.getStackTrace()); // optional
     bodyWriter.name("tracer_time").value(m.getTracerTime()); // optional
+    bodyWriter.name("count").value(m.getCount()); // optional
     bodyWriter.endObject();
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/api/LogMessage.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/LogMessage.java
@@ -6,6 +6,7 @@ public class LogMessage {
   private String tags;
   private String stackTrace;
   private Long tracerTime;
+  private int count;
 
   public String getMessage() {
     return message;
@@ -50,5 +51,14 @@ public class LogMessage {
   public LogMessage tracerTime(Long tracerTime) {
     this.tracerTime = tracerTime;
     return this;
+  }
+
+  public LogMessage count(int count) {
+    this.count = count;
+    return this;
+  }
+
+  public int getCount() {
+    return count;
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
@@ -25,7 +25,10 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
     for (LogCollector.RawLogMessage rawLogMsg : LogCollector.get().drain()) {
 
       LogMessage logMessage =
-          new LogMessage().message(rawLogMsg.message()).tracerTime(rawLogMsg.timestamp);
+          new LogMessage()
+              .message(rawLogMsg.message)
+              .tracerTime(rawLogMsg.timestamp)
+              .count(rawLogMsg.count);
 
       if (rawLogMsg.logLevel != null) {
         logMessage.level(LogMessageLevel.fromString(rawLogMsg.logLevel));

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -22,7 +22,7 @@ class TelemetryServiceSpecification extends DDSpecification {
   def dependency = new Dependency("dependency", "1.0.0", "src", "hash")
   def metric = new Metric().namespace("tracers").metric("metric").points([[1, 2]]).tags(["tag1", "tag2"])
   def distribution = new DistributionSeries().namespace("tracers").metric("distro").points([1, 2, 3]).tags(["tag1", "tag2"]).common(false)
-  def logMessage = new LogMessage().message("log-message").tags("tag1:tag2").level(LogMessageLevel.DEBUG).stackTrace("stack-trace").tracerTime(32423)
+  def logMessage = new LogMessage().message("log-message").tags("tag1:tag2").level(LogMessageLevel.DEBUG).stackTrace("stack-trace").tracerTime(32423).count(1)
 
   def 'happy path without data'() {
     setup:

--- a/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
@@ -330,6 +330,7 @@ class TestTelemetryRouter extends TelemetryRouter {
         if (l.getTracerTime() != null) {
           map.put("tracer_time", l.getTracerTime())
         }
+        map.put("count", l.getCount())
         expected.add(map)
       }
       assert this.payload['logs'] == expected

--- a/telemetry/src/test/groovy/datadog/telemetry/log/LogPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/log/LogPeriodicActionTest.groovy
@@ -10,10 +10,22 @@ class LogPeriodicActionTest extends DDSpecification {
   LogPeriodicAction periodicAction = new LogPeriodicAction()
   TelemetryService telemetryService = Mock()
 
+  List<Throwable> throwablesSameStacktrace
+
   @Override
   void setup(){
     injectSysConfig("dd.instrumentation.telemetry.debug", "true")
     LogCollector.get().drain()
+
+    // Initialize multiple throwables with the same stacktrace
+    throwablesSameStacktrace = new ArrayList<>()
+    for (int i = 0; i < 2; i++) {
+      try {
+        ExceptionHelper.throwExceptionFromDatadogCode("error message")
+      } catch (Exception e) {
+        throwablesSameStacktrace[i] = e
+      }
+    }
   }
 
   @Override
@@ -55,5 +67,36 @@ class LogPeriodicActionTest extends DDSpecification {
       logMessage.getMessage() == 'test'
     } )
     0 * _._
+  }
+
+  void 'deduplication of log messages without exception'() {
+    LogMessage logMessage
+
+    when:
+    LogCollector.get().addLogMessage(LogMessageLevel.ERROR.toString(), "test", null)
+    LogCollector.get().addLogMessage(LogMessageLevel.ERROR.toString(), "test", null)
+    periodicAction.doIteration(telemetryService)
+
+    then:
+    1 * telemetryService.addLogMessage(_) >> { args -> logMessage = args[0] }
+    0 * _
+    logMessage.getMessage() == 'test'
+    logMessage.getCount() == 2
+  }
+
+  void 'deduplication of log messages with exception'() {
+    LogMessage logMessage
+
+    when:
+    LogCollector.get().addLogMessage(LogMessageLevel.ERROR.toString(), "test", throwablesSameStacktrace[0])
+    LogCollector.get().addLogMessage(LogMessageLevel.ERROR.toString(), "test", throwablesSameStacktrace[1])
+    periodicAction.doIteration(telemetryService)
+
+    then:
+    1 * telemetryService.addLogMessage(_) >> { args -> logMessage = args[0] }
+    0 * _
+    logMessage.getMessage() == 'test'
+    logMessage.getStackTrace() != null
+    logMessage.getCount() == 2
   }
 }


### PR DESCRIPTION


# What Does This Do
* Fix deduplication for log messages with exceptions (throwable and usual implementations do not override equals/hashCode).
* Use the new `count` field for deduplicated messages.

# Motivation
We're getting several duplicated logs when exceptions are present.

# Additional Notes

Jira ticket: [APPSEC-51229](https://datadoghq.atlassian.net/browse/APPSEC-51229)

[APPSEC-51229]: https://datadoghq.atlassian.net/browse/APPSEC-51229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ