### PR TITLE
Flush traces when spark application is finished

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -213,6 +213,10 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
         "spark.available_executor_time", computeCurrentAvailableExecutorTime(time));
 
     applicationSpan.finish(time * 1000);
+
+    // write traces synchronously:
+    // as soon as the application finishes, the JVM starts to shut down
+    tracer.flush();
   }
 
   private AgentSpan getOrCreateStreamingBatchSpan(


### PR DESCRIPTION
# What Does This Do

Flush spans when the spark application finishes

Default timeout for the remoteWriter is [1 second](https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteWriter.java#L61) so it will not block the main thread for more than 1 second

# Motivation

Customer losing their spans because the JVM was shut down to quickly, with those debug logs:

```
[dd.trace 2024-02-09 14:12:48:023] [main] DEBUG datadog.trace.agent.core.DDSpan - Finished span (WRITTEN): DDSpan [...]
[dd.trace 2024-02-09 14:12:48:097] [dd-trace-processor] DEBUG datadog.trace.agent.common.writer.ddagent.DDAgentApi - Error while sending 1 (size=61KB) traces. Total: 1, Received: 1, Sent: 0, Failed: 1.
java.io.InterruptedIOException: interrupted
	at okio.Timeout.throwIfReached(Timeout.java:146)
        [...]
	at datadog.trace.agent.common.writer.ddagent.DDAgentApi.sendSerializedTraces(DDAgentApi.java:116)
	at datadog.trace.agent.common.writer.PayloadDispatcherImpl.accept(PayloadDispatcherImpl.java:113)
	at datadog.communication.serialization.FlushingBuffer.flush(FlushingBuffer.java:42)
	at datadog.communication.serialization.msgpack.MsgPackWriter.flush(MsgPackWriter.java:77)
	at datadog.trace.agent.common.writer.PayloadDispatcherImpl.flush(PayloadDispatcherImpl.java:52)
	at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.flushIfNecessary(TraceProcessingWorker.java:275)
	at datadog.trace.agent.common.writer.TraceProcessingWorker$DaemonTraceSerializingHandler.runDutyCycle(TraceProcessingWorker.java:157)
	at datadog.trace.agent.common.writer.TraceProcessingWorker$DaemonTraceSerializingHandler.run(TraceProcessingWorker.java:145)
	at java.lang.Thread.run(Thread.java:750)
[dd.trace 2024-02-09 14:12:48:098] [dd-trace-processor] DEBUG datadog.trace.agent.common.writer.PayloadDispatcherImpl - Failed to send 1 traces
[dd.trace 2024-02-09 14:12:48:098] [dd-trace-processor] DEBUG datadog.trace.agent.common.writer.TraceProcessingWorker - Datadog trace processor exited. Publishing traces stopped
```

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
