### PR TITLE
Fix context store access with null key on DBM MySQL connection

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/MySQLConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/MySQLConnectionInstrumentation.java
@@ -115,7 +115,7 @@ public class MySQLConnectionInstrumentation extends AbstractConnectionInstrument
       }
       ContextStore<Statement, DBQueryInfo> contextStore =
           InstrumentationContext.get(Statement.class, DBQueryInfo.class);
-      if (null == contextStore.get(statement)) {
+      if (null != statement && null == contextStore.get(statement)) {
         DBQueryInfo info = DBQueryInfo.ofPreparedStatement(inputSql);
         contextStore.put(statement, info);
         logQueryInfoInjection(connection, statement, info);


### PR DESCRIPTION
# What Does This Do

Same fix as #6400 but for MySQLConnectionInstrumentation
