### PR TITLE
Make signal client timeout configurable

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityServices.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityServices.java
@@ -78,7 +78,7 @@ public class CiVisibilityServices {
 
     if (ProcessHierarchyUtils.isChild()) {
       InetSocketAddress signalServerAddress = ProcessHierarchyUtils.getSignalServerAddress();
-      this.signalClientFactory = new SignalClient.Factory(signalServerAddress);
+      this.signalClientFactory = new SignalClient.Factory(signalServerAddress, config);
 
       RepoIndexProvider indexFetcher = new RepoIndexFetcher(signalClientFactory);
       this.repoIndexProviderFactory = (repoRoot, scanRoot) -> indexFetcher;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalServerRunnable.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalServerRunnable.java
@@ -110,7 +110,8 @@ class SignalServerRunnable implements Runnable {
 
     Function<Signal, SignalResponse> handler = signalHandlers.get(signalType);
     if (handler == null) {
-      LOGGER.warn("No handler register for signal type {}, skipping signal {}", signalType, signal);
+      LOGGER.warn(
+          "No handler registered for signal type {}, skipping signal {}", signalType, signal);
       return serialize(new ErrorResponse("Deserializer not found for " + signalType));
     }
 
@@ -120,6 +121,11 @@ class SignalServerRunnable implements Runnable {
 
   private ByteBuffer[] serialize(SignalResponse response) {
     ByteBuffer payload = response.serialize();
+    LOGGER.debug(
+        "Serialized response of type {} and size {} bytes",
+        response.getType(),
+        payload.remaining());
+
     ByteBuffer header = ByteBuffer.allocate(Integer.BYTES + 1);
     header.putInt(payload.remaining() + 1);
     header.put(response.getType().getCode());

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/ipc/SignalServerTest.groovy
@@ -6,6 +6,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class SignalServerTest extends Specification {
 
+  def signalClientTimeoutMillis = 10_000
+
   def "test message send and receive"() {
     given:
     def signalProcessed = new AtomicBoolean(false)
@@ -24,7 +26,7 @@ class SignalServerTest extends Specification {
     server.start()
 
     def address = server.getAddress()
-    try (def client = new SignalClient(address)) {
+    try (def client = new SignalClient(address, signalClientTimeoutMillis)) {
       client.send(signal)
       // verify that the signal was processed by the server by the time send() method returns
       // (we want the send() method to be truly synchronous in that regard)
@@ -55,7 +57,7 @@ class SignalServerTest extends Specification {
     server.start()
 
     def address = server.getAddress()
-    try (def client = new SignalClient(address)) {
+    try (def client = new SignalClient(address, signalClientTimeoutMillis)) {
       client.send(signalA)
       client.send(signalB)
     }
@@ -86,11 +88,11 @@ class SignalServerTest extends Specification {
     server.start()
 
     def address = server.getAddress()
-    try (def client = new SignalClient(address)) {
+    try (def client = new SignalClient(address, signalClientTimeoutMillis)) {
       client.send(signalA)
     }
 
-    try (def client = new SignalClient(address)) {
+    try (def client = new SignalClient(address, signalClientTimeoutMillis)) {
       client.send(signalB)
     }
 
@@ -148,7 +150,7 @@ class SignalServerTest extends Specification {
 
     when:
     def address = server.getAddress()
-    try (def client = new SignalClient(address)) {
+    try (def client = new SignalClient(address, signalClientTimeoutMillis)) {
       client.send(signal)
     }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -38,6 +38,8 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_GIT_REMOTE_NAME = "civisibility.git.remote.name";
   public static final String CIVISIBILITY_SIGNAL_SERVER_HOST = "civisibility.signal.server.host";
   public static final String CIVISIBILITY_SIGNAL_SERVER_PORT = "civisibility.signal.server.port";
+  public static final String CIVISIBILITY_SIGNAL_CLIENT_TIMEOUT_MILLIS =
+      "civisibility.signal.client.timeout.millis";
   public static final String CIVISIBILITY_ITR_ENABLED = "civisibility.itr.enabled";
   public static final String CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED =
       "civisibility.ciprovider.integration.enabled";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -182,6 +182,7 @@ import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_MODULE_NA
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_REPO_INDEX_SHARING_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_RESOURCE_FOLDER_NAMES;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SESSION_ID;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SIGNAL_CLIENT_TIMEOUT_MILLIS;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_HOST;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_PORT;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_SOURCE_DATA_ENABLED;
@@ -759,6 +760,7 @@ public class Config {
   private final long ciVisibilityGitUploadTimeoutMillis;
   private final String ciVisibilitySignalServerHost;
   private final int ciVisibilitySignalServerPort;
+  private final int ciVisibilitySignalClientTimeoutMillis;
   private final boolean ciVisibilityItrEnabled;
   private final boolean ciVisibilityCiProviderIntegrationEnabled;
   private final boolean ciVisibilityRepoIndexSharingEnabled;
@@ -1734,6 +1736,8 @@ public class Config {
     ciVisibilitySignalServerPort =
         configProvider.getInteger(
             CIVISIBILITY_SIGNAL_SERVER_PORT, DEFAULT_CIVISIBILITY_SIGNAL_SERVER_PORT);
+    ciVisibilitySignalClientTimeoutMillis =
+        configProvider.getInteger(CIVISIBILITY_SIGNAL_CLIENT_TIMEOUT_MILLIS, 20_000);
     ciVisibilityItrEnabled = configProvider.getBoolean(CIVISIBILITY_ITR_ENABLED, true);
     ciVisibilityCiProviderIntegrationEnabled =
         configProvider.getBoolean(CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED, true);
@@ -2928,6 +2932,10 @@ public class Config {
 
   public int getCiVisibilitySignalServerPort() {
     return ciVisibilitySignalServerPort;
+  }
+
+  public int getCiVisibilitySignalClientTimeoutMillis() {
+    return ciVisibilitySignalClientTimeoutMillis;
   }
 
   public String getCiVisibilitySignalServerHost() {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1737,7 +1737,7 @@ public class Config {
         configProvider.getInteger(
             CIVISIBILITY_SIGNAL_SERVER_PORT, DEFAULT_CIVISIBILITY_SIGNAL_SERVER_PORT);
     ciVisibilitySignalClientTimeoutMillis =
-        configProvider.getInteger(CIVISIBILITY_SIGNAL_CLIENT_TIMEOUT_MILLIS, 20_000);
+        configProvider.getInteger(CIVISIBILITY_SIGNAL_CLIENT_TIMEOUT_MILLIS, 10_000);
     ciVisibilityItrEnabled = configProvider.getBoolean(CIVISIBILITY_ITR_ENABLED, true);
     ciVisibilityCiProviderIntegrationEnabled =
         configProvider.getBoolean(CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED, true);


### PR DESCRIPTION
# What Does This Do
Makes the timeout of CI Visibility signal client configurable.
Adds some debug logging to signal client and signal server.

# Motivation
There is a CI Visibility user who experiences intermittent signal client timeout.

Jira ticket: [CIVIS-9220]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9220]: https://datadoghq.atlassian.net/browse/CIVIS-9220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ