### PR TITLE
Revert "Decrease default WAF timeout to 5ms (#6733)"

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -97,7 +97,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_APPSEC_REPORTING_INBAND = false;
   static final int DEFAULT_APPSEC_TRACE_RATE_LIMIT = 100;
   static final boolean DEFAULT_APPSEC_WAF_METRICS = true;
-  static final int DEFAULT_APPSEC_WAF_TIMEOUT = 5000; // 1ms
+  static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
   static final boolean DEFAULT_API_SECURITY_ENABLED = false;
   static final float DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE = 0.1f; // 10 %
 


### PR DESCRIPTION
# What Does This Do
Revert "Decrease default WAF timeout to 5ms (#6733)"

This reverts commit b2a77cb772acebce465f859556d1461607127806.

# Motivation

So many tests started failing in master per new timeouts.

# Additional Notes
