### PR TITLE
Fix setup job in CI

### DIFF
--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -67,6 +67,7 @@ if pr_url:
     pr_base_ref = data.get("base", {}).get("ref")
 else:
     labels = set()
+    pr_base_ref = ""
 
 branch = os.environ.get("CIRCLE_BRANCH", "")
 run_all = "all" in labels


### PR DESCRIPTION
# What Does This Do
Fix undefined symbol in CI setup job, only for non-PR builds. Previously broken by https://github.com/DataDog/dd-trace-java/pull/6610

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
