### PR TITLE
Mute tracing for subprocesses executed in by the tracer

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerSettingsSupport.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerSettingsSupport.java
@@ -4,6 +4,8 @@ import datadog.trace.api.Config;
 import datadog.trace.api.Platform;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.context.TraceScope;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -116,7 +118,7 @@ public abstract class ProfilerSettingsSupport {
   private String getSELinuxStatus() {
     String value = "Not present";
     if (Platform.isLinux()) {
-      try {
+      try (final TraceScope scope = AgentTracer.get().muteTracing()) {
         ProcessBuilder pb = new ProcessBuilder("getenforce");
         Process process = pb.start();
         // wait for at most 500ms for the process to finish

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/ProcessImplStartAdvice.java
@@ -1,7 +1,5 @@
 package datadog.trace.instrumentation.java.lang;
 
-import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
-
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.java.lang.ProcessImplInstrumentationHelpers;
@@ -16,11 +14,6 @@ class ProcessImplStartAdvice {
     }
 
     if (command.length == 0) {
-      return null;
-    }
-
-    // Don't create spans for agent threads
-    if (AGENT_THREAD_GROUP.equals(Thread.currentThread().getThreadGroup())) {
       return null;
     }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -447,6 +447,8 @@ import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.config.provider.CapturedEnvironmentConfigSource;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.context.TraceScope;
 import datadog.trace.util.PidHelper;
 import datadog.trace.util.Strings;
 import datadog.trace.util.throwable.FatalAgentMisconfigurationError;
@@ -3848,9 +3850,10 @@ public class Config {
     }
 
     // Try hostname command
-    try (final BufferedReader reader =
-        new BufferedReader(
-            new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
+    try (final TraceScope scope = AgentTracer.get().muteTracing();
+        final BufferedReader reader =
+            new BufferedReader(
+                new InputStreamReader(Runtime.getRuntime().exec("hostname").getInputStream()))) {
       possibleHostname = reader.readLine();
     } catch (final Throwable ignore) {
       // Ignore.  Hostname command is not always available


### PR DESCRIPTION
# What Does This Do
The tracer sometimes runs external processes in some cases. Currently, `hostname` and `getenforce`. The subprocess instrumentation creates spans for these, leading to visible `command_execution` spans for `hostname` and/or `enforce` which may be confusing to users.

This commit uses the bew blackhole span API (#6326) to mute tracing during when `hostname` and `getenforce` are run, preventing the creation of these spans.

Also reverts #6478, which would be redundant with the current cases.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
