### PR TITLE
Exclude WAF timeout from telemetry logs

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -25,6 +25,7 @@ import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.trace.api.Config;
 import datadog.trace.api.ProductActivation;
 import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.api.telemetry.WafMetricCollector;
 import io.sqreen.powerwaf.Additive;
 import io.sqreen.powerwaf.Powerwaf;
@@ -412,7 +413,7 @@ public class PowerWAFModule implements AppSecModule {
         resultWithData = doRunPowerwaf(reqCtx, newData, ctxAndAddr, isTransient);
       } catch (TimeoutPowerwafException tpe) {
         reqCtx.increaseTimeouts();
-        log.debug("Timeout calling the WAF", tpe);
+        log.debug(LogCollector.EXCLUDE_TELEMETRY, "Timeout calling the WAF", tpe);
         return;
       } catch (AbstractPowerwafException e) {
         log.error("Error calling WAF", e);


### PR DESCRIPTION
# What Does This Do
Exclude WAF timeout from telemetry logs.

# Motivation

WAF timeouts produces too many telemetry logs. Looking at the stacktrace is somewhat useful to check where the timeout comes from, but we can look at this per-customer. We now have a metric https://github.com/DataDog/dd-trace-java/pull/6597 to check this, and we'll soon also have a telemetry metric.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
