### PR TITLE
Remove buildSingleAdvice test-only method from AbstractTransformerBuilder

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AbstractTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/AbstractTransformerBuilder.java
@@ -42,8 +42,6 @@ abstract class AbstractTransformerBuilder
           buildInstrumentation(module, member);
         }
       }
-    } else if (instrumenter instanceof Instrumenter.ForSingleType) {
-      buildSingleAdvice((Instrumenter.ForSingleType) instrumenter); // for testing purposes
     } else {
       throw new IllegalArgumentException("Unexpected Instrumenter type");
     }
@@ -52,8 +50,6 @@ abstract class AbstractTransformerBuilder
   public abstract ClassFileTransformer installOn(Instrumentation instrumentation);
 
   protected abstract void buildInstrumentation(InstrumenterModule module, Instrumenter member);
-
-  protected abstract void buildSingleAdvice(Instrumenter.ForSingleType instrumenter);
 
   protected static final class VisitingTransformer implements AgentBuilder.Transformer {
     private final AsmVisitorWrapper visitor;

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -2,9 +2,7 @@ package datadog.trace.agent.tooling;
 
 import static datadog.trace.agent.tooling.bytebuddy.DDTransformers.defaultTransformers;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.ANY_CLASS_LOADER;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import datadog.trace.agent.tooling.Instrumenter.WithPostProcessor;
@@ -139,30 +137,6 @@ public final class CombiningTransformerBuilder extends AbstractTransformerBuilde
     }
     if (member instanceof Instrumenter.HasMethodAdvice) {
       ((Instrumenter.HasMethodAdvice) member).methodAdvice(this);
-    }
-    transformers[id] = new AdviceStack(advice);
-
-    advice.clear();
-  }
-
-  @Override
-  protected void buildSingleAdvice(Instrumenter.ForSingleType instrumenter) {
-
-    // this is a test instrumenter which needs a dynamic id
-    int id = nextSupplementaryId++;
-    if (transformers.length <= id) {
-      transformers = Arrays.copyOf(transformers, id + 1);
-    }
-
-    // can't use known-types index because it doesn't include test instrumenters
-    matchers.add(new MatchRecorder.ForType(id, named(instrumenter.instrumentedType())));
-
-    ignoredMethods = isSynthetic();
-    if (instrumenter instanceof Instrumenter.HasTypeAdvice) {
-      ((Instrumenter.HasTypeAdvice) instrumenter).typeAdvice(this);
-    }
-    if (instrumenter instanceof Instrumenter.HasMethodAdvice) {
-      ((Instrumenter.HasMethodAdvice) instrumenter).methodAdvice(this);
     }
     transformers[id] = new AdviceStack(advice);
 

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/LegacyTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/LegacyTransformerBuilder.java
@@ -3,7 +3,6 @@ package datadog.trace.agent.tooling;
 import static datadog.trace.agent.tooling.bytebuddy.DDTransformers.defaultTransformers;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.ANY_CLASS_LOADER;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
-import static net.bytebuddy.matcher.ElementMatchers.isSynthetic;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
@@ -155,17 +154,6 @@ public final class LegacyTransformerBuilder extends AbstractTransformerBuilder {
             + module.names()
             + " instrumentation.class="
             + module.getClass().getName());
-  }
-
-  @Override
-  protected void buildSingleAdvice(Instrumenter.ForSingleType instrumenter) {
-    AgentBuilder.RawMatcher matcher = new SingleTypeMatcher(instrumenter.instrumentedType());
-
-    ignoreMatcher = isSynthetic();
-    adviceBuilder =
-        agentBuilder.type(matcher).and(NOT_DECORATOR_MATCHER).transform(defaultTransformers());
-
-    agentBuilder = registerAdvice((Instrumenter) instrumenter);
   }
 
   @Override


### PR DESCRIPTION
This special code-path was used by some old tests, but is no longer required - removing it simplifies future refactoring