### PR TITLE
Fix logged exception for dependency URIs representing directories

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -2,6 +2,7 @@ package datadog.telemetry.dependency;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collections;
@@ -12,41 +13,48 @@ import org.slf4j.LoggerFactory;
 public class DependencyResolver {
 
   private static final Logger log = LoggerFactory.getLogger(DependencyResolver.class);
-  private static final String JAR_SUFFIX = ".jar";
 
   public static List<Dependency> resolve(URI uri) {
-    final String scheme = uri.getScheme();
     try {
-      JarReader.Extracted metadata = null;
-      String path = null;
-      if ("file".equals(scheme)) {
-        File f;
-        if (uri.isOpaque()) {
-          f = new File(uri.getSchemeSpecificPart());
-        } else {
-          f = new File(uri);
-        }
-        path = f.getAbsolutePath();
-        metadata = JarReader.readJarFile(path);
-      } else if ("jar".equals(scheme) && uri.getSchemeSpecificPart().startsWith("file:")) {
-        path = uri.getSchemeSpecificPart().substring("file:".length());
-        metadata = JarReader.readNestedJarFile(path);
-      } else {
-        log.debug("unsupported dependency type: {}", uri);
-        return Collections.emptyList();
-      }
-      final List<Dependency> dependencies =
-          Dependency.fromMavenPom(metadata.jarName, metadata.pomProperties);
-      if (!dependencies.isEmpty()) {
-        return dependencies;
-      }
-      try (final InputStream is = new FileInputStream(path)) {
-        return Collections.singletonList(
-            Dependency.guessFallbackNoPom(metadata.manifest, metadata.jarName, is));
-      }
+      return internalResolve(uri);
     } catch (Throwable t) {
       log.debug("Failed to determine dependency for uri {}", uri, t);
     }
     return Collections.emptyList();
+  }
+
+  static List<Dependency> internalResolve(final URI uri) throws IOException {
+    final String scheme = uri.getScheme();
+    JarReader.Extracted metadata;
+    String path;
+    if ("file".equals(scheme)) {
+      File f;
+      if (uri.isOpaque()) {
+        f = new File(uri.getSchemeSpecificPart());
+      } else {
+        f = new File(uri);
+      }
+      path = f.getAbsolutePath();
+      metadata = JarReader.readJarFile(path);
+    } else if ("jar".equals(scheme) && uri.getSchemeSpecificPart().startsWith("file:")) {
+      path = uri.getSchemeSpecificPart().substring("file:".length());
+      metadata = JarReader.readNestedJarFile(path);
+    } else {
+      log.debug("unsupported dependency type: {}", uri);
+      return Collections.emptyList();
+    }
+    if (metadata.isDirectory) {
+      log.debug("Extracting dependencies from directories is not supported: {}", uri);
+      return Collections.emptyList();
+    }
+    final List<Dependency> dependencies =
+        Dependency.fromMavenPom(metadata.jarName, metadata.pomProperties);
+    if (!dependencies.isEmpty()) {
+      return dependencies;
+    }
+    try (final InputStream is = new FileInputStream(path)) {
+      return Collections.singletonList(
+          Dependency.guessFallbackNoPom(metadata.manifest, metadata.jarName, is));
+    }
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
@@ -192,6 +192,46 @@ class DependencyResolverSpecification extends DepSpecification {
       hash: '6438819DAB9C9AC18D8A6922C8A923C2ADAEA85D')
   }
 
+  void 'attempt to extract dependencies from directory'() {
+    given:
+    File dir = new File(testDir, 'dir')
+    dir.mkdirs()
+
+    when:
+    def deps = DependencyResolver.resolve(dir.toURI())
+
+    then:
+    deps.isEmpty()
+
+    when: 'resolve without catching exceptions'
+    deps = DependencyResolver.internalResolve(dir.toURI())
+
+    then: 'it does not throw'
+    deps.isEmpty()
+  }
+
+  void 'attempt to extract dependencies from directory within jar'() {
+    given:
+    File file = new File(testDir, "app.jar")
+    ZipOutputStream out = new ZipOutputStream(new FileOutputStream(file))
+    ZipEntry e = new ZipEntry("classes/")
+    out.putNextEntry(e)
+    out.closeEntry()
+    out.close()
+
+    when:
+    def deps = DependencyResolver.resolve(new URI('jar:file:' + file.getAbsolutePath() + "!/classes!/"))
+
+    then:
+    deps.isEmpty()
+
+    when: 'resolve without catching exceptions'
+    deps = DependencyResolver.internalResolve(new URI('jar:file:' + file.getAbsolutePath() + "!/classes!/"))
+
+    then: 'it does not throw'
+    deps.isEmpty()
+  }
+
   private static void knownJarCheck(Map opts) {
     File jarFile = getJar(opts['jarName'])
     List<Dependency> deps = DependencyResolver.resolve(jarFile.toURI())


### PR DESCRIPTION
# What Does This Do
Check if a dependency location is a directory (e.g. an unpacked classes directory), including directories within JARs, and handle it gracefully.

# Motivation
As of v1.30.0, this would generate an internal exception, which is caught, but result in debug logs like:

```
[dd.trace 2024-03-08 13:32:34:092 +0100] [dd-task-scheduler] DEBUG datadog.telemetry.dependency.DependencyResolver - Failed to determine dependency for uri jar:file:/work/dd-trace-java/dd-smoke-tests/spring-boot-3.0-webmvc/build/application/libs/webmvc-3.0-smoketest.jar!/BOOT-INF/classes!/
java.io.FileNotFoundException: /work/dd-trace-java/dd-smoke-tests/spring-boot-3.0-webmvc/build/application/libs/webmvc-3.0-smoketest.jar!/BOOT-INF/classes! (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:111)
        at datadog.telemetry.dependency.DependencyResolver.resolve(DependencyResolver.java:43)
        at datadog.telemetry.dependency.DependencyResolverQueue.pollDependency(DependencyResolverQueue.java:82)
        at datadog.telemetry.dependency.DependencyService.resolveOneDependency(DependencyService.java:38)
        at datadog.telemetry.dependency.DependencyService.run(DependencyService.java:96)
        at datadog.trace.util.AgentTaskScheduler$RunnableTask.run(AgentTaskScheduler.java:41)
        at datadog.trace.util.AgentTaskScheduler$RunnableTask.run(AgentTaskScheduler.java:36)
        at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:311)
        at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:266)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

# Additional Notes

Jira ticket: [APPSEC-52172](https://datadoghq.atlassian.net/browse/APPSEC-52172)

[APPSEC-52172]: https://datadoghq.atlassian.net/browse/APPSEC-52172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ