### PR TITLE
Fix source path calculation for classes in default package

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/instrumentation/CoverageInstrumentationFilter.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/instrumentation/CoverageInstrumentationFilter.java
@@ -13,6 +13,10 @@ public final class CoverageInstrumentationFilter implements Predicate<String> {
 
   @Override
   public boolean test(String className) {
+    if (!className.contains("/")) {
+      // always include classes in default package
+      return true;
+    }
     for (String excludedPackage : excludedPackages) {
       if (className.startsWith(excludedPackage)) {
         return false;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageResolver.java
@@ -2,7 +2,10 @@ package datadog.trace.civisibility.source.index;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import javax.annotation.Nullable;
 
 public interface PackageResolver {
+  /** @return the package path or <code>null</code> if the file is in the default package */
+  @Nullable
   Path getPackage(Path sourceFile) throws IOException;
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageResolverImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/PackageResolverImpl.java
@@ -7,6 +7,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import javax.annotation.Nullable;
 
 public class PackageResolverImpl implements PackageResolver {
 
@@ -26,7 +27,10 @@ public class PackageResolverImpl implements PackageResolver {
    * <p>It simply looks for a line, that contains the <code>package</code> keyword and extracts the
    * part that goes after it and until the nearest <code>;</code> character, then verifies that the
    * extracted part looks plausible by checking the actual file path.
+   *
+   * @return the package path or <code>null</code> if the file is in the default package
    */
+  @Nullable
   @Override
   public Path getPackage(Path sourceFile) throws IOException {
     Path folder = sourceFile.getParent();
@@ -65,6 +69,6 @@ public class PackageResolverImpl implements PackageResolver {
     }
 
     // apparently there is no package declaration - class is located in the default package
-    return fileSystem.getPath("");
+    return null;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -177,8 +177,12 @@ public class RepoIndexBuilder implements RepoIndexProvider {
       } else if (!sourceType.isResource()) {
         indexingStats.sourceFilesVisited++;
         Path packagePath = packageResolver.getPackage(file);
-        packageTree.add(packagePath);
-        return getSourceRoot(file, packagePath);
+        if (packagePath != null) {
+          packageTree.add(packagePath);
+          return getSourceRoot(file, packagePath);
+        } else {
+          return file.getParent();
+        }
 
       } else {
         indexingStats.resourceFilesVisited++;

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/PackageResolverImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/PackageResolverImplTest.groovy
@@ -21,11 +21,11 @@ class PackageResolverImplTest extends Specification {
     def packagePath = packageResolver.getPackage(javaFilePath)
 
     then:
-    packagePath == fileSystem.getPath(expectedPackageName)
+    packagePath == (expectedPackageName != null ? fileSystem.getPath(expectedPackageName) : null)
 
     where:
     path                             | contents                                      | expectedPackageName
-    "/root/src/MyClass.java"         | CLASS_IN_DEFAULT_PACKAGE                      | ""
+    "/root/src/MyClass.java"         | CLASS_IN_DEFAULT_PACKAGE                      | null
     "/root/src/foo/bar/MyClass.java" | CLASS_IN_FOO_BAR_PACKAGE                      | "foo/bar"
     "/root/src/foo/bar/MyClass.java" | BLANK_LINES_BEFORE_PACKAGE                    | "foo/bar"
     "/root/src/foo/bar/MyClass.java" | SPACES_BEFORE_PACKAGE                         | "foo/bar"


### PR DESCRIPTION
# What Does This Do
Fixes source path calculation for classes that reside in default package.

# Additional Notes
ITR coverage instrumentation is also fixed to always consider classes in default package.

Jira ticket: [CIVIS-9338]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9338]: https://datadoghq.atlassian.net/browse/CIVIS-9338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ