### PR TITLE
Cache IAST metric tag values to be used in metrics and spans

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -10,89 +10,72 @@ import java.util.zip.CRC32;
 import javax.annotation.Nonnull;
 
 public interface VulnerabilityType {
-  VulnerabilityType WEAK_CIPHER =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_CIPHER_STRING, NOT_MARKED);
-  VulnerabilityType WEAK_HASH =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_HASH_STRING, NOT_MARKED);
+  VulnerabilityType WEAK_CIPHER = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_CIPHER);
+  VulnerabilityType WEAK_HASH = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_HASH);
   VulnerabilityType INSECURE_COOKIE =
-      new CookieVulnerabilityType(VulnerabilityTypes.INSECURE_COOKIE_STRING, NOT_MARKED);
+      new CookieVulnerabilityType(VulnerabilityTypes.INSECURE_COOKIE);
   VulnerabilityType NO_HTTPONLY_COOKIE =
-      new CookieVulnerabilityType(VulnerabilityTypes.NO_HTTPONLY_COOKIE_STRING, NOT_MARKED);
+      new CookieVulnerabilityType(VulnerabilityTypes.NO_HTTPONLY_COOKIE);
   VulnerabilityType HSTS_HEADER_MISSING =
-      new HeaderVulnerabilityType(VulnerabilityTypes.HSTS_HEADER_MISSING_STRING, NOT_MARKED);
+      new HeaderVulnerabilityType(VulnerabilityTypes.HSTS_HEADER_MISSING);
   VulnerabilityType XCONTENTTYPE_HEADER_MISSING =
-      new HeaderVulnerabilityType(
-          VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING_STRING, NOT_MARKED);
+      new HeaderVulnerabilityType(VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING);
   VulnerabilityType NO_SAMESITE_COOKIE =
-      new CookieVulnerabilityType(VulnerabilityTypes.NO_SAMESITE_COOKIE_STRING, NOT_MARKED);
+      new CookieVulnerabilityType(VulnerabilityTypes.NO_SAMESITE_COOKIE);
 
   InjectionType SQL_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.SQL_INJECTION_STRING, VulnerabilityMarks.SQL_INJECTION_MARK, ' ');
+          VulnerabilityTypes.SQL_INJECTION, VulnerabilityMarks.SQL_INJECTION_MARK);
   InjectionType COMMAND_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.COMMAND_INJECTION_STRING,
-          VulnerabilityMarks.COMMAND_INJECTION_MARK,
-          ' ');
+          VulnerabilityTypes.COMMAND_INJECTION, VulnerabilityMarks.COMMAND_INJECTION_MARK);
   InjectionType PATH_TRAVERSAL =
       new InjectionTypeImpl(
-          VulnerabilityTypes.PATH_TRAVERSAL_STRING,
-          VulnerabilityMarks.PATH_TRAVERSAL_MARK,
-          File.separatorChar);
+          File.separatorChar,
+          VulnerabilityTypes.PATH_TRAVERSAL,
+          VulnerabilityMarks.PATH_TRAVERSAL_MARK);
   InjectionType LDAP_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.LDAP_INJECTION_STRING, VulnerabilityMarks.LDAP_INJECTION_MARK, ' ');
-  InjectionType SSRF =
-      new InjectionTypeImpl(VulnerabilityTypes.SSRF_STRING, VulnerabilityMarks.SSRF_MARK, ' ');
+          VulnerabilityTypes.LDAP_INJECTION, VulnerabilityMarks.LDAP_INJECTION_MARK);
+  InjectionType SSRF = new InjectionTypeImpl(VulnerabilityTypes.SSRF, VulnerabilityMarks.SSRF_MARK);
   InjectionType UNVALIDATED_REDIRECT =
       new InjectionTypeImpl(
-          VulnerabilityTypes.UNVALIDATED_REDIRECT_STRING,
-          VulnerabilityMarks.UNVALIDATED_REDIRECT_MARK,
-          ' ');
-  VulnerabilityType WEAK_RANDOMNESS =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_RANDOMNESS_STRING, NOT_MARKED);
+          VulnerabilityTypes.UNVALIDATED_REDIRECT, VulnerabilityMarks.UNVALIDATED_REDIRECT_MARK);
+  VulnerabilityType WEAK_RANDOMNESS = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_RANDOMNESS);
 
   InjectionType XPATH_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.XPATH_INJECTION_STRING, VulnerabilityMarks.XPATH_INJECTION_MARK, ' ');
+          VulnerabilityTypes.XPATH_INJECTION, VulnerabilityMarks.XPATH_INJECTION_MARK);
 
   InjectionType TRUST_BOUNDARY_VIOLATION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION_STRING,
-          VulnerabilityMarks.TRUST_BOUNDARY_VIOLATION,
-          ' ');
+          VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION, VulnerabilityMarks.TRUST_BOUNDARY_VIOLATION);
 
-  InjectionType XSS =
-      new InjectionTypeImpl(VulnerabilityTypes.XSS_STRING, VulnerabilityMarks.XSS_MARK, ' ');
+  InjectionType XSS = new InjectionTypeImpl(VulnerabilityTypes.XSS, VulnerabilityMarks.XSS_MARK);
 
   InjectionType HEADER_INJECTION =
       new InjectionTypeImpl(
-          VulnerabilityTypes.HEADER_INJECTION_STRING,
-          VulnerabilityMarks.HEADER_INJECTION_MARK,
-          ' ');
+          VulnerabilityTypes.HEADER_INJECTION, VulnerabilityMarks.HEADER_INJECTION_MARK);
 
-  VulnerabilityType STACKTRACE_LEAK =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.STACKTRACE_LEAK_STRING, NOT_MARKED);
+  VulnerabilityType STACKTRACE_LEAK = new VulnerabilityTypeImpl(VulnerabilityTypes.STACKTRACE_LEAK);
 
-  VulnerabilityType VERB_TAMPERING =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.VERB_TAMPERING_STRING, NOT_MARKED);
+  VulnerabilityType VERB_TAMPERING = new VulnerabilityTypeImpl(VulnerabilityTypes.VERB_TAMPERING);
 
   VulnerabilityType ADMIN_CONSOLE_ACTIVE =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE_STRING, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE);
 
   VulnerabilityType DEFAULT_HTML_ESCAPE_INVALID =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID_STRING, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID);
 
-  VulnerabilityType SESSION_TIMEOUT =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.SESSION_TIMEOUT_STRING, NOT_MARKED);
+  VulnerabilityType SESSION_TIMEOUT = new VulnerabilityTypeImpl(VulnerabilityTypes.SESSION_TIMEOUT);
 
   VulnerabilityType DIRECTORY_LISTING_LEAK =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.DIRECTORY_LISTING_LEAK_STRING, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.DIRECTORY_LISTING_LEAK);
   VulnerabilityType INSECURE_JSP_LAYOUT =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_JSP_LAYOUT_STRING, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_JSP_LAYOUT);
 
   VulnerabilityType HARDCODED_SECRET =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.HARDCODED_SECRET_STRING, NOT_MARKED);
+      new VulnerabilityTypeImpl(VulnerabilityTypes.HARDCODED_SECRET);
 
   String name();
 
@@ -107,18 +90,18 @@ public interface VulnerabilityType {
 
   class VulnerabilityTypeImpl implements VulnerabilityType {
 
-    private final String name;
+    private final byte type;
 
     private final int mark;
 
-    public VulnerabilityTypeImpl(@Nonnull final String name, final int vulnerabilityMark) {
-      this.name = name;
-      mark = vulnerabilityMark;
+    public VulnerabilityTypeImpl(final byte type, final int... marks) {
+      this.type = type;
+      mark = computeMarks(marks);
     }
 
     @Override
     public String name() {
-      return name;
+      return VulnerabilityTypes.toString(type);
     }
 
     @Override
@@ -147,14 +130,25 @@ public interface VulnerabilityType {
       final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
       crc.update(bytes, 0, bytes.length);
     }
+
+    private static int computeMarks(final int... marks) {
+      int result = NOT_MARKED;
+      for (final int mark : marks) {
+        result |= mark;
+      }
+      return result;
+    }
   }
 
   class InjectionTypeImpl extends VulnerabilityTypeImpl implements InjectionType {
     private final char evidenceSeparator;
 
-    public InjectionTypeImpl(
-        @Nonnull final String name, final int vulnerabilityMark, final char evidenceSeparator) {
-      super(name, vulnerabilityMark);
+    public InjectionTypeImpl(final byte type, int... marks) {
+      this(' ', type, marks);
+    }
+
+    public InjectionTypeImpl(final char evidenceSeparator, final byte type, int... marks) {
+      super(type, marks);
       this.evidenceSeparator = evidenceSeparator;
     }
 
@@ -165,8 +159,8 @@ public interface VulnerabilityType {
   }
 
   class HeaderVulnerabilityType extends VulnerabilityTypeImpl {
-    public HeaderVulnerabilityType(@Nonnull String name, int vulnerabilityMark) {
-      super(name, vulnerabilityMark);
+    public HeaderVulnerabilityType(byte type, int... marks) {
+      super(type, marks);
     }
 
     @Override
@@ -182,8 +176,8 @@ public interface VulnerabilityType {
   }
 
   class CookieVulnerabilityType extends VulnerabilityTypeImpl {
-    public CookieVulnerabilityType(@Nonnull String name, int vulnerabilityMark) {
-      super(name, vulnerabilityMark);
+    public CookieVulnerabilityType(byte type, int... marks) {
+      super(type, marks);
     }
 
     @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestEndedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestEndedHandler.java
@@ -18,8 +18,6 @@ import javax.annotation.Nonnull;
 public class TelemetryRequestEndedHandler
     implements BiFunction<RequestContext, IGSpanInfo, Flow<Void>> {
 
-  static final String TRACE_METRIC_PREFIX = "_dd.iast.telemetry.";
-
   private final BiFunction<RequestContext, IGSpanInfo, Flow<Void>> delegate;
 
   public TelemetryRequestEndedHandler(
@@ -57,8 +55,7 @@ public class TelemetryRequestEndedHandler
     for (final IastMetricData data : metrics) {
       final IastMetric metric = data.getMetric();
       if (metric.getScope() == REQUEST) {
-        final String tagValue = data.getSpanTag();
-        trace.setTagTop(TRACE_METRIC_PREFIX + tagValue, data.value);
+        trace.setTagTop(data.getSpanTag(), data.value);
       }
     }
   }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/TelemetryRequestEndedHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/telemetry/TelemetryRequestEndedHandlerTest.groovy
@@ -15,13 +15,13 @@ import datadog.trace.api.internal.TraceSegment
 import groovy.transform.CompileDynamic
 import groovy.transform.ToString
 
-import static com.datadog.iast.telemetry.TelemetryRequestEndedHandler.TRACE_METRIC_PREFIX
 import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_SINK
 import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_SOURCE
 import static datadog.trace.api.iast.telemetry.IastMetric.EXECUTED_TAINTED
 import static datadog.trace.api.iast.telemetry.IastMetric.INSTRUMENTED_SOURCE
 import static datadog.trace.api.iast.telemetry.IastMetric.REQUEST_TAINTED
 import static datadog.trace.api.iast.telemetry.IastMetric.Scope
+import static datadog.trace.api.iast.telemetry.IastMetric.TRACE_METRIC_PREFIX
 
 @CompileDynamic
 class TelemetryRequestEndedHandlerTest extends IastModuleImplTestBase {
@@ -133,7 +133,7 @@ class TelemetryRequestEndedHandlerTest extends IastModuleImplTestBase {
   private static String getSpanTagValue(final IastMetric metric, final Byte tagValue = null) {
     return metric.getTag() == null
       ? metric.getName()
-      : String.format("%s.%s", metric.getName(), metric.tag.toString(tagValue).toLowerCase().replaceAll("\\.", "_"))
+      : String.format("%s.%s", metric.getName(), metric.tag.values[tagValue].toLowerCase().replaceAll("\\.", "_"))
   }
 
   private static Data metric(final IastMetric metric, final byte tagValue, final int value) {

--- a/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/SourceTypes.java
@@ -7,89 +7,40 @@ public abstract class SourceTypes {
   public static final byte NONE = -1;
 
   public static final byte REQUEST_PARAMETER_NAME = 0;
-  public static final String REQUEST_PARAMETER_NAME_STRING = "http.request.parameter.name";
   public static final byte REQUEST_PARAMETER_VALUE = 1;
-  public static final String REQUEST_PARAMETER_VALUE_STRING = "http.request.parameter";
   public static final byte REQUEST_HEADER_NAME = 2;
-  public static final String REQUEST_HEADER_NAME_STRING = "http.request.header.name";
   public static final byte REQUEST_HEADER_VALUE = 3;
-  public static final String REQUEST_HEADER_VALUE_STRING = "http.request.header";
   public static final byte REQUEST_COOKIE_NAME = 4;
-  public static final String REQUEST_COOKIE_NAME_STRING = "http.request.cookie.name";
   public static final byte REQUEST_COOKIE_VALUE = 5;
-  public static final String REQUEST_COOKIE_VALUE_STRING = "http.request.cookie.value";
   public static final byte REQUEST_BODY = 6;
-  public static final String REQUEST_BODY_STRING = "http.request.body";
   public static final byte REQUEST_QUERY = 7;
-  public static final String REQUEST_QUERY_STRING = "http.request.query";
   public static final byte REQUEST_PATH_PARAMETER = 8;
-  public static final String REQUEST_PATH_PARAMETER_STRING = "http.request.path.parameter";
   public static final byte REQUEST_MATRIX_PARAMETER = 9;
-  public static final String REQUEST_MATRIX_PARAMETER_STRING = "http.request.matrix.parameter";
   public static final byte REQUEST_MULTIPART_PARAMETER = 10;
-  public static final String REQUEST_MULTIPART_PARAMETER_STRING =
-      "http.request.multipart.parameter";
   public static final byte REQUEST_URI = 11;
-  public static final String REQUEST_URI_STRING = "http.request.uri";
   public static final byte REQUEST_PATH = 12;
-  public static final String REQUEST_PATH_STRING = "http.request.path";
   public static final byte GRPC_BODY = 13;
-  public static final String GRPC_BODY_STRING = "grpc.request.body";
 
-  private static final byte[] VALUES = {
-    REQUEST_PARAMETER_NAME,
-    REQUEST_PARAMETER_VALUE,
-    REQUEST_HEADER_NAME,
-    REQUEST_HEADER_VALUE,
-    REQUEST_COOKIE_NAME,
-    REQUEST_COOKIE_VALUE,
-    REQUEST_BODY,
-    REQUEST_QUERY,
-    REQUEST_PATH_PARAMETER,
-    REQUEST_MATRIX_PARAMETER,
-    REQUEST_MULTIPART_PARAMETER,
-    REQUEST_PATH,
-    REQUEST_URI,
-    GRPC_BODY
+  /** Array indexed with all source types, the index should match the source types values */
+  public static final String[] STRINGS = {
+    "http.request.parameter.name",
+    "http.request.parameter",
+    "http.request.header.name",
+    "http.request.header",
+    "http.request.cookie.name",
+    "http.request.cookie.value",
+    "http.request.body",
+    "http.request.query",
+    "http.request.path.parameter",
+    "http.request.matrix.parameter",
+    "http.request.multipart.parameter",
+    "http.request.uri",
+    "http.request.path",
+    "grpc.request.body"
   };
 
-  public static byte[] values() {
-    return VALUES;
-  }
-
-  public static String toString(final byte sourceType) {
-    switch (sourceType) {
-      case SourceTypes.REQUEST_PARAMETER_NAME:
-        return SourceTypes.REQUEST_PARAMETER_NAME_STRING;
-      case SourceTypes.REQUEST_PARAMETER_VALUE:
-        return SourceTypes.REQUEST_PARAMETER_VALUE_STRING;
-      case SourceTypes.REQUEST_HEADER_NAME:
-        return SourceTypes.REQUEST_HEADER_NAME_STRING;
-      case SourceTypes.REQUEST_HEADER_VALUE:
-        return SourceTypes.REQUEST_HEADER_VALUE_STRING;
-      case SourceTypes.REQUEST_COOKIE_NAME:
-        return SourceTypes.REQUEST_COOKIE_NAME_STRING;
-      case SourceTypes.REQUEST_COOKIE_VALUE:
-        return SourceTypes.REQUEST_COOKIE_VALUE_STRING;
-      case SourceTypes.REQUEST_BODY:
-        return SourceTypes.REQUEST_BODY_STRING;
-      case SourceTypes.REQUEST_QUERY:
-        return SourceTypes.REQUEST_QUERY_STRING;
-      case SourceTypes.REQUEST_PATH_PARAMETER:
-        return SourceTypes.REQUEST_PATH_PARAMETER_STRING;
-      case SourceTypes.REQUEST_MATRIX_PARAMETER:
-        return SourceTypes.REQUEST_MATRIX_PARAMETER_STRING;
-      case SourceTypes.REQUEST_MULTIPART_PARAMETER:
-        return SourceTypes.REQUEST_MULTIPART_PARAMETER_STRING;
-      case SourceTypes.REQUEST_PATH:
-        return SourceTypes.REQUEST_PATH_STRING;
-      case SourceTypes.REQUEST_URI:
-        return SourceTypes.REQUEST_URI_STRING;
-      case SourceTypes.GRPC_BODY:
-        return SourceTypes.GRPC_BODY_STRING;
-      default:
-        return null;
-    }
+  public static String toString(final byte source) {
+    return source < 0 ? null : STRINGS[source];
   }
 
   public static byte namedSource(final byte sourceType) {

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityTypes.java
@@ -1,69 +1,37 @@
 package datadog.trace.api.iast;
 
+import javax.annotation.Nullable;
+
 public abstract class VulnerabilityTypes {
 
   private VulnerabilityTypes() {}
 
   public static final byte WEAK_CIPHER = 0;
-  public static final String WEAK_CIPHER_STRING = "WEAK_CIPHER";
   public static final byte WEAK_HASH = 1;
-  public static final String WEAK_HASH_STRING = "WEAK_HASH";
   public static final byte SQL_INJECTION = 2;
-  public static final String SQL_INJECTION_STRING = "SQL_INJECTION";
   public static final byte COMMAND_INJECTION = 3;
-  public static final String COMMAND_INJECTION_STRING = "COMMAND_INJECTION";
   public static final byte PATH_TRAVERSAL = 4;
-  public static final String PATH_TRAVERSAL_STRING = "PATH_TRAVERSAL";
   public static final byte LDAP_INJECTION = 5;
-  public static final String LDAP_INJECTION_STRING = "LDAP_INJECTION";
   public static final byte SSRF = 6;
-  public static final String SSRF_STRING = "SSRF";
   public static final byte INSECURE_COOKIE = 7;
-  public static final String INSECURE_COOKIE_STRING = "INSECURE_COOKIE";
   public static final byte NO_HTTPONLY_COOKIE = 8;
-  public static final String NO_HTTPONLY_COOKIE_STRING = "NO_HTTPONLY_COOKIE";
   public static final byte HSTS_HEADER_MISSING = 9;
-  public static final String HSTS_HEADER_MISSING_STRING = "HSTS_HEADER_MISSING";
   public static final byte XCONTENTTYPE_HEADER_MISSING = 10;
-  public static final String XCONTENTTYPE_HEADER_MISSING_STRING = "XCONTENTTYPE_HEADER_MISSING";
   public static final byte NO_SAMESITE_COOKIE = 11;
-  public static final String NO_SAMESITE_COOKIE_STRING = "NO_SAMESITE_COOKIE";
   public static final byte UNVALIDATED_REDIRECT = 12;
-  public static final String UNVALIDATED_REDIRECT_STRING = "UNVALIDATED_REDIRECT";
   public static final byte WEAK_RANDOMNESS = 13;
-  public static final String WEAK_RANDOMNESS_STRING = "WEAK_RANDOMNESS";
   public static final byte XPATH_INJECTION = 14;
-  public static final String XPATH_INJECTION_STRING = "XPATH_INJECTION";
   public static final byte TRUST_BOUNDARY_VIOLATION = 15;
-  public static final String TRUST_BOUNDARY_VIOLATION_STRING = "TRUST_BOUNDARY_VIOLATION";
   public static final byte XSS = 16;
-  public static final String XSS_STRING = "XSS";
   public static final byte STACKTRACE_LEAK = 17;
-  public static final String STACKTRACE_LEAK_STRING = "STACKTRACE_LEAK";
   public static final byte HEADER_INJECTION = 18;
-  public static final String HEADER_INJECTION_STRING = "HEADER_INJECTION";
-
   public static final byte VERB_TAMPERING = 19;
-  public static final String VERB_TAMPERING_STRING = "VERB_TAMPERING";
-
   public static final byte DEFAULT_HTML_ESCAPE_INVALID = 20;
-  public static final String DEFAULT_HTML_ESCAPE_INVALID_STRING = "DEFAULT_HTML_ESCAPE_INVALID";
-
   public static final byte SESSION_TIMEOUT = 21;
-  public static final String SESSION_TIMEOUT_STRING = "SESSION_TIMEOUT";
-
   public static final byte DIRECTORY_LISTING_LEAK = 22;
-  public static final String DIRECTORY_LISTING_LEAK_STRING = "DIRECTORY_LISTING_LEAK";
-
   public static final byte INSECURE_JSP_LAYOUT = 23;
-  public static final String INSECURE_JSP_LAYOUT_STRING = "INSECURE_JSP_LAYOUT";
-
   public static final byte ADMIN_CONSOLE_ACTIVE = 24;
-  public static final String ADMIN_CONSOLE_ACTIVE_STRING = "ADMIN_CONSOLE_ACTIVE";
-
   public static final byte HARDCODED_SECRET = 25;
-
-  public static final String HARDCODED_SECRET_STRING = "HARDCODED_SECRET";
 
   /**
    * Use for telemetry only, this is a special vulnerability type that is not reported, reported
@@ -85,96 +53,54 @@ public abstract class VulnerabilityTypes {
    * values will be {@link #SPRING_RESPONSE_TYPES}
    */
   public static final byte SPRING_RESPONSE = -127;
+
   /** Use for spring unvalidated redirect and xss */
   public static final byte[] SPRING_RESPONSE_TYPES = {UNVALIDATED_REDIRECT, XSS};
 
-  private static final byte[] VALUES = {
-    WEAK_CIPHER,
-    WEAK_HASH,
-    SQL_INJECTION,
-    COMMAND_INJECTION,
-    PATH_TRAVERSAL,
-    LDAP_INJECTION,
-    SSRF,
-    INSECURE_COOKIE,
-    NO_HTTPONLY_COOKIE,
-    UNVALIDATED_REDIRECT,
-    WEAK_RANDOMNESS,
-    XPATH_INJECTION,
-    TRUST_BOUNDARY_VIOLATION,
-    HSTS_HEADER_MISSING,
-    XCONTENTTYPE_HEADER_MISSING,
-    NO_SAMESITE_COOKIE,
-    XSS,
-    STACKTRACE_LEAK,
-    HEADER_INJECTION,
-    ADMIN_CONSOLE_ACTIVE,
-    VERB_TAMPERING,
-    DEFAULT_HTML_ESCAPE_INVALID,
-    SESSION_TIMEOUT,
-    DIRECTORY_LISTING_LEAK,
-    INSECURE_JSP_LAYOUT,
-    HARDCODED_SECRET
+  /**
+   * Array indexed with all vulnerability types, the index should match the vulnerability type
+   * values
+   */
+  public static final String[] STRINGS = {
+    "WEAK_CIPHER",
+    "WEAK_HASH",
+    "SQL_INJECTION",
+    "COMMAND_INJECTION",
+    "PATH_TRAVERSAL",
+    "LDAP_INJECTION",
+    "SSRF",
+    "INSECURE_COOKIE",
+    "NO_HTTPONLY_COOKIE",
+    "HSTS_HEADER_MISSING",
+    "XCONTENTTYPE_HEADER_MISSING",
+    "NO_SAMESITE_COOKIE",
+    "UNVALIDATED_REDIRECT",
+    "WEAK_RANDOMNESS",
+    "XPATH_INJECTION",
+    "TRUST_BOUNDARY_VIOLATION",
+    "XSS",
+    "STACKTRACE_LEAK",
+    "HEADER_INJECTION",
+    "VERB_TAMPERING",
+    "DEFAULT_HTML_ESCAPE_INVALID",
+    "SESSION_TIMEOUT",
+    "DIRECTORY_LISTING_LEAK",
+    "INSECURE_JSP_LAYOUT",
+    "ADMIN_CONSOLE_ACTIVE",
+    "HARDCODED_SECRET"
   };
 
-  public static byte[] values() {
-    return VALUES;
+  public static String toString(final byte vulnerability) {
+    return vulnerability < 0 ? null : STRINGS[vulnerability];
   }
 
-  public static String toString(final byte sourceType) {
-    switch (sourceType) {
-      case VulnerabilityTypes.WEAK_CIPHER:
-        return VulnerabilityTypes.WEAK_CIPHER_STRING;
-      case VulnerabilityTypes.WEAK_HASH:
-        return VulnerabilityTypes.WEAK_HASH_STRING;
-      case VulnerabilityTypes.SQL_INJECTION:
-        return VulnerabilityTypes.SQL_INJECTION_STRING;
-      case VulnerabilityTypes.COMMAND_INJECTION:
-        return VulnerabilityTypes.COMMAND_INJECTION_STRING;
-      case VulnerabilityTypes.PATH_TRAVERSAL:
-        return VulnerabilityTypes.PATH_TRAVERSAL_STRING;
-      case VulnerabilityTypes.LDAP_INJECTION:
-        return VulnerabilityTypes.LDAP_INJECTION_STRING;
-      case VulnerabilityTypes.SSRF:
-        return VulnerabilityTypes.SSRF_STRING;
-      case VulnerabilityTypes.INSECURE_COOKIE:
-        return VulnerabilityTypes.INSECURE_COOKIE_STRING;
-      case VulnerabilityTypes.NO_HTTPONLY_COOKIE:
-        return VulnerabilityTypes.NO_HTTPONLY_COOKIE_STRING;
-      case VulnerabilityTypes.UNVALIDATED_REDIRECT:
-        return VulnerabilityTypes.UNVALIDATED_REDIRECT_STRING;
-      case VulnerabilityTypes.WEAK_RANDOMNESS:
-        return VulnerabilityTypes.WEAK_RANDOMNESS_STRING;
-      case VulnerabilityTypes.XPATH_INJECTION:
-        return VulnerabilityTypes.XPATH_INJECTION_STRING;
-      case VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION:
-        return VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION_STRING;
-      case VulnerabilityTypes.HSTS_HEADER_MISSING:
-        return VulnerabilityTypes.HSTS_HEADER_MISSING_STRING;
-      case VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING:
-        return VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING_STRING;
-      case VulnerabilityTypes.NO_SAMESITE_COOKIE:
-        return VulnerabilityTypes.NO_SAMESITE_COOKIE_STRING;
-      case VulnerabilityTypes.XSS:
-        return VulnerabilityTypes.XSS_STRING;
-      case VulnerabilityTypes.STACKTRACE_LEAK:
-        return VulnerabilityTypes.STACKTRACE_LEAK_STRING;
-      case VulnerabilityTypes.HEADER_INJECTION:
-        return VulnerabilityTypes.HEADER_INJECTION_STRING;
-      case VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE:
-        return VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE_STRING;
-      case VulnerabilityTypes.VERB_TAMPERING:
-        return VulnerabilityTypes.VERB_TAMPERING_STRING;
-      case VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID:
-        return VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID_STRING;
-      case VulnerabilityTypes.SESSION_TIMEOUT:
-        return VulnerabilityTypes.SESSION_TIMEOUT_STRING;
-      case VulnerabilityTypes.DIRECTORY_LISTING_LEAK:
-        return VulnerabilityTypes.DIRECTORY_LISTING_LEAK_STRING;
-      case VulnerabilityTypes.INSECURE_JSP_LAYOUT:
-        return VulnerabilityTypes.INSECURE_JSP_LAYOUT_STRING;
-      case VulnerabilityTypes.HARDCODED_SECRET:
-        return VulnerabilityTypes.HARDCODED_SECRET_STRING;
+  @Nullable
+  public static byte[] unwrap(final byte vulnerability) {
+    switch (vulnerability) {
+      case RESPONSE_HEADER:
+        return RESPONSE_HEADER_TYPES;
+      case SPRING_RESPONSE:
+        return SPRING_RESPONSE_TYPES;
       default:
         return null;
     }

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
@@ -13,7 +13,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicLongArray;
@@ -102,10 +101,15 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
 
   public void addMetric(final IastMetric metric, final byte tagValue, final int value) {
     final Tag tag = metric.getTag();
-    if (tag != null && tag.isWrapped(tagValue)) {
-      // e.g.: VulnerabilityTypes.RESPONSE_HEADER
-      for (final byte unwrapped : metric.getTag().unwrap(tagValue)) {
-        increment(metric.getIndex(unwrapped), value);
+    if (tag != null) {
+      final byte[] unwrapped = tag.unwrap(tagValue);
+      if (unwrapped != null) {
+        // e.g.: VulnerabilityTypes.RESPONSE_HEADER
+        for (final byte unwrappedValue : unwrapped) {
+          increment(metric.getIndex(unwrappedValue), value);
+        }
+      } else {
+        increment(metric.getIndex(tagValue), value);
       }
     } else {
       increment(metric.getIndex(tagValue), value);
@@ -133,8 +137,9 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
       if (metric.getTag() == null) {
         prepareMetric(metric, (byte) -1);
       } else {
-        for (final byte tagValue : metric.getTag().getValues()) {
-          prepareMetric(metric, tagValue);
+        final int tagCount = metric.getTag().count();
+        for (byte i = 0; i < tagCount; i++) {
+          prepareMetric(metric, i);
         }
       }
     }
@@ -172,7 +177,7 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
           metric.getName(),
           "count",
           value,
-          computeTag(metric, tagValue));
+          metric.getTelemetryTag(tagValue));
       this.metric = metric;
       this.tagValue = tagValue;
     }
@@ -186,19 +191,7 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
     }
 
     public String getSpanTag() {
-      if (metric.getTag() == null) {
-        return metric.getName();
-      }
-      final String tag = metric.getTag().toString(tagValue);
-      final String spanTag = tag.toLowerCase(Locale.ROOT).replace('.', '_');
-      return metric.getName() + "." + spanTag;
-    }
-
-    public static String computeTag(final IastMetric metric, final byte tagValue) {
-      if (metric.getTag() == null) {
-        return null;
-      }
-      return metric.getTag().getName() + ":" + metric.getTag().toString(tagValue);
+      return metric.getSpanTag(tagValue);
     }
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/SourceTypesTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/SourceTypesTest.groovy
@@ -14,16 +14,22 @@ class SourceTypesTest extends DDSpecification {
     s == output
 
     where:
-    input                               | output
-    SourceTypes.NONE                    | null
-    SourceTypes.REQUEST_PARAMETER_VALUE | SourceTypes.REQUEST_PARAMETER_VALUE_STRING
-    SourceTypes.REQUEST_PARAMETER_NAME  | SourceTypes.REQUEST_PARAMETER_NAME_STRING
-    SourceTypes.REQUEST_HEADER_VALUE    | SourceTypes.REQUEST_HEADER_VALUE_STRING
-    SourceTypes.REQUEST_HEADER_NAME     | SourceTypes.REQUEST_HEADER_NAME_STRING
-    SourceTypes.REQUEST_COOKIE_NAME     | SourceTypes.REQUEST_COOKIE_NAME_STRING
-    SourceTypes.REQUEST_COOKIE_VALUE    | SourceTypes.REQUEST_COOKIE_VALUE_STRING
-    SourceTypes.REQUEST_BODY            | SourceTypes.REQUEST_BODY_STRING
-    SourceTypes.REQUEST_QUERY           | SourceTypes.REQUEST_QUERY_STRING
+    input                                   | output
+    SourceTypes.NONE                        | null
+    SourceTypes.REQUEST_PARAMETER_NAME      | 'http.request.parameter.name'
+    SourceTypes.REQUEST_PARAMETER_VALUE     | 'http.request.parameter'
+    SourceTypes.REQUEST_HEADER_NAME         | 'http.request.header.name'
+    SourceTypes.REQUEST_HEADER_VALUE        | 'http.request.header'
+    SourceTypes.REQUEST_COOKIE_NAME         | 'http.request.cookie.name'
+    SourceTypes.REQUEST_COOKIE_VALUE        | 'http.request.cookie.value'
+    SourceTypes.REQUEST_BODY                | 'http.request.body'
+    SourceTypes.REQUEST_QUERY               | 'http.request.query'
+    SourceTypes.REQUEST_PATH_PARAMETER      | 'http.request.path.parameter'
+    SourceTypes.REQUEST_MATRIX_PARAMETER    | 'http.request.matrix.parameter'
+    SourceTypes.REQUEST_MULTIPART_PARAMETER | 'http.request.multipart.parameter'
+    SourceTypes.REQUEST_URI                 | 'http.request.uri'
+    SourceTypes.REQUEST_PATH                | 'http.request.path'
+    SourceTypes.GRPC_BODY                   | 'grpc.request.body'
   }
 
   void 'named sources'() {

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/VulnerabilityTypesTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/VulnerabilityTypesTest.groovy
@@ -1,0 +1,44 @@
+package datadog.trace.api.iast
+
+import datadog.trace.test.util.DDSpecification
+
+class VulnerabilityTypesTest extends DDSpecification {
+
+  void 'test toString'() {
+    when:
+    final s = VulnerabilityTypes.toString(input)
+
+    then:
+    s == output
+
+    where:
+    input                                          | output
+    -1 as byte                                     | null
+    VulnerabilityTypes.WEAK_CIPHER                 | 'WEAK_CIPHER'
+    VulnerabilityTypes.WEAK_HASH                   | 'WEAK_HASH'
+    VulnerabilityTypes.SQL_INJECTION               | 'SQL_INJECTION'
+    VulnerabilityTypes.COMMAND_INJECTION           | 'COMMAND_INJECTION'
+    VulnerabilityTypes.PATH_TRAVERSAL              | 'PATH_TRAVERSAL'
+    VulnerabilityTypes.LDAP_INJECTION              | 'LDAP_INJECTION'
+    VulnerabilityTypes.SSRF                        | 'SSRF'
+    VulnerabilityTypes.INSECURE_COOKIE             | 'INSECURE_COOKIE'
+    VulnerabilityTypes.NO_HTTPONLY_COOKIE          | 'NO_HTTPONLY_COOKIE'
+    VulnerabilityTypes.HSTS_HEADER_MISSING         | 'HSTS_HEADER_MISSING'
+    VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING | 'XCONTENTTYPE_HEADER_MISSING'
+    VulnerabilityTypes.NO_SAMESITE_COOKIE          | 'NO_SAMESITE_COOKIE'
+    VulnerabilityTypes.UNVALIDATED_REDIRECT        | 'UNVALIDATED_REDIRECT'
+    VulnerabilityTypes.WEAK_RANDOMNESS             | 'WEAK_RANDOMNESS'
+    VulnerabilityTypes.XPATH_INJECTION             | 'XPATH_INJECTION'
+    VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION    | 'TRUST_BOUNDARY_VIOLATION'
+    VulnerabilityTypes.XSS                         | 'XSS'
+    VulnerabilityTypes.STACKTRACE_LEAK             | 'STACKTRACE_LEAK'
+    VulnerabilityTypes.HEADER_INJECTION            | 'HEADER_INJECTION'
+    VulnerabilityTypes.VERB_TAMPERING              | 'VERB_TAMPERING'
+    VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID | 'DEFAULT_HTML_ESCAPE_INVALID'
+    VulnerabilityTypes.SESSION_TIMEOUT             | 'SESSION_TIMEOUT'
+    VulnerabilityTypes.DIRECTORY_LISTING_LEAK      | 'DIRECTORY_LISTING_LEAK'
+    VulnerabilityTypes.INSECURE_JSP_LAYOUT         | 'INSECURE_JSP_LAYOUT'
+    VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE        | 'ADMIN_CONSOLE_ACTIVE'
+    VulnerabilityTypes.HARDCODED_SECRET            | 'HARDCODED_SECRET'
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
@@ -81,7 +81,7 @@ class IastMetricCollectorTest extends DDSpecification {
         if (metric.tag == null) {
           IastMetricCollector.add(metric, value)
         } else {
-          final tag = metric.tag.values[random.nextInt(metric.tag.values.length)]
+          final tag = (byte) random.nextInt(metric.tag.values.length)
           IastMetricCollector.add(metric, tag, value)
         }
       }
@@ -162,7 +162,7 @@ class IastMetricCollectorTest extends DDSpecification {
 
     then:
     if (metric.tag) {
-      final tagString = metric.tag.toString(tag)
+      final tagString = metric.tag.values[tag]
       data.tags.size() == 1
       data.tags.first() == "${metric.tag.name}:${tagString}"
       data.spanTag == "${metric.name}.${tagString.toLowerCase().replaceAll('\\.', '_')}"
@@ -190,11 +190,11 @@ class IastMetricCollectorTest extends DDSpecification {
 
     then:
     if (metric.tag) {
-      final assertedTags = metric.tag.isWrapped(tag) ? metric.tag.unwrap(tag) : [tag]
+      def assertedTags = metric.tag.unwrap(tag) ?: [tag]
       result.size() == assertedTags
       final grouped = result.groupBy { it.tags.first() }
       assertedTags.each {
-        final tagValue = "${metric.tag.name}:${metric.tag.toString(it as byte)}"
+        final tagValue = "${metric.tag.name}:${metric.tag.values[it as byte]}"
         final data = grouped[tagValue].first()
         assert data.metric == metric
         assert data.value.toLong() == value

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.VulnerabilityTypes
 import spock.lang.Specification
 
+import static datadog.trace.api.iast.telemetry.IastMetric.TRACE_METRIC_PREFIX
 
 class IastMetricTest extends Specification {
 
@@ -28,7 +29,7 @@ class IastMetricTest extends Specification {
     metric << (IastMetric.values() as List<IastMetric>)
   }
 
-  void 'test parsing of tags'() {
+  void 'test unwrapping of tags'() {
     when:
     final result = metricTag.unwrap(tag)
 
@@ -38,7 +39,40 @@ class IastMetricTest extends Specification {
     where:
     metricTag                         | tag                                 | expected
     IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.RESPONSE_HEADER  | VulnerabilityTypes.RESPONSE_HEADER_TYPES
-    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.SQL_INJECTION    | new byte[0]
-    IastMetric.Tag.SOURCE_TYPE        | SourceTypes.REQUEST_PARAMETER_VALUE | new byte[0]
+    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.SPRING_RESPONSE  | VulnerabilityTypes.SPRING_RESPONSE_TYPES
+    IastMetric.Tag.VULNERABILITY_TYPE | VulnerabilityTypes.SQL_INJECTION    | null
+    IastMetric.Tag.SOURCE_TYPE        | SourceTypes.REQUEST_PARAMETER_VALUE | null
+  }
+
+  void 'test metric tags'() {
+    when:
+    final telemetryTags = []
+    final spanTags = []
+    if (tag == null) {
+      spanTags.add(metric.getSpanTag((byte) -1))
+    } else {
+      tag.values.eachWithIndex { value, index ->
+        telemetryTags.add(metric.getTelemetryTag((byte) index))
+        spanTags.add(metric.getSpanTag((byte) index))
+      }
+    }
+
+    then:
+    if (tag == null) {
+      telemetryTags.empty
+      spanTags == [TRACE_METRIC_PREFIX + metric.name]
+    } else {
+      tag.values.each {
+        assert telemetryTags.contains(tag.name + ':' + it)
+        assert spanTags.contains(TRACE_METRIC_PREFIX + metric.name + '.' + it.toLowerCase().replace((char) '.', (char) '_'))
+      }
+    }
+
+
+    where:
+    metric                         | tag
+    IastMetric.INSTRUMENTED_SINK   | IastMetric.Tag.VULNERABILITY_TYPE
+    IastMetric.INSTRUMENTED_SOURCE | IastMetric.Tag.SOURCE_TYPE
+    IastMetric.EXECUTED_TAINTED    | null
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/IastMetricPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/IastMetricPeriodicActionTest.groovy
@@ -34,7 +34,7 @@ class IastMetricPeriodicActionTest extends Specification {
     final service = Mock(TelemetryService)
     final iastMetric = IastMetric.INSTRUMENTED_SOURCE
     final tag = SourceTypes.REQUEST_PARAMETER_VALUE
-    final tagString = SourceTypes.REQUEST_PARAMETER_VALUE_STRING
+    final tagString = SourceTypes.toString(tag)
     final value = 23
 
     when:


### PR DESCRIPTION
# What Does This Do
Caches the tag values to be used in telemetry metrics and also the values to be used in the span tags in order to troubleshoot IAST.

# Motivation
There's quite a performance overhead of having to compute those tags every time, having them cached reduced the number of string allocation and the time spent while generating the metrics. 
