### PR TITLE
Add multi-agent warning at startup

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -376,26 +376,30 @@ public final class AgentBootstrap {
   }
 
   private static void multipleAgentsPresentCheck() {
-    final List<String> arguments = getVMArgumentsThroughReflection();
-    StringBuilder sb = new StringBuilder();
-    boolean multipleAgents = false;
-    for (final String arg : arguments) {
-      if (arg.startsWith("-javaagent")) {
-        if (sb.length() > 0) {
-          sb.append("\n");
-          multipleAgents = true;
+    try {
+      final List<String> arguments = ManagementFactory.getRuntimeMXBean().getInputArguments();
+      StringBuilder sb = new StringBuilder();
+      boolean multipleAgents = false;
+      for (final String arg : arguments) {
+        if (arg.startsWith("-javaagent")) {
+          if (sb.length() > 0) {
+            sb.append("\n");
+            multipleAgents = true;
+          }
+          sb.append(arg);
         }
-        sb.append(arg);
       }
-    }
-    if (multipleAgents) {
-      String javaToolOptions = System.getenv("JAVA_TOOL_OPTIONS");
-      if (javaToolOptions != null && javaToolOptions.contains("-javaagent:")) {
-        System.out.println(
-            "WARNING: Multiple javaagents specified (including in JAVA_TOOL_OPTIONS):\n" + sb);
-      } else {
-        System.out.println("WARNING: Multiple javaagents specified:\n" + sb);
+      if (multipleAgents) {
+        String javaToolOptions = System.getenv("JAVA_TOOL_OPTIONS");
+        if (javaToolOptions != null && javaToolOptions.contains("-javaagent:")) {
+          System.out.println(
+              "WARNING: Multiple javaagents specified (including in JAVA_TOOL_OPTIONS):\n" + sb);
+        } else {
+          System.out.println("WARNING: Multiple javaagents specified:\n" + sb);
+        }
       }
+    } catch (SecurityException e) {
+      // Ignore
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Adds a warning if multiple Java agents are present on the command line or JAVA_TOOL_OPTIONS.  Adds a notification if JAVA_TOOL_OPTIONS contains at least one of the agents:

```
WARNING: Multiple javaagents specified (including in JAVA_TOOL_OPTIONS):
-javaagent:/home/user/lib/dd-java-agent.jar
-javaagent:/home/user/lib/other-vendor-agent.jar
```

# Motivation

It is not always clear when a traced application has started with multiple java agents.  Using multiple agents may result in instability.

# Additional Notes

This message is written to stdout since the check is performed early before logging is available.