### PR TITLE
Optimize in-progress tests and suites lookup

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -3,11 +3,11 @@ package datadog.trace.civisibility.events;
 import static datadog.trace.util.Strings.toJson;
 
 import datadog.trace.api.DisableTestTrace;
+import datadog.trace.api.civisibility.DDTest;
+import datadog.trace.api.civisibility.DDTestSuite;
 import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.config.TestIdentifier;
-import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
-import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -19,7 +19,6 @@ import datadog.trace.civisibility.domain.TestFrameworkModule;
 import datadog.trace.civisibility.domain.TestFrameworkSession;
 import datadog.trace.civisibility.domain.TestImpl;
 import datadog.trace.civisibility.domain.TestSuiteImpl;
-import datadog.trace.civisibility.utils.ConcurrentHashMapContextStore;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,31 +28,33 @@ import org.objectweb.asm.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TestEventsHandlerImpl implements TestEventsHandler {
+public class TestEventsHandlerImpl<SuiteKey, TestKey>
+    implements TestEventsHandler<SuiteKey, TestKey> {
 
   private static final Logger log = LoggerFactory.getLogger(TestEventsHandlerImpl.class);
 
   private final CiVisibilityMetricCollector metricCollector;
   private final TestFrameworkSession testSession;
   private final TestFrameworkModule testModule;
-
-  private final ContextStore<TestSuiteDescriptor, TestSuiteImpl> inProgressTestSuites =
-      new ConcurrentHashMapContextStore<>();
-
-  private final ContextStore<TestDescriptor, TestImpl> inProgressTests =
-      new ConcurrentHashMapContextStore<>();
+  private final ContextStore<SuiteKey, TestSuiteImpl> inProgressTestSuites;
+  private final ContextStore<TestKey, TestImpl> inProgressTests;
 
   public TestEventsHandlerImpl(
       CiVisibilityMetricCollector metricCollector,
       TestFrameworkSession testSession,
-      TestFrameworkModule testModule) {
+      TestFrameworkModule testModule,
+      ContextStore<SuiteKey, DDTestSuite> suiteStore,
+      ContextStore<TestKey, DDTest> testStore) {
     this.metricCollector = metricCollector;
     this.testSession = testSession;
     this.testModule = testModule;
+    this.inProgressTestSuites = (ContextStore) suiteStore;
+    this.inProgressTests = (ContextStore) testStore;
   }
 
   @Override
   public void onTestSuiteStart(
+      final SuiteKey descriptor,
       final String testSuiteName,
       final @Nullable String testFramework,
       final @Nullable String testFrameworkVersion,
@@ -79,45 +80,34 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
           Tags.TEST_TRAITS, toJson(Collections.singletonMap("category", toJson(categories)), true));
     }
 
-    TestSuiteDescriptor descriptor = new TestSuiteDescriptor(testSuiteName, testClass);
     inProgressTestSuites.put(descriptor, testSuite);
   }
 
   @Override
-  public void onTestSuiteFinish(final String testSuiteName, final @Nullable Class<?> testClass) {
-    if (skipTrace(testClass)) {
+  public void onTestSuiteFinish(SuiteKey descriptor) {
+    if (skipTrace(descriptor.getClass())) {
       return;
     }
 
-    TestSuiteDescriptor descriptor = new TestSuiteDescriptor(testSuiteName, testClass);
     TestSuiteImpl testSuite = inProgressTestSuites.remove(descriptor);
     testSuite.end(null);
   }
 
   @Override
-  public void onTestSuiteSkip(String testSuiteName, Class<?> testClass, @Nullable String reason) {
-    TestSuiteDescriptor descriptor = new TestSuiteDescriptor(testSuiteName, testClass);
+  public void onTestSuiteSkip(SuiteKey descriptor, @Nullable String reason) {
     TestSuiteImpl testSuite = inProgressTestSuites.get(descriptor);
     if (testSuite == null) {
-      log.debug(
-          "Ignoring skip event, could not find test suite with name {} and class {}",
-          testSuiteName,
-          testClass);
+      log.debug("Ignoring skip event, could not find test suite {}", descriptor);
       return;
     }
     testSuite.setSkipReason(reason);
   }
 
   @Override
-  public void onTestSuiteFailure(
-      String testSuiteName, Class<?> testClass, @Nullable Throwable throwable) {
-    TestSuiteDescriptor descriptor = new TestSuiteDescriptor(testSuiteName, testClass);
+  public void onTestSuiteFailure(SuiteKey descriptor, @Nullable Throwable throwable) {
     TestSuiteImpl testSuite = inProgressTestSuites.get(descriptor);
     if (testSuite == null) {
-      log.debug(
-          "Ignoring fail event, could not find test suite with name {} and class {}",
-          testSuiteName,
-          testClass);
+      log.debug("Ignoring fail event, could not find test suite {}", descriptor);
       return;
     }
     testSuite.setErrorInfo(throwable);
@@ -125,9 +115,10 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
 
   @Override
   public void onTestStart(
+      final SuiteKey suiteDescriptor,
+      final TestKey descriptor,
       final String testSuiteName,
       final String testName,
-      final @Nullable Object testQualifier,
       final @Nullable String testFramework,
       final @Nullable String testFrameworkVersion,
       final @Nullable String testParameters,
@@ -140,7 +131,6 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
       return;
     }
 
-    TestSuiteDescriptor suiteDescriptor = new TestSuiteDescriptor(testSuiteName, testClass);
     TestSuiteImpl testSuite = inProgressTestSuites.get(suiteDescriptor);
     TestImpl test = testSuite.testStart(testName, testMethod, null);
 
@@ -183,71 +173,34 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
       test.setTag(Tags.TEST_IS_RETRY, true);
     }
 
-    TestDescriptor descriptor =
-        new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
     inProgressTests.put(descriptor, test);
   }
 
   @Override
-  public void onTestSkip(
-      String testSuiteName,
-      Class<?> testClass,
-      String testName,
-      @Nullable Object testQualifier,
-      @Nullable String testParameters,
-      @Nullable String reason) {
-    TestDescriptor descriptor =
-        new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
+  public void onTestSkip(TestKey descriptor, @Nullable String reason) {
     TestImpl test = inProgressTests.get(descriptor);
     if (test == null) {
-      log.debug(
-          "Ignoring skip event, could not find test with name {}, suite name{} and class {}",
-          testName,
-          testSuiteName,
-          testClass);
+      log.debug("Ignoring skip event, could not find test {}}", descriptor);
       return;
     }
     test.setSkipReason(reason);
   }
 
   @Override
-  public void onTestFailure(
-      String testSuiteName,
-      Class<?> testClass,
-      String testName,
-      @Nullable Object testQualifier,
-      @Nullable String testParameters,
-      @Nullable Throwable throwable) {
-    TestDescriptor descriptor =
-        new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
+  public void onTestFailure(TestKey descriptor, @Nullable Throwable throwable) {
     TestImpl test = inProgressTests.get(descriptor);
     if (test == null) {
-      log.debug(
-          "Ignoring fail event, could not find test with name {}, suite name{} and class {}",
-          testName,
-          testSuiteName,
-          testClass);
+      log.debug("Ignoring fail event, could not find test {}", descriptor);
       return;
     }
     test.setErrorInfo(throwable);
   }
 
   @Override
-  public void onTestFinish(
-      final String testSuiteName,
-      final Class<?> testClass,
-      final String testName,
-      final @Nullable Object testQualifier,
-      final @Nullable String testParameters) {
-    TestDescriptor descriptor =
-        new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
+  public void onTestFinish(TestKey descriptor) {
     TestImpl test = inProgressTests.remove(descriptor);
     if (test == null) {
-      log.debug(
-          "Ignoring finish event, could not find test with name {}, suite name{} and class {}",
-          testName,
-          testSuiteName,
-          testClass);
+      log.debug("Ignoring finish event, could not find test {}", descriptor);
       return;
     }
     test.end(null);
@@ -255,9 +208,10 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
 
   @Override
   public void onTestIgnore(
+      final SuiteKey suiteDescriptor,
+      final TestKey testDescriptor,
       final String testSuiteName,
       final String testName,
-      final @Nullable Object testQualifier,
       final @Nullable String testFramework,
       final @Nullable String testFrameworkVersion,
       final @Nullable String testParameters,
@@ -267,9 +221,10 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
       final @Nullable Method testMethod,
       final @Nullable String reason) {
     onTestStart(
+        suiteDescriptor,
+        testDescriptor,
         testSuiteName,
         testName,
-        testQualifier,
         testFramework,
         testFrameworkVersion,
         testParameters,
@@ -278,8 +233,8 @@ public class TestEventsHandlerImpl implements TestEventsHandler {
         testMethodName,
         testMethod,
         false);
-    onTestSkip(testSuiteName, testClass, testName, testQualifier, testParameters, reason);
-    onTestFinish(testSuiteName, testClass, testName, testQualifier, testParameters);
+    onTestSkip(testDescriptor, reason);
+    onTestFinish(testDescriptor);
   }
 
   private static boolean skipTrace(final Class<?> testClass) {

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/CucumberUtils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/CucumberUtils.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.junit4;
 import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.events.TestDescriptor;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.util.MethodHandles;
 import datadog.trace.util.Strings;
 import io.cucumber.core.gherkin.Feature;
@@ -107,6 +108,11 @@ public abstract class CucumberUtils {
     String suite = getTestSuiteNameForScenario(description);
     String name = description.getMethodName();
     return new TestDescriptor(suite, null, name, null, null);
+  }
+
+  public static TestSuiteDescriptor toSuiteDescriptor(Description description) {
+    String testSuiteName = CucumberUtils.getTestSuiteNameForFeature(description);
+    return new TestSuiteDescriptor(testSuiteName, null);
   }
 
   public static final class MuzzleHelper {

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/main/java/datadog/trace/instrumentation/junit4/MUnitInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/main/java/datadog/trace/instrumentation/junit4/MUnitInstrumentation.java
@@ -35,6 +35,7 @@ public class MUnitInstrumentation extends InstrumenterModule.CiVisibility
       packageName + ".TestEventsHandlerHolder",
       packageName + ".SkippedByItr",
       packageName + ".JUnit4Utils",
+      packageName + ".MUnitUtils",
       packageName + ".TracingListener",
       packageName + ".MUnitTracingListener",
     };

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/main/java/datadog/trace/instrumentation/junit4/MUnitUtils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/main/java/datadog/trace/instrumentation/junit4/MUnitUtils.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.junit4;
 
+import datadog.trace.api.civisibility.events.TestDescriptor;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.util.MethodHandles;
 import java.lang.invoke.MethodHandle;
 import munit.MUnitRunner;
@@ -18,5 +20,18 @@ public abstract class MUnitUtils {
 
   public static Description createDescription(MUnitRunner runner, Object test) {
     return METHOD_HANDLES.invoke(RUNNER_CREATE_TEST_DESCRIPTION, runner, test);
+  }
+
+  public static TestDescriptor toTestDescriptor(Description description) {
+    String testSuiteName = description.getClassName();
+    Class<?> testClass = description.getTestClass();
+    String testName = description.getMethodName();
+    return new TestDescriptor(testSuiteName, testClass, testName, null, null);
+  }
+
+  public static TestSuiteDescriptor toSuiteDescriptor(Description description) {
+    Class<?> testClass = description.getTestClass();
+    String testSuiteName = description.getClassName();
+    return new TestSuiteDescriptor(testSuiteName, testClass);
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4TracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4TracingListener.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.junit4;
 
+import datadog.trace.api.civisibility.events.TestDescriptor;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
@@ -29,10 +31,12 @@ public class JUnit4TracingListener extends TracingListener {
       return;
     }
 
+    TestSuiteDescriptor suiteDescriptor = JUnit4Utils.toSuiteDescriptor(description);
     Class<?> testClass = description.getTestClass();
     String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
     List<String> categories = JUnit4Utils.getCategories(testClass, null);
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteStart(
+        suiteDescriptor,
         testSuiteName,
         FRAMEWORK_NAME,
         FRAMEWORK_VERSION,
@@ -50,28 +54,27 @@ public class JUnit4TracingListener extends TracingListener {
       return;
     }
 
-    Class<?> testClass = description.getTestClass();
-    String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(testSuiteName, testClass);
+    TestSuiteDescriptor suiteDescriptor = JUnit4Utils.toSuiteDescriptor(description);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(suiteDescriptor);
   }
 
   @Override
   public void testStarted(final Description description) {
+    TestSuiteDescriptor suiteDescriptor = JUnit4Utils.toSuiteDescriptor(description);
+    TestDescriptor testDescriptor = JUnit4Utils.toTestDescriptor(description);
     Class<?> testClass = description.getTestClass();
     Method testMethod = JUnit4Utils.getTestMethod(description);
     String testMethodName = testMethod != null ? testMethod.getName() : null;
-
     String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
     String testName = JUnit4Utils.getTestName(description, testMethod);
-
     String testParameters = JUnit4Utils.getParameters(description);
     List<String> categories = JUnit4Utils.getCategories(testClass, testMethod);
-
     TestRetryPolicy retryPolicy = retryPolicies.get(description);
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestStart(
+        suiteDescriptor,
+        testDescriptor,
         testSuiteName,
         testName,
-        null,
         FRAMEWORK_NAME,
         FRAMEWORK_VERSION,
         testParameters,
@@ -84,32 +87,22 @@ public class JUnit4TracingListener extends TracingListener {
 
   @Override
   public void testFinished(final Description description) {
-    Class<?> testClass = description.getTestClass();
-    String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
-    Method testMethod = JUnit4Utils.getTestMethod(description);
-    String testName = JUnit4Utils.getTestName(description, testMethod);
-    String testParameters = JUnit4Utils.getParameters(description);
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(
-        testSuiteName, testClass, testName, null, testParameters);
+    TestDescriptor testDescriptor = JUnit4Utils.toTestDescriptor(description);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(testDescriptor);
   }
 
   // same callback is executed both for test cases and test suites (for setup/teardown errors)
   @Override
   public void testFailure(final Failure failure) {
     Description description = failure.getDescription();
-    Class<?> testClass = description.getTestClass();
-    String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
     if (JUnit4Utils.isTestSuiteDescription(description)) {
+      TestSuiteDescriptor suiteDescriptor = JUnit4Utils.toSuiteDescriptor(description);
       Throwable throwable = failure.getException();
-      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFailure(
-          testSuiteName, testClass, throwable);
+      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFailure(suiteDescriptor, throwable);
     } else {
-      Method testMethod = JUnit4Utils.getTestMethod(description);
-      String testName = JUnit4Utils.getTestName(description, testMethod);
-      String testParameters = JUnit4Utils.getParameters(description);
+      TestDescriptor testDescriptor = JUnit4Utils.toTestDescriptor(description);
       Throwable throwable = failure.getException();
-      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(
-          testSuiteName, testClass, testName, null, testParameters, throwable);
+      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(testDescriptor, throwable);
     }
   }
 
@@ -124,23 +117,17 @@ public class JUnit4TracingListener extends TracingListener {
     }
 
     Description description = failure.getDescription();
-    Class<?> testClass = description.getTestClass();
-    String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
-
     if (JUnit4Utils.isTestSuiteDescription(description)) {
-      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(testSuiteName, testClass, reason);
+      TestSuiteDescriptor suiteDescriptor = JUnit4Utils.toSuiteDescriptor(description);
+      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(suiteDescriptor, reason);
 
       List<Method> testMethods = JUnit4Utils.getTestMethods(description.getTestClass());
       for (Method testMethod : testMethods) {
         testIgnored(description, testMethod, reason);
       }
     } else {
-      Method testMethod = JUnit4Utils.getTestMethod(description);
-      String testName = JUnit4Utils.getTestName(description, testMethod);
-      String testParameters = JUnit4Utils.getParameters(description);
-
-      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSkip(
-          testSuiteName, testClass, testName, null, testParameters, reason);
+      TestDescriptor testDescriptor = JUnit4Utils.toTestDescriptor(description);
+      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSkip(testDescriptor, reason);
     }
   }
 
@@ -155,12 +142,13 @@ public class JUnit4TracingListener extends TracingListener {
 
     } else if (JUnit4Utils.isTestSuiteDescription(description)) {
 
+      TestSuiteDescriptor suiteDescriptor = JUnit4Utils.toSuiteDescriptor(description);
       Class<?> testClass = description.getTestClass();
       String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
-
       List<String> categories = JUnit4Utils.getCategories(testClass, null);
 
       TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteStart(
+          suiteDescriptor,
           testSuiteName,
           FRAMEWORK_NAME,
           FRAMEWORK_VERSION,
@@ -168,31 +156,31 @@ public class JUnit4TracingListener extends TracingListener {
           categories,
           false,
           TestFrameworkInstrumentation.JUNIT4);
-      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(testSuiteName, testClass, reason);
+      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(suiteDescriptor, reason);
 
       List<Method> testMethods = JUnit4Utils.getTestMethods(testClass);
       for (Method testMethod : testMethods) {
         testIgnored(description, testMethod, reason);
       }
 
-      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(testSuiteName, testClass);
+      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(suiteDescriptor);
     }
   }
 
   private void testIgnored(Description description, Method testMethod, String reason) {
+    TestSuiteDescriptor suiteDescriptor = JUnit4Utils.toSuiteDescriptor(description);
+    TestDescriptor testDescriptor = JUnit4Utils.toTestDescriptor(description);
     Class<?> testClass = description.getTestClass();
     String testMethodName = testMethod != null ? testMethod.getName() : null;
-
     String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
     String testName = JUnit4Utils.getTestName(description, testMethod);
-
     String testParameters = JUnit4Utils.getParameters(description);
     List<String> categories = JUnit4Utils.getCategories(testClass, testMethod);
-
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestIgnore(
+        suiteDescriptor,
+        testDescriptor,
         testSuiteName,
         testName,
-        null,
         FRAMEWORK_NAME,
         FRAMEWORK_VERSION,
         testParameters,

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.junit4;
 
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.events.TestDescriptor;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.util.MethodHandles;
 import datadog.trace.util.Strings;
 import java.lang.annotation.Annotation;
@@ -302,5 +303,11 @@ public abstract class JUnit4Utils {
     String testName = JUnit4Utils.getTestName(description, testMethod);
     String testParameters = JUnit4Utils.getParameters(description);
     return new TestDescriptor(testSuiteName, testClass, testName, testParameters, null);
+  }
+
+  public static TestSuiteDescriptor toSuiteDescriptor(Description description) {
+    Class<?> testClass = description.getTestClass();
+    String testSuiteName = JUnit4Utils.getSuiteName(testClass, description);
+    return new TestSuiteDescriptor(testSuiteName, testClass);
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TestEventsHandlerHolder.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/TestEventsHandlerHolder.java
@@ -1,12 +1,14 @@
 package datadog.trace.instrumentation.junit4;
 
 import datadog.trace.api.civisibility.InstrumentationBridge;
+import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.util.AgentThreadFactory;
 
 public abstract class TestEventsHandlerHolder {
 
-  public static volatile TestEventsHandler TEST_EVENTS_HANDLER;
+  public static volatile TestEventsHandler<TestSuiteDescriptor, TestDescriptor> TEST_EVENTS_HANDLER;
 
   static {
     start();

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/CucumberTracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/CucumberTracingListener.java
@@ -36,34 +36,35 @@ public class CucumberTracingListener implements EngineExecutionListener {
   }
 
   @Override
-  public void executionStarted(final TestDescriptor testDescriptor) {
-    if (testDescriptor.isContainer()) {
-      containerExecutionStarted(testDescriptor);
-    } else if (testDescriptor.isTest()) {
-      testCaseExecutionStarted(testDescriptor);
+  public void executionStarted(final TestDescriptor descriptor) {
+    if (descriptor.isContainer()) {
+      containerExecutionStarted(descriptor);
+    } else if (descriptor.isTest()) {
+      testCaseExecutionStarted(descriptor);
     }
   }
 
   @Override
   public void executionFinished(
-      TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
-    if (testDescriptor.isContainer()) {
-      containerExecutionFinished(testDescriptor, testExecutionResult);
-    } else if (testDescriptor.isTest()) {
-      testCaseExecutionFinished(testDescriptor, testExecutionResult);
+      TestDescriptor descriptor, TestExecutionResult testExecutionResult) {
+    if (descriptor.isContainer()) {
+      containerExecutionFinished(descriptor, testExecutionResult);
+    } else if (descriptor.isTest()) {
+      testCaseExecutionFinished(descriptor, testExecutionResult);
     }
   }
 
-  private void containerExecutionStarted(final TestDescriptor testDescriptor) {
-    UniqueId uniqueId = testDescriptor.getUniqueId();
+  private void containerExecutionStarted(final TestDescriptor suiteDescriptor) {
+    UniqueId uniqueId = suiteDescriptor.getUniqueId();
     if (!CucumberUtils.isFeature(uniqueId)) {
       return;
     }
 
-    String testSuiteName = CucumberUtils.getFeatureName(testDescriptor);
+    String testSuiteName = CucumberUtils.getFeatureName(suiteDescriptor);
     List<String> tags =
-        testDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
+        suiteDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteStart(
+        suiteDescriptor,
         testSuiteName,
         testFramework,
         testFrameworkVersion,
@@ -74,30 +75,25 @@ public class CucumberTracingListener implements EngineExecutionListener {
   }
 
   private void containerExecutionFinished(
-      final TestDescriptor testDescriptor, final TestExecutionResult testExecutionResult) {
-    if (!CucumberUtils.isFeature(testDescriptor.getUniqueId())) {
+      final TestDescriptor suiteDescriptor, final TestExecutionResult testExecutionResult) {
+    if (!CucumberUtils.isFeature(suiteDescriptor.getUniqueId())) {
       return;
     }
 
-    String testSuiteName = CucumberUtils.getFeatureName(testDescriptor);
     Throwable throwable = testExecutionResult.getThrowable().orElse(null);
     if (throwable != null) {
       if (JUnitPlatformUtils.isAssumptionFailure(throwable)) {
-
         String reason = throwable.getMessage();
-        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(testSuiteName, null, reason);
+        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(suiteDescriptor, reason);
 
-        for (TestDescriptor child : testDescriptor.getChildren()) {
+        for (TestDescriptor child : suiteDescriptor.getChildren()) {
           executionSkipped(child, reason);
         }
-
       } else {
-        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFailure(
-            testSuiteName, null, throwable);
+        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFailure(suiteDescriptor, throwable);
       }
     }
-
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(testSuiteName, null);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(suiteDescriptor);
   }
 
   private void testCaseExecutionStarted(final TestDescriptor testDescriptor) {
@@ -109,20 +105,19 @@ public class CucumberTracingListener implements EngineExecutionListener {
 
   private void testResourceExecutionStarted(
       TestDescriptor testDescriptor, ClasspathResourceSource testSource) {
+    TestDescriptor suiteDescriptor = CucumberUtils.getFeatureDescriptor(testDescriptor);
     String classpathResourceName = testSource.getClasspathResourceName();
-
     Pair<String, String> names =
         CucumberUtils.getFeatureAndScenarioNames(testDescriptor, classpathResourceName);
     String testSuiteName = names.getLeft();
     String testName = names.getRight();
-
     List<String> tags =
         testDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
-
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestStart(
+        suiteDescriptor,
+        testDescriptor,
         testSuiteName,
         testName,
-        null,
         testFramework,
         testFrameworkVersion,
         null,
@@ -139,60 +134,47 @@ public class CucumberTracingListener implements EngineExecutionListener {
       final TestDescriptor testDescriptor, final TestExecutionResult testExecutionResult) {
     TestSource testSource = testDescriptor.getSource().orElse(null);
     if (testSource instanceof ClasspathResourceSource) {
-      testResourceExecutionFinished(
-          testDescriptor, testExecutionResult, (ClasspathResourceSource) testSource);
+      testResourceExecutionFinished(testDescriptor, testExecutionResult);
     }
   }
 
   private void testResourceExecutionFinished(
-      TestDescriptor testDescriptor,
-      TestExecutionResult testExecutionResult,
-      ClasspathResourceSource testSource) {
-    String classpathResourceName = testSource.getClasspathResourceName();
-
-    Pair<String, String> names =
-        CucumberUtils.getFeatureAndScenarioNames(testDescriptor, classpathResourceName);
-    String testSuiteName = names.getLeft();
-    String testName = names.getRight();
-
+      TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
     Throwable throwable = testExecutionResult.getThrowable().orElse(null);
     if (throwable != null) {
       if (JUnitPlatformUtils.isAssumptionFailure(throwable)) {
         TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSkip(
-            testSuiteName, null, testName, null, null, throwable.getMessage());
+            testDescriptor, throwable.getMessage());
       } else {
-        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(
-            testSuiteName, null, testName, null, null, throwable);
+        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(testDescriptor, throwable);
       }
     }
-
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(
-        testSuiteName, null, testName, null, null);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(testDescriptor);
   }
 
   @Override
-  public void executionSkipped(final TestDescriptor testDescriptor, final String reason) {
-    TestSource testSource = testDescriptor.getSource().orElse(null);
+  public void executionSkipped(final TestDescriptor descriptor, final String reason) {
+    TestSource testSource = descriptor.getSource().orElse(null);
     if (testSource instanceof ClasspathResourceSource) {
-      testResourceExecutionSkipped(testDescriptor, (ClasspathResourceSource) testSource, reason);
+      testResourceExecutionSkipped(descriptor, (ClasspathResourceSource) testSource, reason);
     }
   }
 
   private void testResourceExecutionSkipped(
       TestDescriptor testDescriptor, ClasspathResourceSource testSource, String reason) {
+    TestDescriptor suiteDescriptor = CucumberUtils.getFeatureDescriptor(testDescriptor);
     String classpathResourceName = testSource.getClasspathResourceName();
     Pair<String, String> names =
         CucumberUtils.getFeatureAndScenarioNames(testDescriptor, classpathResourceName);
     String testSuiteName = names.getLeft();
     String testName = names.getRight();
-
     List<String> tags =
         testDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
-
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestIgnore(
+        suiteDescriptor,
+        testDescriptor,
         testSuiteName,
         testName,
-        null,
         testFramework,
         testFrameworkVersion,
         null,

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/CucumberUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/CucumberUtils.java
@@ -96,6 +96,13 @@ public abstract class CucumberUtils {
     return "feature".equals(lastSegment.getType());
   }
 
+  public static TestDescriptor getFeatureDescriptor(TestDescriptor testDescriptor) {
+    while (testDescriptor != null && !isFeature(testDescriptor.getUniqueId())) {
+      testDescriptor = testDescriptor.getParent().orElse(null);
+    }
+    return testDescriptor;
+  }
+
   public static TestIdentifier toTestIdentifier(TestDescriptor testDescriptor) {
     TestSource testSource = testDescriptor.getSource().orElse(null);
     if (testSource instanceof ClasspathResourceSource) {
@@ -111,21 +118,5 @@ public abstract class CucumberUtils {
     } else {
       return null;
     }
-  }
-
-  private static datadog.trace.api.civisibility.events.TestDescriptor toTestDescriptor(
-      TestDescriptor testDescriptor) {
-    TestSource testSource = testDescriptor.getSource().orElse(null);
-    if (!(testSource instanceof ClasspathResourceSource)) {
-      return null;
-    }
-    ClasspathResourceSource classpathResourceSource = (ClasspathResourceSource) testSource;
-    String classpathResourceName = classpathResourceSource.getClasspathResourceName();
-    Pair<String, String> names =
-        CucumberUtils.getFeatureAndScenarioNames(testDescriptor, classpathResourceName);
-    String testSuiteName = names.getLeft();
-    String testName = names.getRight();
-    return new datadog.trace.api.civisibility.events.TestDescriptor(
-        testSuiteName, null, testName, null, null);
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5CucumberInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5CucumberInstrumentation.java
@@ -7,12 +7,17 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.cucumber.junit.platform.engine.CucumberTestEngine;
+import java.util.Collections;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService;
 
@@ -47,6 +52,11 @@ public class JUnit5CucumberInstrumentation extends InstrumenterModule.CiVisibili
   }
 
   @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("org.junit.platform.engine.TestDescriptor", "java.lang.Object");
+  }
+
+  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("execute").and(takesArgument(0, named("org.junit.platform.engine.ExecutionRequest"))),
@@ -76,6 +86,12 @@ public class JUnit5CucumberInstrumentation extends InstrumenterModule.CiVisibili
         // as a separate module
         return;
       }
+
+      ContextStore<TestDescriptor, Object> contextStore =
+          InstrumentationContext.get(TestDescriptor.class, Object.class);
+      TestEventsHandlerHolder.setContextStores(
+          (ContextStore) contextStore, (ContextStore) contextStore);
+      TestEventsHandlerHolder.start();
 
       CucumberTracingListener tracingListener = new CucumberTracingListener(testEngine);
       EngineExecutionListener originalListener = executionRequest.getEngineExecutionListener();

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/groovy/CucumberTest.groovy
@@ -103,7 +103,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   }
 
   protected void runFeatures(List<String> classpathFeatures, boolean parallel) {
-    TestEventsHandlerHolder.start()
+    TestEventsHandlerHolder.startForcefully()
 
     DiscoverySelector[] selectors = new DiscoverySelector[classpathFeatures.size()]
     for (i in 0..<classpathFeatures.size()) {

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockInstrumentation.java
@@ -7,11 +7,16 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.ContextStore;
+import datadog.trace.bootstrap.InstrumentationContext;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collections;
+import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.junit.platform.engine.EngineExecutionListener;
 import org.junit.platform.engine.ExecutionRequest;
+import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService;
 import org.spockframework.runtime.SpockEngine;
@@ -47,6 +52,11 @@ public class JUnit5SpockInstrumentation extends InstrumenterModule.CiVisibility
   }
 
   @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("org.junit.platform.engine.TestDescriptor", "java.lang.Object");
+  }
+
+  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("execute").and(takesArgument(0, named("org.junit.platform.engine.ExecutionRequest"))),
@@ -76,6 +86,12 @@ public class JUnit5SpockInstrumentation extends InstrumenterModule.CiVisibility
         // as a separate module
         return;
       }
+
+      ContextStore<TestDescriptor, Object> contextStore =
+          InstrumentationContext.get(TestDescriptor.class, Object.class);
+      TestEventsHandlerHolder.setContextStores(
+          (ContextStore) contextStore, (ContextStore) contextStore);
+      TestEventsHandlerHolder.start();
 
       SpockTracingListener tracingListener = new SpockTracingListener(testEngine);
       EngineExecutionListener originalListener = executionRequest.getEngineExecutionListener();

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/SpockTracingListener.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/SpockTracingListener.java
@@ -35,36 +35,36 @@ public class SpockTracingListener implements EngineExecutionListener {
   }
 
   @Override
-  public void executionStarted(final TestDescriptor testDescriptor) {
-    if (testDescriptor.isContainer()) {
-      containerExecutionStarted(testDescriptor);
-    } else if (testDescriptor.isTest()) {
-      testCaseExecutionStarted(testDescriptor);
+  public void executionStarted(final TestDescriptor descriptor) {
+    if (descriptor.isContainer()) {
+      containerExecutionStarted(descriptor);
+    } else if (descriptor.isTest()) {
+      testCaseExecutionStarted(descriptor);
     }
   }
 
   @Override
   public void executionFinished(
-      TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
-    if (testDescriptor.isContainer()) {
-      containerExecutionFinished(testDescriptor, testExecutionResult);
-    } else if (testDescriptor.isTest()) {
-      testCaseExecutionFinished(testDescriptor, testExecutionResult);
+      TestDescriptor descriptor, TestExecutionResult testExecutionResult) {
+    if (descriptor.isContainer()) {
+      containerExecutionFinished(descriptor, testExecutionResult);
+    } else if (descriptor.isTest()) {
+      testCaseExecutionFinished(descriptor, testExecutionResult);
     }
   }
 
-  private void containerExecutionStarted(final TestDescriptor testDescriptor) {
-    if (!SpockUtils.isSpec(testDescriptor)) {
+  private void containerExecutionStarted(final TestDescriptor suiteDescriptor) {
+    if (!SpockUtils.isSpec(suiteDescriptor)) {
       return;
     }
 
-    Class<?> testClass = JUnitPlatformUtils.getJavaClass(testDescriptor);
+    Class<?> testClass = JUnitPlatformUtils.getJavaClass(suiteDescriptor);
     String testSuiteName =
-        testClass != null ? testClass.getName() : testDescriptor.getLegacyReportingName();
-
+        testClass != null ? testClass.getName() : suiteDescriptor.getLegacyReportingName();
     List<String> tags =
-        testDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
+        suiteDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteStart(
+        suiteDescriptor,
         testSuiteName,
         testFramework,
         testFrameworkVersion,
@@ -75,34 +75,28 @@ public class SpockTracingListener implements EngineExecutionListener {
   }
 
   private void containerExecutionFinished(
-      final TestDescriptor testDescriptor, final TestExecutionResult testExecutionResult) {
-    if (!SpockUtils.isSpec(testDescriptor)) {
+      final TestDescriptor suiteDescriptor, final TestExecutionResult testExecutionResult) {
+    if (!SpockUtils.isSpec(suiteDescriptor)) {
       return;
     }
-
-    Class<?> testClass = JUnitPlatformUtils.getJavaClass(testDescriptor);
-    String testSuiteName =
-        testClass != null ? testClass.getName() : testDescriptor.getLegacyReportingName();
 
     Throwable throwable = testExecutionResult.getThrowable().orElse(null);
     if (throwable != null) {
       if (JUnitPlatformUtils.isAssumptionFailure(throwable)) {
 
         String reason = throwable.getMessage();
-        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(
-            testSuiteName, testClass, reason);
+        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(suiteDescriptor, reason);
 
-        for (TestDescriptor child : testDescriptor.getChildren()) {
+        for (TestDescriptor child : suiteDescriptor.getChildren()) {
           executionSkipped(child, reason);
         }
 
       } else {
-        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFailure(
-            testSuiteName, testClass, throwable);
+        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFailure(suiteDescriptor, throwable);
       }
     }
 
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(testSuiteName, testClass);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(suiteDescriptor);
   }
 
   private void testCaseExecutionStarted(final TestDescriptor testDescriptor) {
@@ -113,21 +107,20 @@ public class SpockTracingListener implements EngineExecutionListener {
   }
 
   private void testMethodExecutionStarted(TestDescriptor testDescriptor, MethodSource testSource) {
+    TestDescriptor suiteDescriptor = SpockUtils.getSpecDescriptor(testDescriptor);
     String testSuitName = testSource.getClassName();
     String displayName = testDescriptor.getDisplayName();
-
     String testParameters = JUnitPlatformUtils.getParameters(testSource, displayName);
     List<String> tags =
         testDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
-
     Class<?> testClass = testSource.getJavaClass();
     Method testMethod = SpockUtils.getTestMethod(testSource);
     String testMethodName = testSource.getMethodName();
-
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestStart(
+        suiteDescriptor,
+        testDescriptor,
         testSuitName,
         displayName,
-        null,
         testFramework,
         testFrameworkVersion,
         testParameters,
@@ -142,61 +135,51 @@ public class SpockTracingListener implements EngineExecutionListener {
       final TestDescriptor testDescriptor, final TestExecutionResult testExecutionResult) {
     TestSource testSource = testDescriptor.getSource().orElse(null);
     if (testSource instanceof MethodSource) {
-      testMethodExecutionFinished(testDescriptor, testExecutionResult, (MethodSource) testSource);
+      testMethodExecutionFinished(testDescriptor, testExecutionResult);
     }
   }
 
   private static void testMethodExecutionFinished(
-      TestDescriptor testDescriptor,
-      TestExecutionResult testExecutionResult,
-      MethodSource testSource) {
-    String testSuiteName = testSource.getClassName();
-    Class<?> testClass = testSource.getJavaClass();
-    String displayName = testDescriptor.getDisplayName();
-    String testParameters = JUnitPlatformUtils.getParameters(testSource, displayName);
-
+      TestDescriptor testDescriptor, TestExecutionResult testExecutionResult) {
     Throwable throwable = testExecutionResult.getThrowable().orElse(null);
     if (throwable != null) {
       if (JUnitPlatformUtils.isAssumptionFailure(throwable)) {
         TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSkip(
-            testSuiteName, testClass, displayName, null, testParameters, throwable.getMessage());
+            testDescriptor, throwable.getMessage());
       } else {
-        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(
-            testSuiteName, testClass, displayName, null, testParameters, throwable);
+        TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(testDescriptor, throwable);
       }
     }
-
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(
-        testSuiteName, testClass, displayName, null, testParameters);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(testDescriptor);
   }
 
   @Override
-  public void executionSkipped(final TestDescriptor testDescriptor, final String reason) {
-    TestSource testSource = testDescriptor.getSource().orElse(null);
-
+  public void executionSkipped(final TestDescriptor descriptor, final String reason) {
+    TestSource testSource = descriptor.getSource().orElse(null);
     if (testSource instanceof ClassSource) {
       // The annotation @Disabled is kept at type level.
-      containerExecutionSkipped(testDescriptor, reason);
+      containerExecutionSkipped(descriptor, reason);
 
     } else if (testSource instanceof MethodSource) {
       // The annotation @Disabled is kept at method level.
-      testMethodExecutionSkipped(testDescriptor, (MethodSource) testSource, reason);
+      testMethodExecutionSkipped(descriptor, (MethodSource) testSource, reason);
     }
   }
 
-  private void containerExecutionSkipped(final TestDescriptor testDescriptor, final String reason) {
-    if (!SpockUtils.isSpec(testDescriptor)) {
+  private void containerExecutionSkipped(
+      final TestDescriptor suiteDescriptor, final String reason) {
+    if (!SpockUtils.isSpec(suiteDescriptor)) {
       return;
     }
 
-    Class<?> testClass = JUnitPlatformUtils.getJavaClass(testDescriptor);
+    Class<?> testClass = JUnitPlatformUtils.getJavaClass(suiteDescriptor);
     String testSuiteName =
-        testClass != null ? testClass.getName() : testDescriptor.getLegacyReportingName();
-
+        testClass != null ? testClass.getName() : suiteDescriptor.getLegacyReportingName();
     List<String> tags =
-        testDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
+        suiteDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
 
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteStart(
+        suiteDescriptor,
         testSuiteName,
         testFramework,
         testFrameworkVersion,
@@ -204,32 +187,31 @@ public class SpockTracingListener implements EngineExecutionListener {
         tags,
         false,
         TestFrameworkInstrumentation.SPOCK);
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(testSuiteName, testClass, reason);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteSkip(suiteDescriptor, reason);
 
-    for (TestDescriptor child : testDescriptor.getChildren()) {
+    for (TestDescriptor child : suiteDescriptor.getChildren()) {
       executionSkipped(child, reason);
     }
 
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(testSuiteName, testClass);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(suiteDescriptor);
   }
 
   private void testMethodExecutionSkipped(
       final TestDescriptor testDescriptor, final MethodSource methodSource, final String reason) {
+    TestDescriptor suiteDescriptor = SpockUtils.getSpecDescriptor(testDescriptor);
     String testSuiteName = methodSource.getClassName();
     String displayName = testDescriptor.getDisplayName();
-
     String testParameters = JUnitPlatformUtils.getParameters(methodSource, displayName);
     List<String> tags =
         testDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toList());
-
     Class<?> testClass = methodSource.getJavaClass();
     Method testMethod = SpockUtils.getTestMethod(methodSource);
     String testMethodName = methodSource.getMethodName();
-
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestIgnore(
+        suiteDescriptor,
+        testDescriptor,
         testSuiteName,
         displayName,
-        null,
         testFramework,
         testFrameworkVersion,
         testParameters,

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/SpockUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/SpockUtils.java
@@ -108,26 +108,17 @@ public class SpockUtils {
     }
   }
 
-  private static datadog.trace.api.civisibility.events.TestDescriptor toTestDescriptor(
-      TestDescriptor testDescriptor) {
-    TestSource testSource = testDescriptor.getSource().orElse(null);
-    if (!(testSource instanceof MethodSource) || !(testDescriptor instanceof SpockNode)) {
-      return null;
-    }
-
-    MethodSource methodSource = (MethodSource) testSource;
-    String testSuiteName = methodSource.getClassName();
-    String displayName = testDescriptor.getDisplayName();
-    String testParameters = JUnitPlatformUtils.getParameters(methodSource, displayName);
-    Class<?> testClass = methodSource.getJavaClass();
-    return new datadog.trace.api.civisibility.events.TestDescriptor(
-        testSuiteName, testClass, displayName, testParameters, null);
-  }
-
   public static boolean isSpec(TestDescriptor testDescriptor) {
     UniqueId uniqueId = testDescriptor.getUniqueId();
     List<UniqueId.Segment> segments = uniqueId.getSegments();
     UniqueId.Segment lastSegment = segments.get(segments.size() - 1);
     return "spec".equals(lastSegment.getType());
+  }
+
+  public static TestDescriptor getSpecDescriptor(TestDescriptor testDescriptor) {
+    while (testDescriptor != null && !isSpec(testDescriptor)) {
+      testDescriptor = testDescriptor.getParent().orElse(null);
+    }
+    return testDescriptor;
   }
 }

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/SpockTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/SpockTest.groovy
@@ -101,7 +101,7 @@ class SpockTest extends CiVisibilityInstrumentationTest {
   }
 
   private static void runTests(List<Class<?>> classes) {
-    TestEventsHandlerHolder.start()
+    TestEventsHandlerHolder.startForcefully()
 
     DiscoverySelector[] selectors = new DiscoverySelector[classes.size()]
     for (i in 0..<classes.size()) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5Instrumentation.java
@@ -96,10 +96,8 @@ public class JUnit5Instrumentation extends InstrumenterModule.CiVisibility
 
       ContextStore<TestDescriptor, Object> contextStore =
           InstrumentationContext.get(TestDescriptor.class, Object.class);
-      // FIXME nikita: same has to be done for Spock and Cucumber (tests are failing)
-      TestEventsHandlerHolder.TEST_STORE = (ContextStore) contextStore;
-      TestEventsHandlerHolder.SUITE_STORE = (ContextStore) contextStore;
-      // FIXME nikita: could be a race condition here
+      TestEventsHandlerHolder.setContextStores(
+          (ContextStore) contextStore, (ContextStore) contextStore);
       TestEventsHandlerHolder.start();
 
       TracingListener tracingListener = new TracingListener(testEngine);

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformUtils.java
@@ -107,34 +107,6 @@ public abstract class JUnitPlatformUtils {
     }
   }
 
-  public static datadog.trace.api.civisibility.events.TestDescriptor toTestDescriptor(
-      TestDescriptor testDescriptor) {
-    TestSource testSource = testDescriptor.getSource().orElse(null);
-    if (!(testSource instanceof MethodSource)) {
-      return null;
-    }
-
-    MethodSource methodSource = (MethodSource) testSource;
-    TestDescriptor suiteDescriptor = JUnitPlatformUtils.getSuiteDescriptor(testDescriptor);
-
-    Class<?> testClass;
-    String testSuiteName;
-    if (suiteDescriptor != null) {
-      testClass = JUnitPlatformUtils.getJavaClass(suiteDescriptor);
-      testSuiteName =
-          testClass != null ? testClass.getName() : suiteDescriptor.getLegacyReportingName();
-    } else {
-      testClass = JUnitPlatformUtils.getTestClass(methodSource);
-      testSuiteName = methodSource.getClassName();
-    }
-
-    String testName = methodSource.getMethodName();
-    String displayName = testDescriptor.getDisplayName();
-    String testParameters = JUnitPlatformUtils.getParameters(methodSource, displayName);
-    return new datadog.trace.api.civisibility.events.TestDescriptor(
-        testSuiteName, testClass, testName, testParameters, null);
-  }
-
   public static boolean isAssumptionFailure(Throwable throwable) {
     switch (throwable.getClass().getName()) {
       case "org.junit.AssumptionViolatedException":

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TestEventsHandlerHolder.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TestEventsHandlerHolder.java
@@ -1,15 +1,20 @@
 package datadog.trace.instrumentation.junit5;
 
+import datadog.trace.api.civisibility.DDTest;
+import datadog.trace.api.civisibility.DDTestSuite;
 import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
+import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.util.AgentThreadFactory;
+import org.junit.platform.engine.TestDescriptor;
 
 public abstract class TestEventsHandlerHolder {
 
-  public static volatile TestEventsHandler TEST_EVENTS_HANDLER;
+  public static volatile ContextStore<TestDescriptor, DDTestSuite> SUITE_STORE;
+  public static volatile ContextStore<TestDescriptor, DDTest> TEST_STORE;
+  public static volatile TestEventsHandler<TestDescriptor, TestDescriptor> TEST_EVENTS_HANDLER;
 
   static {
-    start();
     Runtime.getRuntime()
         .addShutdownHook(
             AgentThreadFactory.newAgentThread(
@@ -19,7 +24,8 @@ public abstract class TestEventsHandlerHolder {
   }
 
   public static void start() {
-    TEST_EVENTS_HANDLER = InstrumentationBridge.createTestEventsHandler("junit");
+    TEST_EVENTS_HANDLER =
+        InstrumentationBridge.createTestEventsHandler("junit", SUITE_STORE, TEST_STORE);
   }
 
   public static void stop() {

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TestEventsHandlerHolder.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/TestEventsHandlerHolder.java
@@ -43,8 +43,10 @@ public abstract class TestEventsHandlerHolder {
 
   // used by instrumentation tests
   public static synchronized void startForcefully() {
-    TEST_EVENTS_HANDLER =
-        InstrumentationBridge.createTestEventsHandler("junit", SUITE_STORE, TEST_STORE);
+    if (SUITE_STORE != null && TEST_STORE != null) {
+      TEST_EVENTS_HANDLER =
+          InstrumentationBridge.createTestEventsHandler("junit", SUITE_STORE, TEST_STORE);
+    }
   }
 
   public static synchronized void stop() {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -138,7 +138,7 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
   }
 
   private static void runTests(List<Class<?>> tests) {
-    TestEventsHandlerHolder.start()
+    TestEventsHandlerHolder.startForcefully()
 
     DiscoverySelector[] selectors = new DiscoverySelector[tests.size()]
     for (i in 0..<tests.size()) {

--- a/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateUtils.java
+++ b/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateUtils.java
@@ -8,6 +8,7 @@ import com.intuit.karate.core.ScenarioRuntime;
 import com.intuit.karate.core.Tag;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.events.TestDescriptor;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.util.MethodHandles;
 import datadog.trace.util.Strings;
 import java.lang.invoke.MethodHandle;
@@ -82,13 +83,18 @@ public abstract class KarateUtils {
     return new TestIdentifier(featureName, scenarioName, parameters, null);
   }
 
-  public static TestDescriptor toTestDescriptor(
-      Scenario scenario, ScenarioRuntime scenarioRuntime) {
+  public static TestDescriptor toTestDescriptor(ScenarioRuntime scenarioRuntime) {
+    Scenario scenario = scenarioRuntime.scenario;
     Feature feature = scenario.getFeature();
     String featureName = feature.getNameForReport();
     String scenarioName = KarateUtils.getScenarioName(scenario);
     String parameters = KarateUtils.getParameters(scenario);
     return new TestDescriptor(featureName, null, scenarioName, parameters, scenarioRuntime);
+  }
+
+  public static TestSuiteDescriptor toSuiteDescriptor(FeatureRuntime featureRuntime) {
+    String featureName = KarateUtils.getFeature(featureRuntime).getNameForReport();
+    return new TestSuiteDescriptor(featureName, null);
   }
 
   public static Result abortedResult() {

--- a/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/TestEventsHandlerHolder.java
+++ b/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/TestEventsHandlerHolder.java
@@ -1,12 +1,14 @@
 package datadog.trace.instrumentation.karate;
 
 import datadog.trace.api.civisibility.InstrumentationBridge;
+import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.util.AgentThreadFactory;
 
 public abstract class TestEventsHandlerHolder {
 
-  public static volatile TestEventsHandler TEST_EVENTS_HANDLER;
+  public static volatile TestEventsHandler<TestSuiteDescriptor, TestDescriptor> TEST_EVENTS_HANDLER;
 
   static {
     start();

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/RunContext.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/RunContext.java
@@ -2,7 +2,9 @@ package datadog.trace.instrumentation.scalatest;
 
 import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.config.TestIdentifier;
+import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,7 +31,7 @@ public class RunContext {
   }
 
   private final int runStamp;
-  private final TestEventsHandler eventHandler =
+  private final TestEventsHandler<TestSuiteDescriptor, TestDescriptor> eventHandler =
       InstrumentationBridge.createTestEventsHandler("scalatest");
   private final java.util.Set<TestIdentifier> skippedTests = ConcurrentHashMap.newKeySet();
   private final java.util.Set<TestIdentifier> unskippableTests = ConcurrentHashMap.newKeySet();
@@ -44,7 +46,7 @@ public class RunContext {
     return runStamp;
   }
 
-  public TestEventsHandler getEventHandler() {
+  public TestEventsHandler<TestSuiteDescriptor, TestDescriptor> getEventHandler() {
     return eventHandler;
   }
 

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestEventsHandlerHolder.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestEventsHandlerHolder.java
@@ -1,12 +1,14 @@
 package datadog.trace.instrumentation.testng;
 
 import datadog.trace.api.civisibility.InstrumentationBridge;
+import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.util.AgentThreadFactory;
 
 public abstract class TestEventsHandlerHolder {
 
-  public static volatile TestEventsHandler TEST_EVENTS_HANDLER;
+  public static volatile TestEventsHandler<TestSuiteDescriptor, TestDescriptor> TEST_EVENTS_HANDLER;
 
   static {
     start();

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGUtils.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.testng;
 
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.events.TestDescriptor;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.util.Strings;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
@@ -254,5 +255,11 @@ public abstract class TestNGUtils {
         (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
     String parameters = TestNGUtils.getParameters(result);
     return new TestDescriptor(testSuiteName, testClass, testName, parameters, result);
+  }
+
+  public static TestSuiteDescriptor toSuiteDescriptor(ITestClass testClass) {
+    String testSuiteName = testClass.getName();
+    Class<?> testSuiteClass = testClass.getRealClass();
+    return new TestSuiteDescriptor(testSuiteName, testSuiteClass);
   }
 }

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.testng;
 
+import datadog.trace.api.civisibility.events.TestDescriptor;
+import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.instrumentation.testng.retry.RetryAnalyzer;
 import java.lang.reflect.Method;
@@ -29,10 +31,12 @@ public class TracingListener extends TestNGClassListener
 
   @Override
   protected void onBeforeClass(ITestClass testClass, boolean parallelized) {
+    TestSuiteDescriptor suiteDescriptor = TestNGUtils.toSuiteDescriptor(testClass);
     String testSuiteName = testClass.getName();
     Class<?> testSuiteClass = testClass.getRealClass();
     List<String> groups = TestNGUtils.getGroups(testClass);
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteStart(
+        suiteDescriptor,
         testSuiteName,
         FRAMEWORK_NAME,
         FRAMEWORK_VERSION,
@@ -44,9 +48,8 @@ public class TracingListener extends TestNGClassListener
 
   @Override
   protected void onAfterClass(ITestClass testClass) {
-    String testSuiteName = testClass.getName();
-    Class<?> testSuiteClass = testClass.getRealClass();
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(testSuiteName, testSuiteClass);
+    TestSuiteDescriptor suiteDescriptor = TestNGUtils.toSuiteDescriptor(testClass);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(suiteDescriptor);
   }
 
   @Override
@@ -57,10 +60,10 @@ public class TracingListener extends TestNGClassListener
   @Override
   public void onConfigurationFailure(ITestResult result) {
     // suite setup or suite teardown failed
-    String testSuiteName = result.getInstanceName();
-    Class<?> testClass = TestNGUtils.getTestClass(result);
+    TestSuiteDescriptor suiteDescriptor =
+        TestNGUtils.toSuiteDescriptor(result.getMethod().getTestClass());
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFailure(
-        testSuiteName, testClass, result.getThrowable());
+        suiteDescriptor, result.getThrowable());
   }
 
   @Override
@@ -70,20 +73,22 @@ public class TracingListener extends TestNGClassListener
 
   @Override
   public void onTestStart(final ITestResult result) {
+    TestSuiteDescriptor suiteDescriptor =
+        TestNGUtils.toSuiteDescriptor(result.getMethod().getTestClass());
+    TestDescriptor testDescriptor = TestNGUtils.toTestDescriptor(result);
     String testSuiteName = result.getInstanceName();
     String testName =
         (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
     String testParameters = TestNGUtils.getParameters(result);
     List<String> groups = TestNGUtils.getGroups(result);
-
     Class<?> testClass = TestNGUtils.getTestClass(result);
     Method testMethod = TestNGUtils.getTestMethod(result);
     String testMethodName = testMethod != null ? testMethod.getName() : null;
-
     TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestStart(
+        suiteDescriptor,
+        testDescriptor,
         testSuiteName,
         testName,
-        result,
         FRAMEWORK_NAME,
         FRAMEWORK_VERSION,
         testParameters,
@@ -105,28 +110,16 @@ public class TracingListener extends TestNGClassListener
 
   @Override
   public void onTestSuccess(final ITestResult result) {
-    final String testSuiteName = result.getInstanceName();
-    final Class<?> testClass = TestNGUtils.getTestClass(result);
-    String testName =
-        (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
-    String testParameters = TestNGUtils.getParameters(result);
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(
-        testSuiteName, testClass, testName, result, testParameters);
+    TestDescriptor testDescriptor = TestNGUtils.toTestDescriptor(result);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(testDescriptor);
   }
 
   @Override
   public void onTestFailure(final ITestResult result) {
-    final String testSuiteName = result.getInstanceName();
-    final Class<?> testClass = TestNGUtils.getTestClass(result);
-    String testName =
-        (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
-    String testParameters = TestNGUtils.getParameters(result);
-
-    final Throwable throwable = result.getThrowable();
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(
-        testSuiteName, testClass, testName, result, testParameters, throwable);
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(
-        testSuiteName, testClass, testName, result, testParameters);
+    TestDescriptor testDescriptor = TestNGUtils.toTestDescriptor(result);
+    Throwable throwable = result.getThrowable();
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(testDescriptor, throwable);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(testDescriptor);
   }
 
   @Override
@@ -136,28 +129,19 @@ public class TracingListener extends TestNGClassListener
 
   @Override
   public void onTestSkipped(final ITestResult result) {
-    final String testSuiteName = result.getInstanceName();
-    final Class<?> testClass = TestNGUtils.getTestClass(result);
-    String testName =
-        (result.getName() != null) ? result.getName() : result.getMethod().getMethodName();
-    String testParameters = TestNGUtils.getParameters(result);
-
+    TestDescriptor testDescriptor = TestNGUtils.toTestDescriptor(result);
     Throwable throwable = result.getThrowable();
     if (TestNGUtils.wasRetried(result)) {
       // TestNG reports tests retried with IRetryAnalyzer as skipped,
       // this is done to avoid failing the build when retrying tests.
       // We want to report such tests as failed to Datadog,
       // to provide more accurate data (and to enable flakiness detection)
-      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(
-          testSuiteName, testClass, testName, result, testParameters, throwable);
+      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFailure(testDescriptor, throwable);
     } else {
       // Typically the way of skipping a TestNG test is throwing a SkipException
       String reason = throwable != null ? throwable.getMessage() : null;
-      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSkip(
-          testSuiteName, testClass, testName, result, testParameters, reason);
+      TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSkip(testDescriptor, reason);
     }
-
-    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(
-        testSuiteName, testClass, testName, result, testParameters);
+    TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestFinish(testDescriptor);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
@@ -4,6 +4,7 @@ import datadog.trace.api.civisibility.events.BuildEventsHandler;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.NoOpMetricCollector;
+import datadog.trace.bootstrap.ContextStore;
 
 public abstract class InstrumentationBridge {
 
@@ -20,8 +21,16 @@ public abstract class InstrumentationBridge {
     TEST_EVENTS_HANDLER_FACTORY = testEventsHandlerFactory;
   }
 
-  public static TestEventsHandler createTestEventsHandler(String component) {
+  public static <SuiteKey, TestKey> TestEventsHandler<SuiteKey, TestKey> createTestEventsHandler(
+      String component) {
     return TEST_EVENTS_HANDLER_FACTORY.create(component);
+  }
+
+  public static <SuiteKey, TestKey> TestEventsHandler<SuiteKey, TestKey> createTestEventsHandler(
+      String component,
+      ContextStore<SuiteKey, DDTestSuite> suiteStore,
+      ContextStore<TestKey, DDTest> testStore) {
+    return TEST_EVENTS_HANDLER_FACTORY.create(component, suiteStore, testStore);
   }
 
   public static void registerBuildEventsHandlerFactory(

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestDescriptor.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestDescriptor.java
@@ -48,4 +48,23 @@ public final class TestDescriptor {
   public int hashCode() {
     return Objects.hash(testSuiteName, testClass, testName, testParameters, testQualifier);
   }
+
+  @Override
+  public String toString() {
+    return "TestDescriptor{"
+        + "testSuiteName='"
+        + testSuiteName
+        + '\''
+        + ", testClass="
+        + testClass
+        + ", testName='"
+        + testName
+        + '\''
+        + ", testParameters='"
+        + testParameters
+        + '\''
+        + ", testQualifier="
+        + testQualifier
+        + '}';
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestSuiteDescriptor.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestSuiteDescriptor.java
@@ -28,4 +28,15 @@ public final class TestSuiteDescriptor {
   public int hashCode() {
     return Objects.hash(testSuiteName, testClass);
   }
+
+  @Override
+  public String toString() {
+    return "TestSuiteDescriptor{"
+        + "testSuiteName='"
+        + testSuiteName
+        + '\''
+        + ", testClass="
+        + testClass
+        + '}';
+  }
 }


### PR DESCRIPTION
# What Does This Do
Optimizes lookup of in-progress test and test suites for JUnit 5-based frameworks.

`ConcurrentHashMap` used for storing in-progress tests and suites is being replaced with `ContextStore` that is backed by a field that the tracer injects into JUnit's `TestDescriptor` class (so a test or a test suite corresponding to a specific descriptor is obtained directly from the field).

Jira ticket: [CIVIS-9262]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9262]: https://datadoghq.atlassian.net/browse/CIVIS-9262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ