### PR TITLE
Include aas related tags in profile tag-map

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3403,6 +3403,9 @@ public class Config {
     result.put(SERVICE_TAG, serviceName);
     result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
     result.put(RUNTIME_VERSION_TAG, runtimeVersion);
+    if (azureAppServices) {
+      result.putAll(getAzureAppServicesTags());
+    }
     return Collections.unmodifiableMap(result);
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/AzureAppServicesTagsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/AzureAppServicesTagsTest.groovy
@@ -15,6 +15,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
 
     then:
     !config.localRootSpanTags.keySet().any { it.startsWith("aas")}
+    !config.mergedProfilingTags.keySet().any { it.startsWith("aas")}
   }
 
   def "subscription id parsed"() {
@@ -27,6 +28,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
 
     then:
     config.localRootSpanTags["aas.subscription.id"] == "8c500027-5f00-400e-8f00-60000000000f"
+    config.mergedProfilingTags["aas.subscription.id"] == "8c500027-5f00-400e-8f00-60000000000f"
   }
 
   def "resource id generated"() {
@@ -41,6 +43,7 @@ class AzureAppServicesTagsTest extends DDSpecification {
 
     then:
     config.localRootSpanTags["aas.resource.id"] == "/subscriptions/8c500027-5f00-400e-8f00-60000000000f/resourcegroups/group/providers/microsoft.web/sites/site"
+    config.mergedProfilingTags["aas.resource.id"] == "/subscriptions/8c500027-5f00-400e-8f00-60000000000f/resourcegroups/group/providers/microsoft.web/sites/site"
   }
 
   def "some tags are set to unknown when not defined"() {
@@ -55,6 +58,10 @@ class AzureAppServicesTagsTest extends DDSpecification {
     config.localRootSpanTags["aas.environment.instance_name"] == "unknown"
     config.localRootSpanTags["aas.environment.os"] == "unknown"
     config.localRootSpanTags["aas.environment.extension_version"] == "unknown"
+    config.mergedProfilingTags["aas.environment.instance_id"] == "unknown"
+    config.mergedProfilingTags["aas.environment.instance_name"] == "unknown"
+    config.mergedProfilingTags["aas.environment.os"] == "unknown"
+    config.mergedProfilingTags["aas.environment.extension_version"] == "unknown"
   }
 
   def "tags are set"() {
@@ -74,5 +81,9 @@ class AzureAppServicesTagsTest extends DDSpecification {
     config.localRootSpanTags["aas.environment.instance_name"] == "someComputer"
     config.localRootSpanTags["aas.environment.os"] == "someOs"
     config.localRootSpanTags["aas.environment.extension_version"] == "99"
+    config.mergedProfilingTags["aas.environment.instance_id"] == "someInstance"
+    config.mergedProfilingTags["aas.environment.instance_name"] == "someComputer"
+    config.mergedProfilingTags["aas.environment.os"] == "someOs"
+    config.mergedProfilingTags["aas.environment.extension_version"] == "99"
   }
 }


### PR DESCRIPTION
# What Does This Do
It adds the AAS related tags to uploaded profiles

# Motivation
Supporting billing for AAS profiles

# Additional Notes

Jira ticket: [PROF-9104]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-9104]: https://datadoghq.atlassian.net/browse/PROF-9104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ