### PR TITLE
Fix null test framework name in JUnit 5 instrumentation

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -67,9 +67,9 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
 
     if (testFramework != null) {
       testSuite.setTag(Tags.TEST_FRAMEWORK, testFramework);
-    }
-    if (testFrameworkVersion != null) {
-      testSuite.setTag(Tags.TEST_FRAMEWORK_VERSION, testFrameworkVersion);
+      if (testFrameworkVersion != null) {
+        testSuite.setTag(Tags.TEST_FRAMEWORK_VERSION, testFrameworkVersion);
+      }
     }
     if (categories != null && !categories.isEmpty()) {
       testSuite.setTag(
@@ -154,9 +154,9 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
 
     if (testFramework != null) {
       test.setTag(Tags.TEST_FRAMEWORK, testFramework);
-    }
-    if (testFrameworkVersion != null) {
-      test.setTag(Tags.TEST_FRAMEWORK_VERSION, testFrameworkVersion);
+      if (testFrameworkVersion != null) {
+        test.setTag(Tags.TEST_FRAMEWORK_VERSION, testFrameworkVersion);
+      }
     }
     if (testParameters != null) {
       test.setTag(Tags.TEST_PARAMETERS, testParameters);

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TracingListener.java
@@ -20,7 +20,7 @@ public class TracingListener implements EngineExecutionListener {
 
   public TracingListener(TestEngine testEngine) {
     String engineId = testEngine.getId();
-    testFramework = engineId != null && engineId.startsWith("junit") ? "junit5" : engineId;
+    testFramework = engineId == null || engineId.startsWith("junit") ? "junit5" : engineId;
     testFrameworkVersion = testEngine.getVersion().orElse(null);
   }
 


### PR DESCRIPTION
# What Does This Do
Fixes test framework name calculation in JUnit 5 instrumentation: test framework name is calculated based on the ID of test engine (a JUnit 5 abstraction that encapsulates some framework-specific details) used to execute test cases.
With the fix if the ID of the test engine is `null`, a generic "junit5" framework name will be used.

Also fixes the generic CI Vis logic to only set the test framework version tag if the framework name is available (both because framework version is not very useful without a name, and because there is some logic that depends on either both being present, or both absent.

# Motivation
Fixing the following error:
```
[13:02:51 UTC]  JUnit Jupiter executionError FAILED
[13:02:51 UTC]  
[13:02:51 UTC]    java.lang.IllegalArgumentException: java.lang.IllegalArgumentException: Unexpected tag type(s): test.framework (null) test.framework_version (5.10.1)
[13:02:51 UTC]        at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
[13:02:51 UTC]        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
[13:02:51 UTC]        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486)
[13:02:51 UTC]        at java.base/java.util.concurrent.ForkJoinTask.getThrowableException(ForkJoinTask.java:540)
[13:02:51 UTC]        at java.base/java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:567)
[13:02:51 UTC]        at java.base/java.util.concurrent.ForkJoinTask.join(ForkJoinTask.java:653)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.joinConcurrentTasksInReverseOrderToEnableWorkStealing(ForkJoinPoolHierarchicalTestExecutorService.java:179)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService.invokeAll(ForkJoinPoolHierarchicalTestExecutorService.java:153)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.ForkJoinPoolHierarchicalTestExecutorService$ExclusiveTask.compute(ForkJoinPoolHierarchicalTestExecutorService.java:202)
[13:02:51 UTC]        at java.base/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
[13:02:51 UTC]        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
[13:02:51 UTC]        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
[13:02:51 UTC]        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
[13:02:51 UTC]        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
[13:02:51 UTC]        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
[13:02:51 UTC]    Caused by: java.lang.IllegalArgumentException: Unexpected tag type(s): test.framework (null) test.framework_version (5.10.1)
[13:02:51 UTC]        at datadog.trace.civisibility.utils.SpanUtils.getFrameworks(SpanUtils.java:51)
[13:02:51 UTC]        at datadog.trace.civisibility.utils.SpanUtils.mergeTestFrameworks(SpanUtils.java:27)
[13:02:51 UTC]        at datadog.trace.civisibility.utils.SpanUtils.propagateCiVisibilityTags(SpanUtils.java:22)
[13:02:51 UTC]        at datadog.trace.civisibility.utils.SpanUtils.lambda$propagateCiVisibilityTagsTo$1(SpanUtils.java:18)
[13:02:51 UTC]        at datadog.trace.civisibility.DDTestSuiteImpl.end(DDTestSuiteImpl.java:151)
[13:02:51 UTC]        at datadog.trace.civisibility.events.TestEventsHandlerImpl.onTestSuiteFinish(TestEventsHandlerImpl.java:94)
[13:02:51 UTC]        at datadog.trace.instrumentation.junit5.TracingListener.containerExecutionFinished(TracingListener.java:99)
[13:02:51 UTC]        at datadog.trace.instrumentation.junit5.TracingListener.executionFinished(TracingListener.java:50)
[13:02:51 UTC]        at datadog.trace.instrumentation.junit5.CompositeEngineListener.executionFinished(CompositeEngineListener.java:46)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.NodeTestTask.reportCompletion(NodeTestTask.java:195)
[13:02:51 UTC]        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:100)
```

Jira ticket: [CIVIS-9156]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9156]: https://datadoghq.atlassian.net/browse/CIVIS-9156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ