### PR TITLE
Implement telemetry for CI Visibility

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -53,6 +53,7 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_FLAKY_RETRY_ENABLED = "civisibility.flaky.retry.enabled";
   public static final String CIVISIBILITY_FLAKY_RETRY_COUNT = "civisibility.flaky.retry.count";
   public static final String CIVISIBILITY_MODULE_NAME = "civisibility.module.name";
+  public static final String CIVISIBILITY_TELEMETRY_ENABLED = "civisibility.telemetry.enabled";
 
   /* COVERAGE SETTINGS */
   public static final String CIVISIBILITY_CODE_COVERAGE_ENABLED =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -185,6 +185,7 @@ import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SIGNAL_SE
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_PORT;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SOURCE_DATA_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SOURCE_DATA_ROOT_CHECK_ENABLED;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_TELEMETRY_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_TRACE_SANITATION_ENABLED;
 import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS;
 import static datadog.trace.api.config.CrashTrackingConfig.CRASH_TRACKING_AGENTLESS_DEFAULT;
@@ -767,6 +768,7 @@ public class Config {
   private final boolean ciVisibilityFlakyRetryEnabled;
   private final int ciVisibilityFlakyRetryCount;
   private final String ciVisibilityModuleName;
+  private final boolean ciVisibilityTelemetryEnabled;
 
   private final boolean remoteConfigEnabled;
   private final boolean remoteConfigIntegrityCheckEnabled;
@@ -1748,6 +1750,7 @@ public class Config {
         configProvider.getBoolean(CIVISIBILITY_FLAKY_RETRY_ENABLED, true);
     ciVisibilityFlakyRetryCount = configProvider.getInteger(CIVISIBILITY_FLAKY_RETRY_COUNT, 5);
     ciVisibilityModuleName = configProvider.getString(CIVISIBILITY_MODULE_NAME);
+    ciVisibilityTelemetryEnabled = configProvider.getBoolean(CIVISIBILITY_TELEMETRY_ENABLED, true);
 
     remoteConfigEnabled =
         configProvider.getBoolean(REMOTE_CONFIG_ENABLED, DEFAULT_REMOTE_CONFIG_ENABLED);
@@ -2967,6 +2970,10 @@ public class Config {
 
   public String getCiVisibilityModuleName() {
     return ciVisibilityModuleName;
+  }
+
+  public boolean isCiVisibilityTelemetryEnabled() {
+    return ciVisibilityTelemetryEnabled;
   }
 
   public String getAppSecRulesFile() {

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
@@ -1,0 +1,201 @@
+package datadog.trace.api.civisibility.telemetry;
+
+import datadog.trace.api.civisibility.telemetry.tag.Command;
+import datadog.trace.api.civisibility.telemetry.tag.CoverageEnabled;
+import datadog.trace.api.civisibility.telemetry.tag.Endpoint;
+import datadog.trace.api.civisibility.telemetry.tag.ErrorType;
+import datadog.trace.api.civisibility.telemetry.tag.EventType;
+import datadog.trace.api.civisibility.telemetry.tag.ExitCode;
+import datadog.trace.api.civisibility.telemetry.tag.HasCodeowner;
+import datadog.trace.api.civisibility.telemetry.tag.IsBenchmark;
+import datadog.trace.api.civisibility.telemetry.tag.IsUnsupportedCI;
+import datadog.trace.api.civisibility.telemetry.tag.ItrEnabled;
+import datadog.trace.api.civisibility.telemetry.tag.ItrSkipEnabled;
+import datadog.trace.api.civisibility.telemetry.tag.Library;
+import datadog.trace.api.civisibility.telemetry.tag.RequireGit;
+import datadog.trace.api.civisibility.telemetry.tag.TestFramework;
+import java.util.Arrays;
+
+public enum CiVisibilityCountMetric {
+
+  /** The number of events created */
+  EVENT_CREATED(
+      "event_created",
+      TestFramework.class,
+      EventType.class,
+      HasCodeowner.class,
+      IsUnsupportedCI.class,
+      IsBenchmark.class),
+  /** The number of events finished */
+  EVENT_FINISHED(
+      "event_finished",
+      TestFramework.class,
+      EventType.class,
+      HasCodeowner.class,
+      IsUnsupportedCI.class,
+      IsBenchmark.class),
+  /** The number of code coverage sessions started */
+  CODE_COVERAGE_STARTED("code_coverage_started", TestFramework.class, Library.class),
+  /** The number of code coverage sessions finished */
+  CODE_COVERAGE_FINISHED("code_coverage_finished", TestFramework.class, Library.class),
+  /** The number of events created using the manual API */
+  MANUAL_API_EVENTS("manual_api_events", EventType.class),
+  /** The number of events enqueued for serialization */
+  EVENTS_ENQUEUED_FOR_SERIALIZATION("events_enqueued_for_serialization"),
+  /** The number of requests sent to the endpoint, regardless of success */
+  ENDPOINT_PAYLOAD_REQUESTS("endpoint_payload.requests", Endpoint.class),
+  /** The number of requests sent to the endpoint that errored */
+  ENDPOINT_PAYLOAD_REQUESTS_ERRORS(
+      "endpoint_payload.requests_errors", Endpoint.class, ErrorType.class),
+  /** The number of payloads dropped after all retries */
+  ENDPOINT_PAYLOAD_DROPPED("endpoint_payload.dropped", Endpoint.class),
+  /** The number of git commands executed */
+  GIT_COMMAND("git.command", Command.class),
+  /** The number of git command that errored */
+  GIT_COMMAND_ERRORS("git.command_errors", Command.class, ExitCode.class),
+  /** The number of requests sent to the search commit endpoint */
+  GIT_REQUESTS_SEARCH_COMMITS("git_requests.search_commits"),
+  /** The number of search commit requests sent to the endpoint that errored */
+  GIT_REQUESTS_SEARCH_COMMITS_ERRORS("git_requests.search_commits_errors", ErrorType.class),
+  /** The number of requests sent to the git object pack endpoint */
+  GIT_REQUESTS_OBJECTS_PACK("git_requests.objects_pack"),
+  /** The number of git object pack requests sent to the endpoint that errored */
+  GIT_REQUESTS_OBJECTS_PACK_ERRORS("git_requests.objects_pack_errors", ErrorType.class),
+  /** The number of requests sent to the settings endpoint, regardless of success */
+  GIT_REQUESTS_SETTINGS("git_requests.settings"),
+  /** The number of settings requests sent to the endpoint that errored */
+  GIT_REQUESTS_SETTINGS_ERRORS("git_requests.settings_errors", ErrorType.class),
+  /** The number of settings responses from the endpoint */
+  GIT_REQUESTS_SETTINGS_RESPONSE(
+      "git_requests.settings_response",
+      ItrEnabled.class,
+      ItrSkipEnabled.class,
+      CoverageEnabled.class,
+      RequireGit.class),
+  /** The number of requests sent to the itr skippable tests endpoint */
+  ITR_SKIPPABLE_TESTS_REQUEST("itr_skippable_tests.request"),
+  /** The number of itr skippable tests requests sent to the endpoint that errored */
+  ITR_SKIPPABLE_TESTS_REQUEST_ERRORS("itr_skippable_tests.request_errors", ErrorType.class),
+  /** The number of tests to skip returned by the endpoint */
+  ITR_SKIPPABLE_TESTS_RESPONSE_TESTS("itr_skippable_tests.response_tests"),
+  /** The number of tests or test suites skipped */
+  ITR_SKIPPED("itr_skipped", EventType.class),
+  /** The number of tests or test suites that are seen as unskippable */
+  ITR_UNSKIPPABLE("itr_unskippable", EventType.class),
+  /**
+   * The number of tests or test suites that would've been skipped by ITR but were forced to run
+   * because of their unskippable status
+   */
+  ITR_FORCED_RUN("itr_forced_run", EventType.class),
+  /** The number of successfully collected code coverages that are empty */
+  CODE_COVERAGE_IS_EMPTY("code_coverage.is_empty"),
+  /** The number of errors while processing code coverage */
+  CODE_COVERAGE_ERRORS("code_coverage.errors");
+
+  // need a "holder" class, as accessing static fields from enum constructors is illegal
+  static class IndexHolder {
+    private static int INDEX = 0;
+  }
+
+  private final String name;
+  private final int index;
+  private final Class<? extends TagValue>[] tags;
+  private final TagValue[][] tagValues;
+  private final int[] tagIdxMultipliers;
+
+  @SafeVarargs
+  CiVisibilityCountMetric(String metricName, Class<? extends TagValue>... metricTags) {
+    name = metricName;
+    index = IndexHolder.INDEX;
+    tags = metricTags;
+
+    tagValues = new TagValue[tags.length][];
+    for (int i = 0; i < tags.length; i++) {
+      // getEnumConstants() creates a new copy of the array each time it is called, so "caching" the
+      // results in a field
+      tagValues[i] = tags[i].getEnumConstants();
+    }
+
+    tagIdxMultipliers = new int[tags.length];
+    if (tags.length != 0) {
+      tagIdxMultipliers[0] = 1;
+    }
+    for (int i = 1; i < tags.length; i++) {
+      tagIdxMultipliers[i] =
+          tagIdxMultipliers[i - 1]
+              * (tagValues[i - 1].length + 1); // +1 to account for "no value" (omitted tag)
+    }
+
+    IndexHolder.INDEX = getEndIndex();
+  }
+
+  String getName() {
+    return name;
+  }
+
+  Class<? extends TagValue>[] getTags() {
+    return tags;
+  }
+
+  int getEndIndex() {
+    int delta =
+        tagValues.length > 0
+            ? (tagIdxMultipliers[tagIdxMultipliers.length - 1]
+                * (tagValues[tagValues.length - 1].length + 1))
+            : 1;
+    return index + delta;
+  }
+
+  CiVisibilityMetricData createData(long value, TagValue... tagValues) {
+    return new CiVisibilityMetricData(name, CiVisibilityMetricData.Type.COUNT, value, tagValues);
+  }
+
+  int getIndex(TagValue... tagValues) {
+    int index = this.index;
+    for (TagValue tagValue : tagValues) {
+      index += calculateIdxDelta(tagValue);
+    }
+    return index;
+  }
+
+  private int calculateIdxDelta(TagValue tagValue) {
+    Class<? extends TagValue> tag = tagValue.getDeclaringClass();
+    for (int i = 0; i < tags.length; i++) {
+      if (tag == tags[i]) {
+        return tagIdxMultipliers[i]
+            * (tagValue.ordinal() + 1); // +1 to account for "no value" (omitted tag)
+      }
+    }
+    throw new IllegalArgumentException(
+        "Metric "
+            + name()
+            + " cannot be tagged with "
+            + tag.getSimpleName()
+            + ", allowed tags are "
+            + Arrays.toString(tags));
+  }
+
+  TagValue[] getTagValues(int index) {
+    int tagValueIdx = 0;
+    TagValue[] values = new TagValue[tags.length];
+
+    index -= this.index;
+    for (int i = 0; i < tags.length; i++) {
+      TagValue[] possibleValues = tagValues[i];
+      int tagCardinality = possibleValues.length + 1; // +1 to account for "no value" (omitted tag)
+      int tagOrdinal = index % tagCardinality;
+      // we use 0 to show absence of tag
+      if (tagOrdinal != 0) {
+        tagOrdinal--; // going back from 1-based to 0-based
+        values[tagValueIdx++] = possibleValues[tagOrdinal];
+      }
+      index /= tagCardinality;
+    }
+
+    return tagValueIdx == values.length ? values : Arrays.copyOf(values, tagValueIdx);
+  }
+
+  static int count() {
+    return IndexHolder.INDEX;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
@@ -1,0 +1,73 @@
+package datadog.trace.api.civisibility.telemetry;
+
+import datadog.trace.api.civisibility.telemetry.tag.Command;
+import datadog.trace.api.civisibility.telemetry.tag.Endpoint;
+import java.util.Arrays;
+
+public enum CiVisibilityDistributionMetric {
+
+  /** The size in bytes of the serialized payload */
+  ENDPOINT_PAYLOAD_BYTES("endpoint_payload.bytes", Endpoint.class),
+  /** The time it takes to send the payload sent to the endpoint in ms */
+  ENDPOINT_PAYLOAD_REQUESTS_MS("endpoint_payload.requests_ms", Endpoint.class),
+  /** The number of events included in the payload */
+  ENDPOINT_PAYLOAD_EVENTS_COUNT("endpoint_payload.events_count", Endpoint.class),
+  /** The time it takes to serialize the payload */
+  ENDPOINT_PAYLOAD_EVENTS_SERIALIZATION_MS(
+      "endpoint_payload.events_serialization_ms", Endpoint.class),
+  /** The time it takes to execute a git command */
+  GIT_COMMAND_MS("git.command_ms", Command.class),
+  /** The time it takes to get the response of the search commit request in ms */
+  GIT_REQUESTS_SEARCH_COMMITS_MS("git_requests.search_commits_ms"),
+  /** The time it takes to get the response of the git object pack request in ms */
+  GIT_REQUESTS_OBJECTS_PACK_MS("git_requests.objects_pack_ms"),
+  /** The sum of the sizes of the object pack files inside a single payload */
+  GIT_REQUESTS_OBJECTS_PACK_BYTES("git_requests.objects_pack_bytes"),
+  /** The number of files sent in the object pack payload */
+  GIT_REQUESTS_OBJECTS_PACK_FILES("git_requests.objects_pack_files"),
+  /** The time it takes to get the response of the settings endpoint request in ms */
+  GIT_REQUESTS_SETTINGS_MS("git_requests.settings_ms"),
+  /** The time it takes to get the response of the itr skippable tests endpoint request in ms */
+  ITR_SKIPPABLE_TESTS_REQUEST_MS("itr_skippable_tests.request_ms"),
+  /** The number of bytes received by the skippable tests endpoint */
+  ITR_SKIPPABLE_TESTS_RESPONSE_BYTES("itr_skippable_tests.response_bytes"),
+  /** The number of files covered inside a coverage payload */
+  CODE_COVERAGE_FILES("code_coverage.files");
+
+  private final String name;
+  private final Class<? extends TagValue>[] tags;
+
+  @SafeVarargs
+  CiVisibilityDistributionMetric(String metricName, Class<? extends TagValue>... metricTags) {
+    name = metricName;
+    tags = metricTags;
+  }
+
+  String getName() {
+    return name;
+  }
+
+  CiVisibilityMetricData createData(long value, TagValue... tagValues) {
+    for (TagValue tagValue : tagValues) {
+      assertValid(tagValue);
+    }
+    return new CiVisibilityMetricData(
+        name, CiVisibilityMetricData.Type.DISTRIBUTION, value, tagValues);
+  }
+
+  private void assertValid(TagValue tagValue) {
+    Class<? extends TagValue> tag = tagValue.getDeclaringClass();
+    for (Class<? extends TagValue> aClass : tags) {
+      if (tag == aClass) {
+        return;
+      }
+    }
+    throw new IllegalArgumentException(
+        "Metric "
+            + name()
+            + " cannot be tagged with "
+            + tag.getSimpleName()
+            + ", allowed tags are "
+            + Arrays.toString(tags));
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityMetricCollector.java
@@ -1,0 +1,105 @@
+package datadog.trace.api.civisibility.telemetry;
+
+import datadog.trace.api.telemetry.MetricCollector;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+public class CiVisibilityMetricCollector implements MetricCollector<CiVisibilityMetricData> {
+
+  private static final int COUNTER_CARD_SIZE = 64;
+  private static final CiVisibilityMetricCollector INSTANCE = new CiVisibilityMetricCollector();
+
+  public static CiVisibilityMetricCollector getInstance() {
+    return INSTANCE;
+  }
+
+  private final BlockingQueue<CiVisibilityMetricData> rawMetricsQueue;
+  private final AtomicLongArray counters;
+  /**
+   * Cards are used to avoid iterating over the entire {@link CiVisibilityMetricCollector#counters}
+   * array every time {@link CiVisibilityMetricCollector#prepareMetrics} is called.
+   *
+   * <p>Every card corresponds to {@link CiVisibilityMetricCollector#COUNTER_CARD_SIZE} elements of
+   * the counters array. If a card is "dirty" (set to {@code true}), it means one or more of the
+   * counters that it "covers" was modified. If it is not, then none of the corresponding counters
+   * were touched, and iterating that part of the array can be skipped.
+   */
+  private final AtomicBoolean[] counterDirtyCards;
+
+  CiVisibilityMetricCollector() {
+    this(new ArrayBlockingQueue<>(RAW_QUEUE_SIZE), CiVisibilityCountMetric.count());
+  }
+
+  CiVisibilityMetricCollector(
+      final BlockingQueue<CiVisibilityMetricData> rawMetricsQueue, final int countersTotal) {
+    this.rawMetricsQueue = rawMetricsQueue;
+    this.counters = new AtomicLongArray(countersTotal);
+
+    counterDirtyCards = new AtomicBoolean[(countersTotal - 1) / COUNTER_CARD_SIZE + 1];
+    for (int i = 0; i < counterDirtyCards.length; i++) {
+      counterDirtyCards[i] = new AtomicBoolean(false);
+    }
+  }
+
+  public void add(CiVisibilityDistributionMetric metric, long value, TagValue... tags) {
+    CiVisibilityMetricData metricData = metric.createData(value, tags);
+    rawMetricsQueue.add(metricData);
+  }
+
+  public void add(CiVisibilityCountMetric metric, long value, TagValue... tags) {
+    int counterIdx = metric.getIndex(tags);
+    counters.getAndAdd(counterIdx, value);
+
+    int dirtyCardIdx = counterIdx / COUNTER_CARD_SIZE;
+    counterDirtyCards[dirtyCardIdx].set(true);
+  }
+
+  @Override
+  public void prepareMetrics() {
+    int metricIdx = 0;
+    CiVisibilityCountMetric[] countMetrics = CiVisibilityCountMetric.values();
+
+    for (int dirtyCardIdx = 0; dirtyCardIdx < counterDirtyCards.length; dirtyCardIdx++) {
+      boolean dirty = counterDirtyCards[dirtyCardIdx].getAndSet(false);
+      if (!dirty) {
+        // none of the counters in this card was touched
+        continue;
+      }
+
+      int beginIdx = dirtyCardIdx * COUNTER_CARD_SIZE;
+      int endIdx = Math.min(beginIdx + COUNTER_CARD_SIZE, counters.length());
+      for (int counterIdx = beginIdx; counterIdx < endIdx; counterIdx++) {
+        while (countMetrics[metricIdx].getEndIndex() <= counterIdx) {
+          metricIdx++;
+        }
+
+        long counter = counters.getAndSet(counterIdx, 0);
+        if (counter == 0) {
+          continue;
+        }
+
+        TagValue[] tagValues = countMetrics[metricIdx].getTagValues(counterIdx);
+        CiVisibilityMetricData metricData = countMetrics[metricIdx].createData(counter, tagValues);
+        if (!rawMetricsQueue.offer(metricData)) {
+          return;
+        }
+      }
+    }
+  }
+
+  @Override
+  public Collection<CiVisibilityMetricData> drain() {
+    if (!this.rawMetricsQueue.isEmpty()) {
+      List<CiVisibilityMetricData> drained = new ArrayList<>(this.rawMetricsQueue.size());
+      this.rawMetricsQueue.drainTo(drained);
+      return drained;
+    }
+    return Collections.emptyList();
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityMetricData.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityMetricData.java
@@ -1,0 +1,35 @@
+package datadog.trace.api.civisibility.telemetry;
+
+import datadog.trace.api.telemetry.MetricCollector;
+
+public class CiVisibilityMetricData extends MetricCollector.Metric {
+
+  enum Type {
+    COUNT,
+    DISTRIBUTION;
+
+    private final String typeName;
+
+    Type() {
+      this.typeName = name().toLowerCase();
+    }
+
+    public String getTypeName() {
+      return typeName;
+    }
+  }
+
+  private static final String NAMESPACE = "civisibility";
+
+  CiVisibilityMetricData(String metricName, Type type, long counter, TagValue... tags) {
+    super(NAMESPACE, true, metricName, type.getTypeName(), counter, stringify(tags));
+  }
+
+  private static String[] stringify(TagValue... tags) {
+    String[] tagStrings = new String[tags.length];
+    for (int i = 0; i < tags.length; i++) {
+      tagStrings[i] = tags[i].asString();
+    }
+    return tagStrings;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/TagValue.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/TagValue.java
@@ -1,0 +1,12 @@
+package datadog.trace.api.civisibility.telemetry;
+
+public interface TagValue {
+
+  String asString();
+
+  /** see {@link Enum#getDeclaringClass()} */
+  Class<? extends TagValue> getDeclaringClass();
+
+  /** see {@link Enum#ordinal()} */
+  int ordinal();
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/Command.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/Command.java
@@ -1,0 +1,25 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** The type of Git command that was executed. */
+public enum Command implements TagValue {
+  GET_REPOSITORY,
+  GET_BRANCH,
+  CHECK_SHALLOW,
+  UNSHALLOW,
+  GET_LOCAL_COMMITS,
+  GET_OBJECTS,
+  PACK_OBJECTS;
+
+  private final String s;
+
+  Command() {
+    s = "command:" + name().toLowerCase();
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/CoverageEnabled.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/CoverageEnabled.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether remote settings response has code coverage enabled */
+public enum CoverageEnabled implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "coverage_enabled:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/Endpoint.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/Endpoint.java
@@ -1,0 +1,20 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** The type of endpoint where a request is sent */
+public enum Endpoint implements TagValue {
+  TEST_CYCLE,
+  CODE_COVERAGE;
+
+  private final String s;
+
+  Endpoint() {
+    s = "endpoint:" + name().toLowerCase();
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ErrorType.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ErrorType.java
@@ -1,0 +1,22 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** The type of HTTP request error */
+public enum ErrorType implements TagValue {
+  TIMEOUT,
+  NETWORK,
+  STATUS_CODE_4XX_RESPONSE,
+  STATUS_CODE_5XX_RESPONSE;
+
+  private final String s;
+
+  ErrorType() {
+    s = "error_type:" + name().toLowerCase();
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/EventType.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/EventType.java
@@ -1,0 +1,22 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** The type of test event */
+public enum EventType implements TagValue {
+  TEST,
+  SUITE,
+  MODULE,
+  SESSION;
+
+  private final String s;
+
+  EventType() {
+    s = "event_type:" + name().toLowerCase();
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ExitCode.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ExitCode.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** The exit code of a shell command execution */
+public enum ExitCode implements TagValue {
+  NON_ZERO;
+
+  @Override
+  public String asString() {
+    return "exit_code:1";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/HasCodeowner.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/HasCodeowner.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether CODEOWNERS file could be located when executing a test session */
+public enum HasCodeowner implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "has_codeowner:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/IsBenchmark.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/IsBenchmark.java
@@ -1,0 +1,15 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/**
+ * Whether a test case is a benchmark (that is a test cases of a benchmarking framework, e.g. JMH).
+ */
+public enum IsBenchmark implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "is_benchmark:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/IsUnsupportedCI.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/IsUnsupportedCI.java
@@ -1,0 +1,17 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/**
+ * Whether a test session executes in an unsupported CI provider. "Supporting" means extracting run
+ * metadata (Git and pipeline info) from environment variables (see {@code
+ * datadog.trace.civisibility.ci.CIProviderInfo} implementations for list of supported providers).
+ */
+public enum IsUnsupportedCI implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "is_unsupported_ci:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ItrEnabled.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ItrEnabled.java
@@ -1,0 +1,16 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/**
+ * Whether remote settings response has ITR enabled (ITR can be enabled, while skipping is disabled
+ * if we're running on a default branch)
+ */
+public enum ItrEnabled implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "itr_enabled:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ItrSkipEnabled.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ItrSkipEnabled.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether remote settings response has ITR skipping enabled */
+public enum ItrSkipEnabled implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "itrskip_enabled:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/Library.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/Library.java
@@ -1,0 +1,20 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** The type of code-coverage library used */
+public enum Library implements TagValue {
+  CUSTOM,
+  JACOCO;
+
+  private final String s;
+
+  Library() {
+    s = "library:" + name().toLowerCase();
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/RequireGit.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/RequireGit.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether remote settings response has "wait for Git upload to finish" flag enabled */
+public enum RequireGit implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "require_git:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/TestFramework.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/TestFramework.java
@@ -1,0 +1,26 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** The type of test framework used */
+public enum TestFramework implements TagValue {
+  JUNIT4,
+  JUNIT5,
+  TESTNG,
+  SPOCK,
+  CUCUMBER,
+  MUNIT,
+  SCALATEST,
+  KARATE;
+
+  private final String s;
+
+  TestFramework() {
+    s = "test_framework:" + name().toLowerCase();
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetricTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetricTest.groovy
@@ -1,0 +1,72 @@
+package datadog.trace.api.civisibility.telemetry
+
+import spock.lang.Specification
+
+import java.util.stream.Collectors
+
+class CiVisibilityCountMetricTest extends Specification {
+
+  /**
+   * This test enumerates every possible combination of tags for every metric (including omitting tags),
+   * and for every combination it verifies the following:
+   * <ul>
+   *  <li>that it maps to a unique index (meaning no other combination maps to the same index)</li>
+   *  <li>that tags that were used to compute the index can be derived from the index value</li>
+   * </ul>
+   */
+  def "test metric indices"() {
+    setup:
+    Map<Integer, TagValue[]> indices = new HashMap<>()
+
+    expect:
+    for (CiVisibilityCountMetric metric : CiVisibilityCountMetric.values()) {
+      def metricTags = metric.getTags()
+      // iterate over all possible combinations of metric tags
+      for (TagValue[] tags : cartesianProduct(metricTags)) {
+        def index = metric.getIndex(tags)
+        def existingTags = indices.put(index, tags)
+        if (existingTags != null) {
+          // verify that every metric+tags combination maps to a unique index
+          throw new AssertionError("Index $index maps both to ${getTagsDescription(tags)} and to ${getTagsDescription(existingTags)}")
+        }
+
+        def tagValues = metric.getTagValues(index)
+        if (tagValues != tags) {
+          // verify that getting tag values by index returns the exact same value that were used for index calculation
+          throw new AssertionError("Original tags ${getTagsDescription(tags)} are not equal to tags calculated from index $index: ${getTagsDescription(tagValues)}")
+        }
+      }
+    }
+  }
+
+  private Collection<TagValue[]> cartesianProduct(Class<? extends TagValue>[] sets) {
+    Collection<TagValue[]> tuples = new ArrayList<>()
+    cartesianProductBacktrack(sets, tuples, new ArrayDeque<>(), 0)
+    return tuples
+  }
+
+  private void cartesianProductBacktrack(Class<? extends TagValue>[] sets, Collection<TagValue[]> tuples, Deque<TagValue> currentTuple, int offset) {
+    if (offset == sets.length) {
+      int idx = 0
+      TagValue[] tuple = new TagValue[currentTuple.size()]
+      for (TagValue element : currentTuple) {
+        tuple[tuple.length - ++idx] = element
+      }
+      tuples.add(tuple)
+      return
+    }
+
+    // a branch where we omit current tag
+    cartesianProductBacktrack(sets, tuples, currentTuple, offset + 1)
+
+    for (TagValue element : sets[offset].getEnumConstants()) {
+      currentTuple.push(element)
+      cartesianProductBacktrack(sets, tuples, currentTuple, offset + 1)
+      currentTuple.pop()
+    }
+  }
+
+  private static String getTagsDescription(TagValue[] tags) {
+    return "[" + Arrays.stream(tags).map(tag -> "${tag.getDeclaringClass().getSimpleName()}($tag)").collect(Collectors.joining(",")) + "]"
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/civisibility/telemetry/CiVisibilityMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/civisibility/telemetry/CiVisibilityMetricCollectorTest.groovy
@@ -1,0 +1,232 @@
+package datadog.trace.api.civisibility.telemetry
+
+import datadog.trace.api.civisibility.telemetry.tag.Endpoint
+import datadog.trace.api.civisibility.telemetry.tag.EventType
+import datadog.trace.api.civisibility.telemetry.tag.Library
+import spock.lang.Specification
+
+class CiVisibilityMetricCollectorTest extends Specification {
+
+  def "test distribution metric submission"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_BYTES, 123, Endpoint.CODE_COVERAGE)
+    collector.prepareMetrics()
+    def metrics = collector.drain()
+
+    then:
+    metrics == [
+      new CiVisibilityMetricData(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_BYTES.getName(), CiVisibilityMetricData.Type.DISTRIBUTION, 123, Endpoint.CODE_COVERAGE)
+    ]
+  }
+
+  def "test distribution metrics are not aggregated"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_BYTES, 123, Endpoint.CODE_COVERAGE)
+    collector.add(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_BYTES, 456, Endpoint.CODE_COVERAGE)
+    collector.prepareMetrics()
+    def metrics = collector.drain()
+
+    then:
+    metrics == [
+      new CiVisibilityMetricData(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_BYTES.getName(), CiVisibilityMetricData.Type.DISTRIBUTION, 123, Endpoint.CODE_COVERAGE),
+      new CiVisibilityMetricData(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_BYTES.getName(), CiVisibilityMetricData.Type.DISTRIBUTION, 456, Endpoint.CODE_COVERAGE)
+    ]
+  }
+
+  def "test count metric submission"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS, 123)
+    collector.prepareMetrics()
+    def metrics = collector.drain()
+
+    then:
+    metrics == [
+      new CiVisibilityMetricData(
+      CiVisibilityCountMetric.CODE_COVERAGE_ERRORS.getName(),
+      CiVisibilityMetricData.Type.COUNT,
+      123)
+    ]
+  }
+
+  def "test count metric aggregation"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS, 123)
+    collector.add(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS, 123)
+    collector.prepareMetrics()
+    def metrics = collector.drain()
+
+    then:
+    metrics == [
+      new CiVisibilityMetricData(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS.getName(), CiVisibilityMetricData.Type.COUNT, 246)
+    ]
+  }
+
+  def "test count metrics submitted in different cycles are not aggregated"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS, 123)
+    collector.prepareMetrics()
+
+    collector.add(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS, 123)
+    collector.prepareMetrics()
+
+    def metrics = collector.drain()
+
+    then:
+    metrics == [
+      new CiVisibilityMetricData(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS.getName(), CiVisibilityMetricData.Type.COUNT, 246),
+      new CiVisibilityMetricData(CiVisibilityCountMetric.CODE_COVERAGE_ERRORS.getName(), CiVisibilityMetricData.Type.COUNT, 246)
+    ]
+  }
+
+  def "test count metrics with different tags are not aggregated"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityCountMetric.ITR_FORCED_RUN, 123, EventType.MODULE)
+    collector.add(CiVisibilityCountMetric.ITR_FORCED_RUN, 456, EventType.SESSION)
+    collector.prepareMetrics()
+
+    def metrics = collector.drain()
+
+    then:
+    metrics == [
+      new CiVisibilityMetricData(CiVisibilityCountMetric.ITR_FORCED_RUN.getName(), CiVisibilityMetricData.Type.COUNT, 123, EventType.MODULE),
+      new CiVisibilityMetricData(CiVisibilityCountMetric.ITR_FORCED_RUN.getName(), CiVisibilityMetricData.Type.COUNT, 456, EventType.SESSION)
+    ]
+  }
+
+  def "test different count metrics are not aggregated"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityCountMetric.ITR_FORCED_RUN, 123, EventType.MODULE)
+    collector.add(CiVisibilityCountMetric.ITR_SKIPPED, 456, EventType.MODULE)
+    collector.prepareMetrics()
+
+    def metrics = collector.drain()
+
+    then:
+    metrics.size() == 2
+    metrics.contains(new CiVisibilityMetricData(CiVisibilityCountMetric.ITR_FORCED_RUN.getName(), CiVisibilityMetricData.Type.COUNT, 123, EventType.MODULE))
+    metrics.contains(new CiVisibilityMetricData(CiVisibilityCountMetric.ITR_SKIPPED.getName(), CiVisibilityMetricData.Type.COUNT, 456, EventType.MODULE))
+  }
+
+  def "test exception is thrown when a distribution metric is tagged with a tag that is not allowed for it"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityDistributionMetric.GIT_COMMAND_MS, 123, Library.JACOCO)
+
+    then:
+    thrown IllegalArgumentException
+  }
+
+  def "test exception is thrown when a count metric is tagged with a tag that is not allowed for it"() {
+    setup:
+    def collector = new CiVisibilityMetricCollector()
+
+    when:
+    collector.add(CiVisibilityCountMetric.ITR_FORCED_RUN, 123, Library.JACOCO)
+
+    then:
+    thrown IllegalArgumentException
+  }
+
+  /**
+   * This test enumerates all possible metric+tags variants,
+   * then tries submitting all possible variant pairs (combinations of 2 different metric+tags).
+   * The goal is to ensure that index calculation logic and card-marking are done right.
+   */
+  def "test submission of all possible count metric pairs"() {
+    setup:
+    List<PossibleMetric> possibleMetrics = []
+
+    for (CiVisibilityCountMetric metric : CiVisibilityCountMetric.values()) {
+      def metricTags = metric.getTags()
+      // iterate over all possible combinations of metric tags
+      for (TagValue[] tags : cartesianProduct(metricTags)) {
+        possibleMetrics += new PossibleMetric(metric, tags)
+      }
+    }
+
+    def collector = new CiVisibilityMetricCollector()
+
+    expect:
+    for (int i = 0; i < possibleMetrics.size() - 1; i++) {
+      def firstMetric = possibleMetrics.get(i)
+      for (int j = i + 1; j < possibleMetrics.size(); j++) {
+        def secondMetric = possibleMetrics.get(j)
+
+        // deriving metric values from indices (as indices are unique, it's convenient to check that every metric has the correct value when drained)
+        // +1 is needed because 0 cannot be used as a metric value - metrics with value 0 are not submitted
+        int firstMetricValue = i + 1
+        int secondMetricValue = j + 1
+
+        collector.add(firstMetric.metric, firstMetricValue, firstMetric.tags)
+        collector.add(secondMetric.metric, secondMetricValue, secondMetric.tags)
+        collector.prepareMetrics()
+
+        def metrics = collector.drain()
+        assert metrics.size() == 2
+        assert metrics.contains(new CiVisibilityMetricData(firstMetric.metric.getName(), CiVisibilityMetricData.Type.COUNT, firstMetricValue, firstMetric.tags))
+        assert metrics.contains(new CiVisibilityMetricData(secondMetric.metric.getName(), CiVisibilityMetricData.Type.COUNT, secondMetricValue, secondMetric.tags))
+      }
+    }
+  }
+
+  private Collection<TagValue[]> cartesianProduct(Class<? extends TagValue>[] sets) {
+    Collection<TagValue[]> tuples = new ArrayList<>()
+    cartesianProductBacktrack(sets, tuples, new ArrayDeque<>(), 0)
+    return tuples
+  }
+
+  private void cartesianProductBacktrack(Class<? extends TagValue>[] sets, Collection<TagValue[]> tuples, Deque<TagValue> currentTuple, int offset) {
+    if (offset == sets.length) {
+      int idx = 0
+      TagValue[] tuple = new TagValue[currentTuple.size()]
+      for (TagValue element : currentTuple) {
+        tuple[tuple.length - ++idx] = element
+      }
+      tuples.add(tuple)
+      return
+    }
+
+    // a branch where we omit current tag
+    cartesianProductBacktrack(sets, tuples, currentTuple, offset + 1)
+
+    for (TagValue element : sets[offset].getEnumConstants()) {
+      currentTuple.push(element)
+      cartesianProductBacktrack(sets, tuples, currentTuple, offset + 1)
+      currentTuple.pop()
+    }
+  }
+
+  private static final class PossibleMetric {
+    private final CiVisibilityCountMetric metric
+    private final TagValue[] tags
+
+    PossibleMetric(CiVisibilityCountMetric metric, TagValue[] tags) {
+      this.metric = metric
+      this.tags = tags
+    }
+  }
+
+}

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -7,6 +7,7 @@ import datadog.telemetry.dependency.DependencyPeriodicAction;
 import datadog.telemetry.dependency.DependencyService;
 import datadog.telemetry.integration.IntegrationPeriodicAction;
 import datadog.telemetry.log.LogPeriodicAction;
+import datadog.telemetry.metric.CiVisibilityMetricPeriodicAction;
 import datadog.telemetry.metric.CoreMetricsPeriodicAction;
 import datadog.telemetry.metric.IastMetricPeriodicAction;
 import datadog.telemetry.metric.WafMetricPeriodicAction;
@@ -51,6 +52,9 @@ public class TelemetrySystem {
       actions.add(new WafMetricPeriodicAction());
       if (Verbosity.OFF != Config.get().getIastTelemetryVerbosity()) {
         actions.add(new IastMetricPeriodicAction());
+      }
+      if (Config.get().isCiVisibilityEnabled() && Config.get().isCiVisibilityTelemetryEnabled()) {
+        actions.add(new CiVisibilityMetricPeriodicAction());
       }
     }
     if (null != dependencyService) {

--- a/telemetry/src/main/java/datadog/telemetry/metric/CiVisibilityMetricPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/CiVisibilityMetricPeriodicAction.java
@@ -1,0 +1,13 @@
+package datadog.telemetry.metric;
+
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.api.telemetry.MetricCollector;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class CiVisibilityMetricPeriodicAction extends MetricPeriodicAction {
+  @NonNull
+  @Override
+  public MetricCollector collector() {
+    return CiVisibilityMetricCollector.getInstance();
+  }
+}


### PR DESCRIPTION
# What Does This Do
Implements telemetry mechanism for CI Visibility logic.

# Motivation
To have better observability of CI Visibility behaviour.

# Additional Notes
This PR only contains the generic logic for submitting and aggregating metrics. Actual metric invocations will be added in subsequent PRs.

Jira ticket: [CIVIS-2427]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ