### PR TITLE
Add latestDepTest for Jvm 21 on CI

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1106,6 +1106,20 @@ build_test_jobs: &build_test_jobs
       maxWorkers: 4
       testJvm: "17"
 
+  - xlarge_tests:
+      requires:
+        - ok_to_test
+        - build_latestdep
+      name: test_21_inst_latest
+      gradleTarget: ":instrumentationLatestDepTest"
+      gradleParameters: "-PskipFlakyTests"
+      triggeredBy: *instrumentation_modules
+      stage: instrumentation
+      cacheType: latestdep
+      parallelism: 4
+      maxWorkers: 4
+      testJvm: "21"
+
 {% if flaky %}
   - tests:
       requires:


### PR DESCRIPTION
# What Does This Do

Add a latestDep pipeline on the CI build using a JVM 21

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
