### PR TITLE
Add aerospike 8 latestDepTests

### DIFF
--- a/dd-java-agent/instrumentation/aerospike-4/build.gradle
+++ b/dd-java-agent/instrumentation/aerospike-4/build.gradle
@@ -1,7 +1,7 @@
-apply from: "$rootDir/gradle/java.gradle"
-
-addTestSuiteForDir('latestDepTest', 'test')
-
+ext {
+  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_21
+  latestDepForkedTestMinJavaVersionForTests = JavaVersion.VERSION_21
+}
 muzzle {
   pass {
     group = 'com.aerospike'
@@ -11,13 +11,23 @@ muzzle {
   }
 }
 
+apply from: "$rootDir/gradle/java.gradle"
+
+
+addTestSuiteForDir("latestDepTest", "test")
+addTestSuiteForDir("latest7DepTest", "test")
+addTestSuiteExtendingForDir("latestDepForkedTest", "latestDepTest", "test")
+addTestSuiteExtendingForDir("latest7DepForkedTest", "latest7DepTest", "test")
+
+
 dependencies {
   compileOnly group: 'com.aerospike', name: 'aerospike-client', version: '4.0.0'
 
   testImplementation group: 'com.aerospike', name: 'aerospike-client', version: '4.0.0'
   testImplementation deps.testcontainers
 
-  latestDepTestImplementation group: 'com.aerospike', name: 'aerospike-client', version: '7.+'
+  latest7DepTestImplementation group: 'com.aerospike', name: 'aerospike-client', version: '7.+'
+  latestDepTestImplementation group: 'com.aerospike', name: 'aerospike-client', version: '+'
 }
 
 tasks.withType(Test).configureEach {


### PR DESCRIPTION
# What Does This Do

* Add aerospike 8 latestDepTests (requires java 21)
* Keep latest test on 7.x branch since aerospike will maintain for some time


# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
