### PR TITLE
Fix dynamic invoke for string concat in IBM J9

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/src/main/java/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/src/main/java/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSite.java
@@ -43,7 +43,7 @@ public class StringConcatFactoryCallSite {
       @CallSite.Argument final String name,
       @CallSite.Argument final MethodType concatType,
       @CallSite.Argument final String recipe,
-      @CallSite.Argument final Object[] constants)
+      @CallSite.Argument final Object... constants)
       throws StringConcatException {
     if (INSTRUMENTATION_BRIDGE == null) {
       return makeConcatWithConstants(lookup, name, concatType, recipe, constants);

--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/groovy/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/groovy/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSiteTest.groovy
@@ -1,23 +1,12 @@
 package datadog.trace.instrumentation.java.lang.invoke
 
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.api.Platform
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.propagation.StringModule
 import foo.bar.TestStringConcatFactorySuite
-import groovy.transform.CompileDynamic
-import spock.lang.IgnoreIf
-import spock.lang.Requires
 
 import static foo.bar.TestStringConcatFactorySuite.stringPlusWithPrimitive
 
-@Requires({
-  jvm.java9Compatible
-})
-@IgnoreIf(reason = "https://github.com/DataDog/dd-trace-java/issues/5715", value = {
-  Platform.isJ9()
-})
-@CompileDynamic
 class StringConcatFactoryCallSiteTest extends AgentTestRunner {
 
   @Override


### PR DESCRIPTION
# What Does This Do
Fixes call sites for string concat factory in IBM J9

# Additional Notes

Jira ticket: [APPSEC-10807]



[APPSEC-10807]: https://datadoghq.atlassian.net/browse/APPSEC-10807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ