### PR TITLE
Do not ignore caught exceptions in CI Visibility code

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/CILocalGitInfoBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/CILocalGitInfoBuilder.java
@@ -44,7 +44,8 @@ public class CILocalGitInfoBuilder implements GitInfoBuilder {
         }
       }
     } catch (Exception e) {
-      LOGGER.debug("Error while getting Git folder in " + repositoryPath, e);
+      LOGGER.debug("Error while getting Git folder in {}", repositoryPath, e);
+      LOGGER.warn("Error while getting Git folder");
     }
     return Paths.get(repositoryPath, gitFolderName);
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/GitClientGitInfoBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/GitClientGitInfoBuilder.java
@@ -54,7 +54,8 @@ public class GitClientGitInfoBuilder implements GitInfoBuilder {
       return new GitInfo(remoteUrl, branch, tag, commitInfo);
 
     } catch (Exception e) {
-      LOGGER.debug("Error while getting Git data from " + repositoryPath, e);
+      LOGGER.debug("Error while getting Git data from {}", repositoryPath, e);
+      LOGGER.warn("Error while getting Git data by executing shell commands");
       return GitInfo.NOOP;
     }
   }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -19,8 +19,12 @@ import org.junit.runner.Description;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.ParentRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class JUnit4Utils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JUnit4Utils.class);
 
   private static final String SYNCHRONIZED_LISTENER =
       "org.junit.runner.notification.SynchronizedRunListener";
@@ -127,6 +131,8 @@ public abstract class JUnit4Utils {
     try {
       return testClass.getMethod(methodName);
     } catch (NoSuchMethodException e) {
+      LOGGER.debug("Could not get method named {} in class {}", methodName, testClass, e);
+      LOGGER.warn("Could not get test method", e);
       return null;
     }
   }

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/SpockUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/SpockUtils.java
@@ -13,11 +13,15 @@ import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spockframework.runtime.SpockNode;
 import org.spockframework.runtime.model.FeatureMetadata;
 import org.spockframework.runtime.model.SpecElementInfo;
 
 public class SpockUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SpockUtils.class);
 
   private static final datadog.trace.util.MethodHandles METHOD_HANDLES =
       new datadog.trace.util.MethodHandles(ClassLoaderUtils.getDefaultClassLoader());
@@ -50,7 +54,7 @@ public class SpockUtils {
       return junitPlatformTestTags;
 
     } catch (Throwable throwable) {
-      // ignore
+      LOGGER.warn("Could not get tags from a spock node", throwable);
       return Collections.emptyList();
     }
   }
@@ -79,7 +83,7 @@ public class SpockUtils {
       }
 
     } catch (Throwable e) {
-      // ignore
+      LOGGER.warn("Could not get test method from method source", e);
     }
     return null;
   }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformUtils.java
@@ -18,6 +18,8 @@ import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * !!!!!!!!!!!!!!!! IMPORTANT !!!!!!!!!!!!!!!! Do not use or refer to any classes from {@code
@@ -27,6 +29,8 @@ import org.junit.platform.engine.support.descriptor.MethodSource;
  * <p>Should you have to do something with those classes, do it in a dedicated utility class
  */
 public abstract class JUnitPlatformUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JUnitPlatformUtils.class);
 
   private JUnitPlatformUtils() {}
 
@@ -72,6 +76,8 @@ public abstract class JUnitPlatformUtils {
               testClass, methodName, methodSource.getMethodParameterTypes())
           .orElse(null);
     } catch (JUnitException e) {
+      LOGGER.debug("Could not find method {} in class {}", methodName, testClass, e);
+      LOGGER.warn("Could not find test method");
       return null;
     }
   }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
@@ -246,6 +246,8 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
       }
 
     } catch (Exception e) {
+      LOGGER.debug("Error while getting effective JVM for mojo {}", mojo, e);
+      LOGGER.warn("Error while getting effective JVM");
       return null;
     }
   }

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestUtils.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestUtils.java
@@ -48,11 +48,8 @@ public abstract class ScalatestUtils {
       return CLASS_LOADER.loadClass(className.get());
     } catch (Exception e) {
       log.debug("Could not load class {}", className, e);
+      log.warn("Could not load a Scalatest class");
       return null;
     }
-  }
-
-  public static void test(Object invokeWithFixture) {
-    System.out.println("tdest"); // FIXME remove - scala.Function1
   }
 }

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
@@ -11,6 +11,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.IClass;
 import org.testng.ITestClass;
 import org.testng.ITestContext;
@@ -24,6 +26,8 @@ import org.testng.internal.ITestResultNotifier;
 import org.testng.xml.XmlTest;
 
 public abstract class TestNGUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestNGUtils.class);
 
   private static final datadog.trace.util.MethodHandles METHOD_HANDLES =
       new datadog.trace.util.MethodHandles(TestNG.class.getClassLoader());
@@ -161,6 +165,7 @@ public abstract class TestNGUtils {
       return parallel != null
           && ("methods".equals(parallel.toString()) || "tests".equals(parallel.toString()));
     } catch (Throwable e) {
+      LOGGER.warn("Error while checking if a test class is paralellized");
       return false;
     }
   }


### PR DESCRIPTION
# What Does This Do
Updates CI Visibility core and instrumentations so that caught exceptions are never swallowed.

# Motivation
In future releases of the tracer it will be possible to report exceptions in the tracer code to Datadog using telemetry.
The goal is to see if there are any unexpected exceptions when CI Visibility is used in various envs.

Jira ticket: [CIVIS-2427]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ