### PR TITLE
add support link to RC warning msg

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -136,7 +136,7 @@ jobs:
 
             var changelog = ''
             if ('${{github.event.ref}}'.match(/rc/i)) {
-              changelog += ':warning:  This is a RELEASE CANDIDATE and is NOT intended for use in production. Please contact Datadog support regarding any problems in this RC.\n'
+              changelog += '> [!WARNING]\n> This is a RELEASE CANDIDATE and is NOT intended for use in production. Please contact [Datadog support](https://docs.datadoghq.com/getting_started/support/) regarding any problems in this RC.\n'
             }
             if (prByComponents.size > 0) {
               changelog += '# Components\n\n';


### PR DESCRIPTION
# What Does This Do

Adds a Datadog support link to the RC release notes warning message.