### PR TITLE
Add Datadog-Entity-Id header

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -60,6 +60,7 @@ public class SharedCommunicationObjects {
 
   private ConfigurationPoller createPoller(Config config) {
     String containerId = ContainerInfo.get().getContainerId();
+    String entityId = ContainerInfo.getEntityId();
     Supplier<String> configUrlSupplier;
     String remoteConfigUrl = config.getFinalRemoteConfigUrl();
     if (remoteConfigUrl != null) {
@@ -69,7 +70,7 @@ public class SharedCommunicationObjects {
       configUrlSupplier = new RetryConfigUrlSupplier(this, config);
     }
     return new ConfigurationPoller(
-        config, TRACER_VERSION, containerId, configUrlSupplier, okHttpClient);
+        config, TRACER_VERSION, containerId, entityId, configUrlSupplier, okHttpClient);
   }
 
   // for testing

--- a/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
+++ b/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
@@ -43,6 +43,7 @@ public final class OkHttpUtils {
   private static final String DATADOG_META_LANG_INTERPRETER_VENDOR =
       "Datadog-Meta-Lang-Interpreter-Vendor";
   private static final String DATADOG_CONTAINER_ID = "Datadog-Container-ID";
+  private static final String DATADOG_ENTITY_ID = "Datadog-Entity-ID";
 
   private static final String DD_API_KEY = "DD-API-KEY";
 
@@ -183,8 +184,12 @@ public final class OkHttpUtils {
             .addHeader(DATADOG_META_LANG_INTERPRETER_VENDOR, JAVA_VM_VENDOR);
 
     final String containerId = ContainerInfo.get().getContainerId();
+    final String entityId = ContainerInfo.getEntityId();
     if (containerId != null) {
       builder.addHeader(DATADOG_CONTAINER_ID, containerId);
+    }
+    if (entityId != null) {
+      builder.addHeader(DATADOG_ENTITY_ID, entityId);
     }
 
     for (Map.Entry<String, String> e : headers.entrySet()) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -60,12 +60,14 @@ public class BatchUploader {
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
   private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
   private static final String HEADER_DD_CONTAINER_ID = "Datadog-Container-ID";
+  private static final String HEADER_DD_ENTITY_ID = "Datadog-Entity-ID";
   static final String HEADER_DD_API_KEY = "DD-API-KEY";
   static final int MAX_RUNNING_REQUESTS = 10;
   static final int MAX_ENQUEUED_REQUESTS = 20;
   static final int TERMINATION_TIMEOUT = 5;
 
   private final String containerId;
+  private final String entityId;
   private final ExecutorService okHttpExecutorService;
   private final OkHttpClient client;
   private final HttpUrl urlBase;
@@ -82,12 +84,21 @@ public class BatchUploader {
   }
 
   BatchUploader(Config config, String endpoint, RatelimitedLogger ratelimitedLogger) {
-    this(config, endpoint, ratelimitedLogger, ContainerInfo.get().containerId);
+    this(
+        config,
+        endpoint,
+        ratelimitedLogger,
+        ContainerInfo.get().containerId,
+        ContainerInfo.getEntityId());
   }
 
   // Visible for testing
   BatchUploader(
-      Config config, String endpoint, RatelimitedLogger ratelimitedLogger, String containerId) {
+      Config config,
+      String endpoint,
+      RatelimitedLogger ratelimitedLogger,
+      String containerId,
+      String entityId) {
     instrumentTheWorld = config.isDebuggerInstrumentTheWorld();
     if (endpoint == null || endpoint.length() == 0) {
       throw new IllegalArgumentException("Endpoint url is empty");
@@ -107,6 +118,7 @@ public class BatchUploader {
             new SynchronousQueue<>(),
             new AgentThreadFactory(DEBUGGER_HTTP_DISPATCHER));
     this.containerId = containerId;
+    this.entityId = entityId;
     Duration requestTimeout = Duration.ofSeconds(config.getDebuggerUploadTimeout());
     client =
         OkHttpUtils.buildHttpClient(
@@ -216,6 +228,9 @@ public class BatchUploader {
     }
     if (containerId != null) {
       requestBuilder.addHeader(HEADER_DD_CONTAINER_ID, containerId);
+    }
+    if (entityId != null) {
+      requestBuilder.addHeader(HEADER_DD_ENTITY_ID, entityId);
     }
     Request request = requestBuilder.build();
     log.debug("Sending request: {} CT: {}", request, request.body().contentType());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
@@ -207,7 +207,7 @@ public class BatchUploaderTest {
     // we don't explicitly specify a container ID
     server.enqueue(RESPONSE_200);
     BatchUploader uploaderWithNoContainerId =
-        new BatchUploader(config, url.toString(), ratelimitedLogger, null);
+        new BatchUploader(config, url.toString(), ratelimitedLogger, null, null);
 
     uploaderWithNoContainerId.upload(SNAPSHOT_BUFFER);
     uploaderWithNoContainerId.shutdown();
@@ -221,12 +221,14 @@ public class BatchUploaderTest {
     server.enqueue(RESPONSE_200);
 
     BatchUploader uploaderWithContainerId =
-        new BatchUploader(config, url.toString(), ratelimitedLogger, "testContainerId");
+        new BatchUploader(
+            config, url.toString(), ratelimitedLogger, "testContainerId", "testEntityId");
     uploaderWithContainerId.upload(SNAPSHOT_BUFFER);
     uploaderWithContainerId.shutdown();
 
     RecordedRequest request = server.takeRequest(100, TimeUnit.MILLISECONDS);
     assertEquals("testContainerId", request.getHeader("Datadog-Container-ID"));
+    assertEquals("testEntityId", request.getHeader("Datadog-Entity-ID"));
   }
 
   @Test

--- a/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
@@ -62,6 +62,7 @@ public class ConfigurationPoller
   private final Config config;
   private final String tracerVersion;
   private final String containerId;
+  private final String entityId;
   private final OkHttpClient httpClient;
   private final RatelimitedLogger ratelimitedLogger;
   private final Supplier<String> urlSupplier;
@@ -85,12 +86,14 @@ public class ConfigurationPoller
       Config config,
       String tracerVersion,
       String containerId,
+      String entityId,
       Supplier<String> urlSupplier,
       OkHttpClient client) {
     this(
         config,
         tracerVersion,
         containerId,
+        entityId,
         urlSupplier,
         client,
         new AgentTaskScheduler(AgentThreadFactory.AgentThread.REMOTE_CONFIG));
@@ -101,12 +104,14 @@ public class ConfigurationPoller
       Config config,
       String tracerVersion,
       String containerId,
+      String entityId,
       Supplier<String> urlSupplier,
       OkHttpClient httpClient,
       AgentTaskScheduler taskScheduler) {
     this.config = config;
     this.tracerVersion = tracerVersion;
     this.containerId = containerId;
+    this.entityId = entityId;
     this.urlSupplier = urlSupplier;
     this.keyId = config.getRemoteConfigTargetsKeyId();
     String keyStr = config.getRemoteConfigTargetsKey();
@@ -253,7 +258,7 @@ public class ConfigurationPoller
               .build();
       this.responseFactory = new RemoteConfigResponse.Factory(moshi);
       this.requestFactory =
-          new PollerRequestFactory(config, tracerVersion, containerId, url, moshi);
+          new PollerRequestFactory(config, tracerVersion, containerId, entityId, url, moshi);
     } catch (Exception e) {
       // We can't recover from this, so we'll not try to initialize again.
       fatalOnInitialization = true;

--- a/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 public class PollerRequestFactory {
   private static final String HEADER_DD_API_KEY = "DD-API-KEY";
   private static final String HEADER_CONTAINER_ID = "Datadog-Container-ID";
+  private static final String HEADER_ENTITY_ID = "Datadog-Entity-ID";
 
   private static final Logger log = LoggerFactory.getLogger(PollerRequestFactory.class);
 
@@ -37,11 +38,17 @@ public class PollerRequestFactory {
   private final String hostName;
   private final String tracerVersion;
   private final String containerId;
+  private final String entityId;
   private final Moshi moshi;
   final HttpUrl url;
 
   public PollerRequestFactory(
-      Config config, String tracerVersion, String containerId, String url, Moshi moshi) {
+      Config config,
+      String tracerVersion,
+      String containerId,
+      String entityId,
+      String url,
+      Moshi moshi) {
     this.runtimeId = getRuntimeId(config);
     this.serviceName = TagsHelper.sanitize(config.getServiceName());
     this.apiKey = config.getApiKey();
@@ -51,6 +58,7 @@ public class PollerRequestFactory {
     // Semantic Versioning requires build separated with `+`
     this.tracerVersion = tracerVersion.replace('~', '+');
     this.containerId = containerId;
+    this.entityId = entityId;
     this.url = parseUrl(url);
     this.moshi = moshi;
   }
@@ -88,8 +96,11 @@ public class PollerRequestFactory {
     if (this.apiKey != null) {
       requestBuilder.addHeader(HEADER_DD_API_KEY, this.apiKey);
     }
-    if (containerId != null && !containerId.isEmpty()) {
+    if (containerId != null) {
       requestBuilder.addHeader(HEADER_CONTAINER_ID, containerId);
+    }
+    if (entityId != null) {
+      requestBuilder.addHeader(HEADER_ENTITY_ID, entityId);
     }
     return requestBuilder.build();
   }

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -70,6 +70,7 @@ class ConfigurationPollerSpecification extends DDSpecification {
       Config.get(),
       '0.0.0',
       '',
+      '',
       { -> configUrlSupplier.get() } as Supplier<String>,
       okHttpClient,
       scheduler,

--- a/remote-config/src/test/groovy/datadog/remoteconfig/PollerRequestFactoryTest.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/PollerRequestFactoryTest.groovy
@@ -9,6 +9,7 @@ class PollerRequestFactoryTest extends DDSpecification {
 
   static final String TRACER_VERSION = "v1.2.3"
   static final String CONTAINER_ID = "456"
+  static final String ENTITY_ID = "32423"
   static final String INVALID_REMOTE_CONFIG_URL = "https://invalid.example.com/"
 
   void 'remote config request fields been sanitized'() {
@@ -18,7 +19,7 @@ class PollerRequestFactoryTest extends DDSpecification {
     System.setProperty("dd.tags", "version:1.0.0-SNAPSHOT")
     System.setProperty("dd.trace.global.tags", Tags.GIT_REPOSITORY_URL+":https://github.com/DataDog/dd-trace-java,"+Tags.GIT_COMMIT_SHA + ":1234")
     rebuildConfig()
-    PollerRequestFactory factory = new PollerRequestFactory(Config.get(), TRACER_VERSION, CONTAINER_ID, INVALID_REMOTE_CONFIG_URL, null)
+    PollerRequestFactory factory = new PollerRequestFactory(Config.get(), TRACER_VERSION, CONTAINER_ID, ENTITY_ID, INVALID_REMOTE_CONFIG_URL, null)
 
     when:
     RemoteConfigRequest request = factory.buildRemoteConfigRequest( Collections.singletonList("ASM"), null, null, 0)

--- a/remote-config/src/test/groovy/datadog/remoteconfig/Rcte1TestVectorsSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/Rcte1TestVectorsSpecification.groovy
@@ -51,6 +51,7 @@ class Rcte1TestVectorsSpecification extends DDSpecification {
       Config.get(),
       '0.0.0',
       'containerid',
+      'entityid',
       { -> URL.toString() },
       okHttpClient,
       scheduler

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequest.java
@@ -60,6 +60,10 @@ public class TelemetryRequest {
     if (containerId != null) {
       builder.addHeader("Datadog-Container-ID", containerId);
     }
+    final String entityId = ContainerInfo.getEntityId();
+    if (entityId != null) {
+      builder.addHeader("Datadog-Entity-ID", entityId);
+    }
 
     if (debug) {
       builder.addHeader("DD-Telemetry-Debug-Enabled", "true");

--- a/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
@@ -76,20 +76,22 @@ class TestTelemetryRouter extends TelemetryRouter {
 
     RequestAssertions headers(RequestType requestType) {
       assert this.request.method() == 'POST'
-      assert this.request.headers().names() == [
+      assert this.request.headers().names().containsAll([
         'Content-Type',
         'Content-Length',
         'DD-Client-Library-Language',
         'DD-Client-Library-Version',
         'DD-Telemetry-API-Version',
         'DD-Telemetry-Request-Type'
-      ] as Set
+      ])
       assert this.request.header('Content-Type') == 'application/json; charset=utf-8'
       assert this.request.header('Content-Length').toInteger() > 0
       assert this.request.header('DD-Client-Library-Language') == 'jvm'
       assert this.request.header('DD-Client-Library-Version') == TracerVersion.TRACER_VERSION
       assert this.request.header('DD-Telemetry-API-Version') == 'v2'
       assert this.request.header('DD-Telemetry-Request-Type') == requestType.toString()
+      def entityId = this.request.header('Datadog-Entity-ID')
+      assert entityId == null || entityId.startsWith("in-") || entityId.startsWith("cin-")
       return this
     }
 

--- a/utils/container-utils/src/test/groovy/datadog/common/container/ServerlessInfoTest.groovy
+++ b/utils/container-utils/src/test/groovy/datadog/common/container/ServerlessInfoTest.groovy
@@ -1,4 +1,5 @@
-import datadog.common.container.ServerlessInfo
+package datadog.common.container
+
 import datadog.trace.test.util.DDSpecification
 
 class ServerlessInfoTest extends DDSpecification {


### PR DESCRIPTION
# What Does This Do

Adds `Datadog-Entity-ID` header.

# Motivation

Send a new HTTP header `Datadog-Entity-ID` to the trace-agent. This will allow us to cover more container tagging scenarios.

The reference implementation is in Go: https://github.com/DataDog/dd-trace-go/blob/main/internal/container_linux.go 

## How to build the header value?

If the container ID (the value used for the `Datadog-Container-ID` header) is available and not empty, the value of `Datadog-Entity-ID` must be `cid-<container ID>` 

Else if the tracer runs in the host cgroup namespace (see [isHostCgroupNamespace](https://github.com/DataDog/dd-trace-go/blob/cb699a6311a6036cb3f4589b79db6169f9bbfd01/internal/container_linux.go#L170)), do not report `Datadog-Entity-ID`

Else the value of `Datadog-Entity-ID` must be `in-<cgroup inode>` (see [getCgroupInode](https://github.com/DataDog/dd-trace-go/blob/cb699a6311a6036cb3f4589b79db6169f9bbfd01/internal/container_linux.go#L113C6-L113C20))

System-tests PR: https://github.com/DataDog/system-tests/pull/2029

- [ ] Merge corresponding https://github.com/DataDog/system-tests/pull/2067 one this change is in master

# Additional Notes

Jira ticket: [APMJAVA-1198]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1198]: https://datadoghq.atlassian.net/browse/APMJAVA-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ