### PR TITLE
Add bounds to all range related operations

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Location.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Location.java
@@ -39,16 +39,16 @@ public final class Location {
   }
 
   public static Location forSpanAndClassAndMethod(
-      final AgentSpan span, final String clazz, final String method) {
+      @Nullable final AgentSpan span, final String clazz, final String method) {
     return new Location(spanId(span), clazz, -1, method, serviceName(span));
   }
 
   public static Location forSpanAndFileAndLine(
-      final AgentSpan span, final String file, final int line) {
+      @Nullable final AgentSpan span, final String file, final int line) {
     return new Location(spanId(span), file, line, null, serviceName(span));
   }
 
-  public static Location forSpan(final AgentSpan span) {
+  public static Location forSpan(@Nullable final AgentSpan span) {
     return new Location(spanId(span), null, -1, null, serviceName(span));
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Vulnerability.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Vulnerability.java
@@ -14,6 +14,10 @@ public final class Vulnerability {
 
   private long hash;
 
+  public Vulnerability(@Nonnull final VulnerabilityType type, @Nonnull final Location location) {
+    this(type, location, null);
+  }
+
   public Vulnerability(
       @Nonnull final VulnerabilityType type,
       @Nonnull final Location location,

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -23,38 +23,40 @@ public interface VulnerabilityType {
   VulnerabilityType NO_SAMESITE_COOKIE =
       new CookieVulnerabilityType(VulnerabilityTypes.NO_SAMESITE_COOKIE);
 
-  InjectionType SQL_INJECTION =
-      new InjectionTypeImpl(
+  VulnerabilityType SQL_INJECTION =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.SQL_INJECTION, VulnerabilityMarks.SQL_INJECTION_MARK);
-  InjectionType COMMAND_INJECTION =
-      new InjectionTypeImpl(
+  VulnerabilityType COMMAND_INJECTION =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.COMMAND_INJECTION, VulnerabilityMarks.COMMAND_INJECTION_MARK);
-  InjectionType PATH_TRAVERSAL =
-      new InjectionTypeImpl(
-          File.separatorChar,
+  VulnerabilityType PATH_TRAVERSAL =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.PATH_TRAVERSAL,
+          File.separatorChar,
           VulnerabilityMarks.PATH_TRAVERSAL_MARK);
-  InjectionType LDAP_INJECTION =
-      new InjectionTypeImpl(
+  VulnerabilityType LDAP_INJECTION =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.LDAP_INJECTION, VulnerabilityMarks.LDAP_INJECTION_MARK);
-  InjectionType SSRF = new InjectionTypeImpl(VulnerabilityTypes.SSRF, VulnerabilityMarks.SSRF_MARK);
-  InjectionType UNVALIDATED_REDIRECT =
-      new InjectionTypeImpl(
+  VulnerabilityType SSRF =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.SSRF, VulnerabilityMarks.SSRF_MARK);
+  VulnerabilityType UNVALIDATED_REDIRECT =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.UNVALIDATED_REDIRECT, VulnerabilityMarks.UNVALIDATED_REDIRECT_MARK);
   VulnerabilityType WEAK_RANDOMNESS = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_RANDOMNESS);
 
-  InjectionType XPATH_INJECTION =
-      new InjectionTypeImpl(
+  VulnerabilityType XPATH_INJECTION =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.XPATH_INJECTION, VulnerabilityMarks.XPATH_INJECTION_MARK);
 
-  InjectionType TRUST_BOUNDARY_VIOLATION =
-      new InjectionTypeImpl(
+  VulnerabilityType TRUST_BOUNDARY_VIOLATION =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION, VulnerabilityMarks.TRUST_BOUNDARY_VIOLATION);
 
-  InjectionType XSS = new InjectionTypeImpl(VulnerabilityTypes.XSS, VulnerabilityMarks.XSS_MARK);
+  VulnerabilityType XSS =
+      new VulnerabilityTypeImpl(VulnerabilityTypes.XSS, VulnerabilityMarks.XSS_MARK);
 
-  InjectionType HEADER_INJECTION =
-      new InjectionTypeImpl(
+  VulnerabilityType HEADER_INJECTION =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.HEADER_INJECTION, VulnerabilityMarks.HEADER_INJECTION_MARK);
 
   VulnerabilityType STACKTRACE_LEAK = new VulnerabilityTypeImpl(VulnerabilityTypes.STACKTRACE_LEAK);
@@ -80,8 +82,8 @@ public interface VulnerabilityType {
   VulnerabilityType INSECURE_AUTH_PROTOCOL =
       new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_AUTH_PROTOCOL);
 
-  InjectionType REFLECTION_INJECTION =
-      new InjectionTypeImpl(
+  VulnerabilityType REFLECTION_INJECTION =
+      new VulnerabilityTypeImpl(
           VulnerabilityTypes.REFLECTION_INJECTION, VulnerabilityMarks.REFLECTION_INJECTION_MARK);
 
   String name();
@@ -89,20 +91,25 @@ public interface VulnerabilityType {
   /** A bit flag to ignore tainted ranges for this vulnerability. Set to 0 if none. */
   int mark();
 
-  long calculateHash(@Nonnull final Vulnerability vulnerability);
+  char separator();
 
-  interface InjectionType extends VulnerabilityType {
-    char evidenceSeparator();
-  }
+  long calculateHash(@Nonnull final Vulnerability vulnerability);
 
   class VulnerabilityTypeImpl implements VulnerabilityType {
 
     private final byte type;
 
+    private final char separator;
+
     private final int mark;
 
     public VulnerabilityTypeImpl(final byte type, final int... marks) {
+      this(type, ' ', marks);
+    }
+
+    public VulnerabilityTypeImpl(final byte type, final char separator, final int... marks) {
       this.type = type;
+      this.separator = separator;
       mark = computeMarks(marks);
     }
 
@@ -114,6 +121,11 @@ public interface VulnerabilityType {
     @Override
     public int mark() {
       return mark;
+    }
+
+    @Override
+    public char separator() {
+      return separator;
     }
 
     @Override
@@ -144,24 +156,6 @@ public interface VulnerabilityType {
         result |= mark;
       }
       return result;
-    }
-  }
-
-  class InjectionTypeImpl extends VulnerabilityTypeImpl implements InjectionType {
-    private final char evidenceSeparator;
-
-    public InjectionTypeImpl(final byte type, int... marks) {
-      this(' ', type, marks);
-    }
-
-    public InjectionTypeImpl(final char evidenceSeparator, final byte type, int... marks) {
-      super(type, marks);
-      this.evidenceSeparator = evidenceSeparator;
-    }
-
-    @Override
-    public char evidenceSeparator() {
-      return evidenceSeparator;
     }
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HstsMissingHeaderModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/HstsMissingHeaderModuleImpl.java
@@ -5,7 +5,6 @@ import com.datadog.iast.IastRequestContext;
 import com.datadog.iast.model.Location;
 import com.datadog.iast.model.Vulnerability;
 import com.datadog.iast.model.VulnerabilityType;
-import com.datadog.iast.overhead.Operations;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.sink.HstsMissingHeaderModule;
@@ -51,12 +50,8 @@ public class HstsMissingHeaderModuleImpl extends SinkModuleBase implements HstsM
           return;
         }
         final AgentSpan span = AgentTracer.activeSpan();
-        if (overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
-          reporter.report(
-              span,
-              new Vulnerability(
-                  VulnerabilityType.HSTS_HEADER_MISSING, Location.forSpan(span), null));
-        }
+        report(
+            span, new Vulnerability(VulnerabilityType.HSTS_HEADER_MISSING, Location.forSpan(span)));
       } catch (Throwable e) {
         LOGGER.debug("Exception while checking for missing HSTS headers vulnerability", e);
       }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureAuthProtocolModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/InsecureAuthProtocolModuleImpl.java
@@ -4,12 +4,9 @@ import com.datadog.iast.Dependencies;
 import com.datadog.iast.IastRequestContext;
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.VulnerabilityType;
-import com.datadog.iast.overhead.Operations;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.sink.InsecureAuthProtocolModule;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -42,12 +39,8 @@ public class InsecureAuthProtocolModuleImpl extends SinkModuleBase
     if (authScheme == null) {
       return;
     }
-    final AgentSpan span = AgentTracer.activeSpan();
-    if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
-      return;
-    }
     final Evidence result = new Evidence(String.format("Authorization : %s", authScheme));
-    report(span, VulnerabilityType.INSECURE_AUTH_PROTOCOL, result);
+    report(VulnerabilityType.INSECURE_AUTH_PROTOCOL, result);
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/PathTraversalModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/PathTraversalModuleImpl.java
@@ -1,19 +1,13 @@
 package com.datadog.iast.sink;
 
-import static com.datadog.iast.taint.Ranges.rangesProviderFor;
 import static com.datadog.iast.taint.Tainteds.canBeTainted;
-import static java.util.Arrays.asList;
 
 import com.datadog.iast.Dependencies;
 import com.datadog.iast.model.VulnerabilityType;
-import com.datadog.iast.taint.TaintedObjects;
-import datadog.trace.api.iast.IastContext;
+import com.datadog.iast.util.Iterators;
 import datadog.trace.api.iast.sink.PathTraversalModule;
 import java.io.File;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -28,11 +22,7 @@ public class PathTraversalModuleImpl extends SinkModuleBase implements PathTrave
     if (!canBeTainted(path)) {
       return;
     }
-    final IastContext ctx = IastContext.Provider.get();
-    if (ctx == null) {
-      return;
-    }
-    checkInjection(ctx, VulnerabilityType.PATH_TRAVERSAL, path);
+    checkInjection(VulnerabilityType.PATH_TRAVERSAL, path);
   }
 
   @Override
@@ -40,16 +30,10 @@ public class PathTraversalModuleImpl extends SinkModuleBase implements PathTrave
     if (!canBeTainted(parent) && !canBeTainted(child)) {
       return;
     }
-    final IastContext ctx = IastContext.Provider.get();
-    if (ctx == null) {
-      return;
-    }
     if (parent == null) {
-      checkInjection(ctx, VulnerabilityType.PATH_TRAVERSAL, child);
+      checkInjection(VulnerabilityType.PATH_TRAVERSAL, child);
     } else {
-      final TaintedObjects to = ctx.getTaintedObjects();
-      checkInjection(
-          VulnerabilityType.PATH_TRAVERSAL, rangesProviderFor(to, asList(parent, child)));
+      checkInjection(VulnerabilityType.PATH_TRAVERSAL, Iterators.of(parent, child));
     }
   }
 
@@ -58,28 +42,16 @@ public class PathTraversalModuleImpl extends SinkModuleBase implements PathTrave
     if (!canBeTainted(first) && !canBeTainted(more)) {
       return;
     }
-    final IastContext ctx = IastContext.Provider.get();
-    if (ctx == null) {
-      return;
-    }
-    final TaintedObjects to = ctx.getTaintedObjects();
     if (more.length == 0) {
-      checkInjection(ctx, VulnerabilityType.PATH_TRAVERSAL, first);
+      checkInjection(VulnerabilityType.PATH_TRAVERSAL, first);
     } else {
-      final List<String> items = new ArrayList<>(more.length + 1);
-      items.add(first);
-      Collections.addAll(items, more);
-      checkInjection(VulnerabilityType.PATH_TRAVERSAL, rangesProviderFor(to, items));
+      checkInjection(VulnerabilityType.PATH_TRAVERSAL, Iterators.of(first, more));
     }
   }
 
   @Override
   public void onPathTraversal(final @Nonnull URI uri) {
-    final IastContext ctx = IastContext.Provider.get();
-    if (ctx == null) {
-      return;
-    }
-    checkInjection(ctx, VulnerabilityType.PATH_TRAVERSAL, uri);
+    checkInjection(VulnerabilityType.PATH_TRAVERSAL, uri);
   }
 
   @Override
@@ -87,16 +59,10 @@ public class PathTraversalModuleImpl extends SinkModuleBase implements PathTrave
     if (!canBeTainted(child)) {
       return;
     }
-    final IastContext ctx = IastContext.Provider.get();
-    if (ctx == null) {
-      return;
-    }
     if (parent == null) {
-      checkInjection(ctx, VulnerabilityType.PATH_TRAVERSAL, child);
+      checkInjection(VulnerabilityType.PATH_TRAVERSAL, child);
     } else {
-      final TaintedObjects to = ctx.getTaintedObjects();
-      checkInjection(
-          VulnerabilityType.PATH_TRAVERSAL, rangesProviderFor(to, asList(parent, child)));
+      checkInjection(VulnerabilityType.PATH_TRAVERSAL, Iterators.of(parent, child));
     }
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/SqlInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/SqlInjectionModuleImpl.java
@@ -1,9 +1,10 @@
 package com.datadog.iast.sink;
 
+import static com.datadog.iast.taint.Tainteds.canBeTainted;
+
 import com.datadog.iast.Dependencies;
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.VulnerabilityType;
-import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.sink.SqlInjectionModule;
 import javax.annotation.Nullable;
 
@@ -20,14 +21,10 @@ public class SqlInjectionModuleImpl extends SinkModuleBase implements SqlInjecti
 
   @Override
   public void onJdbcQuery(@Nullable final String queryString, @Nullable final String database) {
-    if (queryString == null) {
+    if (!canBeTainted(queryString)) {
       return;
     }
-    final IastContext ctx = IastContext.Provider.get();
-    if (ctx == null) {
-      return;
-    }
-    final Evidence evidence = checkInjection(ctx, VulnerabilityType.SQL_INJECTION, queryString);
+    final Evidence evidence = checkInjection(VulnerabilityType.SQL_INJECTION, queryString);
     if (evidence != null && database != null) {
       evidence.getContext().put(DATABASE_PARAMETER, database);
     }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/SsrfModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/SsrfModuleImpl.java
@@ -1,20 +1,13 @@
 package com.datadog.iast.sink;
 
-import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED;
-
 import com.datadog.iast.Dependencies;
-import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.Source;
 import com.datadog.iast.model.VulnerabilityType;
-import com.datadog.iast.overhead.Operations;
 import com.datadog.iast.taint.Ranges;
-import com.datadog.iast.taint.TaintedObject;
-import com.datadog.iast.taint.TaintedObjects;
-import datadog.trace.api.iast.IastContext;
+import com.datadog.iast.util.Iterators;
+import com.datadog.iast.util.RangeBuilder;
 import datadog.trace.api.iast.sink.SsrfModule;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import javax.annotation.Nullable;
 
 public class SsrfModuleImpl extends SinkModuleBase implements SsrfModule {
@@ -28,60 +21,41 @@ public class SsrfModuleImpl extends SinkModuleBase implements SsrfModule {
     if (url == null) {
       return;
     }
-    final IastContext ctx = IastContext.Provider.get();
-    if (ctx == null) {
-      return;
-    }
-    checkInjection(ctx, VulnerabilityType.SSRF, url);
+    checkInjection(VulnerabilityType.SSRF, url);
   }
 
   /**
    * if the host or the uri are tainted, we report the url as tainted as well a new range is created
    * covering all the value string in order to simplify the algorithm
-   *
-   * @param value
-   * @param host
-   * @param uri
    */
   @Override
   public void onURLConnection(@Nullable String value, @Nullable Object host, @Nullable Object uri) {
     if (value == null) {
       return;
     }
-    final IastContext ctx = IastContext.Provider.get();
-    if (ctx == null) {
-      return;
-    }
-    final TaintedObjects to = ctx.getTaintedObjects();
-    TaintedObject taintedObject = getTaintedObject(to, host, uri);
-    if (taintedObject == null) {
-      return;
-    }
-    Range[] ranges =
-        Ranges.getNotMarkedRanges(taintedObject.getRanges(), VulnerabilityType.SSRF.mark());
-    if (ranges == null || ranges.length == 0) {
-      return;
-    }
-    final AgentSpan span = AgentTracer.activeSpan();
-    if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
-      return;
-    }
-    Source source = Ranges.highestPriorityRange(ranges).getSource();
-    final Evidence result =
-        new Evidence(value, new Range[] {new Range(0, value.length(), source, NOT_MARKED)});
-    report(span, VulnerabilityType.SSRF, result);
+    checkInjection(VulnerabilityType.SSRF, Iterators.of(host, uri), new SsrfEvidenceBuilder(value));
   }
 
-  @Nullable
-  private TaintedObject getTaintedObject(
-      final TaintedObjects to, @Nullable final Object host, @Nullable final Object uri) {
-    TaintedObject taintedObject = null;
-    if (uri != null) {
-      taintedObject = to.get(uri);
+  private static class SsrfEvidenceBuilder implements EvidenceBuilder {
+
+    private final String url;
+
+    private SsrfEvidenceBuilder(final String url) {
+      this.url = url;
     }
-    if (taintedObject == null && host != null) {
-      taintedObject = to.get(host);
+
+    @Override
+    public void tainted(
+        final StringBuilder evidence,
+        final RangeBuilder ranges,
+        final Object value,
+        final Range[] valueRanges) {
+      if (!ranges.isEmpty()) {
+        return; // skip if already tainted
+      }
+      evidence.append(url);
+      final Source source = Ranges.highestPriorityRange(valueRanges).getSource();
+      ranges.add(Ranges.forCharSequence(url, source));
     }
-    return taintedObject;
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/StacktraceLeakModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/StacktraceLeakModuleImpl.java
@@ -21,7 +21,6 @@ public class StacktraceLeakModuleImpl extends SinkModuleBase implements Stacktra
       Throwable throwable, String moduleName, String className, String methodName) {
     if (throwable != null) {
       final AgentSpan span = AgentTracer.activeSpan();
-
       Evidence evidence =
           new Evidence(
               "ExceptionHandler in "
@@ -29,9 +28,7 @@ public class StacktraceLeakModuleImpl extends SinkModuleBase implements Stacktra
                   + " \r\nthrown "
                   + throwable.getClass().getName());
       Location location = Location.forSpanAndClassAndMethod(span, className, methodName);
-
-      reporter.report(
-          span, new Vulnerability(VulnerabilityType.STACKTRACE_LEAK, location, evidence));
+      report(span, new Vulnerability(VulnerabilityType.STACKTRACE_LEAK, location, evidence));
     }
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/TrustBoundaryViolationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/TrustBoundaryViolationModuleImpl.java
@@ -19,9 +19,9 @@ public class TrustBoundaryViolationModuleImpl extends SinkModuleBase
     if (ctx == null) {
       return;
     }
-    checkInjection(ctx, VulnerabilityType.TRUST_BOUNDARY_VIOLATION, name);
+    checkInjection(VulnerabilityType.TRUST_BOUNDARY_VIOLATION, name);
     if (value != null) {
-      checkInjectionDeeply(ctx, VulnerabilityType.TRUST_BOUNDARY_VIOLATION, value);
+      checkInjectionDeeply(VulnerabilityType.TRUST_BOUNDARY_VIOLATION, value);
     }
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/WeakCipherModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/WeakCipherModuleImpl.java
@@ -3,11 +3,8 @@ package com.datadog.iast.sink;
 import com.datadog.iast.Dependencies;
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.VulnerabilityType;
-import com.datadog.iast.overhead.Operations;
 import datadog.trace.api.Config;
 import datadog.trace.api.iast.sink.WeakCipherModule;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Locale;
 import javax.annotation.Nonnull;
 
@@ -26,10 +23,6 @@ public class WeakCipherModuleImpl extends SinkModuleBase implements WeakCipherMo
     if (!config.getIastWeakCipherAlgorithms().matcher(algorithmId).matches()) {
       return;
     }
-    final AgentSpan span = AgentTracer.activeSpan();
-    if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
-      return;
-    }
-    report(span, VulnerabilityType.WEAK_CIPHER, new Evidence(algorithm));
+    report(VulnerabilityType.WEAK_CIPHER, new Evidence(algorithm));
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/WeakHashModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/WeakHashModuleImpl.java
@@ -3,11 +3,8 @@ package com.datadog.iast.sink;
 import com.datadog.iast.Dependencies;
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.VulnerabilityType;
-import com.datadog.iast.overhead.Operations;
 import datadog.trace.api.Config;
 import datadog.trace.api.iast.sink.WeakHashModule;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Locale;
 import javax.annotation.Nonnull;
 
@@ -26,10 +23,6 @@ public class WeakHashModuleImpl extends SinkModuleBase implements WeakHashModule
     if (!config.getIastWeakHashAlgorithms().contains(algorithmId)) {
       return;
     }
-    final AgentSpan span = AgentTracer.activeSpan();
-    if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
-      return;
-    }
-    report(span, VulnerabilityType.WEAK_HASH, new Evidence(algorithm));
+    report(VulnerabilityType.WEAK_HASH, new Evidence(algorithm));
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/WeakRandomnessModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/WeakRandomnessModuleImpl.java
@@ -3,10 +3,7 @@ package com.datadog.iast.sink;
 import com.datadog.iast.Dependencies;
 import com.datadog.iast.model.Evidence;
 import com.datadog.iast.model.VulnerabilityType;
-import com.datadog.iast.overhead.Operations;
 import datadog.trace.api.iast.sink.WeakRandomnessModule;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Locale;
 import javax.annotation.Nonnull;
 
@@ -21,11 +18,7 @@ public class WeakRandomnessModuleImpl extends SinkModuleBase implements WeakRand
     if (isSecuredInstance(instance)) {
       return;
     }
-    final AgentSpan span = AgentTracer.activeSpan();
-    if (!overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
-      return;
-    }
-    report(span, VulnerabilityType.WEAK_RANDOMNESS, new Evidence(instance.getName()));
+    report(VulnerabilityType.WEAK_RANDOMNESS, new Evidence(instance.getName()));
   }
 
   /**

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/XContentTypeModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/XContentTypeModuleImpl.java
@@ -5,7 +5,6 @@ import com.datadog.iast.IastRequestContext;
 import com.datadog.iast.model.Location;
 import com.datadog.iast.model.Vulnerability;
 import com.datadog.iast.model.VulnerabilityType;
-import com.datadog.iast.overhead.Operations;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.sink.XContentTypeModule;
@@ -40,15 +39,13 @@ public class XContentTypeModuleImpl extends SinkModuleBase implements XContentTy
           return;
         }
         final AgentSpan span = AgentTracer.activeSpan();
-        if (overheadController.consumeQuota(Operations.REPORT_VULNERABILITY, span)) {
-          reporter.report(
-              span,
-              new Vulnerability(
-                  VulnerabilityType.XCONTENTTYPE_HEADER_MISSING, Location.forSpan(span), null));
-        }
+        report(
+            span,
+            new Vulnerability(
+                VulnerabilityType.XCONTENTTYPE_HEADER_MISSING, Location.forSpan(span)));
       }
     } catch (Throwable e) {
-      LOGGER.debug("Exception while checking for missing X Content type optios header", e);
+      LOGGER.debug("Exception while checking for missing X Content type options header", e);
     }
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/XPathInjectionModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/XPathInjectionModuleImpl.java
@@ -23,6 +23,6 @@ public class XPathInjectionModuleImpl extends SinkModuleBase implements XPathInj
     if (ctx == null) {
       return;
     }
-    checkInjection(ctx, VulnerabilityType.InjectionType.XPATH_INJECTION, expression);
+    checkInjection(VulnerabilityType.XPATH_INJECTION, expression);
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/Iterators.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/Iterators.java
@@ -1,0 +1,127 @@
+package com.datadog.iast.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public abstract class Iterators {
+
+  private static final Iterator<?> EMPTY =
+      new Iterator<Object>() {
+        @Override
+        public boolean hasNext() {
+          return false;
+        }
+
+        @Override
+        public Object next() {
+          throw new NoSuchElementException();
+        }
+      };
+
+  private Iterators() {}
+
+  @SuppressWarnings("unchecked")
+  public static <E> Iterator<E> empty() {
+    return (Iterator<E>) EMPTY;
+  }
+
+  @Nonnull
+  public static <E> Iterator<E> of(@Nonnull final E head, @Nullable final E[] tail) {
+    return new HeadedArrayIterator<>(head, tail);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Nonnull
+  public static <E> Iterator<E> of(@Nullable final E... items) {
+    return items == null || items.length == 0 ? empty() : new ArrayIterator<>(items);
+  }
+
+  @Nonnull
+  public static Iterator<?> join(@Nullable final Iterator<?>... iterators) {
+    return iterators == null || iterators.length == 0 ? empty() : new JoinIterator(iterators);
+  }
+
+  private static class HeadedArrayIterator<E> extends ArrayIterator<E> {
+
+    private static final Object[] EMPTY_TAIL = new Object[0];
+
+    private boolean first;
+
+    private final E head;
+
+    @SuppressWarnings("unchecked")
+    private HeadedArrayIterator(final E head, @Nullable final E[] tail) {
+      super(tail == null ? (E[]) EMPTY_TAIL : tail);
+      this.head = head;
+      this.first = true;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return first || super.hasNext();
+    }
+
+    @Override
+    public E next() {
+      if (first) {
+        first = false;
+        return head;
+      }
+      return super.next();
+    }
+  }
+
+  private static class ArrayIterator<E> implements Iterator<E> {
+    private final E[] items;
+    private int index = 0;
+
+    private ArrayIterator(@Nonnull final E[] items) {
+      this.items = items;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return index < items.length;
+    }
+
+    @Override
+    public E next() {
+      if (index >= items.length) {
+        throw new NoSuchElementException();
+      }
+      return items[index++];
+    }
+  }
+
+  private static class JoinIterator implements Iterator<Object> {
+    private final Iterator<?>[] iterators;
+    private int index;
+    @Nullable private Iterator<?> current;
+
+    private JoinIterator(@Nonnull final Iterator<?>[] iterators) {
+      this.iterators = iterators;
+      current = iterators[0];
+      index = 0;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return current != null && current.hasNext();
+    }
+
+    @Override
+    public Object next() {
+      if (current == null || !current.hasNext()) {
+        throw new NoSuchElementException();
+      }
+      final Object result = current.next();
+      if (!current.hasNext()) {
+        index++;
+        current = index >= iterators.length ? null : iterators[index];
+      }
+      return result;
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/RangeBuilder.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/RangeBuilder.java
@@ -1,0 +1,249 @@
+package com.datadog.iast.util;
+
+import com.datadog.iast.model.Range;
+import com.datadog.iast.taint.Ranges;
+import com.datadog.iast.taint.TaintedObject;
+import datadog.trace.api.Config;
+import datadog.trace.api.ConfigDefaults;
+import javax.annotation.Nullable;
+
+/**
+ * The range builder is an optimized data structure to deal with ranges in propagation and evidence
+ * construction operations. The implementation is a hybrid of an array based list (for operations
+ * dealing with ranges one by one) and a linked list (for operations dealing with arrays of ranges).
+ *
+ * <p>This implementation is subject to the following characteristics:
+ *
+ * <ol>
+ *   <li>The number of items in the final array MUST be limited by the threshold.
+ *   <li>Array allocations SHOULD be minimized (ideally only on final array creation).
+ *   <li>The internal state MAY go over threshold but the final array MUST NOT.
+ * </ol>
+ */
+public class RangeBuilder {
+
+  private final int maxSize;
+  private final int arrayChunkSize;
+  private int size;
+  @Nullable protected Entry head;
+  @Nullable protected Entry tail;
+
+  public RangeBuilder() {
+    this(TaintedObject.MAX_RANGE_COUNT);
+  }
+
+  public RangeBuilder(final int maxSize) {
+    this(
+        maxSize,
+        Math.min(ConfigDefaults.DEFAULT_IAST_MAX_RANGE_COUNT, Config.get().getIastMaxRangeCount()));
+  }
+
+  public RangeBuilder(final int maxSize, final int arrayChunkSize) {
+    this.maxSize = maxSize;
+    this.arrayChunkSize = arrayChunkSize;
+    this.head = null;
+    this.tail = null;
+    this.size = 0;
+  }
+
+  public boolean add(final Range range) {
+    if (size >= maxSize) {
+      return false;
+    }
+    if (head == null) {
+      addNewEntry(new SingleEntry(range));
+    } else {
+      final ArrayEntry entry;
+      if (tail instanceof ArrayEntry && tail.size() < arrayChunkSize) {
+        entry = (ArrayEntry) tail;
+      } else {
+        entry = new ArrayEntry(arrayChunkSize);
+        addNewEntry(entry);
+      }
+      entry.add(range);
+    }
+    size += 1;
+    return true;
+  }
+
+  public boolean add(final Range[] ranges) {
+    return add(ranges, 0);
+  }
+
+  public boolean add(final Range[] ranges, final int offset) {
+    if (size >= maxSize) {
+      return false;
+    }
+    if (ranges.length == 0) {
+      return true;
+    }
+
+    if (tail instanceof ArrayEntry && ranges.length <= (arrayChunkSize - tail.size())) {
+      // compact intermediate ranges
+      final ArrayEntry entry = (ArrayEntry) tail;
+      for (Range range : ranges) {
+        entry.add(range.shift(offset));
+      }
+      size += ranges.length;
+      return true;
+    }
+
+    // we might go over the max but, it's OK (better not to generate a new array)
+    final FixedArrayEntry entry = new FixedArrayEntry(ranges, offset);
+    addNewEntry(entry);
+    size += entry.size();
+    return true;
+  }
+
+  public Range[] toArray() {
+    if (head == null) {
+      return Ranges.EMPTY;
+    }
+    if (size == head.size()) {
+      return head.toArray();
+    }
+    final Range[] result = new Range[Math.min(maxSize, size)];
+    int offset = 0;
+    Entry entry = head;
+    while (entry != null && offset < result.length) {
+      offset += entry.arrayCopy(result, offset);
+      entry = entry.next;
+    }
+    return result;
+  }
+
+  public boolean isFull() {
+    return size >= maxSize;
+  }
+
+  public boolean isEmpty() {
+    return size == 0;
+  }
+
+  public int size() {
+    return size;
+  }
+
+  protected void addNewEntry(final Entry entry) {
+    if (head == null || tail == null) {
+      head = entry;
+    } else {
+      tail.next = entry;
+    }
+    tail = entry;
+  }
+
+  protected abstract static class Entry {
+    @Nullable protected Entry next;
+
+    protected abstract int size();
+
+    protected abstract Range[] toArray();
+
+    protected abstract int arrayCopy(Range[] result, int start);
+  }
+
+  /** Optimized case for single range scenarios */
+  protected static class SingleEntry extends Entry {
+    protected final Range range;
+
+    protected SingleEntry(Range range) {
+      this.range = range;
+    }
+
+    @Override
+    protected int size() {
+      return 1;
+    }
+
+    @Override
+    protected Range[] toArray() {
+      return new Range[] {range};
+    }
+
+    @Override
+    protected int arrayCopy(final Range[] result, final int start) {
+      if (start < 0 || start >= result.length) {
+        return 0;
+      }
+      result[start] = range;
+      return 1;
+    }
+  }
+
+  /** Array buffer of entries */
+  protected static class ArrayEntry extends Entry {
+    protected final Range[] ranges;
+    protected int size;
+
+    protected ArrayEntry(final int size) {
+      this.ranges = new Range[size];
+      this.size = 0;
+    }
+
+    protected void add(final Range range) {
+      ranges[size++] = range;
+    }
+
+    @Override
+    protected int size() {
+      return size;
+    }
+
+    @Override
+    protected Range[] toArray() {
+      if (size == ranges.length) {
+        return ranges;
+      }
+      final Range[] result = new Range[size];
+      arrayCopy(result, 0);
+      return result;
+    }
+
+    @Override
+    protected int arrayCopy(final Range[] result, final int start) {
+      final int length = Math.min(size, result.length - start);
+      if (start < 0 || length <= 0) {
+        return 0;
+      }
+      System.arraycopy(ranges, 0, result, start, length);
+      return length;
+    }
+  }
+
+  /** Fixed size array with an offset */
+  protected static class FixedArrayEntry extends Entry {
+    protected final Range[] ranges;
+    protected final int offset;
+
+    protected FixedArrayEntry(final Range[] ranges, final int offset) {
+      this.ranges = ranges;
+      this.offset = offset;
+    }
+
+    @Override
+    protected int size() {
+      return ranges.length;
+    }
+
+    @Override
+    protected Range[] toArray() {
+      if (offset == 0) {
+        return ranges;
+      }
+      final Range[] result = new Range[ranges.length];
+      arrayCopy(result, 0);
+      return result;
+    }
+
+    @Override
+    protected int arrayCopy(final Range[] result, final int start) {
+      final int length = Math.min(result.length - start, ranges.length);
+      if (start < 0 || length <= 0) {
+        return 0;
+      }
+      Ranges.copyShift(ranges, result, start, offset, length);
+      return length;
+    }
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/AbstractSinkModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/AbstractSinkModuleTest.groovy
@@ -59,7 +59,7 @@ class AbstractSinkModuleTest extends IastModuleImplTestBase {
 
     when:
     propagation.taintIfTainted(toReport, input)
-    final evidence = sink.checkInjection(ctx, SSRF, toReport)
+    final evidence = sink.checkInjection(SSRF, toReport)
 
     then:
     evidence.ranges.length == 1

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ReflectionInjectionModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ReflectionInjectionModuleTest.groovy
@@ -64,14 +64,14 @@ class ReflectionInjectionModuleTest extends IastModuleImplTestBase {
     }
 
     where:
-    value             | parameterTypes  | mark                                   | expected
-    null              | null            | NOT_MARKED                             | null
-    '/contains'       | String          | NOT_MARKED                             | null
-    '/==>contains<==' | String          | NOT_MARKED                             | 'java.lang.String#/==>contains<==(java.lang.String)'
-    '/==>contains<==' | String          | VulnerabilityMarks.REFLECTION_INJECTION_MARK | null
-    '/==>contains<==' | String          | VulnerabilityMarks.SQL_INJECTION_MARK  | 'java.lang.String#/==>contains<==(java.lang.String)'
-    '/==>isEmpty<=='  | null            | NOT_MARKED                             | 'java.lang.String#/==>isEmpty<==()'
-    '/==>fake<=='     | [String, null, String] as Class[]  | NOT_MARKED          | 'java.lang.String#/==>fake<==(java.lang.String, UNKNOWN, java.lang.String)'
+    value             | parameterTypes                    | mark                                         | expected
+    null              | null                              | NOT_MARKED                                   | null
+    '/contains'       | CharSequence                      | NOT_MARKED                                   | null
+    '/==>contains<==' | CharSequence                      | NOT_MARKED                                   | 'java.lang.String#/==>contains<==(java.lang.CharSequence)'
+    '/==>contains<==' | CharSequence                      | VulnerabilityMarks.REFLECTION_INJECTION_MARK | null
+    '/==>contains<==' | CharSequence                      | VulnerabilityMarks.SQL_INJECTION_MARK        | 'java.lang.String#/==>contains<==(java.lang.CharSequence)'
+    '/==>isEmpty<=='  | null                              | NOT_MARKED                                   | 'java.lang.String#/==>isEmpty<==()'
+    '/==>fake<=='     | [String, null, String] as Class[] | NOT_MARKED                                   | 'java.lang.String#/==>fake<==(java.lang.String, UNKNOWN, java.lang.String)'
   }
 
   void 'iast module detects reflection injection onFieldName'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/IteratorsTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/IteratorsTest.groovy
@@ -1,0 +1,91 @@
+package com.datadog.iast.util
+
+import spock.lang.Specification
+
+class IteratorsTest extends Specification {
+
+  void 'headed array iterator'() {
+    when:
+    final iterator = Iterators.of(head, tail as String[])
+
+    then:
+    (0..<expected.size()).each {
+      assert iterator.hasNext()
+      final next = iterator.next()
+      final expectedNext = expected.remove(0)
+      assert next == expectedNext
+    }
+
+    when:
+    iterator.next()
+
+    then:
+    thrown(NoSuchElementException)
+
+    where:
+    head    | tail           | expected
+    'hello' | null           | ['hello']
+    'hello' | []             | ['hello']
+    'hello' | ['World!']     | ['hello', 'World!']
+    'hello' | ['World', '!'] | ['hello', 'World', '!']
+  }
+
+  void 'array iterator'() {
+    when:
+    final iterator = Iterators.of(array as String[])
+
+    then:
+    if (!expected.empty) {
+      (0..<expected.size()).each {
+        assert iterator.hasNext()
+        final next = iterator.next()
+        final expectedNext = expected.remove(0)
+        assert next == expectedNext
+      }
+    } else {
+      !iterator.hasNext()
+    }
+
+    when:
+    iterator.next()
+
+    then:
+    thrown(NoSuchElementException)
+
+    where:
+    array                   | expected
+    null                    | []
+    []                      | []
+    ['hello']               | ['hello']
+    ['hello', 'World', '!'] | ['hello', 'World', '!']
+  }
+
+  void 'joined iterator'() {
+    when:
+    final iterator = Iterators.join(iterators as Iterator<?>[])
+
+    then:
+    if (!expected.empty) {
+      (0..<expected.size()).each {
+        assert iterator.hasNext()
+        final next = iterator.next()
+        final expectedNext = expected.remove(0)
+        assert next == expectedNext
+      }
+    } else {
+      !iterator.hasNext()
+    }
+
+    when:
+    iterator.next()
+
+    then:
+    thrown(NoSuchElementException)
+
+    where:
+    iterators                                                | expected
+    [['1', '2', '3'].iterator()]                             | ['1', '2', '3']
+    [['1', '2', '3'].iterator(), [].iterator()]              | ['1', '2', '3']
+    [['1', '2', '3'].iterator(), ['4', '5', '6'].iterator()] | ['1', '2', '3', '4', '5', '6']
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/RangeBuilderTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/RangeBuilderTest.groovy
@@ -1,0 +1,380 @@
+package com.datadog.iast.util
+
+import com.datadog.iast.model.Range
+import com.datadog.iast.model.Source
+import com.datadog.iast.taint.Ranges
+import spock.lang.Specification
+
+class RangeBuilderTest extends Specification {
+
+  void 'test empty builder'() {
+    given:
+    final builder = new RangeBuilder()
+
+    when:
+    final size = builder.size()
+
+    then:
+    size == 0
+    builder.empty
+    builder.toArray() === Ranges.EMPTY
+  }
+
+  void 'test over capacity'() {
+    given:
+    final builder = new RangeBuilder(1)
+    builder.add(range(0))
+
+    when:
+    final addOne = builder.add(range(1))
+
+    then:
+    !addOne
+
+    when:
+    final addRange = builder.add([range(1)] as Range[])
+
+    then:
+    !addRange
+  }
+
+  void 'test single element builder'() {
+    given:
+    final maxSize = 8
+    final arrayChunkSize = 5
+    final builder = new RangeBuilder(maxSize, arrayChunkSize)
+
+    when: 'add single element to the head'
+    builder.add(range(0)) // 0
+
+    then: 'single optimized entry is created'
+    builder.size() == 1
+
+    builder.head instanceof RangeBuilder.SingleEntry
+    builder.head.size() == 1
+
+    builder.tail == builder.head
+
+    with(builder.toArray()) {
+      assert it.length == 1
+      it[0].start == 0
+    }
+
+    when: 'add elements up to the max chunk'
+    (1..arrayChunkSize).each { builder.add(range(it)) } // 1, 2, 3, 4, 5
+
+    then: 'elements are appended to the builder'
+    builder.size() == arrayChunkSize + 1
+
+    builder.head instanceof RangeBuilder.SingleEntry
+    builder.head.size() == 1
+
+    builder.tail instanceof RangeBuilder.ArrayEntry
+    builder.tail.size() == arrayChunkSize
+    builder.tail !== builder.head
+
+    with(builder.toArray()) {
+      assert it.length == arrayChunkSize + 1
+      it.eachWithIndex { range, index -> assert range.start == index } // 0, 1, 2, 3, 4, 5
+    }
+
+    when: 'add elements again up to the chunk size'
+    (0..<arrayChunkSize).each { builder.add(range(it + arrayChunkSize + 1)) } // 6, 7, 8, 9, 10
+
+    then: 'some elements must be discarded'
+    assert builder.size() == maxSize: 'adding one by one we should not go over threshold'
+
+    builder.head instanceof RangeBuilder.SingleEntry
+
+    builder.head.next instanceof RangeBuilder.ArrayEntry
+
+    builder.tail instanceof RangeBuilder.ArrayEntry
+    builder.tail.size() == (maxSize - arrayChunkSize - 1)
+    builder.tail !== builder.head
+    builder.tail !== builder.head.next
+    builder.tail === builder.head.next.next
+
+    with(builder.toArray()) {
+      assert it.length == maxSize: 'the builder should honor the max size'
+      it.eachWithIndex { range, index -> assert range.start == index } // 0, 1, 2, 3, 4, 5, 6, 7
+    }
+  }
+
+  void 'test array builder'() {
+    given:
+    final maxSize = 8
+    final arrayChunkSize = 5
+    final builder = new RangeBuilder(maxSize, arrayChunkSize)
+
+    when: 'add initial array of chunk size'
+    builder.add(asArray((0..<arrayChunkSize).collect { range(it) })) // 0, 1, 2, 3, 4
+
+    then: 'initial array is created'
+    !builder.empty
+
+    builder.head instanceof RangeBuilder.FixedArrayEntry
+    builder.head.size() == arrayChunkSize
+
+    builder.tail == builder.head
+
+    with(builder.toArray()) {
+      assert it.length == arrayChunkSize
+      it.eachWithIndex { range, index -> assert range.start == index } // 0, 1, 2, 3, 4
+    }
+
+    when: 'add array again up to the chunk size'
+    builder.add(asArray((0..<arrayChunkSize).collect { range(it + arrayChunkSize) })) // 5, 6, 7, 8, 9
+
+    then: 'second array is created reusing the arrays'
+    assert builder.size() > maxSize: 'adding arrays we can go over threshold'
+    !builder.empty
+
+    builder.head instanceof RangeBuilder.FixedArrayEntry
+    builder.head.size() == arrayChunkSize
+
+    builder.tail instanceof RangeBuilder.FixedArrayEntry
+    assert builder.tail.size() == arrayChunkSize: 'arrays should not be chunked when inserted'
+
+    with(builder.toArray()) {
+      assert it.length == maxSize: 'the builder should honor the max size'
+      it.eachWithIndex { range, index -> assert range.start == index }  // 0, 1, 2, 3, 4, 5, 6, 7
+    }
+  }
+
+  void 'test array builder with offset'() {
+    given:
+    final maxSize = 8
+    final arrayChunkSize = 5
+    final builder = new RangeBuilder(maxSize, arrayChunkSize)
+
+    when: 'add initial array of chunk size without offset'
+    builder.add(asArray((0..<arrayChunkSize).collect { range(it) })) // 0, 1, 2, 3, 4
+
+    then: 'initial array is created'
+    !builder.empty
+
+    builder.head instanceof RangeBuilder.FixedArrayEntry
+    builder.head.size() == arrayChunkSize
+
+    builder.tail === builder.head
+
+    with(builder.toArray()) {
+      assert it.length == arrayChunkSize
+      it.eachWithIndex { range, index -> assert range.start == index } // 0, 1, 2, 3, 4
+    }
+
+    when:  'add array again up to the chunk size with offset'
+    builder.add(asArray((0..<arrayChunkSize).collect { range(it) }), arrayChunkSize) // 5, 6, 7, 8, 9
+
+    then: 'second array is created reusing the arrays'
+    assert builder.size() > maxSize: 'adding arrays we can go over threshold'
+    !builder.empty
+
+    builder.head instanceof RangeBuilder.FixedArrayEntry
+    builder.head.size() == arrayChunkSize
+
+    builder.tail instanceof RangeBuilder.FixedArrayEntry
+    assert builder.tail.size() == arrayChunkSize: 'arrays should not be chunked when inserted'
+
+    with(builder.toArray()) {
+      assert it.length == maxSize: 'the builder should honor the max size'
+      it.eachWithIndex { range, index -> assert range.start == index } // 0, 1, 2, 3, 4, 5, 6, 7
+    }
+  }
+
+  void 'test mixed elements'() {
+    given:
+    final maxSize = 8
+    final arrayChunkSize = 5
+    final builder = new RangeBuilder(maxSize, arrayChunkSize)
+
+    when:
+    (0..<3).each { builder.add(range(it)) } // 0 (single), [1, 2] (array)
+    builder.add(asArray((3..<5).collect { range(it) })) // [3, 4] (compacted into previous array)
+    (5..<10).each { builder.add(range(it)) } // [5] (compacted into previous], [6, 7] (array), [8, 9] (skipped)
+
+    then:
+    final head = builder.head
+    head instanceof RangeBuilder.SingleEntry
+    head.size() == 1
+
+    final next = builder.head.next
+    next instanceof RangeBuilder.ArrayEntry
+    next.size() == 5
+
+    final tail = next.next
+    tail === builder.tail
+    tail instanceof RangeBuilder.ArrayEntry
+    tail.size() == 2
+
+    builder.toArray().length == maxSize
+    with(builder.toArray()) {
+      assert it.length == maxSize: 'the builder should honor the max size'
+      it.eachWithIndex { range, index -> assert range.start == index } // 0, 1, 2, 3, 4, 5, 6, 7
+    }
+  }
+
+  void 'test single entry'() {
+    when:
+    final entry = new RangeBuilder.SingleEntry(range(0))
+
+    then:
+    entry.size() == 1
+    with(entry.toArray()) {
+      assert it.size() == 1
+      assert it[0] === entry.range
+    }
+
+    when:
+    final target = [null, range(1)] as Range[]
+    entry.arrayCopy(target, 0)
+
+    then:
+    target[0] === entry.range
+
+    when: 'copy before zero'
+    final copied = entry.arrayCopy(target, -1)
+
+    then:
+    copied == 0
+
+    when: 'copy after length'
+    final copied2 = entry.arrayCopy(target, target.length)
+
+    then:
+    copied2 == 0
+  }
+
+  void 'test array entry'() {
+    when:
+    final entry = new RangeBuilder.ArrayEntry(4)
+    entry.add(range(0))
+
+    then:
+    entry.size() == 1
+    with(entry.toArray()) {
+      assert it.size() == 1
+      assert it[0] === entry.ranges[0]
+    }
+
+
+    when:
+    entry.add(range(1))
+
+    then:
+    entry.size() == 2
+    with(entry.toArray()) {
+      assert it.size() == 2
+      assert it[0] === entry.ranges[0]
+      assert it[1] === entry.ranges[1]
+    }
+
+    when:
+    final target = [null, null, range(1)] as Range[]
+    entry.arrayCopy(target, 0)
+
+    then:
+    target[0] === entry.ranges[0]
+    target[1] === entry.ranges[1]
+
+    when: 'fill the array'
+    entry.add(range(2))
+    entry.add(range(3))
+
+    then:
+    entry.toArray() === entry.ranges
+
+    when:
+    final target2 = [range(-1), null, null, null, null] as Range[]
+    entry.arrayCopy(target2, 1)
+
+    then:
+    target2[1] === entry.ranges[0]
+    target2[2] === entry.ranges[1]
+    target2[3] === entry.ranges[2]
+    target2[4] === entry.ranges[3]
+
+    when: 'copy before zero'
+    final copied = entry.arrayCopy(target, -1)
+
+    then:
+    copied == 0
+
+    when: 'copy after length'
+    final copied2 = entry.arrayCopy(target, target.length)
+
+    then:
+    copied2 == 0
+  }
+
+  void 'test fixed entry'() {
+    when:
+    final entry = new RangeBuilder.FixedArrayEntry([range(0), range(1)] as Range[], 0)
+
+    then:
+    entry.size() == 2
+    entry.toArray() === entry.ranges
+
+    when:
+    final target = [null, null, range(2)] as Range[]
+    entry.arrayCopy(target, 0)
+
+    then:
+    target[0] === entry.ranges[0]
+    target[1] === entry.ranges[1]
+
+    when: 'copy before zero'
+    final copied = entry.arrayCopy(target, -1)
+
+    then:
+    copied == 0
+
+    when: 'copy after length'
+    final copied2 = entry.arrayCopy(target, target.length)
+
+    then:
+    copied2 == 0
+  }
+
+  void 'test fixed entry with offset'() {
+    when:
+    final entry = new RangeBuilder.FixedArrayEntry([range(1), range(2)] as Range[], 10)
+
+    then:
+    entry.size() == 2
+    with(entry.toArray()) {
+      assert it.size() == 2
+      assert it[0].start == 11
+      assert it[1].start == 12
+    }
+
+    when:
+    final target = [range(10), null, null] as Range[]
+    entry.arrayCopy(target, 1)
+
+    then:
+    target[0].start === 10
+    target[1].start === 11
+    target[2].start === 12
+
+    when: 'copy before zero'
+    final copied = entry.arrayCopy(target, -1)
+
+    then:
+    copied == 0
+
+    when: 'copy after length'
+    final copied2 = entry.arrayCopy(target, target.length)
+
+    then:
+    copied2 == 0
+  }
+
+  static Range range(final int start) {
+    return new Range(start, 1, new Source((byte) 0, "name-${start}".toString(), "value-${start}".toString()), 0)
+  }
+
+  static Range[] asArray(final Collection<Range> ranges) {
+    return (Range[]) ranges.toArray(new Range[0])
+  }
+}


### PR DESCRIPTION
# What Does This Do
This PR ensure that range related operations (propagation of strings, evidence construction in sinks) take an upper bound regarding the number of elements they can iterate and the number of spans they can generate. 

# Motivation
When dealing with huge string manipulation operations (e.g. joining a high number of strings), IAST might become a bottleneck due to the need to analyze each string separately.
