### PR TITLE
Add CI Static Analysis integration

### DIFF
--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -1,0 +1,25 @@
+name: "DataDog CI Static Analysis"
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+jobs:
+  check-quality:
+    runs-on: ubuntu-latest
+    name: Datadog Static Analyzer
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+      - name: Check code meets quality standards
+        id: datadog-static-analysis
+        uses: DataDog/datadog-static-analyzer-github-action@8f2b6213cadc5fef47befda2dc3f1d7c68f33ddd # 1.0.7
+        with:
+          dd_app_key: ${{ secrets.DD_APP_KEY }}
+          dd_api_key: ${{ secrets.DD_API_KEY }}
+          dd_site: datad0g.com
+          dd_service: "dd-trace-java"
+          dd_env: "ci"
+          cpu_count: 2
+          enable_performance_statistics: false

--- a/.github/workflows/ci-static-analysis.yml
+++ b/.github/workflows/ci-static-analysis.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@8f2b6213cadc5fef47befda2dc3f1d7c68f33ddd # 1.0.7
+        uses: DataDog/datadog-static-analyzer-github-action@v1
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,0 +1,4 @@
+rulesets:
+  - java-best-practices
+  - java-code-style
+  - java-security

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -2,3 +2,5 @@ rulesets:
   - java-best-practices
   - java-code-style
   - java-security
+ignore-paths:
+  - "dd-smoke-tests/**"


### PR DESCRIPTION
# What Does This Do
Add a GitHub Workflow to run DataDog's Static Analyzer.

# Motivation

# Additional Notes

* See [docs](https://docs.datadoghq.com/static_analysis/github_actions)
* And https://github.com/DataDog/datadog-static-analyzer-github-action