### PR TITLE
Fix header injection exclusions

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HeaderInjectionModuleImpl.java
@@ -1,10 +1,12 @@
 package com.datadog.iast.sink;
 
+import static com.datadog.iast.taint.Ranges.allRangesFromAnyHeader;
 import static com.datadog.iast.taint.Ranges.allRangesFromHeader;
+import static com.datadog.iast.taint.Ranges.rangeFromHeader;
 import static com.datadog.iast.util.HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static com.datadog.iast.util.HttpHeader.CONNECTION;
+import static com.datadog.iast.util.HttpHeader.COOKIE;
 import static com.datadog.iast.util.HttpHeader.LOCATION;
-import static com.datadog.iast.util.HttpHeader.ORIGIN;
 import static com.datadog.iast.util.HttpHeader.SEC_WEBSOCKET_ACCEPT;
 import static com.datadog.iast.util.HttpHeader.SEC_WEBSOCKET_LOCATION;
 import static com.datadog.iast.util.HttpHeader.SET_COOKIE;
@@ -64,17 +66,21 @@ public class HeaderInjectionModuleImpl extends SinkModuleBase implements HeaderI
       return;
     }
 
-    // TODO (spec) we should fix this as it's not a 100% accurate
-    if (header == ACCESS_CONTROL_ALLOW_ORIGIN && allRangesFromHeader(ORIGIN, ranges)) {
+    // Exclude access-control-allow-*: when the header starts with access-control-allow- and the
+    // source of the tainted range is a request header
+    if (header == ACCESS_CONTROL_ALLOW_ORIGIN && allRangesFromAnyHeader(ranges)) {
       return;
     }
 
-    // TODO (spec): we should fix this, the source header should be 'Cookie' not 'Set-Cookie'
-    if ((header == SET_COOKIE) && allRangesFromHeader(SET_COOKIE, ranges)) {
+    // Exclude set-cookie header if the source of all the tainted ranges are cookies
+    if ((header == SET_COOKIE) && allRangesFromHeader(COOKIE, ranges)) {
       return;
     }
 
-    // TODO (spec): we are missing the case where the header is reflected from the request
+    // Exclude when the header is reflected from the request
+    if (ranges.length == 1 && rangeFromHeader(name, ranges[0])) {
+      return;
+    }
 
     final AgentSpan span = AgentTracer.activeSpan();
     if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -218,17 +218,39 @@ public final class Ranges {
   }
 
   /**
+   * Checks if all ranges are coming from any header, in case no ranges are provided it will return
+   * {@code true}
+   */
+  public static boolean allRangesFromAnyHeader(@Nonnull final Range[] ranges) {
+    for (Range range : ranges) {
+      final Source source = range.getSource();
+      if (source.getOrigin() != SourceTypes.REQUEST_HEADER_VALUE) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Checks if a range is coming from the header */
+  public static boolean rangeFromHeader(@Nonnull final String header, @Nonnull final Range range) {
+    final Source source = range.getSource();
+    if (source.getOrigin() != SourceTypes.REQUEST_HEADER_VALUE) {
+      return false;
+    }
+    if (!header.equalsIgnoreCase(source.getName())) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
    * Checks if all ranges are coming from the header, in case no ranges are provided it will return
    * {@code true}
    */
   public static boolean allRangesFromHeader(
       @Nonnull final String header, @Nonnull final Range[] ranges) {
     for (Range range : ranges) {
-      final Source source = range.getSource();
-      if (source.getOrigin() != SourceTypes.REQUEST_HEADER_VALUE) {
-        return false;
-      }
-      if (!header.equalsIgnoreCase(source.getName())) {
+      if (!rangeFromHeader(header, range)) {
         return false;
       }
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
@@ -28,6 +28,7 @@ public enum HttpHeader {
       ctx.setxContentTypeOptions(value);
     }
   },
+  COOKIE("Cookie"),
   SET_COOKIE("Set-Cookie"),
   LOCATION("Location"),
   REFERER("Referer"),

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HeaderInjectionModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HeaderInjectionModuleTest.groovy
@@ -1,0 +1,166 @@
+package com.datadog.iast.sink
+
+import com.datadog.iast.IastModuleImplTestBase
+import com.datadog.iast.Reporter
+import com.datadog.iast.model.Vulnerability
+import com.datadog.iast.model.VulnerabilityType
+import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.VulnerabilityMarks
+import datadog.trace.api.iast.sink.HeaderInjectionModule
+
+import static com.datadog.iast.taint.TaintUtils.addFromRangeList
+import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
+import static com.datadog.iast.taint.TaintUtils.taintFormat
+import static com.datadog.iast.util.HttpHeader.CONNECTION
+import static com.datadog.iast.util.HttpHeader.LOCATION
+import static com.datadog.iast.util.HttpHeader.SEC_WEBSOCKET_ACCEPT
+import static com.datadog.iast.util.HttpHeader.SEC_WEBSOCKET_LOCATION
+import static com.datadog.iast.util.HttpHeader.SET_COOKIE
+import static com.datadog.iast.util.HttpHeader.UPGRADE
+import static com.datadog.iast.util.HttpHeader.COOKIE
+import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED
+
+class HeaderInjectionModuleTest extends IastModuleImplTestBase{
+
+  private HeaderInjectionModule module
+
+  def setup() {
+    module = new HeaderInjectionModuleImpl(dependencies)
+  }
+
+  @Override
+  protected Reporter buildReporter() {
+    return Mock(Reporter)
+  }
+
+  void 'check header value injection'() {
+    given:
+    final taintedHeaderValue = mapTainted(headerValue, mark)
+
+    when:
+    module.onHeader(headerName, taintedHeaderValue)
+
+    then:
+    if (expected != null) {
+      1 * reporter.report(_, _) >> { args -> assertEvidence(args[1] as Vulnerability, expected) }
+    } else {
+      0 * reporter.report(_, _)
+    }
+
+    where:
+    headerValue   | mark                                     | headerName               | expected
+    '/==>var<=='  | NOT_MARKED                               | 'headerName'             | "headerName: /==>var<=="
+    '/==>var<=='  | VulnerabilityMarks.XPATH_INJECTION_MARK | 'headerName' | "headerName: /==>var<=="
+    'var'         | NOT_MARKED                                | 'headerName'             | null
+    '/==>var<=='  | VulnerabilityMarks.HEADER_INJECTION_MARK  | 'headerName'             | null
+  }
+
+  void 'check excluded headers'() {
+    given:
+    final taintedHeaderValue = mapTainted('/==>var<==', NOT_MARKED)
+
+    when:
+    module.onHeader(header.name, taintedHeaderValue)
+
+    then:
+    0 * reporter.report(_, _ as Vulnerability)
+
+    where:
+    header << [SEC_WEBSOCKET_LOCATION, SEC_WEBSOCKET_ACCEPT, UPGRADE, CONNECTION, LOCATION]
+  }
+
+  void 'check access-control-allow-* exclusion'(){
+    given:
+    final headerName = 'Access-Control-Allow-Origin'
+    final headerValue = 'headerValue'
+    addFromRangeList(ctx.taintedObjects, 'headerValue', ranges)
+
+    when:
+    module.onHeader(headerName, headerValue)
+
+    then:
+    expected * reporter.report(_, _ as Vulnerability)
+
+    where:
+    ranges | expected
+    [[0, 2, 'sourceName', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]] | 0
+    [
+      [0, 2, 'sourceName', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE],
+      [3, 4, 'sourceName2', 'sourceValue2', SourceTypes.REQUEST_HEADER_VALUE]
+    ] | 0
+    [[0, 2, 'sourceName', 'sourceValue', SourceTypes.GRPC_BODY]] | 1
+    [
+      [0, 2, 'sourceName', 'sourceValue', SourceTypes.GRPC_BODY],
+      [3, 4, 'sourceName2', 'sourceValue2', SourceTypes.REQUEST_HEADER_VALUE]
+    ] | 1
+  }
+
+  void 'check set-cookie exclusion'(){
+    given:
+    final headerValue = 'headerValue'
+    addFromRangeList(ctx.taintedObjects, 'headerValue', ranges)
+
+    when:
+    module.onHeader(SET_COOKIE.name, headerValue)
+
+    then:
+    expected * reporter.report(_, _ as Vulnerability)
+
+    where:
+    ranges | expected
+    [[0, 2, COOKIE, 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]] | 0
+    [
+      [0, 2, COOKIE, 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE],
+      [3, 4, COOKIE, 'sourceValue2', SourceTypes.REQUEST_HEADER_VALUE]
+    ] | 0
+    [
+      [0, 2, COOKIE, 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE],
+      [0, 2, 'sourceName', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]
+    ] | 1
+    [[0, 2, 'sourceName', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]] | 1
+    [[0, 2, 'sourceName', 'sourceValue', SourceTypes.GRPC_BODY]] | 1
+    [[0, 2, SET_COOKIE, 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]] | 1
+  }
+
+  void 'check reflected header exclusion'(){
+    given:
+    final headerName = 'headerName'
+    final headerValue = 'headerValue'
+    addFromRangeList(ctx.taintedObjects, 'headerValue', ranges)
+
+    when:
+    module.onHeader(headerName, headerValue)
+
+    then:
+    expected * reporter.report(_, _ as Vulnerability)
+
+    where:
+    ranges | expected
+    [[0, 2, COOKIE, 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]] | 1
+    [
+      [0, 2, 'headerName', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE],
+      [3, 4, 'headerName', 'sourceValue2', SourceTypes.REQUEST_HEADER_VALUE]
+    ] | 1
+    [[0, 2, 'headerName', 'sourceValue', SourceTypes.REQUEST_HEADER_VALUE]] | 0
+  }
+
+  private String mapTainted(final String value, final int mark) {
+    final result = addFromTaintFormat(ctx.taintedObjects, value, mark)
+    objectHolder.add(result)
+    return result
+  }
+
+  private static void assertVulnerability(final Vulnerability vuln, final VulnerabilityType type ) {
+    assert vuln != null
+    assert vuln.getType() == type
+    assert vuln.getLocation() != null
+  }
+
+  private static void assertEvidence(final Vulnerability vuln, final String expected, final VulnerabilityType type = VulnerabilityType.HEADER_INJECTION) {
+    assertVulnerability(vuln, type)
+    final evidence = vuln.getEvidence()
+    assert evidence != null
+    final formatted = taintFormat(evidence.getValue(), evidence.getRanges())
+    assert formatted == expected
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
@@ -331,6 +331,26 @@ class RangesTest extends DDSpecification {
     ] | false
   }
 
+  void 'test all ranges coming from any header'(){
+    when:
+    final allRangesFrom = Ranges.allRangesFromAnyHeader(ranges as Range[])
+
+    then:
+    allRangesFrom == expected
+
+    where:
+    headers | ranges                                                                                                     | expected
+    [REFERER] | []                                                                                                         | true
+    [REFERER] | [rangeWithSource(REQUEST_HEADER_VALUE, REFERER.name)]                                                       | true
+    [REFERER] | [rangeWithSource(REQUEST_HEADER_VALUE, LOCATION.name)]                                                     | true
+    [REFERER] | [rangeWithSource(GRPC_BODY)]                                                                               | false
+    [REFERER] | [rangeWithSource(REQUEST_HEADER_VALUE, REFERER.name), rangeWithSource(GRPC_BODY)]                           | false
+    [REFERER] | [
+      rangeWithSource(REQUEST_HEADER_VALUE, REFERER.name),
+      rangeWithSource(REQUEST_HEADER_VALUE, LOCATION.name)
+    ] | true
+  }
+
 
   Range[] rangesFromSpec(List<List<Object>> spec) {
     def ranges = new Range[spec.size()]


### PR DESCRIPTION
# What Does This Do

Fix IAST Header Injection exclusions:

- access-control-allow-*: when the header starts with access-control-allow- and the source of the tainted range is a request header 
- set-cookie: We should ignore set-cookie header if the source of all the tainted ranges are cookies
- We should exclude the injection when the tainted string only has one range which comes from a request header with the same name that the header that we are checking in the response.

# Motivation

Discard false positives related with Header Injection

# Additional Notes

Extract test related with Header Injection to a new class

Jira ticket: [[PROJ-IDENT]](https://datadoghq.atlassian.net/browse/APPSEC-45949)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
