### PR TITLE
Fix NPE on traceState() in DDSpanLink.java

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java
@@ -109,7 +109,8 @@ public class DDSpanLink extends SpanLink {
       json.trace_id = link.traceId().toHexString();
       json.span_id = DDSpanId.toHexString(link.spanId());
       json.flags = link.traceFlags() == 0 ? null : link.traceFlags();
-      json.tracestate = (link.traceState() == null  || link.traceState().isEmpty())? null : link.traceState();
+      json.tracestate =
+          (link.traceState() == null || link.traceState().isEmpty()) ? null : link.traceState();
       if (!link.attributes().isEmpty()) {
         json.attributes = link.attributes().asMap();
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java
@@ -109,7 +109,7 @@ public class DDSpanLink extends SpanLink {
       json.trace_id = link.traceId().toHexString();
       json.span_id = DDSpanId.toHexString(link.spanId());
       json.flags = link.traceFlags() == 0 ? null : link.traceFlags();
-      json.tracestate = link.traceState().isEmpty() ? null : link.traceState();
+      json.tracestate = (link.traceState() == null  || link.traceState().isEmpty())? null : link.traceState();
       if (!link.attributes().isEmpty()) {
         json.attributes = link.attributes().asMap();
       }


### PR DESCRIPTION
# What Does This Do
Check if link.traceState() is null before checking if it's empty

# Motivation
NPE observed. 

# Additional Notes

Jira ticket: [[APMS-11554](https://datadoghq.atlassian.net/browse/APMS-11554)]

[APMS-11554]: https://datadoghq.atlassian.net/browse/APMS-11554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ