### PR TITLE
Implement telemetry for CI Visibility intakes

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/AbstractTraceInterceptor.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/AbstractTraceInterceptor.java
@@ -23,6 +23,7 @@ public abstract class AbstractTraceInterceptor implements TraceInterceptor {
     GIT_METADATA(3),
 
     // trace data collection
+    CI_VISIBILITY_TELEMETRY(Integer.MAX_VALUE - 1),
     SERVICE_NAME_COLLECTING(Integer.MAX_VALUE);
 
     private final int idx;

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -10,6 +10,7 @@ apply from: "$rootDir/gradle/version.gradle"
 minimumBranchCoverage = 0.5
 minimumInstructionCoverage = 0.6
 excludedClassesCoverage += [
+  'datadog.trace.civisibility.interceptor.CiVisibilityTelemetryInterceptor',
   'datadog.trace.civisibility.writer.ddintake.CiTestCovMapperV2.PayloadV2',
   'datadog.trace.common.writer.ddintake.DDIntakeMapperDiscovery',
   'datadog.trace.common.writer.ListWriter',

--- a/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTelemetryInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/civisibility/interceptor/CiVisibilityTelemetryInterceptor.java
@@ -1,0 +1,22 @@
+package datadog.trace.civisibility.interceptor;
+
+import datadog.trace.api.civisibility.InstrumentationBridge;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
+import datadog.trace.api.interceptor.AbstractTraceInterceptor;
+import datadog.trace.api.interceptor.MutableSpan;
+import java.util.Collection;
+
+public class CiVisibilityTelemetryInterceptor extends AbstractTraceInterceptor {
+
+  public CiVisibilityTelemetryInterceptor() {
+    super(Priority.CI_VISIBILITY_TELEMETRY);
+  }
+
+  @Override
+  public Collection<? extends MutableSpan> onTraceComplete(
+      Collection<? extends MutableSpan> trace) {
+    InstrumentationBridge.getMetricCollector()
+        .add(CiVisibilityCountMetric.EVENTS_ENQUEUED_FOR_SERIALIZATION, trace.size());
+    return trace;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/TelemetryListener.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/TelemetryListener.java
@@ -1,0 +1,62 @@
+package datadog.trace.common.writer.ddintake;
+
+import datadog.communication.http.OkHttpUtils;
+import datadog.trace.api.civisibility.InstrumentationBridge;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
+import datadog.trace.api.civisibility.telemetry.CiVisibilityDistributionMetric;
+import datadog.trace.api.civisibility.telemetry.tag.Endpoint;
+import datadog.trace.api.civisibility.telemetry.tag.ErrorType;
+import java.io.IOException;
+import okhttp3.Call;
+import okhttp3.Response;
+
+public class TelemetryListener extends OkHttpUtils.CustomListener {
+
+  private final Endpoint endpoint;
+  private long callStartTimestamp;
+
+  public TelemetryListener(Endpoint endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public void callStart(Call call) {
+    callStartTimestamp = System.currentTimeMillis();
+    InstrumentationBridge.getMetricCollector()
+        .add(CiVisibilityCountMetric.ENDPOINT_PAYLOAD_REQUESTS, 1, endpoint);
+  }
+
+  public void requestBodyEnd(Call call, long byteCount) {
+    InstrumentationBridge.getMetricCollector()
+        .add(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_BYTES, (int) byteCount, endpoint);
+  }
+
+  public void responseHeadersEnd(Call call, Response response) {
+    if (!response.isSuccessful()) {
+      int responseCode = response.code();
+      InstrumentationBridge.getMetricCollector()
+          .add(
+              CiVisibilityCountMetric.ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
+              1,
+              endpoint,
+              ErrorType.from(responseCode));
+    }
+  }
+
+  public void callEnd(Call call) {
+    int durationMillis = (int) (System.currentTimeMillis() - callStartTimestamp);
+    InstrumentationBridge.getMetricCollector()
+        .add(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_REQUESTS_MS, durationMillis, endpoint);
+  }
+
+  public void callFailed(Call call, IOException ioe) {
+    int durationMillis = (int) (System.currentTimeMillis() - callStartTimestamp);
+    InstrumentationBridge.getMetricCollector()
+        .add(CiVisibilityDistributionMetric.ENDPOINT_PAYLOAD_REQUESTS_MS, durationMillis, endpoint);
+    InstrumentationBridge.getMetricCollector()
+        .add(
+            CiVisibilityCountMetric.ENDPOINT_PAYLOAD_REQUESTS_ERRORS,
+            1,
+            endpoint,
+            ErrorType.NETWORK);
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -59,6 +59,7 @@ import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import datadog.trace.bootstrap.instrumentation.api.ScopeState;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.civisibility.interceptor.CiVisibilityApmProtocolInterceptor;
+import datadog.trace.civisibility.interceptor.CiVisibilityTelemetryInterceptor;
 import datadog.trace.civisibility.interceptor.CiVisibilityTraceInterceptor;
 import datadog.trace.common.GitMetadataTraceInterceptor;
 import datadog.trace.common.metrics.MetricsAggregator;
@@ -685,6 +686,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           // CI Test Cycle protocol is not available
           addTraceInterceptor(CiVisibilityApmProtocolInterceptor.INSTANCE);
         }
+      }
+
+      if (config.isCiVisibilityTelemetryEnabled()) {
+        addTraceInterceptor(new CiVisibilityTelemetryInterceptor());
       }
     }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDEvpProxyApiTest.groovy
@@ -6,6 +6,7 @@ import datadog.communication.serialization.ByteBufferConsumer
 import datadog.communication.serialization.FlushingBuffer
 import datadog.communication.serialization.msgpack.MsgPackWriter
 import datadog.trace.api.WellKnownTags
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector
 import datadog.trace.api.intake.TrackType
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes
 import datadog.trace.common.writer.Payload

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddintake/DDIntakeApiTest.groovy
@@ -6,6 +6,7 @@ import datadog.communication.serialization.ByteBufferConsumer
 import datadog.communication.serialization.FlushingBuffer
 import datadog.communication.serialization.msgpack.MsgPackWriter
 import datadog.trace.api.WellKnownTags
+import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector
 import datadog.trace.api.intake.TrackType
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes
 import datadog.trace.common.writer.Payload

--- a/internal-api/src/main/java/datadog/trace/api/intake/TrackType.java
+++ b/internal-api/src/main/java/datadog/trace/api/intake/TrackType.java
@@ -1,7 +1,16 @@
 package datadog.trace.api.intake;
 
+import datadog.trace.api.civisibility.telemetry.tag.Endpoint;
+import javax.annotation.Nullable;
+
 public enum TrackType {
-  CITESTCYCLE,
-  CITESTCOV,
-  NOOP
+  CITESTCYCLE(Endpoint.TEST_CYCLE),
+  CITESTCOV(Endpoint.CODE_COVERAGE),
+  NOOP(null);
+
+  @Nullable public final Endpoint endpoint;
+
+  TrackType(Endpoint endpoint) {
+    this.endpoint = endpoint;
+  }
 }


### PR DESCRIPTION
# What Does This Do
Implements sending telemetry metrics for CI Visibility intakes (test events intake and per-test code coverages intake).

# Motivation
Monitoring CI Visibility behaviour to detect unexpected errors/problems.

Jira ticket: [CIVIS-2427]

[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ