### PR TITLE
Add JMH benchmark for dependency resolution

### DIFF
--- a/telemetry/build.gradle
+++ b/telemetry/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'me.champeau.jmh'
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 ext {
@@ -45,5 +49,11 @@ dependencies {
   testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
   testImplementation group: 'org.jboss', name: 'jboss-vfs', version: '3.2.16.Final'
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-loader', version: '1.5.22.RELEASE'
+
+  jmh group: 'org.springframework.boot', name: 'spring-boot-loader', version: '1.5.22.RELEASE'
 }
 
+jmh {
+  jmhVersion = '1.28'
+  duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
+}

--- a/telemetry/src/jmh/java/datadog/telemetry/dependency/DependencyResolverBenchmark.java
+++ b/telemetry/src/jmh/java/datadog/telemetry/dependency/DependencyResolverBenchmark.java
@@ -1,0 +1,48 @@
+package datadog.telemetry.dependency;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.net.URI;
+import java.util.List;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Warmup(iterations = 1, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@OutputTimeUnit(MILLISECONDS)
+@BenchmarkMode(Mode.Throughput)
+@State(Scope.Benchmark)
+public class DependencyResolverBenchmark {
+
+  private static final String PROJECT_DIR = System.getProperty("user.dir");
+
+  private static final URI SIMPLE_JAR_URI =
+      URI.create(
+          "file://"
+              + PROJECT_DIR
+              + "/src/test/resources/datadog/telemetry/dependencies/bson-4.2.0.jar");
+
+  private static final URI NESTED_SPRING_BOOT_JAR_URI =
+      URI.create(
+          "jar:file://"
+              + PROJECT_DIR
+              + "/src/test/resources/datadog/telemetry/dependencies/spring-boot-app.jar!/BOOT-INF/lib/opentracing-util-0.33.0.jar!/");
+
+  @Benchmark
+  public void resolveSimpleJar() {
+    final List<Dependency> result = DependencyResolver.resolve(SIMPLE_JAR_URI);
+    assert !result.isEmpty();
+  }
+
+  @Benchmark
+  public void resolveNestedSpringBootJar() {
+    final List<Dependency> result = DependencyResolver.resolve(NESTED_SPRING_BOOT_JAR_URI);
+    assert !result.isEmpty();
+  }
+}

--- a/telemetry/src/jmh/resources/logback.xml
+++ b/telemetry/src/jmh/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+      </Pattern>
+    </layout>
+  </appender>
+  <root level="ERROR">
+    <appender-ref ref="console" />
+  </root>
+  <logger name="datadog" level="error" />
+</configuration>


### PR DESCRIPTION
# What Does This Do
Add JMH benchmark for dependency resolution

# Motivation
Upcoming changes for nested JARs will have an impact here: https://github.com/DataDog/dd-trace-java/pull/6720

# Additional Notes

Current results in my machine:

```
Benchmark                                                Mode  Cnt    Score    Error   Units
DependencyResolverBenchmark.resolveNestedSpringBootJar  thrpt   25  306.740 ± 16.075  ops/ms
DependencyResolverBenchmark.resolveSimpleJar            thrpt   25   21.441 ±  1.665  ops/ms
```