### PR TITLE
Fix intake telemetry client URL for EU site

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
@@ -59,7 +59,7 @@ public class TelemetryClient {
     String prefix = "";
     if (site.endsWith("datad0g.com")) {
       prefix = "all-http-intake.logs.";
-    } else if (site.endsWith("datadoghq.com")) {
+    } else if (site.endsWith("datadoghq.com") || site.endsWith("datadoghq.eu")) {
       prefix = "instrumentation-telemetry-intake.";
     }
     return "https://" + prefix + site + "/api/v2/apmtelemetry";

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
@@ -5,6 +5,29 @@ import spock.lang.Specification
 
 class TelemetryClientTest extends Specification {
 
+  def "Intake client uses correct URL for site #site"() {
+    setup:
+    def config = Stub(Config)
+    config.getApiKey() >> "dummy-key"
+    config.getAgentTimeout() >> 123
+    config.getSite() >> site
+
+    when:
+    def intakeClient = TelemetryClient.buildIntakeClient(config)
+
+    then:
+    intakeClient.getUrl().toString() == expectedUrl
+
+    where:
+    site                | expectedUrl
+    "datadoghq.com"     | "https://instrumentation-telemetry-intake.datadoghq.com/api/v2/apmtelemetry"
+    "us3.datadoghq.com" | "https://instrumentation-telemetry-intake.us3.datadoghq.com/api/v2/apmtelemetry"
+    "us5.datadoghq.com" | "https://instrumentation-telemetry-intake.us5.datadoghq.com/api/v2/apmtelemetry"
+    "ap1.datadoghq.com" | "https://instrumentation-telemetry-intake.ap1.datadoghq.com/api/v2/apmtelemetry"
+    "datadoghq.eu"      | "https://instrumentation-telemetry-intake.datadoghq.eu/api/v2/apmtelemetry"
+    "datad0g.com"       | "https://all-http-intake.logs.datad0g.com/api/v2/apmtelemetry"
+  }
+
   def "Intake client uses CI Visibility agentless URL if configured to do so"() {
     setup:
     def config = Stub(Config)


### PR DESCRIPTION
# What Does This Do
Fixes URL that is used by intake telemetry client when the tracer is configured to work with EU Datadog site.

# Additional Notes
The list of possible site parameters can be found [here](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site).
The list of agentless telemetry URLs for different sites can be found [here](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/development.md#agentless).

Jira ticket: [CIVIS-2427]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-2427]: https://datadoghq.atlassian.net/browse/CIVIS-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ