### PR TITLE
Improve content of redacted stacktraces in telemetry logs

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/stacktrace/StackUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/stacktrace/StackUtils.java
@@ -49,21 +49,6 @@ public abstract class StackUtils {
         });
   }
 
-  public static <E extends Throwable> E filterPackagesIn(
-      final E exception, final String[] packages) {
-    return filter(
-        exception,
-        ste -> {
-          final String clazz = ste.getClassName();
-          for (String p : packages) {
-            if (clazz.startsWith(p)) {
-              return true;
-            }
-          }
-          return false;
-        });
-  }
-
   private static class OneTimePredicate<T> implements Predicate<T> {
 
     private final Predicate<T> delegate;

--- a/internal-api/src/test/java/datadog/trace/util/stacktrace/StackUtilsTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/stacktrace/StackUtilsTest.java
@@ -57,11 +57,6 @@ public class StackUtilsTest {
 
     final Throwable filtered2 = StackUtils.filterFirstDatadog(withStack(stack));
     assertThat(filtered2.getStackTrace()).isEqualTo(expected);
-
-    final String[] packages = {"datadog.trace.util.stacktrace"};
-    final StackTraceElement[] expected2 = new StackTraceElement[] {stack[1], stack[3]};
-    final Throwable filtered3 = StackUtils.filterPackagesIn(withStack(stack), packages);
-    assertThat(filtered3.getStackTrace()).isEqualTo(expected2);
   }
 
   @Test

--- a/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
@@ -5,7 +5,6 @@ import datadog.telemetry.TelemetryService;
 import datadog.telemetry.api.LogMessage;
 import datadog.telemetry.api.LogMessageLevel;
 import datadog.trace.api.telemetry.LogCollector;
-import datadog.trace.util.stacktrace.StackUtils;
 
 public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAction {
 
@@ -15,7 +14,9 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
    * create the trie and store it as a constant in LogPeriodicAction to be passed in here and used
    * as a filter)
    */
-  static final String[] PACKAGE_LIST = {"datadog.", "com.datadog.", "java.", "javax.", "jakarta."};
+  static final String[] PACKAGE_ALLOW_LIST = {
+    "datadog.", "com.datadog.", "java.", "javax.", "jakarta.", "jdk.", "sun.", "com.sun."
+  };
 
   private static final String UNKNOWN = "<unknown>";
 
@@ -42,31 +43,43 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
   }
 
   private static String renderStackTrace(Throwable t) {
-    StringBuilder stackTrace = new StringBuilder();
+    StringBuilder result = new StringBuilder();
 
     String name = t.getClass().getCanonicalName();
     if (name == null || name.isEmpty()) {
-      stackTrace.append(UNKNOWN);
+      result.append(UNKNOWN);
     } else {
-      stackTrace.append(name);
+      result.append(name);
     }
 
     if (isDataDogCode(t)) {
       String msg = t.getMessage();
-      stackTrace.append(": ");
+      result.append(": ");
       if (msg == null || msg.isEmpty()) {
-        stackTrace.append(UNKNOWN);
+        result.append(UNKNOWN);
       } else {
-        stackTrace.append(msg);
+        result.append(msg);
       }
     }
-    stackTrace.append('\n');
+    result.append('\n');
 
-    Throwable filtered = StackUtils.filterPackagesIn(t, PACKAGE_LIST);
-    for (StackTraceElement stackTraceElement : filtered.getStackTrace()) {
-      stackTrace.append("  at ").append(stackTraceElement).append('\n');
+    final StackTraceElement[] stacktrace = t.getStackTrace();
+    int pendingRedacted = 0;
+    if (stacktrace != null) {
+      for (final StackTraceElement frame : t.getStackTrace()) {
+        final String className = frame.getClassName();
+        if (shouldRedactClass(className)) {
+          pendingRedacted++;
+        } else {
+          writePendingRedacted(result, pendingRedacted);
+          pendingRedacted = 0;
+          result.append("  at ").append(frame).append('\n');
+        }
+      }
     }
-    return stackTrace.toString();
+    writePendingRedacted(result, pendingRedacted);
+
+    return result.toString();
   }
 
   private static boolean isDataDogCode(Throwable t) {
@@ -79,5 +92,22 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
       return false;
     }
     return cn.startsWith("datadog.") || cn.startsWith("com.datadog.");
+  }
+
+  private static boolean shouldRedactClass(final String className) {
+    for (final String prefix : PACKAGE_ALLOW_LIST) {
+      if (className.startsWith(prefix)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static void writePendingRedacted(final StringBuilder result, final int pendingRedacted) {
+    if (pendingRedacted == 1) {
+      result.append("  at ").append("[redacted]\n");
+    } else if (pendingRedacted > 1) {
+      result.append("  at [redacted: ").append(pendingRedacted).append(" frames]\n");
+    }
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/log/LogPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/log/LogPeriodicActionTest.groovy
@@ -131,8 +131,11 @@ class LogPeriodicActionTest extends DDSpecification {
     0 * _
     logMessage.getMessage() == 'test'
     logMessage.getStackTrace() == "${MutableException.canonicalName}\n" +
+      "  at [redacted]\n" +
       "  at java.MyClass.method(file:42)\n" +
-      "  at datadog.MyClass.method(file:42)\n"
+      "  at [redacted]\n" +
+      "  at datadog.MyClass.method(file:42)\n" +
+      "  at [redacted: 2 frames]\n"
   }
 
   static class MutableException extends Exception {


### PR DESCRIPTION


# What Does This Do
* If a frame or group of consecutive frames are redacted, a line will still be sent (e.g. `  at [redacted: 2 frames]`). This will simplify finding the root cause.
* Avoid redacting jdk, sun, com.sun packages.

Before this PR, we could see something like this:

```
Failed to handle exception in instrumentation for org.apache.kafka.clients.consumer.KafkaConsumer
java.lang.NullPointerException
at datadog.trace.agent.tooling.WeakMaps$Adapter.put(WeakMaps.java:74)
at datadog.trace.bootstrap.WeakMapContextStore.put(WeakMapContextStore.java:31)
at datadog.trace.bootstrap.FieldBackedContextStore.put(FieldBackedContextStore.java:28)
...
```

Now we'll get:

```
Failed to handle exception in instrumentation for org.apache.kafka.clients.consumer.KafkaConsumer
java.lang.NullPointerException
at [redacted]
at datadog.trace.agent.tooling.WeakMaps$Adapter.put(WeakMaps.java:74)
at datadog.trace.bootstrap.WeakMapContextStore.put(WeakMapContextStore.java:31)
at datadog.trace.bootstrap.FieldBackedContextStore.put(FieldBackedContextStore.java:28)
at [redacted: 10 frames]
```

# Motivation

# Additional Notes

Jira ticket: [APPSEC-51377](https://datadoghq.atlassian.net/browse/APPSEC-51377)

[APPSEC-51377]: https://datadoghq.atlassian.net/browse/APPSEC-51377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ