### PR TITLE
Add support for GZIP for CI Visibility intakes and EVP endpoints in agentless/evp-proxy-V4 modes

### DIFF
--- a/communication/build.gradle
+++ b/communication/build.gradle
@@ -34,6 +34,7 @@ ext {
     'datadog.communication.http.OkHttpUtils.1',
     'datadog.communication.http.OkHttpUtils.ByteBufferRequestBody',
     'datadog.communication.http.OkHttpUtils.GZipByteBufferRequestBody',
+    'datadog.communication.http.OkHttpUtils.GZipRequestBodyDecorator',
     'datadog.communication.http.OkHttpUtils.JsonRequestBody',
     'datadog.communication.monitor.DDAgentStatsDConnection',
     'datadog.communication.monitor.DDAgentStatsDConnection.*',

--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -42,6 +42,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   public static final String V01_DATASTREAMS_ENDPOINT = "v0.1/pipeline_stats";
 
   public static final String V2_EVP_PROXY_ENDPOINT = "evp_proxy/v2/";
+  public static final String V4_EVP_PROXY_ENDPOINT = "evp_proxy/v4/";
 
   public static final String DATADOG_AGENT_STATE = "Datadog-Agent-State";
 
@@ -60,7 +61,9 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
   private final String[] configEndpoints = {V7_CONFIG_ENDPOINT};
   private final boolean metricsEnabled;
   private final String[] dataStreamsEndpoints = {V01_DATASTREAMS_ENDPOINT};
-  private final String[] evpProxyEndpoints = {V2_EVP_PROXY_ENDPOINT};
+  // ordered from most recent to least recent, as the logic will stick with the first one that is
+  // available
+  private final String[] evpProxyEndpoints = {V4_EVP_PROXY_ENDPOINT, V2_EVP_PROXY_ENDPOINT};
   private final String[] telemetryProxyEndpoints = {TELEMETRY_PROXY_ENDPOINT};
 
   private volatile String traceEndpoint;
@@ -357,6 +360,11 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
 
   public boolean supportsEvpProxy() {
     return evpProxyEndpoint != null;
+  }
+
+  public boolean supportsContentEncodingHeadersWithEvpProxy() {
+    // content encoding headers are supported in /v4 and above
+    return evpProxyEndpoint != null && V4_EVP_PROXY_ENDPOINT.compareTo(evpProxyEndpoint) <= 0;
   }
 
   public String getConfigEndpoint() {

--- a/communication/src/main/java/datadog/communication/http/HttpRetryPolicy.java
+++ b/communication/src/main/java/datadog/communication/http/HttpRetryPolicy.java
@@ -112,7 +112,7 @@ public class HttpRetryPolicy {
     return currentDelay;
   }
 
-  public static final class Factory {
+  public static class Factory {
     private final int maxRetries;
     private final long initialDelay;
     private final double delayFactor;

--- a/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/ddagent/DDAgentFeaturesDiscoveryTest.groovy
@@ -38,6 +38,7 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
   static final String INFO_WITHOUT_DATA_STREAMS_STATE = Strings.sha256(INFO_WITHOUT_DATA_STREAMS_RESPONSE)
   static final String INFO_WITH_LONG_RUNNING_SPANS = loadJsonFile("agent-info-with-long-running-spans.json")
   static final String INFO_WITH_TELEMETRY_PROXY_RESPONSE = loadJsonFile("agent-info-with-telemetry-proxy.json")
+  static final String INFO_WITH_OLD_EVP_PROXY = loadJsonFile("agent-info-with-old-evp-proxy.json")
   static final String PROBE_STATE = "probestate"
 
   def "test parse /info response"() {
@@ -61,6 +62,8 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     features.supportsDebugger()
     features.supportsDebuggerDiagnostics()
     features.supportsEvpProxy()
+    features.supportsContentEncodingHeadersWithEvpProxy()
+    features.getEvpProxyEndpoint() == "evp_proxy/v4/"
     features.getVersion() == "0.99.0"
     !features.supportsLongRunning()
     !features.supportsTelemetryProxy()
@@ -404,6 +407,21 @@ class DDAgentFeaturesDiscoveryTest extends DDSpecification {
     1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_WITH_TELEMETRY_PROXY_RESPONSE) }
     features.supportsTelemetryProxy()
     0 * _
+  }
+
+  def "test parse /info response with old EVP proxy"() {
+    setup:
+    OkHttpClient client = Mock(OkHttpClient)
+    DDAgentFeaturesDiscovery features = new DDAgentFeaturesDiscovery(client, monitoring, agentUrl, true, true)
+
+    when: "/info available"
+    features.discover()
+
+    then:
+    1 * client.newCall(_) >> { Request request -> infoResponse(request, INFO_WITH_OLD_EVP_PROXY) }
+    features.supportsEvpProxy()
+    features.getEvpProxyEndpoint() == "evp_proxy/v2/" // v3 is advertised, but the tracer should ignore it
+    !features.supportsContentEncodingHeadersWithEvpProxy()
   }
 
   def infoResponse(Request request, String json) {

--- a/communication/src/test/resources/agent-features/agent-info-with-old-evp-proxy.json
+++ b/communication/src/test/resources/agent-features/agent-info-with-old-evp-proxy.json
@@ -14,7 +14,6 @@
     "/evp_proxy/v1/",
     "/evp_proxy/v2/",
     "/evp_proxy/v3/",
-    "/evp_proxy/v4/",
     "/debugger/v1/input",
     "/debugger/v1/diagnostics",
     "/v0.7/config"

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/EvpProxyApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/EvpProxyApi.java
@@ -5,6 +5,7 @@ import datadog.communication.http.OkHttpUtils;
 import datadog.trace.civisibility.utils.IOThrowingFunction;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -21,22 +22,36 @@ public class EvpProxyApi implements BackendApi {
   private static final String X_DATADOG_EVP_SUBDOMAIN_HEADER = "X-Datadog-EVP-Subdomain";
   private static final String X_DATADOG_TRACE_ID_HEADER = "x-datadog-trace-id";
   private static final String X_DATADOG_PARENT_ID_HEADER = "x-datadog-parent-id";
+  private static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
+  private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
   private static final String API_SUBDOMAIN = "api";
+  private static final String GZIP_ENCODING = "gzip";
 
   private final String traceId;
   private final HttpRetryPolicy.Factory retryPolicyFactory;
   private final HttpUrl evpProxyUrl;
   private final OkHttpClient httpClient;
+  private final boolean gzipEnabled;
 
   public EvpProxyApi(
       String traceId,
       HttpUrl evpProxyUrl,
       HttpRetryPolicy.Factory retryPolicyFactory,
       OkHttpClient httpClient) {
+    this(traceId, evpProxyUrl, retryPolicyFactory, httpClient, true);
+  }
+
+  public EvpProxyApi(
+      String traceId,
+      HttpUrl evpProxyUrl,
+      HttpRetryPolicy.Factory retryPolicyFactory,
+      OkHttpClient httpClient,
+      boolean gzipEnabled) {
     this.traceId = traceId;
     this.evpProxyUrl = evpProxyUrl.resolve(String.format("api/%s/", API_VERSION));
     this.retryPolicyFactory = retryPolicyFactory;
     this.httpClient = httpClient;
+    this.gzipEnabled = gzipEnabled;
   }
 
   @Override
@@ -44,21 +59,35 @@ public class EvpProxyApi implements BackendApi {
       String uri, RequestBody requestBody, IOThrowingFunction<InputStream, T> responseParser)
       throws IOException {
     final HttpUrl url = evpProxyUrl.resolve(uri);
-    final Request request =
+
+    Request.Builder requestBuilder =
         new Request.Builder()
             .url(url)
             .addHeader(X_DATADOG_EVP_SUBDOMAIN_HEADER, API_SUBDOMAIN)
             .addHeader(X_DATADOG_TRACE_ID_HEADER, traceId)
-            .addHeader(X_DATADOG_PARENT_ID_HEADER, traceId)
-            .post(requestBody)
-            .build();
+            .addHeader(X_DATADOG_PARENT_ID_HEADER, traceId);
+
+    if (gzipEnabled) {
+      requestBuilder.addHeader(ACCEPT_ENCODING_HEADER, GZIP_ENCODING);
+    }
+
+    final Request request = requestBuilder.post(requestBody).build();
 
     HttpRetryPolicy retryPolicy = retryPolicyFactory.create();
     try (okhttp3.Response response =
         OkHttpUtils.sendWithRetries(httpClient, retryPolicy, request)) {
       if (response.isSuccessful()) {
         log.debug("Request to {} returned successful response: {}", uri, response.code());
-        return responseParser.apply(response.body().byteStream());
+
+        InputStream responseBodyStream = response.body().byteStream();
+
+        String contentEncoding = response.header(CONTENT_ENCODING_HEADER);
+        if (GZIP_ENCODING.equalsIgnoreCase(contentEncoding)) {
+          log.debug("Response content encoding is {}, unzipping response body", contentEncoding);
+          responseBodyStream = new GZIPInputStream(responseBodyStream);
+        }
+
+        return responseParser.apply(responseBodyStream);
       } else {
         throw new IOException(
             "Request to "

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
@@ -8,11 +8,15 @@ import datadog.trace.api.civisibility.config.Configurations
 import datadog.trace.api.civisibility.config.TestIdentifier
 import datadog.trace.civisibility.communication.BackendApi
 import datadog.trace.civisibility.communication.EvpProxyApi
+import datadog.trace.civisibility.communication.IntakeApi
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
+import org.apache.commons.io.IOUtils
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
+
+import java.util.zip.GZIPOutputStream
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 
@@ -49,7 +53,7 @@ class ConfigurationApiImplTest extends Specification {
                 "runtime.version"     : "runtimeVersion",
                 "runtime.vendor"      : "vendor",
                 "runtime.architecture": "amd64",
-                "custom": [
+                "custom"              : [
                   "customTag": "customValue"
                 ]
               ]
@@ -57,8 +61,18 @@ class ConfigurationApiImplTest extends Specification {
           ]
         ]
 
+        def response = response
         if (expectedRequest) {
-          response.status(200).send('{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { "code_coverage": true, "tests_skipping": true, "require_git": true, "flaky_test_retries_enabled": true } } }')
+          def requestBody = '{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { "code_coverage": true, "tests_skipping": true, "require_git": true, "flaky_test_retries_enabled": true } } }'.bytes
+
+          def header = request.getHeader("Accept-Encoding")
+          def gzipSupported = header != null && header.contains("gzip")
+          if (gzipSupported) {
+            response.addHeader("Content-Encoding", "gzip")
+            requestBody = gzip(requestBody)
+          }
+
+          response.status(200).send(requestBody)
         } else {
           response.status(400).send()
         }
@@ -86,7 +100,7 @@ class ConfigurationApiImplTest extends Specification {
                 "runtime.version"     : "runtimeVersion",
                 "runtime.vendor"      : "vendor",
                 "runtime.architecture": "amd64",
-                "custom": [
+                "custom"              : [
                   "customTag": "customValue"
                 ]
               ]
@@ -94,13 +108,23 @@ class ConfigurationApiImplTest extends Specification {
           ]
         ]
 
+        def response = response
         if (expectedRequest) {
-          response.status(200).send('{ "data": [' +
+          def requestBody = ('{ "data": [' +
             '{ "id": "49968354e2091cdb", "type": "test", "attributes": ' +
             '{ "configurations": { "test.bundle": "testBundle-a", "custom": { "customTag": "customValue" } }, "suite": "suite-a", "name": "name-a", "parameters": "parameters-a" } },' +
             '{ "id": "49968354e2091cdc", "type": "test", "attributes": ' +
             '   { "configurations": { "test.bundle": "testBundle-b", "custom": { "customTag": "customValue" } }, "suite": "suite-b", "name": "name-b", "parameters": "parameters-b" } }' +
-            '] }')
+            '] }').bytes
+
+          def header = request.getHeader("Accept-Encoding")
+          def gzipSupported = header != null && header.contains("gzip")
+          if (gzipSupported) {
+            response.addHeader("Content-Encoding", "gzip")
+            requestBody = gzip(requestBody)
+          }
+
+          response.status(200).send(requestBody)
         } else {
           response.status(400).send()
         }
@@ -108,13 +132,20 @@ class ConfigurationApiImplTest extends Specification {
     }
   }
 
-  def "test settings request"() {
+  private static byte[] gzip(byte[] payload) {
+    def baos = new ByteArrayOutputStream()
+    try (GZIPOutputStream zip = new GZIPOutputStream(baos)) {
+      IOUtils.copy(new ByteArrayInputStream(payload), zip)
+    }
+    return baos.toByteArray()
+  }
+
+  def "test settings request: #displayName"() {
     given:
-    def evpProxy = givenEvpProxy()
     def tracerEnvironment = givenTracerEnvironment()
 
     when:
-    def configurationApi = new ConfigurationApiImpl(evpProxy, () -> "1234")
+    def configurationApi = new ConfigurationApiImpl(api, () -> "1234")
     def settings = configurationApi.getSettings(tracerEnvironment)
 
     then:
@@ -122,15 +153,21 @@ class ConfigurationApiImplTest extends Specification {
     settings.testsSkippingEnabled
     settings.gitUploadRequired
     settings.flakyTestRetriesEnabled
+
+    where:
+    api                   | displayName
+    givenEvpProxy(false)  | "EVP proxy, compression disabled"
+    givenEvpProxy(true)   | "EVP proxy, compression enabled"
+    givenIntakeApi(false) | "intake, compression disabled"
+    givenIntakeApi(true)  | "intake, compression enabled"
   }
 
-  def "test skippable tests request"() {
+  def "test skippable tests request: #displayName"() {
     given:
-    def evpProxy = givenEvpProxy()
     def tracerEnvironment = givenTracerEnvironment()
 
     when:
-    def configurationApi = new ConfigurationApiImpl(evpProxy, () -> "1234")
+    def configurationApi = new ConfigurationApiImpl(api, () -> "1234")
     def skippableTests = configurationApi.getSkippableTests(tracerEnvironment)
 
     then:
@@ -142,14 +179,37 @@ class ConfigurationApiImplTest extends Specification {
       new Configurations(null, null, null, null, null,
       null, null, "testBundle-b", Collections.singletonMap("customTag", "customValue")))
     ]
+
+    where:
+    api                   | displayName
+    givenEvpProxy(false)  | "EVP proxy, compression disabled"
+    givenEvpProxy(true)   | "EVP proxy, compression enabled"
+    givenIntakeApi(false) | "intake, compression disabled"
+    givenIntakeApi(true)  | "intake, compression enabled"
   }
 
-  private BackendApi givenEvpProxy() {
+  private BackendApi givenEvpProxy(boolean enableGzip) {
     String traceId = "a-trace-id"
     HttpUrl proxyUrl = HttpUrl.get(intakeServer.address)
     HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0)
     OkHttpClient client = OkHttpUtils.buildHttpClient(proxyUrl, REQUEST_TIMEOUT_MILLIS)
-    return new EvpProxyApi(traceId, proxyUrl, retryPolicyFactory, client)
+    return new EvpProxyApi(traceId, proxyUrl, retryPolicyFactory, client, enableGzip)
+  }
+
+  private BackendApi givenIntakeApi(boolean enableGzip) {
+    HttpUrl intakeUrl = HttpUrl.get(String.format("%s/api/%s/", intakeServer.address.toString(), IntakeApi.API_VERSION))
+
+    String apiKey = "api-key"
+    String traceId = "a-trace-id"
+    long timeoutMillis = 1000
+
+    HttpRetryPolicy retryPolicy = Stub(HttpRetryPolicy)
+    retryPolicy.shouldRetry(_) >> false
+
+    HttpRetryPolicy.Factory retryPolicyFactory = Stub(HttpRetryPolicy.Factory)
+    retryPolicyFactory.create() >> retryPolicy
+
+    return new IntakeApi(intakeUrl, apiKey, traceId, timeoutMillis, retryPolicyFactory, enableGzip)
   }
 
   private static TracerEnvironment givenTracerEnvironment() {

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityInstrumentationTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityInstrumentationTest.groovy
@@ -204,11 +204,11 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
   }
 
   def getEventsAsJson(List<List<DDSpan>> traces) {
-    return getSpansAsJson(new CiTestCycleMapperV1(Config.get().getWellKnownTags()), traces)
+    return getSpansAsJson(new CiTestCycleMapperV1(Config.get().getWellKnownTags(), false), traces)
   }
 
   def getCoveragesAsJson(List<List<DDSpan>> traces) {
-    return getSpansAsJson(new CiTestCovMapperV2(), traces)
+    return getSpansAsJson(new CiTestCovMapperV2(false), traces)
   }
 
   def getSpansAsJson(RemoteMapper mapper, List<List<DDSpan>> traces) {

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilitySmokeTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilitySmokeTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.civisibility
 import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.trace.agent.test.server.http.TestHttpServer
 import datadog.trace.test.util.MultipartRequestParser
+import org.apache.commons.io.IOUtils
 import org.msgpack.jackson.dataformat.MessagePackFactory
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -10,6 +11,8 @@ import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
 
 import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 
@@ -48,14 +51,20 @@ abstract class CiVisibilitySmokeTest extends Specification {
   protected TestHttpServer intakeServer = httpServer {
     handlers {
       prefix("/api/v2/citestcycle") {
-        def decodedEvent = msgPackMapper.readValue(request.body, Map)
+        def contentEncodingHeader = request.getHeader("Content-Encoding")
+        def gzipEnabled = contentEncodingHeader != null && contentEncodingHeader.contains("gzip")
+        def requestBody = gzipEnabled ? CiVisibilitySmokeTest.decompress(request.body) : request.body
+        def decodedEvent = msgPackMapper.readValue(requestBody, Map)
         receivedTraces.add(decodedEvent)
 
         response.status(200).send()
       }
 
       prefix("/api/v2/citestcov") {
-        def parsed = MultipartRequestParser.parseRequest(request.body, request.headers.get("Content-Type"))
+        def contentEncodingHeader = request.getHeader("Content-Encoding")
+        def gzipEnabled = contentEncodingHeader != null && contentEncodingHeader.contains("gzip")
+        def requestBody = gzipEnabled ? CiVisibilitySmokeTest.decompress(request.body) : request.body
+        def parsed = MultipartRequestParser.parseRequest(requestBody, request.headers.get("Content-Type"))
         def coverages = parsed.get("coverage1")
         for (def coverage : coverages) {
           def decodedCoverage = msgPackMapper.readValue(coverage.get(), Map)
@@ -66,14 +75,18 @@ abstract class CiVisibilitySmokeTest extends Specification {
       }
 
       prefix("/api/v2/libraries/tests/services/setting") {
-        response.status(200).send('{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { '
+        // not compressing settings response on purpose, to better mimic real backend behavior:
+        // it may choose to compress the response or not based on its size,
+        // so smaller responses (like those of /setting endpoint) are uncompressed,
+        // while the larger ones (skippable and flaky test lists) are compressed
+        response.status(200).send(('{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { '
           + '"code_coverage": ' + codeCoverageEnabled
           + ', "tests_skipping": ' + testsSkippingEnabled
-          + ', "flaky_test_retries_enabled": ' + flakyRetriesEnabled +  '} } }')
+          + ', "flaky_test_retries_enabled": ' + flakyRetriesEnabled +  '} } }').bytes)
       }
 
       prefix("/api/v2/ci/tests/skippable") {
-        response.status(200).send('{ "data": [{' +
+        response.status(200).addHeader("Content-Encoding", "gzip").send(CiVisibilitySmokeTest.compress(('{ "data": [{' +
           '  "id": "d230520a0561ee2f",' +
           '  "type": "test",' +
           '  "attributes": {' +
@@ -94,11 +107,11 @@ abstract class CiVisibilitySmokeTest extends Specification {
           '    "suite": "datadog.smoke.TestSucceed"' +
           '  }' +
           '}] ' +
-          '}')
+          '}').bytes))
       }
 
       prefix("/api/v2/ci/libraries/tests/flaky") {
-        response.status(200).send('{ "data": [{' +
+        response.status(200).addHeader("Content-Encoding", "gzip").send(CiVisibilitySmokeTest.compress(('{ "data": [{' +
           '  "id": "d230520a0561ee2f",' +
           '  "type": "test",' +
           '  "attributes": {' +
@@ -119,9 +132,25 @@ abstract class CiVisibilitySmokeTest extends Specification {
           '    "suite": "datadog.smoke.TestFailed"' +
           '  }' +
           '}] ' +
-          '}')
+          '}').bytes))
       }
     }
+  }
+
+  private static byte[] compress(byte[] bytes) {
+    def baos = new ByteArrayOutputStream()
+    try (GZIPOutputStream zip = new GZIPOutputStream(baos)) {
+      IOUtils.copy(new ByteArrayInputStream(bytes), zip)
+    }
+    return baos.toByteArray()
+  }
+
+  private static byte[] decompress(byte[] bytes) {
+    def baos = new ByteArrayOutputStream()
+    try (GZIPInputStream zip = new GZIPInputStream(new ByteArrayInputStream(bytes))) {
+      IOUtils.copy(zip, baos)
+    }
+    return baos.toByteArray()
   }
 
   protected verifyEventsAndCoverages(String projectName, String toolchain, String toolchainVersion, int expectedEventsCount, int expectedCoveragesCount) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
@@ -483,6 +483,18 @@ class TestHttpServer implements AutoCloseable {
         resp.setContentLength(body.bytes.length)
         resp.writer.print(body)
       }
+
+      void send(byte[] body) {
+        sendWithType(DEFAULT_TYPE, body)
+      }
+
+      void sendWithType(String contentType, byte[] body) {
+        assert body != null
+
+        sendWithType(contentType)
+        resp.setContentLength(body.length)
+        resp.outputStream.write(body)
+      }
     }
   }
 

--- a/dd-java-agent/testing/src/test/groovy/server/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/server/HttpServerTest.groovy
@@ -419,7 +419,7 @@ class HttpServerTest extends AgentTestRunner {
     def server = httpServer {
       handlers {
         all {
-          response.send(null)
+          response.send((byte[]) null)
         }
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/CompositePayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/CompositePayloadDispatcher.java
@@ -35,8 +35,8 @@ public class CompositePayloadDispatcher implements PayloadDispatcher {
   }
 
   @Override
-  public Collection<Class<? extends RemoteApi>> getApis() {
-    Collection<Class<? extends RemoteApi>> apis = new ArrayList<>(delegates.length);
+  public Collection<RemoteApi> getApis() {
+    Collection<RemoteApi> apis = new ArrayList<>(delegates.length);
     for (PayloadDispatcher delegate : delegates) {
       apis.addAll(delegate.getApis());
     }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDIntakeWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDIntakeWriter.java
@@ -137,7 +137,7 @@ public class DDIntakeWriter extends RemoteWriter {
       TrackType trackType = e.getKey();
       RemoteApi intakeApi = e.getValue();
       DDIntakeMapperDiscovery mapperDiscovery =
-          new DDIntakeMapperDiscovery(trackType, wellKnownTags);
+          new DDIntakeMapperDiscovery(trackType, wellKnownTags, intakeApi.isCompressionEnabled());
       return new PayloadDispatcherImpl(mapperDiscovery, intakeApi, healthMetrics, monitoring);
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcher.java
@@ -12,5 +12,5 @@ interface PayloadDispatcher {
   void flush();
 
   // used by tests
-  Collection<Class<? extends RemoteApi>> getApis();
+  Collection<RemoteApi> getApis();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcherImpl.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/PayloadDispatcherImpl.java
@@ -54,8 +54,8 @@ public class PayloadDispatcherImpl implements ByteBufferConsumer, PayloadDispatc
   }
 
   @Override
-  public Collection<Class<? extends RemoteApi>> getApis() {
-    return Collections.singleton(api.getClass());
+  public Collection<RemoteApi> getApis() {
+    return Collections.singleton(api);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
@@ -14,6 +14,16 @@ public abstract class RemoteApi {
   protected long sentTraces = 0;
   protected long failedTraces = 0;
 
+  private final boolean compressionEnabled;
+
+  protected RemoteApi(boolean compressionEnabled) {
+    this.compressionEnabled = compressionEnabled;
+  }
+
+  public boolean isCompressionEnabled() {
+    return compressionEnabled;
+  }
+
   protected void countAndLogSuccessfulSend(final int traceCount, final int sizeInBytes) {
     // count the successful traces
     sentTraces += traceCount;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java
@@ -142,7 +142,7 @@ public abstract class RemoteWriter implements Writer {
   }
 
   // used by tests
-  public Collection<Class<? extends RemoteApi>> getApis() {
+  public Collection<RemoteApi> getApis() {
     return dispatcher.getApis();
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -167,6 +167,7 @@ public class WriterFactory {
           .agentUrl(commObjects.agentUrl)
           .evpProxyEndpoint(featuresDiscovery.getEvpProxyEndpoint())
           .trackType(trackType)
+          .compressionEnabled(featuresDiscovery.supportsContentEncodingHeadersWithEvpProxy())
           .build();
 
     } else {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -67,6 +67,7 @@ public class DDAgentApi extends RemoteApi {
       DDAgentFeaturesDiscovery featuresDiscovery,
       Monitoring monitoring,
       boolean metricsEnabled) {
+    super(false);
     this.featuresDiscovery = featuresDiscovery;
     this.agentUrl = agentUrl;
     this.httpClient = client;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeApi.java
@@ -23,8 +23,11 @@ import org.slf4j.LoggerFactory;
 /** The API pointing to a DD Intake endpoint */
 public class DDIntakeApi extends RemoteApi {
 
-  private static final String DD_API_KEY_HEADER = "dd-api-key";
   private static final Logger log = LoggerFactory.getLogger(DDIntakeApi.class);
+
+  private static final String DD_API_KEY_HEADER = "dd-api-key";
+  private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
+  private static final String GZIP_CONTENT_TYPE = "gzip";
 
   public static DDIntakeApiBuilder builder() {
     return new DDIntakeApiBuilder();
@@ -102,6 +105,7 @@ public class DDIntakeApi extends RemoteApi {
       HttpUrl intakeUrl,
       String apiKey,
       HttpRetryPolicy.Factory retryPolicyFactory) {
+    super(true);
     this.httpClient = httpClient;
     this.intakeUrl = intakeUrl;
     this.apiKey = apiKey;
@@ -116,6 +120,7 @@ public class DDIntakeApi extends RemoteApi {
         new Request.Builder()
             .url(intakeUrl)
             .addHeader(DD_API_KEY_HEADER, apiKey)
+            .addHeader(CONTENT_ENCODING_HEADER, GZIP_CONTENT_TYPE)
             .post(payload.toRequest())
             .build();
     totalTraces += payload.traceCount();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeMapperDiscovery.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeMapperDiscovery.java
@@ -16,12 +16,15 @@ public class DDIntakeMapperDiscovery implements RemoteMapperDiscovery {
 
   private final TrackType trackType;
   private final WellKnownTags wellKnownTags;
+  private final boolean compressionEnabled;
 
   private RemoteMapper mapper;
 
-  public DDIntakeMapperDiscovery(final TrackType trackType, final WellKnownTags wellKnownTags) {
+  public DDIntakeMapperDiscovery(
+      final TrackType trackType, final WellKnownTags wellKnownTags, boolean compressionEnabled) {
     this.trackType = trackType;
     this.wellKnownTags = wellKnownTags;
+    this.compressionEnabled = compressionEnabled;
   }
 
   private void reset() {
@@ -32,9 +35,9 @@ public class DDIntakeMapperDiscovery implements RemoteMapperDiscovery {
   public void discover() {
     reset();
     if (TrackType.CITESTCYCLE.equals(trackType)) {
-      mapper = new CiTestCycleMapperV1(wellKnownTags);
+      mapper = new CiTestCycleMapperV1(wellKnownTags, compressionEnabled);
     } else if (TrackType.CITESTCOV.equals(trackType)) {
-      mapper = new CiTestCovMapperV2();
+      mapper = new CiTestCovMapperV2(compressionEnabled);
     } else {
       mapper = RemoteMapper.NO_OP;
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCovMapperV2Test.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCovMapperV2Test.groovy
@@ -230,7 +230,7 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
 
   private Map getMappedMessage(List<? extends CoreSpan<?>> trace) {
     def buffer = new GrowableBuffer(1024)
-    def mapper = new CiTestCovMapperV2()
+    def mapper = new CiTestCovMapperV2(false)
     mapper.map(trace, new MsgPackWriter(buffer))
 
     WritableByteChannel channel = new ByteArrayWritableByteChannel()

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCycleMapperV1PayloadTest.groovy
@@ -45,7 +45,7 @@ class CiTestCycleMapperV1PayloadTest extends DDSpecification {
     setup:
     List<List<TraceGenerator.PojoSpan>> traces = generateRandomTraces(traceCount, lowCardinality)
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "my-env", "service", "version", "language")
-    CiTestCycleMapperV1 mapper = new CiTestCycleMapperV1(wellKnownTags)
+    CiTestCycleMapperV1 mapper = new CiTestCycleMapperV1(wellKnownTags, false)
     PayloadVerifier verifier = new PayloadVerifier(wellKnownTags, traces, mapper)
     MsgPackWriter packer = new MsgPackWriter(new FlushingBuffer(bufferSize, verifier))
     when:
@@ -178,7 +178,7 @@ class CiTestCycleMapperV1PayloadTest extends DDSpecification {
     List<TraceGenerator.PojoSpan> trace = Collections.singletonList(span)
 
     WellKnownTags wellKnownTags = new WellKnownTags("runtimeid", "hostname", "my-env", "service", "version", "language")
-    CiTestCycleMapperV1 mapper = new CiTestCycleMapperV1(wellKnownTags)
+    CiTestCycleMapperV1 mapper = new CiTestCycleMapperV1(wellKnownTags, false)
 
     ByteBufferConsumer consumer = new CaptureConsumer()
     MsgPackWriter packer = new MsgPackWriter(new FlushingBuffer(100 << 10, consumer))

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDIntakeWriterCombinedTest.groovy
@@ -198,7 +198,7 @@ class DDIntakeWriterCombinedTest extends DDCoreSpecification {
     writer.start()
 
     when:
-    def discovery = new DDIntakeMapperDiscovery(trackType, wellKnownTags)
+    def discovery = new DDIntakeMapperDiscovery(trackType, wellKnownTags, false)
     discovery.discover()
     def mapper = (RemoteMapper) discovery.mapper
     def traceSize = calculateSize(minimalTrace, mapper)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/WriterFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/WriterFactoryTest.groovy
@@ -11,11 +11,13 @@ import datadog.trace.common.writer.ddintake.DDIntakeApi
 import datadog.trace.core.monitor.HealthMetrics
 import datadog.trace.test.util.DDSpecification
 
+import java.util.stream.Collectors
+
 import static datadog.trace.api.config.TracerConfig.PRIORITIZATION_TYPE
 
 class WriterFactoryTest extends DDSpecification {
 
-  def "test writer creation for #configuredType when agentHasEvpProxy=#hasEvpProxy ciVisibilityAgentless=#isCiVisibilityAgentlessEnabled"() {
+  def "test writer creation for #configuredType when agentHasEvpProxy=#hasEvpProxy evpProxySupportsCompression=#evpProxySupportsCompression ciVisibilityAgentless=#isCiVisibilityAgentlessEnabled"() {
     setup:
     def config = Mock(Config)
     config.apiKey >> "my-api-key"
@@ -27,6 +29,7 @@ class WriterFactoryTest extends DDSpecification {
 
     def agentFeaturesDiscovery = Mock(DDAgentFeaturesDiscovery)
     agentFeaturesDiscovery.getEvpProxyEndpoint() >> DDAgentFeaturesDiscovery.V2_EVP_PROXY_ENDPOINT
+    agentFeaturesDiscovery.supportsContentEncodingHeadersWithEvpProxy() >> evpProxySupportsCompression
 
     def sharedComm = new SharedCommunicationObjects()
     sharedComm.setFeaturesDiscovery(agentFeaturesDiscovery)
@@ -39,27 +42,39 @@ class WriterFactoryTest extends DDSpecification {
     config.ciVisibilityAgentlessEnabled >> isCiVisibilityAgentlessEnabled
     def writer = WriterFactory.createWriter(config, sharedComm, sampler, null, HealthMetrics.NO_OP, configuredType)
 
+    def apis
+    def apiClasses
+    if (expectedApiClasses != null) {
+      apis = ((RemoteWriter) writer).apis
+      apiClasses = apis.stream().map(Object::getClass).collect(Collectors.toList())
+    } else {
+      apis = Collections.emptyList()
+      apiClasses = Collections.emptyList()
+    }
+
     then:
     writer.class == expectedWriterClass
-    expectedApiClass == null || new ArrayList<>(((RemoteWriter) writer).apis) == expectedApiClass
+    expectedApiClasses == null || apiClasses == expectedApiClasses
+    expectedApiClasses == null || apis.stream().allMatch(api -> api.isCompressionEnabled() == isCompressionEnabled)
 
     where:
-    configuredType                             | hasEvpProxy | isCiVisibilityAgentlessEnabled | expectedWriterClass  | expectedApiClass
-    "LoggingWriter"                            | true        | true                           | LoggingWriter        | null
-    "PrintingWriter"                           | true        | true                           | PrintingWriter       | null
-    "TraceStructureWriter"                     | true        | true                           | TraceStructureWriter | null
-    "MultiWriter:LoggingWriter,PrintingWriter" | true        | true                           | MultiWriter          | null
-    "DDIntakeWriter"                           | true        | true                           | DDIntakeWriter       | [DDIntakeApi]
-    "DDIntakeWriter"                           | true        | false                          | DDIntakeWriter       | [DDEvpProxyApi]
-    "DDIntakeWriter"                           | false       | true                           | DDIntakeWriter       | [DDIntakeApi]
-    "DDIntakeWriter"                           | false       | false                          | DDIntakeWriter       | [DDIntakeApi]
-    "DDAgentWriter"                            | true        | true                           | DDIntakeWriter       | [DDIntakeApi]
-    "DDAgentWriter"                            | true        | false                          | DDIntakeWriter       | [DDEvpProxyApi]
-    "DDAgentWriter"                            | false       | true                           | DDIntakeWriter       | [DDIntakeApi]
-    "DDAgentWriter"                            | false       | false                          | DDAgentWriter        | [DDAgentApi]
-    "not-found"                                | true        | true                           | DDIntakeWriter       | [DDIntakeApi]
-    "not-found"                                | true        | false                          | DDIntakeWriter       | [DDEvpProxyApi]
-    "not-found"                                | false       | true                           | DDIntakeWriter       | [DDIntakeApi]
-    "not-found"                                | false       | false                          | DDAgentWriter        | [DDAgentApi]
+    configuredType                             | hasEvpProxy | evpProxySupportsCompression | isCiVisibilityAgentlessEnabled | expectedWriterClass  | expectedApiClasses | isCompressionEnabled
+    "LoggingWriter"                            | true        | false                       | true                           | LoggingWriter        | null               | false
+    "PrintingWriter"                           | true        | false                       | true                           | PrintingWriter       | null               | false
+    "TraceStructureWriter"                     | true        | false                       | true                           | TraceStructureWriter | null               | false
+    "MultiWriter:LoggingWriter,PrintingWriter" | true        | false                       | true                           | MultiWriter          | null               | false
+    "DDIntakeWriter"                           | true        | false                       | true                           | DDIntakeWriter       | [DDIntakeApi]      | true
+    "DDIntakeWriter"                           | true        | false                       | false                          | DDIntakeWriter       | [DDEvpProxyApi]    | false
+    "DDIntakeWriter"                           | false       | false                       | true                           | DDIntakeWriter       | [DDIntakeApi]      | true
+    "DDIntakeWriter"                           | false       | false                       | false                          | DDIntakeWriter       | [DDIntakeApi]      | true
+    "DDAgentWriter"                            | true        | false                       | true                           | DDIntakeWriter       | [DDIntakeApi]      | true
+    "DDAgentWriter"                            | true        | false                       | false                          | DDIntakeWriter       | [DDEvpProxyApi]    | false
+    "DDAgentWriter"                            | true        | true                        | false                          | DDIntakeWriter       | [DDEvpProxyApi]    | true
+    "DDAgentWriter"                            | false       | false                       | true                           | DDIntakeWriter       | [DDIntakeApi]      | true
+    "DDAgentWriter"                            | false       | false                       | false                          | DDAgentWriter        | [DDAgentApi]       | false
+    "not-found"                                | true        | false                       | true                           | DDIntakeWriter       | [DDIntakeApi]      | true
+    "not-found"                                | true        | false                       | false                          | DDIntakeWriter       | [DDEvpProxyApi]    | false
+    "not-found"                                | false       | false                       | true                           | DDIntakeWriter       | [DDIntakeApi]      | true
+    "not-found"                                | false       | false                       | false                          | DDAgentWriter        | [DDAgentApi]       | false
   }
 }


### PR DESCRIPTION
# What Does This Do
Adds support for receiving gzip-compressed responses from CI Visibility endpoints in Agentless mode and when using EVP proxy V4.
Adds support for sending gzip-compressed requests to EVP intakes (test events and coverage data) in Agentless mode and when using EVP proxy V4.

# Motivation
Telemetry shows that some the volume of data sent to EVP intakes can be multiple megabytes, and some responses received from CI Vis APIs (notable the skippable tests) can be very big as well.

# Additional Notes
EVP Proxy versions older than V4 do not forward encoding-related headers, so GZIP is only supported when working with V4 or newer.

Jira ticket: [CIVIS-8575]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8575]: https://datadoghq.atlassian.net/browse/CIVIS-8575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ