### PR TITLE
Add location to dependencies in telemetry

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRequestBody.java
@@ -256,6 +256,7 @@ public class TelemetryRequestBody extends RequestBody {
     bodyWriter.name("hash").value(d.hash); // optional
     bodyWriter.name("name").value(d.name);
     bodyWriter.name("version").value(d.version); // optional
+    bodyWriter.name("location").value(d.location); // optional
     bodyWriter.endObject();
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryServiceSpecification.groovy
@@ -301,7 +301,7 @@ class TelemetryServiceSpecification extends DDSpecification {
     bodySize > 0
 
     when: 'sending first part of data'
-    telemetryService = new TelemetryService(testHttpClient, bodySize + 500, false)
+    telemetryService = new TelemetryService(testHttpClient, bodySize + 550, false)
 
     telemetryService.addConfiguration(configuration)
     telemetryService.addIntegration(integration)

--- a/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TestTelemetryRouter.groovy
@@ -255,7 +255,7 @@ class TestTelemetryRouter extends TelemetryRouter {
     PayloadAssertions dependencies(List<Dependency> dependencies) {
       def expected = []
       for (Dependency d : dependencies) {
-        expected.add([hash: d.hash, name: d.name, version: d.version])
+        expected.add([hash: d.hash, name: d.name, version: d.version, location: d.location])
       }
       assert this.payload['dependencies'] == expected
       return this

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverQueueSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverQueueSpecification.groovy
@@ -17,7 +17,7 @@ class DependencyResolverQueueSpecification extends DepSpecification {
     assert dep != null
     assert dep.name == 'junit'
     assert dep.version == '4.12'
-    assert dep.source == 'junit-4.12.jar'
+    assert dep.location == 'junit-4.12.jar'
     assert dep.hash == '4376590587C49AC6DA6935564233F36B092412AE'
 
     when:
@@ -27,7 +27,7 @@ class DependencyResolverQueueSpecification extends DepSpecification {
     assert dep != null
     assert dep.name == 'asm-util'
     assert dep.version == '9.2'
-    assert dep.source == 'asm-util-9.2.jar'
+    assert dep.location == 'asm-util-9.2.jar'
     assert dep.hash == '9A5AEC2CB852B8BD20DAF5D2CE9174891267FE27'
 
     when:
@@ -37,7 +37,7 @@ class DependencyResolverQueueSpecification extends DepSpecification {
     assert dep != null
     assert dep.name == 'org.mongodb:bson'
     assert dep.version == '4.2.0'
-    assert dep.source == 'bson-4.2.0.jar'
+    assert dep.location == 'bson-4.2.0.jar'
     assert dep.hash == 'F87C3A90DA4BB1DA6D3A73CA18004545AD2EF06A'
 
     when:

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
@@ -10,7 +10,8 @@ class DependencyResolverSpecification extends DepSpecification {
   void 'guess groupId/artifactId from bundleSymbolicName - #jar'() {
     expect:
     knownJarCheck(
-      jarName: jar,
+      jar: jar,
+      location: jar,
       name: name,
       hash: hash,
       version: version)
@@ -24,7 +25,8 @@ class DependencyResolverSpecification extends DepSpecification {
   void 'groupId cannot be resolved #jar'() {
     expect:
     knownJarCheck(
-      jarName: jar,
+      jar: jar,
+      location: jar,
       name: name,
       hash: hash,
       version: version)
@@ -39,7 +41,8 @@ class DependencyResolverSpecification extends DepSpecification {
   void 'no version in file name'() {
     expect:
     knownJarCheck(
-      jarName: 'spring-webmvc.jar',
+      jar: 'spring-webmvc.jar',
+      location: 'spring-webmvc.jar',
       name: 'spring-webmvc',
       hash: '5B3B4AAC5C802E31BCC8517EFA9C9818EF625A0A',
       version: '3.0.0.RELEASE'
@@ -49,7 +52,8 @@ class DependencyResolverSpecification extends DepSpecification {
   void 'known jar with maven pom'() {
     expect:
     knownJarCheck(
-      jarName: 'commons-logging-1.2.jar',
+      jar: 'commons-logging-1.2.jar',
+      location: 'commons-logging-1.2.jar!/META-INF/maven/commons-logging/commons-logging/pom.properties',
       name: 'commons-logging:commons-logging',
       version: '1.2')
   }
@@ -57,7 +61,8 @@ class DependencyResolverSpecification extends DepSpecification {
   void 'known jar with manifest implementation'() {
     expect:
     knownJarCheck(
-      jarName: 'junit-4.12.jar',
+      jar: 'junit-4.12.jar',
+      location: 'junit-4.12.jar',
       name: 'junit',
       hash: '4376590587C49AC6DA6935564233F36B092412AE',
       version: '4.12')
@@ -66,7 +71,8 @@ class DependencyResolverSpecification extends DepSpecification {
   void 'known jar with manifest bundle'() {
     expect:
     knownJarCheck(
-      jarName: 'groovy-manifest.jar',
+      jar: 'groovy-manifest.jar',
+      location: 'groovy-manifest.jar',
       name: 'groovy',
       hash: '04DF0875A66F111880217FE1C5C59CA877403239',
       version: '2.4.12')
@@ -76,7 +82,8 @@ class DependencyResolverSpecification extends DepSpecification {
     // this jar has a manifest but should be resolved with its file name
     expect:
     knownJarCheck(
-      jarName: 'multiverse-core-0.7.0.jar',
+      jar: 'multiverse-core-0.7.0.jar',
+      location: 'multiverse-core-0.7.0.jar!/META-INF/maven/org.multiverse/multiverse-core/pom.properties',
       name: 'org.multiverse:multiverse-core',
       version: '0.7.0')
   }
@@ -84,7 +91,8 @@ class DependencyResolverSpecification extends DepSpecification {
   void 'no manifest info bad filename'() {
     // If no manifest info and no suitable file name - calculate sha1 hash
     knownJarCheck(
-      jarName: 'groovy-no-manifest-info.jar',
+      jar: 'groovy-no-manifest-info.jar',
+      location: 'groovy-no-manifest-info.jar',
       name: 'groovy-no-manifest-info.jar',
       version: '',
       hash: '1C1C8E5547A54F593B97584D45F3636F479B9498')
@@ -104,7 +112,7 @@ class DependencyResolverSpecification extends DepSpecification {
     dep.name == 'jakarta.inject'
     dep.version == '2.6.1'
     dep.hash == '29BBEDD4A914066F24257A78B73249900B33C656'
-    dep.source == 'jakarta.inject-2.6.1.jar'
+    dep.location == 'jakarta.inject-2.6.1.jar'
   }
 
   void 'guess artifact name from jar'() {
@@ -121,7 +129,7 @@ class DependencyResolverSpecification extends DepSpecification {
     dep.name == 'freemarker-2.3.27-incubating.jar'
     dep.version == '2.3.27'
     dep.hash == '3F476E5A287F5CE4951E2F61F3287C122C558067'
-    dep.source == 'freemarker-2.3.27-incubating.jar'
+    dep.location == 'freemarker-2.3.27-incubating.jar'
   }
 
   void 'guess artifact name from jar variant'() throws IOException {
@@ -137,7 +145,7 @@ class DependencyResolverSpecification extends DepSpecification {
     dep.name == 'hsqldb'
     dep.version == '2.3.5'
     dep.hash == 'CA0722D57F25455BA0CFCBDCA2C347941BD22601'
-    dep.source == 'hsqldb-2.3.5-jdk6debug.jar'
+    dep.location == 'hsqldb-2.3.5-jdk6debug.jar'
   }
 
   void 'try to determine lib name'() throws IOException {
@@ -184,7 +192,7 @@ class DependencyResolverSpecification extends DepSpecification {
     dep.name == 'io.opentracing:opentracing-util'
     dep.version == '0.33.0'
     dep.hash == null
-    dep.source == 'opentracing-util-0.33.0.jar'
+    dep.location == 'spring-boot-app.jar!/BOOT-INF/lib/opentracing-util-0.33.0.jar!/META-INF/maven/io.opentracing/opentracing-util/pom.properties'
   }
 
   void 'fat jar with multiple pom.properties'() throws IOException {
@@ -235,20 +243,21 @@ class DependencyResolverSpecification extends DepSpecification {
     // this jar has an invalid pom.properties and it should be resolved with its file name
     expect:
     knownJarCheck(
-      jarName: 'invalidpomproperties.jar',
+      jar: 'invalidpomproperties.jar',
+      location: 'invalidpomproperties.jar',
       name: 'invalidpomproperties.jar',
       version: '',
       hash: '6438819DAB9C9AC18D8A6922C8A923C2ADAEA85D')
   }
 
   private static void knownJarCheck(Map opts) {
-    File jarFile = getJar(opts['jarName'])
+    File jarFile = getJar(opts['jar'] as String)
     List<Dependency> deps = DependencyResolver.resolve(jarFile.toURI())
 
     assert deps.size() == 1
     Dependency dep = deps.get(0)
     assert dep != null
-    assert dep.source == opts['jarName']
+    assert dep.location == opts['location']
     assert dep.name == opts['name']
     assert dep.version == opts['version']
     assert dep.hash == opts['hash']

--- a/telemetry/src/test/java/datadog/telemetry/dependency/DependencyServiceTests.java
+++ b/telemetry/src/test/java/datadog/telemetry/dependency/DependencyServiceTests.java
@@ -100,7 +100,7 @@ public class DependencyServiceTests {
 
     assertThat(dep.name, equalTo("groovy"));
     assertThat(dep.version, equalTo("2.4.12"));
-    assertThat(dep.source, equalTo("groovy-manifest.jar"));
+    assertThat(dep.location, equalTo("groovy-manifest.jar"));
     assertThat(dep.hash, equalTo("04DF0875A66F111880217FE1C5C59CA877403239"));
   }
 
@@ -122,7 +122,7 @@ public class DependencyServiceTests {
 
     assertThat(dep.name, equalTo("junit"));
     assertThat(dep.version, equalTo("4.12"));
-    assertThat(dep.source, equalTo("junit-4.12.jar"));
+    assertThat(dep.location, equalTo("junit-4.12.jar"));
     assertThat(dep.hash, equalTo("4376590587C49AC6DA6935564233F36B092412AE"));
   }
 


### PR DESCRIPTION
# What Does This Do

Adds a `location` field to each dependency in telemetry.

The location will serve as a hint for users to understand where a dependency was found. This is currently a challenge for shaded dependencies and nested jars.

Some examples of location:

* `mydep-1.2.jar`
* `mydep.jar!/META-INF/maven/my.dep/pom.properties`
* `myapp.jar!/BOOT-INF/lib/mydep.1.2.jar`

# Motivation

# Additional Notes

Jira ticket: [APPSEC-11466](https://datadoghq.atlassian.net/browse/APPSEC-11466)

To Do:

* [ ] Wait for final approval of the schema change.

[APPSEC-11466]: https://datadoghq.atlassian.net/browse/APPSEC-11466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ