### PR TITLE
Add `scheduledWithFixedDelay` method

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/AgentTaskScheduler.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentTaskScheduler.java
@@ -149,6 +149,18 @@ public class AgentTaskScheduler implements Executor {
     weakScheduleAtFixedRate(RunnableTask.INSTANCE, target, initialDelay, period, unit);
   }
 
+  public <T> Scheduled<T> scheduleWithFixedDelay(
+      Task<T> task, T target, long initialDelay, long period, TimeUnit unit) {
+    final Scheduled<T> scheduled = new Scheduled<>(target);
+    scheduleTarget(task, scheduled, initialDelay, -period, unit);
+    return scheduled;
+  }
+
+  public Scheduled<Runnable> scheduleWithFixedDelay(
+      Runnable target, long initialDelay, long period, TimeUnit unit) {
+    return scheduleWithFixedDelay(RunnableTask.INSTANCE, target, initialDelay, period, unit);
+  }
+
   @SuppressFBWarnings("JLM_JSR166_UTILCONCURRENT_MONITORENTER")
   private <T> void scheduleTarget(
       final Task<T> task,
@@ -303,6 +315,10 @@ public class AgentTaskScheduler implements Executor {
     public boolean reschedule() {
       if (period > 0 && target.get() != null) {
         nextFireTime += period;
+        return true;
+      }
+      if (period < 0 && target.get() != null) {
+        nextFireTime = System.nanoTime() - period;
         return true;
       }
       return false;


### PR DESCRIPTION
# What Does This Do
Add this method to `AgentTaskScheduler` to ensure that there is a fixed delay between tasks, even if the task duration is significantly long.
Equivalent to `ScheduledExecutorServier::scheduleWithFixedDelay` from JDK

# Motivation
Provide feature equivqlent to `ScheduledExecutorServier::scheduleWithFixedDelay`
Some tasks can last as long as the delay and avoiding executing right away the next cycle.

# Additional Notes

Jira ticket: [DEBUG-2076]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2076]: https://datadoghq.atlassian.net/browse/DEBUG-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ