### PR TITLE
Use \n for new line in telemetry log stacktraces

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
@@ -17,7 +17,6 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
    */
   static final String[] PACKAGE_LIST = {"datadog.", "com.datadog.", "java.", "javax.", "jakarta."};
 
-  private static final String RET = "\r\n";
   private static final String UNKNOWN = "<unknown>";
 
   @Override
@@ -61,11 +60,11 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
         stackTrace.append(msg);
       }
     }
-    stackTrace.append(RET);
+    stackTrace.append('\n');
 
     Throwable filtered = StackUtils.filterPackagesIn(t, PACKAGE_LIST);
     for (StackTraceElement stackTraceElement : filtered.getStackTrace()) {
-      stackTrace.append("  at ").append(stackTraceElement).append(RET);
+      stackTrace.append("  at ").append(stackTraceElement).append('\n');
     }
     return stackTrace.toString();
   }

--- a/telemetry/src/test/groovy/datadog/telemetry/log/LogFilteringTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/log/LogFilteringTest.groovy
@@ -30,7 +30,7 @@ class LogFilteringTest extends DDSpecification {
     then:
     1 * telemetryService.addLogMessage( { LogMessage logMessage ->
       logMessage.getMessage() == 'Debug message'
-      String[] stackTraceLines = logMessage.stackTrace.split("\r\n")
+      String[] stackTraceLines = logMessage.stackTrace.split("\n")
 
       stackTraceLines[0] == "java.lang.Exception"
       ExceptionHelper.isDataDogOrJava(stackTraceLines[1])
@@ -56,7 +56,7 @@ class LogFilteringTest extends DDSpecification {
     then:
     1 * telemetryService.addLogMessage( { LogMessage logMessage ->
       logMessage.getMessage() == 'Debug message'
-      String[] stackTraceLines = logMessage.stackTrace.split("\r\n")
+      String[] stackTraceLines = logMessage.stackTrace.split("\n")
 
       stackTraceLines[0] == "java.lang.Exception: Exception Message"
       ExceptionHelper.isDataDogOrJava(stackTraceLines[1])


### PR DESCRIPTION


# What Does This Do
Our backend will process both, so just use the simplest convention.

# Motivation

# Additional Notes
