### PR TITLE
Bump ddprof-java to 1.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.19.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "0.99.0",
+    ddprof        : "1.1.0",
     asm           : "9.6",
     cafe_crypto   : "0.1.0",
     lz4           : "1.7.1"


### PR DESCRIPTION
# What Does This Do
Updates the ddprof dependency to 1.1.0

# Motivation
The version [1.1.0](https://github.com/DataDog/java-profiler/releases/tag/v_1.1.0) contains a bug fix preventing occasional sigsegv when using wallclock profiler.

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
