### PR TITLE
Add exception debugging for span error

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -62,11 +62,16 @@ public class DebuggerContext {
     String serializeValue(CapturedContext.CapturedValue value);
   }
 
+  public interface ExceptionDebugger {
+    void handleException(Throwable t);
+  }
+
   private static volatile ProbeResolver probeResolver;
   private static volatile ClassFilter classFilter;
   private static volatile MetricForwarder metricForwarder;
   private static volatile Tracer tracer;
   private static volatile ValueSerializer valueSerializer;
+  private static volatile ExceptionDebugger exceptionDebugger;
 
   public static void initProbeResolver(ProbeResolver probeResolver) {
     DebuggerContext.probeResolver = probeResolver;
@@ -86,6 +91,10 @@ public class DebuggerContext {
 
   public static void initValueSerializer(ValueSerializer valueSerializer) {
     DebuggerContext.valueSerializer = valueSerializer;
+  }
+
+  public static void initExceptionDebugger(ExceptionDebugger exceptionDebugger) {
+    DebuggerContext.exceptionDebugger = exceptionDebugger;
   }
 
   /**
@@ -320,5 +329,13 @@ public class DebuggerContext {
     } catch (Exception ex) {
       LOGGER.debug("Error in commit: ", ex);
     }
+  }
+
+  public static void handleException(Throwable t) {
+    ExceptionDebugger exDebugger = exceptionDebugger;
+    if (exDebugger == null) {
+      return;
+    }
+    exDebugger.handleException(t);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -2,6 +2,8 @@ package com.datadog.debugger.agent;
 
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 
+import com.datadog.debugger.exception.DefaultExceptionDebugger;
+import com.datadog.debugger.exception.ExceptionProbeManager;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.symbol.SymDBEnablement;
@@ -75,6 +77,10 @@ public class DebuggerAgent {
     snapshotSerializer = new JsonSnapshotSerializer();
     DebuggerContext.initValueSerializer(snapshotSerializer);
     DebuggerContext.initTracer(new DebuggerTracer(debuggerSink.getProbeStatusSink()));
+    if (config.isDebuggerExceptionEnabled()) {
+      DebuggerContext.initExceptionDebugger(
+          new DefaultExceptionDebugger(new ExceptionProbeManager()));
+    }
     if (config.isDebuggerInstrumentTheWorld()) {
       setupInstrumentTheWorldTransformer(
           config, instrumentation, debuggerSink, statsdMetricForwarder);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -1,0 +1,32 @@
+package com.datadog.debugger.exception;
+
+import datadog.trace.bootstrap.debugger.DebuggerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default implementation of {@link DebuggerContext.ExceptionDebugger} that uses {@link
+ * ExceptionProbeManager} to instrument the exception stacktrace and send snapshots.
+ */
+public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugger {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExceptionDebugger.class);
+  private final ExceptionProbeManager exceptionProbeManager;
+
+  public DefaultExceptionDebugger(ExceptionProbeManager exceptionProbeManager) {
+    this.exceptionProbeManager = exceptionProbeManager;
+  }
+
+  @Override
+  public void handleException(Throwable t) {
+    String fingerprint = Fingerprinter.fingerprint(t);
+    if (fingerprint == null) {
+      LOGGER.debug("Unable to fingerprint exception", t);
+      return;
+    }
+    if (exceptionProbeManager.isAlreadyInstrumented(fingerprint)) {
+      // TODO trigger send snapshots already captured
+    } else {
+      exceptionProbeManager.instrument(fingerprint, t.getStackTrace());
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -1,0 +1,18 @@
+package com.datadog.debugger.exception;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Manages the probes used for instrumentation of exception stacktraces. */
+public class ExceptionProbeManager {
+  private final Set<String> fingerprints = ConcurrentHashMap.newKeySet();
+
+  public void instrument(String fingerprint, StackTraceElement[] stackTraceElements) {
+    fingerprints.add(fingerprint);
+    // TODO instrument each frame, filtering out thirdparty code
+  }
+
+  public boolean isAlreadyInstrumented(String fingerprint) {
+    return fingerprints.contains(fingerprint);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
@@ -1,0 +1,60 @@
+package com.datadog.debugger.exception;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Computes a fingerprint of an exception based on its stacktrace and exception type. */
+public class Fingerprinter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Fingerprinter.class);
+
+  // compute fingerprint of the Throwable based on the stacktrace and exception type
+  public static String fingerprint(Throwable t) {
+    t = getInnerMostThrowable(t);
+    if (t == null) {
+      LOGGER.debug("Unable to find root cause of exception");
+      return null;
+    }
+    Class<? extends Throwable> clazz = t.getClass();
+    // TODO filter out Error
+    MessageDigest digest;
+    try {
+      // TODO avoid lookup a new instance every time
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      LOGGER.debug("Unable to find digest algorithm SHA-256", e);
+      return null;
+    }
+    String typeName = clazz.getTypeName();
+    digest.update(typeName.getBytes());
+    StackTraceElement[] stackTrace = t.getStackTrace();
+    for (StackTraceElement stackTraceElement : stackTrace) {
+      // TODO filter out thirdparty code
+      digest.update(stackTraceElement.toString().getBytes());
+    }
+    byte[] bytes = digest.digest();
+    return bytesToHex(bytes);
+  }
+
+  private static Throwable getInnerMostThrowable(Throwable t) {
+    int i = 100;
+    while (t.getCause() != null && i > 0) {
+      t = t.getCause();
+      i--;
+    }
+    if (i == 0) {
+      return null;
+    }
+    return t;
+  }
+
+  // convert byte[] to hex string
+  private static String bytesToHex(byte[] bytes) {
+    StringBuilder result = new StringBuilder(bytes.length * 2);
+    for (byte b : bytes) {
+      result.append(Integer.toHexString((b & 0xff)));
+    }
+    return result.toString();
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
@@ -30,6 +30,13 @@ public class Fingerprinter {
     digest.update(typeName.getBytes());
     StackTraceElement[] stackTrace = t.getStackTrace();
     for (StackTraceElement stackTraceElement : stackTrace) {
+      String className = stackTraceElement.getClassName();
+      if (className.startsWith("java.")
+          || className.startsWith("jdk.")
+          || className.startsWith("sun.")
+          || className.startsWith("com.sun.")) {
+        continue;
+      }
       // TODO filter out thirdparty code
       digest.update(stackTraceElement.toString().getBytes());
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -1,0 +1,20 @@
+package com.datadog.debugger.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class DefaultExceptionDebuggerTest {
+
+  @Test
+  public void test() {
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager();
+    DefaultExceptionDebugger exceptionDebugger =
+        new DefaultExceptionDebugger(exceptionProbeManager);
+    RuntimeException exception = new RuntimeException("test");
+    String fingerprint = Fingerprinter.fingerprint(exception);
+    exceptionDebugger.handleException(exception);
+    exceptionDebugger.handleException(exception);
+    assertTrue(exceptionProbeManager.isAlreadyInstrumented(fingerprint));
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -1,0 +1,16 @@
+package com.datadog.debugger.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ExceptionProbeManagerTest {
+  @Test
+  public void test() {
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager();
+    RuntimeException exception = new RuntimeException("test");
+    String fingerprint = Fingerprinter.fingerprint(exception);
+    exceptionProbeManager.instrument(fingerprint, exception.getStackTrace());
+    assertTrue(exceptionProbeManager.isAlreadyInstrumented(fingerprint));
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/FingerprinterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/FingerprinterTest.java
@@ -1,0 +1,47 @@
+package com.datadog.debugger.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class FingerprinterTest {
+
+  final Throwable TEST_THROWABLE = new RuntimeException("test");
+  final String TEST_FINGERPRINT = "ff3e1b608464f0d0908f870e4fd7558dbdcab2c77e4592d8fffcdb778fc06d";
+
+  @Test
+  void basic() {
+    String fingerprint = Fingerprinter.fingerprint(TEST_THROWABLE);
+    assertEquals(TEST_FINGERPRINT, fingerprint);
+  }
+
+  @Test
+  void inner() {
+    Throwable t = new RuntimeException("outer", TEST_THROWABLE);
+    String fingerprint = Fingerprinter.fingerprint(t);
+    assertEquals(TEST_FINGERPRINT, fingerprint);
+  }
+
+  @Test
+  void innerInfiniteLoop() {
+    Exception outer = new RuntimeException("outer");
+    Exception innerCause1 = new RuntimeException("cause1", outer);
+    Exception innerCause2 = new RuntimeException("cause2", innerCause1);
+    outer.initCause(innerCause2);
+    Assertions.assertNull(Fingerprinter.fingerprint(outer));
+  }
+
+  @Test
+  void emptyStacktrace() {
+    assertEquals(
+        "843ff84fcbdc76707588c035f63b0e69b6f9b2c53f9a019ef4e5d1a2243778",
+        Fingerprinter.fingerprint(new EmptyException("test")));
+  }
+
+  static class EmptyException extends Exception {
+    public EmptyException(String message) {
+      super(message, null, false, false);
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/FingerprinterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/FingerprinterTest.java
@@ -8,7 +8,34 @@ import org.junit.jupiter.api.Test;
 class FingerprinterTest {
 
   final Throwable TEST_THROWABLE = new RuntimeException("test");
-  final String TEST_FINGERPRINT = "ff3e1b608464f0d0908f870e4fd7558dbdcab2c77e4592d8fffcdb778fc06d";
+
+  {
+    TEST_THROWABLE.setStackTrace(
+        new StackTraceElement[] {
+          new StackTraceElement(
+              "com.datadog.debugger.exception.FingerprinterTest",
+              "<init>",
+              "FingerprinterTest.java",
+              10),
+          new StackTraceElement(
+              "org.junit.platform.commons.util.ReflectionUtils",
+              "newInstance",
+              "ReflectionUtils.java",
+              552),
+          new StackTraceElement(
+              "org.junit.jupiter.engine.execution.ConstructorInvocation",
+              "proceed",
+              "ConstructorInvocation.java",
+              56),
+          new StackTraceElement(
+              "org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation",
+              "proceed",
+              "InvocationInterceptorChain.java",
+              131),
+        });
+  }
+
+  final String TEST_FINGERPRINT = "2ec0db28f254ffa383cbb26a32269bf739ba937b9dd8f111d22294e6a494855";
 
   @Test
   void basic() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -171,6 +171,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DEBUGGER_SYMBOL_ENABLED = false;
   static final boolean DEFAULT_DEBUGGER_SYMBOL_FORCE_UPLOAD = false;
   static final int DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD = 100; // nb of classes
+  static final boolean DEFAULT_DEBUGGER_EXCEPTION_ENABLED = false;
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   static final String DEFAULT_TRACE_ANNOTATIONS = null;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -29,6 +29,8 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_SYMBOL_FORCE_UPLOAD = "internal.force.symbol.database.upload";
   public static final String DEBUGGER_SYMBOL_INCLUDES = "symbol.database.includes";
   public static final String DEBUGGER_SYMBOL_FLUSH_THRESHOLD = "symbol.database.flush.threshold";
+  public static final String DEBUGGER_EXCEPTION_ENABLED =
+      "dynamic.instrumentation.exception.enabled";
 
   private DebuggerConfig() {}
 }

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -51,6 +51,8 @@ dependencies {
   api project(':internal-api')
   implementation project(':utils:container-utils')
   implementation project(':utils:socket-utils')
+  // for span exception debugging
+  implementation project(':dd-java-agent:agent-debugger:debugger-bootstrap')
 
   implementation deps.slf4j
   implementation deps.moshi

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -22,6 +22,7 @@ import datadog.trace.api.metrics.SpanMetrics;
 import datadog.trace.api.profiling.TransientProfilingContextHolder;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
+import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
@@ -364,6 +365,9 @@ public class DDSpan
 
       setTag(DDTags.ERROR_MSG, message);
       setTag(DDTags.ERROR_TYPE, error.getClass().getName());
+      if (isLocalRootSpan()) {
+        DebuggerContext.handleException(error);
+      }
     }
     return this;
   }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -42,6 +42,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_CAPTURE_TIMEOUT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_CLASSFILE_DUMP_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_DIAGNOSTICS_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_METRICS_ENABLED;
@@ -193,6 +194,7 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CAPTURE_TIMEOUT;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CLASSFILE_DUMP_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_DIAGNOSTICS_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_INSTRUMENT_THE_WORLD;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_PAYLOAD_SIZE;
@@ -791,6 +793,7 @@ public class Config {
   private final boolean debuggerSymbolForceUpload;
   private final String debuggerSymbolIncludes;
   private final int debuggerSymbolFlushThreshold;
+  private final boolean debuggerExceptionEnabled;
 
   private final boolean awsPropagationEnabled;
   private final boolean sqsPropagationEnabled;
@@ -1800,6 +1803,8 @@ public class Config {
     debuggerSymbolFlushThreshold =
         configProvider.getInteger(
             DEBUGGER_SYMBOL_FLUSH_THRESHOLD, DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD);
+    debuggerExceptionEnabled =
+        configProvider.getBoolean(DEBUGGER_EXCEPTION_ENABLED, DEFAULT_DEBUGGER_EXCEPTION_ENABLED);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");
@@ -3031,6 +3036,10 @@ public class Config {
     return debuggerSymbolFlushThreshold;
   }
 
+  public boolean isDebuggerExceptionEnabled() {
+    return debuggerExceptionEnabled;
+  }
+
   public String getFinalDebuggerProbeUrl() {
     // by default poll from datadog agent
     return "http://" + agentHost + ":" + agentPort;
@@ -4201,6 +4210,22 @@ public class Config {
         + debuggerInstrumentTheWorld
         + ", debuggerExcludeFile="
         + debuggerExcludeFiles
+        + ", debuggerCaptureTimeout="
+        + debuggerCaptureTimeout
+        + ", debuggerRedactIdentifiers="
+        + debuggerRedactedIdentifiers
+        + ", debuggerRedactTypes="
+        + debuggerRedactedTypes
+        + ", debuggerSymbolEnabled="
+        + debuggerSymbolEnabled
+        + ", debuggerSymbolForceUpload="
+        + debuggerSymbolForceUpload
+        + ", debuggerSymbolFlushThreshold="
+        + debuggerSymbolFlushThreshold
+        + ", debuggerSymbolIncludes="
+        + debuggerSymbolIncludes
+        + ", debuggerExceptionEnabled="
+        + debuggerExceptionEnabled
         + ", awsPropagationEnabled="
         + awsPropagationEnabled
         + ", sqsPropagationEnabled="


### PR DESCRIPTION
# What Does This Do
Hook into DDSpan::addThrowable to callback into debugger module to instrument the stacktrace and send snapshots.
This is still work-in-progress. We first introduce the hook with a fingerprint of the exception only if the
`DD_DYNAMIC_INSTRUMENTATION_EXCEPTION_ENABLED` config parameter is set to true

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ