### PR TITLE
Use pool class name to get fixed test names

### DIFF
--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -36,7 +36,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
   @Shared
   def akkaInvokeForkJoinTask = { e, c -> e.invoke((ForkJoinTask) c) }
 
-  def "#poolImpl '#name' propagates"() {
+  def "#poolName '#name' propagates"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -88,6 +88,8 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
     "submit Callable"      | submitCallable          | new ForkJoinExecutorConfigurator.AkkaForkJoinPool(2, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true)
     "submit ForkJoinTask"  | akkaSubmitForkJoinTask  | new ForkJoinExecutorConfigurator.AkkaForkJoinPool(2, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true)
     "invoke ForkJoinTask"  | akkaInvokeForkJoinTask  | new ForkJoinExecutorConfigurator.AkkaForkJoinPool(2, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true)
+
+    poolName = poolImpl.class.simpleName
   }
 
   def "dispatcher propagates context" () {
@@ -119,7 +121,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
     trace.get(1).parentId == trace.get(0).spanId
   }
 
-  def "#poolImpl '#name' reports after canceled jobs"() {
+  def "#poolName '#name' reports after canceled jobs"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -170,5 +172,6 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
     name              | method         | poolImpl
     "submit Runnable" | submitRunnable | new ForkJoinPool()
     "submit Callable" | submitCallable | new ForkJoinPool()
+    poolName = poolImpl.class.simpleName
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/lambda-testing/src/test/groovy/ExecutorLambdaTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/lambda-testing/src/test/groovy/ExecutorLambdaTest.groovy
@@ -21,7 +21,7 @@ class ExecutorLambdaTest extends AgentTestRunner {
   @Shared
   def scheduleCallable = { e, c -> e.schedule((Callable) c, 10, TimeUnit.MILLISECONDS) }
 
-  def "#poolImpl '#name' wrap lambdas"() {
+  def "#poolName '#name' wrap lambdas"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -61,5 +61,7 @@ class ExecutorLambdaTest extends AgentTestRunner {
     "execute Runnable"  | executeRunnable  | { LambdaGenerator.wrapRunnable(it) } | new ThreadPoolExecutor(1, 1, 5, TimeUnit.SECONDS, new TaskQueue())
     "submit Runnable"   | submitRunnable   | { LambdaGenerator.wrapRunnable(it) } | new ThreadPoolExecutor(1, 1, 5, TimeUnit.SECONDS, new TaskQueue())
     "submit Callable"   | submitCallable   | { LambdaGenerator.wrapCallable(it) } | new ThreadPoolExecutor(1, 1, 5, TimeUnit.SECONDS, new TaskQueue())
+
+    poolName = poolImpl.class.simpleName
   }
 }

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -69,7 +69,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
   }
 
   @Unroll
-  def "#poolImpl '#name' propagates"() {
+  def "#poolName '#name' propagates"() {
     setup:
     assumeTrue(poolImpl != null) // skip for Java 7 CompletableFuture, non-Linux Netty EPoll
     def pool = poolImpl
@@ -237,10 +237,11 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
     "schedule Runnable"      | scheduleRunnable    | MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor())
     "schedule Callable"      | scheduleCallable    | MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor())
     // spotless:on
+    poolName = poolImpl.class.simpleName
   }
 
   @Unroll
-  def "#poolImpl '#name' doesn't propagate"() {
+  def "#poolName '#name' doesn't propagate"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -304,6 +305,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
     "schedule at fixed rate"    | scheduleAtFixedRate    | new ScheduledThreadPoolExecutor(1)
     "schedule with fixed delay" | scheduleWithFixedDelay | new ScheduledThreadPoolExecutor(1)
     // spotless:on
+    poolName = poolImpl.class.simpleName
   }
 
   def "excluded ToBeIgnoredExecutor doesn't propagate"() {
@@ -354,7 +356,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
   }
 
   @Unroll
-  def "#poolImpl '#name' wraps"() {
+  def "#poolName '#name' wraps"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -388,10 +390,11 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
     "execute Runnable"  | executeRunnable  | { new RunnableWrapper(it) } | new ScheduledThreadPoolExecutor(1)
     "submit Runnable"   | submitRunnable   | { new RunnableWrapper(it) } | new ScheduledThreadPoolExecutor(1)
     "schedule Runnable" | scheduleRunnable | { new RunnableWrapper(it) } | new ScheduledThreadPoolExecutor(1)
+    poolName = poolImpl.class.simpleName
   }
 
   @Unroll
-  def "#poolImpl '#name' reports after canceled jobs"() {
+  def "#poolName '#name' reports after canceled jobs"() {
     setup:
     assumeTrue(poolImpl != null) // skip for non-Linux Netty EPoll
     def pool = poolImpl
@@ -481,6 +484,8 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
     //    "submit Callable"     | submitCallable     | MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor())
     //    "schedule Runnable"   | scheduleRunnable   | MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor())
     //    "schedule Callable"   | scheduleCallable   | MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor())
+
+    poolName = poolImpl.class.simpleName
   }
 
   static class ToBeIgnoredExecutor extends ThreadPoolExecutor {

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/NettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/NettyExecutorInstrumentationTest.groovy
@@ -52,7 +52,7 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
   @Shared
   def scheduleCallable = { e, c -> e.schedule((Callable) c, 10, TimeUnit.MILLISECONDS) }
 
-  def "#poolImpl '#name' propagates"() {
+  def "#poolName '#name' propagates"() {
     setup:
     assumeTrue(poolImpl != null) // skip for non-Linux Netty EPoll
     def pool = poolImpl
@@ -195,9 +195,10 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
     "schedule Runnable"      | scheduleRunnable    | localEventLoopGroup
     "schedule Callable"      | scheduleCallable    | localEventLoopGroup
 
+    poolName = poolImpl.class.simpleName
   }
 
-  def "#poolImpl '#name' reports after canceled jobs"() {
+  def "#poolName '#name' reports after canceled jobs"() {
     setup:
     assumeTrue(poolImpl != null) // skip for non-Linux Netty EPoll
     def pool = poolImpl
@@ -272,6 +273,8 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
     "submit Callable"        | submitCallable      | localEventLoopGroup.next()
     "schedule Runnable"      | scheduleRunnable    | localEventLoopGroup.next()
     "schedule Callable"      | scheduleCallable    | localEventLoopGroup.next()
+
+    poolName = poolImpl.class.simpleName
   }
 
   def epollExecutor() {

--- a/dd-java-agent/instrumentation/jetty-util/src/test/groovy/JettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-util/src/test/groovy/JettyExecutorInstrumentationTest.groovy
@@ -35,7 +35,7 @@ class JettyExecutorInstrumentationTest extends AgentTestRunner {
   @Shared
   def invokeAny = { e, c -> e.invokeAny([(Callable) c]) }
 
-  def "#poolImpl '#name' propagates"() {
+  def "#poolName '#name' propagates"() {
     setup:
     assumeTrue(poolImpl != null) // skip for Java 7 CompletableFuture, non-Linux Netty EPoll
     def pool = poolImpl
@@ -74,5 +74,6 @@ class JettyExecutorInstrumentationTest extends AgentTestRunner {
     "execute Runnable"       | executeRunnable     | new MonitoredQueuedThreadPool(8)
     "execute Runnable"       | executeRunnable     | new QueuedThreadPool(8)
     "execute Runnable"       | executeRunnable     | new ReservedThreadExecutor(delegate(), 1)
+    poolName = poolImpl.class.simpleName
   }
 }

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -34,7 +34,7 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
   @Shared
   def scalaInvokeForkJoinTask = { e, c -> e.invoke((ForkJoinTask) c) }
 
-  def "#poolImpl '#name' propagates"() {
+  def "#poolName '#name' propagates"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -79,9 +79,11 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
     "submit Callable"      | submitCallable           | new ForkJoinPool()
     "submit ForkJoinTask"  | scalaSubmitForkJoinTask  | new ForkJoinPool()
     "invoke ForkJoinTask"  | scalaInvokeForkJoinTask  | new ForkJoinPool()
+
+    poolName = poolImpl.class.simpleName
   }
 
-  def "#poolImpl '#name' reports after canceled jobs"() {
+  def "#poolName '#name' reports after canceled jobs"() {
     setup:
     def pool = poolImpl
     def m = method
@@ -132,5 +134,6 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
     name              | method         | poolImpl
     "submit Runnable" | submitRunnable | new ForkJoinPool()
     "submit Callable" | submitCallable | new ForkJoinPool()
+    poolName = poolImpl.class.simpleName
   }
 }


### PR DESCRIPTION
# What Does This Do

Use pool class name rather than relying on `Object.toString()` to get fixed test names

# Motivation

This causes issues with CI visibility.

# Additional Notes

Jira ticket: [APMJAVA-1241]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1241]: https://datadoghq.atlassian.net/browse/APMJAVA-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ