### PR TITLE
Adjust log level or error messages written by repo indexer

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -74,7 +74,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
           Integer.MAX_VALUE,
           repoIndexingFileVisitor);
     } catch (Exception e) {
-      log.error("Failed to build index of {}", scanRootPath, e);
+      log.debug("Failed to build index of {}", scanRootPath, e);
     }
 
     long duration = System.currentTimeMillis() - startTime;
@@ -95,7 +95,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
     try {
       return path.toRealPath();
     } catch (Exception e) {
-      log.error("Could not determine real path for {}", path, e);
+      log.debug("Could not determine real path for {}", path, e);
       return path;
     }
   }
@@ -163,7 +163,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
           }
         }
       } catch (Exception e) {
-        log.error("Failed to index file {}", file, e);
+        log.debug("Failed to index file {}", file, e);
       }
       return FileVisitResult.CONTINUE;
     }
@@ -197,7 +197,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
     @Override
     public FileVisitResult visitFileFailed(Path file, IOException exc) {
       if (exc != null) {
-        log.error("Failed to visit file: {}", file, exc);
+        log.debug("Failed to visit file: {}", file, exc);
       }
       return FileVisitResult.CONTINUE;
     }
@@ -205,7 +205,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
     @Override
     public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
       if (exc != null) {
-        log.error("Failed to visit directory: {}", dir, exc);
+        log.debug("Failed to visit directory: {}", dir, exc);
       }
       return FileVisitResult.CONTINUE;
     }


### PR DESCRIPTION
# What Does This Do

Changes log level of repo indexing error messages from ERROR to DEBUG.

# Motivation
Logging something as error implies that something is wrong with the application/build - ie. either the result can't be trusted or the system will eventually fail.
In the case of repo indexing errors, the issue breaks neither the tests, nor the tracer. Moreover, it is something that the users have no influence over, so we're effectively spamming their logs with errors they cannot remove.

Jira ticket: [CIVIS-8777]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8777]: https://datadoghq.atlassian.net/browse/CIVIS-8777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ