### PR TITLE
add failure to load dd profiler as periodic JFR event

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerSettings.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-ddprof/src/main/java/com/datadog/profiling/controller/ddprof/DatadogProfilerSettings.java
@@ -9,7 +9,7 @@ public class DatadogProfilerSettings extends ProfilerSettingsSupport {
   private final DatadogProfiler datadogProfiler;
 
   public DatadogProfilerSettings(DatadogProfiler datadogProfiler) {
-    super(ConfigProvider.getInstance());
+    super(ConfigProvider.getInstance(), null, false);
     this.datadogProfiler = datadogProfiler;
   }
 

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/JfrProfilerSettings.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/JfrProfilerSettings.java
@@ -14,20 +14,15 @@ final class JfrProfilerSettings extends ProfilerSettingsSupport {
   private static final String EXCEPTION_HISTO_SIZE_LIMIT_KEY = "Exception Histo Size Limit";
   private final String jfrImplementation;
 
-  private static final class SingletonHolder {
-    private static final JfrProfilerSettings INSTANCE = new JfrProfilerSettings();
-  }
-
-  public JfrProfilerSettings() {
-    super(ConfigProvider.getInstance());
+  public JfrProfilerSettings(
+      ConfigProvider configProvider,
+      String ddprofUnavailableReason,
+      boolean hasJfrStackDepthApplied) {
+    super(configProvider, ddprofUnavailableReason, hasJfrStackDepthApplied);
     this.jfrImplementation =
         Platform.isNativeImage()
             ? "native-image"
             : (Platform.isOracleJDK8() ? "oracle" : "openjdk");
-  }
-
-  public static JfrProfilerSettings instance() {
-    return SingletonHolder.INSTANCE;
   }
 
   public void publish() {
@@ -64,6 +59,9 @@ final class JfrProfilerSettings extends ProfilerSettingsSupport {
         new ProfilerSettingEvent(STACK_DEPTH_KEY, String.valueOf(stackDepth)).commit();
       }
       new ProfilerSettingEvent(SELINUX_STATUS_KEY, seLinuxStatus).commit();
+      if (ddprofUnavailableReason != null) {
+        new ProfilerSettingEvent(DDPROF_UNAVAILABLE_REASON_KEY, ddprofUnavailableReason).commit();
+      }
     }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -29,7 +29,6 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_ULTRA_MINIMAL;
 import com.datadog.profiling.controller.ConfigurationException;
 import com.datadog.profiling.controller.Controller;
 import com.datadog.profiling.controller.ControllerContext;
-import com.datadog.profiling.controller.UnsupportedEnvironmentException;
 import com.datadog.profiling.controller.jfr.JFRAccess;
 import com.datadog.profiling.controller.jfr.JfpUtils;
 import com.datadog.profiling.controller.openjdk.events.AvailableProcessorCoresEvent;
@@ -69,6 +68,7 @@ public final class OpenJdkController implements Controller {
 
   private final ConfigProvider configProvider;
   private final Map<String, String> recordingSettings;
+  private final boolean jfrStackDepthApplied;
 
   public static Controller instance(ConfigProvider configProvider)
       throws ConfigurationException, ClassNotFoundException {
@@ -85,11 +85,7 @@ public final class OpenJdkController implements Controller {
       throws ConfigurationException, ClassNotFoundException {
     // configure the JFR stackdepth before we try to load any JFR classes
     int requestedStackDepth = getConfiguredStackDepth(configProvider);
-    if (JFRAccess.instance().setStackDepth(requestedStackDepth)) {
-      // if we successfully set the stack depth, mark it as applied
-      // this will allow emitting the settings event with the current stack depth
-      JfrProfilerSettings.instance().markJfrStackDepthApplied();
-    }
+    this.jfrStackDepthApplied = JFRAccess.instance().setStackDepth(requestedStackDepth);
     boolean shouldCleanupJfrRepository =
         configProvider.getBoolean(
             PROFILING_DEBUG_CLEANUP_REPO, PROFILING_DEBUG_CLEANUP_REPO_DEFAULT);
@@ -266,10 +262,15 @@ public final class OpenJdkController implements Controller {
 
   @Override
   public OpenJdkOngoingRecording createRecording(
-      final String recordingName, ControllerContext.Snapshot context)
-      throws UnsupportedEnvironmentException {
+      final String recordingName, ControllerContext.Snapshot context) {
     return new OpenJdkOngoingRecording(
-        recordingName, recordingSettings, getMaxSize(), RECORDING_MAX_AGE, configProvider, context);
+        recordingName,
+        recordingSettings,
+        getMaxSize(),
+        RECORDING_MAX_AGE,
+        configProvider,
+        context,
+        jfrStackDepthApplied);
   }
 
   private static void disableEvent(

--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/test/java/com/datadog/profiling/controller/openjdk/OpenJdkOngoingRecordingTest.java
@@ -37,7 +37,8 @@ public class OpenJdkOngoingRecordingTest {
     when(recording.getState()).thenReturn(RecordingState.RUNNING);
     when(recording.getName()).thenReturn(TEST_NAME);
 
-    ongoingRecording = new OpenJdkOngoingRecording(recording, new ControllerContext().snapshot());
+    ongoingRecording =
+        new OpenJdkOngoingRecording(recording, new ControllerContext().snapshot(), true);
   }
 
   @Test

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerContext.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ControllerContext.java
@@ -13,22 +13,23 @@ import java.util.Set;
 public class ControllerContext {
 
   private boolean isDatadogProfilerEnabled;
+  private String datadogProfilerUnavailableReason;
   private Set<ProfilingMode> datadogProfilingModes = EnumSet.noneOf(ProfilingMode.class);
 
-  public boolean isDatadogProfilerEnabled() {
-    return isDatadogProfilerEnabled;
-  }
-
-  public void setDatadogProfilerEnabled(boolean datadogProfilerActive) {
+  public ControllerContext setDatadogProfilerEnabled(boolean datadogProfilerActive) {
     isDatadogProfilerEnabled = datadogProfilerActive;
+    return this;
   }
 
-  public Set<ProfilingMode> getDatadogProfilingModes() {
-    return datadogProfilingModes;
-  }
-
-  public void setDatadogProfilingModes(Set<ProfilingMode> datadogProfilingModes) {
+  public ControllerContext setDatadogProfilingModes(Set<ProfilingMode> datadogProfilingModes) {
     this.datadogProfilingModes = datadogProfilingModes;
+    return this;
+  }
+
+  public ControllerContext setDatadogProfilerUnavailableReason(
+      String datadogProfilerUnavailableReason) {
+    this.datadogProfilerUnavailableReason = datadogProfilerUnavailableReason;
+    return this;
   }
 
   /**
@@ -42,15 +43,23 @@ public class ControllerContext {
 
   public static final class Snapshot {
     private final boolean isDatadogProfilerEnabled;
+    private final String datadogProfilerUnavailableReason;
     private final Set<ProfilingMode> datadogProfilingModes;
 
     public Snapshot(ControllerContext context) {
-      this(context.isDatadogProfilerEnabled, EnumSet.copyOf(context.datadogProfilingModes));
+      this(
+          context.isDatadogProfilerEnabled,
+          EnumSet.copyOf(context.datadogProfilingModes),
+          context.datadogProfilerUnavailableReason);
     }
 
-    private Snapshot(boolean isDatadogProfilerEnabled, Set<ProfilingMode> datadogProfilingModes) {
+    private Snapshot(
+        boolean isDatadogProfilerEnabled,
+        Set<ProfilingMode> datadogProfilingModes,
+        String datadogProfilerFailureReason) {
       this.isDatadogProfilerEnabled = isDatadogProfilerEnabled;
       this.datadogProfilingModes = datadogProfilingModes;
+      this.datadogProfilerUnavailableReason = datadogProfilerFailureReason;
     }
 
     public boolean isDatadogProfilerEnabled() {
@@ -59,6 +68,10 @@ public class ControllerContext {
 
     public Set<ProfilingMode> getDatadogProfilingModes() {
       return datadogProfilingModes;
+    }
+
+    public String getDatadogProfilerUnavailableReason() {
+      return datadogProfilerUnavailableReason;
     }
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerSettingsSupport.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/ProfilerSettingsSupport.java
@@ -32,6 +32,8 @@ public abstract class ProfilerSettingsSupport {
   protected static final String STACK_DEPTH_KEY = "Stack Depth";
   protected static final String SELINUX_STATUS_KEY = "SELinux Status";
 
+  protected static final String DDPROF_UNAVAILABLE_REASON_KEY = "DDProf Unavailable Reason";
+
   protected final int uploadPeriod;
   protected final int uploadTimeout;
   protected final String uploadCompression;
@@ -49,10 +51,15 @@ public abstract class ProfilerSettingsSupport {
   protected final boolean hasNativeStacks;
   protected final String seLinuxStatus;
 
-  protected final int stackDepth;
-  protected volatile boolean hasJfrStackDepthApplied = false;
+  protected final String ddprofUnavailableReason;
 
-  protected ProfilerSettingsSupport(ConfigProvider configProvider) {
+  protected final int stackDepth;
+  protected final boolean hasJfrStackDepthApplied;
+
+  protected ProfilerSettingsSupport(
+      ConfigProvider configProvider,
+      String ddprofUnavailableReason,
+      boolean hasJfrStackDepthApplied) {
     uploadPeriod =
         configProvider.getInteger(
             ProfilingConfig.PROFILING_UPLOAD_PERIOD,
@@ -113,6 +120,8 @@ public abstract class ProfilerSettingsSupport {
             ProfilingConfig.PROFILING_DATADOG_PROFILER_STACKDEPTH);
 
     seLinuxStatus = getSELinuxStatus();
+    this.ddprofUnavailableReason = ddprofUnavailableReason;
+    this.hasJfrStackDepthApplied = hasJfrStackDepthApplied;
   }
 
   private String getSELinuxStatus() {
@@ -153,10 +162,6 @@ public abstract class ProfilerSettingsSupport {
 
   /** To be defined in controller specific way. Eg. one could emit JFR events. */
   public abstract void publish();
-
-  public void markJfrStackDepthApplied() {
-    hasJfrStackDepthApplied = true;
-  }
 
   private static String readPerfEventsParanoidSetting() {
     String value = "unknown";


### PR DESCRIPTION
# What Does This Do

Publishes reason the dd profiler failed to load as a recurrent event (assuming there is JFR present, this makes debugging easier). Tested end to end with a contrived failure.


<img width="476" alt="Screenshot 2024-02-23 at 11 42 09" src="https://github.com/DataDog/dd-trace-java/assets/16439049/3df26fcd-1499-4d5b-bae1-b710c7ee20b8">


# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
