### PR TITLE
Refactor ExceptionProbe to get one per frame

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -272,7 +272,7 @@ public class CapturedContext implements ValueReferenceResolver {
     return locals;
   }
 
-  public CapturedThrowable getThrowable() {
+  public CapturedThrowable getCapturedThrowable() {
     return throwable;
   }
 

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -322,7 +322,7 @@ public class DebuggerContext {
         } else if (exitStatus.probeImplementation.getEvaluateAt() == MethodLocation.EXIT) {
           probeImplementation = exitStatus.probeImplementation;
         } else {
-          throw new IllegalStateException("no probe details");
+          throw new IllegalStateException("no probe details for " + encodedProbeId);
         }
         probeImplementation.commit(entryContext, exitContext, caughtExceptions);
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationUpdater.java
@@ -40,6 +40,10 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
         DebuggerSink debuggerSink);
   }
 
+  public interface RetransformListener {
+    void onRetransform(String className);
+  }
+
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationUpdater.class);
 
   private final Instrumentation instrumentation;
@@ -52,6 +56,7 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
   private final Map<String, ProbeDefinition> appliedDefinitions = new ConcurrentHashMap<>();
   private final DebuggerSink sink;
   private final ClassesToRetransformFinder finder;
+  private RetransformListener retransformListener;
   private final String serviceName;
   private final Map<String, InstrumentationResult> instrumentationResults =
       new ConcurrentHashMap<>();
@@ -177,22 +182,13 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
     }
   }
 
-  private Configuration createEmptyConfiguration() {
-    if (currentConfiguration != null) {
-      return Configuration.builder()
-          .setService(currentConfiguration.getService())
-          .addAllowList(currentConfiguration.getAllowList())
-          .addDenyList(currentConfiguration.getDenyList())
-          .setSampling(currentConfiguration.getSampling())
-          .build();
-    }
-    return Configuration.builder().setService(serviceName).build();
-  }
-
   private void retransformClasses(List<Class<?>> classesToBeTransformed) {
     for (Class<?> clazz : classesToBeTransformed) {
       try {
         LOGGER.info("Re-transforming class: {}", clazz.getTypeName());
+        if (retransformListener != null) {
+          retransformListener.onRetransform(clazz.getTypeName());
+        }
         instrumentation.retransformClasses(clazz);
       } catch (Exception ex) {
         ExceptionHelper.logException(LOGGER, ex, "Re-transform error:");
@@ -261,6 +257,10 @@ public class ConfigurationUpdater implements DebuggerContext.ProbeResolver, Conf
     }
     instrumentation.removeTransformer(currentTransformer);
     currentTransformer = null;
+  }
+
+  public void setRetransformListener(RetransformListener retransformListener) {
+    this.retransformListener = retransformListener;
   }
 
   // only visible for tests

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -82,8 +82,10 @@ public class DebuggerAgent {
     DebuggerContext.initValueSerializer(snapshotSerializer);
     DebuggerContext.initTracer(new DebuggerTracer(debuggerSink.getProbeStatusSink()));
     if (config.isDebuggerExceptionEnabled()) {
-      DebuggerContext.initExceptionDebugger(
-          new DefaultExceptionDebugger(configurationUpdater, classNameFiltering));
+      DefaultExceptionDebugger defaultExceptionDebugger =
+          new DefaultExceptionDebugger(configurationUpdater, classNameFiltering);
+      DebuggerContext.initExceptionDebugger(defaultExceptionDebugger);
+      configurationUpdater.setRetransformListener(defaultExceptionDebugger);
     }
     if (config.isDebuggerInstrumentTheWorld()) {
       setupInstrumentTheWorldTransformer(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -12,7 +12,8 @@ import org.slf4j.LoggerFactory;
  * Default implementation of {@link DebuggerContext.ExceptionDebugger} that uses {@link
  * ExceptionProbeManager} to instrument the exception stacktrace and send snapshots.
  */
-public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugger {
+public class DefaultExceptionDebugger
+    implements DebuggerContext.ExceptionDebugger, ConfigurationUpdater.RetransformListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExceptionDebugger.class);
   private final ExceptionProbeManager exceptionProbeManager;
   private final ConfigurationUpdater configurationUpdater;
@@ -46,6 +47,11 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
       // TODO make it async
       configurationUpdater.accept(EXCEPTION, exceptionProbeManager.getProbes());
     }
+  }
+
+  @Override
+  public void onRetransform(String className) {
+    exceptionProbeManager.clearInstrumentedMethodsByClassName(className);
   }
 
   ExceptionProbeManager getExceptionProbeManager() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -3,9 +3,11 @@ package com.datadog.debugger.probe;
 import static java.util.Collections.emptyList;
 
 import com.datadog.debugger.el.ProbeCondition;
+import com.datadog.debugger.exception.ExceptionProbeManager;
 import com.datadog.debugger.exception.Fingerprinter;
+import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
-import com.datadog.debugger.util.ClassNameFiltering;
+import com.datadog.debugger.instrumentation.MethodInfo;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
@@ -17,8 +19,7 @@ import org.slf4j.LoggerFactory;
 
 public class ExceptionProbe extends LogProbe {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionProbe.class);
-  private final String fingerprint;
-  private final transient ClassNameFiltering classNameFiltering;
+  private final ExceptionProbeManager exceptionProbeManager;
 
   public ExceptionProbe(
       ProbeId probeId,
@@ -26,8 +27,7 @@ public class ExceptionProbe extends LogProbe {
       ProbeCondition probeCondition,
       Capture capture,
       Sampling sampling,
-      String fingerprint,
-      ClassNameFiltering classNameFiltering) {
+      ExceptionProbeManager exceptionProbeManager) {
     super(
         LANGUAGE,
         probeId,
@@ -40,12 +40,7 @@ public class ExceptionProbe extends LogProbe {
         probeCondition,
         capture,
         sampling);
-    this.fingerprint = fingerprint;
-    this.classNameFiltering = classNameFiltering;
-  }
-
-  public String getFingerprint() {
-    return fingerprint;
+    this.exceptionProbeManager = exceptionProbeManager;
   }
 
   @Override
@@ -68,12 +63,14 @@ public class ExceptionProbe extends LogProbe {
     if (methodLocation != MethodLocation.EXIT) {
       return;
     }
-    if (context.getThrowable() == null) {
+    if (context.getCapturedThrowable() == null) {
       return;
     }
-    String currentFingerprint =
-        Fingerprinter.fingerprint(context.getThrowable().getThrowable(), classNameFiltering);
-    if (fingerprint.equals(currentFingerprint)) {
+    String fingerprint =
+        Fingerprinter.fingerprint(
+            context.getCapturedThrowable().getThrowable(),
+            exceptionProbeManager.getClassNameFiltering());
+    if (exceptionProbeManager.shouldCaptureException(where, fingerprint)) {
       LOGGER.debug("Capturing exception matching fingerprint: {}", fingerprint);
       // capture only on uncaught exception matching the fingerprint
       ((ExceptionProbeStatus) status).setCapture(true);
@@ -86,7 +83,7 @@ public class ExceptionProbe extends LogProbe {
       CapturedContext entryContext,
       CapturedContext exitContext,
       List<CapturedContext.CapturedThrowable> caughtExceptions) {
-    LOGGER.debug("committing exception probe id={}  fingerprint={}", id, fingerprint);
+    LOGGER.debug("committing exception probe id={}", id);
     super.commit(entryContext, exitContext, caughtExceptions);
   }
 
@@ -100,6 +97,17 @@ public class ExceptionProbe extends LogProbe {
     }
     // drop line number for exception probe
     this.location = new ProbeLocation(type, method, where.getSourceFile(), emptyList());
+  }
+
+  @Override
+  public InstrumentationResult.Status instrument(
+      MethodInfo methodInfo, List<DiagnosticMessage> diagnostics, List<ProbeId> probeIds) {
+    Where preciseWhere = Where.from(methodInfo);
+    if (exceptionProbeManager.addInstrumentedMethod(preciseWhere, this)) {
+      return super.instrument(methodInfo, diagnostics, probeIds);
+    }
+    LOGGER.debug("exception probe is already instrumented for {}", preciseWhere);
+    return InstrumentationResult.Status.INSTALLED;
   }
 
   public static class ExceptionProbeStatus extends LogStatus {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -380,7 +380,7 @@ public class LogProbe extends ProbeDefinition {
       sample(logStatus, methodLocation);
     }
     logStatus.setCondition(evaluateCondition(context, logStatus));
-    CapturedContext.CapturedThrowable throwable = context.getThrowable();
+    CapturedContext.CapturedThrowable throwable = context.getCapturedThrowable();
     if (logStatus.hasConditionErrors() && throwable != null) {
       logStatus.addError(
           new EvaluationError(
@@ -475,7 +475,7 @@ public class LogProbe extends ProbeDefinition {
       shouldCommit = true;
     }
     if (entryStatus.shouldReportError()) {
-      if (entryContext.getThrowable() != null) {
+      if (entryContext.getCapturedThrowable() != null) {
         // report also uncaught exception
         snapshot.setEntry(entryContext);
       }
@@ -483,7 +483,7 @@ public class LogProbe extends ProbeDefinition {
       shouldCommit = true;
     }
     if (exitStatus.shouldReportError()) {
-      if (exitContext.getThrowable() != null) {
+      if (exitContext.getCapturedThrowable() != null) {
         // report also uncaught exception
         snapshot.setExit(exitContext);
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
@@ -1,11 +1,13 @@
 package com.datadog.debugger.probe;
 
 import com.datadog.debugger.agent.Generated;
+import com.datadog.debugger.instrumentation.MethodInfo;
 import com.datadog.debugger.instrumentation.Types;
 import com.datadog.debugger.util.ClassFileLines;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
+import datadog.trace.util.Strings;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,6 +60,13 @@ public class Where {
       lines[i] = SourceLine.fromString(defs[i]);
     }
     return lines;
+  }
+
+  public static Where from(MethodInfo methodInfo) {
+    String typeName = Strings.getClassName(methodInfo.getClassNode().name);
+    String methodName = methodInfo.getMethodNode().name;
+    String signature = methodInfo.getMethodNode().desc;
+    return new Where(typeName, methodName, signature, (SourceLine[]) null, null);
   }
 
   public String getTypeName() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -178,7 +178,7 @@ public class MoshiSnapshotHelper {
       jsonWriter.endObject();
       handleSerializationResult(jsonWriter, resultLocals, resultArgs, resultStaticFields);
       jsonWriter.name(THROWABLE);
-      throwableAdapter.toJson(jsonWriter, capturedContext.getThrowable());
+      throwableAdapter.toJson(jsonWriter, capturedContext.getCapturedThrowable());
       jsonWriter.endObject();
     }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CaptureAssertionHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CaptureAssertionHelper.java
@@ -103,7 +103,7 @@ class CaptureAssertionHelper {
       addThis(expectedExitContext, captures.getReturn());
       assertEquals(expectedExitContext, captures.getReturn());
     } else {
-      assertNotNull(captures.getReturn().getThrowable());
+      assertNotNull(captures.getReturn().getCapturedThrowable());
     }
   }
 
@@ -124,13 +124,13 @@ class CaptureAssertionHelper {
           new CapturedContext(
               returnArgs.get(exceptionKind), null, null, UNHANDLED_EXCEPTION, correlationFields);
       assertEquals(
-          expectedUnhandled.getThrowable().getMessage(),
-          captures.getReturn().getThrowable().getMessage());
+          expectedUnhandled.getCapturedThrowable().getMessage(),
+          captures.getReturn().getCapturedThrowable().getMessage());
       assertEquals(
-          expectedUnhandled.getThrowable().getType(),
-          captures.getReturn().getThrowable().getType());
+          expectedUnhandled.getCapturedThrowable().getType(),
+          captures.getReturn().getCapturedThrowable().getType());
     } else {
-      assertNull(captures.getReturn().getThrowable());
+      assertNull(captures.getReturn().getCapturedThrowable());
     }
     if (exceptionKind == DebuggerTransformerTest.ExceptionKind.HANDLED) {
       assertEquals(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -2341,7 +2341,7 @@ public class CapturedSnapshotTest {
 
   private void assertCaptureThrowable(
       CapturedContext context, String typeName, String message, String methodName, int lineNumber) {
-    CapturedContext.CapturedThrowable throwable = context.getThrowable();
+    CapturedContext.CapturedThrowable throwable = context.getCapturedThrowable();
     assertCaptureThrowable(throwable, typeName, message, methodName, lineNumber);
   }
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -27,7 +27,7 @@ public class CapturedSnapshot20 {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
     AgentSpan span = tracerAPI.buildSpan("process").start();
     try (AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL)) {
-      if (arg.equals("exception")) {
+      if (arg.equals("exception") || arg.equals("illegal")) {
         return new CapturedSnapshot20().processWithException(arg);
       }
       return new CapturedSnapshot20().process(arg);
@@ -46,6 +46,9 @@ public class CapturedSnapshot20 {
 
   private int processWithException(String arg) {
     int intLocal = intField + 42;
+    if (arg.equals("illegal")) {
+      throw new IllegalArgumentException("illegal argument");
+    }
     throw new RuntimeException("oops");
   }
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
@@ -72,7 +72,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
           assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
           assertFullMethodCaptureArgs(snapshot.getCaptures().getEntry());
           assertNull(snapshot.getCaptures().getEntry().getLocals());
-          assertNull(snapshot.getCaptures().getEntry().getThrowable());
+          assertNull(snapshot.getCaptures().getEntry().getCapturedThrowable());
           assertNull(snapshot.getCaptures().getEntry().getFields());
           assertFullMethodCaptureArgs(snapshot.getCaptures().getReturn());
           assertCaptureReturnValue(
@@ -81,7 +81,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
               "42, foobar, 3.42, {key1=val1, key2=val2, key3=val3}, var1,var2,var3");
           assertNotNull(snapshot.getCaptures().getReturn().getLocals());
           assertEquals(1, snapshot.getCaptures().getReturn().getLocals().size()); // @return
-          assertNull(snapshot.getCaptures().getReturn().getThrowable());
+          assertNull(snapshot.getCaptures().getReturn().getCapturedThrowable());
           assertNull(snapshot.getCaptures().getReturn().getFields());
           snapshotReceived.set(true);
         });
@@ -366,7 +366,8 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
     JsonSnapshotSerializer.IntakeRequest intakeRequest = adapter.fromJson(bodyStr).get(0);
     Snapshot snapshot = intakeRequest.getDebugger().getSnapshot();
     assertEquals("123356536", snapshot.getProbe().getId());
-    CapturedContext.CapturedThrowable throwable = snapshot.getCaptures().getReturn().getThrowable();
+    CapturedContext.CapturedThrowable throwable =
+        snapshot.getCaptures().getReturn().getCapturedThrowable();
     assertEquals("oops uncaught!", throwable.getMessage());
     assertTrue(throwable.getStacktrace().size() > 0);
     assertEquals(


### PR DESCRIPTION
# What Does This Do
Instead of having multiple probes for each frame when sharing same frame for different exception (and fingerprint) we have only one instance of ExceptionProbe per frame and using ExceptionProbeManager we make sure that:
1. we only instrument once.
2. we compute the fingerprint and assess if we need to capture the exception or not for this frame
When instrumenting, we store a normalized version of a Where instance with className + methodName + signature. The normalization can only happen at instrumentation time to resolve which line correspond to which method (in case of overloaded methods).
When retransformations happen for a class we need to remove the instrumented method from ExceptionProbeManager by introducing a listener mechanism in ConfigurationUpdater.

# Motivation
Following comment: https://github.com/DataDog/dd-trace-java/pull/6641#discussion_r1483071837

# Additional Notes

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
