### PR TITLE
Align apache http client 5 instrumentation names

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
@@ -27,7 +27,8 @@ public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.CanShortcutTypeMatching {
 
   public ApacheHttpAsyncClientInstrumentation() {
-    super("httpasyncclient5", "apache-httpasyncclient5");
+    super(
+        "httpasyncclient5", "apache-httpasyncclient5", "httpasyncclient", "apache-httpasyncclient");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientDecorator.java
@@ -17,7 +17,14 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
 
   @Override
   protected String[] instrumentationNames() {
-    return new String[] {"httpclient5", "apache-httpclient5", "apache-http-client5"};
+    return new String[] {
+      "httpclient5",
+      "apache-httpclient5",
+      "apache-http-client5",
+      "httpclient",
+      "apache-httpclient",
+      "apache-http-client"
+    };
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientInstrumentation.java
@@ -23,7 +23,13 @@ public class ApacheHttpClientInstrumentation extends Instrumenter.Tracing
     implements Instrumenter.CanShortcutTypeMatching {
 
   public ApacheHttpClientInstrumentation() {
-    super("httpclient5", "apache-httpclient5", "apache-http-client5");
+    super(
+        "httpclient5",
+        "apache-httpclient5",
+        "apache-http-client5",
+        "httpclient",
+        "apache-httpclient",
+        "apache-http-client");
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Align the instrumentation names used for apache http client 5 with the one expected according to the documentation

![image](https://github.com/DataDog/dd-trace-java/assets/7393723/fe54ae82-abc1-41b6-8080-7f82f1f231c3)


# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
