### PR TITLE
Decouple ConfigurationUpdater and exception probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/Configuration.java
@@ -208,6 +208,19 @@ public class Configuration {
       return this;
     }
 
+    public Configuration.Builder add(Collection<? extends ProbeDefinition> definitions) {
+      if (definitions == null) {
+        return this;
+      }
+      for (ProbeDefinition definition : definitions) {
+        if (definition instanceof MetricProbe) add((MetricProbe) definition);
+        if (definition instanceof LogProbe) add((LogProbe) definition);
+        if (definition instanceof SpanProbe) add((SpanProbe) definition);
+        if (definition instanceof SpanDecorationProbe) add((SpanDecorationProbe) definition);
+      }
+      return this;
+    }
+
     public Configuration.Builder add(MetricProbe probe) {
       if (metricProbes == null) {
         metricProbes = new ArrayList<>();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationAcceptor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationAcceptor.java
@@ -1,0 +1,13 @@
+package com.datadog.debugger.agent;
+
+import com.datadog.debugger.probe.ProbeDefinition;
+import java.util.Collection;
+
+public interface ConfigurationAcceptor {
+  enum Source {
+    REMOTE_CONFIG,
+    EXCEPTION
+  }
+
+  void accept(Source source, Collection<? extends ProbeDefinition> definitions);
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -30,8 +30,7 @@ import org.slf4j.LoggerFactory;
  * Handles configuration updates if required by installing a new ClassFileTransformer and triggering
  * re-transformation of required classes
  */
-public class ConfigurationUpdater
-    implements DebuggerContext.ProbeResolver, DebuggerProductChangesListener.ConfigurationAcceptor {
+public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, ConfigurationAcceptor {
 
   public interface TransformerSupplier {
     DebuggerTransformer supply(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.agent;
 
-import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.REMOTE_CONFIG;
+import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CONFIG;
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 import static java.util.Collections.emptyList;
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -1,10 +1,10 @@
 package com.datadog.debugger.agent;
 
+import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.REMOTE_CONFIG;
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 import static java.util.Collections.emptyList;
 
 import com.datadog.debugger.exception.DefaultExceptionDebugger;
-import com.datadog.debugger.exception.ExceptionProbeManager;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.symbol.SymDBEnablement;
@@ -65,15 +65,13 @@ public class DebuggerAgent {
     debuggerSink.start();
     // TODO filtering out thirdparty code
     ClassNameFiltering classNameFiltering = new ClassNameFiltering(emptyList());
-    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     ConfigurationUpdater configurationUpdater =
         new ConfigurationUpdater(
             instrumentation,
             DebuggerAgent::createTransformer,
             config,
             debuggerSink,
-            classesToRetransformFinder,
-            exceptionProbeManager);
+            classesToRetransformFinder);
     sink = debuggerSink;
     StatsdMetricForwarder statsdMetricForwarder =
         new StatsdMetricForwarder(config, probeStatusSink);
@@ -85,8 +83,7 @@ public class DebuggerAgent {
     DebuggerContext.initTracer(new DebuggerTracer(debuggerSink.getProbeStatusSink()));
     if (config.isDebuggerExceptionEnabled()) {
       DebuggerContext.initExceptionDebugger(
-          new DefaultExceptionDebugger(
-              exceptionProbeManager, configurationUpdater, classNameFiltering));
+          new DefaultExceptionDebugger(configurationUpdater, classNameFiltering));
     }
     if (config.isDebuggerInstrumentTheWorld()) {
       setupInstrumentTheWorldTransformer(
@@ -160,7 +157,7 @@ public class DebuggerAgent {
           DebuggerProductChangesListener.Adapter.deserializeConfiguration(
               outputStream.toByteArray());
       LOGGER.debug("Probe definitions loaded from file {}", probeFilePath);
-      configurationUpdater.accept(configuration);
+      configurationUpdater.accept(REMOTE_CONFIG, configuration.getDefinitions());
     } catch (IOException ex) {
       LOGGER.error("Unable to load config file {}: {}", probeFilePath, ex);
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.agent;
 
-import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.REMOTE_CONFIG;
+import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CONFIG;
 
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
@@ -34,15 +34,6 @@ public class DebuggerProductChangesListener implements ProductListener {
   public static final int MAX_ALLOWED_SPAN_DECORATION_PROBES = 100;
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DebuggerProductChangesListener.class);
-
-  public interface ConfigurationAcceptor {
-    enum Source {
-      REMOTE_CONFIG,
-      EXCEPTION
-    }
-
-    void accept(Source source, Collection<? extends ProbeDefinition> definitions);
-  }
 
   static class Adapter {
     static final JsonAdapter<Configuration> CONFIGURATION_JSON_ADAPTER =

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerProductChangesListener.java
@@ -1,19 +1,26 @@
 package com.datadog.debugger.agent;
 
+import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.REMOTE_CONFIG;
+
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
+import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
+import datadog.remoteconfig.ConfigurationChangesListener;
 import datadog.remoteconfig.state.ParsedConfigKey;
 import datadog.remoteconfig.state.ProductListener;
 import datadog.trace.api.Config;
 import datadog.trace.util.TagsHelper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import okio.Okio;
@@ -21,15 +28,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DebuggerProductChangesListener implements ProductListener {
+  public static final int MAX_ALLOWED_METRIC_PROBES = 100;
+  public static final int MAX_ALLOWED_LOG_PROBES = 100;
+  public static final int MAX_ALLOWED_SPAN_PROBES = 100;
+  public static final int MAX_ALLOWED_SPAN_DECORATION_PROBES = 100;
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DebuggerProductChangesListener.class);
 
   public interface ConfigurationAcceptor {
-    void accept(Configuration configuration);
-  }
+    enum Source {
+      REMOTE_CONFIG,
+      EXCEPTION
+    }
 
-  interface ConfigChunkBuilder {
-    void buildWith(Configuration.Builder builder);
+    void accept(Source source, Collection<? extends ProbeDefinition> definitions);
   }
 
   static class Adapter {
@@ -80,7 +92,7 @@ public class DebuggerProductChangesListener implements ProductListener {
 
   private final String serviceName;
   private final ConfigurationAcceptor configurationAcceptor;
-  private final Map<String, ConfigChunkBuilder> configChunks = new HashMap<>();
+  private final Map<String, Consumer<DefinitionBuilder>> configChunks = new HashMap<>();
 
   DebuggerProductChangesListener(Config config, ConfigurationAcceptor configurationAcceptor) {
     this.serviceName = TagsHelper.sanitize(config.getServiceName());
@@ -96,20 +108,24 @@ public class DebuggerProductChangesListener implements ProductListener {
     String configId = configKey.getConfigId();
     if (configId.startsWith("metricProbe_")) {
       MetricProbe metricProbe = Adapter.deserializeMetricProbe(content);
-      configChunks.put(configId, (builder) -> builder.add(metricProbe));
+      configChunks.put(configId, definitions -> definitions.add(metricProbe));
     } else if (configId.startsWith("logProbe_")) {
       LogProbe logProbe = Adapter.deserializeLogProbe(content);
-      configChunks.put(configId, (builder) -> builder.add(logProbe.copy()));
+      configChunks.put(configId, definitions -> definitions.add(logProbe));
     } else if (configId.startsWith("spanProbe_")) {
       SpanProbe spanProbe = Adapter.deserializeSpanProbe(content);
-      configChunks.put(configId, (builder) -> builder.add(spanProbe));
+      configChunks.put(configId, definitions -> definitions.add(spanProbe));
     } else if (configId.startsWith("spanDecorationProbe_")) {
       SpanDecorationProbe spanDecorationProbe = Adapter.deserializeSpanDecorationProbe(content);
-      configChunks.put(configId, (builder) -> builder.add(spanDecorationProbe));
+      configChunks.put(configId, definitions -> definitions.add(spanDecorationProbe));
     } else if (IS_UUID.test(configId)) {
       Configuration newConfig = Adapter.deserializeConfiguration(content);
       if (newConfig.getService().equals(serviceName)) {
-        configChunks.put(configId, (builder) -> builder.add(newConfig));
+        configChunks.put(
+            configId,
+            (builder) -> {
+              builder.addAll(newConfig.getDefinitions());
+            });
       } else {
         throw new IOException(
             "got config.serviceName = " + newConfig.getService() + ", ignoring configuration");
@@ -128,17 +144,73 @@ public class DebuggerProductChangesListener implements ProductListener {
   }
 
   @Override
-  public void commit(
-      datadog.remoteconfig.ConfigurationChangesListener.PollingRateHinter pollingRateHinter) {
+  public void commit(ConfigurationChangesListener.PollingRateHinter pollingRateHinter) {
+    DefinitionBuilder builder = new DefinitionBuilder();
+    for (Consumer<DefinitionBuilder> chunk : configChunks.values()) {
+      chunk.accept(builder);
+    }
+    configurationAcceptor.accept(REMOTE_CONFIG, builder.build());
+  }
 
-    Configuration.Builder builder = Configuration.builder().setService(serviceName);
+  static class DefinitionBuilder {
+    private final Collection<ProbeDefinition> definitions = new ArrayList<>();
+    private int metricProbeCount = 0;
+    private int logProbeCount = 0;
+    private int spanProbeCount = 0;
+    private int spanDecorationProbeCount = 0;
 
-    for (ConfigChunkBuilder chunk : configChunks.values()) {
-      chunk.buildWith(builder);
+    void add(MetricProbe probe) {
+      if (metricProbeCount >= MAX_ALLOWED_METRIC_PROBES) {
+        LOGGER.debug("Max allowed metric probes reached, ignoring new probe: {}", probe);
+        return;
+      }
+      definitions.add(probe);
+      metricProbeCount++;
     }
 
-    Configuration config = builder.build();
+    void add(LogProbe probe) {
+      if (logProbeCount >= MAX_ALLOWED_LOG_PROBES) {
+        LOGGER.debug("Max allowed log probes reached, ignoring new probe: {}", probe);
+        return;
+      }
+      definitions.add(probe);
+      logProbeCount++;
+    }
 
-    configurationAcceptor.accept(config);
+    void add(SpanProbe probe) {
+      if (spanProbeCount >= MAX_ALLOWED_SPAN_PROBES) {
+        LOGGER.debug("Max allowed span probes reached, ignoring new probe: {}", probe);
+        return;
+      }
+      definitions.add(probe);
+      spanProbeCount++;
+    }
+
+    void add(SpanDecorationProbe probe) {
+      if (spanDecorationProbeCount >= MAX_ALLOWED_SPAN_DECORATION_PROBES) {
+        LOGGER.debug("Max allowed span decoration probes reached, ignoring new probe: {}", probe);
+        return;
+      }
+      definitions.add(probe);
+      spanDecorationProbeCount++;
+    }
+
+    void addAll(Collection<ProbeDefinition> newDefinitions) {
+      for (ProbeDefinition definition : newDefinitions) {
+        if (definition instanceof MetricProbe) {
+          add((MetricProbe) definition);
+        } else if (definition instanceof LogProbe) {
+          add((LogProbe) definition);
+        } else if (definition instanceof SpanProbe) {
+          add((SpanProbe) definition);
+        } else if (definition instanceof SpanDecorationProbe) {
+          add((SpanDecorationProbe) definition);
+        }
+      }
+    }
+
+    Collection<ProbeDefinition> build() {
+      return definitions;
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.exception;
 
-import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.EXCEPTION;
+import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.EXCEPTION;
 
 import com.datadog.debugger.agent.ConfigurationUpdater;
 import com.datadog.debugger.util.ClassNameFiltering;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.exception;
 
+import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.EXCEPTION;
+
 import com.datadog.debugger.agent.ConfigurationUpdater;
 import com.datadog.debugger.util.ClassNameFiltering;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
@@ -17,6 +19,11 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
   private final ClassNameFiltering classNameFiltering;
 
   public DefaultExceptionDebugger(
+      ConfigurationUpdater configurationUpdater, ClassNameFiltering classNameFiltering) {
+    this(new ExceptionProbeManager(classNameFiltering), configurationUpdater, classNameFiltering);
+  }
+
+  DefaultExceptionDebugger(
       ExceptionProbeManager exceptionProbeManager,
       ConfigurationUpdater configurationUpdater,
       ClassNameFiltering classNameFiltering) {
@@ -36,7 +43,12 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
       // TODO trigger send snapshots already captured
     } else {
       exceptionProbeManager.createProbesForException(fingerprint, t.getStackTrace());
-      configurationUpdater.reapplyCurrentConfig();
+      // TODO make it async
+      configurationUpdater.accept(EXCEPTION, exceptionProbeManager.getProbes());
     }
+  }
+
+  ExceptionProbeManager getExceptionProbeManager() {
+    return exceptionProbeManager;
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.agent;
 
-import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.REMOTE_CONFIG;
+import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CONFIG;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationUpdaterTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.agent;
 
-import static java.util.Collections.emptyList;
+import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.REMOTE_CONFIG;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -14,14 +15,13 @@ import static org.mockito.Mockito.when;
 
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
-import com.datadog.debugger.exception.ExceptionProbeManager;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
+import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
-import com.datadog.debugger.util.ClassNameFiltering;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
@@ -48,7 +48,9 @@ public class ConfigurationUpdaterTest {
   private static final ProbeId METRIC_ID2 = new ProbeId("cfbf2919-e4c1-5fb9-b85e-937881d6f7e9", 5);
   private static final ProbeId LOG_ID = new ProbeId("d0c03a2a-f5d2-60ca-c96f-a48992e708fa", 2);
   private static final ProbeId LOG_ID2 = new ProbeId("d0c03a2b-f5d2-60ca-c96f-a48992e708fa", 6);
-  private static final String SERVICE_NAME = "service-name";
+  private static final ProbeId SPAN_ID = new ProbeId("cfbf2918-e4c1-5fb9-b85e-937881d6f7e9", 1);
+  private static final ProbeId SPAN_DECORATION_ID =
+      new ProbeId("cfbf2918-e4c1-5fb9-b85e-937881d6f7e9", 1);
 
   @Mock private Instrumentation inst;
   @Mock private DebuggerTransformer transformer;
@@ -70,7 +72,7 @@ public class ConfigurationUpdaterTest {
   @Test
   public void acceptNoProbes() {
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
-    configurationUpdater.accept(null);
+    configurationUpdater.accept(REMOTE_CONFIG, null);
     verify(inst, never()).addTransformer(any(), eq(true));
     verifyNoInteractions(debuggerSink);
   }
@@ -80,9 +82,9 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSinkWithMockStatusSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
@@ -110,7 +112,7 @@ public class ConfigurationUpdaterTest {
             .map(getClassName)
             .map(className -> LogProbe.builder().probeId(PROBE_ID).where(className, "foo").build())
             .collect(Collectors.toList());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     for (Class<?> expectedClass : classes) {
@@ -127,7 +129,7 @@ public class ConfigurationUpdaterTest {
         Arrays.asList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build(),
             LogProbe.builder().probeId(PROBE_ID2).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
@@ -146,7 +148,7 @@ public class ConfigurationUpdaterTest {
     List<LogProbe> logProbes =
         Arrays.asList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
@@ -157,7 +159,7 @@ public class ConfigurationUpdaterTest {
         Arrays.asList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build(),
             LogProbe.builder().probeId(PROBE_ID2).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(2, appliedDefinitions.size());
     assertTrue(appliedDefinitions.containsKey(PROBE_ID2.getEncodedId()));
@@ -174,7 +176,7 @@ public class ConfigurationUpdaterTest {
         Arrays.asList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build(),
             LogProbe.builder().probeId(PROBE_ID2).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
@@ -185,7 +187,7 @@ public class ConfigurationUpdaterTest {
     logProbes =
         Arrays.asList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     appliedDefinitions = configurationUpdater.getAppliedDefinitions();
     assertEquals(1, appliedDefinitions.size());
     assertTrue(appliedDefinitions.containsKey(PROBE_ID.getEncodedId()));
@@ -204,7 +206,9 @@ public class ConfigurationUpdaterTest {
     List<MetricProbe> metricProbes =
         Arrays.asList(
             MetricProbe.builder().probeId(METRIC_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(metricProbes, logProbes, emptyList()));
+    List<ProbeDefinition> definitions = new ArrayList<>(metricProbes);
+    definitions.addAll(logProbes);
+    configurationUpdater.accept(REMOTE_CONFIG, definitions);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
@@ -220,12 +224,12 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder()
                 .probeId(PROBE_ID)
                 .where(null, null, null, 1966, "src/main/java/java/lang/String.java")
                 .build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     verify(inst).retransformClasses(eq(String.class));
@@ -245,12 +249,12 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class, runnable.getClass()});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder()
                 .probeId(PROBE_ID)
                 .where("", "", "", 1966, "java/lang/String.java")
                 .build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     verify(inst).retransformClasses(eq(String.class));
@@ -269,12 +273,12 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class, runnable.getClass()});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder()
                 .probeId(PROBE_ID)
                 .where("", "", "", 136, "ConfigurationUpdaterTest$2")
                 .build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     verify(inst).retransformClasses(eq(runnable.getClass()));
@@ -300,11 +304,11 @@ public class ConfigurationUpdaterTest {
             .where("java.util.HashMap", "<init>", "void ()")
             .build();
     List<LogProbe> logProbes = Arrays.asList(probe1, probe2);
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(PROBE_ID2));
-    logProbes = Collections.singletonList(probe1);
-    configurationUpdater.accept(createApp(logProbes));
+    logProbes = singletonList(probe1);
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(probeStatusSink).removeDiagnostics(eq(PROBE_ID2));
     verify(inst).removeTransformer(any());
     ArgumentCaptor<Class<?>[]> captor = ArgumentCaptor.forClass(Class[].class);
@@ -331,8 +335,7 @@ public class ConfigurationUpdaterTest {
             },
             tracerConfig,
             debuggerSinkWithMockStatusSink,
-            new ClassesToRetransformFinder(),
-            new ExceptionProbeManager(new ClassNameFiltering(emptyList())));
+            new ClassesToRetransformFinder());
     LogProbe probe1 =
         LogProbe.builder()
             .language(LANGUAGE)
@@ -346,12 +349,12 @@ public class ConfigurationUpdaterTest {
             .where("java.lang.String", "indexOf", "int (int)")
             .build();
     List<LogProbe> logProbes = Arrays.asList(probe1, probe2);
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
     verify(probeStatusSink).addReceived(eq(PROBE_ID2));
-    logProbes = Collections.singletonList(probe1);
+    logProbes = singletonList(probe1);
     expectedDefinitions.set(1);
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(probeStatusSink).removeDiagnostics(eq(PROBE_ID2));
     verify(inst).removeTransformer(any());
     ArgumentCaptor<Class<?>[]> captor = ArgumentCaptor.forClass(Class[].class);
@@ -369,11 +372,11 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSinkWithMockStatusSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(probeStatusSink).addReceived(eq(PROBE_ID));
-    configurationUpdater.accept(null);
+    configurationUpdater.accept(REMOTE_CONFIG, null);
     verify(probeStatusSink).removeDiagnostics(eq(PROBE_ID));
     verify(inst).removeTransformer(any());
     verify(inst, times(2)).retransformClasses(any());
@@ -385,7 +388,7 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder()
                 .probeId(PROBE_ID)
                 .where("java.lang.String", "concat")
@@ -394,7 +397,7 @@ public class ConfigurationUpdaterTest {
                         DSL.when(DSL.eq(DSL.ref("arg"), DSL.value("foo"))), "arg == 'foo'"))
                 .build());
     logProbes.get(0).buildLocation(null);
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     ProbeImplementation probeImplementation = configurationUpdater.resolve(PROBE_ID.getEncodedId());
     Assertions.assertEquals(
         PROBE_ID.getEncodedId(), probeImplementation.getProbeId().getEncodedId());
@@ -408,9 +411,9 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder().probeId(PROBE_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).retransformClasses(eq(String.class));
     // simulate that there is a snapshot probe instrumentation left in HashMap class
     ProbeImplementation probeImplementation =
@@ -419,31 +422,13 @@ public class ConfigurationUpdaterTest {
   }
 
   @Test
-  public void acceptMaxProbes() {
-    when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
-    List<LogProbe> logProbes = new ArrayList<>();
-    for (int i = 0; i < 200; i++) {
-      logProbes.add(
-          LogProbe.builder()
-              .probeId(String.valueOf(i), 0)
-              .where("java.lang.String", "concat" + i)
-              .build());
-    }
-    ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
-    configurationUpdater.accept(createApp(logProbes));
-    Assertions.assertEquals(
-        ConfigurationUpdater.MAX_ALLOWED_LOG_PROBES,
-        configurationUpdater.getAppliedDefinitions().size());
-  }
-
-  @Test
   public void acceptNewMetric() {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<MetricProbe> metricProbes =
-        Collections.singletonList(
+        singletonList(
             MetricProbe.builder().probeId(METRIC_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createAppMetrics(metricProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, metricProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
@@ -456,9 +441,9 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder().probeId(LOG_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createAppLogs(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).addTransformer(any(), eq(true));
     verify(inst).getAllLoadedClasses();
     Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
@@ -483,9 +468,9 @@ public class ConfigurationUpdaterTest {
             .where("java.util.HashMap", "<init>", "void ()")
             .build();
     List<MetricProbe> metricProbes = Arrays.asList(metricProbe1, metricProbe2);
-    configurationUpdater.accept(createAppMetrics(metricProbes));
-    metricProbes = Collections.singletonList(metricProbe1);
-    configurationUpdater.accept(createAppMetrics(metricProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, metricProbes);
+    metricProbes = singletonList(metricProbe1);
+    configurationUpdater.accept(REMOTE_CONFIG, metricProbes);
     verify(inst).removeTransformer(any());
     ArgumentCaptor<Class<?>[]> captor = ArgumentCaptor.forClass(Class[].class);
     verify(inst, times(3)).retransformClasses(captor.capture());
@@ -515,9 +500,9 @@ public class ConfigurationUpdaterTest {
             .where("java.util.HashMap", "<init>", "void ()")
             .build();
     List<LogProbe> logProbes = Arrays.asList(logProbe1, logProbe2);
-    configurationUpdater.accept(createAppLogs(logProbes));
-    logProbes = Collections.singletonList(logProbe1);
-    configurationUpdater.accept(createAppLogs(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
+    logProbes = singletonList(logProbe1);
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     verify(inst).removeTransformer(any());
     ArgumentCaptor<Class<?>[]> captor = ArgumentCaptor.forClass(Class[].class);
     verify(inst, times(3)).retransformClasses(captor.capture());
@@ -535,10 +520,10 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<MetricProbe> metricProbes =
-        Collections.singletonList(
+        singletonList(
             MetricProbe.builder().probeId(METRIC_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createAppMetrics(metricProbes));
-    configurationUpdater.accept(null);
+    configurationUpdater.accept(REMOTE_CONFIG, metricProbes);
+    configurationUpdater.accept(REMOTE_CONFIG, null);
     verify(inst).removeTransformer(any());
     verify(inst, times(2)).retransformClasses(any());
     assertEquals(0, configurationUpdater.getAppliedDefinitions().size());
@@ -549,10 +534,10 @@ public class ConfigurationUpdaterTest {
     when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
     ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
     List<LogProbe> logProbes =
-        Collections.singletonList(
+        singletonList(
             LogProbe.builder().probeId(LOG_ID).where("java.lang.String", "concat").build());
-    configurationUpdater.accept(createAppLogs(logProbes));
-    configurationUpdater.accept(null);
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
+    configurationUpdater.accept(REMOTE_CONFIG, null);
     verify(inst).removeTransformer(any());
     verify(inst, times(2)).retransformClasses(any());
     assertEquals(0, configurationUpdater.getAppliedDefinitions().size());
@@ -575,15 +560,15 @@ public class ConfigurationUpdaterTest {
                 .probeId(PROBE_ID2)
                 .where("java.util.HashMap", "<init>", "void ()")
                 .build());
-    configurationUpdater.accept(createApp(logProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, logProbes);
     List<MetricProbe> metricProbes =
-        Collections.singletonList(
+        singletonList(
             MetricProbe.builder()
                 .language(LANGUAGE)
                 .probeId(METRIC_ID)
                 .where("java.lang.StringBuilder", "append")
                 .build());
-    configurationUpdater.accept(createAppMetrics(metricProbes));
+    configurationUpdater.accept(REMOTE_CONFIG, metricProbes);
     verify(inst).removeTransformer(any());
     ArgumentCaptor<Class<?>[]> captor = ArgumentCaptor.forClass(Class[].class);
     verify(inst, times(5)).retransformClasses(captor.capture());
@@ -598,21 +583,35 @@ public class ConfigurationUpdaterTest {
     assertTrue(appliedDefinitions.containsKey(METRIC_ID.getEncodedId()));
   }
 
-  private static Configuration createApp(List<LogProbe> logProbes) {
-    return Configuration.builder().setService(SERVICE_NAME).addLogProbes(logProbes).build();
+  @Test
+  public void acceptNewSpan() {
+    when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
+    ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
+    SpanProbe spanProbe =
+        SpanProbe.builder().probeId(SPAN_ID).where("java.lang.String", "concat").build();
+    configurationUpdater.accept(REMOTE_CONFIG, singletonList(spanProbe));
+    verify(inst).addTransformer(any(), eq(true));
+    verify(inst).getAllLoadedClasses();
+    Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
+    assertEquals(1, appliedDefinitions.size());
+    assertTrue(appliedDefinitions.containsKey(SPAN_ID.getEncodedId()));
   }
 
-  private static Configuration createApp(
-      List<MetricProbe> metricProbes, List<LogProbe> logProbes, List<SpanProbe> spanProbes) {
-    return new Configuration(SERVICE_NAME, metricProbes, logProbes, spanProbes);
-  }
-
-  private static Configuration createAppMetrics(List<MetricProbe> metricProbes) {
-    return Configuration.builder().setService(SERVICE_NAME).addMetricProbes(metricProbes).build();
-  }
-
-  private static Configuration createAppLogs(List<LogProbe> logProbes) {
-    return Configuration.builder().setService(SERVICE_NAME).addLogProbes(logProbes).build();
+  @Test
+  public void acceptNewDecorationSpan() {
+    when(inst.getAllLoadedClasses()).thenReturn(new Class[] {String.class});
+    ConfigurationUpdater configurationUpdater = createConfigUpdater(debuggerSink);
+    SpanDecorationProbe spanProbe =
+        SpanDecorationProbe.builder()
+            .probeId(SPAN_DECORATION_ID)
+            .where("java.lang.String", "concat")
+            .build();
+    configurationUpdater.accept(REMOTE_CONFIG, singletonList(spanProbe));
+    verify(inst).addTransformer(any(), eq(true));
+    verify(inst).getAllLoadedClasses();
+    Map<String, ProbeDefinition> appliedDefinitions = configurationUpdater.getAppliedDefinitions();
+    assertEquals(1, appliedDefinitions.size());
+    assertTrue(appliedDefinitions.containsKey(SPAN_DECORATION_ID.getEncodedId()));
   }
 
   private DebuggerTransformer createTransformer(
@@ -625,11 +624,6 @@ public class ConfigurationUpdaterTest {
 
   private ConfigurationUpdater createConfigUpdater(DebuggerSink sink) {
     return new ConfigurationUpdater(
-        inst,
-        this::createTransformer,
-        tracerConfig,
-        sink,
-        new ClassesToRetransformFinder(),
-        new ExceptionProbeManager(new ClassNameFiltering(emptyList())));
+        inst, this::createTransformer, tracerConfig, sink, new ClassesToRetransformFinder());
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProductChangesListenerTest.java
@@ -42,7 +42,7 @@ public class DebuggerProductChangesListenerTest {
   final ConfigurationChangesListener.PollingHinterNoop pollingHinter =
       new ConfigurationChangesListener.PollingHinterNoop();
 
-  class SimpleAcceptor implements DebuggerProductChangesListener.ConfigurationAcceptor {
+  class SimpleAcceptor implements ConfigurationAcceptor {
     private Collection<? extends ProbeDefinition> definitions;
 
     @Override

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -13,15 +13,13 @@ class DefaultExceptionDebuggerTest {
   @Test
   public void test() {
     ClassNameFiltering classNameFiltering = new ClassNameFiltering(emptyList());
-    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     ConfigurationUpdater configurationUpdater = mock(ConfigurationUpdater.class);
     DefaultExceptionDebugger exceptionDebugger =
-        new DefaultExceptionDebugger(
-            exceptionProbeManager, configurationUpdater, classNameFiltering);
+        new DefaultExceptionDebugger(configurationUpdater, classNameFiltering);
     RuntimeException exception = new RuntimeException("test");
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     exceptionDebugger.handleException(exception);
     exceptionDebugger.handleException(exception);
-    assertTrue(exceptionProbeManager.isAlreadyInstrumented(fingerprint));
+    assertTrue(exceptionDebugger.getExceptionProbeManager().isAlreadyInstrumented(fingerprint));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.exception;
 
+import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.REMOTE_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -126,8 +127,7 @@ public class ExceptionProbeInstrumentationTest {
             ExceptionProbeInstrumentationTest::createTransformer,
             config,
             new DebuggerSink(config, probeStatusSink),
-            new ClassesToRetransformFinder(),
-            exceptionProbeManager);
+            new ClassesToRetransformFinder());
     TestSnapshotListener listener = new TestSnapshotListener(config, probeStatusSink);
     DebuggerAgentHelper.injectSink(listener);
     DebuggerContext.initProbeResolver(configurationUpdater);
@@ -135,7 +135,7 @@ public class ExceptionProbeInstrumentationTest {
     DebuggerContext.initExceptionDebugger(
         new DefaultExceptionDebugger(
             exceptionProbeManager, configurationUpdater, classNameFiltering));
-    configurationUpdater.accept(null);
+    configurationUpdater.accept(REMOTE_CONFIG, null);
     return listener;
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -1,6 +1,6 @@
 package com.datadog.debugger.exception;
 
-import static com.datadog.debugger.agent.DebuggerProductChangesListener.ConfigurationAcceptor.Source.REMOTE_CONFIG;
+import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
@@ -10,6 +10,7 @@ import com.datadog.debugger.sink.Snapshot;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -62,6 +63,7 @@ public class ProbeStateIntegrationTest extends ServerAppDebuggerIntegrationTest 
   @Test
   @DisplayName("testDisableEnableProbesUsingDenyList")
   @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
+  @Disabled("Not supported for config coming from RemoteConfig")
   void testDisableEnableProbesUsingDenyList() throws Exception {
     LogProbe logProbe =
         LogProbe.builder().probeId(PROBE_ID).where(TEST_APP_CLASS_NAME, FULL_METHOD_NAME).build();
@@ -93,6 +95,7 @@ public class ProbeStateIntegrationTest extends ServerAppDebuggerIntegrationTest 
   @Test
   @DisplayName("testDisableEnableProbesUsingAllowList")
   @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
+  @Disabled("Not supported for config coming from RemoteConfig")
   void testDisableEnableProbesUsingAllowList() throws Exception {
     LogProbe logProbe =
         LogProbe.builder().probeId(PROBE_ID).where(TEST_APP_CLASS_NAME, FULL_METHOD_NAME).build();


### PR DESCRIPTION
# What Does This Do
Introducing the concept of source for `ConfigurationUpdater` that is just a list of `ProbeDefinition`. As RemoteConfig configuration are only for probes for now, we are reducing it to this list. Hence the `accept`
method in `ConfigurationUpdater` is taking a source (`REMOTE_CONFIG` or `EXCEPTION`) and a list of `ProbeDefinition`. For RemoteConfig part, we are building this list instead of `Configuration` object and capping the number of probes per type at that level now instead of `ConfigurationUpdater`. The side effect of this is that now there is no capping for probe definitions coming from file. `Configuration::accept` method is now responsible to merge definitions from all source (`REMOTE_CONFIG` and `EXCEPTION`) and create a `Configuration` object that will be applied as before. As a consequence, `ExceptionProbeManager` can now be created directly into `DefaultExceptionDebugger` class.

# Motivation
Decouple `ConfigurationUpdater` and `ExceptionProbeManager`

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ