### PR TITLE
Update CODEOWNERS to include dd-trace-java team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,20 @@
 # Default owners, overridden by file/directory specific owners below
 * @DataDog/apm-java
 
+# Shared ownership (CI, build, configuration, etc.)
+# @DataDog/dd-trace-java
+.circleci/             @DataDog/dd-trace-java
+.github/               @DataDog/dd-trace-java
+.gitlab/               @DataDog/dd-trace-java
+*.gradle               @DataDog/dd-trace-java
+gradle*                @DataDog/dd-trace-java
+gradle/                @DataDog/dd-trace-java
+**/ConfigDefaults.java @DataDog/dd-trace-java
+**/Config.java         @DataDog/dd-trace-java
+
 # @DataDog/profiling-java
-dd-java-agent/agent-profiling/                                                             @DataDog/profiling-java
 dd-java-agent/agent-crashtracking/                                                         @DataDog/profiling-java
+dd-java-agent/agent-profiling/                                                             @DataDog/profiling-java
 dd-java-agent/instrumentation/exception-profiling/                                         @DataDog/profiling-java
 dd-java-agent/instrumentation/java-directbytebuffer/                                       @DataDog/profiling-java
 dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jfr/   @DataDog/profiling-java
@@ -16,14 +27,14 @@ dd-smoke-tests/profiling-integration-tests/                                     
 # @DataDog/ci-app-libraries-java
 dd-java-agent/agent-ci-visibility/         @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/cucumber/    @DataDog/ci-app-libraries-java
+dd-java-agent/instrumentation/gradle/      @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/jacoco/      @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/junit-4.10/  @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/junit-5.3/   @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/karate/      @DataDog/ci-app-libraries-java
+dd-java-agent/instrumentation/maven-3.2.1/ @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/scalatest/   @DataDog/ci-app-libraries-java
 dd-java-agent/instrumentation/testng/      @DataDog/ci-app-libraries-java
-dd-java-agent/instrumentation/gradle/      @DataDog/ci-app-libraries-java
-dd-java-agent/instrumentation/maven-3.2.1/ @DataDog/ci-app-libraries-java
 dd-smoke-tests/gradle/                     @DataDog/ci-app-libraries-java
 dd-smoke-tests/maven/                      @DataDog/ci-app-libraries-java
 **/civisibility/                           @DataDog/ci-app-libraries-java
@@ -31,19 +42,21 @@ dd-smoke-tests/maven/                      @DataDog/ci-app-libraries-java
 **/CiVisibility*.groovy                    @DataDog/ci-app-libraries-java
 
 # @DataDog/debugger-java (Live Debugger)
-dd-java-agent/agent-debugger/ @DataDog/debugger-java
+dd-java-agent/agent-debugger/              @DataDog/debugger-java
 dd-smoke-tests/debugger-integration-tests/ @DataDog/debugger-java
 
 # @DataDog/asm-java (AppSec/IAST)
 dd-java-agent/agent-iast/              @DataDog/asm-java
-dd-java-agent/instrumentation/*iast*   @DataDog/asm-java
 dd-java-agent/instrumentation/*appsec* @DataDog/asm-java
+dd-java-agent/instrumentation/*iast*   @DataDog/asm-java
 dd-java-agent/instrumentation/json/    @DataDog/asm-java
+dd-java-agent/instrumentation/commons-fileupload/ @DataDog/asm-java
+dd-java-agent/instrumentation/spring-security-5/  @DataDog/asm-java
 dd-smoke-tests/iast-util/              @DataDog/asm-java
 dd-smoke-tests/spring-security/        @DataDog/asm-java
-dd-java-agent/instrumentation/commons-fileupload/    @DataDog/asm-java
-dd-java-agent/instrumentation/spring-security-5/ @DataDog/asm-java
 **/appsec/                             @DataDog/asm-java
 **/iast/                               @DataDog/asm-java
 **/Iast*.java                          @DataDog/asm-java
 **/Iast*.groovy                        @DataDog/asm-java
+**/AppSec*.java                        @DataDog/asm-java
+**/AppSec*.groovy                      @DataDog/asm-java


### PR DESCRIPTION
# What Does This Do
Updates CODEOWNERS to propose a new owner of shared code - @DataDog/dd-trace-java 

# Motivation
The goal here is to empower teams to move efficiently while reducing the overhead/rubber-stamping required from the current @DataDog/apm-java team

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
