### PR TITLE
Implement telemetry for CI Visibility APIs

### DIFF
--- a/dd-java-agent/agent-ci-visibility/build.gradle
+++ b/dd-java-agent/agent-ci-visibility/build.gradle
@@ -38,6 +38,7 @@ excludedClassesCoverage += [
   "datadog.trace.civisibility.config.CachingModuleExecutionSettingsFactory",
   "datadog.trace.civisibility.config.CachingModuleExecutionSettingsFactory.Key",
   "datadog.trace.civisibility.config.CiVisibilitySettings",
+  "datadog.trace.civisibility.config.ConfigurationApiImpl",
   "datadog.trace.civisibility.config.ConfigurationApiImpl.MultiEnvelopeDto",
   "datadog.trace.civisibility.config.ConfigurationApi.1",
   "datadog.trace.civisibility.config.ModuleExecutionSettingsFactoryImpl",

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/BackendApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/BackendApi.java
@@ -1,13 +1,19 @@
 package datadog.trace.civisibility.communication;
 
+import datadog.communication.http.OkHttpUtils;
 import datadog.trace.civisibility.utils.IOThrowingFunction;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 import okhttp3.RequestBody;
 
 /** API for posting HTTP requests to backend */
 public interface BackendApi {
 
-  <T> T post(String uri, RequestBody requestBody, IOThrowingFunction<InputStream, T> responseParser)
+  <T> T post(
+      String uri,
+      RequestBody requestBody,
+      IOThrowingFunction<InputStream, T> responseParser,
+      @Nullable OkHttpUtils.CustomListener requestListener)
       throws IOException;
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/EvpProxyApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/EvpProxyApi.java
@@ -6,6 +6,7 @@ import datadog.trace.civisibility.utils.IOThrowingFunction;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
+import javax.annotation.Nullable;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -56,7 +57,10 @@ public class EvpProxyApi implements BackendApi {
 
   @Override
   public <T> T post(
-      String uri, RequestBody requestBody, IOThrowingFunction<InputStream, T> responseParser)
+      String uri,
+      RequestBody requestBody,
+      IOThrowingFunction<InputStream, T> responseParser,
+      @Nullable OkHttpUtils.CustomListener requestListener)
       throws IOException {
     final HttpUrl url = evpProxyUrl.resolve(uri);
 
@@ -66,6 +70,10 @@ public class EvpProxyApi implements BackendApi {
             .addHeader(X_DATADOG_EVP_SUBDOMAIN_HEADER, API_SUBDOMAIN)
             .addHeader(X_DATADOG_TRACE_ID_HEADER, traceId)
             .addHeader(X_DATADOG_PARENT_ID_HEADER, traceId);
+
+    if (requestListener != null) {
+      requestBuilder.tag(OkHttpUtils.CustomListener.class, requestListener);
+    }
 
     if (gzipEnabled) {
       requestBuilder.addHeader(ACCEPT_ENCODING_HEADER, GZIP_ENCODING);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/IntakeApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/IntakeApi.java
@@ -6,6 +6,7 @@ import datadog.trace.civisibility.utils.IOThrowingFunction;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
+import javax.annotation.Nullable;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -61,7 +62,10 @@ public class IntakeApi implements BackendApi {
 
   @Override
   public <T> T post(
-      String uri, RequestBody requestBody, IOThrowingFunction<InputStream, T> responseParser)
+      String uri,
+      RequestBody requestBody,
+      IOThrowingFunction<InputStream, T> responseParser,
+      @Nullable OkHttpUtils.CustomListener requestListener)
       throws IOException {
     HttpUrl url = hostUrl.resolve(uri);
     Request.Builder requestBuilder =
@@ -71,6 +75,10 @@ public class IntakeApi implements BackendApi {
             .addHeader(DD_API_KEY_HEADER, apiKey)
             .addHeader(X_DATADOG_TRACE_ID_HEADER, traceId)
             .addHeader(X_DATADOG_PARENT_ID_HEADER, traceId);
+
+    if (requestListener != null) {
+      requestBuilder.tag(OkHttpUtils.CustomListener.class, requestListener);
+    }
 
     if (gzipEnabled) {
       requestBuilder.addHeader(ACCEPT_ENCODING_HEADER, GZIP_ENCODING);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/TelemetryListener.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/TelemetryListener.java
@@ -1,0 +1,132 @@
+package datadog.trace.civisibility.communication;
+
+import datadog.communication.http.OkHttpUtils;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityDistributionMetric;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.api.civisibility.telemetry.tag.ErrorType;
+import java.io.IOException;
+import javax.annotation.Nullable;
+import okhttp3.Call;
+import okhttp3.Response;
+
+public class TelemetryListener extends OkHttpUtils.CustomListener {
+
+  private final CiVisibilityMetricCollector metricCollector;
+  private final @Nullable CiVisibilityCountMetric requestCountMetric;
+  private final @Nullable CiVisibilityCountMetric requestErrorsMetric;
+  private final @Nullable CiVisibilityDistributionMetric requestBytesMetric;
+  private final @Nullable CiVisibilityDistributionMetric requestDurationMetric;
+  private final @Nullable CiVisibilityDistributionMetric responseBytesMetric;
+  private long callStartTimestamp;
+
+  private TelemetryListener(
+      CiVisibilityMetricCollector metricCollector,
+      @Nullable CiVisibilityCountMetric requestCountMetric,
+      @Nullable CiVisibilityCountMetric requestErrorsMetric,
+      @Nullable CiVisibilityDistributionMetric requestBytesMetric,
+      @Nullable CiVisibilityDistributionMetric requestDurationMetric,
+      @Nullable CiVisibilityDistributionMetric responseBytesMetric) {
+    this.metricCollector = metricCollector;
+    this.requestCountMetric = requestCountMetric;
+    this.requestErrorsMetric = requestErrorsMetric;
+    this.requestBytesMetric = requestBytesMetric;
+    this.requestDurationMetric = requestDurationMetric;
+    this.responseBytesMetric = responseBytesMetric;
+  }
+
+  public void callStart(Call call) {
+    callStartTimestamp = System.currentTimeMillis();
+    if (requestCountMetric != null) {
+      metricCollector.add(requestCountMetric, 1);
+    }
+  }
+
+  public void requestBodyEnd(Call call, long byteCount) {
+    if (requestBytesMetric != null) {
+      metricCollector.add(requestBytesMetric, (int) byteCount);
+    }
+  }
+
+  public void responseHeadersEnd(Call call, Response response) {
+    if (requestErrorsMetric != null) {
+      if (!response.isSuccessful()) {
+        int responseCode = response.code();
+        metricCollector.add(requestErrorsMetric, 1, ErrorType.from(responseCode));
+      }
+    }
+  }
+
+  @Override
+  public void responseBodyEnd(Call call, long byteCount) {
+    if (responseBytesMetric != null) {
+      metricCollector.add(responseBytesMetric, (int) byteCount);
+    }
+  }
+
+  public void callEnd(Call call) {
+    if (requestDurationMetric != null) {
+      int durationMillis = (int) (System.currentTimeMillis() - callStartTimestamp);
+      metricCollector.add(requestDurationMetric, durationMillis);
+    }
+  }
+
+  public void callFailed(Call call, IOException ioe) {
+    if (requestDurationMetric != null) {
+      int durationMillis = (int) (System.currentTimeMillis() - callStartTimestamp);
+      metricCollector.add(requestDurationMetric, durationMillis);
+    }
+
+    if (requestErrorsMetric != null) {
+      metricCollector.add(requestErrorsMetric, 1, ErrorType.NETWORK);
+    }
+  }
+
+  public static final class Builder {
+    private final CiVisibilityMetricCollector metricCollector;
+    private @Nullable CiVisibilityCountMetric requestCountMetric;
+    private @Nullable CiVisibilityCountMetric requestErrorsMetric;
+    private @Nullable CiVisibilityDistributionMetric requestBytesMetric;
+    private @Nullable CiVisibilityDistributionMetric requestDurationMetric;
+    private @Nullable CiVisibilityDistributionMetric responseBytesMetric;
+
+    public Builder(CiVisibilityMetricCollector metricCollector) {
+      this.metricCollector = metricCollector;
+    }
+
+    public Builder requestCount(@Nullable CiVisibilityCountMetric requestCountMetric) {
+      this.requestCountMetric = requestCountMetric;
+      return this;
+    }
+
+    public Builder requestErrors(@Nullable CiVisibilityCountMetric requestErrorsMetric) {
+      this.requestErrorsMetric = requestErrorsMetric;
+      return this;
+    }
+
+    public Builder requestBytes(@Nullable CiVisibilityDistributionMetric requestBytesMetric) {
+      this.requestBytesMetric = requestBytesMetric;
+      return this;
+    }
+
+    public Builder requestDuration(@Nullable CiVisibilityDistributionMetric requestDurationMetric) {
+      this.requestDurationMetric = requestDurationMetric;
+      return this;
+    }
+
+    public Builder responseBytes(@Nullable CiVisibilityDistributionMetric responseBytesMetric) {
+      this.responseBytesMetric = responseBytesMetric;
+      return this;
+    }
+
+    public OkHttpUtils.CustomListener build() {
+      return new TelemetryListener(
+          metricCollector,
+          requestCountMetric,
+          requestErrorsMetric,
+          requestBytesMetric,
+          requestDurationMetric,
+          responseBytesMetric);
+    }
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/CiVisibilitySettings.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/CiVisibilitySettings.java
@@ -5,22 +5,29 @@ import java.nio.file.Path;
 public class CiVisibilitySettings {
 
   public static final CiVisibilitySettings DEFAULT =
-      new CiVisibilitySettings(false, false, false, false);
+      new CiVisibilitySettings(false, false, false, false, false);
 
+  private final boolean itr_enabled;
   private final boolean code_coverage;
   private final boolean tests_skipping;
   private final boolean require_git;
   private final boolean flaky_test_retries_enabled;
 
   public CiVisibilitySettings(
+      boolean itr_enabled,
       boolean code_coverage,
       boolean tests_skipping,
       boolean require_git,
       boolean flaky_test_retries_enabled) {
+    this.itr_enabled = itr_enabled;
     this.code_coverage = code_coverage;
     this.tests_skipping = tests_skipping;
     this.require_git = require_git;
     this.flaky_test_retries_enabled = flaky_test_retries_enabled;
+  }
+
+  public boolean isItrEnabled() {
+    return itr_enabled;
   }
 
   public boolean isCodeCoverageEnabled() {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -3,8 +3,17 @@ package datadog.trace.civisibility.config;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.civisibility.config.TestIdentifier;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityDistributionMetric;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.api.civisibility.telemetry.tag.CoverageEnabled;
+import datadog.trace.api.civisibility.telemetry.tag.ItrEnabled;
+import datadog.trace.api.civisibility.telemetry.tag.ItrSkipEnabled;
+import datadog.trace.api.civisibility.telemetry.tag.RequireGit;
 import datadog.trace.civisibility.communication.BackendApi;
+import datadog.trace.civisibility.communication.TelemetryListener;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
@@ -24,18 +33,23 @@ public class ConfigurationApiImpl implements ConfigurationApi {
   private static final String FLAKY_TESTS_URI = "ci/libraries/tests/flaky";
 
   private final BackendApi backendApi;
+  private final CiVisibilityMetricCollector metricCollector;
   private final Supplier<String> uuidGenerator;
 
   private final JsonAdapter<EnvelopeDto<TracerEnvironment>> requestAdapter;
   private final JsonAdapter<EnvelopeDto<CiVisibilitySettings>> settingsResponseAdapter;
   private final JsonAdapter<MultiEnvelopeDto<TestIdentifier>> testIdentifiersResponseAdapter;
 
-  public ConfigurationApiImpl(BackendApi backendApi) {
-    this(backendApi, () -> UUID.randomUUID().toString());
+  public ConfigurationApiImpl(BackendApi backendApi, CiVisibilityMetricCollector metricCollector) {
+    this(backendApi, metricCollector, () -> UUID.randomUUID().toString());
   }
 
-  ConfigurationApiImpl(BackendApi backendApi, Supplier<String> uuidGenerator) {
+  ConfigurationApiImpl(
+      BackendApi backendApi,
+      CiVisibilityMetricCollector metricCollector,
+      Supplier<String> uuidGenerator) {
     this.backendApi = backendApi;
+    this.metricCollector = metricCollector;
     this.uuidGenerator = uuidGenerator;
 
     Moshi moshi =
@@ -65,26 +79,65 @@ public class ConfigurationApiImpl implements ConfigurationApi {
             new DataDto<>(uuid, "ci_app_test_service_libraries_settings", tracerEnvironment));
     String json = requestAdapter.toJson(settingsRequest);
     RequestBody requestBody = RequestBody.create(JSON, json);
-    return backendApi.post(
-        SETTINGS_URI,
-        requestBody,
-        is -> settingsResponseAdapter.fromJson(Okio.buffer(Okio.source(is))).data.attributes);
+
+    OkHttpUtils.CustomListener telemetryListener =
+        new TelemetryListener.Builder(metricCollector)
+            .requestCount(CiVisibilityCountMetric.GIT_REQUESTS_SETTINGS)
+            .requestErrors(CiVisibilityCountMetric.GIT_REQUESTS_SETTINGS_ERRORS)
+            .requestDuration(CiVisibilityDistributionMetric.GIT_REQUESTS_SETTINGS_MS)
+            .build();
+
+    CiVisibilitySettings settings =
+        backendApi.post(
+            SETTINGS_URI,
+            requestBody,
+            is -> settingsResponseAdapter.fromJson(Okio.buffer(Okio.source(is))).data.attributes,
+            telemetryListener);
+
+    metricCollector.add(
+        CiVisibilityCountMetric.GIT_REQUESTS_SETTINGS_RESPONSE,
+        1,
+        settings.isItrEnabled() ? ItrEnabled.TRUE : null,
+        settings.isTestsSkippingEnabled() ? ItrSkipEnabled.TRUE : null,
+        settings.isCodeCoverageEnabled() ? CoverageEnabled.TRUE : null,
+        settings.isGitUploadRequired() ? RequireGit.TRUE : null);
+
+    return settings;
   }
 
   @Override
   public Collection<TestIdentifier> getSkippableTests(TracerEnvironment tracerEnvironment)
       throws IOException {
-    return getTestsData(SKIPPABLE_TESTS_URI, "test_params", tracerEnvironment);
+    OkHttpUtils.CustomListener telemetryListener =
+        new TelemetryListener.Builder(metricCollector)
+            .requestCount(CiVisibilityCountMetric.ITR_SKIPPABLE_TESTS_REQUEST)
+            .requestErrors(CiVisibilityCountMetric.ITR_SKIPPABLE_TESTS_REQUEST_ERRORS)
+            .requestDuration(CiVisibilityDistributionMetric.ITR_SKIPPABLE_TESTS_REQUEST_MS)
+            .responseBytes(CiVisibilityDistributionMetric.ITR_SKIPPABLE_TESTS_RESPONSE_BYTES)
+            .build();
+
+    Collection<TestIdentifier> skippableTests =
+        getTestsData(SKIPPABLE_TESTS_URI, "test_params", tracerEnvironment, telemetryListener);
+
+    metricCollector.add(
+        CiVisibilityCountMetric.ITR_SKIPPABLE_TESTS_RESPONSE_TESTS, skippableTests.size());
+
+    return skippableTests;
   }
 
   @Override
   public Collection<TestIdentifier> getFlakyTests(TracerEnvironment tracerEnvironment)
       throws IOException {
-    return getTestsData(FLAKY_TESTS_URI, "flaky_test_from_libraries_params", tracerEnvironment);
+    return getTestsData(
+        FLAKY_TESTS_URI, "flaky_test_from_libraries_params", tracerEnvironment, null);
   }
 
   private Collection<TestIdentifier> getTestsData(
-      String endpoint, String dataType, TracerEnvironment tracerEnvironment) throws IOException {
+      String endpoint,
+      String dataType,
+      TracerEnvironment tracerEnvironment,
+      OkHttpUtils.CustomListener requestListener)
+      throws IOException {
     String uuid = uuidGenerator.get();
     EnvelopeDto<TracerEnvironment> request =
         new EnvelopeDto<>(new DataDto<>(uuid, dataType, tracerEnvironment));
@@ -94,7 +147,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
         backendApi.post(
             endpoint,
             requestBody,
-            is -> testIdentifiersResponseAdapter.fromJson(Okio.buffer(Okio.source(is))).data);
+            is -> testIdentifiersResponseAdapter.fromJson(Okio.buffer(Okio.source(is))).data,
+            requestListener);
     return response.stream().map(DataDto::getAttributes).collect(Collectors.toList());
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
@@ -1,6 +1,8 @@
 package datadog.trace.civisibility.git.tree;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityDistributionMetric;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.civisibility.utils.FileUtils;
@@ -16,7 +18,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +27,7 @@ public class GitDataUploaderImpl implements GitDataUploader {
   private static final Logger LOGGER = LoggerFactory.getLogger(GitDataUploaderImpl.class);
 
   private final Config config;
+  private final CiVisibilityMetricCollector metricCollector;
   private final GitDataApi gitDataApi;
   private final GitClient gitClient;
   private final GitInfoProvider gitInfoProvider;
@@ -35,12 +38,14 @@ public class GitDataUploaderImpl implements GitDataUploader {
 
   public GitDataUploaderImpl(
       Config config,
+      CiVisibilityMetricCollector metricCollector,
       GitDataApi gitDataApi,
       GitClient gitClient,
       GitInfoProvider gitInfoProvider,
       String repoRoot,
       String remoteName) {
     this.config = config;
+    this.metricCollector = metricCollector;
     this.gitDataApi = gitDataApi;
     this.gitClient = gitClient;
     this.gitInfoProvider = gitInfoProvider;
@@ -133,17 +138,24 @@ public class GitDataUploaderImpl implements GitDataUploader {
       String currentCommit = latestCommits.get(0);
 
       Path packFilesDirectory = gitClient.createPackFiles(objectHashes);
-      try (Stream<Path> packFiles = Files.list(packFilesDirectory)) {
-        packFiles
-            .filter(pf -> pf.getFileName().toString().endsWith(".pack")) // skipping ".idx" files
-            .forEach(
-                pf -> {
-                  try {
-                    gitDataApi.uploadPackFile(remoteUrl, currentCommit, pf);
-                  } catch (Exception e) {
-                    throw new RuntimeException("Could not upload pack file " + pf, e);
-                  }
-                });
+      try {
+        List<Path> packFiles =
+            Files.list(packFilesDirectory)
+                .filter(
+                    pf -> pf.getFileName().toString().endsWith(".pack")) // skipping ".idx" files
+                .collect(Collectors.toList());
+
+        metricCollector.add(
+            CiVisibilityDistributionMetric.GIT_REQUESTS_OBJECTS_PACK_FILES, packFiles.size());
+
+        for (Path packFile : packFiles) {
+          try {
+            gitDataApi.uploadPackFile(remoteUrl, currentCommit, packFile);
+          } catch (Exception e) {
+            throw new RuntimeException("Could not upload pack file " + packFile, e);
+          }
+        }
+
       } finally {
         FileUtils.delete(packFilesDirectory);
       }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ConfigurationApiImplTest.groovy
@@ -6,6 +6,7 @@ import datadog.communication.http.OkHttpUtils
 import datadog.trace.agent.test.server.http.TestHttpServer
 import datadog.trace.api.civisibility.config.Configurations
 import datadog.trace.api.civisibility.config.TestIdentifier
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector
 import datadog.trace.civisibility.communication.BackendApi
 import datadog.trace.civisibility.communication.EvpProxyApi
 import datadog.trace.civisibility.communication.IntakeApi
@@ -143,9 +144,10 @@ class ConfigurationApiImplTest extends Specification {
   def "test settings request: #displayName"() {
     given:
     def tracerEnvironment = givenTracerEnvironment()
+    def metricCollector = Stub(CiVisibilityMetricCollector)
 
     when:
-    def configurationApi = new ConfigurationApiImpl(api, () -> "1234")
+    def configurationApi = new ConfigurationApiImpl(api, metricCollector, () -> "1234")
     def settings = configurationApi.getSettings(tracerEnvironment)
 
     then:
@@ -165,9 +167,10 @@ class ConfigurationApiImplTest extends Specification {
   def "test skippable tests request: #displayName"() {
     given:
     def tracerEnvironment = givenTracerEnvironment()
+    def metricCollector = Stub(CiVisibilityMetricCollector)
 
     when:
-    def configurationApi = new ConfigurationApiImpl(api, () -> "1234")
+    def configurationApi = new ConfigurationApiImpl(api, metricCollector, () -> "1234")
     def skippableTests = configurationApi.getSkippableTests(tracerEnvironment)
 
     then:

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataApiTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataApiTest.groovy
@@ -4,6 +4,7 @@ import com.squareup.moshi.Moshi
 import datadog.communication.http.HttpRetryPolicy
 import datadog.communication.http.OkHttpUtils
 import datadog.trace.agent.test.server.http.TestHttpServer
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector
 import datadog.trace.civisibility.communication.BackendApi
 import datadog.trace.civisibility.communication.EvpProxyApi
 import datadog.trace.test.util.MultipartRequestParser
@@ -90,10 +91,11 @@ class GitDataApiTest extends Specification {
 
   def "test commits search"() {
     given:
+    def metricCollector = Stub(CiVisibilityMetricCollector)
     def evpProxy = givenEvpProxy()
 
     when:
-    def gitDataApi = new GitDataApi(evpProxy)
+    def gitDataApi = new GitDataApi(evpProxy, metricCollector)
     def commits = new ArrayList<>(gitDataApi.searchCommits("gitRemoteUrl", ["sha1", "sha2"]))
 
     then:
@@ -102,11 +104,12 @@ class GitDataApiTest extends Specification {
 
   def "test pack file upload"() {
     given:
+    def metricCollector = Stub(CiVisibilityMetricCollector)
     def evpProxy = givenEvpProxy()
     def packFile = givenPackFile()
 
     when:
-    def gitDataApi = new GitDataApi(evpProxy)
+    def gitDataApi = new GitDataApi(evpProxy, metricCollector)
     gitDataApi.uploadPackFile("gitRemoteUrl", "sha1", packFile)
 
     then:

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataUploaderImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataUploaderImplTest.groovy
@@ -40,7 +40,7 @@ class GitDataUploaderImplTest extends Specification {
     gitInfoProvider.getGitInfo(repoRoot) >> new GitInfo(repoUrl, null, null, null)
 
     def gitClient = new GitClient(metricCollector, repoRoot, "25 years ago", 3, TIMEOUT_MILLIS)
-    def uploader = new GitDataUploaderImpl(config, api, gitClient, gitInfoProvider, repoRoot, "origin")
+    def uploader = new GitDataUploaderImpl(config, metricCollector, api, gitClient, gitInfoProvider, repoRoot, "origin")
 
     when:
     def future = uploader.startOrObserveGitDataUpload()

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
@@ -27,7 +27,7 @@ public enum CiVisibilityDistributionMetric {
   GIT_REQUESTS_OBJECTS_PACK_MS("git_requests.objects_pack_ms"),
   /** The sum of the sizes of the object pack files inside a single payload */
   GIT_REQUESTS_OBJECTS_PACK_BYTES("git_requests.objects_pack_bytes"),
-  /** The number of files sent in the object pack payload */
+  /** The number of pack files created in a test session */
   GIT_REQUESTS_OBJECTS_PACK_FILES("git_requests.objects_pack_files"),
   /** The time it takes to get the response of the settings endpoint request in ms */
   GIT_REQUESTS_SETTINGS_MS("git_requests.settings_ms"),


### PR DESCRIPTION
# What Does This Do
Implements sending telemetry metrics for API endpoints that are specific to CI Visibility (events and coverage data intakes, Git data API, etc).

# Motivation
Monitoring CI Visibility behaviour to detect unexpected errors/problems.

Jira ticket: [CIVIS-2427]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->

[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ