### PR TITLE
Update Gradle smoke tests

### DIFF
--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -94,20 +94,20 @@ class GradleDaemonSmokeTest extends CiVisibilitySmokeTest {
     "4.0"                 | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
     "5.0"                 | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
     "6.0"                 | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
-    "7.6.3"               | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
+    "7.6.4"               | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
     "8.3"                 | "test-succeed-new-instrumentation"                 | false              | true            | false        | 5              | 1
     LATEST_GRADLE_VERSION | "test-succeed-new-instrumentation"                 | false              | true            | false        | 5              | 1
     "8.3"                 | "test-succeed-new-instrumentation"                 | true               | true            | false        | 5              | 1
     LATEST_GRADLE_VERSION | "test-succeed-new-instrumentation"                 | true               | true            | false        | 5              | 1
-    "7.6.3"               | "test-succeed-multi-module-legacy-instrumentation" | false              | true            | false        | 7              | 2
+    "7.6.4"               | "test-succeed-multi-module-legacy-instrumentation" | false              | true            | false        | 7              | 2
     LATEST_GRADLE_VERSION | "test-succeed-multi-module-new-instrumentation"    | false              | true            | false        | 7              | 2
-    "7.6.3"               | "test-succeed-multi-forks-legacy-instrumentation"  | false              | true            | false        | 6              | 2
+    "7.6.4"               | "test-succeed-multi-forks-legacy-instrumentation"  | false              | true            | false        | 6              | 2
     LATEST_GRADLE_VERSION | "test-succeed-multi-forks-new-instrumentation"     | false              | true            | false        | 6              | 2
-    "7.6.3"               | "test-skip-legacy-instrumentation"                 | false              | true            | false        | 2              | 0
+    "7.6.4"               | "test-skip-legacy-instrumentation"                 | false              | true            | false        | 2              | 0
     LATEST_GRADLE_VERSION | "test-skip-new-instrumentation"                    | false              | true            | false        | 2              | 0
-    "7.6.3"               | "test-failed-legacy-instrumentation"               | false              | false           | false        | 4              | 0
+    "7.6.4"               | "test-failed-legacy-instrumentation"               | false              | false           | false        | 4              | 0
     LATEST_GRADLE_VERSION | "test-failed-new-instrumentation"                  | false              | false           | false        | 4              | 0
-    "7.6.3"               | "test-corrupted-config-legacy-instrumentation"     | false              | false           | false        | 1              | 0
+    "7.6.4"               | "test-corrupted-config-legacy-instrumentation"     | false              | false           | false        | 1              | 0
     LATEST_GRADLE_VERSION | "test-corrupted-config-new-instrumentation"        | false              | false           | false        | 1              | 0
     LATEST_GRADLE_VERSION | "test-succeed-junit-5"                             | false              | true            | false        | 5              | 1
     LATEST_GRADLE_VERSION | "test-failed-flaky-retries"                        | false              | false           | true         | 8              | 0

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-5/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-5/build.gradleTest
@@ -13,6 +13,8 @@ testing {
 
             dependencies {
               implementation 'org.junit.platform:junit-platform-launcher:1.9.3'
+              implementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+              implementation 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
             }
         }
     }

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-legacy-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-legacy-instrumentation/build.gradleTest
@@ -8,9 +8,9 @@ repositories {
 dependencies {
   testImplementation 'junit:junit:4.10'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.3'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
-  testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
+  testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.3'
 }
 
 test {

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-new-instrumentation/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-new-instrumentation/build.gradleTest
@@ -8,9 +8,9 @@ repositories {
 dependencies {
   testImplementation 'junit:junit:4.10'
   testImplementation 'org.junit.platform:junit-platform-launcher:1.9.3'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
-  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
-  testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
+  testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.3'
 }
 
 test {


### PR DESCRIPTION
# What Does This Do
Updates Gradle smoke tests:
- changes Gradle version from 7.6.3 to 7.6.4 following a recent release
- add missing (or updates incorrect) JUnit version in some of the test fixture projects

Jira ticket: [CIVIS-2427]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ