### PR TITLE
Upgrade to ddprof 0.97.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.19.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.96.0",
+    ddprof        : "0.97.0",
     asm           : "9.6",
     cafe_crypto   : "0.1.0",
     lz4           : "1.7.1"


### PR DESCRIPTION
# What Does This Do
Fix bug in stackwalker when kernel frames are walkable
Default to `create_timer` (reduces number of file handles required)
https://github.com/DataDog/java-profiler/releases/tag/v_0.97.0
# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
