### PR TITLE
Do not use ddprof in J9 smoketests

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -1,6 +1,7 @@
 package datadog.smoketest
 
 import datadog.trace.agent.test.server.http.TestHttpServer
+import datadog.trace.api.Platform
 import datadog.trace.test.agent.decoder.DecodedSpan
 import datadog.trace.test.agent.decoder.Decoder
 import datadog.trace.test.agent.decoder.DecodedMessage
@@ -99,8 +100,8 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.profiling.start-delay=${PROFILING_START_DELAY_SECONDS}",
     "-Ddd.profiling.upload.period=${PROFILING_RECORDING_UPLOAD_PERIOD_SECONDS}",
     "-Ddd.profiling.url=${getProfilingUrl()}",
-    "-Ddd.profiling.ddprof.enabled=true",
-    "-Ddd.profiling.ddprof.alloc.enabled=true",
+    "-Ddd.profiling.ddprof.enabled=${isDdprofSafe()}",
+    "-Ddd.profiling.ddprof.alloc.enabled=${isDdprofSafe()}",
     "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=${logLevel()}",
     "-Dorg.slf4j.simpleLogger.defaultLogLevel=${logLevel()}",
     "-Ddd.site="
@@ -115,6 +116,11 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.env=${ENV}",
     "-Ddd.version=${VERSION}"
   ]
+
+  private static boolean isDdprofSafe() {
+    // currently the J9 handling of jmethodIDs will cause frequent crashes
+    return !Platform.isJ9()
+  }
 
   def setup() {
     traceCount.set(0)


### PR DESCRIPTION
# What Does This Do
This PR will change the smoketests not to use ddprof on J9

# Motivation
On J9 the jmethoidID handling is very brittle and leads to frequent crashes. We want to avoid the crashes in smoketests.

# Additional Notes

Jira ticket: [PROF-9151]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-9151]: https://datadoghq.atlassian.net/browse/PROF-9151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ