### PR TITLE
Refactor checkout merge commit in CI

### DIFF
--- a/.circleci/checkout_merge_commit.sh
+++ b/.circleci/checkout_merge_commit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CIRCLE_PULL_REQUEST="${CIRCLE_PULL_REQUEST:-}"
+CCI_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
+
+if [[ "${CIRCLE_BRANCH:-}" != "master" && -n "${CCI_PR_NUMBER:-}" ]]
+then
+  FETCH_REFS="${FETCH_REFS:-} +refs/pull/${CCI_PR_NUMBER}/merge:refs/pull/${CCI_PR_NUMBER}/merge +refs/pull/${CCI_PR_NUMBER}/head:refs/pull/${CCI_PR_NUMBER}/head"
+  git fetch -u origin ${FETCH_REFS}
+  head_ref="$(git show-ref --hash refs/pull/${CCI_PR_NUMBER}/head)"
+  merge_ref="$(git show-ref --hash refs/pull/${CCI_PR_NUMBER}/merge)"
+  if git merge-base --is-ancestor "$head_ref" "$merge_ref"; then
+    git checkout "pull/${CCI_PR_NUMBER}/merge"
+  else
+    echo "[WARN] There is a merge conflict between master and PR ${CCI_PR_NUMBER}, merge branch cannot be checked out."
+    git checkout "pull/${CCI_PR_NUMBER}/head"
+  fi
+fi

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -101,21 +101,7 @@ commands:
       - checkout
       - run:
           name: Checkout merge commit
-          command: |
-            CCI_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
-
-            if [[ "$CIRCLE_BRANCH" != "master" && -n "${CCI_PR_NUMBER}" ]]
-            then
-              FETCH_REFS="${FETCH_REFS} +refs/pull/${CCI_PR_NUMBER}/merge:refs/pull/${CCI_PR_NUMBER}/merge +refs/pull/${CCI_PR_NUMBER}/head:refs/pull/${CCI_PR_NUMBER}/head"
-              git fetch -u origin ${FETCH_REFS}
-
-              if git merge-base --is-ancestor $(git show-ref --hash refs/pull/${CCI_PR_NUMBER}/head) $(git show-ref --hash refs/pull/${CCI_PR_NUMBER}/merge); then
-                git checkout "pull/${CCI_PR_NUMBER}/merge"
-              else
-                echo "[WARN] There is a merge conflict between master and PR ${CCI_PR_NUMBER}, merge branch cannot be checked out."
-                git checkout "pull/${CCI_PR_NUMBER}/head"
-              fi
-            fi
+          command: .circleci/checkout_merge_commit.sh
 
       - check_for_leftover_files
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Checkout merge commit
+          command: .circleci/checkout_merge_commit.sh
+      - run:
           name: Install dependencies
           command: pip3 install jinja2 requests
       - run:


### PR DESCRIPTION


# What Does This Do
* Move logic to a standalone script (easier to test).
* Use it during pipeline setup. This ensures changes to Circle CI config itself are tested in the post-merge state.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
