### PR TITLE
Run CodeQL in master only

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ master ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
 
 jobs:
   analyze:


### PR DESCRIPTION
# What Does This Do

Moves CodeQL job to master only. The job takes 30min to run, and results are generally not very interesting (we'll still get them through CI Static Analysis (see https://github.com/DataDog/dd-trace-java/pull/6484)). We'll still have DataDog Static Analyzer in PRs, which is more comprehensive and takes just 2 minutes to run (see https://github.com/DataDog/dd-trace-java/pull/6589).

# Motivation

# Additional Notes
