### PR TITLE
Change telemetry logs tracer time to seconds

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
@@ -39,7 +39,7 @@ public class LogCollector {
       return;
     }
     RawLogMessage rawLogMessage =
-        new RawLogMessage(logLevel, message, throwable, System.currentTimeMillis());
+        new RawLogMessage(logLevel, message, throwable, System.currentTimeMillis() / 1000);
     AtomicInteger count = rawLogMessages.computeIfAbsent(rawLogMessage, k -> new AtomicInteger());
     count.incrementAndGet();
   }

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/LogCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/LogCollectorTest.groovy
@@ -4,9 +4,25 @@ import datadog.trace.test.util.DDSpecification
 
 class LogCollectorTest extends DDSpecification {
 
+  void "tracer time is set"() {
+    setup:
+    def logCollector = new LogCollector(1)
+
+    when:
+    logCollector.addLogMessage("ERROR", "Message 1", null)
+
+    then:
+    def log = logCollector.drain().toList().get(0)
+    def ts = log.timestamp
+    ts > 0L
+    // Check tracer time is not in millis
+    ts < 1706529524286L
+  }
+
   void "limit log messages in LogCollector"() {
     setup:
     def logCollector = new LogCollector(3)
+
     when:
     logCollector.addLogMessage("ERROR", "Message 1", null)
     logCollector.addLogMessage("ERROR", "Message 2", null)


### PR DESCRIPTION
# What Does This Do



# Motivation

Tracer time in logs is UNIX timestamp in seconds, per the spec.

# Additional Notes
