### PR TITLE
Fix nested JAR resolver when URI has no trailing slash

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -1,7 +1,6 @@
 package datadog.telemetry.dependency;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -52,7 +51,7 @@ public class DependencyResolver {
     if (!dependencies.isEmpty()) {
       return dependencies;
     }
-    try (final InputStream is = new FileInputStream(path)) {
+    try (final InputStream is = metadata.inputStreamSupplier.get()) {
       return Collections.singletonList(
           Dependency.guessFallbackNoPom(metadata.manifest, metadata.jarName, is));
     }

--- a/telemetry/src/main/java/datadog/telemetry/dependency/JarReader.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/JarReader.java
@@ -141,6 +141,11 @@ class JarReader {
     }
 
     @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return this.innerInputStream.read(b, off, len);
+    }
+
+    @Override
     public void close() throws IOException {
       this.innerInputStream.close();
       this.outerJar.close();

--- a/telemetry/src/main/java/datadog/telemetry/dependency/JarReader.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/JarReader.java
@@ -1,6 +1,7 @@
 package datadog.telemetry.dependency;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.NoSuchFileException;
@@ -20,23 +21,30 @@ class JarReader {
     final Map<String, Properties> pomProperties;
     final Attributes manifest;
     final boolean isDirectory;
+    final InputStreamSupplier inputStreamSupplier;
 
     public Extracted(
         final String jarName,
         final Map<String, Properties> pomProperties,
         final Attributes manifest,
-        final boolean isDirectory) {
+        final boolean isDirectory,
+        final InputStreamSupplier inputStreamSupplier) {
       this.jarName = jarName;
       this.pomProperties = pomProperties;
       this.manifest = manifest;
       this.isDirectory = isDirectory;
+      this.inputStreamSupplier = inputStreamSupplier;
+    }
+
+    public interface InputStreamSupplier {
+      InputStream get() throws IOException;
     }
   }
 
   public static Extracted readJarFile(String jarPath) throws IOException {
     final File jarFile = new File(jarPath);
     if (jarFile.isDirectory()) {
-      return new Extracted(jarFile.getName(), new HashMap<>(), new Attributes(), true);
+      return new Extracted(jarFile.getName(), new HashMap<>(), new Attributes(), true, () -> null);
     }
     try (final JarFile jar = new JarFile(jarPath, false /* no verify */)) {
       final Map<String, Properties> pomProperties = new HashMap<>();
@@ -54,7 +62,12 @@ class JarReader {
       final Manifest manifest = jar.getManifest();
       final Attributes attributes =
           (manifest == null) ? new Attributes() : manifest.getMainAttributes();
-      return new Extracted(new File(jar.getName()).getName(), pomProperties, attributes, false);
+      return new Extracted(
+          new File(jar.getName()).getName(),
+          pomProperties,
+          attributes,
+          false,
+          () -> new FileInputStream(jarPath));
     }
   }
 
@@ -64,10 +77,7 @@ class JarReader {
       throw new IllegalArgumentException("Invalid nested jar path: " + jarPath);
     }
     final String outerJarPath = jarPath.substring(0, sepIdx);
-    String innerJarPath = jarPath.substring(sepIdx + 2);
-    if (innerJarPath.endsWith("!/")) {
-      innerJarPath = innerJarPath.substring(0, innerJarPath.length() - 2);
-    }
+    final String innerJarPath = getInnerJarPath(jarPath);
     try (final JarFile outerJar = new JarFile(outerJarPath, false /* no verify */)) {
       final ZipEntry entry = outerJar.getEntry(innerJarPath);
       if (entry == null) {
@@ -75,7 +85,7 @@ class JarReader {
       }
       if (entry.isDirectory()) {
         return new Extracted(
-            new File(innerJarPath).getName(), new HashMap<>(), new Attributes(), true);
+            new File(innerJarPath).getName(), new HashMap<>(), new Attributes(), true, () -> null);
       }
       try (final InputStream is = outerJar.getInputStream(entry);
           final JarInputStream innerJar = new JarInputStream(is, false /* no verify */)) {
@@ -91,8 +101,53 @@ class JarReader {
         final Manifest manifest = innerJar.getManifest();
         final Attributes attributes =
             (manifest == null) ? new Attributes() : manifest.getMainAttributes();
-        return new Extracted(new File(innerJarPath).getName(), pomProperties, attributes, false);
+        return new Extracted(
+            new File(innerJarPath).getName(),
+            pomProperties,
+            attributes,
+            false,
+            () -> new NestedJarInputStream(outerJarPath, innerJarPath));
       }
+    }
+  }
+
+  private static String getInnerJarPath(final String jarPath) {
+    final int sepIdx = jarPath.indexOf("!/");
+    if (sepIdx == -1) {
+      throw new IllegalArgumentException("Invalid nested jar path: " + jarPath);
+    }
+    String innerJarPath = jarPath.substring(sepIdx + 2);
+    final int innerSepIdx = innerJarPath.indexOf('!');
+    if (innerSepIdx != -1) {
+      innerJarPath = innerJarPath.substring(0, innerSepIdx);
+    }
+    return innerJarPath;
+  }
+
+  static class NestedJarInputStream extends InputStream implements AutoCloseable {
+    private final JarFile outerJar;
+    private final InputStream innerInputStream;
+
+    public NestedJarInputStream(final String outerPath, final String innerPath) throws IOException {
+      super();
+      this.outerJar = new JarFile(outerPath, false /* no verify */);
+      final ZipEntry entry = outerJar.getEntry(innerPath);
+      if (entry == null) {
+        this.outerJar.close();
+        throw new NoSuchFileException("Nested jar not found: " + innerPath);
+      }
+      this.innerInputStream = outerJar.getInputStream(entry);
+    }
+
+    @Override
+    public int read() throws IOException {
+      return this.innerInputStream.read();
+    }
+
+    @Override
+    public void close() throws IOException {
+      this.innerInputStream.close();
+      this.outerJar.close();
     }
   }
 }

--- a/telemetry/src/main/java/datadog/telemetry/dependency/JarReader.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/JarReader.java
@@ -132,10 +132,6 @@ class JarReader {
       super();
       this.outerJar = new JarFile(outerPath, false /* no verify */);
       final ZipEntry entry = outerJar.getEntry(innerPath);
-      if (entry == null) {
-        this.outerJar.close();
-        throw new NoSuchFileException("Nested jar not found: " + innerPath);
-      }
       this.innerInputStream = outerJar.getInputStream(entry);
     }
 


### PR DESCRIPTION
# What Does This Do
* Fixes dependency resolver for nested dependencies when URI has no trailing slash.
* Also fix fallback resolver when a nested dependency has no Maven metadata.

# Motivation
For v1.31.0+, this issue would result in exceptions logged at debug level:

```
[dd.trace 2024-03-08 13:32:35:110 +0100] [dd-task-scheduler] DEBUG datadog.telemetry.dependency.DependencyResolver - Failed to determine dependency for uri jar:file:/work/dd-trace-java/dd-smoke-tests/spring-boot-3.0-webmvc/build/application/libs/webmvc-3.0-smoketest.jar!/BOOT-INF/lib/spring-boot-3.0.0.jar!/
java.io.FileNotFoundException: /work/dd-trace-java/dd-smoke-tests/spring-boot-3.0-webmvc/build/application/libs/webmvc-3.0-smoketest.jar!/BOOT-INF/lib/spring-boot-3.0.0.jar! (No such file or directory)
        at java.base/java.io.FileInputStream.open0(Native Method)
        at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
        at java.base/java.io.FileInputStream.<init>(FileInputStream.java:111)
        at datadog.telemetry.dependency.DependencyResolver.resolve(DependencyResolver.java:43)
        at datadog.telemetry.dependency.DependencyResolverQueue.pollDependency(DependencyResolverQueue.java:82)
        at datadog.telemetry.dependency.DependencyService.resolveOneDependency(DependencyService.java:38)
        at datadog.telemetry.dependency.DependencyService.run(DependencyService.java:96)
        at datadog.trace.util.AgentTaskScheduler$RunnableTask.run(AgentTaskScheduler.java:41)
        at datadog.trace.util.AgentTaskScheduler$RunnableTask.run(AgentTaskScheduler.java:36)
        at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:311)
        at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:266)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

# Additional Notes

* Jira ticket: [APPSEC-52172](https://datadoghq.atlassian.net/browse/APPSEC-52172)
* Depends on https://github.com/DataDog/dd-trace-java/pull/6792

[APPSEC-52172]: https://datadoghq.atlassian.net/browse/APPSEC-52172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ