### PR TITLE
Minify AppSec rules

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -1,3 +1,6 @@
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
 plugins {
   id "com.github.johnrengelman.shadow"
   id "me.champeau.jmh"
@@ -34,6 +37,14 @@ shadowJar {
 
 jar {
   archiveClassifier = 'unbundled'
+}
+
+processResources {
+  doLast {
+    fileTree(dir: outputs.files.asPath, includes: ['**/*.json']).each {
+      it.text = JsonOutput.toJson(new JsonSlurper().parse(it))
+    }
+  }
 }
 
 jmh {


### PR DESCRIPTION
# What Does This Do
Minify AppSec rules.

# Motivation
Reduce JAR size and load time.

# Additional Notes

This partially offsets the startup time regression introduced by https://github.com/DataDog/dd-trace-java/pull/6754 when `DD_APPSEC_ENABLED=true`.