### PR TITLE
Fix JSONObject instrumentation advice

### DIFF
--- a/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONObjectInstrumentation.java
+++ b/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONObjectInstrumentation.java
@@ -58,7 +58,7 @@ public class JSONObjectInstrumentation extends Instrumenter.Iast
   }
 
   public static class GetAdvice {
-    @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
+    @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterMethod(@Advice.This Object self, @Advice.Return final Object result) {
       if (result instanceof Integer


### PR DESCRIPTION


# What Does This Do
Instrumentation for `JSONObject#get` in IAST is not using an inlined advice. This seems to be causing a NoClassDefFoundError. This only happens when `DD_IAST_ENABLED=true` and has no impact in the application since it is caught by our mechanism for unhandled exceptions in instrumentation. It might have had some performance impact in services with `DD_IAST_ENABLED=true` and intensive use of `JSONObject#get`.

# Motivation

# Additional Notes

Jira ticket: [APPSEC-51413](https://datadoghq.atlassian.net/browse/APPSEC-51413)