### PR TITLE
Avoid permission issues for the crash uploader script

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/ScriptInitializer.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/ScriptInitializer.java
@@ -58,7 +58,9 @@ public final class ScriptInitializer {
     if (scriptPath.getFileName().toString().toLowerCase(Locale.ROOT).contains("dd_crash_uploader")
         && Files.notExists(scriptPath)) {
       try {
-        Files.createDirectories(scriptPath.getParent());
+        Files.createDirectories(
+            scriptPath.getParent(),
+            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx")));
       } catch (FileAlreadyExistsException ignored) {
         // can be safely ignored; if the folder exists we will just reuse it
       }
@@ -86,7 +88,7 @@ public final class ScriptInitializer {
             .forEach(line -> writeLine(bw, line));
       }
     }
-    Files.setPosixFilePermissions(scriptPath, PosixFilePermissions.fromString("r-xr-x---"));
+    Files.setPosixFilePermissions(scriptPath, PosixFilePermissions.fromString("r-xr-xr-x"));
   }
 
   private static void writeLine(BufferedWriter bw, String line) {


### PR DESCRIPTION
# What Does This Do
For the crash tracking it adjusts the folder and file permissions such that they are not restricted to a single user/group.

# Motivation
The crash tracking script initialization routine is creating the script on the fly. By default the defined folder and the script itself will be accessing only to the user/group that created them. This is causing issues on mutli-user systems where the script and the directory hierarchy may be created by one user and then used by another one.

# Additional Notes

Jira ticket: [PROF-9159]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-9159]: https://datadoghq.atlassian.net/browse/PROF-9159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ