### PR TITLE
Implement telemetry for early flakiness detection

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -12,6 +12,7 @@ import datadog.trace.api.civisibility.coverage.CoverageProbeStore;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.tag.EventType;
+import datadog.trace.api.civisibility.telemetry.tag.IsNew;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -223,7 +224,12 @@ public class TestImpl implements DDTest {
       span.finish();
     }
 
-    metricCollector.add(CiVisibilityCountMetric.EVENT_FINISHED, 1, instrumentation, EventType.TEST);
+    metricCollector.add(
+        CiVisibilityCountMetric.EVENT_FINISHED,
+        1,
+        instrumentation,
+        EventType.TEST,
+        span.getTag(Tags.TEST_IS_NEW) != null ? IsNew.TRUE : null);
   }
 
   /**

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
@@ -2,6 +2,7 @@ package datadog.trace.civisibility.domain.buildsystem;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.civisibility.CIConstants;
 import datadog.trace.api.civisibility.events.BuildEventsHandler;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -129,7 +130,7 @@ public class BuildSystemModuleImpl extends AbstractTestModule implements BuildSy
     if (result.isEarlyFlakeDetectionEnabled()) {
       setTag(Tags.TEST_EARLY_FLAKE_ENABLED, true);
       if (result.isEarlyFlakeDetectionFaulty()) {
-        setTag(Tags.TEST_EARLY_FLAKE_ABORT_REASON, "faulty");
+        setTag(Tags.TEST_EARLY_FLAKE_ABORT_REASON, CIConstants.EFD_ABORT_REASON_FAULTY);
       }
     }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
@@ -2,6 +2,7 @@ package datadog.trace.civisibility.domain.headless;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.civisibility.CIConstants;
 import datadog.trace.api.civisibility.config.EarlyFlakeDetectionSettings;
 import datadog.trace.api.civisibility.config.ModuleExecutionSettings;
 import datadog.trace.api.civisibility.config.TestIdentifier;
@@ -156,7 +157,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
     if (earlyFlakeDetectionSettings.isEnabled()) {
       setTag(Tags.TEST_EARLY_FLAKE_ENABLED, true);
       if (earlyFlakeDetectionLimitReached(earlyFlakeDetectionsUsed.get())) {
-        setTag(Tags.TEST_EARLY_FLAKE_ABORT_REASON, "faulty");
+        setTag(Tags.TEST_EARLY_FLAKE_ABORT_REASON, CIConstants.EFD_ABORT_REASON_FAULTY);
       }
     }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
@@ -2,8 +2,11 @@ package datadog.trace.civisibility.domain.headless;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.civisibility.CIConstants;
 import datadog.trace.api.civisibility.config.ModuleExecutionSettings;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.api.civisibility.telemetry.TagValue;
+import datadog.trace.api.civisibility.telemetry.tag.EarlyFlakeDetectionAbortReason;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.InstrumentationType;
@@ -15,6 +18,8 @@ import datadog.trace.civisibility.domain.TestFrameworkSession;
 import datadog.trace.civisibility.source.MethodLinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.utils.SpanUtils;
+import java.util.Collection;
+import java.util.Collections;
 import javax.annotation.Nullable;
 
 /**
@@ -85,5 +90,14 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
         Tags.TEST_EARLY_FLAKE_ENABLED,
         Tags.TEST_EARLY_FLAKE_ABORT_REASON,
         DDTags.CI_ITR_TESTS_SKIPPED);
+  }
+
+  @Override
+  protected Collection<TagValue> additionalTelemetryTags() {
+    if (CIConstants.EFD_ABORT_REASON_FAULTY.equals(
+        span.getTag(Tags.TEST_EARLY_FLAKE_ABORT_REASON))) {
+      return Collections.singleton(EarlyFlakeDetectionAbortReason.FAULTY);
+    }
+    return Collections.emptySet();
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/CIConstants.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/CIConstants.java
@@ -4,4 +4,10 @@ public interface CIConstants {
   String TEST_PASS = "pass";
   String TEST_FAIL = "fail";
   String TEST_SKIP = "skip";
+
+  /**
+   * Indicates that early flakiness detection feature was aborted in a test session because too many
+   * test cases were considered new.
+   */
+  String EFD_ABORT_REASON_FAULTY = "faulty";
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
@@ -3,6 +3,8 @@ package datadog.trace.api.civisibility.telemetry;
 import datadog.trace.api.civisibility.telemetry.tag.Command;
 import datadog.trace.api.civisibility.telemetry.tag.CoverageEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.CoverageErrorType;
+import datadog.trace.api.civisibility.telemetry.tag.EarlyFlakeDetectionAbortReason;
+import datadog.trace.api.civisibility.telemetry.tag.EarlyFlakeDetectionEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.Endpoint;
 import datadog.trace.api.civisibility.telemetry.tag.ErrorType;
 import datadog.trace.api.civisibility.telemetry.tag.EventType;
@@ -10,6 +12,7 @@ import datadog.trace.api.civisibility.telemetry.tag.ExitCode;
 import datadog.trace.api.civisibility.telemetry.tag.HasCodeowner;
 import datadog.trace.api.civisibility.telemetry.tag.IsBenchmark;
 import datadog.trace.api.civisibility.telemetry.tag.IsHeadless;
+import datadog.trace.api.civisibility.telemetry.tag.IsNew;
 import datadog.trace.api.civisibility.telemetry.tag.IsUnsupportedCI;
 import datadog.trace.api.civisibility.telemetry.tag.ItrEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.ItrSkipEnabled;
@@ -37,7 +40,9 @@ public enum CiVisibilityCountMetric {
       IsHeadless.class,
       HasCodeowner.class,
       IsUnsupportedCI.class,
-      IsBenchmark.class),
+      IsBenchmark.class,
+      EarlyFlakeDetectionAbortReason.class,
+      IsNew.class),
   /**
    * The number of per-test code coverage sessions started (each test case counts as a separate
    * session)
@@ -86,6 +91,7 @@ public enum CiVisibilityCountMetric {
       ItrEnabled.class,
       ItrSkipEnabled.class,
       CoverageEnabled.class,
+      EarlyFlakeDetectionEnabled.class,
       RequireGit.class),
   /** The number of requests sent to the itr skippable tests endpoint */
   ITR_SKIPPABLE_TESTS_REQUEST("itr_skippable_tests.request"),
@@ -101,7 +107,11 @@ public enum CiVisibilityCountMetric {
    * The number of tests or test suites that would've been skipped by ITR but were forced to run
    * because of their unskippable status
    */
-  ITR_FORCED_RUN("itr_forced_run", EventType.class);
+  ITR_FORCED_RUN("itr_forced_run", EventType.class),
+  /** The number of requests sent to the known tests endpoint */
+  EFD_REQUEST("early_flake_detection.request"),
+  /** The number of known tests requests sent to the endpoint that errored */
+  EFD_REQUEST_ERRORS("early_flake_detection.request_errors", ErrorType.class);
 
   // need a "holder" class, as accessing static fields from enum constructors is illegal
   static class IndexHolder {

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
@@ -36,7 +36,13 @@ public enum CiVisibilityDistributionMetric {
   /** The number of bytes received by the skippable tests endpoint */
   ITR_SKIPPABLE_TESTS_RESPONSE_BYTES("itr_skippable_tests.response_bytes"),
   /** The number of files covered inside a coverage payload */
-  CODE_COVERAGE_FILES("code_coverage.files");
+  CODE_COVERAGE_FILES("code_coverage.files"),
+  /* The time it takes to get the response of the known tests endpoint request in ms */
+  EFD_REQUEST_MS("early_flake_detection.request_ms"),
+  /** The number of bytes received by the known tests endpoint */
+  EFD_RESPONSE_BYTES("early_flake_detection.response_bytes"),
+  /** The number of tests received by the known tests endpoint */
+  EFD_RESPONSE_TESTS("early_flake_detection.response_tests");
 
   private static final String NAMESPACE = "civisibility";
 

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/EarlyFlakeDetectionAbortReason.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/EarlyFlakeDetectionAbortReason.java
@@ -1,0 +1,19 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+public enum EarlyFlakeDetectionAbortReason implements TagValue {
+  FAULTY,
+  SLOW;
+
+  private final String s;
+
+  EarlyFlakeDetectionAbortReason() {
+    s = "early_flake_detection_abort_reason:" + name().toLowerCase();
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/EarlyFlakeDetectionEnabled.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/EarlyFlakeDetectionEnabled.java
@@ -1,0 +1,12 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+public enum EarlyFlakeDetectionEnabled implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "early_flake_detection_enabled:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/IsNew.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/IsNew.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether a test case is a new one. */
+public enum IsNew implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "is_new:true";
+  }
+}


### PR DESCRIPTION
# What Does This Do
Adds telemetry metrics to early flakiness detection logic.

Jira ticket: [CIVIS-8329]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-8329]: https://datadoghq.atlassian.net/browse/CIVIS-8329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ