### PR TITLE
Configure byte-buddy to use simpler method-graph

### DIFF
--- a/dd-java-agent/testing/src/test/groovy/locator/ClassInjectingForkedTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/locator/ClassInjectingForkedTest.groovy
@@ -2,6 +2,10 @@ package locator
 
 import datadog.trace.agent.test.AgentTestRunner
 import net.bytebuddy.agent.builder.AgentBuilder
+import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.dynamic.DynamicType
+import net.bytebuddy.utility.JavaModule
+import spock.lang.Shared
 
 import java.lang.instrument.ClassFileTransformer
 
@@ -33,11 +37,20 @@ class ClassInjectingForkedTest extends AgentTestRunner {
     super.cleanupAfterAgent()
   }
 
+  @Override
+  void onTransformation(TypeDescription typeDescription, ClassLoader classLoader, JavaModule module, boolean loaded, DynamicType dynamicType) {
+    transformed += typeDescription.name
+  }
+
+  @Shared
+  def transformed = []
+
   def "should find classes injected via defineClass"() {
     setup:
     def instrumented = new ClassInjectingTestInstrumentation.ToBeInstrumented("test")
 
     expect:
+    transformed.contains('locator.ClassInjectingTestInstrumentation$ToBeInstrumented')
     instrumented.message == "test:instrumented:${ClassInjectingTransformer.NAME}"
   }
 }

--- a/dd-java-agent/testing/src/test/java/locator/ClassInjectingTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/locator/ClassInjectingTestInstrumentation.java
@@ -8,6 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.test.base.TestInstrumentation;
 import datadog.trace.agent.tooling.Instrumenter;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -24,7 +26,7 @@ public class ClassInjectingTestInstrumentation extends TestInstrumentation
   @Override
   public ElementMatcher<TypeDescription> structureMatcher() {
     // additional constraint which requires loading the InjectedInterface to match
-    return hasInterface(declaresAnnotation(named("java.lang.FunctionalInterface")));
+    return hasInterface(declaresAnnotation(named(getClass().getName() + "$ToBeMatched")));
   }
 
   @Override
@@ -39,6 +41,9 @@ public class ClassInjectingTestInstrumentation extends TestInstrumentation
       message = message + ":instrumented";
     }
   }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  public @interface ToBeMatched {}
 
   public static final class ToBeInstrumented {
     private final String message;

--- a/dd-java-agent/testing/src/test/java/locator/ClassInjectingTestInstrumentation.java
+++ b/dd-java-agent/testing/src/test/java/locator/ClassInjectingTestInstrumentation.java
@@ -1,17 +1,30 @@
 package locator;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.declaresAnnotation;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.test.base.TestInstrumentation;
 import datadog.trace.agent.tooling.Instrumenter;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
 
 @AutoService(Instrumenter.class)
-public class ClassInjectingTestInstrumentation extends TestInstrumentation {
+public class ClassInjectingTestInstrumentation extends TestInstrumentation
+    implements Instrumenter.WithTypeStructure {
+
   @Override
   public String instrumentedType() {
     return getClass().getName() + "$ToBeInstrumented";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> structureMatcher() {
+    // additional constraint which requires loading the InjectedInterface to match
+    return hasInterface(declaresAnnotation(named("java.lang.FunctionalInterface")));
   }
 
   @Override

--- a/dd-java-agent/testing/src/test/java/locator/ClassInjectingTransformer.java
+++ b/dd-java-agent/testing/src/test/java/locator/ClassInjectingTransformer.java
@@ -59,7 +59,8 @@ public class ClassInjectingTransformer implements AgentBuilder.Transformer, AsmV
           null,
           "java/lang/Object",
           null);
-      cw.visitAnnotation("Ljava/lang/FunctionalInterface;", true).visitEnd();
+      String markerName = ClassInjectingTestInstrumentation.class.getName() + "$ToBeMatched";
+      cw.visitAnnotation("L" + markerName.replace(".", "/") + ";", true).visitEnd();
       byte[] bytes = cw.toByteArray();
       defineMethod.invoke(classLoader, binaryName.replace("/", "."), bytes, 0, bytes.length, null);
     } catch (Throwable e) {

--- a/dd-java-agent/testing/src/test/java/locator/ClassInjectingTransformer.java
+++ b/dd-java-agent/testing/src/test/java/locator/ClassInjectingTransformer.java
@@ -59,6 +59,7 @@ public class ClassInjectingTransformer implements AgentBuilder.Transformer, AsmV
           null,
           "java/lang/Object",
           null);
+      cw.visitAnnotation("Ljava/lang/FunctionalInterface;", true).visitEnd();
       byte[] bytes = cw.toByteArray();
       defineMethod.invoke(classLoader, binaryName.replace("/", "."), bytes, 0, bytes.length, null);
     } catch (Throwable e) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -120,6 +120,7 @@ public final class TraceInstrumentationConfig {
 
   public static final String RESOLVER_CACHE_CONFIG = "resolver.cache.config";
   public static final String RESOLVER_CACHE_DIR = "resolver.cache.dir";
+  public static final String RESOLVER_SIMPLE_METHOD_GRAPH = "resolver.simple.method.graph";
   public static final String RESOLVER_USE_LOADCLASS = "resolver.use.loadclass";
   public static final String RESOLVER_USE_URL_CACHES = "resolver.use.url.caches";
   public static final String RESOLVER_RESET_INTERVAL = "resolver.reset.interval";

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -37,6 +37,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_CACHE_DIR;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_NAMES_ARE_UNIQUE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_RESET_INTERVAL;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_SIMPLE_METHOD_GRAPH;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_URL_CACHES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
@@ -116,6 +117,7 @@ public class InstrumenterConfig {
   private final ResolverCacheConfig resolverCacheConfig;
   private final String resolverCacheDir;
   private final boolean resolverNamesAreUnique;
+  private final boolean resolverSimpleMethodGraph;
   private final boolean resolverUseLoadClass;
   private final Boolean resolverUseUrlCaches;
   private final int resolverResetInterval;
@@ -196,6 +198,9 @@ public class InstrumenterConfig {
             RESOLVER_CACHE_CONFIG, ResolverCacheConfig.class, ResolverCacheConfig.MEMOS);
     resolverCacheDir = configProvider.getString(RESOLVER_CACHE_DIR);
     resolverNamesAreUnique = configProvider.getBoolean(RESOLVER_NAMES_ARE_UNIQUE, false);
+    resolverSimpleMethodGraph =
+        // use simpler approach everywhere except GraalVM, where it affects reachability analysis
+        configProvider.getBoolean(RESOLVER_SIMPLE_METHOD_GRAPH, !Platform.isNativeImageBuilder());
     resolverUseLoadClass = configProvider.getBoolean(RESOLVER_USE_LOADCLASS, true);
     resolverUseUrlCaches = configProvider.getBoolean(RESOLVER_USE_URL_CACHES);
     resolverResetInterval =
@@ -353,6 +358,10 @@ public class InstrumenterConfig {
     return resolverNamesAreUnique;
   }
 
+  public boolean isResolverSimpleMethodGraph() {
+    return resolverSimpleMethodGraph;
+  }
+
   public boolean isResolverUseLoadClass() {
     return resolverUseLoadClass;
   }
@@ -479,6 +488,8 @@ public class InstrumenterConfig {
         + resolverCacheDir
         + ", resolverNamesAreUnique="
         + resolverNamesAreUnique
+        + ", resolverSimpleMethodGraph="
+        + resolverSimpleMethodGraph
         + ", resolverUseLoadClass="
         + resolverUseLoadClass
         + ", resolverUseUrlCaches="


### PR DESCRIPTION
# What Does This Do

Configures byte-buddy to use a simpler method graph compiler which just considers locally declared methods. This approach is enough for our transformations which insert advice into methods. And since our transformations use either `@Advice` or `AsmVisitorWrapper` we can also turn off generation of visibility bridges and use a simpler type strategy.

To disable this optimization add this JVM option:
```
-Ddd.resolver.simple.method.graph=false
```
or set this environment variable:
```
DD_RESOLVER_SIMPLE_METHOD_GRAPH=false
```

# Motivation

For spring-petclinic this reduces the number of class-file lookups by a fifth.

OTel uses a similar configuration for byte-buddy: https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v2.0.0/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/AgentInstaller.java#L140

# Additional Notes

We don't enable the simpler method graph compiler when creating GraalVM native images because it appears to affect the reachability analysis, resulting in intermittent warnings like `Discovered unresolved field during parsing`.

Jira ticket: [APMS-11443]



[APMS-11443]: https://datadoghq.atlassian.net/browse/APMS-11443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ