### PR TITLE
Ensure superclasses and interfaces are loaded before classes that extend/implement them

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/classloading/ClassDefining.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/classloading/ClassDefining.java
@@ -1,0 +1,21 @@
+package datadog.trace.bootstrap.instrumentation.classloading;
+
+/** Provides a way for a single optional observer to be notified before a class is defined. */
+public final class ClassDefining {
+  private static volatile Observer OBSERVER = (loader, bytecode, offset, length) -> {};
+
+  /** Registers the given observer to get notifications about class definitions. */
+  public static void observe(Observer observer) {
+    OBSERVER = observer;
+  }
+
+  /** Called from advice added to j.l.ClassLoader by DefineClassInstrumentation. */
+  public static void begin(ClassLoader loader, byte[] bytecode, int offset, int length) {
+    OBSERVER.beforeDefineClass(loader, bytecode, offset, length);
+  }
+
+  /** Observer of class definitions. */
+  public interface Observer {
+    void beforeDefineClass(ClassLoader loader, byte[] bytecode, int offset, int length);
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/MemoizedMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/MemoizedMatchers.java
@@ -23,6 +23,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 /** Supplies memoized matchers. */
 public final class MemoizedMatchers implements HierarchyMatchers.Supplier {
   public static void registerAsSupplier() {
+    PreloadHierarchy.observeClassDefinitions();
     HierarchyMatchers.registerIfAbsent(new MemoizedMatchers());
     Memoizer.resetState();
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/PreloadHierarchy.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/PreloadHierarchy.java
@@ -1,0 +1,50 @@
+package datadog.trace.agent.tooling.bytebuddy.memoize;
+
+import datadog.trace.bootstrap.instrumentation.classloading.ClassDefining;
+import net.bytebuddy.jar.asm.ClassReader;
+
+/** Ensures superclasses and interfaces are loaded before classes that extend/implement them. */
+final class PreloadHierarchy implements ClassDefining.Observer {
+  private static final PreloadHierarchy PRELOADER = new PreloadHierarchy();
+
+  static void observeClassDefinitions() {
+    ClassDefining.observe(PRELOADER);
+  }
+
+  private static final int RECENTLY_CHECKED_MASK = (1 << 5) - 1;
+  private final String[] recentlyChecked = new String[RECENTLY_CHECKED_MASK + 1];
+
+  @Override
+  public void beforeDefineClass(ClassLoader loader, byte[] bytecode, int offset, int length) {
+    try {
+      // check first byte matches the standard class header
+      if (bytecode[offset] != (byte) 0xCA) {
+        return; // ignore non-standard formats like J9 ROMs
+      }
+      // minimal parsing of bytecode to get name of superclass and any interfaces
+      ClassReader cr = new ClassReader(bytecode, offset, length);
+      String superName = cr.getSuperName();
+      if (null != superName && !"java/lang/Object".equals(superName)) {
+        preload(loader, superName);
+      }
+      for (String interfaceName : cr.getInterfaces()) {
+        preload(loader, interfaceName);
+      }
+    } catch (Throwable ignore) {
+      // stop preloading as soon as we encounter any issue
+    }
+  }
+
+  /** Attempts to preload the named class using same class-loader as the original request. */
+  private void preload(ClassLoader loader, String internalName) throws ClassNotFoundException {
+    int slot = internalName.hashCode() & RECENTLY_CHECKED_MASK;
+    if (!internalName.equals(recentlyChecked[slot])) {
+      recentlyChecked[slot] = internalName;
+      String name = internalName.replace('/', '.');
+      // take advantage of no-match filter to avoid preloading known uninteresting classes
+      if (!NoMatchFilter.contains(name)) {
+        loader.loadClass(name);
+      }
+    }
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -41,6 +41,7 @@
 1 io.micronaut.tracing.*
 1 io.opentelemetry.javaagent.*
 1 java.*
+0 java.lang.ClassLoader
 # allow exception profiling instrumentation
 0 java.lang.Exception
 0 java.lang.Error

--- a/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/DefineClassInstrumentation.java
+++ b/dd-java-agent/instrumentation/classloading/src/main/java/datadog/trace/instrumentation/classloading/DefineClassInstrumentation.java
@@ -1,0 +1,63 @@
+package datadog.trace.instrumentation.classloading;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.bootstrap.DatadogClassLoader;
+import datadog.trace.bootstrap.instrumentation.classloading.ClassDefining;
+import java.security.ProtectionDomain;
+import net.bytebuddy.asm.Advice;
+
+/** Updates j.l.ClassLoader to notify the tracer when classes are about to be defined. */
+@AutoService(Instrumenter.class)
+public final class DefineClassInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForBootstrap, Instrumenter.ForSingleType {
+  public DefineClassInstrumentation() {
+    super("defineclass");
+  }
+
+  @Override
+  public boolean isEnabled() {
+    // only enable this when memoizing type hierarchies, where it provides the most ROI
+    return super.isEnabled() && InstrumenterConfig.get().isResolverMemoizingEnabled();
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "java.lang.ClassLoader";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(
+                named("defineClass")
+                    .and(
+                        takesArguments(
+                            String.class,
+                            byte[].class,
+                            int.class,
+                            int.class,
+                            ProtectionDomain.class))),
+        DefineClassInstrumentation.class.getName() + "$DefineClassAdvice");
+  }
+
+  public static class DefineClassAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onEnter(
+        @Advice.This ClassLoader loader,
+        @Advice.Argument(1) byte[] bytecode,
+        @Advice.Argument(2) int offset,
+        @Advice.Argument(3) int length) {
+      if (null != loader && loader.getClass() != DatadogClassLoader.class) {
+        ClassDefining.begin(loader, bytecode, offset, length);
+      }
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

Updates `j.l.ClassLoader` to notify the tracer before defining a class. The tracer can then attempt to preload the superclass and any interfaces, which will make sure those types are memoized/cached before the initial type is matched.

To disable this optimization add this JVM option:
```
-Ddd.integration.defineclass.enabled=false
```
or set this environment variable:
```
DD_INTEGRATION_DEFINECLASS_ENABLED=false
```

# Motivation

For spring-petclinic (when memoization is enabled) this reduces the number of class-file lookups by over a third.

(from 1970 lookups to 1226 lookups) 

Jira ticket: [APMS-11443]


[APMS-11443]: https://datadoghq.atlassian.net/browse/APMS-11443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ