### PR TITLE
Trigger WAF request metrics only at end of request only

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -79,6 +79,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private Additive additive;
   // set after additive is set
   private volatile PowerwafMetrics wafMetrics;
+  private volatile boolean blocked;
 
   // to be called by the Event Dispatcher
   public void addAll(DataBundle newData) {
@@ -103,6 +104,14 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   public PowerwafMetrics getWafMetrics() {
     return wafMetrics;
+  }
+
+  public void setBlocked() {
+    this.blocked = true;
+  }
+
+  public boolean isBlocked() {
+    return blocked;
   }
 
   public Additive getOrCreateAdditive(PowerwafContext ctx, boolean createMetrics) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -28,6 +28,7 @@ import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.api.internal.TraceSegment;
+import datadog.trace.api.telemetry.WafMetricCollector;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.util.Strings;
@@ -173,6 +174,14 @@ public class GatewayBridge {
             // If extracted any Api Schemas - commit them
             if (!ctx.commitApiSchemas(traceSeg)) {
               log.debug("Unable to commit, api security schemas and will be skipped");
+            }
+
+            if (ctx.isBlocked()) {
+              WafMetricCollector.get().wafRequestBlocked();
+            } else if (!collectedEvents.isEmpty()) {
+              WafMetricCollector.get().wafRequestTriggered();
+            } else {
+              WafMetricCollector.get().wafRequest();
             }
           }
 

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -453,13 +453,8 @@ public class PowerWAFModule implements AppSecModule {
         reqCtx.reportEvents(events);
 
         if (flow.isBlocking()) {
-          WafMetricCollector.get().wafRequestBlocked();
-        } else {
-          WafMetricCollector.get().wafRequestTriggered();
+          reqCtx.setBlocked();
         }
-
-      } else {
-        WafMetricCollector.get().wafRequest();
       }
 
       if (resultWithData != null && resultWithData.schemas != null) {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -408,6 +408,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> { pwafAdditive.close() }
+    1 * ctx.setBlocked()
     0 * _
 
     when:
@@ -486,6 +487,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.reportEvents(hasSize(2))
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
+    1 * ctx.setBlocked()
     0 * _
   }
 
@@ -582,6 +584,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getWafMetrics() >> metrics
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
+    1 * ctx.setBlocked()
     0 * ctx._(*_)
     flow.blocking == true
     flow.action instanceof Flow.Action.RequestBlockingAction
@@ -645,6 +648,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getWafMetrics() >> metrics
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
+    1 * ctx.setBlocked()
     0 * ctx._(*_)
     flow.blocking == true
     flow.action.statusCode == 418
@@ -669,6 +673,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getWafMetrics() >> null
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
+    1 * ctx.setBlocked()
     0 * ctx._(*_)
     metrics == null
   }
@@ -719,6 +724,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     }
     1 * ctx.getWafMetrics() >> metrics
     1 * ctx.reportEvents(*_)
+    1 * ctx.setBlocked()
     0 * ctx._(*_)
     flow.blocking == true
   }


### PR DESCRIPTION


# What Does This Do

Trigger WAF request metrics only at end of request only. Otherwise, they can be incremented multiple times per request if there are multiple WAF calls.

# Motivation

# Additional Notes

Jira ticket: [APPSEC-51509](https://datadoghq.atlassian.net/browse/APPSEC-51509)

[APPSEC-51509]: https://datadoghq.atlassian.net/browse/APPSEC-51509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ