### PR TITLE
Make system-tests required in CI

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1336,6 +1336,7 @@ build_test_jobs: &build_test_jobs
 {% endfor %}
         - profiling
         - debugger
+        - system-tests
       name: required
       stage: required
 


### PR DESCRIPTION
# What Does This Do
Make system-tests required for PRs. They have been fairly stable for quite some time, and they are important for ASM products.

This does not include parametric tests.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
