### PR TITLE
Move -Ddd.benchmark.output.dir to the main run parameter

### DIFF
--- a/benchmark/startup/insecure-bank/benchmark.json
+++ b/benchmark/startup/insecure-bank/benchmark.json
@@ -2,32 +2,32 @@
   "name": "startup_insecure-bank",
   "setup": "bash -c \"mkdir -p ${OUTPUT_DIR}/${VARIANT}\"",
   "service": "bash -c \"${UTILS_DIR}/run-on-server-ready.sh http://localhost:8080/login 'pkill java'\"",
-  "run": "bash -c \"java ${JAVA_OPTS} -Ddd.benchmark.output.dir=${OUTPUT_DIR}/${VARIANT} -jar ${INSECURE_BANK} &> ${OUTPUT_DIR}/${VARIANT}/insecure-bank.log\"",
+  "run": "bash -c \"java -javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/${VARIANT} ${JAVA_OPTS} -jar ${INSECURE_BANK} &> ${OUTPUT_DIR}/${VARIANT}/insecure-bank.log\"",
   "iterations": 10,
   "timeout": 60,
   "variants": {
     "tracing": {
       "env": {
         "VARIANT": "tracing",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true"
+        "JAVA_OPTS": ""
       }
     },
     "iast": {
       "env": {
         "VARIANT": "iast",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.iast.enabled=true"
+        "JAVA_OPTS": "-Ddd.iast.enabled=true"
       }
     },
     "iast_TELEMETRY_OFF": {
       "env": {
         "VARIANT": "iast_TELEMETRY_OFF",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.iast.enabled=true -Ddd.iast.telemetry.verbosity=OFF"
+        "JAVA_OPTS": "-Ddd.iast.enabled=true -Ddd.iast.telemetry.verbosity=OFF"
       }
     },
     "iast_HARDCODED_SECRET_DISABLED": {
       "env": {
         "VARIANT": "iast_HARDCODED_SECRET_DISABLED",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.iast.enabled=true -Ddd.iast.hardcoded-secret.enabled=false"
+        "JAVA_OPTS": "-Ddd.iast.enabled=true -Ddd.iast.hardcoded-secret.enabled=false"
       }
     }
   }

--- a/benchmark/startup/insecure-bank/benchmark.json
+++ b/benchmark/startup/insecure-bank/benchmark.json
@@ -2,26 +2,26 @@
   "name": "startup_insecure-bank",
   "setup": "bash -c \"mkdir -p ${OUTPUT_DIR}/${VARIANT}\"",
   "service": "bash -c \"${UTILS_DIR}/run-on-server-ready.sh http://localhost:8080/login 'pkill java'\"",
-  "run": "bash -c \"java ${JAVA_OPTS} -jar ${INSECURE_BANK} &> ${OUTPUT_DIR}/${VARIANT}/insecure-bank.log\"",
+  "run": "bash -c \"java ${JAVA_OPTS} -Ddd.benchmark.output.dir=${OUTPUT_DIR}/${VARIANT} -jar ${INSECURE_BANK} &> ${OUTPUT_DIR}/${VARIANT}/insecure-bank.log\"",
   "iterations": 10,
   "timeout": 60,
   "variants": {
     "tracing": {
       "env": {
         "VARIANT": "tracing",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/tracing"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true"
       }
     },
     "iast": {
       "env": {
         "VARIANT": "iast",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast -Ddd.iast.enabled=true"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.iast.enabled=true"
       }
     },
     "iast_TELEMETRY_OFF": {
       "env": {
         "VARIANT": "iast_TELEMETRY_OFF",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast_TELEMETRY_OFF -Ddd.iast.enabled=true -Ddd.iast.telemetry.verbosity=OFF"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.iast.enabled=true -Ddd.iast.telemetry.verbosity=OFF"
       }
     },
     "iast_HARDCODED_SECRET_DISABLED": {

--- a/benchmark/startup/petclinic/benchmark.json
+++ b/benchmark/startup/petclinic/benchmark.json
@@ -2,32 +2,32 @@
   "name": "startup_petclinic",
   "setup": "bash -c \"mkdir -p ${OUTPUT_DIR}/${VARIANT}\"",
   "service": "bash -c \"${UTILS_DIR}/run-on-server-ready.sh http://localhost:8080 'pkill java'\"",
-  "run": "bash -c \"java ${JAVA_OPTS} -Ddd.benchmark.output.dir=${OUTPUT_DIR}/${VARIANT} -jar ${PETCLINIC} &> ${OUTPUT_DIR}/${VARIANT}/petclinic.log\"",
+  "run": "bash -c \"java -javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/${VARIANT} ${JAVA_OPTS} -jar ${PETCLINIC} &> ${OUTPUT_DIR}/${VARIANT}/petclinic.log\"",
   "iterations": 10,
   "timeout": 60,
   "variants": {
     "tracing": {
       "env": {
         "VARIANT": "tracing",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true"
+        "JAVA_OPTS": ""
       }
     },
     "profiling": {
       "env": {
         "VARIANT": "profiling",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.profiling.enabled=true"
+        "JAVA_OPTS": "-Ddd.profiling.enabled=true"
       }
     },
     "appsec": {
       "env": {
         "VARIANT": "appsec",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.appsec.enabled=true"
+        "JAVA_OPTS": "-Ddd.appsec.enabled=true"
       }
     },
     "iast": {
       "env": {
         "VARIANT": "iast",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.iast.enabled=true"
+        "JAVA_OPTS": "-Ddd.iast.enabled=true"
       }
     }
   }

--- a/benchmark/startup/petclinic/benchmark.json
+++ b/benchmark/startup/petclinic/benchmark.json
@@ -2,32 +2,32 @@
   "name": "startup_petclinic",
   "setup": "bash -c \"mkdir -p ${OUTPUT_DIR}/${VARIANT}\"",
   "service": "bash -c \"${UTILS_DIR}/run-on-server-ready.sh http://localhost:8080 'pkill java'\"",
-  "run": "bash -c \"java ${JAVA_OPTS} -jar ${PETCLINIC} &> ${OUTPUT_DIR}/${VARIANT}/petclinic.log\"",
+  "run": "bash -c \"java ${JAVA_OPTS} -Ddd.benchmark.output.dir=${OUTPUT_DIR}/${VARIANT} -jar ${PETCLINIC} &> ${OUTPUT_DIR}/${VARIANT}/petclinic.log\"",
   "iterations": 10,
   "timeout": 60,
   "variants": {
     "tracing": {
       "env": {
         "VARIANT": "tracing",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/tracing"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true"
       }
     },
     "profiling": {
       "env": {
         "VARIANT": "profiling",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/profiling -Ddd.profiling.enabled=true"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.profiling.enabled=true"
       }
     },
     "appsec": {
       "env": {
         "VARIANT": "appsec",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/appsec -Ddd.appsec.enabled=true"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.appsec.enabled=true"
       }
     },
     "iast": {
       "env": {
         "VARIANT": "iast",
-        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.benchmark.output.dir=${OUTPUT_DIR}/iast -Ddd.iast.enabled=true"
+        "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.benchmark.enabled=true -Ddd.iast.enabled=true"
       }
     }
   }


### PR DESCRIPTION
# What Does This Do
Fixes startup benchmarks that where failing due to missing reports folder:

```
FileNotFoundError: [Errno 2] No such file or directory: '/go/src/github.com/DataDog/apm-reliability/dd-trace-java/reports/startup/insecure-bank/iast_HARDCODED_SECRET_DISABLED/benchmark-baseline.json'
```
