### PR TITLE
feat(packaging): Add OCI packaging support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,6 +96,40 @@ package-arm:
   variables:
     PRODUCT_NAME: auto_inject-java
 
+package-oci:
+  stage: package
+  extends: .package-oci
+  when: on_success # this can't use 'needs: [build]', since build is not available in the scheduled pipeline
+  script:
+    - ../.gitlab/build_java_package_oci.sh
+
+release-staging-repo-oci-package:
+  stage: deploy
+  extends: .release-oci-package
+  variables:
+    TARGET_REPO: staging
+    TARGET_BRANCH: beta
+    AUTO_RELEASE: $AUTO_RELEASE_STAGING
+    PRODUCT_NAME: auto_inject-java
+
+release-prod-beta-repo-oci-package:
+  stage: deploy
+  extends: .release-oci-package
+  variables:
+    TARGET_REPO: prod
+    TARGET_BRANCH: beta
+    AUTO_RELEASE: $AUTO_RELEASE_PROD_BETA
+    PRODUCT_NAME: auto_inject-java
+
+release-prod-repo-oci-package:
+  stage: deploy
+  extends: .release-oci-package
+  variables:
+    TARGET_REPO: prod
+    TARGET_BRANCH: stable
+    AUTO_RELEASE: $AUTO_RELEASE_PROD_STABLE
+    PRODUCT_NAME: auto_inject-java
+
 deploy_to_reliability_env:
   stage: deploy
   rules:

--- a/.gitlab/build_java_package_oci.sh
+++ b/.gitlab/build_java_package_oci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ -z "$CI_COMMIT_TAG" ] ; then
+  source ../upstream.env
+  VERSION=$UPSTREAM_TRACER_VERSION$CI_VERSION_SUFFIX
+else
+  VERSION=${CI_COMMIT_TAG##v}
+fi
+
+echo -n "$VERSION" > auto_inject-java.version
+
+mkdir -p sources
+cp ../workspace/dd-java-agent/build/libs/*.jar sources/dd-java-agent.jar
+cp auto_inject-java.version sources/version
+
+datadog-package create \
+    --version=$VERSION \
+    --package=auto_inject-java \
+    --archive=true \
+    --archive-path auto_inject-java-$VERSION.tar \
+    ./sources


### PR DESCRIPTION
# What Does This Do
Adds OCI packaging support to the `dd-trace-java` library, following https://github.com/DataDog/auto_inject/pull/147 & https://github.com/DataDog/auto_inject/pull/149

# Motivation
Package tracing libraries to be downloaded at runtime

# Additional Notes
N/A

Jira ticket: [RC-1645]


[RC-1645]: https://datadoghq.atlassian.net/browse/RC-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ