### PR TITLE
PoC disable tracing via remote-config

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -238,6 +238,11 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     List<? extends SamplingRule.TraceSamplingRule> getTraceSamplingRules() {
       return null
     }
+
+    @Override
+    boolean isTracingEnabled() {
+      return false
+    }
   }
 
   boolean originalAppSecRuntimeValue

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -557,6 +557,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
             .setSpanSamplingRules(spanSamplingRules.getRules())
             .setTraceSamplingRules(traceSamplingRules.getRules())
             .setTracingTags(config.getGlobalTags())
+            .setTracingEnabled(config.isTraceEnabled())
             .apply();
 
     this.logs128bTraceIdEnabled = InstrumenterConfig.get().isLogs128bTraceIdEnabled();
@@ -740,6 +741,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         .setBaggageMapping(config.getBaggageMapping())
         .setTraceSampleRate(config.getTraceSampleRate())
         .setTracingTags(config.getGlobalTags())
+        .setTracingEnabled(config.isTraceEnabled())
         .apply();
   }
 
@@ -939,6 +941,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
    * @param trace a list of the spans related to the same trace
    */
   void write(final List<DDSpan> trace) {
+    if (trace.isEmpty() || !trace.get(0).traceConfig().isTracingEnabled()) {
+      return;
+    }
+
     List<DDSpan> writtenTrace = interceptCompleteTrace(trace);
     if (writtenTrace.isEmpty()) {
       return;

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -166,6 +166,7 @@ final class TracingConfigPoller {
 
     maybeOverride(builder::setTraceSampleRate, libConfig.traceSampleRate);
     maybeOverride(builder::setTracingTags, parseTagListToMap(libConfig.tracingTags));
+    maybeOverride(builder::setTracingEnabled, libConfig.tracingEnabled);
     builder.apply();
   }
 
@@ -241,6 +242,9 @@ final class TracingConfigPoller {
 
     @Json(name = "tracing_tags")
     public List<String> tracingTags;
+
+    @Json(name = "tracing_enabled")
+    public Boolean tracingEnabled;
   }
 
   static final class ServiceMappingEntry implements Map.Entry<String, String> {

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -352,6 +352,7 @@ class CoreTracerTest extends DDCoreSpecification {
     tracer.captureTraceConfig().requestHeaderTags == [:]
     tracer.captureTraceConfig().responseHeaderTags == [:]
     tracer.captureTraceConfig().traceSampleRate == null
+    tracer.captureTraceConfig().tracingEnabled
 
     when:
     updater.accept(key, '''
@@ -385,7 +386,8 @@ class CoreTracerTest extends DDCoreSpecification {
              "tag_name": "whatever.the.user.wants.this.header"
           }]
           ,
-          "tracing_sampling_rate": 0.5
+          "tracing_sampling_rate": 0.5,
+          "tracing_enabled": false
         }
       }
       '''.getBytes(StandardCharsets.UTF_8), null)
@@ -408,6 +410,7 @@ class CoreTracerTest extends DDCoreSpecification {
       'this.header':'whatever.the.user.wants.this.header'
     ]
     tracer.captureTraceConfig().traceSampleRate == 0.5
+    !tracer.captureTraceConfig().tracingEnabled
 
     when:
     updater.remove(key, null)

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -110,6 +110,8 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     String preferredServiceName;
 
+    boolean tracingEnabled;
+
     Builder() {}
 
     Builder(Snapshot snapshot) {
@@ -126,6 +128,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
       this.traceSampleRate = snapshot.traceSampleRate;
       this.tracingTags = snapshot.tracingTags;
       this.preferredServiceName = snapshot.preferredServiceName;
+      this.tracingEnabled = snapshot.tracingEnabled;
     }
 
     public Builder setRuntimeMetricsEnabled(boolean runtimeMetricsEnabled) {
@@ -204,6 +207,11 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     public Builder setPreferredServiceName(String preferredServiceName) {
       this.preferredServiceName = preferredServiceName;
+      return this;
+    }
+
+    public Builder setTracingEnabled(boolean tracingEnabled) {
+      this.tracingEnabled = tracingEnabled;
       return this;
     }
 
@@ -306,6 +314,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     final Map<String, String> tracingTags;
 
     final String preferredServiceName;
+    final boolean tracingEnabled;
 
     protected Snapshot(DynamicConfig<?>.Builder builder, Snapshot oldSnapshot) {
 
@@ -324,6 +333,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
       this.traceSamplingRules = builder.traceSamplingRules;
       this.tracingTags = builder.tracingTags;
       this.preferredServiceName = builder.preferredServiceName;
+      this.tracingEnabled = builder.tracingEnabled;
     }
 
     private static <K, V> Map<K, V> nullToEmpty(Map<K, V> mapping) {
@@ -386,6 +396,11 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     }
 
     @Override
+    public boolean isTracingEnabled() {
+      return tracingEnabled;
+    }
+
+    @Override
     public Map<String, String> getTracingTags() {
       return tracingTags;
     }
@@ -419,6 +434,8 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
           + tracingTags
           + ", preferredServiceName="
           + preferredServiceName
+          + ", tracingEnabled="
+          + tracingEnabled
           + '}';
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/TraceConfig.java
@@ -45,4 +45,6 @@ public interface TraceConfig {
    * @return The tracer sampler Trace Sampling Rules, or an empty collection if no rule is defined.
    */
   List<? extends TraceSamplingRule> getTraceSamplingRules();
+
+  boolean isTracingEnabled();
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1291,5 +1291,10 @@ public class AgentTracer {
     public List<? extends SamplingRule.TraceSamplingRule> getTraceSamplingRules() {
       return Collections.emptyList();
     }
+
+    @Override
+    public boolean isTracingEnabled() {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR implements tracing disabling by stopping trace publishing but keeping span creation.

This change satisfies one of the `TestDynamicConfigTracingEnabled' system test scenarios where tracing is initially enabled and then disabled via remote config.

# Motivation

In-app APM Service Disablement RFC

# Additional Notes

Jira ticket: [APMJAVA-1248]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1248]: https://datadoghq.atlassian.net/browse/APMJAVA-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ