### PR TITLE
Support context propagation over selected Axis2 transport senders

### DIFF
--- a/dd-java-agent/instrumentation/axis-2/build.gradle
+++ b/dd-java-agent/instrumentation/axis-2/build.gradle
@@ -9,6 +9,7 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
+addTestSuiteForDir('latestDepForkedTest', 'test')
 configurations.all {
   // the version used by axis2 isn't available in a public repository - we don't need it, so exclude it
   exclude group: 'org.apache.woden', module: 'woden'

--- a/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisMessageDecorator.java
+++ b/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisMessageDecorator.java
@@ -1,13 +1,20 @@
 package datadog.trace.instrumentation.axis2;
 
+import static datadog.trace.api.Functions.UTF8_ENCODE;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
 import static datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes.SOAP;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import java.net.URI;
+import org.apache.axis2.addressing.EndpointReference;
 import org.apache.axis2.context.MessageContext;
 
 public class AxisMessageDecorator extends BaseDecorator {
@@ -15,7 +22,12 @@ public class AxisMessageDecorator extends BaseDecorator {
 
   public static final CharSequence AXIS2 = UTF8BytesString.create("axis2");
   public static final CharSequence AXIS2_MESSAGE = UTF8BytesString.create("axis2.message");
+  public static final CharSequence AXIS2_TRANSPORT = UTF8BytesString.create("axis2.transport");
   public static final String AXIS2_CONTINUATION_KEY = "dd.trace.axis2.continuation";
+  public static final String AXIS2_ASYNC_SPAN_KEY = "dd.trace.axis2.asyncSpan";
+
+  private static final DDCache<String, UTF8BytesString> SOAP_ACTIONS =
+      DDCaches.newFixedSizeCache(32);
 
   private AxisMessageDecorator() {}
 
@@ -47,7 +59,7 @@ public class AxisMessageDecorator extends BaseDecorator {
   }
 
   public void onMessage(final AgentSpan span, final MessageContext message) {
-    final CharSequence soapAction = UTF8BytesString.create(soapAction(message));
+    final CharSequence soapAction = SOAP_ACTIONS.computeIfAbsent(soapAction(message), UTF8_ENCODE);
     span.setResourceName(soapAction);
     if (message.isServerSide() && Config.get().isAxisPromoteResourceName()) {
       final AgentSpan localRoot = span.getLocalRootSpan();
@@ -84,5 +96,34 @@ public class AxisMessageDecorator extends BaseDecorator {
   @Override
   public AgentSpan afterStart(AgentSpan span) {
     return super.afterStart(span).setMeasured(true);
+  }
+
+  public void onTransport(AgentSpan span, MessageContext message) {
+    // mark axis2.transport spans as client spans
+    span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT);
+    String toAddress;
+    EndpointReference to = message.getTo();
+    if (null != to && !to.hasAnonymousAddress() && !to.hasNoneAddress()) {
+      toAddress = to.getAddress();
+    } else {
+      toAddress = (String) message.getProperty("TransportURL");
+    }
+    if (null != toAddress) {
+      URI uri = URIUtils.safeParse(toAddress);
+      if (null != uri) {
+        // same tag logic as UriBasedClientDecorator.onURI
+        String host = uri.getHost();
+        int port = uri.getPort();
+        if (null != host && !host.isEmpty()) {
+          span.setTag(Tags.PEER_HOSTNAME, host);
+          if (Config.get().isHttpClientSplitByDomain() && host.charAt(0) >= 'A') {
+            span.setServiceName(host);
+          }
+          if (port > 0) {
+            setPeerPort(span, port);
+          }
+        }
+      }
+    }
   }
 }

--- a/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisTransportInstrumentation.java
+++ b/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/AxisTransportInstrumentation.java
@@ -1,0 +1,115 @@
+package datadog.trace.instrumentation.axis2;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.propagate;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.axis2.AxisMessageDecorator.AXIS2_ASYNC_SPAN_KEY;
+import static datadog.trace.instrumentation.axis2.AxisMessageDecorator.AXIS2_TRANSPORT;
+import static datadog.trace.instrumentation.axis2.AxisMessageDecorator.DECORATE;
+import static datadog.trace.instrumentation.axis2.TextMapInjectAdapter.SETTER;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.asm.Advice;
+import org.apache.axis2.context.MessageContext;
+
+@AutoService(Instrumenter.class)
+public final class AxisTransportInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForKnownTypes, Instrumenter.ForConfiguredType {
+
+  public AxisTransportInstrumentation() {
+    super("axis2", "axis2-transport");
+  }
+
+  @Override
+  public String[] knownMatchingTypes() {
+    return new String[] {"com.ibm.ws.websvcs.transport.http.HTTPTransportSender"};
+  }
+
+  @Override
+  public String configuredMatchingType() {
+    // this won't match any class unless the property is set
+    return InstrumenterConfig.get().getAxisTransportClassName();
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".AxisMessageDecorator", packageName + ".TextMapInjectAdapter",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("invoke"))
+            .and(takesArgument(0, named("org.apache.axis2.context.MessageContext"))),
+        getClass().getName() + "$TransportAdvice");
+  }
+
+  public static final class TransportAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static AgentScope beginTransport(@Advice.Argument(0) final MessageContext message) {
+      // only create a span if the message has a clear action and there's a surrounding request
+      if (DECORATE.shouldTrace(message)) {
+        AgentSpan span = startSpan(AXIS2_TRANSPORT);
+        DECORATE.afterStart(span);
+        DECORATE.onTransport(span, message);
+        DECORATE.onMessage(span, message);
+
+        // the transport handler will copy TRANSPORT_HEADERS to the outgoing request
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        Map<String, Object> headers = (Map) message.getProperty("TRANSPORT_HEADERS");
+        if (null == headers) {
+          headers = new HashMap<>();
+          message.setProperty("TRANSPORT_HEADERS", headers);
+        }
+        try {
+          propagate().inject(span, headers, SETTER);
+        } catch (Throwable ignore) {
+        }
+
+        return activateSpan(span);
+      }
+      return null;
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    public static void finishTransport(
+        @Advice.Enter final AgentScope scope,
+        @Advice.Argument(0) final MessageContext message,
+        @Advice.Thrown final Throwable error) {
+      if (null == scope) {
+        return;
+      }
+
+      AgentSpan span = scope.span();
+      if (null != error) {
+        // cancel async tracking when we know there's an error
+        message.removePropertyNonReplicable(AXIS2_ASYNC_SPAN_KEY);
+        DECORATE.onError(span, error);
+      }
+      scope.close();
+      if (span.equals(message.getPropertyNonReplicable(AXIS2_ASYNC_SPAN_KEY))) {
+        // delay finishing span until async callback completes...
+      } else {
+        Object statusCode = message.getProperty("transport.http.statusCode");
+        if (statusCode instanceof Integer) {
+          span.setHttpStatusCode((Integer) statusCode);
+        }
+        DECORATE.beforeFinish(span, message);
+        span.finish();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/TextMapInjectAdapter.java
@@ -1,0 +1,13 @@
+package datadog.trace.instrumentation.axis2;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import java.util.Map;
+
+public class TextMapInjectAdapter implements AgentPropagation.Setter<Map<String, Object>> {
+  public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
+
+  @Override
+  public void set(Map<String, Object> carrier, String key, String value) {
+    carrier.put(key, value);
+  }
+}

--- a/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/WebSphereAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/axis-2/src/main/java/datadog/trace/instrumentation/axis2/WebSphereAsyncInstrumentation.java
@@ -1,0 +1,70 @@
+package datadog.trace.instrumentation.axis2;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static datadog.trace.instrumentation.axis2.AxisMessageDecorator.AXIS2_ASYNC_SPAN_KEY;
+import static datadog.trace.instrumentation.axis2.AxisMessageDecorator.AXIS2_TRANSPORT;
+import static datadog.trace.instrumentation.axis2.AxisMessageDecorator.DECORATE;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+import org.apache.axis2.context.MessageContext;
+
+@AutoService(Instrumenter.class)
+public final class WebSphereAsyncInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForSingleType {
+
+  public WebSphereAsyncInstrumentation() {
+    super("axis2", "axis2-transport");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.ibm.ws.websvcs.transport.http.SOAPOverHTTPSender";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {packageName + ".AxisMessageDecorator"};
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        isMethod().and(named("sendSOAPRequestAsync")),
+        getClass().getName() + "$CaptureAsyncAdvice");
+    transformer.applyAdvice(
+        isMethod().and(named("releaseBuffer")), getClass().getName() + "$ReleaseAsyncAdvice");
+  }
+
+  public static final class CaptureAsyncAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void beginAsync(@Advice.Argument(0) final MessageContext message) {
+      AgentSpan span = activeSpan();
+      if (null != span && AXIS2_TRANSPORT.equals(span.getSpanName())) {
+        message.setNonReplicableProperty(AXIS2_ASYNC_SPAN_KEY, span);
+      }
+    }
+  }
+
+  public static final class ReleaseAsyncAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void finishAsync(@Advice.FieldValue("msgContext") final MessageContext message) {
+      AgentSpan span = (AgentSpan) message.getPropertyNonReplicable(AXIS2_ASYNC_SPAN_KEY);
+      if (null != span) {
+        message.removePropertyNonReplicable(AXIS2_ASYNC_SPAN_KEY);
+        // same as AxisTransportInstrumentation.TransportAdvice.finishTransport
+        Object statusCode = message.getProperty("transport.http.statusCode");
+        if (statusCode instanceof Integer) {
+          span.setHttpStatusCode((Integer) statusCode);
+        }
+        DECORATE.beforeFinish(span, message);
+        span.finish();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/axis-2/src/test/groovy/datadog/trace/instrumentation/axis2/AxisEngineTest.groovy
+++ b/dd-java-agent/instrumentation/axis-2/src/test/groovy/datadog/trace/instrumentation/axis2/AxisEngineTest.groovy
@@ -25,6 +25,7 @@ import org.apache.axis2.transport.http.SimpleHTTPServer
 import org.apache.axis2.transport.local.LocalTransportReceiver
 import org.apache.axis2.transport.local.LocalTransportSender
 import spock.lang.Shared
+import test.TestService
 
 import javax.xml.namespace.QName
 

--- a/dd-java-agent/instrumentation/axis-2/src/test/groovy/datadog/trace/instrumentation/axis2/AxisTransportForkedTest.groovy
+++ b/dd-java-agent/instrumentation/axis-2/src/test/groovy/datadog/trace/instrumentation/axis2/AxisTransportForkedTest.groovy
@@ -1,0 +1,204 @@
+package datadog.trace.instrumentation.axis2
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.asserts.TraceAssert
+import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.config.TraceInstrumentationConfig
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
+import org.apache.axiom.soap.SOAPFactory
+import org.apache.axis2.addressing.EndpointReference
+import org.apache.axis2.context.ConfigurationContext
+import org.apache.axis2.description.AxisService
+import org.apache.axis2.description.TransportOutDescription
+import org.apache.axis2.engine.AxisConfiguration
+import org.apache.axis2.engine.AxisEngine
+import org.apache.axis2.receivers.RawXMLINOnlyMessageReceiver
+import org.apache.axis2.receivers.RawXMLINOutMessageReceiver
+import spock.lang.Shared
+import test.TestSender
+import test.TestService
+
+import javax.xml.namespace.QName
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
+import static org.apache.axiom.om.OMAbstractFactory.getSOAP11Factory
+import static org.apache.axis2.Constants.SERVICE_CLASS
+import static org.apache.axis2.context.ConfigurationContextFactory.createConfigurationContextFromFileSystem
+import static org.apache.axis2.deployment.util.Utils.fillAxisService
+import static org.apache.axis2.description.WSDL2Constants.MEP_URI_IN_ONLY
+import static org.apache.axis2.description.WSDL2Constants.MEP_URI_IN_OUT
+import static org.apache.axis2.description.WSDL2Constants.MEP_URI_ROBUST_IN_ONLY
+
+class AxisTransportForkedTest extends AgentTestRunner {
+
+  @Shared
+  SOAPFactory soapFactory = getSOAP11Factory()
+
+  @Shared
+  ConfigurationContext serverContext
+
+  @Shared
+  AxisConfiguration serverConfig
+
+  @Shared
+  TransportOutDescription transportOut
+
+  @Shared
+  AxisService testService
+
+  @Override
+  void configurePreAgent() {
+    super.configurePreAgent()
+
+    injectSysConfig(TraceInstrumentationConfig.AXIS_TRANSPORT_CLASS_NAME, 'test.TestSender')
+  }
+
+  def setupSpec() throws Exception {
+    serverContext = createConfigurationContextFromFileSystem(null)
+    serverConfig = serverContext.getAxisConfiguration()
+
+    transportOut = new TransportOutDescription('SOAPOverHTTP')
+    transportOut.setSender(new TestSender())
+    serverConfig.addTransportOut(transportOut)
+
+    // add message receivers for some standard flows
+    serverConfig.addMessageReceiver(MEP_URI_IN_ONLY, new RawXMLINOnlyMessageReceiver())
+    serverConfig.addMessageReceiver(MEP_URI_IN_OUT, new RawXMLINOutMessageReceiver())
+    serverConfig.addMessageReceiver(MEP_URI_ROBUST_IN_ONLY, new RawXMLINOutMessageReceiver())
+
+    // register our simple test service
+    testService = new AxisService('TestService')
+    testService.addParameter(SERVICE_CLASS, TestService.name)
+    fillAxisService(testService, serverConfig, null, null)
+    serverConfig.addService(testService)
+  }
+
+  def "test context propagated to transport headers"() {
+    when:
+    def message1 = testMessage()
+    message1.setSoapAction('testAction')
+    message1.setProperty("TRANSPORT_HEADERS", ["foo":"bar"] as HashMap)
+    def message2 = testMessage()
+    // no action, expect span to use testDestination
+    AgentSpan span0 = startSpan('test')
+    span0.setServiceName('testSpan')
+    activateSpan(span0).withCloseable {
+      AxisEngine.send(message1)
+      AxisEngine.send(message2)
+    }
+    span0.finish()
+
+    then:
+    assertTraces(1) {
+      trace(5) {
+        testSpan(it, 0)
+        axisSpan(it, 1, 'http://my-host:8080/TestService/testAction', span(0))
+        transportSpan(it, 2, 'http://my-host:8080/TestService/testAction', span(1))
+        axisSpan(it, 3, 'testAction', span(0))
+        transportSpan(it, 4, 'testAction', span(3))
+      }
+    }
+  }
+
+  def testMessage() {
+    def message = serverContext.createMessageContext()
+
+    // create a simple message for our test service
+    message.setTo(new EndpointReference('http://my-host:8080/TestService/testAction'))
+    message.setFaultTo(new EndpointReference('http://my-host:8080/TestService/testFault'))
+    message.setEnvelope(soapFactory.getDefaultEnvelope())
+    message.setTransportOut(transportOut)
+
+    // create an operation context (normally the transport layer would do this)
+    def operationContext = serverContext
+      .createServiceGroupContext(testService.getAxisServiceGroup())
+      .getServiceContext(testService)
+      .createOperationContext(new QName('testAction'))
+    message.setOperationContext(operationContext)
+
+    return message
+  }
+
+  def testSpan(TraceAssert trace, int index, Object parentSpan = null) {
+    trace.span {
+      serviceName "testSpan"
+      operationName "test"
+      if (parentSpan == null) {
+        parent()
+      } else {
+        childOf((DDSpan) parentSpan)
+      }
+      topLevel parentSpan == null
+      tags {
+        defaultTags()
+      }
+    }
+  }
+
+  def axisSpan(TraceAssert trace, int index, String soapAction, Object parentSpan, Object error = null) {
+    trace.span {
+      serviceName "testSpan"
+      operationName "axis2.message"
+      resourceName soapAction
+      spanType DDSpanTypes.SOAP
+      errored error != null
+      measured true
+      if (parentSpan == null) {
+        parent()
+      } else {
+        childOf((DDSpan) parentSpan)
+      }
+      topLevel parentSpan == null
+      tags {
+        if (error instanceof Exception) {
+          "error.message" error.message
+          "error.type" { it == error.class.name }
+          "error.stack" String
+        }
+        "$Tags.COMPONENT" "axis2"
+        defaultTags()
+      }
+    }
+  }
+
+  def axisSpanWithError(TraceAssert trace, int index, String soapAction, Object parentSpan) {
+    axisSpan(trace, index, soapAction, parentSpan, true)
+  }
+
+  def axisSpanWithException(TraceAssert trace, int index, String soapAction, Object parentSpan, Exception error) {
+    axisSpan(trace, index, soapAction, parentSpan, error)
+  }
+
+  def transportSpan(TraceAssert trace, int index, String soapAction, Object parentSpan, Object error = null) {
+    trace.span {
+      serviceName "testSpan"
+      operationName "axis2.transport"
+      resourceName soapAction
+      spanType DDSpanTypes.SOAP
+      errored error != null
+      measured true
+      if (parentSpan == null) {
+        parent()
+      } else {
+        childOf((DDSpan) parentSpan)
+      }
+      topLevel parentSpan == null
+      tags {
+        if (error instanceof Exception) {
+          "error.message" error.message
+          "error.type" { it == error.class.name }
+          "error.stack" String
+        }
+        "$Tags.COMPONENT" "axis2"
+        "$Tags.SPAN_KIND" "client"
+        "$Tags.HTTP_STATUS" 200
+        "$Tags.PEER_HOSTNAME" "my-host"
+        "$Tags.PEER_PORT" 8080
+        defaultTags()
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/axis-2/src/test/java/test/TestSender.java
+++ b/dd-java-agent/instrumentation/axis-2/src/test/java/test/TestSender.java
@@ -1,0 +1,38 @@
+package test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.axis2.context.MessageContext;
+import org.apache.axis2.transport.local.LocalTransportSender;
+
+/** Test sender that checks the outgoing TRANSPORT_HEADERS have the expected propagation headers. */
+public class TestSender extends LocalTransportSender {
+  private static final Set<String> EXPECTED_HEADERS =
+      new HashSet<>(
+          Arrays.asList(
+              "x-datadog-trace-id",
+              "x-datadog-parent-id",
+              "x-datadog-sampling-priority",
+              "x-datadog-tags",
+              "traceparent",
+              "tracestate"));
+
+  @Override
+  public InvocationResponse invoke(MessageContext messageContext) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> headers =
+        (Map<String, Object>) messageContext.getProperty("TRANSPORT_HEADERS");
+    if (null == headers) {
+      throw new RuntimeException("Missing TRANSPORT_HEADERS");
+    }
+    Set<String> missing = new HashSet<>(EXPECTED_HEADERS);
+    missing.removeAll(headers.keySet());
+    if (!missing.isEmpty()) {
+      throw new RuntimeException("Missing propagation headers: " + missing);
+    }
+    messageContext.setProperty("transport.http.statusCode", 200);
+    return InvocationResponse.CONTINUE;
+  }
+}

--- a/dd-java-agent/instrumentation/axis-2/src/test/java/test/TestService.java
+++ b/dd-java-agent/instrumentation/axis-2/src/test/java/test/TestService.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.axis2;
+package test;
 
 import org.apache.axiom.om.OMElement;
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -61,6 +61,8 @@ public final class TraceInstrumentationConfig {
   public static final String HTTP_URL_CONNECTION_CLASS_NAME =
       "trace.http.url.connection.class.name";
 
+  public static final String AXIS_TRANSPORT_CLASS_NAME = "trace.axis.transport.class.name";
+
   public static final String RUNTIME_CONTEXT_FIELD_INJECTION =
       "trace.runtime.context.field.injection";
   public static final String SERIALVERSIONUID_FIELD_INJECTION =

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -26,6 +26,7 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATI
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_ENABLED_DEFAULT;
+import static datadog.trace.api.config.TraceInstrumentationConfig.AXIS_TRANSPORT_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_URL_CONNECTION_CLASS_NAME;
 import static datadog.trace.api.config.TraceInstrumentationConfig.INTEGRATIONS_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.JAX_RS_ADDITIONAL_ANNOTATIONS;
@@ -106,6 +107,7 @@ public class InstrumenterConfig {
   private final String jdbcConnectionClassName;
 
   private final String httpURLConnectionClassName;
+  private final String axisTransportClassName;
 
   private final boolean directAllocationProfilingEnabled;
 
@@ -183,6 +185,7 @@ public class InstrumenterConfig {
     jdbcConnectionClassName = configProvider.getString(JDBC_CONNECTION_CLASS_NAME, "");
 
     httpURLConnectionClassName = configProvider.getString(HTTP_URL_CONNECTION_CLASS_NAME, "");
+    axisTransportClassName = configProvider.getString(AXIS_TRANSPORT_CLASS_NAME, "");
 
     directAllocationProfilingEnabled =
         configProvider.getBoolean(
@@ -304,6 +307,10 @@ public class InstrumenterConfig {
 
   public String getHttpURLConnectionClassName() {
     return httpURLConnectionClassName;
+  }
+
+  public String getAxisTransportClassName() {
+    return axisTransportClassName;
   }
 
   public boolean isDirectAllocationProfilingEnabled() {
@@ -473,6 +480,9 @@ public class InstrumenterConfig {
         + '\''
         + ", httpURLConnectionClassName='"
         + httpURLConnectionClassName
+        + '\''
+        + ", axisTransportClassName='"
+        + axisTransportClassName
         + '\''
         + ", excludedClasses="
         + excludedClasses


### PR DESCRIPTION
# What Does This Do

Adds `axis2.transport` spans around calls to selected Axis2 transport senders, currently:
```
com.ibm.ws.websvcs.transport.http.HTTPTransportSender
```
and injects the current trace context into the outgoing `TRANSPORT_HEADERS`.

Also provides a configuration option to do the same for an arbitrary transport sender, for test / triage purposes:
```
-Ddd.trace.axis.transport.class.name=<sender.class.name>
```
```
DD_TRACE_AXIS_TRANSPORT_CLASS_NAME=<sender.class.name>
```

Asynchronous WebSphere JAX-WS requests are handled by storing the `axis2.transport` span created by the transport sender instrumentation in the message context being processed and closing out that span once the response has been processed, when the async resources are released - or earlier in the case of an error. This approach lets us keep the transport sender instrumentation generic.

# Motivation

Supports context propagation for distributed Axis2 messages in WebSphere, which uses its own toolkit of HTTP components to build its JAX-WS transport. Given the nature of that code it is less brittle to do the propagation at the Axis2 transport layer rather than attempt to cover all the ways the underlying IBM HTTP components can be combined.

# Additional Notes

I also introduced a cache to re-use SOAP names previously converted to `UTF8BytesString` to reduce allocations.

Jira ticket: [APMS-11517]


[APMS-11517]: https://datadoghq.atlassian.net/browse/APMS-11517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ