### PR TITLE
Remote Config. Add target service+env check.

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -76,6 +76,25 @@ final class TracingConfigPoller {
               Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
 
       if (null != overrides && null != overrides.libConfig) {
+        ServiceTarget serviceTarget = overrides.serviceTarget;
+        if (serviceTarget != null) {
+          String targetService = serviceTarget.service;
+          String thisService = Config.get().getServiceName();
+          if (targetService != null && !targetService.equalsIgnoreCase(thisService)) {
+            log.debug(
+                "Skipping config for service {}. Current service is {}",
+                targetService,
+                thisService);
+            throw new IllegalArgumentException("service mismatch");
+          }
+          String targetEnv = serviceTarget.env;
+          String thisEnv = Config.get().getEnv();
+          if (targetEnv != null && !targetEnv.equalsIgnoreCase(thisEnv)) {
+            log.debug("Skipping config for env {}. Current env is {}", targetEnv, thisEnv);
+            throw new IllegalArgumentException("env mismatch");
+          }
+        }
+
         receivedOverrides = true;
         applyConfigOverrides(overrides.libConfig);
         if (log.isDebugEnabled()) {
@@ -145,8 +164,19 @@ final class TracingConfigPoller {
   }
 
   static final class ConfigOverrides {
+    @Json(name = "service_target")
+    public ServiceTarget serviceTarget;
+
     @Json(name = "lib_config")
     public LibConfig libConfig;
+  }
+
+  static final class ServiceTarget {
+    @Json(name = "service")
+    public String service;
+
+    @Json(name = "env")
+    public String env;
   }
 
   static final class LibConfig {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -438,6 +438,134 @@ class CoreTracerTest extends DDCoreSpecification {
     null      | "test"
     "some"    | "some"
   }
+
+  def "reject configuration when target service+env mismatch"() {
+    setup:
+    injectSysConfig(SERVICE_NAME, service)
+    injectSysConfig(ENV, env)
+
+    def key = ParsedConfigKey.parse("datadog/2/APM_TRACING/config_overrides/config")
+    def poller = Mock(ConfigurationPoller)
+    def sco = new SharedCommunicationObjects(
+      okHttpClient: Mock(OkHttpClient),
+      monitoring: Mock(Monitoring),
+      agentUrl: HttpUrl.get('https://example.com'),
+      featuresDiscovery: Mock(DDAgentFeaturesDiscovery),
+      configurationPoller: poller
+      )
+
+    def updater
+
+    when:
+    def tracer = CoreTracer.builder()
+      .sharedCommunicationObjects(sco)
+      .pollForTracingConfiguration()
+      .build()
+
+    then:
+    1 * poller.addListener(Product.APM_TRACING, _ as ProductListener) >> {
+      updater = it[1] // capture config updater for further testing
+    }
+    and:
+    tracer.captureTraceConfig().serviceMapping == [:]
+
+    when:
+    updater.accept(key, """
+      {
+        "service_target": {
+          "service": "${targetService}",
+          "env": "${targetEnv}"
+        },
+        "lib_config":
+        {
+          "tracing_service_mapping":
+          [{
+             "from_key": "foobar",
+             "to_name": "bar"
+          }]
+        }
+      }
+      """.getBytes(StandardCharsets.UTF_8), null)
+    updater.commit()
+
+    then: "configuration should not be applied"
+    tracer.captureTraceConfig().serviceMapping == [:]
+    and:
+    thrown(IllegalArgumentException)
+
+    cleanup:
+    tracer?.close()
+
+    where:
+    service   | env    | targetService | targetEnv
+    "service" | "env"  | "service_1"   | "env"
+    "service" | "env"  | "service"     | "env_1"
+    "service" | "env"  | "service_2"   | "env_2"
+  }
+
+  def "accept configuration when target service+env match case-insensitive"() {
+    setup:
+    injectSysConfig(SERVICE_NAME, service)
+    injectSysConfig(ENV, env)
+
+    def key = ParsedConfigKey.parse("datadog/2/APM_TRACING/config_overrides/config")
+    def poller = Mock(ConfigurationPoller)
+    def sco = new SharedCommunicationObjects(
+      okHttpClient: Mock(OkHttpClient),
+      monitoring: Mock(Monitoring),
+      agentUrl: HttpUrl.get('https://example.com'),
+      featuresDiscovery: Mock(DDAgentFeaturesDiscovery),
+      configurationPoller: poller
+      )
+
+    def updater
+
+    when:
+    def tracer = CoreTracer.builder()
+      .sharedCommunicationObjects(sco)
+      .pollForTracingConfiguration()
+      .build()
+
+    then:
+    1 * poller.addListener(Product.APM_TRACING, _ as ProductListener) >> {
+      updater = it[1] // capture config updater for further testing
+    }
+    and:
+    tracer.captureTraceConfig().serviceMapping == [:]
+
+    when:
+    updater.accept(key, """
+      {
+        "service_target": {
+          "service": "${targetService}",
+          "env": "${targetEnv}"
+        },
+        "lib_config":
+        {
+          "tracing_service_mapping":
+          [{
+             "from_key": "foobar",
+             "to_name": "bar"
+          }]
+        }
+      }
+      """.getBytes(StandardCharsets.UTF_8), null)
+    updater.commit()
+
+    then: "configuration should be applied"
+    tracer.captureTraceConfig().serviceMapping == ["foobar":"bar"]
+
+    cleanup:
+    tracer?.close()
+
+    where:
+    service   | env   | targetService | targetEnv
+    "service" | "env" | "service"     | "env"
+    "service" | "env" | "SERVICE"     | "env"
+    "service" | "env" | "service"     | "ENV"
+    "service" | "env" | "SERVICE"     | "ENV"
+    "SERVICE" | "ENV" | "service"     | "env"
+  }
 }
 
 class ControllableSampler implements Sampler, PrioritySampler {


### PR DESCRIPTION
# What Does This Do
Add the target service and env checks.

# Motivation
Prevent remote config update if service+env doesn't match.

# Additional Notes

Jira ticket: [APMJAVA-1222]
- [ ] Enable [system test](https://github.com/DataDog/system-tests/blob/main/tests/parametric/test_dynamic_configuration.py#L265) once this PR merged
- [ ] Extends system tests to make sure that the check is case-insensitive

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1222]: https://datadoghq.atlassian.net/browse/APMJAVA-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ