### PR TITLE
Initial flush interval for long running spans

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -206,6 +206,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH = false;
   static final boolean DEFAULT_TRACE_LONG_RUNNING_ENABLED = false;
+  static final long DEFAULT_TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL = 20; // seconds
   static final long DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL = 120; // seconds -> 2 minutes
 
   static final float DEFAULT_TRACE_FLUSH_INTERVAL = 1;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -116,6 +116,8 @@ public final class TracerConfig {
 
   public static final String TRACE_LONG_RUNNING_ENABLED = "trace.experimental.long-running.enabled";
 
+  public static final String TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL =
+      "trace.experimental.long-running.initial.flush.interval";
   public static final String TRACE_LONG_RUNNING_FLUSH_INTERVAL =
       "trace.experimental.long-running.flush.interval";
   public static final String TRACE_PEER_SERVICE_DEFAULTS_ENABLED =

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/LongRunningTracesTrackerTest.groovy
@@ -6,9 +6,11 @@ import datadog.communication.monitor.Monitoring
 import datadog.trace.api.Config
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.sampling.PrioritySampling
-import datadog.trace.api.time.SystemTimeSource
+import datadog.trace.api.time.ControllableTimeSource
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.test.util.DDSpecification
+
+import java.util.concurrent.TimeUnit
 
 class LongRunningTracesTrackerTest extends DDSpecification {
   Config config = Mock(Config)
@@ -16,21 +18,25 @@ class LongRunningTracesTrackerTest extends DDSpecification {
   def sharedCommunicationObjects = Mock(SharedCommunicationObjects)
   DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(null, Monitoring.DISABLED, null, false, false)
   LongRunningTracesTracker tracker
-  def tracer = Stub(CoreTracer)
+  def tracer = Mock(CoreTracer)
   def traceConfig = Stub(CoreTracer.ConfigSnapshot)
   PendingTraceBuffer.DelayingPendingTraceBuffer buffer
   PendingTrace.Factory factory = null
+  def timeSource = new ControllableTimeSource()
 
   def setup() {
+    timeSource.set(0L)
     features.supportsLongRunning = true
     tracer.captureTraceConfig() >> traceConfig
+    tracer.getTimeWithNanoTicks(_) >> { Long x -> x }
     traceConfig.getServiceMapping() >> [:]
+    config.getLongRunningTraceInitialFlushInterval() >> 10
     config.getLongRunningTraceFlushInterval() >> 20
     config.longRunningTraceEnabled >> true
     sharedCommunicationObjects.featuresDiscovery(_) >> features
-    buffer = new PendingTraceBuffer.DelayingPendingTraceBuffer(maxTrackedTraces, SystemTimeSource.INSTANCE, config, sharedCommunicationObjects, HealthMetrics.NO_OP)
+    buffer = new PendingTraceBuffer.DelayingPendingTraceBuffer(maxTrackedTraces, timeSource, config, sharedCommunicationObjects, HealthMetrics.NO_OP)
     tracker = buffer.runningTracesTracker
-    factory = new PendingTrace.Factory(tracer, buffer, SystemTimeSource.INSTANCE, false, HealthMetrics.NO_OP)
+    factory = new PendingTrace.Factory(tracer, buffer, timeSource, false, HealthMetrics.NO_OP)
   }
 
   def "null is not added"() {
@@ -120,6 +126,44 @@ class LongRunningTracesTrackerTest extends DDSpecification {
 
     then:
     tracker.traceArray.size() == 0
+  }
+
+  def flushAt(long timeMilli) {
+    timeSource.set(TimeUnit.MILLISECONDS.toNanos(timeMilli))
+    tracker.flushAndCompact(timeMilli)
+  }
+
+  def "flush logic with initial flush"() {
+    given:
+    def trace = newTraceToTrack()
+    tracker.add(trace)
+
+    when: // Before the initial flush
+    flushAt(tracker.initialFlushPeriodMilli - 1000)
+
+    then:
+    0 * tracer.write(_)
+
+    when: // After the initial flush
+    flushAt(tracker.initialFlushPeriodMilli + 1000)
+
+    then:
+    1 * tracer.write(_)
+    trace.getLastWriteTime() == TimeUnit.MILLISECONDS.toNanos(tracker.initialFlushPeriodMilli + 1000)
+
+    when: // Before the regular flush
+    flushAt(tracker.initialFlushPeriodMilli + tracker.flushPeriodMilli - 1000)
+
+    then:
+    0 * tracer.write(_)
+    trace.getLastWriteTime() == TimeUnit.MILLISECONDS.toNanos(tracker.initialFlushPeriodMilli + 1000)
+
+    when: // After the first regular flush
+    flushAt(tracker.initialFlushPeriodMilli + tracker.flushPeriodMilli + 2000)
+
+    then:
+    1 * tracer.write(_)
+    trace.getLastWriteTime() == TimeUnit.MILLISECONDS.toNanos(tracker.initialFlushPeriodMilli + tracker.flushPeriodMilli + 2000)
   }
 
   PendingTrace newTraceToTrack() {

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -14,6 +14,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_HTTP_SERVER_ERROR_STATUSE
 import static datadog.trace.api.ConfigDefaults.DEFAULT_PARTIAL_FLUSH_MIN_SPANS
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVICE_NAME
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL
 import static datadog.trace.api.DDTags.HOST_TAG
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_VALUE
@@ -102,6 +103,7 @@ import static datadog.trace.api.config.TracerConfig.ID_GENERATION_STRATEGY
 import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_ENABLED
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_ENABLED
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_FLUSH_INTERVAL
+import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL
 import static datadog.trace.api.config.TracerConfig.PARTIAL_FLUSH_MIN_SPANS
 import static datadog.trace.api.config.TracerConfig.PRIORITIZATION_TYPE
 import static datadog.trace.api.config.TracerConfig.PRIORITY_SAMPLING
@@ -2333,6 +2335,27 @@ class ConfigTest extends DDSpecification {
     then:
     config.configFileStatus == "src/test/resources/dd-java-tracer.properties"
     config.serviceName == "args service name"
+  }
+
+  def "long running trace invalid initial flush_interval set to default: #configuredFlushInterval"() {
+    when:
+    def prop = new Properties()
+    prop.setProperty(TRACE_LONG_RUNNING_ENABLED, "true")
+    prop.setProperty(TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL, configuredFlushInterval)
+    Config config = Config.get(prop)
+
+    then:
+    config.longRunningTraceEnabled == true
+    config.longRunningTraceInitialFlushInterval == flushInterval
+
+    where:
+    configuredFlushInterval | flushInterval
+    "invalid"     | DEFAULT_TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL
+    "-1"          | DEFAULT_TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL
+    "9"           | DEFAULT_TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL
+    "451"         | DEFAULT_TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL
+    "10"          | 10
+    "450"         | 450
   }
 
   def "long running trace invalid flush_interval set to default: #configuredFlushInterval"() {


### PR DESCRIPTION
# What Does This Do

Add the parameter `trace.experimental.long-running.initial.flush.interval` defaulting to 20s to control how long before flushing long running traces for the first time

# Motivation

Reduce the delay to see long running spans in datadog, without having to set a frequent flush interval 

# Additional Notes

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
