### PR TITLE
Decrease default WAF timeout to 5ms

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -97,7 +97,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_REPORTING_INBAND = false;
   static final int DEFAULT_APPSEC_TRACE_RATE_LIMIT = 100;
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
-  static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
+  static final int DEFAULT_APPSEC_WAF_TIMEOUT = 5000; // 1ms
   static final boolean DEFAULT_API_SECURITY_ENABLED = false;
   static final float DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE = 0.1f; // 10 %
 


### PR DESCRIPTION
# What Does This Do
* Decrease default WAF timeout to 5ms. This covers ~p95 of our tests so far. It can be changed with `DD_APPSEC_WAF_TIMEOUT` environment variable or `-Ddd.appsec.waf.timeout`. It is set in microseconds.
* Smoke test adjusted to tolerate some timeouts under high load.

# Motivation
Minimize the maximum latency impact the WAF may have by default.

# Additional Notes

* Note that latency is improving in the benchmarks results here, so it seems we are hitting the timeout in the benchmark. This should be fine, since the benchmark is a load test which is precisely one of the scenarios where we should be timing out.