### PR TITLE
Revert "Fix dependency resolution to nested JARs (#6603)"

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/Dependency.java
@@ -128,11 +128,6 @@ public final class Dependency {
 
   public static synchronized Dependency guessFallbackNoPom(
       Manifest manifest, String source, InputStream is) throws IOException {
-    final int slashIndex = source.lastIndexOf('/');
-    if (slashIndex >= 0) {
-      source = source.substring(slashIndex + 1);
-    }
-
     String artifactId;
     String groupId = null;
     String version;
@@ -220,7 +215,7 @@ public final class Dependency {
     }
 
     if (md != null) {
-      // Compute hash for all dependencies that have no pom
+      // Compute hash for all dependencies that has no pom
       // No reliable version calculate hash and use any version
       md.reset();
       is = new DigestInputStream(is, md);

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
@@ -145,7 +145,7 @@ class DependencyResolverSpecification extends DepSpecification {
     File temp = File.createTempFile('temp', '.zip')
 
     expect:
-    DependencyResolver.resolve(temp.toURI()).isEmpty()
+    DependencyResolver.extractDependenciesFromJar(temp).isEmpty()
 
     cleanup:
     temp.delete()
@@ -157,7 +157,7 @@ class DependencyResolverSpecification extends DepSpecification {
     temp.delete()
 
     expect:
-    DependencyResolver.resolve(temp.toURI()).isEmpty()
+    DependencyResolver.extractDependenciesFromJar(temp).isEmpty()
   }
 
   void 'try to determine invalid jar lib'() throws IOException {
@@ -166,7 +166,16 @@ class DependencyResolverSpecification extends DepSpecification {
     temp.write("just a text file")
 
     expect:
-    DependencyResolver.resolve(temp.toURI()).isEmpty()
+    DependencyResolver.extractDependenciesFromJar(temp).isEmpty()
+  }
+
+  void 'try to determine invalid jar lib'() throws IOException {
+    setup:
+    File temp = File.createTempFile('temp', '.jar')
+    temp.write("just a text file")
+
+    expect:
+    DependencyResolver.getNestedDependency(temp.toURI()) == null
   }
 
   void 'spring boot dependency'() throws IOException {
@@ -181,9 +190,9 @@ class DependencyResolverSpecification extends DepSpecification {
 
     then:
     dep != null
-    dep.name == 'io.opentracing:opentracing-util'
+    dep.name == 'opentracing-util-0.33.0.jar'
     dep.version == '0.33.0'
-    dep.hash == null
+    dep.hash == '132630F17E198A1748F23CE33597EFDF4A807FB9'
     dep.source == 'opentracing-util-0.33.0.jar'
   }
 
@@ -243,7 +252,7 @@ class DependencyResolverSpecification extends DepSpecification {
 
   private static void knownJarCheck(Map opts) {
     File jarFile = getJar(opts['jarName'])
-    List<Dependency> deps = DependencyResolver.resolve(jarFile.toURI())
+    List<Dependency> deps = DependencyResolver.extractDependenciesFromJar(jarFile)
 
     assert deps.size() == 1
     Dependency dep = deps.get(0)


### PR DESCRIPTION
# What Does This Do
Revert https://github.com/DataDog/dd-trace-java/pull/6603

This reverts commit 00ed7e722ee9c8accb8946ef6e6ba882b5a50b13.

# Motivation

This seems to be the cause of prematurely closed streams during Spring Boot classloading (#6704). While #6711 might be a proper fix, we have not been able to reproduce the original issue yet, so I'm reverting the original PR until we can reproduce the issue and verify the fix.

# Additional Notes

Jira ticket: [APPSEC-51864](https://datadoghq.atlassian.net/browse/APPSEC-51864)

[APPSEC-51864]: https://datadoghq.atlassian.net/browse/APPSEC-51864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ