### PR TITLE
Build only release artifacts in build_lib CI job

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -950,7 +950,7 @@ jobs:
 build_test_jobs: &build_test_jobs
   - build:
       name: build_lib
-      gradleTarget: shadowJar
+      gradleTarget: :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar
       cacheType: lib
       collectLibs: true
   - build:


### PR DESCRIPTION


# What Does This Do
The main build_lib job should not spend time building shadow JARs that are only used for intermediate stages (these are covered by other jobs).

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
