### PR TITLE
Revert "Log object key name to spans for AWS s3"

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -106,7 +106,6 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
 
     // S3
     request.getValueForField("Bucket", String.class).ifPresent(name -> setBucketName(span, name));
-    request.getValueForField("Key", String.class).ifPresent(key -> setObjectKey(span, key));
     request
         .getValueForField("StorageClass", String.class)
         .ifPresent(
@@ -214,10 +213,6 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     span.setTag(InstrumentationTags.AWS_BUCKET_NAME, name);
     span.setTag(InstrumentationTags.BUCKET_NAME, name);
     setPeerService(span, InstrumentationTags.AWS_BUCKET_NAME, name);
-  }
-
-  private static void setObjectKey(AgentSpan span, String objectKey) {
-    span.setTag(InstrumentationTags.AWS_OBJECT_KEY, objectKey);
   }
 
   private static void setQueueName(AgentSpan span, String name) {

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -140,9 +140,6 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
               if (operation == "PutObject") {
                 "aws.storage.class" "GLACIER"
               }
-              if (operation == "PutObject" || operation == "GetObject") {
-                "aws.object.key" "somekey"
-              }
               peerServiceFrom("aws.bucket.name")
               checkPeerService = true
             } else if (service == "Sqs" && operation == "CreateQueue") {
@@ -273,9 +270,6 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
             if (service == "S3") {
               "aws.bucket.name" "somebucket"
               "bucketname" "somebucket"
-              if (operation == "PutObject" || operation == "GetObject") {
-                "aws.object.key" "somekey"
-              }
               peerServiceFrom("aws.bucket.name")
               checkPeerService = true
             } else if (service == "Sqs" && operation == "CreateQueue") {
@@ -401,7 +395,6 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
             "aws.agent" "java-aws-sdk"
             "aws.bucket.name" "somebucket"
             "bucketname" "somebucket"
-            "aws.object.key" "somekey"
             errorTags SdkClientException, "Unable to execute HTTP request: Read timed out"
             peerServiceFrom("aws.bucket.name")
             defaultTags()

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/LegacyAws2ClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/test/groovy/LegacyAws2ClientForkedTest.groovy
@@ -130,9 +130,6 @@ class LegacyAws2ClientForkedTest extends AgentTestRunner {
               if (operation == "PutObject") {
                 "aws.storage.class" "GLACIER"
               }
-              if (operation == "PutObject" || operation == "GetObject") {
-                "aws.object.key" "somekey"
-              }
             } else if (service == "Sqs" && operation == "CreateQueue") {
               "aws.queue.name" "somequeue"
               "queuename" "somequeue"
@@ -268,9 +265,6 @@ class LegacyAws2ClientForkedTest extends AgentTestRunner {
             if (service == "S3") {
               "aws.bucket.name" "somebucket"
               "bucketname" "somebucket"
-              if (operation == "PutObject" || operation == "GetObject") {
-                "aws.object.key" "somekey"
-              }
             } else if (service == "Sqs" && operation == "CreateQueue") {
               "aws.queue.name" "somequeue"
               "queuename" "somequeue"
@@ -406,7 +400,6 @@ class LegacyAws2ClientForkedTest extends AgentTestRunner {
             "aws.agent" "java-aws-sdk"
             "aws.bucket.name" "somebucket"
             "bucketname" "somebucket"
-            "aws.object.key" "somekey"
             errorTags SdkClientException, "Unable to execute HTTP request: Read timed out"
             defaultTags()
           }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InstrumentationTags.java
@@ -22,7 +22,6 @@ public class InstrumentationTags {
   public static final String AWS_ENDPOINT = "aws.endpoint";
   public static final String AWS_BUCKET_NAME = "aws.bucket.name";
   public static final String BUCKET_NAME = "bucketname";
-  public static final String AWS_OBJECT_KEY = "aws.object.key";
   public static final String AWS_QUEUE_URL = "aws.queue.url";
 
   public static final String AWS_QUEUE_NAME = "aws.queue.name";


### PR DESCRIPTION
# What Does This Do
Reverts #6311 

# Motivation
Handles the issues described in #6524 and #6528 

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
