### PR TITLE
use JFR timestamping for queue time thresholds

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/src/main/java/com/datadog/profiling/controller/jfr/SimpleJFRAccess.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/implementation/src/main/java/com/datadog/profiling/controller/jfr/SimpleJFRAccess.java
@@ -42,4 +42,14 @@ public class SimpleJFRAccess extends JFRAccess {
     }
     return true;
   }
+
+  @Override
+  public long timestamp() {
+    return JVM.counterTime();
+  }
+
+  @Override
+  public double toNanosConversionFactor() {
+    return JVM.getJVM().getTimeConversionFactor();
+  }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/JFRAccess.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-jfr/src/main/java/com/datadog/profiling/controller/jfr/JFRAccess.java
@@ -1,5 +1,6 @@
 package com.datadog.profiling.controller.jfr;
 
+import com.datadog.profiling.utils.Timestamper;
 import java.lang.instrument.Instrumentation;
 import java.util.ServiceLoader;
 import javax.annotation.Nullable;
@@ -11,7 +12,7 @@ import org.slf4j.LoggerFactory;
  * Provides access to the JFR internal API. For Java 9 and newer, the JFR access requires
  * instrumentation in order to patch the module access.
  */
-public abstract class JFRAccess {
+public abstract class JFRAccess implements Timestamper {
   private static final Logger log = LoggerFactory.getLogger(JFRAccess.class);
 
   /** No-op JFR access implementation. */

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/QueueTimeTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/QueueTimeTracker.java
@@ -1,25 +1,23 @@
 package com.datadog.profiling.ddprof;
 
-import com.datadoghq.profiler.JavaProfiler;
 import datadog.trace.api.profiling.QueueTiming;
-import datadog.trace.bootstrap.instrumentation.api.TaskWrapper;
 import java.lang.ref.WeakReference;
 
 public class QueueTimeTracker implements QueueTiming {
 
-  private final JavaProfiler profiler;
+  private final DatadogProfiler profiler;
   private final Thread origin;
-  private final long threshold;
   private final long startTicks;
   private WeakReference<Object> weakTask;
+  // FIXME this can be eliminated by altering the instrumentation
+  //  since it is known when the item is polled from the queue
   private Class<?> scheduler;
 
-  public QueueTimeTracker(JavaProfiler profiler, long threshold) {
+  public QueueTimeTracker(DatadogProfiler profiler, long startTicks) {
     this.profiler = profiler;
     this.origin = Thread.currentThread();
-    this.threshold = threshold;
     // TODO get this from JFR if available instead of making a JNI call
-    this.startTicks = profiler.getCurrentTicks();
+    this.startTicks = startTicks;
   }
 
   @Override
@@ -37,16 +35,8 @@ public class QueueTimeTracker implements QueueTiming {
     assert weakTask != null && scheduler != null;
     Object task = this.weakTask.get();
     if (task != null) {
-      // potentially avoidable JNI call
-      long endTicks = profiler.getCurrentTicks();
-      if (profiler.isThresholdExceeded(threshold, startTicks, endTicks)) {
-        // note: because this type traversal can update secondary_super_cache (see JDK-8180450)
-        // we avoid doing this unless we are absolutely certain we will record the event
-        Class<?> taskType = TaskWrapper.getUnwrappedType(task);
-        if (taskType != null) {
-          profiler.recordQueueTime(startTicks, endTicks, taskType, scheduler, origin);
-        }
-      }
+      // indirection reduces shallow size of the tracker instance
+      profiler.recordQueueTimeEvent(startTicks, task, scheduler, origin);
     }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-utils/src/main/java/com/datadog/profiling/utils/Timestamper.java
+++ b/dd-java-agent/agent-profiling/profiling-utils/src/main/java/com/datadog/profiling/utils/Timestamper.java
@@ -1,0 +1,48 @@
+package com.datadog.profiling.utils;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+public interface Timestamper {
+
+  Timestamper DEFAULT = new Timestamper() {};
+
+  default long timestamp() {
+    return System.nanoTime();
+  }
+
+  default double toNanosConversionFactor() {
+    return 1D;
+  }
+
+  final class Registration {
+    volatile Timestamper pending = Timestamper.DEFAULT;
+    private static final AtomicReferenceFieldUpdater<Registration, Timestamper> UPDATER =
+        AtomicReferenceFieldUpdater.newUpdater(Registration.class, Timestamper.class, "pending");
+
+    private static final Registration INSTANCE = new Registration();
+  }
+
+  /**
+   * One shot chance to override the timestamper, which allows delayed initialisation of the
+   * timestamp source.
+   *
+   * @return whether override was successful
+   */
+  static boolean override(Timestamper timestamper) {
+    return Registration.UPDATER.compareAndSet(
+        Registration.INSTANCE, Timestamper.DEFAULT, timestamper);
+  }
+
+  final class Singleton {
+    //
+    static final Timestamper TIMESTAMPER = Registration.INSTANCE.pending;
+  }
+
+  /**
+   * Gets the registered timestamper (e.g. using JFR) if one has been registered, otherwise uses the
+   * default timer.
+   */
+  static Timestamper timestamper() {
+    return Singleton.TIMESTAMPER;
+  }
+}

--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -11,6 +11,7 @@ import com.datadog.profiling.controller.ProfilingSystem;
 import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.controller.jfr.JFRAccess;
 import com.datadog.profiling.uploader.ProfileUploader;
+import com.datadog.profiling.utils.Timestamper;
 import datadog.trace.api.Config;
 import datadog.trace.api.Platform;
 import datadog.trace.api.config.ProfilingConfig;
@@ -117,6 +118,7 @@ public class ProfilingAgent {
 
       try {
         JFRAccess.setup(inst);
+        Timestamper.override(JFRAccess.instance());
         ControllerContext context = new ControllerContext();
         final Controller controller = CompositeController.build(configProvider, context);
 


### PR DESCRIPTION
# What Does This Do

Exposes and feeds TSC counter from JFR to be used in queue time tracking. WIP because this exercise exposed need for refactoring to make changes like this maintainable. Will rebase on top of the pending refactoring.

WIP - this change 

# Motivation

Do not incur JNI overhead when recording time in queue

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
