### PR TITLE
Avoid NumberFormatException when logging 128bit trace ID

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -891,7 +891,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public AgentSpan blackholeSpan() {
-    return new AgentTracer.BlackholeAgentSpan(DDTraceId.from(getTraceId()));
+    final AgentSpan active = activeSpan();
+    return new AgentTracer.BlackholeAgentSpan(
+        active != null ? active.getTraceId() : DDTraceId.ZERO);
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/BlackholeSpanTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/BlackholeSpanTest.groovy
@@ -7,8 +7,10 @@ import datadog.trace.core.test.DDCoreSpecification
 class BlackholeSpanTest extends DDCoreSpecification {
   def "should mute tracing"() {
     setup:
+    injectSysConfig("trace.128.bit.traceid.logging.enabled", moreBits)
     def writer = new ListWriter()
-    def tracer = tracerBuilder().writer(writer).build()
+    def props = new Properties()
+    def tracer = tracerBuilder().withProperties(props).writer(writer).build()
     when:
     def child = null
     def bh = null
@@ -37,8 +39,13 @@ class BlackholeSpanTest extends DDCoreSpecification {
     assert writer.firstTrace().containsAll([root, child])
     assert !writer.firstTrace().contains(bh)
     assert !writer.firstTrace().contains(ignored)
+
     cleanup:
     writer.close()
     tracer.close()
+    where:
+    moreBits | _
+    "true"   | _
+    "false"  | _
   }
 }


### PR DESCRIPTION
# What Does This Do

When `trace.128.bit.traceid.logging.enabled` is `true` and the aws instrumentation is not using the legacy tracing (by default) a NumberFormatException like this is thrown:

```
java.lang.NumberFormatException: String value xxxxxxxxx exceeds range of unsigned long.
    at datadog.trace.api.internal.util.LongStringUtils.numberFormatOutOfLongRange(LongStringUtils.java:130)
    at datadog.trace.api.internal.util.LongStringUtils.parseUnsignedLong(LongStringUtils.java:91)
    at datadog.trace.api.DDTraceId.from(DDTraceId.java:38)
    at datadog.trace.agent.core.CoreTracer.blackholeSpan(CoreTracer.java:894)
```
This PR adds a tests and fix to remediate to it
# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
