### PR TITLE
Optimizations to check if string arrays can be tainted

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/XssModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/XssModuleImpl.java
@@ -98,7 +98,7 @@ public class XssModuleImpl extends SinkModuleBase implements XssModule {
 
   @Override
   public void onXss(@Nonnull CharSequence s, @Nullable String file, int line) {
-    if (!canBeTainted(s) || file == null || file.isEmpty()) {
+    if (!canBeTainted(s) || !canBeTainted(file)) {
       return;
     }
     final IastContext ctx = IastContext.Provider.get();


### PR DESCRIPTION
# What Does This Do
Creates an specialized version of the `canBeTainted` method working with `String` instead of `CharSequence`

# Motivation
In some JVM implementation the difference between `invokevirtual` and `invokeinterface` for this method is noticeable making it worth it to have an specialized version.

