### PR TITLE
Fix string format when escaped patterns are used

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
@@ -915,6 +915,10 @@ class StringModuleTest extends IastModuleImplTestBase {
     'Hello ==>%s<=='                | ['World!']                          | 'Hello ==>World!<==' // tainted placeholder [non tainted parameter]
     'He==>llo %s!<=='               | ['World']                           | 'He==>llo <====>World<====>!<==' // tainted placeholder (2) [non tainted parameter]
     'He==>llo %s!<=='               | ['W==>or<==ld']                     | 'He==>llo <==W==>or<==ld==>!<==' // tainted placeholder (3) [mixing with tainted parameter]
+    'Hello %n %n %s!%n'             | ['W==>or<==ld']                     | 'Hello \n \n W==>or<==ld!\n' // \n character
+    'Hello %% %% %s!%%'             | ['W==>or<==ld']                     | 'Hello % % W==>or<==ld!%' // % character
+    '==>Hello %n %s!<=='            | ['World']                           | '==>Hello <====>\n<====> <====>World<====>!<==' // \n character in tainted format (each placeholder generates a separate range)
+    '==>Hello %% %s!<=='            | ['World']                           | '==>Hello <====>%<====> <====>World<====>!<==' // % character in tainted format (each placeholder generates a separate range)
   }
 
   void 'onStringFormat literals: #literals args: #argsTainted'() {


### PR DESCRIPTION
# What Does This Do
Fixes the handling of tainted parameters in `String#format` when escaped patterns like `%%` and `%n` are used.

# Motivation
The current code is throwing `java.lang.ArrayIndexOutOfBoundsException` due to bad argument handling.

# Additional Notes

Jira ticket: [APPSEC-52173]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-52173]: https://datadoghq.atlassian.net/browse/APPSEC-52173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ