### PR TITLE
Enable Data Streams without adding context into Kafka headers

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
@@ -47,6 +47,7 @@ public final class KafkaConsumerInstrumentation extends InstrumenterModule.Traci
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      packageName + ".TextMapInjectAdapterInterface",
       packageName + ".KafkaConsumerInfo",
       packageName + ".KafkaConsumerInstrumentationHelper",
       packageName + ".KafkaDecorator",

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -140,8 +140,7 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
           // message size.
           // The stats are saved in the pathway context and sent in PayloadSizeAdvice.
           propagate()
-              .injectPathwayContextWithoutSendingStats(
-                  span, record.headers(), setter, sortedTags);
+              .injectPathwayContextWithoutSendingStats(span, record.headers(), setter, sortedTags);
           AvroSchemaExtractor.tryExtractProducer(record, span);
         }
       } catch (final IllegalStateException e) {
@@ -159,8 +158,7 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
         if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
             || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
           propagate()
-              .injectPathwayContextWithoutSendingStats(
-                  span, record.headers(), setter, sortedTags);
+              .injectPathwayContextWithoutSendingStats(span, record.headers(), setter, sortedTags);
           AvroSchemaExtractor.tryExtractProducer(record, span);
         }
       }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -58,7 +58,9 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".KafkaDecorator",
+      packageName + ".TextMapInjectAdapterInterface",
       packageName + ".TextMapInjectAdapter",
+      packageName + ".NoopTextMapInjectAdapter",
       packageName + ".KafkaProducerCallback",
       "datadog.trace.instrumentation.kafka_common.StreamingContext",
       packageName + ".AvroSchemaExtractor",

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -13,7 +13,6 @@ import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_PRODUCE;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.PRODUCER_DECORATE;
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.TIME_IN_QUEUE_ENABLED;
-import static datadog.trace.instrumentation.kafka_clients.TextMapInjectAdapter.SETTER;
 import static datadog.trace.instrumentation.kafka_common.StreamingContext.STREAMING_CONTEXT;
 import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
@@ -113,6 +112,7 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
         span.setTag(InstrumentationTags.TOMBSTONE, true);
       }
 
+      TextMapInjectAdapterInterface setter = NoopTextMapInjectAdapter.NOOP_SETTER;
       // Do not inject headers for batch versions below 2
       // This is how similar check is being done in Kafka client itself:
       // https://github.com/apache/kafka/blob/05fcfde8f69b0349216553f711fdfc3f0259c601/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java#L411-L412
@@ -120,7 +120,6 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
       // This can help in mixed client environments where clients < 0.11 that do not support
       // headers attempt to read messages that were produced by clients > 0.11 and the magic
       // value of the broker(s) is >= 2
-      TextMapInjectAdapter setter = TextMapInjectAdapter.NOOP_SETTER;
       if (apiVersions.maxUsableProduceMagic() >= RecordBatch.MAGIC_VALUE_V2
           && Config.get().isKafkaClientPropagationEnabled()
           && !Config.get().isKafkaClientPropagationDisabledForTopic(record.topic())) {
@@ -135,51 +134,38 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
       sortedTags.put(TYPE_TAG, "kafka");
       try {
         propagate().inject(span, record.headers(), setter);
-        if (STREAMING_CONTEXT.empty() || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
+        if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
+            || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
           // inject the context in the headers, but delay sending the stats until we know the
           // message size.
           // The stats are saved in the pathway context and sent in PayloadSizeAdvice.
           propagate()
-              .injectPathwayContextWithoutSendingStats(span, record.headers(), setter, sortedTags);
+              .injectPathwayContextWithoutSendingStats(
+                  span, record.headers(), setter, sortedTags);
           AvroSchemaExtractor.tryExtractProducer(record, span);
         }
-        sortedTags.put(TOPIC_TAG, record.topic());
-        sortedTags.put(TYPE_TAG, "kafka");
-        try {
-          propagate().inject(span, record.headers(), SETTER);
-          if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
-              || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
-            // inject the context in the headers, but delay sending the stats until we know the
-            // message size.
-            // The stats are saved in the pathway context and sent in PayloadSizeAdvice.
-            propagate()
-                .injectPathwayContextWithoutSendingStats(
-                    span, record.headers(), SETTER, sortedTags);
-            AvroSchemaExtractor.tryExtractProducer(record, span);
-          }
-        } catch (final IllegalStateException e) {
-          // headers must be read-only from reused record. try again with new one.
-          record =
-              new ProducerRecord<>(
-                  record.topic(),
-                  record.partition(),
-                  record.timestamp(),
-                  record.key(),
-                  record.value(),
-                  record.headers());
+      } catch (final IllegalStateException e) {
+        // headers must be read-only from reused record. try again with new one.
+        record =
+            new ProducerRecord<>(
+                record.topic(),
+                record.partition(),
+                record.timestamp(),
+                record.key(),
+                record.value(),
+                record.headers());
 
-          propagate().inject(span, record.headers(), SETTER);
-          if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
-              || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
-            propagate()
-                .injectPathwayContextWithoutSendingStats(
-                    span, record.headers(), SETTER, sortedTags);
-            AvroSchemaExtractor.tryExtractProducer(record, span);
-          }
+        propagate().inject(span, record.headers(), setter);
+        if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
+            || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
+          propagate()
+              .injectPathwayContextWithoutSendingStats(
+                  span, record.headers(), setter, sortedTags);
+          AvroSchemaExtractor.tryExtractProducer(record, span);
         }
-        if (TIME_IN_QUEUE_ENABLED) {
-          SETTER.injectTimeInQueue(record.headers());
-        }
+      }
+      if (TIME_IN_QUEUE_ENABLED) {
+        setter.injectTimeInQueue(record.headers());
       }
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/NoopTextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/NoopTextMapInjectAdapter.java
@@ -1,0 +1,18 @@
+package datadog.trace.instrumentation.kafka_clients;
+
+import org.apache.kafka.common.header.Headers;
+
+public class NoopTextMapInjectAdapter implements TextMapInjectAdapterInterface {
+
+  public static final NoopTextMapInjectAdapter NOOP_SETTER = new NoopTextMapInjectAdapter();
+  @Override
+  public void set(final Headers headers, final String key, final String value) {
+  }
+
+  @Override
+  public void set(Headers headers, String key, byte[] value) {
+  }
+
+  public void injectTimeInQueue(Headers headers) {
+  }
+}

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/NoopTextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/NoopTextMapInjectAdapter.java
@@ -5,14 +5,12 @@ import org.apache.kafka.common.header.Headers;
 public class NoopTextMapInjectAdapter implements TextMapInjectAdapterInterface {
 
   public static final NoopTextMapInjectAdapter NOOP_SETTER = new NoopTextMapInjectAdapter();
-  @Override
-  public void set(final Headers headers, final String key, final String value) {
-  }
 
   @Override
-  public void set(Headers headers, String key, byte[] value) {
-  }
+  public void set(final Headers headers, final String key, final String value) {}
 
-  public void injectTimeInQueue(Headers headers) {
-  }
+  @Override
+  public void set(Headers headers, String key, byte[] value) {}
+
+  public void injectTimeInQueue(Headers headers) {}
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
@@ -7,36 +7,20 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.header.Headers;
 
-public class TextMapInjectAdapter implements AgentPropagation.BinarySetter<Headers> {
-  private final boolean isNoOp;
-
-  public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter(false);
-  public static final TextMapInjectAdapter NOOP_SETTER = new TextMapInjectAdapter(true);
-
-  public TextMapInjectAdapter(boolean isNoOp) {
-    this.isNoOp = isNoOp;
-  }
+public class TextMapInjectAdapter implements TextMapInjectAdapterInterface {
+  public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
 
   @Override
   public void set(final Headers headers, final String key, final String value) {
-    if (isNoOp) {
-      return;
-    }
     headers.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
   }
 
   @Override
   public void set(Headers headers, String key, byte[] value) {
-    if (isNoOp) {
-      return;
-    }
     headers.remove(key).add(key, value);
   }
 
   public void injectTimeInQueue(Headers headers) {
-    if (isNoOp) {
-      return;
-    }
     ByteBuffer buf = ByteBuffer.allocate(8);
     buf.putLong(System.currentTimeMillis());
     headers.add(KAFKA_PRODUCED_KEY, buf.array());

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
@@ -8,20 +8,35 @@ import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.header.Headers;
 
 public class TextMapInjectAdapter implements AgentPropagation.BinarySetter<Headers> {
+  private final boolean isNoOp;
 
-  public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
+  public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter(false);
+  public static final TextMapInjectAdapter NOOP_SETTER = new TextMapInjectAdapter(true);
+
+  public TextMapInjectAdapter(boolean isNoOp) {
+    this.isNoOp = isNoOp;
+  }
 
   @Override
   public void set(final Headers headers, final String key, final String value) {
+    if (isNoOp) {
+      return;
+    }
     headers.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
   }
 
   @Override
   public void set(Headers headers, String key, byte[] value) {
+    if (isNoOp) {
+      return;
+    }
     headers.remove(key).add(key, value);
   }
 
   public void injectTimeInQueue(Headers headers) {
+    if (isNoOp) {
+      return;
+    }
     ByteBuffer buf = ByteBuffer.allocate(8);
     buf.putLong(System.currentTimeMillis());
     headers.add(KAFKA_PRODUCED_KEY, buf.array());

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.kafka_clients;
 
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_PRODUCED_KEY;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.header.Headers;

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapterInterface.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapterInterface.java
@@ -1,0 +1,8 @@
+package datadog.trace.instrumentation.kafka_clients;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import org.apache.kafka.common.header.Headers;
+
+public interface TextMapInjectAdapterInterface extends AgentPropagation.BinarySetter<Headers>{
+  public void injectTimeInQueue(Headers headers);
+}

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapterInterface.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapterInterface.java
@@ -3,6 +3,6 @@ package datadog.trace.instrumentation.kafka_clients;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import org.apache.kafka.common.header.Headers;
 
-public interface TextMapInjectAdapterInterface extends AgentPropagation.BinarySetter<Headers>{
+public interface TextMapInjectAdapterInterface extends AgentPropagation.BinarySetter<Headers> {
   public void injectTimeInQueue(Headers headers);
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTestBase.groovy
@@ -916,6 +916,10 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
         void onMessage(ConsumerRecord<String, String> record) {
           TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
           records.add(record)
+          if (isDataStreamsEnabled()) {
+            // even if header propagation is disabled, we want data streams to work.
+            TEST_DATA_STREAMS_WRITER.waitForGroups(2)
+          }
         }
       })
 

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -64,6 +64,7 @@ public class KafkaStreamTaskInstrumentation extends InstrumenterModule.Tracing
   @Override
   public String[] helperClassNames() {
     return new String[] {
+      "datadog.trace.instrumentation.kafka_clients.TextMapInjectAdapterInterface",
       "datadog.trace.instrumentation.kafka_clients.TracingIterableDelegator",
       "datadog.trace.instrumentation.kafka_common.Utils",
       "datadog.trace.instrumentation.kafka_common.StreamingContext",


### PR DESCRIPTION
# What Does This Do

This PR allows customers to enable a limited version of Data Streams monitoring, but without passing context through headers.
This can be useful is really high throughput pipelines with small message size, in which the header size would hugely impact the total throughput through Kafka.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
