### PR TITLE
Do not switch to agent telemetry client on detecting agent telemetry endpoint availability when intake client is preferred

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRouter.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRouter.java
@@ -12,9 +12,8 @@ public class TelemetryRouter {
 
   private final DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery;
   private final TelemetryClient agentClient;
-
   private final TelemetryClient intakeClient;
-
+  private final boolean useIntakeClientByDefault;
   private TelemetryClient currentClient;
   private boolean errorReported;
 
@@ -26,6 +25,7 @@ public class TelemetryRouter {
     this.ddAgentFeaturesDiscovery = ddAgentFeaturesDiscovery;
     this.agentClient = agentClient;
     this.intakeClient = intakeClient;
+    this.useIntakeClientByDefault = useIntakeClientByDefault;
     this.currentClient = useIntakeClientByDefault ? intakeClient : agentClient;
   }
 
@@ -50,12 +50,12 @@ public class TelemetryRouter {
       if (requestFailed) {
         reportErrorOnce(currentClient.getUrl(), result);
       }
-      if (agentSupportsTelemetryProxy || requestFailed) {
+      if ((agentSupportsTelemetryProxy && !useIntakeClientByDefault) || requestFailed) {
         errorReported = false;
-        if (agentSupportsTelemetryProxy) {
-          log.info("Agent Telemetry endpoint is now available. Telemetry will be sent to Agent.");
-        } else {
+        if (requestFailed) {
           log.info("Intake Telemetry endpoint failed. Telemetry will be sent to Agent.");
+        } else {
+          log.info("Agent Telemetry endpoint is now available. Telemetry will be sent to Agent.");
         }
         currentClient = agentClient;
       }


### PR DESCRIPTION
# What Does This Do

Updates telemetry client switch logic.
Prior to the change the logic could switch from intake client to agent client in the following circumstances:
- if a telemetry request fails
- if agent is available and has telemetry proxy endpoint

With the change the logic is to do the switch if:
- if a telemetry request fails
- if agent is available, has telemetry proxy endpoint and _the tracer is not configured for "agentless" mode_.

# Motivation
If the tracer is explicitly configured to work in agentless mode, the intake telemetry client should be the preferred one.

Jira ticket: [CIVIS-2427]
<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ