### PR TITLE
Fix issue with call site test that should not run in JDK8

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/groovy/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/java-lang-9/src/test/groovy/datadog/trace/instrumentation/java/lang/invoke/StringConcatFactoryCallSiteTest.groovy
@@ -4,9 +4,13 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.propagation.StringModule
 import foo.bar.TestStringConcatFactorySuite
+import spock.lang.Requires
 
 import static foo.bar.TestStringConcatFactorySuite.stringPlusWithPrimitive
 
+@Requires({
+  jvm.java9Compatible
+})
 class StringConcatFactoryCallSiteTest extends AgentTestRunner {
 
   @Override


### PR DESCRIPTION
# What Does This Do
Fixes the `StringConcatFactoryTest` that should not run under JDK8 that was broken due to: https://github.com/DataDog/dd-trace-java/pull/6634
