### PR TITLE
Improve release candidate detection and its changelog warning

### DIFF
--- a/.github/workflows/draft-release-notes-on-tag.yaml
+++ b/.github/workflows/draft-release-notes-on-tag.yaml
@@ -16,12 +16,13 @@ jobs:
           result-encoding: string
           script: |
             // Get the milestone title ("X.Y.Z") from tag name ("vX.Y.Z(-rc)")
-            const match = '${{github.event.ref}}'.match(/v(\d+\.\d+\.\d+)(?:-rc\d+)?/i)
+            const match = '${{github.event.ref}}'.match(/v(\d+\.\d+\.\d+)(-rc\d+)?/i)
             if (!match) {
               core.setFailed('Failed to parse tag name into milestone name: ${{github.event.ref}}')
               return
             }
             const milestoneTitle = match[1]
+            const isReleaseCandidate = match[2] !== undefined
 
             // Look for the milestone
             const milestone = (await github.paginate('GET /repos/{owner}/{repo}/milestones', {
@@ -135,8 +136,10 @@ jobs:
             }
 
             var changelog = ''
-            if ('${{github.event.ref}}'.match(/rc/i)) {
-              changelog += ':warning:  This is a RELEASE CANDIDATE and is NOT intended for use in production. Please contact Datadog support regarding any problems in this RC.\n'
+            if (isReleaseCandidate) {
+              changelog += '> [!WARNING]\n' +
+                '> This is a **release candidate** and is **not** intended for use in production.  \n' +
+                'Please [open an issue](https://github.com/DataDog/dd-trace-java/issues/new) regarding any problems in this release candidate.\n\n'
             }
             if (prByComponents.size > 0) {
               changelog += '# Components\n\n';


### PR DESCRIPTION
# What Does This Do

Improve release candidate detection and the related changelog warning

# Motivation

# Additional Notes

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
