### PR TITLE
Partial IAST opt-out when AppSec is enabled

### DIFF
--- a/benchmark/load/petclinic/benchmark.json
+++ b/benchmark/load/petclinic/benchmark.json
@@ -30,6 +30,12 @@
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.appsec.enabled=true"
       }
     },
+    "appsec_no_iast": {
+      "env": {
+        "VARIANT": "appsec",
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.appsec.enabled=true -Ddd.iast.enabled=false"
+      }
+    },
     "iast": {
       "env": {
         "VARIANT": "iast",

--- a/benchmark/startup/petclinic/benchmark.json
+++ b/benchmark/startup/petclinic/benchmark.json
@@ -24,6 +24,12 @@
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/appsec -Ddd.appsec.enabled=true"
       }
     },
+    "appsec_no_iast": {
+      "env": {
+        "VARIANT": "appsec",
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/appsec_no_iast -Ddd.appsec.enabled=true -Ddd.iast.enabled=false"
+      }
+    },
     "iast": {
       "env": {
         "VARIANT": "iast",

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastOptOutContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastOptOutContext.java
@@ -1,0 +1,38 @@
+package com.datadog.iast;
+
+import com.datadog.iast.taint.TaintedObjects;
+import datadog.trace.api.iast.IastContext;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+public class IastOptOutContext implements IastContext {
+
+  @SuppressWarnings("unchecked")
+  @NotNull
+  @Override
+  public TaintedObjects getTaintedObjects() {
+    return TaintedObjects.NoOp.INSTANCE;
+  }
+
+  public static class Provider extends IastContext.Provider {
+
+    final IastContext optOutContext = new IastOptOutContext();
+
+    @Nullable
+    @Override
+    public IastContext resolve() {
+      return optOutContext;
+    }
+
+    @Override
+    public IastContext buildRequestContext() {
+      return new IastRequestContext(optOutContext.getTaintedObjects());
+    }
+
+    @Override
+    public void releaseRequestContext(@Nonnull final IastContext context) {
+      // nothing to release in opt out mode
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -1,5 +1,6 @@
 package com.datadog.iast;
 
+import static datadog.trace.api.ProductActivation.FULLY_ENABLED;
 import static datadog.trace.api.iast.IastContext.Mode.GLOBAL;
 import static datadog.trace.api.iast.IastDetectionMode.UNLIMITED;
 
@@ -48,6 +49,8 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.telemetry.Verbosity;
 import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.stacktrace.StackWalkerFactory;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -67,16 +70,17 @@ public class IastSystem {
   public static void start(
       final SubscriptionService ss, @Nullable OverheadController overheadController) {
     final Config config = Config.get();
-    if (config.getIastActivation() != ProductActivation.FULLY_ENABLED) {
-      LOGGER.debug("IAST is disabled");
+    final ProductActivation iast = config.getIastActivation();
+    final ProductActivation appSec = config.getAppSecActivation();
+    if (iast != FULLY_ENABLED && appSec != FULLY_ENABLED) {
+      LOGGER.debug("IAST is disabled: iast={}, appSec={}", iast, appSec);
       return;
     }
     DEBUG = config.isIastDebugEnabled();
     LOGGER.debug("IAST is starting: debug={}", DEBUG);
     final Reporter reporter = new Reporter(config, AgentTaskScheduler.INSTANCE);
     final boolean globalContext = config.getIastContextMode() == GLOBAL;
-    final IastContext.Provider contextProvider =
-        globalContext ? new IastGlobalContext.Provider() : new IastRequestContext.Provider();
+    final IastContext.Provider contextProvider = contextProvider(iast, globalContext);
     if (overheadController == null) {
       overheadController =
           OverheadController.build(
@@ -90,7 +94,7 @@ public class IastSystem {
         new Dependencies(
             config, reporter, overheadController, StackWalkerFactory.INSTANCE, contextProvider);
     final boolean addTelemetry = config.getIastTelemetryVerbosity() != Verbosity.OFF;
-    iastModules(dependencies).forEach(InstrumentationBridge::registerIastModule);
+    iastModules(iast, dependencies).forEach(InstrumentationBridge::registerIastModule);
     registerRequestStartedCallback(ss, addTelemetry, dependencies);
     registerRequestEndedCallback(ss, addTelemetry, dependencies);
     registerHeadersCallback(ss);
@@ -98,35 +102,77 @@ public class IastSystem {
     LOGGER.debug("IAST started");
   }
 
-  private static Stream<IastModule> iastModules(final Dependencies dependencies) {
-    return Stream.of(
-        new StringModuleImpl(),
-        new FastCodecModule(),
-        new SqlInjectionModuleImpl(dependencies),
-        new PathTraversalModuleImpl(dependencies),
-        new CommandInjectionModuleImpl(dependencies),
-        new WeakCipherModuleImpl(dependencies),
-        new WeakHashModuleImpl(dependencies),
-        new LdapInjectionModuleImpl(dependencies),
-        new PropagationModuleImpl(),
-        new HttpResponseHeaderModuleImpl(dependencies),
-        new HstsMissingHeaderModuleImpl(dependencies),
-        new InsecureCookieModuleImpl(),
-        new NoHttpOnlyCookieModuleImpl(),
-        new XContentTypeModuleImpl(dependencies),
-        new NoSameSiteCookieModuleImpl(),
-        new SsrfModuleImpl(dependencies),
-        new UnvalidatedRedirectModuleImpl(dependencies),
-        new WeakRandomnessModuleImpl(dependencies),
-        new XPathInjectionModuleImpl(dependencies),
-        new TrustBoundaryViolationModuleImpl(dependencies),
-        new XssModuleImpl(dependencies),
-        new StacktraceLeakModuleImpl(dependencies),
-        new HeaderInjectionModuleImpl(dependencies),
-        new ApplicationModuleImpl(dependencies),
-        new HardcodedSecretModuleImpl(dependencies),
-        new InsecureAuthProtocolModuleImpl(dependencies),
-        new ReflectionInjectionModuleImpl(dependencies));
+  private static IastContext.Provider contextProvider(
+      final ProductActivation iast, final boolean global) {
+    if (iast != FULLY_ENABLED) {
+      return new IastOptOutContext.Provider();
+    } else {
+      return global ? new IastGlobalContext.Provider() : new IastRequestContext.Provider();
+    }
+  }
+
+  private static Stream<IastModule> iastModules(
+      final ProductActivation iast, final Dependencies dependencies) {
+    Stream<Class<? extends IastModule>> modules =
+        Stream.of(
+            StringModuleImpl.class,
+            FastCodecModule.class,
+            SqlInjectionModuleImpl.class,
+            PathTraversalModuleImpl.class,
+            CommandInjectionModuleImpl.class,
+            WeakCipherModuleImpl.class,
+            WeakHashModuleImpl.class,
+            LdapInjectionModuleImpl.class,
+            PropagationModuleImpl.class,
+            HttpResponseHeaderModuleImpl.class,
+            HstsMissingHeaderModuleImpl.class,
+            InsecureCookieModuleImpl.class,
+            NoHttpOnlyCookieModuleImpl.class,
+            XContentTypeModuleImpl.class,
+            NoSameSiteCookieModuleImpl.class,
+            SsrfModuleImpl.class,
+            UnvalidatedRedirectModuleImpl.class,
+            WeakRandomnessModuleImpl.class,
+            XPathInjectionModuleImpl.class,
+            TrustBoundaryViolationModuleImpl.class,
+            XssModuleImpl.class,
+            StacktraceLeakModuleImpl.class,
+            HeaderInjectionModuleImpl.class,
+            ApplicationModuleImpl.class,
+            HardcodedSecretModuleImpl.class,
+            InsecureAuthProtocolModuleImpl.class,
+            ReflectionInjectionModuleImpl.class);
+    if (iast != FULLY_ENABLED) {
+      modules = modules.filter(IastSystem::isOptOut);
+    }
+    return modules.map(type -> newIastModule(dependencies, type));
+  }
+
+  private static boolean isOptOut(final Class<? extends IastModule> module) {
+    for (final Class<?> itf : module.getInterfaces()) {
+      if (itf.getDeclaredAnnotation(IastModule.OptOut.class) != null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <M extends IastModule> M newIastModule(
+      final Dependencies dependencies, final Class<M> type) {
+    try {
+      final Constructor<M> ctor = (Constructor<M>) type.getDeclaredConstructors()[0];
+      if (ctor.getParameterCount() == 0) {
+        return ctor.newInstance();
+      } else {
+        return ctor.newInstance(dependencies);
+      }
+    } catch (final Throwable e) {
+      // should never happen and be caught on IAST tests
+      throw new UndeclaredThrowableException(
+          e,
+          "Modules should have either default constructor or take only one param of type Dependencies");
+    }
   }
 
   private static void registerRequestStartedCallback(

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastTag.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastTag.java
@@ -1,46 +1,85 @@
 package com.datadog.iast;
 
+import datadog.trace.api.Config;
+import datadog.trace.api.ProductActivation;
 import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import javax.annotation.Nullable;
 
 public interface IastTag {
 
-  Enabled SKIPPED = new Enabled(0);
-  Enabled ANALYZED = new Enabled(1);
+  void setTagTop(@Nullable final TraceSegment trace);
 
-  String key();
+  void setTag(@Nullable final AgentSpan span);
 
-  Object value();
+  abstract class BaseTag<E> implements IastTag {
 
-  default void setTagTop(@Nullable final TraceSegment trace) {
-    if (trace != null) {
-      trace.setTagTop(key(), value());
+    protected abstract String key();
+
+    protected abstract E value();
+
+    @Override
+    public void setTagTop(@Nullable final TraceSegment trace) {
+      if (trace != null) {
+        trace.setTagTop(key(), value());
+      }
+    }
+
+    @Override
+    public void setTag(@Nullable final AgentSpan span) {
+      if (span != null) {
+        span.setTag(key(), value());
+      }
     }
   }
 
-  default void setTag(@Nullable final AgentSpan span) {
-    if (span != null) {
-      span.setTag(key(), value());
-    }
+  class NoOp implements IastTag {
+    private static final IastTag INSTANCE = new NoOp();
+
+    @Override
+    public void setTagTop(@Nullable TraceSegment trace) {}
+
+    @Override
+    public void setTag(@Nullable AgentSpan span) {}
   }
 
-  class Enabled implements IastTag {
+  /**
+   * Sets the value for {@code "_dd.iast.enabled"} in the requests, if IAST is not full activated it
+   * should not set any values.
+   *
+   * <ul>
+   *   <li>{@code 0} for requests skipped by sampling.
+   *   <li>{@code 1} for requests analyzed by IAST.
+   * </ul>
+   */
+  class Enabled extends BaseTag<Integer> {
+
+    public static final IastTag SKIPPED = Enabled.withValue(0);
+
+    public static final IastTag ANALYZED = Enabled.withValue(1);
 
     private final int value;
 
-    public Enabled(int value) {
+    private Enabled(int value) {
       this.value = value;
     }
 
     @Override
-    public String key() {
+    protected String key() {
       return "_dd.iast.enabled";
     }
 
     @Override
-    public Object value() {
+    protected Integer value() {
       return value;
+    }
+
+    public static IastTag withValue(final int value) {
+      if (Config.get().getIastActivation() == ProductActivation.FULLY_ENABLED) {
+        return new Enabled(value);
+      } else {
+        return NoOp.INSTANCE;
+      }
     }
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -1,6 +1,6 @@
 package com.datadog.iast;
 
-import static com.datadog.iast.IastTag.ANALYZED;
+import static com.datadog.iast.IastTag.Enabled.ANALYZED;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
 import com.datadog.iast.model.Vulnerability;

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestEndedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestEndedHandler.java
@@ -1,7 +1,7 @@
 package com.datadog.iast;
 
-import static com.datadog.iast.IastTag.ANALYZED;
-import static com.datadog.iast.IastTag.SKIPPED;
+import static com.datadog.iast.IastTag.Enabled.ANALYZED;
+import static com.datadog.iast.IastTag.Enabled.SKIPPED;
 
 import com.datadog.iast.overhead.OverheadController;
 import datadog.trace.api.gateway.Flow;

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/StacktraceLeakModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/StacktraceLeakModuleImpl.java
@@ -8,11 +8,11 @@ import com.datadog.iast.model.VulnerabilityType;
 import datadog.trace.api.iast.sink.StacktraceLeakModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import org.jetbrains.annotations.NotNull;
+import javax.annotation.Nonnull;
 
 public class StacktraceLeakModuleImpl extends SinkModuleBase implements StacktraceLeakModule {
 
-  public StacktraceLeakModuleImpl(@NotNull Dependencies dependencies) {
+  public StacktraceLeakModuleImpl(@Nonnull Dependencies dependencies) {
     super(dependencies);
   }
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastOptOutContextTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastOptOutContextTest.groovy
@@ -1,0 +1,68 @@
+package com.datadog.iast
+
+import com.datadog.iast.model.Range
+import com.datadog.iast.taint.TaintedObjects
+import datadog.trace.api.gateway.RequestContext
+import datadog.trace.api.gateway.RequestContextSlot
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.test.util.DDSpecification
+import spock.lang.Shared
+
+class IastOptOutContextTest extends DDSpecification {
+
+  @Shared
+  protected static final AgentTracer.TracerAPI ORIGINAL_TRACER = AgentTracer.get()
+
+  private RequestContext reqCtx = Stub(RequestContext)
+
+  private AgentSpan span = Stub(AgentSpan) {
+    getSpanId() >> 123456
+    getRequestContext() >> reqCtx
+  }
+
+  protected AgentTracer.TracerAPI tracer = Stub(AgentTracer.TracerAPI) {
+    activeSpan() >> span
+  }
+
+  private IastOptOutContext.Provider provider
+
+  void setup() {
+    AgentTracer.forceRegister(tracer)
+    provider = new IastOptOutContext.Provider()
+  }
+
+  void cleanup() {
+    AgentTracer.forceRegister(ORIGINAL_TRACER)
+  }
+
+  void 'provider scopes the context to a request using the no-op map'() {
+    given:
+    final iastReqCtx = provider.buildRequestContext()
+    reqCtx.getData(RequestContextSlot.IAST) >> iastReqCtx
+
+    when:
+    def resolvedCtx = provider.resolve()
+
+    then:
+    resolvedCtx !== iastReqCtx
+    resolvedCtx === provider.optOutContext
+    iastReqCtx.taintedObjects === resolvedCtx.taintedObjects
+  }
+
+  void 'release does nothing to the tainted objects'() {
+    when:
+    final ctx = provider.buildRequestContext()
+    final TaintedObjects to = ctx.taintedObjects
+    to.taint(UUID.randomUUID(), [] as Range[])
+
+    then:
+    to.count() == 0
+
+    when:
+    provider.releaseRequestContext(ctx)
+
+    then:
+    to.count() == 0
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastTagTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastTagTest.groovy
@@ -4,12 +4,12 @@ import datadog.trace.api.internal.TraceSegment
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
 
-import static com.datadog.iast.IastTag.ANALYZED
-import static com.datadog.iast.IastTag.SKIPPED
+import static com.datadog.iast.IastTag.Enabled.ANALYZED
+import static com.datadog.iast.IastTag.Enabled.SKIPPED
 
 class IastTagTest extends DDSpecification {
 
-  void 'tags are sent on the segment'(final IastTag tag) {
+  void 'tags are sent on the segment'() {
     given:
     final segment = Mock(TraceSegment)
 
@@ -20,12 +20,12 @@ class IastTagTest extends DDSpecification {
     1 * segment.setTagTop(tag.key(), tag.value())
 
     where:
-    tag      | _
+    tag              | _
     ANALYZED | _
-    SKIPPED  | _
+    SKIPPED | _
   }
 
-  void 'tags dont fail with null segment'(final IastTag tag) {
+  void 'tags dont fail with null segment'() {
     when:
     tag.setTagTop(null)
 
@@ -33,12 +33,12 @@ class IastTagTest extends DDSpecification {
     noExceptionThrown()
 
     where:
-    tag      | _
+    tag              | _
     ANALYZED | _
-    SKIPPED  | _
+    SKIPPED | _
   }
 
-  void 'tags are sent on the span'(final IastTag tag) {
+  void 'tags are sent on the span'() {
     given:
     final span = Mock(AgentSpan)
 
@@ -49,12 +49,12 @@ class IastTagTest extends DDSpecification {
     1 * span.setTag(tag.key(), tag.value())
 
     where:
-    tag      | _
+    tag              | _
     ANALYZED | _
-    SKIPPED  | _
+    SKIPPED | _
   }
 
-  void 'tags dont fail with null span'(final IastTag tag) {
+  void 'tags dont fail with null span'() {
     when:
     tag.setTag(null)
 
@@ -62,8 +62,28 @@ class IastTagTest extends DDSpecification {
     noExceptionThrown()
 
     where:
-    tag      | _
+    tag              | _
     ANALYZED | _
-    SKIPPED  | _
+    SKIPPED | _
+  }
+
+  void 'enabled tags are not set if IAST is opt-out'() {
+    given:
+    injectSysConfig('iast.enabled', 'false')
+    final span = Mock(AgentSpan)
+    final segment = Mock(TraceSegment)
+    final tag = IastTag.Enabled.withValue(1)
+
+    when:
+    tag.setTag(span)
+
+    then:
+    0 * _
+
+    when:
+    tag.setTagTop(segment)
+
+    then:
+    0 * _
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -24,7 +24,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-import static com.datadog.iast.IastTag.ANALYZED
+import static com.datadog.iast.IastTag.Enabled.ANALYZED
 import static com.datadog.iast.test.TaintedObjectsUtils.noOpTaintedObjects
 import static datadog.trace.api.config.IastConfig.IAST_DEDUPLICATION_ENABLED
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -239,7 +239,8 @@ public abstract class InstrumenterModule implements Instrumenter {
 
     @Override
     public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-      return enabledSystems.contains(TargetSystem.IAST);
+      return enabledSystems.contains(TargetSystem.IAST)
+          || (isOptOutEnabled() && enabledSystems.contains(TargetSystem.APPSEC));
     }
 
     /**
@@ -266,6 +267,10 @@ public abstract class InstrumenterModule implements Instrumenter {
     @Override
     public Advice.PostProcessor.Factory postProcessor() {
       return IastPostProcessorFactory.INSTANCE;
+    }
+
+    protected boolean isOptOutEnabled() {
+      return false;
     }
   }
 

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
@@ -29,7 +29,8 @@ public class IastInstrumentation extends CallSiteInstrumentation {
 
   @Override
   public boolean isApplicable(final Set<TargetSystem> enabledSystems) {
-    return enabledSystems.contains(TargetSystem.IAST);
+    return enabledSystems.contains(TargetSystem.IAST)
+        || (isOptOutEnabled() && enabledSystems.contains(TargetSystem.APPSEC));
   }
 
   @Override
@@ -44,6 +45,10 @@ public class IastInstrumentation extends CallSiteInstrumentation {
     } else {
       return Advices.fromCallSites(callSites);
     }
+  }
+
+  protected boolean isOptOutEnabled() {
+    return false;
   }
 
   public static final class IastMatcher

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JakartaWSResponseInstrumentation.java
@@ -37,6 +37,11 @@ public class JakartaWSResponseInstrumentation extends InstrumenterModule.Iast
   }
 
   @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
+  @Override
   public String hierarchyMarkerType() {
     return "jakarta.ws.rs.core.Response$ResponseBuilder";
   }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JavaxWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/JavaxWSResponseInstrumentation.java
@@ -46,6 +46,11 @@ public class JavaxWSResponseInstrumentation extends InstrumenterModule.Iast
     return extendsClass(named(hierarchyMarkerType()));
   }
 
+  @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
   public static class HeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Sink(VulnerabilityTypes.RESPONSE_HEADER)

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/JavaxWSResponseInstrumentation.java
@@ -46,6 +46,11 @@ public class JavaxWSResponseInstrumentation extends InstrumenterModule.Iast
     return extendsClass(named(hierarchyMarkerType()));
   }
 
+  @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
   public static class HeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Sink(VulnerabilityTypes.RESPONSE_HEADER)

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -48,6 +48,11 @@ public final class HttpServletResponseInstrumentation extends InstrumenterModule
   }
 
   @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
+  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("addCookie").and(takesArgument(0, named("javax.servlet.http.Cookie"))),

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
@@ -43,6 +43,11 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
   }
 
   @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
+  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("addCookie")

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/IastServletContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/IastServletContextInstrumentation.java
@@ -57,6 +57,11 @@ public final class IastServletContextInstrumentation extends InstrumenterModule.
         IastServletContextInstrumentation.class.getName() + "$IastContextAdvice");
   }
 
+  @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
   public static class IastContextAdvice {
     @Sink(VulnerabilityTypes.APPLICATION)
     @Advice.OnMethodExit(suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/tomcat-appsec-7/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/build.gradle
@@ -23,6 +23,9 @@ dependencies {
   compileOnly group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '7.0.4'
   compileOnly group: 'org.apache.tomcat', name: 'tomcat-coyote', version: '7.0.4'
   implementation project(':dd-java-agent:instrumentation:tomcat-5.5-common')
+
+  testImplementation group: 'org.apache.tomcat', name: 'tomcat-catalina', version: '7.0.4'
+  testImplementation group: 'org.apache.tomcat', name: 'tomcat-coyote', version: '7.0.4'
 }
 
 // testing happens in tomcat-5.5 module

--- a/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/ErrorReportValueInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/ErrorReportValueInstrumentation.java
@@ -28,6 +28,11 @@ public class ErrorReportValueInstrumentation extends InstrumenterModule.Iast
   }
 
   @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
+  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         isMethod()

--- a/dd-java-agent/instrumentation/tomcat-appsec-7/src/test/groovy/datadog/trace/instrumentation/tomcat7/ErrorReportValueInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/src/test/groovy/datadog/trace/instrumentation/tomcat7/ErrorReportValueInstrumentationTest.groovy
@@ -1,0 +1,81 @@
+package datadog.trace.instrumentation.tomcat7
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.sink.StacktraceLeakModule
+import org.apache.catalina.connector.Request
+import org.apache.catalina.connector.Response
+import org.apache.catalina.valves.ErrorReportValve
+
+class ErrorReportValueInstrumentationTest extends AgentTestRunner {
+
+  void 'test vulnerability detection'() {
+    given:
+    final reporter = new ErrorReportValve()
+    final req = Stub(Request)
+    final resp = Stub(Response) {
+      getStatus() >> 500
+      isError() >> true
+    }
+    final t = new Throwable()
+    final module = Mock(StacktraceLeakModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    reporter.report(req, resp, t)
+
+    then:
+    if (shouldReport) {
+      1 * module.onStacktraceLeak(t, _, _, _)
+    } else {
+      0 * module._
+    }
+  }
+
+  protected boolean isShouldReport() {
+    return false
+  }
+}
+
+class AppSecErrorReportValueInstrumentationTest extends ErrorReportValueInstrumentationTest {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('appsec.enabled', 'true')
+    super.configurePreAgent()
+  }
+
+  @Override
+  protected boolean isShouldReport() {
+    return true
+  }
+}
+
+class IastErrorReportValueInstrumentationTest extends ErrorReportValueInstrumentationTest {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('iast.enabled', 'true')
+    super.configurePreAgent()
+  }
+
+  @Override
+  protected boolean isShouldReport() {
+    return true
+  }
+}
+
+class IastDisabledErrorReportValueInstrumentationTest extends ErrorReportValueInstrumentationTest {
+
+  @Override
+  protected void configurePreAgent() {
+    injectSysConfig('appsec.enabled', 'true')
+    injectSysConfig('iast.enabled', 'false')
+    super.configurePreAgent()
+  }
+
+  @Override
+  protected boolean isShouldReport() {
+    return false
+  }
+}

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/HttpServerResponseInstrumentation.java
@@ -56,6 +56,11 @@ public class HttpServerResponseInstrumentation extends InstrumenterModule.Iast
     return implementsInterface(named(hierarchyMarkerType()));
   }
 
+  @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
   public static class PutHeaderAdvice1 {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     @Sink(VulnerabilityTypes.RESPONSE_HEADER)

--- a/dd-java-agent/instrumentation/vertx-web-3.9/src/main/java/datadog/trace/instrumentation/vertx_3_9/Vertx39HttpServertResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.9/src/main/java/datadog/trace/instrumentation/vertx_3_9/Vertx39HttpServertResponseInstrumentation.java
@@ -43,6 +43,11 @@ public class Vertx39HttpServertResponseInstrumentation extends InstrumenterModul
     return implementsInterface(named(hierarchyMarkerType()));
   }
 
+  @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
   public static class InstrumenterAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     @Sink(VulnerabilityTypes.RESPONSE_HEADER)

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
@@ -1,5 +1,9 @@
 package datadog.trace.api.iast;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,4 +14,8 @@ public interface IastModule {
   default void onUnexpectedException(final String message, final Throwable error) {
     LOG.warn(message, error);
   }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  @interface OptOut {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/ApplicationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/ApplicationModule.java
@@ -1,8 +1,10 @@
 package datadog.trace.api.iast.sink;
 
 import datadog.trace.api.iast.IastModule;
+import datadog.trace.api.iast.IastModule.OptOut;
 import javax.annotation.Nullable;
 
+@OptOut
 public interface ApplicationModule extends IastModule {
 
   void onRealPath(@Nullable String realPath);

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/HstsMissingHeaderModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/HstsMissingHeaderModule.java
@@ -1,3 +1,6 @@
 package datadog.trace.api.iast.sink;
 
+import datadog.trace.api.iast.IastModule.OptOut;
+
+@OptOut
 public interface HstsMissingHeaderModule extends HttpRequestEndModule {}

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/HttpResponseHeaderModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/HttpResponseHeaderModule.java
@@ -1,9 +1,11 @@
 package datadog.trace.api.iast.sink;
 
 import datadog.trace.api.iast.IastModule;
+import datadog.trace.api.iast.IastModule.OptOut;
 import datadog.trace.api.iast.util.Cookie;
 import javax.annotation.Nonnull;
 
+@OptOut
 public interface HttpResponseHeaderModule extends IastModule {
 
   void onHeader(@Nonnull String name, String value);

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/InsecureCookieModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/InsecureCookieModule.java
@@ -1,3 +1,6 @@
 package datadog.trace.api.iast.sink;
 
+import datadog.trace.api.iast.IastModule.OptOut;
+
+@OptOut
 public interface InsecureCookieModule<T> extends HttpCookieModule<T> {}

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/NoHttpOnlyCookieModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/NoHttpOnlyCookieModule.java
@@ -1,3 +1,6 @@
 package datadog.trace.api.iast.sink;
 
+import datadog.trace.api.iast.IastModule.OptOut;
+
+@OptOut
 public interface NoHttpOnlyCookieModule<T> extends HttpCookieModule<T> {}

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/NoSameSiteCookieModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/NoSameSiteCookieModule.java
@@ -1,3 +1,6 @@
 package datadog.trace.api.iast.sink;
 
+import datadog.trace.api.iast.IastModule.OptOut;
+
+@OptOut
 public interface NoSameSiteCookieModule<T> extends HttpCookieModule<T> {}

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/StacktraceLeakModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/StacktraceLeakModule.java
@@ -1,9 +1,12 @@
 package datadog.trace.api.iast.sink;
 
 import datadog.trace.api.iast.IastModule;
+import datadog.trace.api.iast.IastModule.OptOut;
 import javax.annotation.Nullable;
 
+@OptOut
 public interface StacktraceLeakModule extends IastModule {
+
   void onStacktraceLeak(
       @Nullable final Throwable expression, String moduleName, String className, String methodName);
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/XContentTypeModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/XContentTypeModule.java
@@ -1,3 +1,6 @@
 package datadog.trace.api.iast.sink;
 
+import datadog.trace.api.iast.IastModule.OptOut;
+
+@OptOut
 public interface XContentTypeModule extends HttpRequestEndModule {}

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/IastModuleTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/IastModuleTest.groovy
@@ -1,17 +1,57 @@
 package datadog.trace.api.iast
 
+import datadog.trace.api.iast.sink.ApplicationModule
+import datadog.trace.api.iast.sink.HstsMissingHeaderModule
+import datadog.trace.api.iast.sink.HttpResponseHeaderModule
+import datadog.trace.api.iast.sink.InsecureCookieModule
+import datadog.trace.api.iast.sink.NoHttpOnlyCookieModule
+import datadog.trace.api.iast.sink.NoSameSiteCookieModule
+import datadog.trace.api.iast.sink.StacktraceLeakModule
+import datadog.trace.api.iast.sink.XContentTypeModule
 import datadog.trace.test.util.DDSpecification
 
 class IastModuleTest extends DDSpecification {
 
   void 'exceptions are logged'() {
     setup:
-    final module = new IastModule() { }
+    final module = new IastModule() {}
 
     when:
     module.onUnexpectedException('hello', new Error('Boom!!!'))
 
     then:
     noExceptionThrown()
+  }
+
+  void 'test opt-out modules'() {
+    given:
+    final module = clazz
+    final expected = shouldBeOptOut(clazz)
+
+    when:
+    final enabled = module.getDeclaredAnnotation(IastModule.OptOut) != null
+
+    then:
+    enabled == expected
+
+    where:
+    clazz << InstrumentationBridge.getIastModules()
+  }
+
+  @SuppressWarnings('GroovyFallthrough')
+  private static boolean shouldBeOptOut(final Class<?> target) {
+    switch (target) {
+      case HttpResponseHeaderModule:
+      case InsecureCookieModule:
+      case NoHttpOnlyCookieModule:
+      case NoSameSiteCookieModule:
+      case HstsMissingHeaderModule:
+      case XContentTypeModule:
+      case ApplicationModule:
+      case StacktraceLeakModule:
+        return true
+      default:
+        return false
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do
Enables certain IAST instrumentations when AppSec is enabled, the rationale is to enable all instrumentations that do not require taint tracking / call sites and provide value without any noticeable overhead. 

The list of vulnerabilities that will be enabled in opt-out are:

- HSTS header missing
- X-Content-Type header missing
- Insecure cookies
- No HTTPOnly cookie
- No SameSite cookie
- Stack trace leak
- Application related vulnerabilities (insecure JSP layout, default html escape invalid, admin console active, ...)

# Motivation

# Additional Notes

Jira ticket: [APPSEC-10441]



[APPSEC-10441]: https://datadoghq.atlassian.net/browse/APPSEC-10441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ