### PR TITLE
Implement a mechanism for adding ad-hoc listeners to OKHTTP requests

### DIFF
--- a/communication/build.gradle
+++ b/communication/build.gradle
@@ -33,6 +33,7 @@ ext {
     'datadog.communication.http.OkHttpUtils',
     'datadog.communication.http.OkHttpUtils.1',
     'datadog.communication.http.OkHttpUtils.ByteBufferRequestBody',
+    'datadog.communication.http.OkHttpUtils.CustomListener',
     'datadog.communication.http.OkHttpUtils.GZipByteBufferRequestBody',
     'datadog.communication.http.OkHttpUtils.GZipRequestBodyDecorator',
     'datadog.communication.http.OkHttpUtils.JsonRequestBody',

--- a/communication/build.gradle
+++ b/communication/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   testImplementation deps.bytebuddy
   testImplementation group: 'org.msgpack', name: 'msgpack-core', version: '0.8.20'
   testImplementation group: 'org.msgpack', name: 'jackson-dataformat-msgpack', version: '0.8.20'
+  testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: versions.okhttp_legacy
 }
 
 ext {

--- a/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
+++ b/communication/src/main/java/datadog/communication/http/OkHttpUtils.java
@@ -23,6 +23,7 @@ import okhttp3.ConnectionPool;
 import okhttp3.ConnectionSpec;
 import okhttp3.Credentials;
 import okhttp3.Dispatcher;
+import okhttp3.EventListener;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -100,6 +101,8 @@ public final class OkHttpUtils {
         timeoutMillis);
   }
 
+  public abstract static class CustomListener extends EventListener {}
+
   private static OkHttpClient buildHttpClient(
       final String unixDomainSocketPath,
       final String namedPipe,
@@ -115,6 +118,12 @@ public final class OkHttpUtils {
     final OkHttpClient.Builder builder = new OkHttpClient.Builder();
 
     builder
+        .eventListenerFactory(
+            call -> {
+              Request request = call.request();
+              CustomListener listener = request.tag(CustomListener.class);
+              return listener != null ? listener : EventListener.NONE;
+            })
         .connectTimeout(timeoutMillis, MILLISECONDS)
         .writeTimeout(timeoutMillis, MILLISECONDS)
         .readTimeout(timeoutMillis, MILLISECONDS)

--- a/communication/src/test/groovy/datadog/communication/http/OkHttpUtilsTest.groovy
+++ b/communication/src/test/groovy/datadog/communication/http/OkHttpUtilsTest.groovy
@@ -1,0 +1,46 @@
+package datadog.communication.http
+
+import okhttp3.Call
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import spock.lang.Shared
+import spock.lang.Specification
+
+class OkHttpUtilsTest extends Specification {
+
+  @Shared
+  MockWebServer server = new MockWebServer()
+
+  def cleanupSpec() {
+    server.shutdown()
+  }
+
+  def "It is possible to register a custom listener for HTTP requests"() {
+    setup:
+    def url = server.url("/")
+    def client = OkHttpUtils.buildHttpClient(url, 1000)
+    def listener = new TestListener()
+
+    server.enqueue(new MockResponse())
+
+    when:
+    def request = new Request.Builder()
+      .url(url)
+      .get()
+      .tag(OkHttpUtils.CustomListener, listener)
+      .build()
+    client.newCall(request).execute()
+
+    then:
+    listener.notified
+  }
+
+  private static final class TestListener extends OkHttpUtils.CustomListener {
+    private boolean notified
+
+    void callStart(Call call) {
+      notified = true
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
Adds a mechanism for registering ad-hoc event listeners for okhttp requests.
A listener can be registered when building a request:
```
class MyListener extends OkHttpUtils.CustomListener {
    // override event handlers
} 

final Request request =
        new Request.Builder()
            .url(...)
            .post(...)
            .tag(OkHttpUtils.CustomListener.class, new MyListener())
            .build();
```

# Motivation
This is needed for CI Visibility telemetry. There are metrics like requests count, errors count, request size, etc for events/coverages intake, CI Visibility Git API and other endpoitns.

# Additional Notes
`EventListener.NONE` is what all the requests are using by default: it is a listener that has an empty handler for every event.
With the new mechanism this "empty" listener is replaced with a custom one for those requests that have the corresponding tag.

This PR only adds the means for registering custom listeners. Actual listeners will be added in a separate PR.

Jira ticket: [CIVIS-2427]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ