### PR TITLE
Ensure span links attributes can't be null

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanLink.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanLink.java
@@ -14,11 +14,11 @@ public class SpanLink implements AgentSpanLink {
 
   protected SpanLink(
       DDTraceId traceId, long spanId, byte traceFlags, String traceState, Attributes attributes) {
-    this.traceId = traceId;
+    this.traceId = traceId == null ? DDTraceId.ZERO : traceId;
     this.spanId = spanId;
     this.traceFlags = traceFlags;
-    this.traceState = (traceState == null) ? "" : traceState;
-    this.attributes = attributes;
+    this.traceState = traceState == null ? "" : traceState;
+    this.attributes = attributes == null ? EMPTY : attributes;
   }
 
   /**

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/SpanLinkTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/instrumentation/api/SpanLinkTest.groovy
@@ -39,6 +39,18 @@ class SpanLinkTest extends DDSpecification {
     sampled << [true, false]
   }
 
+  def "test span links api"() {
+    when:
+    def link = new SpanLink(null, 0L, 0 as byte, null, null)
+
+    then:
+    link.traceId() == DDTraceId.ZERO
+    link.traceState() != null
+    link.traceState().isEmpty()
+    link.attributes() != null
+    link.attributes().isEmpty()
+  }
+
   def "test span link attributes api"() {
     when:
     def attributes = SpanLinkAttributes.builder().build()


### PR DESCRIPTION
# What Does This Do

Make sure span links trace ids and attributes can't be `null`.

# Motivation

Follow up PR of #6758 

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
