### PR TITLE
Forward the build job ID to downstream job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,7 @@ build: &build
     - GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M" ./gradlew clean :dd-java-agent:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
     - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
+    - echo "BUILD_JOB_ID=$CI_JOB_ID" >> build.env
   artifacts:
     paths:
       - 'workspace/dd-java-agent/build/libs/*.jar'
@@ -127,7 +128,8 @@ deploy_to_profiling_backend:
     project: DataDog/profiling-backend
     branch: dogfooding
   variables:
-    UPSTREAM_PACKAGE_JOB: build
+    UPSTREAM_PACKAGE_JOB: $BUILD_JOB_NAME
+    UPSTREAM_PACKAGE_JOB_ID: $BUILD_JOB_ID
     UPSTREAM_PROJECT_ID: $CI_PROJECT_ID
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     UPSTREAM_PIPELINE_ID: $CI_PIPELINE_ID


### PR DESCRIPTION
# What Does This Do
Forwards the build job ID to the downstream job

# Motivation
The downstream 'dogfooding' job will need the 'build' ID as well so it is able to download the build artifacts.

# Additional Notes

Jira ticket: [PROF-9001]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-9001]: https://datadoghq.atlassian.net/browse/PROF-9001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ