### PR TITLE
[WIP] Optimization: assume java.* types are always visible

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/TypeFactory.java
@@ -377,6 +377,11 @@ final class TypeFactory {
       return outline().getDeclaringType();
     }
 
+    @Override
+    public boolean isVisibleTo(TypeDescription type) {
+      return name.startsWith("java.") || super.isVisibleTo(type);
+    }
+
     private TypeDescription outline() {
       if (null != delegate) {
         return delegate; // will be at least an outline, no need to re-resolve


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]