### PR TITLE
Fix equality in the range builder test causing failures in some VMs

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/RangeBuilderTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/RangeBuilderTest.groovy
@@ -353,9 +353,9 @@ class RangeBuilderTest extends Specification {
     entry.arrayCopy(target, 1)
 
     then:
-    target[0].start === 10
-    target[1].start === 11
-    target[2].start === 12
+    target[0].start == 10
+    target[1].start == 11
+    target[2].start == 12
 
     when: 'copy before zero'
     final copied = entry.arrayCopy(target, -1)


### PR DESCRIPTION
# What Does This Do
Fix a test failing on some VMs due to groovy equality with integers

IBM 8 [example](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/34594/workflows/36819e3b-e45c-4fa7-b88a-ac1114d43daa/jobs/1226445)

