### PR TITLE
Update telemetry intake client to use CI Visibility agentless URL, if configured

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -16,7 +16,6 @@ import datadog.trace.util.AgentThreadFactory;
 import java.lang.instrument.Instrumentation;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,11 +75,7 @@ public class TelemetrySystem {
     DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery = sco.featuresDiscovery(config);
 
     TelemetryClient agentClient = TelemetryClient.buildAgentClient(sco.okHttpClient, sco.agentUrl);
-    TelemetryClient intakeClient =
-        TelemetryClient.buildIntakeClient(
-            config.getSite(),
-            TimeUnit.SECONDS.toMillis(config.getAgentTimeout()),
-            config.getApiKey());
+    TelemetryClient intakeClient = TelemetryClient.buildIntakeClient(config);
 
     boolean useIntakeClientByDefault =
         config.isCiVisibilityEnabled() && config.isCiVisibilityAgentlessEnabled();

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
@@ -5,21 +5,27 @@ import spock.lang.Specification
 
 class TelemetryClientTest extends Specification {
 
-  def "Uses CI Visibility agentless URL if configured to do so"() {
+  def "Intake client uses CI Visibility agentless URL if configured to do so"() {
     setup:
     def config = Stub(Config)
     config.getApiKey() >> "dummy-key"
     config.getAgentTimeout() >> 123
-    config.isCiVisibilityEnabled() >> true
-    config.isCiVisibilityAgentlessEnabled() >> true
-
-    def agentlessUrl = "http://ci.visibility.agentless.url"
-    config.getCiVisibilityAgentlessUrl() >> agentlessUrl
+    config.getSite() >> "datad0g.com"
+    config.isCiVisibilityEnabled() >> ciVisEnabled
+    config.isCiVisibilityAgentlessEnabled() >> ciVisAgentlessEnabled
+    config.getCiVisibilityAgentlessUrl() >> ciVisAgentlessUrl
 
     when:
     def intakeClient = TelemetryClient.buildIntakeClient(config)
 
     then:
-    intakeClient.getUrl().toString() == agentlessUrl + "/api/v2/apmtelemetry"
+    intakeClient.getUrl().toString() == expectedUrl
+
+    where:
+    ciVisEnabled | ciVisAgentlessEnabled | ciVisAgentlessUrl                    | expectedUrl
+    true         | true                  | "http://ci.visibility.agentless.url" | "http://ci.visibility.agentless.url/api/v2/apmtelemetry"
+    false        | true                  | "http://ci.visibility.agentless.url" | "https://all-http-intake.logs.datad0g.com/api/v2/apmtelemetry"
+    true         | false                 | "http://ci.visibility.agentless.url" | "https://all-http-intake.logs.datad0g.com/api/v2/apmtelemetry"
+    true         | true                  | null                                 | "https://all-http-intake.logs.datad0g.com/api/v2/apmtelemetry"
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
@@ -1,0 +1,25 @@
+package datadog.telemetry
+
+import datadog.trace.api.Config
+import spock.lang.Specification
+
+class TelemetryClientTest extends Specification {
+
+  def "Uses CI Visibility agentless URL if configured to do so"() {
+    setup:
+    def config = Stub(Config)
+    config.getApiKey() >> "dummy-key"
+    config.getAgentTimeout() >> 123
+    config.isCiVisibilityEnabled() >> true
+    config.isCiVisibilityAgentlessEnabled() >> true
+
+    def agentlessUrl = "http://ci.visibility.agentless.url"
+    config.getCiVisibilityAgentlessUrl() >> agentlessUrl
+
+    when:
+    def intakeClient = TelemetryClient.buildIntakeClient(config)
+
+    then:
+    intakeClient.getUrl().toString() == agentlessUrl + "/api/v2/apmtelemetry"
+  }
+}


### PR DESCRIPTION
# What Does This Do
Updates telemetry intake client to use CI Visibility agentless URL if CI Visibility agentless mode is enabled and the URL is configured.

# Motivation
Some users who run the tracer in agentless mode might need to use a non-standard URL.
A non-standard URL is also needed in smoke tests that start a mock intake server.

# Additional Notes
The custom URL is only used if CI Visibility is enabled.

Jira ticket: [CIVIS-2427]
<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ