### PR TITLE
Fix remote config activation configuration name

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -92,7 +92,10 @@ public class Agent {
     PROFILING(propertyNameToSystemPropertyName(ProfilingConfig.PROFILING_ENABLED), false),
     APPSEC(propertyNameToSystemPropertyName(AppSecConfig.APPSEC_ENABLED), false),
     IAST(propertyNameToSystemPropertyName(IastConfig.IAST_ENABLED), false),
-    REMOTE_CONFIG(propertyNameToSystemPropertyName(RemoteConfigConfig.REMOTE_CONFIG_ENABLED), true),
+    REMOTE_CONFIG(
+        propertyNameToSystemPropertyName(RemoteConfigConfig.REMOTE_CONFIGURATION_ENABLED), true),
+    DEPRECATED_REMOTE_CONFIG(
+        propertyNameToSystemPropertyName(RemoteConfigConfig.REMOTE_CONFIG_ENABLED), true),
     CWS(propertyNameToSystemPropertyName(CwsConfig.CWS_ENABLED), false),
     CIVISIBILITY(propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_ENABLED), false),
     CIVISIBILITY_AGENTLESS(
@@ -209,7 +212,9 @@ public class Agent {
     usmEnabled = isFeatureEnabled(AgentFeature.USM);
     appSecEnabled = isFeatureEnabled(AgentFeature.APPSEC);
     appSecFullyDisabled = isAppSecFullyDisabled();
-    remoteConfigEnabled = isFeatureEnabled(AgentFeature.REMOTE_CONFIG);
+    remoteConfigEnabled =
+        isFeatureEnabled(AgentFeature.REMOTE_CONFIG)
+            || isFeatureEnabled(AgentFeature.DEPRECATED_REMOTE_CONFIG);
     cwsEnabled = isFeatureEnabled(AgentFeature.CWS);
     telemetryEnabled = isFeatureEnabled(AgentFeature.TELEMETRY);
     debuggerEnabled = isFeatureEnabled(AgentFeature.DEBUGGER);

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/RemoteConfigConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/RemoteConfigConfig.java
@@ -1,7 +1,10 @@
 package datadog.trace.api.config;
 
 public class RemoteConfigConfig {
-  public static final String REMOTE_CONFIG_ENABLED = "remote_config.enabled";
+  /** Replaced by {@link #REMOTE_CONFIGURATION_ENABLED} according the RFC. */
+  @Deprecated public static final String REMOTE_CONFIG_ENABLED = "remote_config.enabled";
+
+  public static final String REMOTE_CONFIGURATION_ENABLED = "remote_configuration.enabled";
   public static final String REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED =
       "remote_config.integrity_check.enabled";
   public static final String REMOTE_CONFIG_URL = "remote_config.url";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -319,6 +319,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_SUMMARY_
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL;
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIGURATION_ENABLED;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_ENABLED;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED;
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_MAX_PAYLOAD_SIZE;
@@ -1750,7 +1751,8 @@ public class Config {
     ciVisibilityModuleName = configProvider.getString(CIVISIBILITY_MODULE_NAME);
 
     remoteConfigEnabled =
-        configProvider.getBoolean(REMOTE_CONFIG_ENABLED, DEFAULT_REMOTE_CONFIG_ENABLED);
+        configProvider.getBoolean(
+            REMOTE_CONFIGURATION_ENABLED, DEFAULT_REMOTE_CONFIG_ENABLED, REMOTE_CONFIG_ENABLED);
     remoteConfigIntegrityCheckEnabled =
         configProvider.getBoolean(
             REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED, DEFAULT_REMOTE_CONFIG_INTEGRITY_CHECK_ENABLED);

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -82,7 +82,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_COMPRESS
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_PERIOD
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_TIMEOUT
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_URL
-import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_ENABLED
+import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIGURATION_ENABLED
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_MAX_PAYLOAD_SIZE
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_POLL_INTERVAL_SECONDS
 import static datadog.trace.api.config.RemoteConfigConfig.REMOTE_CONFIG_URL
@@ -230,7 +230,7 @@ class ConfigTest extends DDSpecification {
     prop.setProperty(PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE, "1122")
     prop.setProperty(PROFILING_AGENTLESS, "true")
 
-    prop.setProperty(REMOTE_CONFIG_ENABLED, "true")
+    prop.setProperty(REMOTE_CONFIGURATION_ENABLED, "true")
     prop.setProperty(REMOTE_CONFIG_URL, "remote config url")
     prop.setProperty(REMOTE_CONFIG_POLL_INTERVAL_SECONDS, "3")
     prop.setProperty(REMOTE_CONFIG_MAX_PAYLOAD_SIZE, "2")
@@ -409,7 +409,7 @@ class ConfigTest extends DDSpecification {
     System.setProperty(PREFIX + PROFILING_EXCEPTION_HISTOGRAM_MAX_COLLECTION_SIZE, "1122")
     System.setProperty(PREFIX + PROFILING_AGENTLESS, "true")
 
-    System.setProperty(PREFIX + REMOTE_CONFIG_ENABLED, "true")
+    System.setProperty(PREFIX + REMOTE_CONFIGURATION_ENABLED, "true")
     System.setProperty(PREFIX + REMOTE_CONFIG_URL, "remote config url")
     System.setProperty(PREFIX + REMOTE_CONFIG_POLL_INTERVAL_SECONDS, "3")
     System.setProperty(PREFIX + REMOTE_CONFIG_MAX_PAYLOAD_SIZE, "2")


### PR DESCRIPTION
# What Does This Do

Fix remote config activation configuration name according to the RFC from `DD_REMOTE_CONFIG_ENABLED` to `DD_REMOTE_CONFIGURATION_ENABLED`.

# Motivation

This is a follow up fix for the issue #6640 

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
