### PR TITLE
Reduce long running default flush interval to 120 seconds

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -206,7 +206,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH = false;
   static final boolean DEFAULT_TRACE_LONG_RUNNING_ENABLED = false;
-  static final long DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL = 300; // seconds -> 5 minutes
+  static final long DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL = 120; // seconds -> 2 minutes
 
   static final float DEFAULT_TRACE_FLUSH_INTERVAL = 1;
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -580,7 +580,7 @@ class ConfigTest extends DDSpecification {
     config.agentPort == 123
     config.agentUrl == "http://somewhere:123"
     config.longRunningTraceEnabled
-    config.longRunningTraceFlushInterval == 300
+    config.longRunningTraceFlushInterval == 120
   }
 
   def "default when configured incorrectly"() {


### PR DESCRIPTION
# What Does This Do

Reduce long running default flush interval to 120 seconds

# Motivation

User feedback: 5 minutes not being reactive enough

# Additional Notes

All internal spark jobs are already using 120 seconds for their flush interval

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
