### PR TITLE
Improve the performance of the IAST cookie parser

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HttpResponseHeaderModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HttpResponseHeaderModuleImpl.java
@@ -1,6 +1,7 @@
 package com.datadog.iast.sink;
 
 import static com.datadog.iast.util.HttpHeader.SET_COOKIE;
+import static com.datadog.iast.util.HttpHeader.SET_COOKIE2;
 import static java.util.Collections.singletonList;
 
 import com.datadog.iast.Dependencies;
@@ -41,8 +42,8 @@ public class HttpResponseHeaderModuleImpl extends SinkModuleBase
       if (ctx instanceof IastRequestContext) {
         header.addToContext((IastRequestContext) ctx, value);
       }
-      if (header == SET_COOKIE) {
-        onCookies(CookieSecurityParser.parse(value));
+      if (header == SET_COOKIE || header == SET_COOKIE2) {
+        onCookies(CookieSecurityParser.parse(header, value));
       }
       if (null != InstrumentationBridge.UNVALIDATED_REDIRECT) {
         InstrumentationBridge.UNVALIDATED_REDIRECT.onHeader(name, value);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/HttpHeader.java
@@ -29,6 +29,7 @@ public enum HttpHeader {
     }
   },
   SET_COOKIE("Set-Cookie"),
+  SET_COOKIE2("Set-Cookie2"),
   LOCATION("Location"),
   REFERER("Referer"),
   SEC_WEBSOCKET_LOCATION("Sec-WebSocket-Location"),

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/HttpResponseHeaderModuleTest.groovy
@@ -205,6 +205,7 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
   void 'range test'(){
     given:
     addFromRangeList(ctx.taintedObjects, headerValue, ranges)
+    ignoreCookieVulnerabilities() // TODO this test is broken (it should only test header injection)
 
     when:
     module.onHeader(headerName, headerValue)
@@ -231,6 +232,7 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
     given:
     Vulnerability savedVul
     addFromRangeList(ctx.taintedObjects, headerValue, ranges)
+    ignoreCookieVulnerabilities() // TODO this test is broken (it should only test header injection)
 
     when:
     module.onHeader(headerName, headerValue)
@@ -272,5 +274,17 @@ class HttpResponseHeaderModuleTest extends IastModuleImplTestBase {
     assert evidence != null
     final formatted = taintFormat(evidence.getValue(), evidence.getRanges())
     assert formatted == expected
+  }
+
+  private void ignoreCookieVulnerabilities() {
+    InstrumentationBridge.registerIastModule(Stub(InsecureCookieModuleImpl) {
+      isVulnerable(_ as Cookie) >> false
+    })
+    InstrumentationBridge.registerIastModule(Stub(NoHttpOnlyCookieModuleImpl){
+      isVulnerable(_ as Cookie) >> false
+    })
+    InstrumentationBridge.registerIastModule(Stub(NoSameSiteCookieModuleImpl){
+      isVulnerable(_ as Cookie) >> false
+    })
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/CookieSecurityParserTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/CookieSecurityParserTest.groovy
@@ -29,22 +29,21 @@ class CookieSecurityParserTest extends Specification {
     sameSite == badCookie.getSameSite()
 
     where:
-    header                                                                                                                                           | cookieName | isSecure | isHttpOnly | sameSite
-    "user-id=7"                                                                                                                                      | "user-id"  | false    | false      | null
-    "user-id=7;Secure"                                                                                                                               | "user-id"  | true     | false      | null
-    "user-id=7;Secure;HttpOnly"                                                                                                                      | "user-id"  | true     | true       | null
-    "CUSTOMER=WILE_E_COYOTE; version='1'"                                                                                                            | "CUSTOMER" | false    | false      | null
-    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT"                                                                      | "CUSTOMER" | false    | false      | null
-    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT;SameSite=Lax;HttpOnly"                                                | "CUSTOMER" | false    | true       | 'Lax'
-    "PREF=ID=1eda537de48ac25d:CR=1:TM=1112868587:LM=1112868587:S=t3FPA-mT9lTR3bxU;expires=Sun, 17-Jan-2038 19:14:07 GMT; path=/; domain=.google.com" | "PREF"     | false    | false      | null
-    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; Secure"                                                              | "CUSTOMER" | true     | false      | null
-    "CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; path=\"/acme\";SameSite=Strict"                                      | "CUSTOMER" | false    | false      | 'Strict'
+    header                                                                                                                                                       | cookieName | isSecure | isHttpOnly | sameSite
+    "Set-Cookie: user-id=7"                                                                                                                                      | "user-id"  | false    | false      | null
+    'Set-Cookie: user-id="7"'                                                                                                                                    | "user-id"  | false    | false      | null
+    "Set-Cookie: user-id=7;Secure"                                                                                                                               | "user-id"  | true     | false      | null
+    "Set-Cookie: user-id=7;Secure;HttpOnly"                                                                                                                      | "user-id"  | true     | true       | null
+    "Set-Cookie: CUSTOMER=WILE_E_COYOTE; version='1'"                                                                                                            | "CUSTOMER" | false    | false      | null
+    "Set-Cookie: CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT"                                                                      | "CUSTOMER" | false    | false      | null
+    "Set-Cookie: CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT;SameSite=Lax;HttpOnly"                                                | "CUSTOMER" | false    | true       | 'Lax'
+    "Set-Cookie: PREF=ID=1eda537de48ac25d:CR=1:TM=1112868587:LM=1112868587:S=t3FPA-mT9lTR3bxU;expires=Sun, 17-Jan-2038 19:14:07 GMT; path=/; domain=.google.com" | "PREF"     | false    | false      | null
+    "Set-Cookie: CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; Secure"                                                              | "CUSTOMER" | true     | false      | null
+    "Set-Cookie: CUSTOMER=WILE_E_COYOTE; path=/; expires=Wednesday, 09-Nov-99 23:12:40 GMT; path=\"/acme\";SameSite=Strict"                                      | "CUSTOMER" | false    | false      | 'Strict'
   }
 
 
   void 'parsing multi cookie header'() {
-    given:
-    String headerValue = "A=1;Secure;HttpOnly=true;SameSite=Strict;version='1',B=2;Secure;SameSite=Strict,C=3"
     when:
     final badCookies = CookieSecurityParser.parse(headerValue)
 
@@ -66,5 +65,35 @@ class CookieSecurityParserTest extends Specification {
     !badCookies.get(2).isSecure()
     !badCookies.get(2).isHttpOnly()
     badCookies.get(2).getSameSite() == null
+
+    where:
+    headerValue                                                                                       | _
+    "Set-Cookie: A=1;Secure;HttpOnly=true;SameSite=Strict;version='1',B=2;Secure;SameSite=Strict,C=3" | _
+    "Set-Cookie2: A=1;Secure;HttpOnly=true;SameSite=Strict,B=2;Secure;SameSite=Strict,C=3"            | _
+  }
+
+  void 'parsing wrong header'() {
+    when:
+    final cookies = CookieSecurityParser.parse('Un-Set-Cookie: user-id=7')
+
+    then:
+    cookies.empty
+  }
+
+  void 'parsing badly formatted cookies'() {
+    when:
+    final cookies = CookieSecurityParser.parse(header)
+
+    then:
+    cookies.size() == 1
+    final cookie = cookies.first()
+    cookie.cookieName == 'user-id'
+    cookie.secure
+
+
+    where:
+    header                              | _
+    'Set-Cookie: user-id=7;;;Secure;;'  | _
+    'Set-Cookie: user-id=7;Secure===;;' | _
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/HttpHeaderTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/HttpHeaderTest.groovy
@@ -52,7 +52,7 @@ class HttpHeaderTest extends Specification {
 
   void 'ensure headers can be used in the map'() {
     when:
-    final matches = header.name  ==~ /[a-zA-Z-]+/
+    final matches = header.name  ==~ /[a-zA-Z0-9-]+/
 
     then:
     matches


### PR DESCRIPTION
# What Does This Do
Improves the performance of the cookie parser by reducing string allocations and avoiding going over the string more than once, and only creating new strings for what is needed

# Motivation
In applications making heavy usage of cookies the parse might become effectively a bottleneck.


