### PR TITLE
Remove noisy telemetry log with exception

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StringTemplateBuilder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/StringTemplateBuilder.java
@@ -53,7 +53,6 @@ public class StringTemplateBuilder {
                   sb, segment.getParsedExpr().getDsl(), result.getValue(), status, limits);
             }
           } catch (EvaluationException ex) {
-            LOGGER.debug("Evaluation error: ", ex);
             status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
             status.setLogTemplateErrors(true);
             String msg =

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -437,7 +437,6 @@ public class LogProbe extends ProbeDefinition {
         return false;
       }
     } catch (EvaluationException ex) {
-      LOGGER.debug("Evaluation error: ", ex);
       status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
       status.setConditionErrors(true);
       return false;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/SpanDecorationProbe.java
@@ -156,7 +156,6 @@ public class SpanDecorationProbe extends ProbeDefinition {
             continue;
           }
         } catch (EvaluationException ex) {
-          LOGGER.debug("Evaluation error: ", ex);
           status.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
           continue;
         }


### PR DESCRIPTION

# What Does This Do
Telemetry log will send log with exception as parameter. Exceptions for expression evaluation can be very noisy because evaluated for each execution.

# Motivation
too much telemetry logs for faulty expression in probe definitons

# Additional Notes


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
