### PR TITLE
Get access to tag values from the top of TraceSegments

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastRequestContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastRequestContext.java
@@ -17,7 +17,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -26,7 +25,6 @@ public class IastRequestContext implements IastContext, HasMetricCollector {
   static final int MAP_SIZE = TaintedMap.DEFAULT_CAPACITY;
 
   private final VulnerabilityBatch vulnerabilityBatch;
-  private final AtomicBoolean spanDataIsSet;
   private final OverheadContext overheadContext;
   private TaintedObjects taintedObjects;
   @Nullable private IastMetricCollector collector;
@@ -47,7 +45,6 @@ public class IastRequestContext implements IastContext, HasMetricCollector {
 
   public IastRequestContext(final TaintedObjects taintedObjects) {
     this.vulnerabilityBatch = new VulnerabilityBatch();
-    this.spanDataIsSet = new AtomicBoolean(false);
     this.overheadContext = new OverheadContext(Config.get().getIastVulnerabilitiesPerRequest());
     this.taintedObjects = taintedObjects;
   }
@@ -90,10 +87,6 @@ public class IastRequestContext implements IastContext, HasMetricCollector {
 
   public void setContentType(final String contentType) {
     this.contentType = contentType;
-  }
-
-  public boolean getAndSetSpanDataIsSet() {
-    return spanDataIsSet.getAndSet(true);
   }
 
   public OverheadContext getOverheadContext() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -53,15 +53,16 @@ class ReporterTest extends DDSpecification {
     span.getSpanId() >> spanId
 
     final v = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("MD5")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
 
     when:
     reporter.report(span, v)
 
     then:
+    1 * traceSegment.getDataTop('iast') >> null
     1 * traceSegment.setDataTop('iast', _) >> { batch = it[1] as VulnerabilityBatch }
     JSONAssert.assertEquals('''{
       "vulnerabilities": [
@@ -98,22 +99,26 @@ class ReporterTest extends DDSpecification {
     span.getSpanId() >> spanId
 
     final v1 = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("MD5")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
     final v2 = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 2)),
-    new Evidence("MD4")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 2)),
+      new Evidence("MD4")
+      )
 
     when:
     reporter.report(span, v1)
     reporter.report(span, v2)
 
     then:
+    // first vulnerability
+    1 * traceSegment.getDataTop('iast') >> null
     1 * traceSegment.setDataTop('iast', _) >> { batch = it[1] as VulnerabilityBatch }
+    // second vulnerability
+    1 * traceSegment.getDataTop('iast') >> { return batch } // second vulnerability
     JSONAssert.assertEquals('''{
       "vulnerabilities": [
         {
@@ -229,10 +234,10 @@ class ReporterTest extends DDSpecification {
     span.getRequestContext() >> null
     span.getSpanId() >> 12345L
     final v = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(null, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("MD5")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(null, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
 
     when:
     reporter.report(span, v)
@@ -243,20 +248,20 @@ class ReporterTest extends DDSpecification {
     0 * _
   }
 
-  void 'null IastRequestContext does not throw'() {
+  void 'null IastRequestContext also is able to send vulnerabilities'() {
     given:
     final Reporter reporter = new Reporter()
     final reqCtx = Mock(RequestContext)
     final spanId = 123456
-    reqCtx.getData(RequestContextSlot.IAST) >> null
+    final traceSegment = Mock(TraceSegment)
     final span = Mock(AgentSpan)
     span.getRequestContext() >> reqCtx
     span.getSpanId() >> spanId
     final v = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("MD5")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
 
     when:
     reporter.report(span, v)
@@ -264,7 +269,12 @@ class ReporterTest extends DDSpecification {
     then:
     noExceptionThrown()
     1 * span.getRequestContext() >> reqCtx
-    1 * reqCtx.getData(RequestContextSlot.IAST)
+    1 * reqCtx.getData(RequestContextSlot.IAST) >> null
+    1 * reqCtx.getTraceSegment() >> traceSegment
+    1 * traceSegment.getDataTop('iast') >> null
+    1 * traceSegment.setDataTop('iast', _ as VulnerabilityBatch)
+    1 * traceSegment.setTagTop('manual.keep', true)
+    1 * traceSegment.setTagTop('_dd.iast.enabled', 1)
     0 * _
   }
 
@@ -273,17 +283,17 @@ class ReporterTest extends DDSpecification {
     final span1 = Mock(AgentSpan)
     span1.getSpanId() >> 123456
     final vulnerability1 = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span1, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("GOOD")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span1, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
     final span2 = Mock(AgentSpan)
     span1.getSpanId() >> 7890
     final vulnerability2 = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span2, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("BAD")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span2, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("BAD")
+      )
 
     expect:
     vulnerability1 == vulnerability2
@@ -294,17 +304,17 @@ class ReporterTest extends DDSpecification {
     final span1 = Mock(AgentSpan)
     span1.getSpanId() >> 123456
     final vulnerability1 = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span1, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("GOOD")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span1, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
     final span2 = Mock(AgentSpan)
     span1.getSpanId() >> 7890
     final vulnerability2 = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span2, new StackTraceElement("foo", "foo", "foo", 2)),
-    new Evidence("BAD")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span2, new StackTraceElement("foo", "foo", "foo", 2)),
+      new Evidence("BAD")
+      )
 
     expect:
     vulnerability1 != vulnerability2
@@ -317,10 +327,10 @@ class ReporterTest extends DDSpecification {
     final batch = new VulnerabilityBatch()
     final span = spanWithBatch(batch)
     final vulnerability = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("GOOD")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
 
     when: 'first time a vulnerability is reported'
     reporter.report(span, vulnerability)
@@ -342,10 +352,10 @@ class ReporterTest extends DDSpecification {
     final batch = new VulnerabilityBatch()
     final span = spanWithBatch(batch)
     final vulnerability = new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("GOOD")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
 
     when: 'first time a vulnerability is reported'
     reporter.report(span, vulnerability)
@@ -369,10 +379,10 @@ class ReporterTest extends DDSpecification {
     final span = spanWithBatch(batch)
     final vulnerabilityBuilder = { int index ->
       new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(span, new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
-      new Evidence("GOOD")
-      )
+        VulnerabilityType.WEAK_HASH,
+        Location.forSpanAndStack(span, new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
+        new Evidence("GOOD")
+        )
     }
 
     when: 'the deduplication cache is filled for the first time'
@@ -409,10 +419,10 @@ class ReporterTest extends DDSpecification {
     final span = spanWithBatch(batch)
     final vulnerabilityBuilder = { int index ->
       new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(span, new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
-      new Evidence("GOOD")
-      )
+        VulnerabilityType.WEAK_HASH,
+        Location.forSpanAndStack(span, new StackTraceElement(index.toString(), index.toString(), index.toString(), index)),
+        new Evidence("GOOD")
+        )
     }
 
     when: 'a few duplicates are reported in a concurrent scenario'
@@ -440,7 +450,9 @@ class ReporterTest extends DDSpecification {
   }
 
   private AgentSpan spanWithBatch(final VulnerabilityBatch batch) {
-    final traceSegment = Mock(TraceSegment)
+    final traceSegment = Mock(TraceSegment) {
+      getDataTop('iast') >> batch
+    }
     final ctx = Mock(IastRequestContext) {
       it.getVulnerabilityBatch() >> batch
     }
@@ -457,22 +469,22 @@ class ReporterTest extends DDSpecification {
 
   private Vulnerability defaultVulnerability(){
     return new Vulnerability(
-    VulnerabilityType.WEAK_HASH,
-    Location.forSpanAndStack(null, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("MD5")
-    )
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(null, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("MD5")
+      )
   }
 
   private Vulnerability cookieVulnerability(){
     return new Vulnerability(
-    VulnerabilityType.INSECURE_COOKIE,
-    Location.forSpanAndStack(null, new StackTraceElement("foo", "foo", "foo", 1)),
-    new Evidence("cookie-name")
-    )
+      VulnerabilityType.INSECURE_COOKIE,
+      Location.forSpanAndStack(null, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("cookie-name")
+      )
   }
 
   private Vulnerability headerVulnerability(){
     return new Vulnerability(
-    VulnerabilityType.XCONTENTTYPE_HEADER_MISSING, Location.forSpan(null), null)
+      VulnerabilityType.XCONTENTTYPE_HEADER_MISSING, Location.forSpan(null), null)
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -531,6 +531,12 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     }
 
     @Override
+    Object getDataTop(String key) {
+      check()
+      return delegate.getDataTop(key)
+    }
+
+    @Override
     void effectivelyBlocked() {
       check()
       delegate.effectivelyBlocked()
@@ -540,6 +546,12 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     void setDataCurrent(String key, Object value) {
       check()
       delegate.setDataCurrent(key, value)
+    }
+
+    @Override
+    Object getDataCurrent(String key) {
+      check()
+      return delegate.getDataCurrent(key)
     }
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
@@ -55,6 +55,14 @@ public interface TraceSegment {
    */
   void setDataTop(String key, Object value);
 
+  /**
+   * Gets the value of the tag from the top of this {@code TraceSegment}.
+   *
+   * @param key key of the data
+   * @return value of the data
+   */
+  Object getDataTop(String key);
+
   /** Mark the request as effectively blocked, by setting the tag appsec.blocked */
   void effectivelyBlocked();
 
@@ -66,6 +74,14 @@ public interface TraceSegment {
    * @param value value of the data
    */
   void setDataCurrent(String key, Object value);
+
+  /**
+   * Gets the value of the tag from the current span in this {@code TraceSegment}.
+   *
+   * @param key key of the data
+   * @return value of the data
+   */
+  Object getDataCurrent(String key);
 
   class NoOp implements TraceSegment {
     public static final TraceSegment INSTANCE = new NoOp();
@@ -82,9 +98,19 @@ public interface TraceSegment {
     public void setDataTop(String key, Object value) {}
 
     @Override
+    public Object getDataTop(String key) {
+      return null;
+    }
+
+    @Override
     public void effectivelyBlocked() {}
 
     @Override
     public void setDataCurrent(String key, Object value) {}
+
+    @Override
+    public Object getDataCurrent(String key) {
+      return null;
+    }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -922,14 +922,27 @@ public class DDSpanContext
   }
 
   @Override
+  public Object getDataTop(String key) {
+    return getRootSpanContextOrThis().getDataCurrent(key);
+  }
+
+  @Override
   public void effectivelyBlocked() {
     setTag("appsec.blocked", "true");
   }
 
   @Override
   public void setDataCurrent(String key, Object value) {
+    this.setTag(getTagName(key), value);
+  }
+
+  @Override
+  public Object getDataCurrent(String key) {
+    return this.getTag(getTagName(key));
+  }
+
+  private String getTagName(String key) {
     // TODO is this decided?
-    String tagKey = "_dd." + key + ".json";
-    this.setTag(tagKey, value);
+    return "_dd." + key + ".json";
   }
 }


### PR DESCRIPTION
# What Does This Do
Add getters to query for data from the top of the current trace segment.

# Motivation
From IAST we want to be able to add vulnerabilities even when there is no active request (e.g. Kafka)

# Additional Notes

Jira ticket: [APPSEC-10440]

This is required to make IAST work in Kafka consumers: https://github.com/DataDog/dd-trace-java/pull/6465


[APPSEC-10440]: https://datadoghq.atlassian.net/browse/APPSEC-10440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ