### PR TITLE
Handle remote config 204 responses gracefully

### DIFF
--- a/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
+++ b/remote-config/src/main/java/datadog/remoteconfig/ConfigurationPoller.java
@@ -305,6 +305,10 @@ public class ConfigurationPoller
         log.debug("Remote configuration endpoint is disabled");
         return;
       }
+      if (response.code() == 204) {
+        log.debug("No configuration changes (HTTP 204 No Content)");
+        return;
+      }
       ResponseBody body = response.body();
       if (response.isSuccessful()) {
         if (body == null) {

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -747,10 +747,12 @@ class ConfigurationPollerSpecification extends DDSpecification {
   }
 
   void 'accepts an empty object as a response to indicate no changes'() {
+    given:
+    def listener = Mock(ConfigurationChangesTypedListener)
+    def deserializer = Mock(ConfigurationDeserializer)
+
     when:
-    poller.addListener(Product.ASM_DD,
-      { throw new RuntimeException('should not be called') } as ConfigurationDeserializer,
-      { throw new RuntimeException('should not be called' ) } as ConfigurationChangesTypedListener)
+    poller.addListener(Product.ASM_DD, deserializer, listener)
     poller.start()
 
     then:
@@ -762,7 +764,39 @@ class ConfigurationPollerSpecification extends DDSpecification {
     then:
     1 * okHttpClient.newCall(_ as Request) >> { request = it[0]; call }
     1 * call.execute() >> { buildOKResponse('{}') }
+    0 * deserializer._
+    0 * listener._
     0 * _._
+  }
+
+  void 'accepts HTTP 204 as a response to indicate no changes'() {
+    given:
+    Response resp = new Response.Builder()
+      .request(REQUEST)
+      .protocol(Protocol.HTTP_1_1)
+      .message('No Content')
+      .body(ResponseBody.create(MediaType.parse("application/json"), ""))
+      .code(204)
+      .build()
+    def listener = Mock(ConfigurationChangesTypedListener)
+    def deserializer = Mock(ConfigurationDeserializer)
+
+    when:
+    poller.addListener(Product.ASM_DD, deserializer, listener)
+    poller.start()
+
+    then:
+    1 * scheduler.scheduleAtFixedRate(_, poller, 0, DEFAULT_POLL_PERIOD, TimeUnit.MILLISECONDS) >> { task = it[0]; scheduled }
+
+    when:
+    task.run(poller)
+
+    then:
+    1 * okHttpClient.newCall(_ as Request) >> { request = it[0]; call }
+    1 * call.execute() >> resp
+    0 * deserializer._
+    0 * listener._
+    0 * _
   }
 
   void 'applies and remove called for product listener'() {


### PR DESCRIPTION


# What Does This Do
When there are no configuration changes, the agent can answer with HTTP 204 No Content. In that case, the tracer is working but produces an internal exception, which pollutes logs (and telemetry logs).

If we find HTTP 204 code, we just skip any further RC processing.

# Motivation

# Additional Notes
