### PR TITLE
Add class filtering and exception probe conditions

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -651,6 +651,7 @@ public class CapturedContext implements ValueReferenceResolver {
   public static class CapturedThrowable {
     private final String type;
     private final String message;
+    private final transient Throwable throwable;
 
     /*
      * Need to exclude stacktrace from equals/hashCode computation.
@@ -662,13 +663,16 @@ public class CapturedContext implements ValueReferenceResolver {
       this(
           throwable.getClass().getTypeName(),
           throwable.getLocalizedMessage(),
-          captureFrames(throwable.getStackTrace()));
+          captureFrames(throwable.getStackTrace()),
+          throwable);
     }
 
-    public CapturedThrowable(String type, String message, List<CapturedStackFrame> stacktrace) {
+    public CapturedThrowable(
+        String type, String message, List<CapturedStackFrame> stacktrace, Throwable t) {
       this.type = type;
       this.message = message;
       this.stacktrace = new ArrayList<>(stacktrace);
+      this.throwable = t;
     }
 
     public String getType() {
@@ -681,6 +685,10 @@ public class CapturedContext implements ValueReferenceResolver {
 
     public List<CapturedStackFrame> getStacktrace() {
       return stacktrace;
+    }
+
+    public Throwable getThrowable() {
+      return throwable;
     }
 
     private static List<CapturedStackFrame> captureFrames(StackTraceElement[] stackTrace) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.agent;
 
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
+import static java.util.Collections.emptyList;
 
 import com.datadog.debugger.exception.DefaultExceptionDebugger;
 import com.datadog.debugger.exception.ExceptionProbeManager;
@@ -9,6 +10,7 @@ import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.symbol.SymDBEnablement;
 import com.datadog.debugger.symbol.SymbolAggregator;
 import com.datadog.debugger.uploader.BatchUploader;
+import com.datadog.debugger.util.ClassNameFiltering;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.remoteconfig.ConfigurationPoller;
@@ -61,7 +63,9 @@ public class DebuggerAgent {
             config, diagnosticEndpoint, ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics());
     DebuggerSink debuggerSink = new DebuggerSink(config, probeStatusSink);
     debuggerSink.start();
-    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager();
+    // TODO filtering out thirdparty code
+    ClassNameFiltering classNameFiltering = new ClassNameFiltering(emptyList());
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
             instrumentation,
@@ -81,7 +85,8 @@ public class DebuggerAgent {
     DebuggerContext.initTracer(new DebuggerTracer(debuggerSink.getProbeStatusSink()));
     if (config.isDebuggerExceptionEnabled()) {
       DebuggerContext.initExceptionDebugger(
-          new DefaultExceptionDebugger(exceptionProbeManager, configurationUpdater));
+          new DefaultExceptionDebugger(
+              exceptionProbeManager, configurationUpdater, classNameFiltering));
     }
     if (config.isDebuggerInstrumentTheWorld()) {
       setupInstrumentTheWorldTransformer(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -109,7 +109,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
   }
 
   // Used only for tests
-  DebuggerTransformer(Config config, Configuration configuration) {
+  public DebuggerTransformer(Config config, Configuration configuration) {
     this(
         config,
         configuration,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.exception;
 
 import com.datadog.debugger.agent.ConfigurationUpdater;
+import com.datadog.debugger.util.ClassNameFiltering;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,16 +14,20 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExceptionDebugger.class);
   private final ExceptionProbeManager exceptionProbeManager;
   private final ConfigurationUpdater configurationUpdater;
+  private final ClassNameFiltering classNameFiltering;
 
   public DefaultExceptionDebugger(
-      ExceptionProbeManager exceptionProbeManager, ConfigurationUpdater configurationUpdater) {
+      ExceptionProbeManager exceptionProbeManager,
+      ConfigurationUpdater configurationUpdater,
+      ClassNameFiltering classNameFiltering) {
     this.exceptionProbeManager = exceptionProbeManager;
     this.configurationUpdater = configurationUpdater;
+    this.classNameFiltering = classNameFiltering;
   }
 
   @Override
   public void handleException(Throwable t) {
-    String fingerprint = Fingerprinter.fingerprint(t);
+    String fingerprint = Fingerprinter.fingerprint(t, classNameFiltering);
     if (fingerprint == null) {
       LOGGER.debug("Unable to fingerprint exception", t);
       return;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.exception;
 
+import com.datadog.debugger.util.ClassNameFiltering;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import org.slf4j.Logger;
@@ -10,7 +11,7 @@ public class Fingerprinter {
   private static final Logger LOGGER = LoggerFactory.getLogger(Fingerprinter.class);
 
   // compute fingerprint of the Throwable based on the stacktrace and exception type
-  public static String fingerprint(Throwable t) {
+  public static String fingerprint(Throwable t, ClassNameFiltering classNameFiltering) {
     t = getInnerMostThrowable(t);
     if (t == null) {
       LOGGER.debug("Unable to find root cause of exception");
@@ -31,13 +32,9 @@ public class Fingerprinter {
     StackTraceElement[] stackTrace = t.getStackTrace();
     for (StackTraceElement stackTraceElement : stackTrace) {
       String className = stackTraceElement.getClassName();
-      if (className.startsWith("java.")
-          || className.startsWith("jdk.")
-          || className.startsWith("sun.")
-          || className.startsWith("com.sun.")) {
+      if (classNameFiltering.apply(className)) {
         continue;
       }
-      // TODO filter out thirdparty code
       digest.update(stackTraceElement.toString().getBytes());
     }
     byte[] bytes = digest.digest();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -81,7 +81,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
 
   @Override
   public InstrumentationResult.Status instrument() {
-    if (isLineProbe) {
+    if (definition.isLineProbe()) {
       if (!addLineCaptures(classFileLines)) {
         return InstrumentationResult.Status.ERROR;
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -8,7 +8,6 @@ import static com.datadog.debugger.instrumentation.Types.STRING_TYPE;
 
 import com.datadog.debugger.instrumentation.DiagnosticMessage.Kind;
 import com.datadog.debugger.probe.ProbeDefinition;
-import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.util.ClassFileLines;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import java.util.ArrayList;
@@ -43,7 +42,6 @@ public abstract class Instrumentor {
   protected final List<DiagnosticMessage> diagnostics;
   protected final List<ProbeId> probeIds;
   protected final boolean isStatic;
-  protected final boolean isLineProbe;
   protected final LabelNode methodEnterLabel;
   protected int localVarBaseOffset;
   protected int argOffset;
@@ -63,8 +61,6 @@ public abstract class Instrumentor {
     this.classFileLines = methodInfo.getClassFileLines();
     this.diagnostics = diagnostics;
     this.probeIds = probeIds;
-    Where.SourceLine[] sourceLines = definition.getWhere().getSourceLines();
-    isLineProbe = sourceLines != null && sourceLines.length > 0;
     isStatic = (methodNode.access & Opcodes.ACC_STATIC) != 0;
     methodEnterLabel = insertMethodEnterLabel();
     argOffset = isStatic ? 0 : 1;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -93,7 +93,7 @@ public class MetricInstrumentor extends Instrumentor {
 
   @Override
   public InstrumentationResult.Status instrument() {
-    if (isLineProbe) {
+    if (definition.isLineProbe()) {
       return addLineMetric(classFileLines);
     }
     switch (definition.getEvaluateAt()) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumentor.java
@@ -35,7 +35,7 @@ public class SpanInstrumentor extends Instrumentor {
 
   @Override
   public InstrumentationResult.Status instrument() {
-    if (isLineProbe) {
+    if (definition.isLineProbe()) {
       return addRangeSpan(classFileLines);
     }
     spanVar = newVar(DEBUGGER_SPAN_TYPE);
@@ -147,7 +147,7 @@ public class SpanInstrumentor extends Instrumentor {
 
   private String buildResourceName() {
     String resourceName = stripPackagePath(classNode.name) + "." + methodNode.name;
-    if (isLineProbe) {
+    if (definition.isLineProbe()) {
       Where.SourceLine[] targetLines = definition.getWhere().getSourceLines();
       if (targetLines == null || targetLines.length == 0) {
         return resourceName;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -1,11 +1,24 @@
 package com.datadog.debugger.probe;
 
+import static java.util.Collections.emptyList;
+
 import com.datadog.debugger.el.ProbeCondition;
+import com.datadog.debugger.exception.Fingerprinter;
+import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.util.ClassNameFiltering;
+import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import datadog.trace.bootstrap.debugger.ProbeLocation;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExceptionProbe extends LogProbe {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionProbe.class);
   private final String fingerprint;
+  private final transient ClassNameFiltering classNameFiltering;
 
   public ExceptionProbe(
       ProbeId probeId,
@@ -13,7 +26,8 @@ public class ExceptionProbe extends LogProbe {
       ProbeCondition probeCondition,
       Capture capture,
       Sampling sampling,
-      String fingerprint) {
+      String fingerprint,
+      ClassNameFiltering classNameFiltering) {
     super(
         LANGUAGE,
         probeId,
@@ -27,5 +41,81 @@ public class ExceptionProbe extends LogProbe {
         capture,
         sampling);
     this.fingerprint = fingerprint;
+    this.classNameFiltering = classNameFiltering;
+  }
+
+  public String getFingerprint() {
+    return fingerprint;
+  }
+
+  @Override
+  public boolean isLineProbe() {
+    // Exception probe are always method probe even if there is a line number
+    return false;
+  }
+
+  @Override
+  public CapturedContext.Status createStatus() {
+    return new ExceptionProbeStatus(this);
+  }
+
+  @Override
+  public void evaluate(
+      CapturedContext context, CapturedContext.Status status, MethodLocation methodLocation) {
+    if (!(status instanceof ExceptionProbeStatus)) {
+      throw new IllegalStateException("Invalid status: " + status.getClass());
+    }
+    if (methodLocation != MethodLocation.EXIT) {
+      return;
+    }
+    if (context.getThrowable() == null) {
+      return;
+    }
+    String currentFingerprint =
+        Fingerprinter.fingerprint(context.getThrowable().getThrowable(), classNameFiltering);
+    if (fingerprint.equals(currentFingerprint)) {
+      LOGGER.debug("Capturing exception matching fingerprint: {}", fingerprint);
+      // capture only on uncaught exception matching the fingerprint
+      ((ExceptionProbeStatus) status).setCapture(true);
+      super.evaluate(context, status, methodLocation);
+    }
+  }
+
+  @Override
+  public void commit(
+      CapturedContext entryContext,
+      CapturedContext exitContext,
+      List<CapturedContext.CapturedThrowable> caughtExceptions) {
+    LOGGER.debug("committing exception probe id={}  fingerprint={}", id, fingerprint);
+    super.commit(entryContext, exitContext, caughtExceptions);
+  }
+
+  @Override
+  public void buildLocation(InstrumentationResult result) {
+    String type = where.getTypeName();
+    String method = where.getMethodName();
+    if (result != null) {
+      type = result.getTypeName();
+      method = result.getMethodName();
+    }
+    // drop line number for exception probe
+    this.location = new ProbeLocation(type, method, where.getSourceFile(), emptyList());
+  }
+
+  public static class ExceptionProbeStatus extends LogStatus {
+    private boolean capture;
+
+    public ExceptionProbeStatus(ProbeImplementation probeImplementation) {
+      super(probeImplementation);
+    }
+
+    public void setCapture(boolean capture) {
+      this.capture = capture;
+    }
+
+    @Override
+    public boolean shouldSend() {
+      return super.shouldSend() && capture;
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -161,6 +161,11 @@ public abstract class ProbeDefinition implements ProbeImplementation {
     return null;
   }
 
+  public boolean isLineProbe() {
+    Where.SourceLine[] sourceLines = where.getSourceLines();
+    return sourceLines != null && sourceLines.length > 0;
+  }
+
   public abstract static class Builder<T extends Builder> {
     protected String language = LANGUAGE;
     protected ProbeId probeId;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassNameFiltering.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassNameFiltering.java
@@ -1,0 +1,24 @@
+package com.datadog.debugger.util;
+
+import datadog.trace.util.ClassNameTrie;
+import java.util.Arrays;
+import java.util.List;
+
+/** A class to filter out classes based on their package name. */
+public class ClassNameFiltering {
+  // Hardcode filtering out JDK classes
+  private static final List<String> JDK_FILTER_OUT_PACKAGES =
+      Arrays.asList("java.", "javax.", "sun.", "com.sun.", "jdk.");
+  private final ClassNameTrie trie;
+
+  public ClassNameFiltering(List<String> packages) {
+    ClassNameTrie.Builder builder = new ClassNameTrie.Builder();
+    JDK_FILTER_OUT_PACKAGES.forEach(s -> builder.put(s + "*", 1));
+    packages.forEach(s -> builder.put(s + "*", 1));
+    this.trie = builder.buildTrie();
+  }
+
+  public boolean apply(String className) {
+    return trie.apply(className) > 0;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -41,6 +41,7 @@ import com.datadog.debugger.sink.Snapshot;
 import com.datadog.debugger.util.MoshiHelper;
 import com.datadog.debugger.util.MoshiSnapshotTestHelper;
 import com.datadog.debugger.util.SerializerWithLimits;
+import com.datadog.debugger.util.TestSnapshotListener;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
@@ -130,8 +131,7 @@ public class CapturedSnapshotTest {
   @Test
   public void methodNotFound() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "foobar", null);
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "foobar", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
     assertEquals(2, result);
@@ -142,7 +142,7 @@ public class CapturedSnapshotTest {
   @Test
   public void methodProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -160,7 +160,7 @@ public class CapturedSnapshotTest {
   @Test
   public void singleLineProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbeAtExit(CLASS_NAME, "main", "int (java.lang.String)", "8");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -178,7 +178,7 @@ public class CapturedSnapshotTest {
   @Test
   public void resolutionFails() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(CLASS_NAME, "main", "int (java.lang.String)", "8");
     DebuggerAgentHelper.injectSink(listener);
     DebuggerContext.initProbeResolver((encodedProbeId) -> null);
@@ -193,8 +193,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot01";
     LogProbe lineProbe = createProbe(PROBE_ID1, CLASS_NAME, "main", "int (java.lang.String)", "8");
     LogProbe methodProbe = createProbe(PROBE_ID2, CLASS_NAME, "main", "int (java.lang.String)");
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, lineProbe, methodProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, lineProbe, methodProbe);
     DebuggerAgentHelper.injectSink(listener);
     DebuggerContext.initProbeResolver(
         (encodedProbeId) -> {
@@ -209,8 +208,7 @@ public class CapturedSnapshotTest {
   @Test
   public void constructor() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot02";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "<init>", "(String, Object)");
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "<init>", "(String, Object)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
     assertEquals(42, result);
@@ -220,8 +218,7 @@ public class CapturedSnapshotTest {
   @Test
   public void overloadedConstructor() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot02";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "<init>", "()");
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "<init>", "()");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
     assertEquals(42, result);
@@ -231,8 +228,7 @@ public class CapturedSnapshotTest {
   @Test
   public void veryOldClassFile() throws Exception {
     final String CLASS_NAME = "antlr.Token"; // compiled with jdk 1.2
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "<init>", "()");
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "<init>", "()");
     Class<?> testClass = Class.forName(CLASS_NAME);
     assertNotNull(testClass);
     testClass.newInstance();
@@ -242,8 +238,7 @@ public class CapturedSnapshotTest {
   @Test
   public void oldJavacBug() throws Exception {
     final String CLASS_NAME = "com.datadog.debugger.classfiles.JavacBug"; // compiled with jdk 1.6
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "main", null);
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "main", null);
     Class<?> testClass = Class.forName(CLASS_NAME);
     assertNotNull(testClass);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -254,8 +249,7 @@ public class CapturedSnapshotTest {
   @Test
   public void nestedConstructor() throws Exception {
     final String CLASS_NAME = "CapturedSnapshot02";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "<init>", "(Throwable)");
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "<init>", "(Throwable)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "init").get();
     assertEquals(42, result);
@@ -265,8 +259,7 @@ public class CapturedSnapshotTest {
   @Test
   public void nestedConstructor2() throws Exception {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot13";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "<init>", "(int)");
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "<init>", "(int)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(42, result);
@@ -276,8 +269,7 @@ public class CapturedSnapshotTest {
   @Test
   public void nestedConstructor3() throws Exception {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot14";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "<init>", "(int, int, int)");
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "<init>", "(int, int, int)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(42, result);
@@ -287,8 +279,7 @@ public class CapturedSnapshotTest {
   @Test
   public void inheritedConstructor() throws Exception {
     final String CLASS_NAME = "CapturedSnapshot06";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME + "$Inherited", "<init>", null);
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME + "$Inherited", "<init>", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(42, result);
@@ -304,7 +295,7 @@ public class CapturedSnapshotTest {
   @Test
   public void largeStackInheritedConstructor() throws Exception {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot15";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             CLASS_NAME,
             createProbe(PROBE_ID1, CLASS_NAME, "<init>", "()"),
@@ -318,7 +309,7 @@ public class CapturedSnapshotTest {
   @Test
   public void multiMethods() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot03";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             CLASS_NAME,
             createProbe(PROBE_ID1, CLASS_NAME, "f1", "(int)"),
@@ -340,8 +331,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     LogProbe probe = createProbe(PROBE_ID1, CLASS_NAME, "f1", "(int)");
     LogProbe probe2 = createProbe(PROBE_ID2, CLASS_NAME, "f1", "(int)");
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, probe, probe2);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe, probe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(48, result);
@@ -355,9 +345,7 @@ public class CapturedSnapshotTest {
   }
 
   private List<Snapshot> assertSnapshots(
-      DebuggerTransformerTest.TestSnapshotListener listener,
-      int expectedCount,
-      ProbeId... probeIds) {
+      TestSnapshotListener listener, int expectedCount, ProbeId... probeIds) {
     assertEquals(expectedCount, listener.snapshots.size());
     for (int i = 0; i < probeIds.length; i++) {
       assertEquals(probeIds[i].getId(), listener.snapshots.get(i).getProbe().getId());
@@ -368,7 +356,7 @@ public class CapturedSnapshotTest {
   @Test
   public void catchBlock() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot02";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "f", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
@@ -382,7 +370,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot02";
     final int LINE_START = 46;
     final int LINE_END = 48;
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             CLASS_NAME,
             createProbe(
@@ -410,7 +398,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot02";
     final int LINE_START = 45;
     final int LINE_END = 49;
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             CLASS_NAME,
             createProbe(
@@ -429,7 +417,7 @@ public class CapturedSnapshotTest {
   @Test
   public void sourceFileProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot03";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".java", 4));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -446,7 +434,7 @@ public class CapturedSnapshotTest {
   @Test
   public void simpleSourceFileProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot10";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, "CapturedSnapshot10.java", 11));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
@@ -464,7 +452,7 @@ public class CapturedSnapshotTest {
   public void sourceFileProbeFullPath() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot10";
     String DIR_CLASS_NAME = CLASS_NAME.replace('.', '/');
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             CLASS_NAME,
             createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", 11));
@@ -484,7 +472,7 @@ public class CapturedSnapshotTest {
   public void sourceFileProbeFullPathTopLevelClass() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot10";
     String DIR_CLASS_NAME = CLASS_NAME.replace('.', '/');
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             "com.datadog.debugger.TopLevel01",
             createSourceFileProbe(PROBE_ID, "src/main/java/" + DIR_CLASS_NAME + ".java", 21));
@@ -505,7 +493,7 @@ public class CapturedSnapshotTest {
   public void methodProbeLineProbeMix() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot11";
     String DIR_CLASS_NAME = CLASS_NAME.replace('.', '/');
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             CLASS_NAME,
             createSourceFileProbe(PROBE_ID1, "src/main/java/" + DIR_CLASS_NAME + ".java", 10),
@@ -535,7 +523,7 @@ public class CapturedSnapshotTest {
   public void sourceFileProbeScala() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot101";
     final String FILE_NAME = CLASS_NAME + ".scala";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, FILE_NAME, 3));
     String source = getFixtureContent("/" + FILE_NAME);
     Class<?> testClass = ScalaHelper.compileAndLoad(source, CLASS_NAME, FILE_NAME);
@@ -553,7 +541,7 @@ public class CapturedSnapshotTest {
   @Test
   public void sourceFileProbeGroovy() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot201";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".groovy", 4));
     String source = getFixtureContent("/" + CLASS_NAME + ".groovy");
     GroovyClassLoader groovyClassLoader = new GroovyClassLoader();
@@ -572,7 +560,7 @@ public class CapturedSnapshotTest {
   @Test
   public void sourceFileProbeKotlin() {
     final String CLASS_NAME = "CapturedSnapshot301";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".kt", 4));
     URL resource = CapturedSnapshotTest.class.getResource("/" + CLASS_NAME + ".kt");
     assertNotNull(resource);
@@ -601,8 +589,7 @@ public class CapturedSnapshotTest {
     LogProbe simpleDataProbe = builder.capture(1, 100, 255, Limits.DEFAULT_FIELD_COUNT).build();
     builder = createProbeBuilder(PROBE_ID2, CLASS_NAME, "createCompositeData", "()");
     LogProbe compositeDataProbe = builder.capture(1, 3, 255, Limits.DEFAULT_FIELD_COUNT).build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, simpleDataProbe, compositeDataProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, simpleDataProbe, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(143, result);
@@ -633,8 +620,7 @@ public class CapturedSnapshotTest {
     LogProbe.Builder builder =
         createProbeBuilder(PROBE_ID, CLASS_NAME, "createCompositeData", "()");
     LogProbe compositeDataProbe = builder.capture(2, 3, 255, Limits.DEFAULT_FIELD_COUNT).build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, compositeDataProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(143, result);
@@ -658,8 +644,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot04";
     LogProbe.Builder builder = createProbeBuilder(PROBE_ID, CLASS_NAME, "createSimpleData", "()");
     LogProbe simpleDataProbe = builder.capture(1, 100, 2, Limits.DEFAULT_FIELD_COUNT).build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, simpleDataProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(143, result);
@@ -677,8 +662,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot04";
     LogProbe.Builder builder = createProbeBuilder(PROBE_ID, CLASS_NAME, "createSimpleData", "()");
     LogProbe simpleDataProbe = builder.capture(0, 100, 50, Limits.DEFAULT_FIELD_COUNT).build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, simpleDataProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(143, result);
@@ -695,8 +679,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot04";
     LogProbe.Builder builder = createProbeBuilder(PROBE_ID, CLASS_NAME, "createSimpleData", "()");
     LogProbe simpleDataProbe = builder.capture(0, 100, 50, Limits.DEFAULT_FIELD_COUNT).build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, simpleDataProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(143, result);
@@ -714,8 +697,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot04";
     LogProbe.Builder builder = createProbeBuilder(PROBE_ID, CLASS_NAME, "createSimpleData", "()");
     LogProbe simpleDataProbe = builder.capture(1, 100, 50, Limits.DEFAULT_FIELD_COUNT).build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, simpleDataProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, simpleDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(143, result);
@@ -735,8 +717,7 @@ public class CapturedSnapshotTest {
     LogProbe.Builder builder =
         createProbeBuilder(PROBE_ID, CLASS_NAME, "createCompositeData", "()");
     LogProbe compositeDataProbe = builder.capture(2, 3, 255, 2).build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, compositeDataProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, compositeDataProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     assertEquals(143, result);
@@ -770,7 +751,7 @@ public class CapturedSnapshotTest {
   @Test
   public void uncaughtException() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot05";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "triggerUncaughtException", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
@@ -820,7 +801,7 @@ public class CapturedSnapshotTest {
                     "@exception instanceof \"CapturedSnapshot05$CustomException\" and @exception.detailMessage == 'oops' and @exception.additionalMsg == 'I did it again'"))
             .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     try {
       Reflect.on(testClass).call("main", "triggerUncaughtException").get();
@@ -841,7 +822,7 @@ public class CapturedSnapshotTest {
   @Test
   public void caughtException() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot05";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(
             CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "triggerCaughtException", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
@@ -862,8 +843,7 @@ public class CapturedSnapshotTest {
     LogProbe probe1 = createProbe(PROBE_ID1, CLASS_NAME, "triggerSwallowedException", null, "26");
     LogProbe probe2 = createProbe(PROBE_ID2, CLASS_NAME, "triggerSwallowedException", null, "29");
     LogProbe probe3 = createProbe(PROBE_ID3, CLASS_NAME, "triggerSwallowedException", null, "32");
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, probe1, probe2, probe3);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1, probe2, probe3);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "triggerSwallowedException").get();
     assertEquals(-1, result);
@@ -907,7 +887,7 @@ public class CapturedSnapshotTest {
                     "not(isDefined(@exception))"))
             .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
     assertEquals(2, result);
@@ -924,7 +904,7 @@ public class CapturedSnapshotTest {
             .where(CLASS_NAME, 8)
             .sampling(new LogProbe.Sampling(1))
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", "1").get();
@@ -944,7 +924,7 @@ public class CapturedSnapshotTest {
             .addLogProbes(Arrays.asList(probe1, probe2))
             .add(new LogProbe.Sampling(1))
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, config);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, config);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", "").get();
@@ -979,7 +959,7 @@ public class CapturedSnapshotTest {
                     "(fld == 11 && typed.fld.fld.msg == \"hello\") && (arg == '5' && @duration >= 0)"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
@@ -1013,7 +993,7 @@ public class CapturedSnapshotTest {
                             DSL.eq(DSL.ref("arg"), DSL.value("5")))),
                     "(fld == 11 && typed.fld.fld.msg == \"hello\") && arg == '5'"))
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 100; i++) {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
@@ -1034,7 +1014,7 @@ public class CapturedSnapshotTest {
                     DSL.when(DSL.eq(DSL.ref("strField"), DSL.value("foo"))), "strField == 'foo'"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "0").get();
     assertEquals(42, result);
@@ -1057,7 +1037,7 @@ public class CapturedSnapshotTest {
                 new ProbeCondition(DSL.when(DSL.eq(DSL.ref("arg"), DSL.value("5"))), "arg == '5'"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "0").get();
     assertEquals(3, result);
@@ -1079,7 +1059,7 @@ public class CapturedSnapshotTest {
                             DSL.value("hello"))),
                     "nullTyped.fld.fld.msg == 'hello'"))
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(1, listener.snapshots.size());
@@ -1102,7 +1082,7 @@ public class CapturedSnapshotTest {
                             DSL.getMember(DSL.ref("maybeStr"), "value"), DSL.value("maybe foo"))),
                     "maybeStr.value == 'maybe foo'"))
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -1166,8 +1146,7 @@ public class CapturedSnapshotTest {
         createProbeBuilder(PROBE_ID2, CLASS_NAME, "doit", "int (java.lang.String)")
             .when(probeCondition2)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, probe1, probe2);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1, probe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -1272,8 +1251,7 @@ public class CapturedSnapshotTest {
                     DSL.when(DSL.ge(DSL.ref("@duration"), DSL.value(0))), "@duration >= 0"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, probe1, probe2);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1, probe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -1285,7 +1263,7 @@ public class CapturedSnapshotTest {
   @Test
   public void fields() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot06";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "f", "()"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
@@ -1326,8 +1304,7 @@ public class CapturedSnapshotTest {
                     DSL.when(DSL.eq(DSL.ref("intValue"), DSL.value(24))), "intValue == 24"))
             .evaluateAt(MethodLocation.ENTRY)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(INHERITED_CLASS_NAME, probe);
+    TestSnapshotListener listener = installProbes(INHERITED_CLASS_NAME, probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "inherited").get();
     assertEquals(42, result);
@@ -1346,8 +1323,7 @@ public class CapturedSnapshotTest {
   @Test
   public void staticFields() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot15";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "<init>", "()");
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "<init>", "()");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     long result = Reflect.on(testClass).call("main", "").get();
     assertEquals(4_000_000_001L, result);
@@ -1371,8 +1347,7 @@ public class CapturedSnapshotTest {
                     DSL.when(DSL.eq(DSL.ref("intValue"), DSL.value(48))), "intValue == 48"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(INHERITED_CLASS_NAME, logProbe);
+    TestSnapshotListener listener = installProbes(INHERITED_CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "inherited").get();
     assertEquals(42, result);
@@ -1393,7 +1368,7 @@ public class CapturedSnapshotTest {
     CorrelationAccess spyCorrelationAccess = spy(CorrelationAccess.instance());
     setCorrelationSingleton(spyCorrelationAccess);
     doReturn(true).when(spyCorrelationAccess).isAvailable();
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "33"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "static", "email@address").get();
@@ -1410,7 +1385,7 @@ public class CapturedSnapshotTest {
     CorrelationAccess spyCorrelationAccess = spy(CorrelationAccess.instance());
     setCorrelationSingleton(spyCorrelationAccess);
     doReturn(true).when(spyCorrelationAccess).isAvailable();
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "44"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "capturing", "email@address").get();
@@ -1426,8 +1401,7 @@ public class CapturedSnapshotTest {
   public void tracerInstrumentedClass() throws Exception {
     DebuggerContext.initClassFilter(new DenyListHelper(null));
     final String CLASS_NAME = "com.datadog.debugger.jaxrs.MyResource";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbe(CLASS_NAME, "createResource", null);
+    TestSnapshotListener listener = installSingleProbe(CLASS_NAME, "createResource", null);
     // load a class file that was previously instrumented by the DD tracer as JAX-RS resource
     Class<?> testClass =
         loadClass(CLASS_NAME, getClass().getResource("/MyResource.class").getFile());
@@ -1454,7 +1428,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot09";
     LogProbe nativeMethodProbe = createProbe(PROBE_ID1, CLASS_NAME, "nativeMethod", "()");
     LogProbe abstractMethodProbe = createProbe(PROBE_ID2, CLASS_NAME, "abstractMethod", "()");
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, nativeMethodProbe, abstractMethodProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -1477,8 +1451,7 @@ public class CapturedSnapshotTest {
     // @1f7ef9ea, parent loader 'app')
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot12";
     LogProbe abstractMethodProbe = createProbe(PROBE_ID, CLASS_NAME, "<init>", null);
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, abstractMethodProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, abstractMethodProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     assertNotNull(testClass);
   }
@@ -1486,7 +1459,7 @@ public class CapturedSnapshotTest {
   @Test
   public void overloadedMethods() throws Exception {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot16";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "overload", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -1501,7 +1474,7 @@ public class CapturedSnapshotTest {
   @Test
   public void noDebugInfoEmptyMethod() throws Exception {
     final String CLASS_NAME = "CapturedSnapshot03";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "empty", null));
     Map<String, byte[]> classFileBuffers = compile(CLASS_NAME, SourceCompiler.DebugInfo.NONE, "8");
     Class<?> testClass = loadClass(CLASS_NAME, classFileBuffers);
@@ -1514,8 +1487,7 @@ public class CapturedSnapshotTest {
   public void instrumentTheWorld() throws Exception {
     final String CLASS_NAME = "CapturedSnapshot01";
     Map<String, byte[]> classFileBuffers = compile(CLASS_NAME);
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        setupInstrumentTheWorldTransformer(null);
+    TestSnapshotListener listener = setupInstrumentTheWorldTransformer(null);
     Class<?> testClass;
     try {
       testClass = loadClass(CLASS_NAME, classFileBuffers);
@@ -1536,8 +1508,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "CapturedSnapshot01";
     Map<String, byte[]> classFileBuffers = compile(CLASS_NAME);
     URL resource = getClass().getResource(excludeFileName);
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        setupInstrumentTheWorldTransformer(resource.getPath());
+    TestSnapshotListener listener = setupInstrumentTheWorldTransformer(resource.getPath());
     Class<?> testClass;
     try {
       testClass = loadClass(CLASS_NAME, classFileBuffers);
@@ -1552,7 +1523,7 @@ public class CapturedSnapshotTest {
   @Test
   public void objectDynamicType() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot17";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "processWithArg", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
@@ -1568,7 +1539,7 @@ public class CapturedSnapshotTest {
   @Test
   public void exceptionAsLocalVariable() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot18";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "14"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
@@ -1592,7 +1563,7 @@ public class CapturedSnapshotTest {
                 new ProbeCondition(DSL.when(DSL.eq(DSL.ref("arg"), DSL.value("1"))), "arg == '1'"))
             .evaluateAt(MethodLocation.ENTRY)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -1609,7 +1580,7 @@ public class CapturedSnapshotTest {
                     DSL.when(DSL.eq(DSL.ref("@return"), DSL.value(3))), "@return == 3"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -1626,7 +1597,7 @@ public class CapturedSnapshotTest {
                     DSL.when(DSL.eq(DSL.ref("@return"), DSL.value(0))), "@return == 0"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -1643,7 +1614,7 @@ public class CapturedSnapshotTest {
             .when(new ProbeCondition(DSL.when(DSL.gt(DSL.ref("after"), DSL.value(0))), "after > 0"))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     try {
       Reflect.on(testClass).call("main", "triggerUncaughtException").get();
@@ -1669,7 +1640,7 @@ public class CapturedSnapshotTest {
   public void enumConstructorArgs() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot23";
     final String ENUM_CLASS = CLASS_NAME + "$MyEnum";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(ENUM_CLASS, createProbe(PROBE_ID, ENUM_CLASS, "<init>", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -1686,7 +1657,7 @@ public class CapturedSnapshotTest {
   @Test
   public void enumValues() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot23";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, "convert", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "2").get();
@@ -1702,7 +1673,7 @@ public class CapturedSnapshotTest {
   public void recursiveCapture() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot24";
     final String INNER_CLASS = CLASS_NAME + "$Holder";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(INNER_CLASS, createProbe(PROBE_ID, INNER_CLASS, "size", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -1713,7 +1684,7 @@ public class CapturedSnapshotTest {
   public void recursiveCaptureException() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot24";
     final String INNER_CLASS = CLASS_NAME + "$HolderWithException";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installProbes(INNER_CLASS, createProbe(PROBE_ID, INNER_CLASS, "size", null));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     try {
@@ -1749,7 +1720,7 @@ public class CapturedSnapshotTest {
                 new ProbeCondition(
                     DSL.when(DSL.ge(DSL.len(DSL.ref("holder")), DSL.value(0))), "len(holder) >= 0"))
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, logProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     Assertions.assertEquals(1, result);
@@ -1762,8 +1733,7 @@ public class CapturedSnapshotTest {
   @Test
   public void beforeForLoopLineProbe() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot02";
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installSingleProbeAtExit(CLASS_NAME, null, null, "46");
+    TestSnapshotListener listener = installSingleProbeAtExit(CLASS_NAME, null, null, "46");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "synchronizedBlock").get();
     assertEquals(76, result);
@@ -1785,8 +1755,7 @@ public class CapturedSnapshotTest {
             .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, probe1, probe2);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1, probe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -1807,7 +1776,7 @@ public class CapturedSnapshotTest {
             .captureSnapshot(true)
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe1);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "secret123").get();
     Assertions.assertEquals(42, result);
@@ -1867,8 +1836,7 @@ public class CapturedSnapshotTest {
             .captureSnapshot(true)
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, probe1, probe2, probe3);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1, probe2, probe3);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "secret123").get();
     Assertions.assertEquals(42, result);
@@ -1898,7 +1866,7 @@ public class CapturedSnapshotTest {
             .captureSnapshot(true)
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe1);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "secret123").get();
     Assertions.assertEquals(42, result);
@@ -1923,7 +1891,7 @@ public class CapturedSnapshotTest {
             .captureSnapshot(true)
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(CLASS_NAME, probe1);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "secret123").get();
     Assertions.assertEquals(42, result);
@@ -1986,8 +1954,7 @@ public class CapturedSnapshotTest {
             .captureSnapshot(true)
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        installProbes(CLASS_NAME, probe1, probe2, probe3);
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe1, probe2, probe3);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "secret123").get();
     Assertions.assertEquals(42, result);
@@ -2062,7 +2029,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot29";
     final String RECORD_NAME = "com.datadog.debugger.MyRecord1";
     LogProbe probe1 = createProbeAtExit(PROBE_ID, RECORD_NAME, "age", null);
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(RECORD_NAME, probe1);
+    TestSnapshotListener listener = installProbes(RECORD_NAME, probe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME, "17");
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(42, result);
@@ -2082,7 +2049,7 @@ public class CapturedSnapshotTest {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot29";
     final String RECORD_NAME = "com.datadog.debugger.MyRecord2";
     LogProbe probe1 = createProbe(PROBE_ID, RECORD_NAME, null, null, "29");
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(RECORD_NAME, probe1);
+    TestSnapshotListener listener = installProbes(RECORD_NAME, probe1);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME, "17");
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(42, result);
@@ -2134,8 +2101,7 @@ public class CapturedSnapshotTest {
         new SpanDecorationProbeInstrumentationTest.TestTraceInterceptor();
     tracer.addTraceInterceptor(traceInterceptor);
     try {
-      DebuggerTransformerTest.TestSnapshotListener snapshotListener =
-          installProbes(CLASS_NAME, configuration);
+      TestSnapshotListener snapshotListener = installProbes(CLASS_NAME, configuration);
       DebuggerContext.initTracer(new DebuggerTracer(mock(ProbeStatusSink.class)));
       MetricProbesInstrumentationTest.MetricForwarderListener metricListener =
           new MetricProbesInstrumentationTest.MetricForwarderListener();
@@ -2165,8 +2131,7 @@ public class CapturedSnapshotTest {
     }
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener setupInstrumentTheWorldTransformer(
-      String excludeFileName) {
+  private TestSnapshotListener setupInstrumentTheWorldTransformer(String excludeFileName) {
     Config config = mock(Config.class);
     when(config.isDebuggerEnabled()).thenReturn(true);
     when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
@@ -2176,8 +2141,7 @@ public class CapturedSnapshotTest {
         .thenReturn("http://localhost:8126/debugger/v1/input");
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        new DebuggerTransformerTest.TestSnapshotListener(config, mock(ProbeStatusSink.class));
+    TestSnapshotListener listener = new TestSnapshotListener(config, mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
     currentTransformer =
         DebuggerAgent.setupInstrumentTheWorldTransformer(
@@ -2204,26 +2168,26 @@ public class CapturedSnapshotTest {
     }
   }
 
-  private Snapshot assertOneSnapshot(DebuggerTransformerTest.TestSnapshotListener listener) {
+  private Snapshot assertOneSnapshot(TestSnapshotListener listener) {
     assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
     assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
     return snapshot;
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installSingleProbe(
+  private TestSnapshotListener installSingleProbe(
       String typeName, String methodName, String signature, String... lines) {
     LogProbe logProbes = createProbe(PROBE_ID, typeName, methodName, signature, lines);
     return installProbes(typeName, logProbes);
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installSingleProbeAtExit(
+  private TestSnapshotListener installSingleProbeAtExit(
       String typeName, String methodName, String signature, String... lines) {
     LogProbe logProbes = createProbeAtExit(PROBE_ID, typeName, methodName, signature, lines);
     return installProbes(typeName, logProbes);
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installProbes(
+  private TestSnapshotListener installProbes(
       String expectedClassName, Configuration configuration) {
     Config config = mock(Config.class);
     when(config.isDebuggerEnabled()).thenReturn(true);
@@ -2235,8 +2199,7 @@ public class CapturedSnapshotTest {
     Collection<LogProbe> logProbes = configuration.getLogProbes();
     instrumentationListener = new MockInstrumentationListener();
     probeStatusSink = mock(ProbeStatusSink.class);
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        new DebuggerTransformerTest.TestSnapshotListener(config, probeStatusSink);
+    TestSnapshotListener listener = new TestSnapshotListener(config, probeStatusSink);
     currentTransformer =
         new DebuggerTransformer(config, configuration, instrumentationListener, listener);
     instr.addTransformer(currentTransformer);
@@ -2278,8 +2241,7 @@ public class CapturedSnapshotTest {
     return null;
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installProbes(
-      String expectedClassName, LogProbe... logProbes) {
+  private TestSnapshotListener installProbes(String expectedClassName, LogProbe... logProbes) {
     return installProbes(
         expectedClassName,
         Configuration.builder()

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -21,6 +21,7 @@ import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
+import com.datadog.debugger.util.ClassNameFiltering;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
@@ -331,7 +332,7 @@ public class ConfigurationUpdaterTest {
             tracerConfig,
             debuggerSinkWithMockStatusSink,
             new ClassesToRetransformFinder(),
-            new ExceptionProbeManager());
+            new ExceptionProbeManager(new ClassNameFiltering(emptyList())));
     LogProbe probe1 =
         LogProbe.builder()
             .language(LANGUAGE)
@@ -629,6 +630,6 @@ public class ConfigurationUpdaterTest {
         tracerConfig,
         sink,
         new ClassesToRetransformFinder(),
-        new ExceptionProbeManager());
+        new ExceptionProbeManager(new ClassNameFiltering(emptyList())));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -22,7 +22,7 @@ import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
-import com.datadog.debugger.sink.Snapshot;
+import com.datadog.debugger.util.TestSnapshotListener;
 import datadog.trace.api.Config;
 import datadog.trace.api.GlobalTracer;
 import datadog.trace.api.Tracer;
@@ -69,27 +69,6 @@ public class DebuggerTransformerTest {
     NONE,
     UNHANDLED,
     HANDLED
-  }
-
-  static class TestSnapshotListener extends DebuggerSink {
-    boolean skipped;
-    DebuggerContext.SkipCause cause;
-    List<Snapshot> snapshots = new ArrayList<>();
-
-    public TestSnapshotListener(Config config, ProbeStatusSink probeStatusSink) {
-      super(config, probeStatusSink);
-    }
-
-    @Override
-    public void skipSnapshot(String probeId, DebuggerContext.SkipCause cause) {
-      skipped = true;
-      this.cause = cause;
-    }
-
-    @Override
-    public void addSnapshot(Snapshot snapshot) {
-      snapshots.add(snapshot);
-    }
   }
 
   static final String VAR_NAME = "var";

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -13,6 +13,7 @@ import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.sink.Snapshot;
+import com.datadog.debugger.util.TestSnapshotListener;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
@@ -55,7 +56,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void methodPlainLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe("this is log line", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -68,7 +69,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void methodLargePlainLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(STR_8K + "123", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -81,7 +82,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void methodTemplateArgLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(
             "this is log line with arg={arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
@@ -95,7 +96,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void methodTemplateArgLogLarge() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(STR_8K + "{arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -108,7 +109,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void methodTemplateLargeArgLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(
             "this is log line with arg={arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
@@ -125,7 +126,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void methodTemplateTooLargeArgLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe("{arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", STR_8K + "123").get();
@@ -147,7 +148,7 @@ public class LogProbesInstrumentationTest {
                 "int (java.lang.String)")
             .evaluateAt(MethodLocation.EXIT)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(probe);
+    TestSnapshotListener listener = installProbes(probe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -173,7 +174,7 @@ public class LogProbesInstrumentationTest {
             CLASS_NAME,
             "main",
             "int (java.lang.String)");
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
+    TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -237,7 +238,7 @@ public class LogProbesInstrumentationTest {
                 "int (java.lang.String)")
             .captureSnapshot(additionalCapture)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
+    TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -248,7 +249,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void linePlainLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe("this is log line", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -261,7 +262,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateVarLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe("this is log line with local var={var1}", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -274,7 +275,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateMultipleVarLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot04";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(
             "nullObject={nullObject} sdata={sdata.strValue} cdata={cdata.s1.intValue}",
             CLASS_NAME,
@@ -292,7 +293,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateEscapeLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(
             "this is log line with {{curly braces}} and with local var={{{var1}}}",
             CLASS_NAME,
@@ -311,7 +312,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateInvalidVarLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe("this is log line with local var={var42}", CLASS_NAME, null, null, "9");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -328,7 +329,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateNullFieldLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot04";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(
             "this is log line with field={nullObject.intValue}", CLASS_NAME, null, null, "25");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
@@ -349,7 +350,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateIndexOutOfBoundsLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot06";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe(
             "this is log line with element of list={strList[10]}", CLASS_NAME, null, null, "24");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
@@ -368,7 +369,7 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateThisLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot06";
-    DebuggerTransformerTest.TestSnapshotListener listener =
+    TestSnapshotListener listener =
         installSingleProbe("this is log line for this={this}", CLASS_NAME, null, null, "24");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
@@ -391,7 +392,7 @@ public class LogProbesInstrumentationTest {
             .template(LOG_TEMPLATE, parseTemplate(LOG_TEMPLATE))
             .captureSnapshot(true)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(logProbes);
+    TestSnapshotListener listener = installProbes(logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "5").get();
     Assertions.assertEquals(3, result);
@@ -488,7 +489,7 @@ public class LogProbesInstrumentationTest {
                 LOG_ID2, additionalTemplate, CLASS_NAME, "main", "int (java.lang.String)")
             .captureSnapshot(true)
             .build();
-    DebuggerTransformerTest.TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
+    TestSnapshotListener listener = installProbes(logProbe1, logProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -496,13 +497,13 @@ public class LogProbesInstrumentationTest {
     return listener.snapshots;
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installSingleProbe(
+  private TestSnapshotListener installSingleProbe(
       String template, String typeName, String methodName, String signature, String... lines) {
     LogProbe logProbe = createProbe(LOG_ID, template, typeName, methodName, signature, lines);
     return installProbes(Configuration.builder().setService(SERVICE_NAME).add(logProbe).build());
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installProbes(LogProbe... logProbes) {
+  private TestSnapshotListener installProbes(LogProbe... logProbes) {
     return installProbes(
         Configuration.builder()
             .setService(SERVICE_NAME)
@@ -534,7 +535,7 @@ public class LogProbesInstrumentationTest {
     return createProbeBuilder(id, template, typeName, methodName, signature, lines).build();
   }
 
-  private DebuggerTransformerTest.TestSnapshotListener installProbes(Configuration configuration) {
+  private TestSnapshotListener installProbes(Configuration configuration) {
     Config config = mock(Config.class);
     when(config.isDebuggerEnabled()).thenReturn(true);
     when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
@@ -546,8 +547,7 @@ public class LogProbesInstrumentationTest {
         (encodedProbeId) -> resolver(encodedProbeId, configuration.getLogProbes());
     currentTransformer = new DebuggerTransformer(config, configuration);
     instr.addTransformer(currentTransformer);
-    DebuggerTransformerTest.TestSnapshotListener listener =
-        new DebuggerTransformerTest.TestSnapshotListener(config, mock(ProbeStatusSink.class));
+    TestSnapshotListener listener = new TestSnapshotListener(config, mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
     DebuggerContext.initProbeResolver(resolver);
     DebuggerContext.initClassFilter(new DenyListHelper(null));
@@ -564,7 +564,7 @@ public class LogProbesInstrumentationTest {
     return null;
   }
 
-  private Snapshot assertOneSnapshot(DebuggerTransformerTest.TestSnapshotListener listener) {
+  private Snapshot assertOneSnapshot(TestSnapshotListener listener) {
     Assertions.assertFalse(listener.skipped, "Snapshot skipped because " + listener.cause);
     Assertions.assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -170,7 +170,8 @@ public class SnapshotSerializationTest {
             Arrays.asList(
                 new CapturedStackFrame("f1", 12),
                 new CapturedStackFrame("f2", 23),
-                new CapturedStackFrame("f3", 34))));
+                new CapturedStackFrame("f3", 34)),
+            null));
     String buffer = adapter.toJson(snapshot);
 
     Snapshot deserializedSnapshot = adapter.fromJson(buffer);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -240,7 +240,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   public void lineActiveSpanSimpleTag() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration = createDecoration("tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 41);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 44);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(84, result);
@@ -273,7 +273,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
         createDecoration(eq(ref("arg"), value("5")), "arg == '5'", "tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 41);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 44);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 10; i++) {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
@@ -289,7 +289,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
         createDecoration(eq(ref("noarg"), value("5")), "arg == '5'", "tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 41);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 44);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "5").get();
     assertEquals(84, result);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -1,21 +1,25 @@
 package com.datadog.debugger.exception;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import com.datadog.debugger.agent.ConfigurationUpdater;
+import com.datadog.debugger.util.ClassNameFiltering;
 import org.junit.jupiter.api.Test;
 
 class DefaultExceptionDebuggerTest {
 
   @Test
   public void test() {
-    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager();
+    ClassNameFiltering classNameFiltering = new ClassNameFiltering(emptyList());
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     ConfigurationUpdater configurationUpdater = mock(ConfigurationUpdater.class);
     DefaultExceptionDebugger exceptionDebugger =
-        new DefaultExceptionDebugger(exceptionProbeManager, configurationUpdater);
+        new DefaultExceptionDebugger(
+            exceptionProbeManager, configurationUpdater, classNameFiltering);
     RuntimeException exception = new RuntimeException("test");
-    String fingerprint = Fingerprinter.fingerprint(exception);
+    String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     exceptionDebugger.handleException(exception);
     exceptionDebugger.handleException(exception);
     assertTrue(exceptionProbeManager.isAlreadyInstrumented(fingerprint));

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -1,0 +1,161 @@
+package com.datadog.debugger.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static utils.InstrumentationTestHelper.compileAndLoadClass;
+
+import com.datadog.debugger.agent.ClassesToRetransformFinder;
+import com.datadog.debugger.agent.Configuration;
+import com.datadog.debugger.agent.ConfigurationUpdater;
+import com.datadog.debugger.agent.DebuggerAgentHelper;
+import com.datadog.debugger.agent.DebuggerTransformer;
+import com.datadog.debugger.agent.JsonSnapshotSerializer;
+import com.datadog.debugger.probe.ExceptionProbe;
+import com.datadog.debugger.sink.DebuggerSink;
+import com.datadog.debugger.sink.ProbeStatusSink;
+import com.datadog.debugger.sink.Snapshot;
+import com.datadog.debugger.util.ClassNameFiltering;
+import com.datadog.debugger.util.TestSnapshotListener;
+import datadog.trace.agent.tooling.TracerInstaller;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.core.CoreTracer;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.joor.Reflect;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ExceptionProbeInstrumentationTest {
+  private final Instrumentation instr = ByteBuddyAgent.install();
+  private ClassFileTransformer currentTransformer;
+  private final ClassNameFiltering classNameFiltering =
+      new ClassNameFiltering(
+          Arrays.asList(
+              "org.gradle.",
+              "worker.org.gradle.",
+              "org.junit.",
+              "org.joor.",
+              "com.datadog.debugger.exception."));;
+
+  @BeforeEach
+  public void before() {
+    CoreTracer tracer = CoreTracer.builder().build();
+    TracerInstaller.forceInstallGlobalTracer(tracer);
+  }
+
+  @AfterEach
+  public void after() {
+    if (currentTransformer != null) {
+      instr.removeTransformer(currentTransformer);
+    }
+  }
+
+  @Test
+  public void noException() throws Exception {
+    Config config = createConfig();
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
+    TestSnapshotListener listener =
+        setupExceptionDebugging(config, exceptionProbeManager, classNameFiltering);
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    callMethodThrowingException(testClass); // instrument exception stacktrace
+    assertEquals(2, exceptionProbeManager.getProbes().size());
+    callMethodNoException(testClass);
+    assertEquals(0, listener.snapshots.size());
+  }
+
+  @Test
+  public void basic() throws Exception {
+    Config config = createConfig();
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
+    TestSnapshotListener listener =
+        setupExceptionDebugging(config, exceptionProbeManager, classNameFiltering);
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    callMethodThrowingException(testClass); // instrument exception stacktrace
+    assertEquals(2, exceptionProbeManager.getProbes().size());
+    callMethodThrowingException(testClass); // generate snapshots
+    Map<String, String> probeIdByMethodName =
+        exceptionProbeManager.getProbes().stream()
+            .collect(
+                Collectors.toMap(
+                    exceptionProbe -> exceptionProbe.getWhere().getMethodName(),
+                    ExceptionProbe::getId));
+    assertEquals(2, listener.snapshots.size());
+    Snapshot snapshot0 = listener.snapshots.get(0);
+    assertEquals(probeIdByMethodName.get("processWithException"), snapshot0.getProbe().getId());
+    assertEquals("oops", snapshot0.getCaptures().getReturn().getThrowable().getMessage());
+    assertTrue(snapshot0.getCaptures().getReturn().getLocals().containsKey("@exception"));
+    Snapshot snapshot1 = listener.snapshots.get(1);
+    assertEquals(probeIdByMethodName.get("main"), snapshot1.getProbe().getId());
+    assertEquals("oops", snapshot1.getCaptures().getReturn().getThrowable().getMessage());
+    assertTrue(snapshot1.getCaptures().getReturn().getLocals().containsKey("@exception"));
+  }
+
+  private static void callMethodThrowingException(Class<?> testClass) {
+    try {
+      Reflect.on(testClass).call("main", "exception").get();
+      Assertions.fail("should not reach this code");
+    } catch (RuntimeException ex) {
+      assertEquals("oops", ex.getCause().getCause().getMessage());
+    }
+  }
+
+  private static void callMethodNoException(Class<?> testClass) {
+    int result = Reflect.on(testClass).call("main", "1").get();
+    assertEquals(84, result);
+  }
+
+  private TestSnapshotListener setupExceptionDebugging(
+      Config config,
+      ExceptionProbeManager exceptionProbeManager,
+      ClassNameFiltering classNameFiltering) {
+    ProbeStatusSink probeStatusSink = mock(ProbeStatusSink.class);
+    ConfigurationUpdater configurationUpdater =
+        new ConfigurationUpdater(
+            instr,
+            ExceptionProbeInstrumentationTest::createTransformer,
+            config,
+            new DebuggerSink(config, probeStatusSink),
+            new ClassesToRetransformFinder(),
+            exceptionProbeManager);
+    TestSnapshotListener listener = new TestSnapshotListener(config, probeStatusSink);
+    DebuggerAgentHelper.injectSink(listener);
+    DebuggerContext.initProbeResolver(configurationUpdater);
+    DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
+    DebuggerContext.initExceptionDebugger(
+        new DefaultExceptionDebugger(
+            exceptionProbeManager, configurationUpdater, classNameFiltering));
+    configurationUpdater.accept(null);
+    return listener;
+  }
+
+  private static Config createConfig() {
+    Config config = mock(Config.class);
+    when(config.isDebuggerEnabled()).thenReturn(true);
+    when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
+    when(config.isDebuggerVerifyByteCode()).thenReturn(true);
+    when(config.getFinalDebuggerSnapshotUrl())
+        .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
+    when(config.getDebuggerUploadBatchSize()).thenReturn(100);
+    return config;
+  }
+
+  private static DebuggerTransformer createTransformer(
+      Config config,
+      Configuration configuration,
+      DebuggerTransformer.InstrumentationListener listener,
+      DebuggerSink debuggerSink) {
+    return new DebuggerTransformer(config, configuration, listener, debuggerSink);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -60,7 +60,7 @@ public class ExceptionProbeInstrumentationTest {
   }
 
   @Test
-  public void noException() throws Exception {
+  public void onlyInstrument() throws Exception {
     Config config = createConfig();
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     TestSnapshotListener listener =
@@ -74,7 +74,7 @@ public class ExceptionProbeInstrumentationTest {
   }
 
   @Test
-  public void basic() throws Exception {
+  public void instrumentAndCaptureSnapshots() throws Exception {
     Config config = createConfig();
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     TestSnapshotListener listener =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -2,14 +2,17 @@ package com.datadog.debugger.exception;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.datadog.debugger.util.ClassNameFiltering;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class ExceptionProbeManagerTest {
   @Test
   public void test() {
-    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager();
+    ClassNameFiltering classNameFiltering = new ClassNameFiltering(Collections.emptyList());
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     RuntimeException exception = new RuntimeException("test");
-    String fingerprint = Fingerprinter.fingerprint(exception);
+    String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     exceptionProbeManager.createProbesForException(fingerprint, exception.getStackTrace());
     assertTrue(exceptionProbeManager.isAlreadyInstrumented(fingerprint));
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/FingerprinterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/FingerprinterTest.java
@@ -1,7 +1,9 @@
 package com.datadog.debugger.exception;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.datadog.debugger.util.ClassNameFiltering;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -36,17 +38,18 @@ class FingerprinterTest {
   }
 
   final String TEST_FINGERPRINT = "2ec0db28f254ffa383cbb26a32269bf739ba937b9dd8f111d22294e6a494855";
+  final ClassNameFiltering classNameFiltering = new ClassNameFiltering(emptyList());
 
   @Test
   void basic() {
-    String fingerprint = Fingerprinter.fingerprint(TEST_THROWABLE);
+    String fingerprint = Fingerprinter.fingerprint(TEST_THROWABLE, classNameFiltering);
     assertEquals(TEST_FINGERPRINT, fingerprint);
   }
 
   @Test
   void inner() {
     Throwable t = new RuntimeException("outer", TEST_THROWABLE);
-    String fingerprint = Fingerprinter.fingerprint(t);
+    String fingerprint = Fingerprinter.fingerprint(t, classNameFiltering);
     assertEquals(TEST_FINGERPRINT, fingerprint);
   }
 
@@ -56,14 +59,14 @@ class FingerprinterTest {
     Exception innerCause1 = new RuntimeException("cause1", outer);
     Exception innerCause2 = new RuntimeException("cause2", innerCause1);
     outer.initCause(innerCause2);
-    Assertions.assertNull(Fingerprinter.fingerprint(outer));
+    Assertions.assertNull(Fingerprinter.fingerprint(outer, classNameFiltering));
   }
 
   @Test
   void emptyStacktrace() {
     assertEquals(
         "843ff84fcbdc76707588c035f63b0e69b6f9b2c53f9a019ef4e5d1a2243778",
-        Fingerprinter.fingerprint(new EmptyException("test")));
+        Fingerprinter.fingerprint(new EmptyException("test"), classNameFiltering));
   }
 
   static class EmptyException extends Exception {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TestSnapshotListener.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TestSnapshotListener.java
@@ -1,0 +1,30 @@
+package com.datadog.debugger.util;
+
+import com.datadog.debugger.sink.DebuggerSink;
+import com.datadog.debugger.sink.ProbeStatusSink;
+import com.datadog.debugger.sink.Snapshot;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.debugger.DebuggerContext;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSnapshotListener extends DebuggerSink {
+  public boolean skipped;
+  public DebuggerContext.SkipCause cause;
+  public List<Snapshot> snapshots = new ArrayList<>();
+
+  public TestSnapshotListener(Config config, ProbeStatusSink probeStatusSink) {
+    super(config, probeStatusSink);
+  }
+
+  @Override
+  public void skipSnapshot(String probeId, DebuggerContext.SkipCause cause) {
+    skipped = true;
+    this.cause = cause;
+  }
+
+  @Override
+  public void addSnapshot(Snapshot snapshot) {
+    snapshots.add(snapshot);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -31,6 +31,9 @@ public class CapturedSnapshot20 {
         return new CapturedSnapshot20().processWithException(arg);
       }
       return new CapturedSnapshot20().process(arg);
+    } catch (Exception ex) {
+      span.addThrowable(ex);
+      throw ex;
     } finally {
       span.finish();
     }


### PR DESCRIPTION
# What Does This Do
Exception probes are capturing only for uncaught exception exception that matches the fingerprint stored
Add exception probe instrumentation tests
Filtering is hardcoded for JDK packages
Exception probe instrumentation is using line from the stack frame to identify the right method. In the snapshot the probe drop the line number to make sure it is interpreted as correct method probe snapshot

# Motivation
Exception debugging

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ