### PR TITLE
Fix dependency resolution for nested JARs

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
@@ -128,6 +128,11 @@ public final class Dependency {
 
   public static synchronized Dependency guessFallbackNoPom(
       Manifest manifest, String source, InputStream is) throws IOException {
+    final int slashIndex = source.lastIndexOf('/');
+    if (slashIndex >= 0) {
+      source = source.substring(slashIndex + 1);
+    }
+
     String artifactId;
     String groupId = null;
     String version;
@@ -215,7 +220,7 @@ public final class Dependency {
     }
 
     if (md != null) {
-      // Compute hash for all dependencies that has no pom
+      // Compute hash for all dependencies that have no pom
       // No reliable version calculate hash and use any version
       md.reset();
       is = new DigestInputStream(is, md);

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -1,12 +1,12 @@
 package datadog.telemetry.dependency;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.jar.JarFile;
@@ -20,19 +20,7 @@ public class DependencyResolver {
   private static final String JAR_SUFFIX = ".jar";
 
   public static List<Dependency> resolve(URI uri) {
-    return extractDependenciesFromURI(uri);
-  }
-
-  /**
-   * Identify library from a URI
-   *
-   * @param uri URI to a dependency
-   * @return dependency, or null if unable to qualify jar
-   */
-  // package private for testing
-  static List<Dependency> extractDependenciesFromURI(URI uri) {
-    String scheme = uri.getScheme();
-    List<Dependency> dependencies = Collections.emptyList();
+    final String scheme = uri.getScheme();
     try {
       if ("file".equals(scheme)) {
         File f;
@@ -41,30 +29,17 @@ public class DependencyResolver {
         } else {
           f = new File(uri);
         }
-        dependencies = extractDependenciesFromJar(f);
+        return extractFromFile(f);
       } else if ("jar".equals(scheme)) {
-        Dependency dependency = getNestedDependency(uri);
-        if (dependency != null) {
-          dependencies = Collections.singletonList(dependency);
-        }
+        return extractFromJarURI(uri);
       }
-    } catch (RuntimeException rte) {
-      log.debug("Failed to determine dependency for uri {}", uri, rte);
+    } catch (Throwable t) {
+      log.debug("Failed to determine dependency for uri {}", uri, t);
     }
-    // TODO : moving jboss vfs here is probably a idea
-    // it might however require to do somme checks to make sure it's only applied to jboss
-    // and not any application server that also uses vfs:// locations
-
-    return dependencies;
+    return Collections.emptyList();
   }
 
-  /**
-   * Identify a library from a .jar file
-   *
-   * @param jar jar dependency
-   * @return detected dependency, {@code null} if unable to get dependency from jar
-   */
-  static List<Dependency> extractDependenciesFromJar(File jar) {
+  private static List<Dependency> extractFromFile(final File jar) throws IOException {
     if (!jar.exists()) {
       log.debug("unable to find dependency {} (path does not exist)", jar);
       return Collections.emptyList();
@@ -73,57 +48,31 @@ public class DependencyResolver {
       return Collections.emptyList();
     }
 
-    List<Dependency> dependencies = Collections.emptyList();
-    try (JarFile file = new JarFile(jar, false /* no verify */)) {
-
-      // Try to get from maven properties
-      dependencies = Dependency.fromMavenPom(file);
-
-      // Try to guess from manifest or file name
-      if (dependencies.isEmpty()) {
-        try (InputStream is = Files.newInputStream(jar.toPath())) {
-          Manifest manifest = file.getManifest();
-          dependencies =
-              Collections.singletonList(Dependency.guessFallbackNoPom(manifest, jar.getName(), is));
-        }
-      }
-    } catch (IOException e) {
-      log.debug("unable to read jar file {}", jar, e);
+    try (final JarFile file = new JarFile(jar, false /* no verify */);
+        final InputStream is = new FileInputStream(jar)) {
+      return extractFromJarFile(file, is);
     }
-
-    return dependencies;
   }
 
   /* for jar urls as handled by spring boot */
-  static Dependency getNestedDependency(URI uri) {
-    String lastPart = null;
-    String fileName = null;
-    try {
-      URL url = uri.toURL();
-      JarURLConnection jarConnection = (JarURLConnection) url.openConnection();
-      Manifest manifest = jarConnection.getManifest();
-
-      JarFile jarFile = jarConnection.getJarFile();
-
-      // the !/ separator is hardcoded into JarURLConnection class
-      String jarFileName = jarFile.getName();
-      int posSep = jarFileName.indexOf("!/");
-      if (posSep == -1) {
-        log.debug("Unable to guess nested dependency for uri '{}': '!/' not found", uri);
-        return null;
-      }
-      lastPart = jarFileName.substring(posSep + 1);
-      fileName = lastPart.substring(lastPart.lastIndexOf("/") + 1);
-
-      return Dependency.guessFallbackNoPom(manifest, fileName, jarConnection.getInputStream());
-    } catch (Exception e) {
-      log.debug("unable to open nested jar manifest for {}", uri, e);
+  private static List<Dependency> extractFromJarURI(final URI uri) throws IOException {
+    final URL url = uri.toURL();
+    final JarURLConnection conn = (JarURLConnection) url.openConnection();
+    try (final JarFile jar = conn.getJarFile();
+        final InputStream is = url.openStream()) {
+      return extractFromJarFile(jar, is);
     }
-    log.debug(
-        "Unable to guess nested dependency for uri '{}', lastPart: '{}', fileName: '{}'",
-        uri,
-        lastPart,
-        fileName);
-    return null;
+  }
+
+  private static List<Dependency> extractFromJarFile(final JarFile jar, final InputStream is)
+      throws IOException {
+    // Try Maven's pom.properties
+    final List<Dependency> deps = Dependency.fromMavenPom(jar);
+    if (!deps.isEmpty()) {
+      return deps;
+    }
+    // Try manifest or file name
+    final Manifest manifest = jar.getManifest();
+    return Collections.singletonList(Dependency.guessFallbackNoPom(manifest, jar.getName(), is));
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
@@ -145,7 +145,7 @@ class DependencyResolverSpecification extends DepSpecification {
     File temp = File.createTempFile('temp', '.zip')
 
     expect:
-    DependencyResolver.extractDependenciesFromJar(temp).isEmpty()
+    DependencyResolver.resolve(temp.toURI()).isEmpty()
 
     cleanup:
     temp.delete()
@@ -157,7 +157,7 @@ class DependencyResolverSpecification extends DepSpecification {
     temp.delete()
 
     expect:
-    DependencyResolver.extractDependenciesFromJar(temp).isEmpty()
+    DependencyResolver.resolve(temp.toURI()).isEmpty()
   }
 
   void 'try to determine invalid jar lib'() throws IOException {
@@ -166,16 +166,7 @@ class DependencyResolverSpecification extends DepSpecification {
     temp.write("just a text file")
 
     expect:
-    DependencyResolver.extractDependenciesFromJar(temp).isEmpty()
-  }
-
-  void 'try to determine invalid jar lib'() throws IOException {
-    setup:
-    File temp = File.createTempFile('temp', '.jar')
-    temp.write("just a text file")
-
-    expect:
-    DependencyResolver.getNestedDependency(temp.toURI()) == null
+    DependencyResolver.resolve(temp.toURI()).isEmpty()
   }
 
   void 'spring boot dependency'() throws IOException {
@@ -190,9 +181,9 @@ class DependencyResolverSpecification extends DepSpecification {
 
     then:
     dep != null
-    dep.name == 'opentracing-util-0.33.0.jar'
+    dep.name == 'io.opentracing:opentracing-util'
     dep.version == '0.33.0'
-    dep.hash == '132630F17E198A1748F23CE33597EFDF4A807FB9'
+    dep.hash == null
     dep.source == 'opentracing-util-0.33.0.jar'
   }
 
@@ -252,7 +243,7 @@ class DependencyResolverSpecification extends DepSpecification {
 
   private static void knownJarCheck(Map opts) {
     File jarFile = getJar(opts['jarName'])
-    List<Dependency> deps = DependencyResolver.extractDependenciesFromJar(jarFile)
+    List<Dependency> deps = DependencyResolver.resolve(jarFile.toURI())
 
     assert deps.size() == 1
     Dependency dep = deps.get(0)


### PR DESCRIPTION
# What Does This Do
When finding nested jar (e.g. in Spring Boot), we were only applying a
subset of the dependency resolution logic. Now the same heuristics are
applied to nested jars.

In practice, this means that for nested JARs we will:
* Identify the dependency more accurately (e.g. extract group id).
* Find shaded dependencies.

# Motivation

# Additional Notes

Jira ticket: [APPSEC-11822](https://datadoghq.atlassian.net/browse/APPSEC-11822)

[APPSEC-11822]: https://datadoghq.atlassian.net/browse/APPSEC-11822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ