### PR TITLE
extract headers and baggage when propagation is disabled

### DIFF
--- a/dd-java-agent/instrumentation/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat-5.5/build.gradle
@@ -1,3 +1,7 @@
+ext {
+  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_11
+  latestDepForkedTestMinJavaVersionForTests = JavaVersion.VERSION_11
+}
 muzzle {
   // Catalina doesn't reliably depend on coyote, so we use a different dependency that does.
   pass {
@@ -34,6 +38,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuite('latestDepTest')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'latestDepTest')
 
 def tomcatVersion = '5.5.12' // earliest 5.5.x available in maven central (with all needed dependencies).
 
@@ -44,14 +49,11 @@ configurations.all {
   }
 }
 
-tasks.named("latestDepTest").configure {
-  javaLauncher = getJavaLauncherFor(11)
+[compileLatestDepTestGroovy, compileLatestDepForkedTestGroovy].each {
+  it.javaLauncher = getJavaLauncherFor(11)
 }
-tasks.named("compileLatestDepTestJava").configure {
+[compileLatestDepTestJava, compileLatestDepForkedTestJava].each {
   setJavaVersion(it, 11)
-}
-tasks.named("compileLatestDepTestGroovy").configure {
-  javaLauncher = getJavaLauncherFor(11)
 }
 
 

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatNoPropagationForkedTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatNoPropagationForkedTest.groovy
@@ -1,0 +1,94 @@
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.utils.OkHttpUtils
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.config.TracerConfig
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.instrumentation.servlet5.TestServlet5
+import okhttp3.Request
+import org.apache.catalina.Context
+import org.apache.catalina.Wrapper
+import spock.lang.Shared
+
+class TomcatNoPropagationForkedTest extends AgentTestRunner {
+  @Shared
+  TomcatServer server = new TomcatServer("/", false, { Context ctx ->
+    Wrapper wrapper = ctx.createWrapper()
+    wrapper.name = UUID.randomUUID()
+    wrapper.servletClass = TestServlet5.name
+    wrapper.asyncSupported = true
+    ctx.addChild(wrapper)
+    ctx.addServletMappingDecoded("/*", wrapper.name)
+  })
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig(TracerConfig.PROPAGATION_STYLE_EXTRACT, "none")
+  }
+
+  @Override
+  void setupSpec() {
+    server.start()
+  }
+
+  @Override
+  void cleanupSpec() {
+    server.stop()
+  }
+
+  def "should not extract propagated context but collect headers"() {
+    setup:
+    def client = OkHttpUtils.client()
+    def request = new Request.Builder()
+      .url(server.address().resolve(SUCCESS.relativePath()).toURL())
+      .get()
+      .header("X-Forwarded-For", "1.2.3.4")
+      .build()
+    def response = runUnderTrace("parent", {
+      client.newCall(request).execute()
+    })
+
+    expect:
+    response.code() == SUCCESS.status
+    response.body().string() == SUCCESS.body
+
+    and:
+    assertTraces(2) {
+      trace(1) {
+        span {
+          operationName "parent"
+        }
+      }
+      trace(2) {
+        span {
+          operationName "servlet.request"
+          spanType DDSpanTypes.HTTP_SERVER
+          errored false
+          parent()
+          tags {
+            "$Tags.COMPONENT" "tomcat-server"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.HTTP_CLIENT_IP" { it != null }
+            "$Tags.PEER_HOST_IPV4" { it != null }
+            "$Tags.PEER_PORT" { it != null }
+            "$Tags.HTTP_HOSTNAME" { it != null }
+            "$Tags.HTTP_URL" { it != null }
+            "servlet.context" "/"
+            "$Tags.HTTP_METHOD" { it != null }
+            "$Tags.HTTP_STATUS" 200
+            "$Tags.HTTP_USER_AGENT" { it != null }
+            "$Tags.HTTP_FORWARDED_IP" "1.2.3.4"
+            defaultTags(false)
+          }
+        }
+        span {
+          operationName "controller"
+          childOfPrevious()
+        }
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -151,7 +151,7 @@ public class HttpCodec {
           extractors.add(XRayHttpCodec.newExtractor(config, traceConfigSupplier));
           break;
         case NONE:
-          extractors.add(NoneCodec.EXTRACTOR);
+          extractors.add(NoneCodec.newExtractor(config, traceConfigSupplier));
           break;
         case TRACECONTEXT:
           extractors.add(W3CHttpCodec.newExtractor(config, traceConfigSupplier));

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/NoneCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/NoneCodec.java
@@ -1,10 +1,65 @@
 package datadog.trace.core.propagation;
 
+import datadog.trace.api.Config;
+import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
-import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.core.DDSpanContext;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NoneCodec {
+  private static final Logger log = LoggerFactory.getLogger(NoneCodec.class);
+
+  private static class NoneContextInterpreter extends ContextInterpreter {
+    private NoneContextInterpreter(Config config) {
+      super(config);
+    }
+
+    @Override
+    public TracePropagationStyle style() {
+      return TracePropagationStyle.NONE;
+    }
+
+    @Override
+    public boolean accept(String key, String value) {
+      if (null == key || key.isEmpty()) {
+        return true;
+      }
+      if (LOG_EXTRACT_HEADER_NAMES) {
+        log.debug("Header: {}", key);
+      }
+      char first = Character.toLowerCase(key.charAt(0));
+      switch (first) {
+        case 'x':
+          if (handledXForwarding(key, value)) {
+            return true;
+          }
+          break;
+        case 'f':
+          if (handledForwarding(key, value)) {
+            return true;
+          }
+          break;
+        case 'u':
+          if (handledUserAgent(key, value)) {
+            return true;
+          }
+          break;
+        default:
+      }
+
+      if (handledIpHeaders(key, value)) {
+        return true;
+      }
+      if (handleTags(key, value)) {
+        return true;
+      }
+      handleMappedBaggage(key, value);
+      return true;
+    }
+  }
 
   public static final HttpCodec.Injector INJECTOR =
       new HttpCodec.Injector() {
@@ -13,11 +68,8 @@ public class NoneCodec {
             DDSpanContext context, C carrier, AgentPropagation.Setter<C> setter) {}
       };
 
-  public static final HttpCodec.Extractor EXTRACTOR =
-      new HttpCodec.Extractor() {
-        @Override
-        public <C> TagContext extract(C carrier, AgentPropagation.ContextVisitor<C> getter) {
-          return null;
-        }
-      };
+  public static HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier) {
+    return new TagContextExtractor(traceConfigSupplier, () -> new NoneContextInterpreter(config));
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/HttpExtractorTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.core.propagation
 
+import static datadog.trace.api.TracePropagationStyle.NONE
+
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTraceId
@@ -63,7 +65,7 @@ class HttpExtractorTest extends DDSpecification {
     }
 
     if (expectDatadogFields) {
-      if (tagContext) {
+      if (tagContext && b3TraceId != null) {
         assert context.tags == ["b3.traceid": b3TraceId, "b3.spanid": b3SpanId, "some-tag": "my-interesting-info"]
       } else {
         assert context.tags == ["some-tag": "my-interesting-info"]
@@ -88,6 +90,7 @@ class HttpExtractorTest extends DDSpecification {
     [DATADOG]          | "1"               | outOfRangeTraceId | "a"               | "b"               | null            | null           | false            | false               | false
     [DATADOG, B3MULTI] | "1"               | "2"               | outOfRangeTraceId | "b"               | "1"             | "2"            | true             | false               | false
     [DATADOG, B3MULTI] | "1"               | "2"               | "a"               | outOfRangeTraceId | "1"             | "2"            | true             | false               | false
+    [NONE]             | "1"               | "2"               | null              | null              | null            | null           | true             | false               | true
     // spotless:on
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/NoneHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/NoneHttpExtractorTest.groovy
@@ -1,0 +1,327 @@
+package datadog.trace.core.propagation
+
+import static datadog.trace.api.config.TracerConfig.PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED
+import static datadog.trace.core.CoreTracer.TRACE_ID_MAX
+import static datadog.trace.core.propagation.DatadogHttpCodec.DATADOG_TAGS_KEY
+import static datadog.trace.core.propagation.DatadogHttpCodec.ORIGIN_KEY
+import static datadog.trace.core.propagation.DatadogHttpCodec.OT_BAGGAGE_PREFIX
+import static datadog.trace.core.propagation.DatadogHttpCodec.SAMPLING_PRIORITY_KEY
+import static datadog.trace.core.propagation.DatadogHttpCodec.SPAN_ID_KEY
+import static datadog.trace.core.propagation.DatadogHttpCodec.TRACE_ID_KEY
+
+import datadog.trace.api.Config
+import datadog.trace.api.DD128bTraceId
+import datadog.trace.api.DD64bTraceId
+import datadog.trace.api.DDSpanId
+import datadog.trace.api.DDTraceId
+import datadog.trace.api.DynamicConfig
+import datadog.trace.api.config.TracerConfig
+import datadog.trace.api.internal.util.LongStringUtils
+import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.bootstrap.ActiveSubsystems
+import datadog.trace.bootstrap.instrumentation.api.ContextVisitors
+import datadog.trace.bootstrap.instrumentation.api.TagContext
+import datadog.trace.test.util.DDSpecification
+
+class NoneHttpExtractorTest extends DDSpecification {
+
+  private DynamicConfig dynamicConfig
+  private HttpCodec.Extractor _extractor
+
+  private HttpCodec.Extractor getExtractor() {
+    _extractor ?: (_extractor = createExtractor(Config.get()))
+  }
+
+  private HttpCodec.Extractor createExtractor(Config config) {
+    NoneCodec.newExtractor(config, { dynamicConfig.captureTraceConfig() })
+  }
+
+  boolean origAppSecActive
+
+  void setup() {
+    dynamicConfig = DynamicConfig.create()
+      .setHeaderTags(["SOME_HEADER": "some-tag"])
+      .setBaggageMapping(["SOME_CUSTOM_BAGGAGE_HEADER": "some-baggage", "SOME_CUSTOM_BAGGAGE_HEADER_2": "some-CaseSensitive-baggage"])
+      .apply()
+    origAppSecActive = ActiveSubsystems.APPSEC_ACTIVE
+    ActiveSubsystems.APPSEC_ACTIVE = true
+
+    injectSysConfig(PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED, "true")
+  }
+
+  void cleanup() {
+    ActiveSubsystems.APPSEC_ACTIVE = origAppSecActive
+    extractor.cleanup()
+  }
+
+  def "extract http headers"() {
+    setup:
+    injectEnvConfig("DD_TRACE_REQUEST_HEADER_TAGS_COMMA_ALLOWED", "$allowComma")
+    def extractor = createExtractor(Config.get())
+    def headers = [
+      ""                                      : "empty key",
+      (TRACE_ID_KEY.toUpperCase())            : traceId,
+      (SPAN_ID_KEY.toUpperCase())             : spanId,
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k1"): "v1",
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "v2",
+      SOME_HEADER                             : "my-interesting-info,and-more",
+      SOME_CUSTOM_BAGGAGE_HEADER              : "my-interesting-baggage-info",
+      SOME_CUSTOM_BAGGAGE_HEADER_2            : "my-interesting-baggage-info-2",
+    ]
+    def expectedTagValue = allowComma ? "my-interesting-info,and-more" : "my-interesting-info"
+
+    if (samplingPriority != PrioritySampling.UNSET) {
+      headers.put(SAMPLING_PRIORITY_KEY, "$samplingPriority".toString())
+    }
+
+    if (origin) {
+      headers.put(ORIGIN_KEY, origin)
+    }
+
+    when:
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    context.traceId == DDTraceId.ZERO
+    context.spanId == DDSpanId.ZERO
+    context.baggage == [
+      "some-baggage"              : "my-interesting-baggage-info",
+      "some-CaseSensitive-baggage": "my-interesting-baggage-info-2"]
+    context.tags == ["some-tag": "$expectedTagValue"]
+    context.samplingPriority == samplingPriority
+    context.origin == origin
+
+    cleanup:
+    extractor.cleanup()
+
+    where:
+    traceId               | spanId                | samplingPriority              | origin   | allowComma
+    "1"                   | "2"                   | PrioritySampling.UNSET        | null     | true
+    "2"                   | "3"                   | PrioritySampling.UNSET        | null     | false
+    "$TRACE_ID_MAX"       | "${TRACE_ID_MAX - 1}" | PrioritySampling.UNSET        | null     | true
+    "${TRACE_ID_MAX - 1}" | "$TRACE_ID_MAX"       | PrioritySampling.UNSET        | null     | false
+  }
+
+  def "extract header tags with no propagation"() {
+    when:
+    TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    !(context instanceof ExtractedContext)
+    context.getTags() == ["some-tag": "my-interesting-info"]
+    assert ((TagContext) context).origin == null
+
+    where:
+    headers << [
+      [SOME_HEADER: "my-interesting-info"],
+      [(ORIGIN_KEY): "my-origin", SOME_HEADER: "my-interesting-info"],
+    ]
+  }
+
+  def "extract headers with forwarding"() {
+    when:
+    TagContext context = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context != null
+    !(context instanceof ExtractedContext)
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    when:
+    context = extractor.extract(fullCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    !(context instanceof ExtractedContext)
+    context.traceId == DDTraceId.ZERO
+    context.spanId == DDSpanId.ZERO
+    context.forwarded == "for=$forwardedIp:$forwardedPort"
+
+    where:
+    forwardedIp = "1.2.3.4"
+    forwardedPort = "1234"
+    tagOnlyCtx = [
+      "Forwarded" : "for=$forwardedIp:$forwardedPort"
+    ]
+    fullCtx = [
+      (TRACE_ID_KEY.toUpperCase()): 1,
+      (SPAN_ID_KEY.toUpperCase()) : 2,
+      "Forwarded" : "for=$forwardedIp:$forwardedPort"
+    ]
+  }
+
+  def "extract headers with x-forwarding"() {
+    setup:
+    String forwardedIp = '1.2.3.4'
+    String forwardedPort = '1234'
+    def tagOnlyCtx = [
+      "X-Forwarded-For" : forwardedIp,
+      "X-Forwarded-Port": forwardedPort
+    ]
+    def fullCtx = [
+      (TRACE_ID_KEY.toUpperCase()): 1,
+      (SPAN_ID_KEY.toUpperCase()) : 2,
+      "x-forwarded-for"           : forwardedIp,
+      "x-forwarded-port"          : forwardedPort
+    ]
+
+    when:
+    TagContext context = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    context != null
+    !(context instanceof ExtractedContext)
+    context.XForwardedFor == forwardedIp
+    context.XForwardedPort == forwardedPort
+
+    when:
+    context = extractor.extract(fullCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    !(context instanceof ExtractedContext)
+    context.traceId == DDTraceId.ZERO
+    context.spanId.toLong() == 0
+    context.XForwardedFor == forwardedIp
+    context.XForwardedPort == forwardedPort
+  }
+
+  def "extract empty headers returns null"() {
+    expect:
+    extractor.extract(["ignored-header": "ignored-value"], ContextVisitors.stringValuesMap()) == null
+  }
+
+  void 'extract headers with ip resolution disabled'() {
+    setup:
+    injectSysConfig(TracerConfig.TRACE_CLIENT_IP_RESOLVER_ENABLED, 'false')
+
+    def tagOnlyCtx = [
+      'X-Forwarded-For': '::1',
+      'User-agent': 'foo/bar',
+    ]
+
+    when:
+    TagContext ctx = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    ctx != null
+    ctx.XForwardedFor == null
+    ctx.userAgent == 'foo/bar'
+  }
+
+
+  void 'extract headers with ip resolution disabled — appsec disabled variant'() {
+    setup:
+    ActiveSubsystems.APPSEC_ACTIVE = false
+
+    def tagOnlyCtx = [
+      'X-Forwarded-For': '::1',
+      'User-agent': 'foo/bar',
+    ]
+
+    when:
+    TagContext ctx = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    ctx != null
+    ctx.XForwardedFor == null
+  }
+
+  void 'custom IP header collection does not disable standard ip header collection'() {
+    setup:
+    injectSysConfig(TracerConfig.TRACE_CLIENT_IP_HEADER, "my-header")
+
+    def tagOnlyCtx = [
+      'X-Forwarded-For': '::1',
+      'My-Header': '8.8.8.8',
+    ]
+
+    when:
+    def ctx = extractor.extract(tagOnlyCtx, ContextVisitors.stringValuesMap())
+
+    then:
+    ctx != null
+    ctx.XForwardedFor == '::1'
+    ctx.customIpHeader == '8.8.8.8'
+  }
+
+  def "extract http headers with 128-bit trace ID"() {
+    setup:
+    def headers = [
+      (TRACE_ID_KEY.toUpperCase())            : traceId.toString(),
+      (SPAN_ID_KEY.toUpperCase())             : "2",
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k1"): "v1",
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "v2",
+      SOME_HEADER                             : "my-interesting-info"
+    ] + additionalHeader
+
+    when:
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    context.traceId == DDTraceId.ZERO
+    context.spanId == DDSpanId.ZERO
+    context.baggage.isEmpty()
+    context.tags == ["some-tag": "my-interesting-info"]
+
+    where:
+    hexId << [
+      "1",
+      "123456789abcdef0",
+      "123456789abcdef0123456789abcdef0",
+      "64184f2400000000123456789abcdef0",
+      "f" * 32
+    ]
+    traceId = DD128bTraceId.fromHex(hexId)
+    is128bTrace = traceId.toHighOrderLong() != 0
+    expectedTraceId = is128bTrace ? traceId : DD64bTraceId.from(traceId.toLong())
+    additionalHeader = is128bTrace ? [(DATADOG_TAGS_KEY.toUpperCase()) : '_dd.p.tid=' + LongStringUtils.toHexStringPadded(traceId.toHighOrderLong(), 16)] : [:]
+  }
+
+  def "extract http headers with invalid non-numeric ID"() {
+    setup:
+    def headers = [
+      (TRACE_ID_KEY.toUpperCase())            : "traceId",
+      (SPAN_ID_KEY.toUpperCase())             : "spanId",
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k1"): "v1",
+      (OT_BAGGAGE_PREFIX.toUpperCase() + "k2"): "v2",
+      SOME_HEADER                             : "my-interesting-info",
+    ]
+
+    when:
+    TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    context instanceof TagContext
+    context.tags == ["some-tag": "my-interesting-info"]
+  }
+
+  def "extract common http headers"() {
+    setup:
+    def headers = [
+      (HttpCodec.USER_AGENT_KEY): 'some-user-agent',
+      (HttpCodec.X_CLUSTER_CLIENT_IP_KEY): '1.1.1.1',
+      (HttpCodec.X_REAL_IP_KEY): '2.2.2.2',
+      (HttpCodec.X_CLIENT_IP_KEY): '3.3.3.3',
+      (HttpCodec.TRUE_CLIENT_IP_KEY): '4.4.4.4',
+      (HttpCodec.FORWARDED_FOR_KEY): '5.5.5.5',
+      (HttpCodec.X_FORWARDED_KEY): '6.6.6.6',
+      (HttpCodec.FASTLY_CLIENT_IP_KEY): '7.7.7.7',
+      (HttpCodec.CF_CONNECTING_IP_KEY): '8.8.8.8',
+      (HttpCodec.CF_CONNECTING_IP_V6_KEY): '9.9.9.9',
+    ]
+
+    when:
+    final TagContext context = extractor.extract(headers, ContextVisitors.stringValuesMap())
+
+    then:
+    assert context.userAgent == 'some-user-agent'
+    assert context.XClusterClientIp == '1.1.1.1'
+    assert context.XRealIp == '2.2.2.2'
+    assert context.XClientIp == '3.3.3.3'
+    assert context.trueClientIp == '4.4.4.4'
+    assert context.forwardedFor == '5.5.5.5'
+    assert context.XForwarded == '6.6.6.6'
+    assert context.fastlyClientIp == '7.7.7.7'
+    assert context.cfConnectingIp == '8.8.8.8'
+    assert context.cfConnectingIpv6 == '9.9.9.9'
+  }
+}


### PR DESCRIPTION
# What Does This Do

When the propagation style is none, today we loose some tags on server spans like:
* client_ip
* x-forwarded-for
* user_agent

The problem is that the extraction of those tags is linked to the extraction of the whole context.

This PR aims to keep extracting a TagContext on propagation style none in order to surface those headers along with mapped headers and mapped baggage.

The tracing and pathway context are anyway not extracted that will make a new trace to be started on the receiver style as supposed to be with none propagation style

# Motivation

# Additional Notes

Jira ticket: [APMS-11334]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-11334]: https://datadoghq.atlassian.net/browse/APMS-11334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ