### PR TITLE
Fix nested JAR resolver when URI has no trailing slash (#6794) (1.31.x backport)

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyResolver.java
@@ -1,7 +1,6 @@
 package datadog.telemetry.dependency;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -52,7 +51,7 @@ public class DependencyResolver {
     if (!dependencies.isEmpty()) {
       return dependencies;
     }
-    try (final InputStream is = new FileInputStream(path)) {
+    try (final InputStream is = metadata.inputStreamSupplier.get()) {
       return Collections.singletonList(
           Dependency.guessFallbackNoPom(metadata.manifest, metadata.jarName, is));
     }

--- a/telemetry/src/main/java/datadog/telemetry/dependency/JarReader.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/JarReader.java
@@ -1,6 +1,7 @@
 package datadog.telemetry.dependency;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.NoSuchFileException;
@@ -20,23 +21,30 @@ class JarReader {
     final Map<String, Properties> pomProperties;
     final Attributes manifest;
     final boolean isDirectory;
+    final InputStreamSupplier inputStreamSupplier;
 
     public Extracted(
         final String jarName,
         final Map<String, Properties> pomProperties,
         final Attributes manifest,
-        final boolean isDirectory) {
+        final boolean isDirectory,
+        final InputStreamSupplier inputStreamSupplier) {
       this.jarName = jarName;
       this.pomProperties = pomProperties;
       this.manifest = manifest;
       this.isDirectory = isDirectory;
+      this.inputStreamSupplier = inputStreamSupplier;
+    }
+
+    public interface InputStreamSupplier {
+      InputStream get() throws IOException;
     }
   }
 
   public static Extracted readJarFile(String jarPath) throws IOException {
     final File jarFile = new File(jarPath);
     if (jarFile.isDirectory()) {
-      return new Extracted(jarFile.getName(), new HashMap<>(), new Attributes(), true);
+      return new Extracted(jarFile.getName(), new HashMap<>(), new Attributes(), true, () -> null);
     }
     try (final JarFile jar = new JarFile(jarPath, false /* no verify */)) {
       final Map<String, Properties> pomProperties = new HashMap<>();
@@ -54,7 +62,12 @@ class JarReader {
       final Manifest manifest = jar.getManifest();
       final Attributes attributes =
           (manifest == null) ? new Attributes() : manifest.getMainAttributes();
-      return new Extracted(new File(jar.getName()).getName(), pomProperties, attributes, false);
+      return new Extracted(
+          new File(jar.getName()).getName(),
+          pomProperties,
+          attributes,
+          false,
+          () -> new FileInputStream(jarPath));
     }
   }
 
@@ -64,10 +77,7 @@ class JarReader {
       throw new IllegalArgumentException("Invalid nested jar path: " + jarPath);
     }
     final String outerJarPath = jarPath.substring(0, sepIdx);
-    String innerJarPath = jarPath.substring(sepIdx + 2);
-    if (innerJarPath.endsWith("!/")) {
-      innerJarPath = innerJarPath.substring(0, innerJarPath.length() - 2);
-    }
+    final String innerJarPath = getInnerJarPath(jarPath);
     try (final JarFile outerJar = new JarFile(outerJarPath, false /* no verify */)) {
       final ZipEntry entry = outerJar.getEntry(innerJarPath);
       if (entry == null) {
@@ -75,7 +85,7 @@ class JarReader {
       }
       if (entry.isDirectory()) {
         return new Extracted(
-            new File(innerJarPath).getName(), new HashMap<>(), new Attributes(), true);
+            new File(innerJarPath).getName(), new HashMap<>(), new Attributes(), true, () -> null);
       }
       try (final InputStream is = outerJar.getInputStream(entry);
           final JarInputStream innerJar = new JarInputStream(is, false /* no verify */)) {
@@ -91,8 +101,54 @@ class JarReader {
         final Manifest manifest = innerJar.getManifest();
         final Attributes attributes =
             (manifest == null) ? new Attributes() : manifest.getMainAttributes();
-        return new Extracted(new File(innerJarPath).getName(), pomProperties, attributes, false);
+        return new Extracted(
+            new File(innerJarPath).getName(),
+            pomProperties,
+            attributes,
+            false,
+            () -> new NestedJarInputStream(outerJarPath, innerJarPath));
       }
+    }
+  }
+
+  private static String getInnerJarPath(final String jarPath) {
+    final int sepIdx = jarPath.indexOf("!/");
+    if (sepIdx == -1) {
+      throw new IllegalArgumentException("Invalid nested jar path: " + jarPath);
+    }
+    String innerJarPath = jarPath.substring(sepIdx + 2);
+    final int innerSepIdx = innerJarPath.indexOf('!');
+    if (innerSepIdx != -1) {
+      innerJarPath = innerJarPath.substring(0, innerSepIdx);
+    }
+    return innerJarPath;
+  }
+
+  static class NestedJarInputStream extends InputStream implements AutoCloseable {
+    private final JarFile outerJar;
+    private final InputStream innerInputStream;
+
+    public NestedJarInputStream(final String outerPath, final String innerPath) throws IOException {
+      super();
+      this.outerJar = new JarFile(outerPath, false /* no verify */);
+      final ZipEntry entry = outerJar.getEntry(innerPath);
+      this.innerInputStream = outerJar.getInputStream(entry);
+    }
+
+    @Override
+    public int read() throws IOException {
+      return this.innerInputStream.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return this.innerInputStream.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      this.innerInputStream.close();
+      this.outerJar.close();
     }
   }
 }


### PR DESCRIPTION

# What Does This Do

#6794 backport

(cherry picked from commit cab4638496cadcf048f01451db88bb913f182a2d)


# Motivation

# Additional Notes

Jira ticket: [APPSEC-52172](https://datadoghq.atlassian.net/browse/APPSEC-52172)

[APPSEC-52172]: https://datadoghq.atlassian.net/browse/APPSEC-52172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ