### PR TITLE
Add support for precise tainting of byte array objects

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/FastCodecModule.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/FastCodecModule.java
@@ -1,5 +1,7 @@
 package com.datadog.iast.propagation;
 
+import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED;
+
 import datadog.trace.api.iast.propagation.CodecModule;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -14,8 +16,13 @@ public class FastCodecModule extends PropagationModuleImpl implements CodecModul
 
   @Override
   public void onStringFromBytes(
-      @Nonnull final byte[] value, @Nullable final String charset, @Nonnull final String result) {
-    taintIfTainted(result, value);
+      @Nonnull final byte[] value,
+      int offset,
+      int length,
+      @Nullable final String charset,
+      @Nonnull final String result) {
+    // create a new range shifted to the result string coordinates
+    taintIfTainted(result, value, offset, length, false, NOT_MARKED);
   }
 
   @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -514,7 +514,7 @@ public class PropagationModuleImpl implements PropagationModule {
           to.taint(value, ranges);
         } else {
           // append ranges
-          final Range[] newRanges = Ranges.insert(tainted.getRanges(), ranges);
+          final Range[] newRanges = Ranges.mergeRangesSorted(tainted.getRanges(), ranges);
           tainted.setRanges(newRanges);
         }
       }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -243,32 +243,32 @@ public final class Ranges {
     return new Range[size > MAX_RANGE_COUNT ? MAX_RANGE_COUNT : (int) size];
   }
 
-  /** Insert the new range maintaining order (it assumes that both arrays are already sorted) */
-  public static Range[] insert(final Range[] currentRanges, final Range... newRanges) {
-    if (newRanges.length == 0) {
-      return currentRanges;
+  /** Merge the new ranges maintaining order (it assumes that both arrays are already sorted) */
+  public static Range[] mergeRangesSorted(final Range[] leftRanges, final Range[] rightRanges) {
+    if (leftRanges.length == 0) {
+      return rightRanges;
     }
-    if (currentRanges.length == 0) {
-      return newRanges;
+    if (rightRanges.length == 0) {
+      return leftRanges;
     }
-    int newIndex = 0;
-    Range newRange = newRanges[0];
-    final Range[] result = new Range[newRanges.length + currentRanges.length];
-    for (int currentIndex = 0; currentIndex < currentRanges.length; currentIndex++) {
-      final Range current = currentRanges[currentIndex];
-      if (newRange == null) {
-        result[currentIndex + newRanges.length] = current;
+    int rightIndex = 0;
+    Range rightRange = rightRanges[0];
+    final Range[] result = new Range[rightRanges.length + leftRanges.length];
+    for (int leftIndex = 0; leftIndex < leftRanges.length; leftIndex++) {
+      final Range leftRange = leftRanges[leftIndex];
+      if (rightRange == null) {
+        result[leftIndex + rightRanges.length] = leftRange;
       } else {
-        if (newRange.getStart() < current.getStart()) {
-          result[currentIndex + newIndex] = newRange;
-          newIndex++;
-          newRange = newIndex >= newRanges.length ? null : newRanges[newIndex];
+        if (rightRange.getStart() < leftRange.getStart()) {
+          result[leftIndex + rightIndex] = rightRange;
+          rightIndex++;
+          rightRange = rightIndex >= rightRanges.length ? null : rightRanges[rightIndex];
         }
-        result[currentIndex + newIndex] = current;
+        result[leftIndex + rightIndex] = leftRange;
       }
     }
-    for (; newIndex < newRanges.length; newIndex++) {
-      result[currentRanges.length + newIndex] = newRanges[newIndex];
+    for (; rightIndex < rightRanges.length; rightIndex++) {
+      result[leftRanges.length + rightIndex] = rightRanges[rightIndex];
     }
     return result;
   }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/BaseCodecModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/BaseCodecModuleTest.groovy
@@ -11,7 +11,7 @@ import static com.datadog.iast.taint.TaintUtils.addFromTaintFormat
 @CompileDynamic
 abstract class BaseCodecModuleTest extends IastModuleImplTestBase {
 
-  private CodecModule module
+  protected CodecModule module
 
   def setup() {
     module = buildModule()
@@ -38,8 +38,8 @@ abstract class BaseCodecModuleTest extends IastModuleImplTestBase {
     'onUrlDecode'       | ['test', 'utf-8', '']
     'onStringGetBytes'  | ['test', 'utf-8', null]
     'onStringGetBytes'  | ['test', 'utf-8', [] as byte[]]
-    'onStringFromBytes' | ['test'.bytes, 'utf-8', null]
-    'onStringFromBytes' | ['test'.bytes, 'utf-8', '']
+    'onStringFromBytes' | ['test'.bytes, 0, 2, 'utf-8', null]
+    'onStringFromBytes' | ['test'.bytes, 0, 2, 'utf-8', '']
     'onBase64Encode'    | ['test'.bytes, null]
     'onBase64Encode'    | ['test'.bytes, [] as byte[]]
     'onBase64Decode'    | ['test'.bytes, null]
@@ -57,7 +57,7 @@ abstract class BaseCodecModuleTest extends IastModuleImplTestBase {
     method              | args
     'onUrlDecode'       | ['test', 'utf-8', 'decoded']
     'onStringGetBytes'  | ['test', 'utf-8', 'test'.getBytes('utf-8')]
-    'onStringFromBytes' | ['test'.getBytes('utf-8'), 'utf-8', 'test']
+    'onStringFromBytes' | ['test'.getBytes('utf-8'), 0, 2, 'utf-8', 'test']
     'onBase64Encode'    | ['test'.bytes, 'dGVzdA=='.bytes]
     'onBase64Decode'    | ['dGVzdA=='.bytes, 'test'.bytes]
   }
@@ -138,7 +138,7 @@ abstract class BaseCodecModuleTest extends IastModuleImplTestBase {
     final result = charset == null ? new String(bytes) : new String(bytes, (String) charset)
 
     when:
-    module.onStringFromBytes(bytes, charset, result)
+    module.onStringFromBytes(bytes, 0, bytes.length, charset, result)
 
     then:
     final to = taintedObjects.get(result)
@@ -146,7 +146,7 @@ abstract class BaseCodecModuleTest extends IastModuleImplTestBase {
       assert to != null
       assert to.get() == result
       final sourceTainted = taintedObjects.get(parsed)
-      assertOnStringFromBytes(bytes, charset, sourceTainted, to)
+      assertOnStringFromBytes(bytes, 0, bytes.length, charset, sourceTainted, to)
     } else {
       assert to == null
     }
@@ -239,7 +239,7 @@ abstract class BaseCodecModuleTest extends IastModuleImplTestBase {
 
   protected abstract void assertOnUrlDecode(final String value, final String encoding, final TaintedObject source, final TaintedObject target)
 
-  protected abstract void assertOnStringFromBytes(final byte[] value, final String encoding, final TaintedObject source, final TaintedObject target)
+  protected abstract void assertOnStringFromBytes(final byte[] value, final int offset, final int length, final String encoding, final TaintedObject source, final TaintedObject target)
 
   protected abstract void assertOnStringGetBytes(final String value, final String encoding, final TaintedObject source, final TaintedObject target)
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/RangesTest.groovy
@@ -311,16 +311,16 @@ class RangesTest extends DDSpecification {
     range(2, 4) | [range(6, 4)] | [] // [2, 3, 4, 5] | [6, 7, 8, 9] -> []
   }
 
-  void 'insert range'() {
+  void 'merge ranges keeping order'() {
     when:
-    final result = Ranges.insert(array as Range[], toInsert as Range[])
+    final result = Ranges.mergeRangesSorted(left as Range[], right as Range[])
 
     then:
     final expectedArray = expected as Range[]
     result == expectedArray
 
     where:
-    array                      | toInsert                   | expected
+    left                       | right                      | expected
     []                         | []                         | []
     []                         | [range(2, 2)]              | [range(2, 2)]
     [range(2, 2)]              | []                         | [range(2, 2)]

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ByteBufferTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ByteBufferTest.groovy
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.java.io
 
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.VulnerabilityMarks
 import datadog.trace.api.iast.propagation.PropagationModule
 import foo.bar.TestByteBufferSuite
 
@@ -24,6 +25,20 @@ class ByteBufferTest extends AgentTestRunner {
     TestByteBufferSuite.wrap(message)
 
     then:
-    1 * module.taintIfTainted(_ as ByteBuffer, message)
+    1 * module.taintIfTainted(_ as ByteBuffer, message, true, VulnerabilityMarks.NOT_MARKED)
+  }
+
+  void 'test array method'() {
+    given:
+    final message = ByteBuffer.wrap('Hello World!'.bytes)
+    final module = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(module)
+
+    when:
+    final result = TestByteBufferSuite.array(message)
+
+    then:
+    result == message.array()
+    1 * module.taintIfTainted(_ as byte[], message, true, VulnerabilityMarks.NOT_MARKED)
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestByteBufferSuite.java
+++ b/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestByteBufferSuite.java
@@ -7,4 +7,8 @@ public class TestByteBufferSuite {
   public static ByteBuffer wrap(final byte[] bytes) {
     return ByteBuffer.wrap(bytes);
   }
+
+  public static byte[] array(final ByteBuffer buffer) {
+    return buffer.array();
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -220,25 +220,80 @@ public class StringCallSite {
     return result;
   }
 
-  // TODO include other constructors with offsets
   @CallSite.After("void java.lang.String.<init>(byte[])")
-  @CallSite.After("void java.lang.String.<init>(byte[], java.lang.String)")
-  @CallSite.After("void java.lang.String.<init>(byte[], java.nio.charset.Charset)")
-  public static String afterByteArrayConstructor(
+  public static String afterByteArrayCtor(
       @CallSite.AllArguments @Nonnull final Object[] params,
       @CallSite.Return @Nonnull final String result) {
     final CodecModule module = InstrumentationBridge.CODEC;
     try {
       if (module != null) {
-        String charset = null;
-        if (params.length > 1) {
-          charset =
-              params[1] instanceof Charset ? ((Charset) params[1]).name() : (String) params[1];
+        final byte[] bytes = (byte[]) params[0];
+        if (bytes != null) {
+          module.onStringFromBytes(bytes, 0, bytes.length, null, result);
         }
-        module.onStringFromBytes((byte[]) params[0], charset, result);
       }
     } catch (final Throwable e) {
-      module.onUnexpectedException("afterByteArrayConstructor threw", e);
+      module.onUnexpectedException("afterByteArrayCtor threw", e);
+    }
+    return result;
+  }
+
+  @CallSite.After("void java.lang.String.<init>(byte[], java.lang.String)")
+  @CallSite.After("void java.lang.String.<init>(byte[], java.nio.charset.Charset)")
+  public static String afterByteArrayCtor2(
+      @CallSite.AllArguments @Nonnull final Object[] params,
+      @CallSite.Return @Nonnull final String result) {
+    final CodecModule module = InstrumentationBridge.CODEC;
+    try {
+      if (module != null) {
+        final byte[] bytes = (byte[]) params[0];
+        if (bytes != null) {
+          final String charset =
+              params[1] instanceof Charset ? ((Charset) params[1]).name() : (String) params[1];
+          module.onStringFromBytes(bytes, 0, bytes.length, charset, result);
+        }
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afterByteArrayCtor2 threw", e);
+    }
+    return result;
+  }
+
+  @CallSite.After("void java.lang.String.<init>(byte[], int, int)")
+  public static String afterByteArrayCtor3(
+      @CallSite.AllArguments @Nonnull final Object[] params,
+      @CallSite.Return @Nonnull final String result) {
+    final CodecModule module = InstrumentationBridge.CODEC;
+    try {
+      if (module != null) {
+        final byte[] bytes = (byte[]) params[0];
+        if (bytes != null) {
+          module.onStringFromBytes(bytes, (int) params[1], (int) params[2], null, result);
+        }
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afterByteArrayCtor3 threw", e);
+    }
+    return result;
+  }
+
+  @CallSite.After("void java.lang.String.<init>(byte[], int, int, java.lang.String)")
+  @CallSite.After("void java.lang.String.<init>(byte[], int, int, java.nio.charset.Charset)")
+  public static String afterByteArrayCtor4(
+      @CallSite.AllArguments @Nonnull final Object[] params,
+      @CallSite.Return @Nonnull final String result) {
+    final CodecModule module = InstrumentationBridge.CODEC;
+    try {
+      if (module != null) {
+        final byte[] bytes = (byte[]) params[0];
+        if (bytes != null) {
+          final String charset =
+              params[3] instanceof Charset ? ((Charset) params[3]).name() : (String) params[3];
+          module.onStringFromBytes(bytes, (int) params[1], (int) params[2], charset, result);
+        }
+      }
+    } catch (final Throwable e) {
+      module.onUnexpectedException("afterByteArrayCtor4 threw", e);
     }
     return result;
   }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
@@ -99,6 +99,13 @@ public class TestStringSuite {
     return result;
   }
 
+  public static String stringConstructor(final byte[] value, final int offset, final int length) {
+    LOGGER.debug("Before string stringConstructor {} {} {}", value, offset, length);
+    final String result = new String(value, offset, length);
+    LOGGER.debug("After string stringConstructor {}", result);
+    return result;
+  }
+
   public static String stringConstructor(final byte[] value, final String charset)
       throws UnsupportedEncodingException {
     LOGGER.debug("Before string stringConstructor {} {}", value, charset);
@@ -107,9 +114,26 @@ public class TestStringSuite {
     return result;
   }
 
+  public static String stringConstructor(
+      final byte[] value, final int offset, final int length, final String charset)
+      throws UnsupportedEncodingException {
+    LOGGER.debug("Before string stringConstructor {} {} {} {}", value, offset, length, charset);
+    final String result = new String(value, offset, length, charset);
+    LOGGER.debug("After string stringConstructor {}", result);
+    return result;
+  }
+
   public static String stringConstructor(final byte[] value, final Charset charset) {
     LOGGER.debug("Before string stringConstructor {} {}", value, charset);
     final String result = new String(value, charset);
+    LOGGER.debug("After string stringConstructor {}", result);
+    return result;
+  }
+
+  public static String stringConstructor(
+      final byte[] value, final int offset, final int length, final Charset charset) {
+    LOGGER.debug("Before string stringConstructor {} {} {} {}", value, offset, length, charset);
+    final String result = new String(value, offset, length, charset);
     LOGGER.debug("After string stringConstructor {}", result);
     return result;
   }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/CodecModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/CodecModule.java
@@ -8,7 +8,12 @@ public interface CodecModule extends IastModule {
 
   void onUrlDecode(@Nonnull String value, @Nullable String encoding, @Nonnull String result);
 
-  void onStringFromBytes(@Nonnull byte[] value, @Nullable String charset, @Nonnull String result);
+  void onStringFromBytes(
+      @Nonnull byte[] value,
+      int offset,
+      int length,
+      @Nullable String charset,
+      @Nonnull String result);
 
   void onStringGetBytes(@Nonnull String value, @Nullable String charset, @Nonnull byte[] result);
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -19,6 +19,18 @@ public interface PropagationModule extends IastModule {
    */
   void taint(@Nullable IastContext ctx, @Nullable Object target, byte origin);
 
+  /** @see #taint(IastContext, Object, byte, int, int) */
+  void taint(@Nullable Object target, byte origin, int start, int length);
+
+  /**
+   * Taints the object with a source with the selected origin, range and no name. If target is a
+   * char sequence it will be used as value.
+   *
+   * <p>If the value is already tainted this method will append a new range.
+   */
+  void taint(
+      @Nullable IastContext ctx, @Nullable Object target, byte origin, int start, int length);
+
   /** @see #taint(IastContext, Object, byte, CharSequence) */
   void taint(@Nullable Object target, byte origin, @Nullable CharSequence name);
 
@@ -49,6 +61,33 @@ public interface PropagationModule extends IastModule {
    * priority source of the input to taint the object.
    */
   void taintIfTainted(@Nullable IastContext ctx, @Nullable Object target, @Nullable Object input);
+
+  /** @see #taintIfTainted(IastContext, Object, Object, int, int, boolean, int) */
+  void taintIfTainted(
+      @Nullable Object target,
+      @Nullable Object input,
+      int start,
+      int length,
+      boolean keepRanges,
+      int mark);
+
+  /**
+   * Taints the object only if the input value has a tainted range that intersects with the
+   * specified range. It will try to reuse sources from the input value according to:
+   *
+   * <ul>
+   *   <li>keepRanges=true will reuse the ranges from the intersection and mark them
+   *   <li>keepRanges=false will use the highest priority source from the intersection and mark it
+   * </ul>
+   */
+  void taintIfTainted(
+      @Nullable IastContext ctx,
+      @Nullable Object target,
+      @Nullable Object input,
+      int start,
+      int length,
+      boolean keepRanges,
+      int mark);
 
   /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
   void taintIfTainted(


### PR DESCRIPTION
# What Does This Do
Adds support for accurate tainting of byte array instances.

# Motivation
We need to keep track of multiple ranges in order to add proper support for Kafka 3.x as they use byte buffers extensively.

