### PR TITLE
Add task to index instrumenters by their (ordered) module

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -175,7 +175,7 @@ public final class CombiningTransformerBuilder extends AbstractTransformerBuilde
   }
 
   @Override
-  public void applyAdvice(ElementMatcher<? super MethodDescription> matcher, String className) {
+  public void applyAdvice(ElementMatcher<? super MethodDescription> matcher, String adviceClass) {
     Advice.WithCustomMapping customMapping = Advice.withCustomMapping();
     if (postProcessor != null) {
       customMapping = customMapping.with(postProcessor);
@@ -184,7 +184,7 @@ public final class CombiningTransformerBuilder extends AbstractTransformerBuilde
         new AgentBuilder.Transformer.ForAdvice(customMapping)
             .include(Utils.getBootstrapProxy(), Utils.getAgentClassLoader())
             .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
-            .advice(not(ignoredMethods).and(matcher), className));
+            .advice(not(ignoredMethods).and(matcher), adviceClass));
   }
 
   @Override

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/LegacyTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/LegacyTransformerBuilder.java
@@ -174,13 +174,13 @@ public final class LegacyTransformerBuilder extends AbstractTransformerBuilder {
   }
 
   @Override
-  public void applyAdvice(ElementMatcher<? super MethodDescription> matcher, String className) {
+  public void applyAdvice(ElementMatcher<? super MethodDescription> matcher, String adviceClass) {
     adviceBuilder =
         adviceBuilder.transform(
             new AgentBuilder.Transformer.ForAdvice()
                 .include(Utils.getBootstrapProxy(), Utils.getAgentClassLoader())
                 .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
-                .advice(not(ignoreMatcher).and(matcher), className));
+                .advice(not(ignoreMatcher).and(matcher), adviceClass));
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/Instrumenter.java
@@ -39,6 +39,9 @@ public interface Instrumenter {
     ElementMatcher<TypeDescription> hierarchyMatcher();
   }
 
+  /** Instrumentation that transforms types on the bootstrap class-path. */
+  interface ForBootstrap {}
+
   /**
    * Instrumentation that matches a series of types configured at runtime. This is used for last
    * minute additions in the field such as testing a new JDBC driver that is not yet in the allowed
@@ -107,9 +110,7 @@ public interface Instrumenter {
     void methodAdvice(MethodTransformer transformer);
   }
 
-  /** Instrumentation that transforms types on the bootstrap class-path. */
-  interface ForBootstrap {}
-
+  /** Applies type advice from an instrumentation that {@link HasTypeAdvice}. */
   interface TypeTransformer {
     void applyAdvice(TransformingAdvice typeAdvice);
 
@@ -118,10 +119,12 @@ public interface Instrumenter {
     }
   }
 
+  /** Applies method advice from an instrumentation that {@link HasMethodAdvice}. */
   interface MethodTransformer {
-    void applyAdvice(ElementMatcher<? super MethodDescription> matcher, String className);
+    void applyAdvice(ElementMatcher<? super MethodDescription> matcher, String adviceClass);
   }
 
+  /** Contributes a transformation step to the dynamic type builder. */
   interface TransformingAdvice {
     DynamicType.Builder<?> transform(
         DynamicType.Builder<?> builder,

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterIndex.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterIndex.java
@@ -1,0 +1,204 @@
+package datadog.trace.agent.tooling;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
+import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Maintains an index of known {@link Instrumenter} types sorted by {@link InstrumenterModule}. */
+final class InstrumenterIndex {
+  private static final Logger log = LoggerFactory.getLogger(InstrumenterIndex.class);
+
+  private static final String INSTRUMENTER_INDEX_NAME = "instrumenter.index";
+
+  private final int moduleCount;
+  private final int instrumenterCount;
+
+  // packed sequence of module types and their expected instrumenter types:
+  // module1, memberCount, memberA, memberB, module2, memberCount, memberC, ...
+  // (each string is encoded as its length plus that number of ASCII bytes)
+  private final byte[] packedNames;
+
+  private int nameIndex;
+
+  private int moduleIndex;
+  private int instrumenterIndex;
+
+  // current module details
+  private String moduleName;
+  private int memberCount;
+  private int memberIndex;
+
+  private InstrumenterIndex(int moduleCount, int instrumenterCount, byte[] packedNames) {
+    this.moduleCount = moduleCount;
+    this.instrumenterCount = instrumenterCount;
+    this.packedNames = packedNames;
+  }
+
+  /** Total number of modules in this index. */
+  public int getModuleCount() {
+    return moduleCount;
+  }
+
+  /** Total number of instrumenters in this index. */
+  public int getInstrumenterCount() {
+    return instrumenterCount;
+  }
+
+  /** Moves to the next indexed module. */
+  public String nextModule() {
+    if (moduleIndex >= moduleCount) {
+      throw new NoSuchElementException();
+    }
+
+    // skip names expected by previous module
+    while (memberIndex++ < memberCount) {
+      instrumenterIndex++;
+      skipName();
+    }
+
+    // setup next module
+    moduleName = readName();
+    moduleIndex++;
+    memberCount = readNumber();
+    memberIndex = 0;
+
+    return moduleName;
+  }
+
+  /** The id pre-allocated to the instrumenter; {@code -1} if it's not indexed. */
+  public int instrumenterId(String instrumenterName) {
+    if (memberIndex++ < memberCount) {
+      int id = instrumenterIndex++;
+      if (instrumenterName.equals(readName())) {
+        return id; // only use when the observed name matches the expected name
+      }
+    }
+    return -1;
+  }
+
+  /** Reads an unsigned byte from the packed name sequence. */
+  private int readNumber() {
+    return 0xFF & (int) packedNames[nameIndex++];
+  }
+
+  /** Reads an ASCII string from the packed name sequence. */
+  private String readName() {
+    int length = readNumber();
+    if (length > 0) {
+      String name = new String(packedNames, nameIndex, length, US_ASCII);
+      nameIndex += length;
+      return name;
+    } else {
+      return moduleName; // empty string means this is a self-referencing module
+    }
+  }
+
+  /** Skips an ASCII string in the packed name sequence. */
+  private void skipName() {
+    nameIndex += readNumber();
+  }
+
+  public static InstrumenterIndex readIndex() {
+    ClassLoader instrumenterClassLoader = Instrumenter.class.getClassLoader();
+    URL indexResource = instrumenterClassLoader.getResource(INSTRUMENTER_INDEX_NAME);
+    if (null != indexResource) {
+      try (DataInputStream in =
+          new DataInputStream(new BufferedInputStream(indexResource.openStream()))) {
+        int moduleCount = in.readInt();
+        int instrumenterCount = in.readInt();
+        int packedNamesLength = in.readInt();
+        byte[] packedNames = new byte[packedNamesLength];
+        in.readFully(packedNames);
+        return new InstrumenterIndex(moduleCount, instrumenterCount, packedNames);
+      } catch (Throwable e) {
+        log.error("Problem reading {}", INSTRUMENTER_INDEX_NAME, e);
+      }
+    }
+    return null;
+  }
+
+  /** Generates an index of known {@link Instrumenter}s in each {@link InstrumenterModule}. */
+  static class IndexGenerator {
+
+    private final List<String> moduleNames = new ArrayList<>();
+    private final List<List<String>> instrumenterNames = new ArrayList<>();
+
+    private int moduleCount = 0;
+    private int instrumenterCount = 0;
+    private int packedNamesLength = 0;
+
+    public void buildIndex() {
+      log.debug("Generating InstrumenterIndex");
+      for (InstrumenterModule module :
+          InstrumenterModules.load(Instrumenter.class.getClassLoader())) {
+        moduleCount++;
+        String moduleName = module.getClass().getName();
+        packedNamesLength += 1 + moduleName.length() + 1; // includes byte for memberCount
+        moduleNames.add(moduleName);
+        List<String> memberNames = new ArrayList<>();
+        for (Instrumenter member : module.typeInstrumentations()) {
+          instrumenterCount++;
+          // self-referencing modules use empty string to represent themselves as a member
+          String memberName = module == member ? "" : member.getClass().getName();
+          packedNamesLength += 1 + memberName.length();
+          memberNames.add(memberName);
+        }
+        instrumenterNames.add(memberNames);
+      }
+    }
+
+    public void writeIndex(Path indexFile) throws IOException {
+      try (DataOutputStream out =
+          new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(indexFile)))) {
+        out.writeInt(moduleCount);
+        out.writeInt(instrumenterCount);
+        out.writeInt(packedNamesLength);
+        for (int i = 0; i < moduleCount; i++) {
+          String moduleName = moduleNames.get(i);
+          List<String> memberNames = instrumenterNames.get(i);
+          out.writeByte(moduleName.length());
+          out.writeBytes(moduleName);
+          out.writeByte(memberNames.size());
+          for (String memberName : memberNames) {
+            out.writeByte(memberName.length());
+            out.writeBytes(memberName);
+          }
+        }
+      }
+    }
+
+    /**
+     * Called from 'generateInstrumenterIndex' task in 'dd-java-agent/instrumentation/build.gradle'.
+     */
+    public static void main(String[] args) throws IOException {
+      if (args.length < 1) {
+        throw new IllegalArgumentException("Expected: resources-dir");
+      }
+
+      Path resourcesDir = Paths.get(args[0]).toAbsolutePath();
+
+      // satisfy some instrumenters that cache matchers in initializers
+      HierarchyMatchers.registerIfAbsent(HierarchyMatchers.simpleChecks());
+      SharedTypePools.registerIfAbsent(SharedTypePools.simpleCache());
+
+      IndexGenerator indexGenerator = new IndexGenerator();
+      indexGenerator.buildIndex();
+      indexGenerator.writeIndex(resourcesDir.resolve(INSTRUMENTER_INDEX_NAME));
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -69,6 +69,11 @@ public abstract class InstrumenterModule implements Instrumenter {
     enabled = InstrumenterConfig.get().isIntegrationEnabled(instrumentationNames, defaultEnabled());
   }
 
+  /** Modules with higher order values are applied <i>after</i> those with lower values. */
+  public int order() {
+    return 0;
+  }
+
   public int instrumentationId() {
     return instrumentationId;
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModules.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModules.java
@@ -1,0 +1,56 @@
+package datadog.trace.agent.tooling;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Provides a sorted sequence of {@link InstrumenterModule}s. */
+public final class InstrumenterModules {
+  static final Logger log = LoggerFactory.getLogger(InstrumenterModules.class);
+
+  public static Iterable<InstrumenterModule> load(ClassLoader loader) {
+    List<InstrumenterModule> modules = new ArrayList<>();
+    for (String moduleName : loadModuleNames(loader)) {
+      try {
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        Class<InstrumenterModule> moduleType = (Class) loader.loadClass(moduleName);
+        modules.add(moduleType.getConstructor().newInstance());
+      } catch (Throwable e) {
+        log.error("Failed to load - InstrumenterModule={}", moduleName, e);
+      }
+    }
+    modules.sort(Comparator.comparing(InstrumenterModule::order));
+    return modules;
+  }
+
+  private static String[] loadModuleNames(ClassLoader loader) {
+    Set<String> lines = new LinkedHashSet<>();
+    try {
+      Enumeration<URL> urls =
+          loader.getResources("META-INF/services/datadog.trace.agent.tooling.InstrumenterModule");
+      while (urls.hasMoreElements()) {
+        try (BufferedReader reader =
+            new BufferedReader(
+                new InputStreamReader(urls.nextElement().openStream(), StandardCharsets.UTF_8))) {
+          String line = reader.readLine();
+          while (line != null) {
+            lines.add(line);
+            line = reader.readLine();
+          }
+        }
+      }
+    } catch (Throwable e) {
+      log.error("Failed to load - InstrumenterModule list", e);
+    }
+    return lines.toArray(new String[0]);
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/VisitingAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/VisitingAdvice.java
@@ -6,6 +6,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.utility.JavaModule;
 
+/** {@link AsmVisitorWrapper} type advice. */
 final class VisitingAdvice implements Instrumenter.TransformingAdvice {
   private final AsmVisitorWrapper visitor;
 

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -141,9 +141,28 @@ tasks.named('shadowJar').configure {
   dependencies deps.excludeShared
 }
 
+tasks.register('generateInstrumenterIndex', JavaExec) {
+  // temporary config to add slf4j-simple so we get logging from instrumenters while indexing
+  def slf4jSimple = project.configurations.maybeCreate('slf4j-simple')
+  project.dependencies.add('slf4j-simple', "org.slf4j:slf4j-simple:${versions.slf4j}")
+
+  def resourcesDir = "${sourceSets.main.output.resourcesDir}"
+  def indexFile = "${resourcesDir}/instrumenter.index"
+
+  it.group = 'Build'
+  it.description = "Generate instrumenter.index"
+  it.mainClass = 'datadog.trace.agent.tooling.InstrumenterIndex$IndexGenerator'
+  it.classpath = project.configurations.runtimeClasspath + slf4jSimple
+  it.inputs.files(it.classpath)
+  it.outputs.files(indexFile)
+  it.args = [resourcesDir]
+
+  dependsOn 'processResources'
+}
+
 tasks.register('generateKnownTypesIndex', JavaExec) {
   // temporary config to add slf4j-simple so we get logging from instrumenters while indexing
-  def slf4jSimple = project.configurations.create('slf4j-simple')
+  def slf4jSimple = project.configurations.maybeCreate('slf4j-simple')
   project.dependencies.add('slf4j-simple', "org.slf4j:slf4j-simple:${versions.slf4j}")
 
   def resourcesDir = "${sourceSets.main.output.resourcesDir}"
@@ -160,4 +179,4 @@ tasks.register('generateKnownTypesIndex', JavaExec) {
   dependsOn 'processResources'
 }
 
-shadowJar.dependsOn 'generateKnownTypesIndex'
+shadowJar.dependsOn 'generateInstrumenterIndex', 'generateKnownTypesIndex'

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/muzzle/MuzzleGenerateTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/integration/muzzle/MuzzleGenerateTest.groovy
@@ -8,16 +8,11 @@ class MuzzleGenerateTest extends Specification {
   def "muzzle references generated for all instrumentation"() {
     setup:
     List<Class> missingMatchers = []
-    ClassLoader agentClassLoader = IntegrationTestUtils.getAgentClassLoader()
-    Class<?> instrumenterClass = agentClassLoader.loadClass('datadog.trace.agent.tooling.Instrumenter')
+    ClassLoader agentClassLoader = IntegrationTestUtils.agentClassLoader
     Class<?> instrumenterModuleClass = agentClassLoader.loadClass('datadog.trace.agent.tooling.InstrumenterModule')
-    for (Object instrumenter : ServiceLoader.load(instrumenterClass, agentClassLoader)) {
-      if (!instrumenterModuleClass.isInstance(instrumenter)) {
-        // muzzle only applies to instrumenter modules
-        continue
-      }
-      if (instrumenter.instrumentationMuzzle == null) {
-        missingMatchers.add(instrumenter.class)
+    for (Object module : ServiceLoader.load(instrumenterModuleClass, agentClassLoader)) {
+      if (module.instrumentationMuzzle == null) {
+        missingMatchers.add(module.class)
       }
     }
     expect:


### PR DESCRIPTION
# What Does This Do

Introduces `InstrumenterModule::order()` to declare ordering between modules. Modules with higher order values are applied _after_ those with lower values. This is used to sort modules when discovering them via `META-INF/services`

The sorted list is used to create a build-time index of known modules and their `Instrumenter`s. This index will be used to iterate over modules at runtime and provide a stable id for each expected `Instrumenter`

# Additional Notes

We need stable `Instrumenter` ids to build the "known-types" index, which uses a trie to match against known class-names and return the matched `Instrumenter` ids. This new index lets us capture the expected sequence of modules and their `Instrumenter`s. We to capture both because with the change to use modules the same `Instrumenter` type could appear under different modules, but constructed with different arguments. Recording the module surrounding the `Instrumenter` helps disambiguate between these different constructions.

Jira ticket: [AIT-9441]

[AIT-9441]: https://datadoghq.atlassian.net/browse/AIT-9441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ