### PR TITLE
Add support for periodic submission of telemetry distribution series

### DIFF
--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -145,6 +145,8 @@ excludedClassesCoverage += [
   'datadog.trace.api.iast.util.Cookie',
   'datadog.trace.api.iast.util.Cookie.Builder',
   'datadog.trace.api.telemetry.LogCollector.RawLogMessage',
+  "datadog.trace.api.telemetry.MetricCollector.DistributionSeriesPoint",
+  "datadog.trace.api.telemetry.MetricCollector",
   // stubs
   'datadog.trace.api.profiling.Timing.NoOp',
   'datadog.trace.api.profiling.Timer.NoOp',

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/MetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/MetricCollector.java
@@ -120,11 +120,11 @@ public interface MetricCollector<M extends Metric> {
     public final String metricName;
     public final boolean common;
     public final String namespace;
-    public final Integer value;
+    public final int value;
     public final List<String> tags;
 
     public DistributionSeriesPoint(
-        String metricName, boolean common, String namespace, Integer value, List<String> tags) {
+        String metricName, boolean common, String namespace, int value, List<String> tags) {
       this.metricName = metricName;
       this.common = common;
       this.namespace = namespace;

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/MetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/MetricCollector.java
@@ -6,6 +6,7 @@ import static java.util.Collections.singletonList;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -19,6 +20,10 @@ public interface MetricCollector<M extends Metric> {
   void prepareMetrics();
 
   Collection<M> drain();
+
+  default Collection<DistributionSeriesPoint> drainDistributionSeries() {
+    return Collections.emptySet();
+  }
 
   class Metric {
     public final String metricName;
@@ -103,6 +108,57 @@ public interface MetricCollector<M extends Metric> {
           + '\''
           + ", timestamp="
           + timestamp
+          + ", value="
+          + value
+          + ", tags="
+          + tags
+          + '}';
+    }
+  }
+
+  class DistributionSeriesPoint {
+    public final String metricName;
+    public final boolean common;
+    public final String namespace;
+    public final Integer value;
+    public final List<String> tags;
+
+    public DistributionSeriesPoint(
+        String metricName, boolean common, String namespace, Integer value, List<String> tags) {
+      this.metricName = metricName;
+      this.common = common;
+      this.namespace = namespace;
+      this.value = value;
+      this.tags = tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      DistributionSeriesPoint that = (DistributionSeriesPoint) o;
+      return common == that.common
+          && Objects.equals(metricName, that.metricName)
+          && Objects.equals(namespace, that.namespace)
+          && Objects.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(metricName, common, namespace, tags);
+    }
+
+    @Override
+    public String toString() {
+      return "DistributionSeriesPoint{"
+          + "metricName='"
+          + metricName
+          + '\''
+          + ", common="
+          + common
+          + ", namespace='"
+          + namespace
+          + '\''
           + ", value="
           + value
           + ", tags="

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryService.java
@@ -108,7 +108,6 @@ public class TelemetryService {
   }
 
   public boolean addDistributionSeries(DistributionSeries series) {
-    // TODO doesn't seem to be used
     return this.distributionSeries.offer(series);
   }
 

--- a/telemetry/src/main/java/datadog/telemetry/api/DistributionSeries.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/DistributionSeries.java
@@ -28,6 +28,10 @@ public class DistributionSeries {
     return this;
   }
 
+  public void addPoint(Integer point) {
+    points.add(point);
+  }
+
   public List<String> getTags() {
     return tags;
   }

--- a/telemetry/src/main/java/datadog/telemetry/api/DistributionSeries.java
+++ b/telemetry/src/main/java/datadog/telemetry/api/DistributionSeries.java
@@ -28,7 +28,7 @@ public class DistributionSeries {
     return this;
   }
 
-  public void addPoint(Integer point) {
+  public void addPoint(int point) {
     points.add(point);
   }
 

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryRunnableSpecification.groovy
@@ -62,6 +62,7 @@ class TelemetryRunnableSpecification extends DDSpecification {
 
     then:
     1 * metricCollector.drain() >> []
+    1 * metricCollector.drainDistributionSeries() >> []
     1 * periodicAction.doIteration(telemetryService)
 
     then: 'two partial and one final telemetry data requests'
@@ -157,6 +158,7 @@ class TelemetryRunnableSpecification extends DDSpecification {
 
     then:
     1 * metricCollector.drain() >> []
+    1 * metricCollector.drainDistributionSeries() >> []
     1 * periodicAction.doIteration(telemetryService)
 
     then:
@@ -187,6 +189,7 @@ class TelemetryRunnableSpecification extends DDSpecification {
     then:
     1 * metricCollector.prepareMetrics()
     1 * metricCollector.drain() >> []
+    1 * metricCollector.drainDistributionSeries() >> []
     1 * periodicAction.doIteration(telemetryService)
     1 * telemetryService.sendTelemetryEvents()
 

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionTest.groovy
@@ -2,6 +2,7 @@ package datadog.telemetry.metric
 
 
 import datadog.telemetry.TelemetryService
+import datadog.telemetry.api.DistributionSeries
 import datadog.telemetry.api.Metric
 import datadog.trace.api.telemetry.MetricCollector
 import edu.umd.cs.findbugs.annotations.NonNull
@@ -21,6 +22,7 @@ class MetricPeriodicActionTest extends Specification {
     action.doIteration(service)
 
     then:
+    metricCollector.drainDistributionSeries() >> []
     metricCollector.drain() >> metrics
     expected.each { Metric metric ->
       1 * service.addMetric({ it ->
@@ -41,7 +43,38 @@ class MetricPeriodicActionTest extends Specification {
     [col(counter: 2L, tags: ['a:b', 'c:d']), col(counter: 6L, tags: ['a:b', 'c:d'])] | [tel(points: [[_, 2L], [_, 6L]], tags: ['a:b', 'c:d'])]
   }
 
-  private MetricCollector.Metric col(final Map metric) {
+  void 'test that common distribution series are joined before being sent to telemetry'() {
+    given:
+    final service = Mock(TelemetryService)
+    final MetricCollector<MetricCollector.Metric> metricCollector = Mock(MetricCollector)
+    final action = new DefaultMetricPeriodicAction(metricCollector)
+
+    when:
+    action.doIteration(service)
+
+    then:
+    metricCollector.drain() >> []
+    metricCollector.drainDistributionSeries() >> distributionSeries
+    expected.each { DistributionSeries series ->
+      1 * service.addDistributionSeries({ it ->
+        assertDistributionSeries(it, series)
+      })
+    }
+    0 * _
+
+    where:
+    distributionSeries                                                                     | expected
+    [rawSeries(value: 2)]                                                                  | [series(points: [2])]
+    [rawSeries(value: 2), rawSeries(value: 6)]                                             | [series(points: [2, 6])]
+    [rawSeries(value: 2), rawSeries(namespace: 'other', value: 6)]                         | [series(points: [2]), series(namespace: 'other', points: [6])]
+    [rawSeries(value: 2), rawSeries(common: false, value: 6)]                              | [series(points: [2]), series(common: false, points: [6])]
+    [rawSeries(value: 2), rawSeries(metric: 'other', value: 6)]                            | [series(points: [2]), series(metric: 'other', points: [6])]
+    [rawSeries(value: 2), rawSeries(tags: ['a:b'], value: 6)]                              | [series(points: [2]), series(tags: ['a:b'], points: [6])]
+    [rawSeries(value: 2, tags: ['a:b']), rawSeries(value: 6, tags: ['c:d'])]               | [series(points: [2], tags: ['a:b']), series(points: [6], tags: ['c:d'])]
+    [rawSeries(value: 2, tags: ['a:b', 'c:d']), rawSeries(value: 6, tags: ['a:b', 'c:d'])] | [series(points: [2, 6], tags: ['a:b', 'c:d'])]
+  }
+
+  private static MetricCollector.Metric col(final Map metric) {
     metric.namespace = metric.namespace ?: 'namespace'
     metric.metric = metric.metric ?: 'metric'
     metric.common = metric.common == null ? true : metric.common
@@ -57,7 +90,7 @@ class MetricPeriodicActionTest extends Specification {
   }
 
   @NamedVariant
-  private Metric tel(@NamedDelegate final Metric metric) {
+  private static Metric tel(@NamedDelegate final Metric metric) {
     metric.namespace = metric.namespace ?: 'namespace'
     metric.metric = metric.metric ?: 'metric'
     metric.common = metric.common == null ? true : metric.common
@@ -66,7 +99,30 @@ class MetricPeriodicActionTest extends Specification {
     return metric
   }
 
-  private boolean assertMetric(Metric received, Metric expected) {
+  private static MetricCollector.DistributionSeriesPoint rawSeries(final Map point) {
+    point.namespace = point.namespace ?: 'namespace'
+    point.metric = point.metric ?: 'metric'
+    point.common = point.common == null ? true : point.common
+    point.tags = point.tags ?: []
+    return new MetricCollector.DistributionSeriesPoint(
+      point.metric as String,
+      point.common as boolean,
+      point.namespace as String,
+      point.value as Integer,
+      point.tags as List<String>
+      )
+  }
+
+  private static DistributionSeries series(final Map distributionSeries) {
+    return new DistributionSeries()
+      .namespace(distributionSeries.namespace as String ?: 'namespace')
+      .metric(distributionSeries.metric as String ?: 'metric')
+      .common(distributionSeries.common == null ? true : distributionSeries.common as Boolean)
+      .tags(distributionSeries.tags as List<String> ?: [])
+      .points(distributionSeries.points as List<Integer>)
+  }
+
+  private static boolean assertMetric(Metric received, Metric expected) {
     if (!Objects.equals(received.namespace, expected.namespace)) {
       return false
     }
@@ -90,6 +146,14 @@ class MetricPeriodicActionTest extends Specification {
     return receivedPoints.containsAll(expectedPoints)
   }
 
+  private static boolean assertDistributionSeries(DistributionSeries received, DistributionSeries expected) {
+    return Objects.equals(received.namespace, expected.namespace) &&
+      Objects.equals(received.metric, expected.metric) &&
+      Objects.equals(received.common, expected.common) &&
+      Objects.equals(received.tags, expected.tags) &&
+      received.points.size() == expected.points.size() &&
+      received.points.containsAll(expected.points)
+  }
 
   class DefaultMetricPeriodicAction extends MetricPeriodicAction {
 


### PR DESCRIPTION
# What Does This Do
Adds support for periodical polling and submission of distribution series telemetry.

# Motivation
Distribution series will be used by future CI Visibility telemetry logic.

# Additional Notes
Most of the logic for sending distribution series data was implemented previously.
This PR adds the missing part - polling periodic metric collectors, aggregating drained data and passing it over to telemetry service.

Jira ticket: [CIVIS-2427]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ