### PR TITLE
Do not compute DBInfo on every statement call

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastConnectionCallSite.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastConnectionCallSite.java
@@ -1,19 +1,41 @@
 package datadog.trace.instrumentation.jdbc;
 
+import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStore;
+import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStoreId;
+
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
 import java.sql.Connection;
+import javax.annotation.Nonnull;
 
 @Sink(VulnerabilityTypes.SQL_INJECTION)
 @CallSite(
     spi = IastCallSites.class,
     helpers = {JDBCDecorator.class})
 public class IastConnectionCallSite {
+
+  private static ContextStore<Connection, DBInfo> DB_INFO_STORE = null;
+
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  public static DBInfo getDBInfo(final Connection connection) {
+    if (DB_INFO_STORE == null) {
+      final int storeId = getContextStoreId(Connection.class.getName(), DBInfo.class.getName());
+      final ContextStore<?, ?> store = getContextStore(storeId);
+      DB_INFO_STORE = (ContextStore<Connection, DBInfo>) store;
+    }
+    if (DB_INFO_STORE == null) {
+      return JDBCDecorator.parseDBInfoFromConnection(connection);
+    } else {
+      return JDBCDecorator.parseDBInfo(connection, DB_INFO_STORE);
+    }
+  }
 
   @CallSite.Before(
       "java.sql.PreparedStatement java.sql.Connection.prepareStatement(java.lang.String)")
@@ -37,7 +59,7 @@ public class IastConnectionCallSite {
     final SqlInjectionModule module = InstrumentationBridge.SQL_INJECTION;
     if (module != null) {
       try {
-        final DBInfo dbInfo = JDBCDecorator.parseDBInfoFromConnection(conn);
+        final DBInfo dbInfo = getDBInfo(conn);
         module.onJdbcQuery(sql, dbInfo.getType());
       } catch (final Throwable e) {
         module.onUnexpectedException("beforePrepare threw", e);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastStatementCallSite.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/IastStatementCallSite.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.jdbc;
 
+import static datadog.trace.instrumentation.jdbc.IastConnectionCallSite.getDBInfo;
+
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
 import datadog.trace.api.iast.InstrumentationBridge;
@@ -35,7 +37,7 @@ public class IastStatementCallSite {
     final SqlInjectionModule module = InstrumentationBridge.SQL_INJECTION;
     if (module != null) {
       try {
-        final DBInfo dbInfo = JDBCDecorator.parseDBInfoFromConnection(statement.getConnection());
+        final DBInfo dbInfo = getDBInfo(statement.getConnection());
         module.onJdbcQuery(sql, dbInfo.getType());
       } catch (final Throwable e) {
         module.onUnexpectedException("beforeExecute threw", e);


### PR DESCRIPTION
# What Does This Do
Uses context stores to cache the `DBInfo` instances computed for JDBC connections

# Motivation
The computation of the DBInfo is not cheap, so we should use the cached instances included in the context stores.

