### PR TITLE
Refactor hardcoded secret smoke test

### DIFF
--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/HardcodedSecretController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/HardcodedSecretController.java
@@ -1,0 +1,13 @@
+package datadog.smoketest.springboot.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HardcodedSecretController {
+
+  @RequestMapping("/hardcodedSecret")
+  public String hardcodedSecret() {
+    return "AGE-SECRET-KEY-1QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ";
+  }
+}

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -54,9 +54,6 @@ import org.xml.sax.SAXException;
 @RestController
 public class IastWebController {
 
-  private final String HARDCODED_SECRET =
-      "AGE-SECRET-KEY-1QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ";
-
   private final Resource xml;
   private final Hasher hasher;
   private final Random random;
@@ -66,11 +63,6 @@ public class IastWebController {
     hasher.sha1();
     random = new Random();
     xml = resource;
-  }
-
-  @RequestMapping("/hardcodedSecret")
-  public String hardcodedSecret() {
-    return HARDCODED_SECRET;
   }
 
   @RequestMapping("/greeting")

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -43,9 +43,9 @@ class IastSpringBootSmokeTest extends AbstractIastSpringBootTest {
     hasVulnerabilityInLogs {
       vul ->
       vul.type == 'HARDCODED_SECRET'
-      && vul.location.method == '<init>'
-      && vul.location.path == 'datadog.smoketest.springboot.controller.IastWebController'
-      && vul.location.line == 57
+      && vul.location.method == 'hardcodedSecret'
+      && vul.location.path == 'datadog.smoketest.springboot.controller.HardcodedSecretController'
+      && vul.location.line == 11
       && vul.evidence.value == 'age-secret-key'
     }
   }


### PR DESCRIPTION
# What Does This Do

Extract hardcoded secret vulnerability to another controller to avoid modify the vulnerability line in the test assertion every time the IastWebController is modified to add more vulnerability cases
