### PR TITLE
Enhance 'runtime_version' tag to encode graalvm source

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -25,6 +25,7 @@ import datadog.common.version.VersionInfo;
 import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.Platform;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.api.profiling.RecordingData;
@@ -168,6 +169,9 @@ public final class ProfileUploader {
       GitInfo gitInfo = GitInfoProvider.INSTANCE.getGitInfo();
       tagsMap.put(Tags.GIT_REPOSITORY_URL, gitInfo.getRepositoryURL());
       tagsMap.put(Tags.GIT_COMMIT_SHA, gitInfo.getCommit().getSha());
+    }
+    if (Platform.isGraalVM()) {
+      tagsMap.put(DDTags.RUNTIME_VERSION_TAG, tagsMap.get(DDTags.RUNTIME_VERSION_TAG) + "-graalvm");
     }
 
     // Comma separated tags string for V2.4 format


### PR DESCRIPTION
# What Does This Do
It will suffix the 'runtime_version' tag with `-graalvm` if running as a native image.

# Motivation
The SubstrateVM (GraalVM native image runtime) implementation of JFR does not properly trim the stacktraces, leaving several frames of runtime internals there. 
We can trim those stacktraces in our backend but doing that for all incoming recordings would be too costly - therefore we need to have a quick way to identify such recordings based on the tags.

# Additional Notes

Jira ticket: [PROF-9285]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-9285]: https://datadoghq.atlassian.net/browse/PROF-9285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ