### PR TITLE
Fix for No @ToJson SamplingRules deserialization exception

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -33,7 +33,9 @@ excludedClassesCoverage += [
   'datadog.trace.core.propagation.HttpCodec.Extractor',
   'datadog.trace.core.flare.*',
   // FIXME(DSM): test coverage needed
-  'datadog.trace.core.datastreams.DataStreamContextInjector'
+  'datadog.trace.core.datastreams.DataStreamContextInjector',
+  'datadog.trace.common.sampling.TraceSamplingRules.RuleAdapter',
+  'datadog.trace.common.sampling.SpanSamplingRules.RuleAdapter',
 ]
 
 addTestSuite('traceAgentTest')

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
@@ -4,6 +4,7 @@ import com.squareup.moshi.FromJson;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.Moshi;
+import com.squareup.moshi.ToJson;
 import com.squareup.moshi.Types;
 import datadog.trace.api.sampling.SamplingRule;
 import java.io.File;
@@ -202,6 +203,12 @@ public class SpanSamplingRules {
     @FromJson
     Rule fromJson(JsonRule jsonRule) {
       return Rule.create(jsonRule);
+    }
+
+    @ToJson
+    JsonRule toJson(TraceSamplingRules.Rule rule) {
+      // This method only purpose is to prevent a "No @ToJson adapter for class" exception.
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
@@ -3,6 +3,7 @@ package datadog.trace.common.sampling;
 import com.squareup.moshi.FromJson;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import com.squareup.moshi.ToJson;
 import com.squareup.moshi.Types;
 import datadog.trace.api.sampling.SamplingRule;
 import java.lang.reflect.ParameterizedType;
@@ -145,7 +146,6 @@ public class TraceSamplingRules {
     String name;
     String resource;
     Map<String, String> tags;
-    String target_span;
     String sample_rate;
 
     @Override
@@ -158,6 +158,12 @@ public class TraceSamplingRules {
     @FromJson
     Rule fromJson(JsonRule jsonRule) {
       return Rule.create(jsonRule);
+    }
+
+    @ToJson
+    JsonRule toJson(Rule rule) {
+      // This method only purpose is to prevent a "No @ToJson adapter for class" exception.
+      throw new UnsupportedOperationException();
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

This aims to prevent `No @ToJson` when `TraceSamplingRules` get initialized.

# Motivation

Fix for #6494

# Additional Notes

#6494

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
