### PR TITLE
Fixes muzzle reporting to be more accurate for telemetry

### DIFF
--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -248,8 +248,6 @@ class MuzzlePlugin implements Plugin<Project> {
       }
     }
 
-    // spring-aop is muzzle tested but not an actual integration to be reported
-    map.remove("spring-data:org.springframework:spring-aop")
     dumpVersionsToCsv(project, map)
   }
 
@@ -258,7 +256,7 @@ class MuzzlePlugin implements Plugin<Project> {
     final RepositorySystem system = newRepositorySystem()
     final RepositorySystemSession session = newRepositorySystemSession(system)
     def versions = new TreeMap<String, TestedArtifact>()
-    project.muzzle.directives.findAll { !((MuzzleDirective) it).isCoreJdk() }.each {
+    project.muzzle.directives.findAll { !((MuzzleDirective) it).isCoreJdk() && !((MuzzleDirective) it).isSkipFromReport() }.each {
       def range = resolveVersionRange(it as MuzzleDirective, system, session)
       def cp = project.sourceSets.main.runtimeClasspath
       def cl = new URLClassLoader(cp*.toURI()*.toURL() as URL[], null as ClassLoader)
@@ -555,6 +553,7 @@ class MuzzleDirective {
   List<String> excludedDependencies = new ArrayList<>()
   boolean assertPass
   boolean assertInverse = false
+  boolean skipFromReport = false
   boolean coreJdk = false
   String javaVersion
 

--- a/buildSrc/src/main/groovy/MuzzlePlugin.groovy
+++ b/buildSrc/src/main/groovy/MuzzlePlugin.groovy
@@ -247,6 +247,9 @@ class MuzzlePlugin implements Plugin<Project> {
         ] as BiFunction)
       }
     }
+
+    // spring-aop is muzzle tested but not an actual integration to be reported
+    map.remove("spring-data:org.springframework:spring-aop")
     dumpVersionsToCsv(project, map)
   }
 

--- a/dd-java-agent/instrumentation/spring-data-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/spring-data-1.8/build.gradle
@@ -15,13 +15,13 @@ muzzle {
     assertInverse = true
   }
 
-  // spring-aop is not explicitly instrumented so it is removed from the generated muzzle report later
   pass {
     group = 'org.springframework'
     module = 'spring-aop'
     versions = "[1.2,6)"
     extraDependency "org.springframework.data:spring-data-commons:1.8.0.RELEASE"
     assertInverse = true
+    skipFromReport = true
   }
 }
 

--- a/dd-java-agent/instrumentation/spring-data-1.8/build.gradle
+++ b/dd-java-agent/instrumentation/spring-data-1.8/build.gradle
@@ -14,6 +14,8 @@ muzzle {
     extraDependency "org.springframework:spring-aop:1.2"
     assertInverse = true
   }
+
+  // spring-aop is not explicitly instrumented so it is removed from the generated muzzle report later
   pass {
     group = 'org.springframework'
     module = 'spring-aop'


### PR DESCRIPTION
# What Does This Do
Remove `spring-aop` from being reported as supported due to the muzzle reports even though it is simply a dependency for `spring-data-commons`

# Motivation
Cleaning up reporting code to improve future endeavors to rely on version data from tracer telemetry data extracted from Muzzle reports

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
