### PR TITLE
Limit DependencyResolverQueue size with a config flag

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -200,7 +200,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_TELEMETRY_METRICS_INTERVAL = 10; // in seconds
   static final boolean DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED = true;
   static final boolean DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED = false;
-  static final int DEFAULT_TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE = Integer.MAX_VALUE;
+  static final int DEFAULT_TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE = 100000;
 
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = true;
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -200,6 +200,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_TELEMETRY_METRICS_INTERVAL = 10; // in seconds
   static final boolean DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED = true;
   static final boolean DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED = false;
+  static final int DEFAULT_TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE = Integer.MAX_VALUE;
 
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = true;
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -78,7 +78,8 @@ public final class GeneralConfig {
   public static final String TELEMETRY_DEPENDENCY_COLLECTION_ENABLED =
       "telemetry.dependency-collection.enabled";
   public static final String TELEMETRY_LOG_COLLECTION_ENABLED = "telemetry.log-collection.enabled";
-
+  public static final String TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE =
+      "telemetry.dependency-resolution.queue.size";
   public static final String TELEMETRY_DEBUG_REQUESTS_ENABLED = "telemetry.debug.requests.enabled";
 
   private GeneralConfig() {}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -101,6 +101,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_SERVLET_ROOT_CONTEXT_SERV
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SITE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_STARTUP_LOGS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED;
@@ -244,6 +245,7 @@ import static datadog.trace.api.config.GeneralConfig.STATSD_CLIENT_SOCKET_BUFFER
 import static datadog.trace.api.config.GeneralConfig.STATSD_CLIENT_SOCKET_TIMEOUT;
 import static datadog.trace.api.config.GeneralConfig.TAGS;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_DEPENDENCY_COLLECTION_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_HEARTBEAT_INTERVAL;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_LOG_COLLECTION_ENABLED;
@@ -884,6 +886,7 @@ public class Config {
   private final boolean isTelemetryDependencyServiceEnabled;
   private final boolean telemetryMetricsEnabled;
   private final boolean isTelemetryLogCollectionEnabled;
+  private final int telemetryDependencyResolutionQueueSize;
 
   private final boolean azureAppServices;
   private final String traceAgentPath;
@@ -1549,7 +1552,10 @@ public class Config {
     isTelemetryLogCollectionEnabled =
         configProvider.getBoolean(
             TELEMETRY_LOG_COLLECTION_ENABLED, DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED);
-
+    telemetryDependencyResolutionQueueSize =
+        configProvider.getInteger(
+            TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE,
+            DEFAULT_TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE);
     clientIpEnabled = configProvider.getBoolean(CLIENT_IP_ENABLED, DEFAULT_CLIENT_IP_ENABLED);
 
     appSecReportingInband =
@@ -2662,6 +2668,10 @@ public class Config {
 
   public boolean isTelemetryLogCollectionEnabled() {
     return isTelemetryLogCollectionEnabled;
+  }
+
+  public int getTelemetryDependencyResolutionQueueSize() {
+    return telemetryDependencyResolutionQueueSize;
   }
 
   public boolean isClientIpEnabled() {

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
@@ -49,7 +49,9 @@ public class DependencyResolverQueue {
 
       // this resolver will be disabled so we can clear the stored URIs from processedUrlsSet
       // since they will no longer be checked against for duplicates
-      processedUrlsSet.clear();
+      synchronized (this) {
+        processedUrlsSet.clear();
+      }
       return;
     }
 

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
@@ -19,6 +19,8 @@ public class DependencyResolverQueue {
   private final Set<URI> processedUrlsSet; // guarded by this
   private static int MAX_QUEUE_SIZE = Config.get().getTelemetryDependencyResolutionQueueSize();
 
+  private boolean resolverQueueDisabled = false;
+
   public DependencyResolverQueue() {
     newUrlsQueue = new ConcurrentLinkedQueue<>();
     processedUrlsSet = new HashSet<>();
@@ -32,13 +34,25 @@ public class DependencyResolverQueue {
   }
 
   public void queueURI(URI uri) {
-    if (uri == null) {
+    if (resolverQueueDisabled || uri == null || newUrlsQueue.size() >= MAX_QUEUE_SIZE) {
       return;
     }
-    if (processedUrlsSet.size() >= MAX_QUEUE_SIZE || newUrlsQueue.size() >= MAX_QUEUE_SIZE) {
-      log.debug("DependencyResolverQueue is full, URI {} will not be queued", uri);
+
+    // once the processedUrlsSet reaches MAX_QUEUE_SIZE, we have reached the user-defined limit of
+    // unique dependencies to queue
+    // and we will disable the resolver queue from adding any more URI's.
+    if (processedUrlsSet.size() >= MAX_QUEUE_SIZE) {
+      resolverQueueDisabled = true;
+
+      log.warn(
+          "DependencyResolverQueue limit has been reached, additional dependencies will not be queued");
+
+      // this resolver will be disabled so we can clear the stored URIs since they will no longer be
+      // checked for duplicates
+      processedUrlsSet.clear();
       return;
     }
+
     // we ignore .class files directly within webapp folder (they aren't part of dependencies)
     String path = uri.getPath();
     if (path != null && path.endsWith(".class")) {

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolverQueue.java
@@ -34,21 +34,21 @@ public class DependencyResolverQueue {
   }
 
   public void queueURI(URI uri) {
-    if (resolverQueueDisabled || uri == null || newUrlsQueue.size() >= MAX_QUEUE_SIZE) {
+    if (resolverQueueDisabled || uri == null) {
       return;
     }
 
-    // once the processedUrlsSet reaches MAX_QUEUE_SIZE, we have reached the user-defined limit of
-    // unique dependencies to queue
-    // and we will disable the resolver queue from adding any more URI's.
-    if (processedUrlsSet.size() >= MAX_QUEUE_SIZE) {
+    // once the queue reaches MAX_QUEUE_SIZE, we have reached the user-defined limit of
+    // unique dependencies to queue and we will disable the resolver queue from adding any more
+    // URI's.
+    if (processedUrlsSet.size() >= MAX_QUEUE_SIZE || newUrlsQueue.size() >= MAX_QUEUE_SIZE) {
       resolverQueueDisabled = true;
 
       log.warn(
           "DependencyResolverQueue limit has been reached, additional dependencies will not be queued");
 
-      // this resolver will be disabled so we can clear the stored URIs since they will no longer be
-      // checked for duplicates
+      // this resolver will be disabled so we can clear the stored URIs from processedUrlsSet
+      // since they will no longer be checked against for duplicates
       processedUrlsSet.clear();
       return;
     }

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverQueueSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverQueueSpecification.groovy
@@ -1,7 +1,5 @@
 package datadog.telemetry.dependency
 
-import datadog.trace.api.Config
-
 class DependencyResolverQueueSpecification extends DepSpecification {
 
   DependencyResolverQueue resolverQueue = new DependencyResolverQueue()

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverQueueSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverQueueSpecification.groovy
@@ -1,5 +1,7 @@
 package datadog.telemetry.dependency
 
+import datadog.trace.api.Config
+
 class DependencyResolverQueueSpecification extends DepSpecification {
 
   DependencyResolverQueue resolverQueue = new DependencyResolverQueue()
@@ -52,5 +54,52 @@ class DependencyResolverQueueSpecification extends DepSpecification {
 
     then: 'it has no effect'
     assert deps.isEmpty()
+  }
+
+  void 'resolve set of dependencies with queue limit'() {
+    when:
+    resolverQueue = new DependencyResolverQueue(3)
+    resolverQueue.queueURI(getJar('junit-4.12.jar').toURI())
+    resolverQueue.queueURI(getJar('asm-util-9.2.jar').toURI())
+    resolverQueue.queueURI(getJar('bson-4.2.0.jar').toURI())
+    // this dependency should be dropped
+    resolverQueue.queueURI(getJar('commons-logging-1.2.jar').toURI())
+
+    and:
+    def dep = resolverQueue.pollDependency().get(0)
+
+    then:
+    assert dep != null
+    assert dep.name == 'junit'
+    assert dep.version == '4.12'
+    assert dep.source == 'junit-4.12.jar'
+    assert dep.hash == '4376590587C49AC6DA6935564233F36B092412AE'
+
+    when:
+    dep = resolverQueue.pollDependency().get(0)
+
+    then:
+    assert dep != null
+    assert dep.name == 'asm-util'
+    assert dep.version == '9.2'
+    assert dep.source == 'asm-util-9.2.jar'
+    assert dep.hash == '9A5AEC2CB852B8BD20DAF5D2CE9174891267FE27'
+
+    when:
+    dep = resolverQueue.pollDependency().get(0)
+
+    then:
+    assert dep != null
+    assert dep.name == 'org.mongodb:bson'
+    assert dep.version == '4.2.0'
+    assert dep.source == 'bson-4.2.0.jar'
+    assert dep.hash == 'F87C3A90DA4BB1DA6D3A73CA18004545AD2EF06A'
+
+    when:
+    def deps = resolverQueue.pollDependency()
+
+    then:
+    assert deps.isEmpty()
+
   }
 }


### PR DESCRIPTION
# What Does This Do
Allows the user to set a limit to the size of the telemetry `DependencyResolverQueue` to prevent OOM errors when there are a large number of dependencies
Introduces a new config variable (`dd.telemetry.dependency-resolution.queue.size`) which takes an integer to set as the limit for the number of dependencies to store in the queue.
# Motivation
Resolve [APMS-11445](https://datadoghq.atlassian.net/browse/APMS-11445?atlOrigin=eyJpIjoiYWJjZmQzOGIyMzhhNDRlOTkyZDZmMWE1ZDc4YTM2YTMiLCJwIjoiaiJ9)
# Additional Notes

Jira ticket: [APMS-11445]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-11445]: https://datadoghq.atlassian.net/browse/APMS-11445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMS-11445]: https://datadoghq.atlassian.net/browse/APMS-11445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ