### PR TITLE
increase muzzle parallelism

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -746,7 +746,7 @@ jobs:
   muzzle:
     <<: *defaults
     resource_class: medium
-    parallelism: 3
+    parallelism: 4
     steps:
       - setup_code
 


### PR DESCRIPTION
# What Does This Do

Muzzle seems often short of memory.
Reduce the probability of failure by decreasing the number of tasks per executor.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
