### PR TITLE
Fix PowerWAFModuleSpecification flaky test

### DIFF
--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -1014,6 +1014,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> { pwafAdditive.close() }
+    _ * ctx.increaseTimeouts()
     0 * _
 
     when: 'removing data and override config'
@@ -1036,6 +1037,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     1 * reconf.reloadSubscriptions()
+    _ * ctx.increaseTimeouts()
     0 * _
 
     when: 'data is readded'
@@ -1058,6 +1060,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * flow.setAction({ it.blocking })
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     1 * flow.isBlocking()
+    _ * ctx.increaseTimeouts()
     0 * _
 
     when: 'toggling the rule off'
@@ -1078,6 +1081,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true) >> { pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
+    _ * ctx.increaseTimeouts()
     0 * _
   }
 
@@ -1106,6 +1110,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true) >> { pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
+    _ * ctx.increaseTimeouts()
     0 * _
 
     when: 'rule enabled in config a has no effect'
@@ -1128,6 +1133,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
+    _ * ctx.increaseTimeouts()
     0 * _
 
     when: 'rule enabled in config c overrides b'
@@ -1153,6 +1159,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * flow.setAction({ it.blocking })
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
+    _ * ctx.increaseTimeouts()
     0 * _
 
     when: 'removing c restores the state before c was added (rule disabled)'
@@ -1173,6 +1180,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
+    _ * ctx.increaseTimeouts()
     0 * _
   }
 


### PR DESCRIPTION
# What Does This Do
Tolerate `increaseTimeouts` calls in this particular test. This seems to be flaky since https://github.com/datadog/dd-trace-java/pull/6597 with the introduction of timeouts reporting (hence the `increaseTimeouts` call). The WAF might have been timing out before without affecting the logic of the test.

So we'll just ignore timeouts here, and will further investigate any other failure (when breaking because of other assertions).

# Motivation

# Additional Notes
The failure is reproducible locally under high load (e.g. `stress --cpu 16 --vm 8`).