### PR TITLE
Fix reporting httpResourceRemoveTrailingSlash config in the `New instance: Config` log

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -4029,7 +4029,7 @@ public class Config {
         + httpClientTagQueryString
         + ", httpClientSplitByDomain="
         + httpClientSplitByDomain
-        + ", httpResourceRemoveTrailingSlash"
+        + ", httpResourceRemoveTrailingSlash="
         + httpResourceRemoveTrailingSlash
         + ", dbClientSplitByInstance="
         + dbClientSplitByInstance


### PR DESCRIPTION
# What Does This Do

Adds an equal sign after `httpResourceRemoveTrailingSlashfalse` in the **New instance: Config** log

Expected values: `httpResourceRemoveTrailingSlash=false` or `httpResourceRemoveTrailingSlash=true`

# Motivation

At the moment, the log looks like this:
> httpClientTagQueryString=false, httpClientSplitByDomain=false, httpResourceRemoveTrailingSlashfalse

Compared to other configs, httpResourceRemoveTrailingSlash is missing an `=` sign. 

This means the value would be
- httpResourceRemoveTrailingSlashfalse or
- httpResourceRemoveTrailingSlashtrue

This PR would make it
- httpResourceRemoveTrailingSlash=false or
- httpResourceRemoveTrailingSlash=true

To make it easier to parse when reviewing, this PR adds a missing equal sign
# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
