### PR TITLE
Refactoring of TagsPostProcessor

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -784,8 +784,7 @@ public class DDSpanContext
       final MetadataConsumer consumer, int longRunningVersion, List<AgentSpanLink> links) {
     synchronized (unsafeTags) {
       // Tags
-      Map<String, Object> tags =
-          TagsPostProcessorFactory.instance().processTagsWithContext(unsafeTags, this);
+      Map<String, Object> tags = TagsPostProcessorFactory.instance().processTags(unsafeTags, this);
       String linksTag = DDSpanLink.toTag(links);
       if (linksTag != null) {
         tags.put(SPAN_LINKS, linksTag);

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
@@ -16,7 +16,9 @@ public class BaseServiceAdder implements TagsPostProcessor {
   @Override
   public Map<String, Object> processTags(
       Map<String, Object> unsafeTags, DDSpanContext spanContext) {
-    if (ddService != null && !ddService.toString().equalsIgnoreCase(spanContext.getServiceName())) {
+    if (ddService != null
+        && spanContext != null
+        && !ddService.toString().equalsIgnoreCase(spanContext.getServiceName())) {
       unsafeTags.put(DDTags.BASE_SERVICE, ddService);
     }
     return unsafeTags;

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/BaseServiceAdder.java
@@ -14,13 +14,7 @@ public class BaseServiceAdder implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(Map<String, Object> unsafeTags) {
-    // we are only able to do something if the span service name is known
-    return unsafeTags;
-  }
-
-  @Override
-  public Map<String, Object> processTagsWithContext(
+  public Map<String, Object> processTags(
       Map<String, Object> unsafeTags, DDSpanContext spanContext) {
     if (ddService != null && !ddService.toString().equalsIgnoreCase(spanContext.getServiceName())) {
       unsafeTags.put(DDTags.BASE_SERVICE, ddService);

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
@@ -5,6 +5,7 @@ import datadog.trace.api.DDTags;
 import datadog.trace.api.naming.NamingSchema;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.core.DDSpanContext;
 import java.util.Map;
 import javax.annotation.Nonnull;
 
@@ -29,7 +30,8 @@ public class PeerServiceCalculator implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+  public Map<String, Object> processTags(
+      Map<String, Object> unsafeTags, DDSpanContext spanContext) {
     Object peerService = unsafeTags.get(Tags.PEER_SERVICE);
     // the user set it
     if (peerService != null) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PostProcessorChain.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/PostProcessorChain.java
@@ -13,16 +13,11 @@ public class PostProcessorChain implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(Map<String, Object> unsafeTags) {
-    return processTagsWithContext(unsafeTags, null);
-  }
-
-  @Override
-  public Map<String, Object> processTagsWithContext(
+  public Map<String, Object> processTags(
       Map<String, Object> unsafeTags, DDSpanContext spanContext) {
     Map<String, Object> currentTags = unsafeTags;
     for (final TagsPostProcessor tagsPostProcessor : chain) {
-      currentTags = tagsPostProcessor.processTagsWithContext(currentTags, spanContext);
+      currentTags = tagsPostProcessor.processTags(currentTags, spanContext);
     }
     return currentTags;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/QueryObfuscator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/QueryObfuscator.java
@@ -5,6 +5,7 @@ import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.core.DDSpanContext;
 import datadog.trace.util.Strings;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -55,7 +56,8 @@ public class QueryObfuscator implements TagsPostProcessor {
   }
 
   @Override
-  public Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+  public Map<String, Object> processTags(
+      Map<String, Object> unsafeTags, DDSpanContext spanContext) {
     Object query = unsafeTags.get(DDTags.HTTP_QUERY);
     if (query instanceof CharSequence) {
       query = obfuscate(query.toString());

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessor.java
@@ -4,10 +4,5 @@ import datadog.trace.core.DDSpanContext;
 import java.util.Map;
 
 public interface TagsPostProcessor {
-  Map<String, Object> processTags(Map<String, Object> unsafeTags);
-
-  default Map<String, Object> processTagsWithContext(
-      Map<String, Object> unsafeTags, DDSpanContext spanContext) {
-    return processTags(unsafeTags);
-  }
+  Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext);
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/BaseServiceAdderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/BaseServiceAdderTest.groovy
@@ -12,7 +12,7 @@ class BaseServiceAdderTest extends DDSpecification {
     def spanContext = Mock(DDSpanContext)
 
     when:
-    def enrichedTags = calculator.processTagsWithContext([:], spanContext)
+    def enrichedTags = calculator.processTags([:], spanContext)
 
     then:
     1 * spanContext.getServiceName() >> serviceName

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PeerServiceCalculatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PeerServiceCalculatorTest.groovy
@@ -13,7 +13,7 @@ class PeerServiceCalculatorTest extends DDSpecification {
     setup:
     def calculator = new PeerServiceCalculator(new NamingSchemaV0().peerService(), Collections.emptyMap())
     when:
-    def enrichedTags = calculator.processTags(tags)
+    def enrichedTags = calculator.processTags(tags, null)
     then:
     // tags are not modified
     assert enrichedTags == tags
@@ -33,7 +33,7 @@ class PeerServiceCalculatorTest extends DDSpecification {
     def calculator = new PeerServiceCalculator(new NamingSchemaV1().peerService(), Collections.emptyMap())
     when:
     tags.put(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT)
-    def calculated = calculator.processTags(tags)
+    def calculated = calculator.processTags(tags, null)
 
     then:
     calculated.get(DDTags.PEER_SERVICE_SOURCE) == provenance
@@ -56,7 +56,7 @@ class PeerServiceCalculatorTest extends DDSpecification {
     injectSysConfig(TracerConfig.TRACE_PEER_SERVICE_DEFAULTS_ENABLED, "true")
     def calculator = new PeerServiceCalculator(new NamingSchemaV0().peerService(), Collections.emptyMap())
     when:
-    def calculated = calculator.processTags(["span.kind": "client", "peer.hostname": "test"])
+    def calculated = calculator.processTags(["span.kind": "client", "peer.hostname": "test"], null)
     then:
     assert calculated.get(Tags.PEER_SERVICE) == "test"
   }
@@ -70,7 +70,7 @@ class PeerServiceCalculatorTest extends DDSpecification {
     def tags = ["span.kind": kind, "peer.hostname": "test"]
 
     then:
-    assert calculator.processTags(tags).containsKey(Tags.PEER_SERVICE) == calculate
+    assert calculator.processTags(tags, null).containsKey(Tags.PEER_SERVICE) == calculate
 
     where:
     kind       | calculate
@@ -87,7 +87,7 @@ class PeerServiceCalculatorTest extends DDSpecification {
     def calculator = new PeerServiceCalculator(new NamingSchemaV0().peerService(), Config.get().getPeerServiceMapping())
 
     when:
-    def calculated = calculator.processTags(tags)
+    def calculated = calculator.processTags(tags, null)
 
     then:
     assert calculated.get(Tags.PEER_SERVICE) == expected
@@ -108,7 +108,7 @@ class PeerServiceCalculatorTest extends DDSpecification {
     def calculator = new PeerServiceCalculator(new NamingSchemaV0().peerService(), Config.get().getPeerServiceComponentOverrides())
 
     when:
-    def calculated = calculator.processTags(tags)
+    def calculated = calculator.processTags(tags, null)
 
     then:
     assert calculated.get(Tags.PEER_SERVICE) == expected

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PostProcessorChainTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/PostProcessorChainTest.groovy
@@ -1,6 +1,6 @@
 package datadog.trace.core.tagprocessor
 
-
+import datadog.trace.core.DDSpanContext
 import datadog.trace.test.util.DDSpecification
 
 class PostProcessorChainTest extends DDSpecification {
@@ -8,7 +8,7 @@ class PostProcessorChainTest extends DDSpecification {
     setup:
     def processor1 = new TagsPostProcessor() {
         @Override
-        Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+        Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext) {
           unsafeTags.put("key1", "processor1")
           unsafeTags.put("key2", "processor1")
           return unsafeTags
@@ -16,7 +16,7 @@ class PostProcessorChainTest extends DDSpecification {
       }
     def processor2 = new TagsPostProcessor() {
         @Override
-        Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+        Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext) {
           unsafeTags.put("key1", "processor2")
           return unsafeTags
         }
@@ -26,7 +26,7 @@ class PostProcessorChainTest extends DDSpecification {
     def tags = ["key1": "root", "key3": "root"]
 
     when:
-    def out = chain.processTags(tags)
+    def out = chain.processTags(tags, null)
 
     then:
     assert out == ["key1": "processor2", "key2": "processor1", "key3": "root"]
@@ -36,13 +36,13 @@ class PostProcessorChainTest extends DDSpecification {
     setup:
     def processor1 = new TagsPostProcessor() {
         @Override
-        Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+        Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext) {
           return ["my": "tag"]
         }
       }
     def processor2 = new TagsPostProcessor() {
         @Override
-        Map<String, Object> processTags(Map<String, Object> unsafeTags) {
+        Map<String, Object> processTags(Map<String, Object> unsafeTags, DDSpanContext spanContext) {
           if (unsafeTags.containsKey("test")) {
             unsafeTags.put("found", "true")
           }
@@ -54,7 +54,7 @@ class PostProcessorChainTest extends DDSpecification {
     def tags = ["test": "test"]
 
     when:
-    def out = chain.processTags(tags)
+    def out = chain.processTags(tags, null)
 
     then:
     assert out == ["my": "tag"]

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/QueryObfuscatorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/tagprocessor/QueryObfuscatorTest.groovy
@@ -14,7 +14,7 @@ class QueryObfuscatorTest extends DDSpecification {
     ]
 
     when:
-    def result = obfuscator.processTags(tags)
+    def result = obfuscator.processTags(tags, null)
 
     then:
     assert result.get(DDTags.HTTP_QUERY) == expectedQuery


### PR DESCRIPTION
# What Does This Do
Removed redundant proxy-methods. Merged `TagsPostProcessor.processTags()` and `TagsPostProcessor.processTagsWithContext()` into single method.

# Motivation
This is preparation for to future work on span late post processing

# Additional Notes

<!--
Jira ticket: [PROJ-IDENT]


# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
