### PR TITLE
Fix issue with cookie parser and empty cookie values

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/CookieSecurityParser.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/CookieSecurityParser.java
@@ -61,7 +61,8 @@ public class CookieSecurityParser {
         }
         boolean addCookie = false;
         boolean eof = i == headerValue.length() - 1;
-        if (eof || next == ',' || next == '=' || next == ';') {
+        boolean separator = next == ',' || next == '=' || next == ';';
+        if (eof || separator) {
           if (next == ',') {
             if (quoteCount % 2 == 0 && version == 1) {
               addCookie = true; // multiple cookie separator
@@ -69,7 +70,7 @@ public class CookieSecurityParser {
               continue;
             }
           }
-          final int end = eof ? i + 1 : i;
+          final int end = separator ? i : i + 1;
           switch (state) {
             case COOKIE_NAME:
               cookieName = headerValue.substring(start, end).trim();

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/CookieSecurityParserTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/CookieSecurityParserTest.groovy
@@ -30,6 +30,7 @@ class CookieSecurityParserTest extends Specification {
 
     where:
     header                                                                                                                                                       | cookieName | isSecure | isHttpOnly | sameSite
+    "Set-Cookie: user-id="                                                                                                                                       | "user-id"  | false    | false      | null
     "Set-Cookie: user-id=7"                                                                                                                                      | "user-id"  | false    | false      | null
     'Set-Cookie: user-id="7"'                                                                                                                                    | "user-id"  | false    | false      | null
     "Set-Cookie: user-id=7;Secure"                                                                                                                               | "user-id"  | true     | false      | null


### PR DESCRIPTION
# What Does This Do
Fix issue with the cookie parser and empty cookies like `Set-Cookie: user-id=`
