### PR TITLE
Replace ASM transient mechanism with WAF ephemeral addresses

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -2,7 +2,6 @@ package com.datadog.appsec.gateway;
 
 import com.datadog.appsec.event.data.Address;
 import com.datadog.appsec.event.data.DataBundle;
-import com.datadog.appsec.event.data.KnownAddresses;
 import com.datadog.appsec.report.AppSecEvent;
 import com.datadog.appsec.util.StandardizedLogging;
 import datadog.trace.api.http.StoredBodySupplier;
@@ -74,6 +73,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private boolean rawReqBodyPublished;
   private boolean convertedReqBodyPublished;
   private boolean respDataPublished;
+  private boolean pathParamsPublished;
   private Map<String, String> apiSchemas;
 
   // should be guarded by this
@@ -327,7 +327,11 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   }
 
   public boolean isPathParamsPublished() {
-    return persistentData.containsKey(KnownAddresses.REQUEST_PATH_PARAMS);
+    return pathParamsPublished;
+  }
+
+  public void setPathParamsPublished(boolean pathParamsPublished) {
+    this.pathParamsPublished = pathParamsPublished;
   }
 
   public boolean isRawReqBodyPublished() {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -216,14 +216,10 @@ public class GatewayBridge {
           EVENTS.requestPathParams(),
           (ctx_, data) -> {
             AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
-            if (ctx == null) {
+            if (ctx == null || ctx.isPathParamsPublished()) {
               return NoopFlow.INSTANCE;
             }
-
-            if (ctx.isPathParamsPublished()) {
-              log.debug("Second or subsequent publication of request params");
-              return NoopFlow.INSTANCE;
-            }
+            ctx.setPathParamsPublished(true);
 
             while (true) {
               DataSubscriberInfo subInfo = pathParamsSubInfo;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -511,8 +511,7 @@ public class PowerWAFModule implements AppSecModule {
       PowerwafMetrics metrics = reqCtx.getWafMetrics();
 
       if (isTransient) {
-        DataBundle bundle = DataBundle.unionOf(newData, reqCtx);
-        return runPowerwafTransient(metrics, bundle, ctxAndAddr);
+        return runPowerwafTransient(additive, metrics, newData, ctxAndAddr);
       } else {
         return runPowerwafAdditive(additive, metrics, newData, ctxAndAddr);
       }
@@ -527,9 +526,9 @@ public class PowerWAFModule implements AppSecModule {
   }
 
   private Powerwaf.ResultWithData runPowerwafTransient(
-      PowerwafMetrics metrics, DataBundle bundle, CtxAndAddresses ctxAndAddr)
+      Additive additive, PowerwafMetrics metrics, DataBundle bundle, CtxAndAddresses ctxAndAddr)
       throws AbstractPowerwafException {
-    return ctxAndAddr.ctx.runRules(
+    return additive.runEphemeral(
         new DataBundleMapWrapper(ctxAndAddr.addressesOfInterest, bundle), LIMITS, metrics);
   }
 

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -6,7 +6,6 @@ import com.datadog.appsec.event.EventDispatcher
 import com.datadog.appsec.event.EventProducerService
 import com.datadog.appsec.event.data.DataBundle
 import com.datadog.appsec.event.data.KnownAddresses
-import com.datadog.appsec.event.data.SingletonDataBundle
 import com.datadog.appsec.report.AppSecEvent
 import com.datadog.appsec.report.AppSecEventWrapper
 import datadog.trace.api.internal.TraceSegment
@@ -380,8 +379,10 @@ class GatewayBridgeSpecification extends DDSpecification {
   void 'path params is not published twice'() {
     Flow flow
 
+    setup:
+    pathParamsCB.apply(ctx, [a: 'b'])
+
     when:
-    arCtx.addAll(new SingletonDataBundle(KnownAddresses.REQUEST_PATH_PARAMS, [a: 'b']))
     flow = pathParamsCB.apply(ctx, [c: 'd'])
 
     then:


### PR DESCRIPTION
# What Does This Do
This pull request signifies an important enhancement in ASM. Originally, we employed a transient mechanism to manage temporary data submissions to the WAF. The recent introduction of ephemeral addresses in `libddwaf` presents a native and more efficient implementation of this transient mechanism. Through this PR, we are transitioning from the older transient method to utilizing ephemeral addresses.

# Motivation
This improvement is required by #6375 

# Additional Notes
Upgrading WAF to version `1.16.0` made it possible to start using ephemeral addresses (see: #6658)

Jira ticket: [APPSEC-51774]

[APPSEC-51774]: https://datadoghq.atlassian.net/browse/APPSEC-51774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ