### PR TITLE
Add request sampling back in http sources

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/GrpcRequestMessageHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/GrpcRequestMessageHandler.java
@@ -2,6 +2,7 @@ package com.datadog.iast;
 
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
@@ -31,7 +32,7 @@ public class GrpcRequestMessageHandler implements BiFunction<RequestContext, Obj
   public Flow<Void> apply(final RequestContext ctx, final Object o) {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null && o != null) {
-      final IastContext iastCtx = IastContext.Provider.get(ctx);
+      final IastContext iastCtx = ctx.getData(RequestContextSlot.IAST);
       final byte source = SourceTypes.GRPC_BODY;
       final int tainted =
           module.taintDeeply(iastCtx, o, source, GrpcRequestMessageHandler::isProtobufArtifact);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestEndedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/RequestEndedHandler.java
@@ -7,6 +7,7 @@ import com.datadog.iast.overhead.OverheadController;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.sink.HttpRequestEndModule;
@@ -27,7 +28,7 @@ public class RequestEndedHandler implements BiFunction<RequestContext, IGSpanInf
   @Override
   public Flow<Void> apply(final RequestContext requestContext, final IGSpanInfo igSpanInfo) {
     final TraceSegment traceSegment = requestContext.getTraceSegment();
-    final IastContext iastCtx = IastContext.Provider.get(requestContext);
+    final IastContext iastCtx = requestContext.getData(RequestContextSlot.IAST);
     if (iastCtx != null) {
       for (HttpRequestEndModule module : requestEndModules()) {
         if (module != null) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestEndedHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/telemetry/TelemetryRequestEndedHandler.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.iast.telemetry.IastMetric.Scope.REQUEST;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.telemetry.IastMetric;
 import datadog.trace.api.iast.telemetry.IastMetricCollector;
@@ -33,7 +34,7 @@ public class TelemetryRequestEndedHandler
   }
 
   private static void onRequestEnded(final RequestContext context) {
-    final IastContext iastCtx = IastContext.Provider.get(context);
+    final IastContext iastCtx = context.getData(RequestContextSlot.IAST);
     if (!(iastCtx instanceof HasMetricCollector)) {
       return;
     }

--- a/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastHttpServerTest.groovy
+++ b/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastHttpServerTest.groovy
@@ -7,7 +7,7 @@ import datadog.trace.agent.test.base.WithHttpServer
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor
 import datadog.trace.api.gateway.IGSpanInfo
 import datadog.trace.api.gateway.RequestContext
-import datadog.trace.api.iast.IastContext
+import datadog.trace.api.gateway.RequestContextSlot
 import groovy.json.JsonBuilder
 import groovy.transform.CompileStatic
 
@@ -29,11 +29,11 @@ abstract class IastHttpServerTest<SERVER> extends WithHttpServer<SERVER> impleme
   protected Closure getRequestEndAction() {
     { RequestContext requestContext, IGSpanInfo igSpanInfo ->
       // request end action
-      IastRequestContext iastRequestContext = IastContext.Provider.get(requestContext)
+      IastRequestContext iastRequestContext = requestContext.getData(RequestContextSlot.IAST)
       if (iastRequestContext) {
         TaintedObjects taintedObjects = iastRequestContext.getTaintedObjects()
         TAINTED_OBJECTS.offer(new TaintedObjectCollection(taintedObjects))
-        List<Vulnerability> vulns = iastRequestContext.getVulnerabilityBatch().getVulnerabilities()
+        List<Vulnerability> vulns = iastRequestContext.getVulnerabilityBatch().getVulnerabilities() ?: []
         VULNERABILITIES.offer(vulns)
       }
     }

--- a/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastRequestTestRunner.groovy
+++ b/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastRequestTestRunner.groovy
@@ -5,7 +5,7 @@ import com.datadog.iast.taint.TaintedObjects
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.api.gateway.IGSpanInfo
 import datadog.trace.api.gateway.RequestContext
-import datadog.trace.api.iast.IastContext
+import datadog.trace.api.gateway.RequestContextSlot
 import okhttp3.OkHttpClient
 
 import java.util.concurrent.LinkedBlockingQueue
@@ -21,7 +21,7 @@ class IastRequestTestRunner extends IastAgentTestRunner implements IastRequestCo
   protected Closure getRequestEndAction() {
     { RequestContext requestContext, IGSpanInfo igSpanInfo ->
       // request end action
-      IastRequestContext iastRequestContext = IastContext.Provider.get(requestContext)
+      IastRequestContext iastRequestContext = requestContext.getData(RequestContextSlot.IAST)
       if (iastRequestContext) {
         TaintedObjects taintedObjects = iastRequestContext.getTaintedObjects()
         TAINTED_OBJECTS.offer(new TaintedObjectCollection(taintedObjects))

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/iast/TaintableEnumerationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/iast/TaintableEnumerationTest.groovy
@@ -1,44 +1,26 @@
 package datadog.trace.agent.tooling.iast
 
-import datadog.trace.api.gateway.RequestContext
-import datadog.trace.api.gateway.RequestContextSlot
+
 import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.test.util.DDSpecification
 import spock.lang.Shared
 
 class TaintableEnumerationTest extends DDSpecification {
 
   @Shared
-  protected static final AgentTracer.TracerAPI ORIGINAL_TRACER = AgentTracer.get()
-
-  protected AgentTracer.TracerAPI tracer = Mock(AgentTracer.TracerAPI)
-
-  protected IastContext iastCtx = Mock(IastContext)
-
-  protected RequestContext reqCtx = Mock(RequestContext) {
-    getData(RequestContextSlot.IAST) >> iastCtx
-  }
-
-  protected AgentSpan span = Mock(AgentSpan) {
-    getRequestContext() >> reqCtx
-  }
+  protected IastContext iastCtx = Stub(IastContext)
 
   protected PropagationModule module
 
-
   void setup() {
-    AgentTracer.forceRegister(tracer)
     module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
   }
 
   void cleanup() {
-    AgentTracer.forceRegister(ORIGINAL_TRACER)
     InstrumentationBridge.clearIastModules()
   }
 
@@ -47,35 +29,34 @@ class TaintableEnumerationTest extends DDSpecification {
     final values = (1..10).collect { "value$it".toString() }
     final origin = SourceTypes.REQUEST_PARAMETER_NAME
     final name = 'test'
-    final enumeration = TaintableEnumeration.wrap(Collections.enumeration(values), module, origin, name)
+    final enumeration = TaintableEnumeration.wrap(iastCtx, Collections.enumeration(values), module, origin, name)
 
     when:
     final result = enumeration.collect()
 
     then:
     result == values
-    values.each { 1 * module.taint(_, it, origin, name) }
-    1 * tracer.activeSpan() >> span // only one access to the active context
+    values.each { 1 * module.taint(iastCtx, it, origin, name) }
   }
 
   void 'underlying enumerated values are tainted with the value as a name'() {
     given:
     final values = (1..10).collect { "value$it".toString() }
     final origin = SourceTypes.REQUEST_PARAMETER_NAME
-    final enumeration = TaintableEnumeration.wrap(Collections.enumeration(values), module, origin, true)
+    final enumeration = TaintableEnumeration.wrap(iastCtx, Collections.enumeration(values), module, origin, true)
 
     when:
     final result = enumeration.collect()
 
     then:
     result == values
-    values.each { 1 * module.taint(_, it, origin, it) }
+    values.each { 1 * module.taint(iastCtx, it, origin, it) }
   }
 
   void 'taintable enumeration leaves no trace in case of error'() {
     given:
     final origin = SourceTypes.REQUEST_PARAMETER_NAME
-    final enumeration = TaintableEnumeration.wrap(new BadEnumeration(), module, origin, true)
+    final enumeration = TaintableEnumeration.wrap(iastCtx, new BadEnumeration(), module, origin, true)
 
     when:
     enumeration.hasMoreElements()

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
@@ -11,8 +11,12 @@ import akka.http.javadsl.model.HttpHeader;
 import akka.http.scaladsl.model.headers.Cookie;
 import akka.http.scaladsl.model.headers.HttpCookiePair;
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -50,20 +54,23 @@ public class CookieHeaderInstrumentation extends InstrumenterModule.Iast
         CookieHeaderInstrumentation.class.getName() + "$TaintAllCookiesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class TaintAllCookiesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     static void after(
-        @Advice.This HttpHeader cookie, @Advice.Return Seq<HttpCookiePair> cookiePairs) {
+        @Advice.This HttpHeader cookie,
+        @Advice.Return Seq<HttpCookiePair> cookiePairs,
+        @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule prop = InstrumentationBridge.PROPAGATION;
       if (prop == null || cookiePairs == null || cookiePairs.isEmpty()) {
         return;
       }
-      if (!prop.isTainted(cookie)) {
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      if (!prop.isTainted(ctx, cookie)) {
         return;
       }
 
-      final IastContext ctx = IastContext.Provider.get();
       Iterator<HttpCookiePair> iterator = cookiePairs.iterator();
       while (iterator.hasNext()) {
         HttpCookiePair pair = iterator.next();

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
@@ -8,6 +8,7 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 
 /**
  * Detects when a header name is directly called from user code. This uses call site instrumentation
@@ -27,7 +28,7 @@ public class HeaderNameCallSite {
       return result;
     }
     try {
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
       if (ctx == null) {
         return result;
       }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.akkahttp.iast;
 import akka.http.javadsl.model.HttpHeader;
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -26,7 +27,11 @@ public class HeaderNameCallSite {
       return result;
     }
     try {
-      module.taintIfTainted(result, header, SourceTypes.REQUEST_HEADER_NAME, result);
+      final IastContext ctx = IastContext.Provider.get();
+      if (ctx == null) {
+        return result;
+      }
+      module.taintIfTainted(ctx, result, header, SourceTypes.REQUEST_HEADER_NAME, result);
     } catch (final Throwable e) {
       module.onUnexpectedException("onHeaderNames threw", e);
     }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpHeaderSubclassesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpHeaderSubclassesInstrumentation.java
@@ -11,8 +11,13 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import akka.http.scaladsl.model.HttpHeader;
 import akka.http.scaladsl.model.HttpRequest;
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -53,17 +58,21 @@ public class HttpHeaderSubclassesInstrumentation extends InstrumenterModule.Iast
         HttpHeaderSubclassesInstrumentation.class.getName() + "$HttpHeaderSubclassesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class HttpHeaderSubclassesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
-    static void onExit(@Advice.This HttpHeader h, @Advice.Return String retVal) {
+    static void onExit(
+        @Advice.This HttpHeader h,
+        @Advice.Return String retVal,
+        @ActiveRequestContext RequestContext reqCtx) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation == null) {
         return;
       }
-
-      propagation.taintIfTainted(retVal, h);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      propagation.taintIfTainted(ctx, retVal, h);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
@@ -12,8 +12,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import akka.http.scaladsl.model.HttpHeader;
 import akka.http.scaladsl.model.HttpRequest;
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
@@ -58,25 +62,28 @@ public class HttpRequestInstrumentation extends InstrumenterModule.Iast
   }
 
   @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class RequestHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     static void onExit(
-        @Advice.This HttpRequest thiz, @Advice.Return(readOnly = false) Seq<HttpHeader> headers) {
+        @Advice.This HttpRequest thiz,
+        @Advice.Return(readOnly = false) Seq<HttpHeader> headers,
+        @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation == null || headers == null || headers.isEmpty()) {
         return;
       }
 
-      if (!propagation.isTainted(thiz)) {
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      if (!propagation.isTainted(ctx, thiz)) {
         return;
       }
 
-      final IastContext ctx = IastContext.Provider.get();
       Iterator<HttpHeader> iterator = headers.iterator();
       while (iterator.hasNext()) {
         HttpHeader h = iterator.next();
-        if (propagation.isTainted(h)) {
+        if (propagation.isTainted(ctx, h)) {
           continue;
         }
         // unfortunately, the call to h.value() is instrumented, but
@@ -86,22 +93,26 @@ public class HttpRequestInstrumentation extends InstrumenterModule.Iast
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class EntityAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     static void onExit(
         @Advice.This HttpRequest thiz,
-        @Advice.Return(readOnly = false, typing = DYNAMIC) Object entity) {
+        @Advice.Return(readOnly = false, typing = DYNAMIC) Object entity,
+        @ActiveRequestContext RequestContext reqCtx) {
+
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation == null || entity == null) {
         return;
       }
 
-      if (propagation.isTainted(entity)) {
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      if (propagation.isTainted(ctx, entity)) {
         return;
       }
 
-      propagation.taintIfTainted(entity, thiz);
+      propagation.taintIfTainted(ctx, entity, thiz);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
@@ -64,13 +64,14 @@ public class PathMatcherInstrumentation extends InstrumenterModule.Iast
       scala.Tuple1 tuple = (scala.Tuple1) extractions;
       Object value = tuple._1();
 
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+
       // in the test, 4 instances of PathMatcher$Match are created, all with the same value
-      if (module.isTainted(value)) {
+      if (module.isTainted(ctx, value)) {
         return;
       }
 
       if (value instanceof String) {
-        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         module.taint(ctx, value, SourceTypes.REQUEST_PATH_PARAMETER);
       }
     }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/RequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/RequestContextInstrumentation.java
@@ -10,8 +10,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import akka.http.scaladsl.model.HttpRequest;
 import akka.http.scaladsl.server.RequestContext;
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -43,18 +47,27 @@ public class RequestContextInstrumentation extends InstrumenterModule.Iast
   }
 
   @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class GetRequestAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     static void onExit(
-        @Advice.This RequestContext requestContext, @Advice.Return HttpRequest request) {
+        @Advice.This RequestContext requestContext,
+        @Advice.Return HttpRequest request,
+        @ActiveRequestContext datadog.trace.api.gateway.RequestContext reqCtx) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
-      if (propagation == null || propagation.isTainted(request)) {
+      if (propagation == null) {
         return;
       }
 
-      propagation.taintIfTainted(request, requestContext);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+
+      if (propagation.isTainted(ctx, request)) {
+        return;
+      }
+
+      propagation.taintIfTainted(ctx, request, requestContext);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
@@ -10,8 +10,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import akka.http.scaladsl.model.Uri;
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
@@ -63,34 +67,44 @@ public class UriInstrumentation extends InstrumenterModule.Iast
         UriInstrumentation.class.getName() + "$TaintQueryAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class TaintQueryStringAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
-    static void after(@Advice.This Uri uri, @Advice.Return scala.Option<String> ret) {
+    static void after(
+        @Advice.This Uri uri,
+        @Advice.Return scala.Option<String> ret,
+        @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod == null || ret.isEmpty()) {
         return;
       }
-      mod.taintIfTainted(ret.get(), uri);
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      mod.taintIfTainted(ctx, ret.get(), uri);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class TaintQueryAdvice {
     // bind uri to a variable of type Object so that this advice can also
     // be used from FromDataInstrumentaton
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
-    static void after(@Advice.This /*Uri*/ Object uri, @Advice.Return Uri.Query ret) {
+    static void after(
+        @Advice.This /*Uri*/ Object uri,
+        @Advice.Return Uri.Query ret,
+        @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule prop = InstrumentationBridge.PROPAGATION;
       if (prop == null || ret.isEmpty()) {
         return;
       }
 
-      if (!prop.isTainted(uri)) {
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+
+      if (!prop.isTainted(ctx, uri)) {
         return;
       }
 
-      final IastContext ctx = IastContext.Provider.get();
       Iterator<Tuple2<String, String>> iterator = ret.iterator();
       while (iterator.hasNext()) {
         Tuple2<String, String> pair = iterator.next();

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintCookieFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintCookieFunction.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import akka.http.scaladsl.model.headers.HttpCookiePair;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
 
@@ -19,10 +21,14 @@ public class TaintCookieFunction
     if (mod == null || httpCookiePair == null) {
       return v1;
     }
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     final String name = httpCookiePair.name();
     final String value = httpCookiePair.value();
-    mod.taint(name, SourceTypes.REQUEST_COOKIE_NAME, name);
-    mod.taint(value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+    mod.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+    mod.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintFutureHelper.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintFutureHelper.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.compat.java8.JFunction1;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
@@ -10,7 +12,10 @@ public class TaintFutureHelper {
       Future<T> f, Object input, PropagationModule mod, ExecutionContext ec) {
     JFunction1<T, T> mapf =
         t -> {
-          mod.taintIfTainted(t, input);
+          IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+          if (ctx != null) {
+            mod.taintIfTainted(ctx, t, input);
+          }
           return t;
         };
     return f.map(mapf, ec);

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMapFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMapFunction.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.Tuple1;
 import scala.Tuple2;
 import scala.collection.Iterator;
@@ -23,7 +24,10 @@ public class TaintMapFunction
       return v1;
     }
 
-    final IastContext ctx = IastContext.Provider.get();
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     Iterator<Tuple2<String, String>> iterator = m.iterator();
     while (iterator.hasNext()) {
       Tuple2<String, String> e = iterator.next();

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMultiMapFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMultiMapFunction.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.Tuple1;
 import scala.Tuple2;
 import scala.collection.Iterator;
@@ -24,7 +25,10 @@ public class TaintMultiMapFunction
       return v1;
     }
 
-    final IastContext ctx = IastContext.Provider.get();
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     Iterator<Tuple2<String, List<String>>> entriesIterator = m.iterator();
     while (entriesIterator.hasNext()) {
       Tuple2<String, List<String>> e = entriesIterator.next();

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintOptionalCookieFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintOptionalCookieFunction.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import akka.http.scaladsl.model.headers.HttpCookiePair;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.Option;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
@@ -20,11 +22,15 @@ public class TaintOptionalCookieFunction
     if (mod == null || httpCookiePair == null || httpCookiePair.isEmpty()) {
       return v1;
     }
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     final HttpCookiePair cookie = httpCookiePair.get();
     final String name = cookie.name();
     final String value = cookie.value();
-    mod.taint(name, SourceTypes.REQUEST_COOKIE_NAME, name);
-    mod.taint(value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+    mod.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+    mod.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import akka.http.scaladsl.server.RequestContext;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
 
@@ -19,7 +21,11 @@ public class TaintRequestContextFunction
     if (mod == null || reqCtx == null) {
       return v1;
     }
-    mod.taint(reqCtx, SourceTypes.REQUEST_BODY);
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
+    mod.taint(ctx, reqCtx, SourceTypes.REQUEST_BODY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import akka.http.scaladsl.model.HttpRequest;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
@@ -20,7 +22,11 @@ public class TaintRequestFunction implements JFunction1<Tuple1<HttpRequest>, Tup
     if (mod == null || httpRequest == null) {
       return v1;
     }
-    mod.taint(httpRequest, SourceTypes.REQUEST_BODY);
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
+    mod.taint(ctx, httpRequest, SourceTypes.REQUEST_BODY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSeqFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSeqFunction.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
@@ -27,7 +28,10 @@ public class TaintSeqFunction
       return v1;
     }
 
-    final IastContext ctx = IastContext.Provider.get();
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     Iterator<Tuple2<String, String>> iterator = seq.iterator();
     Set<String> seenKeys = Collections.newSetFromMap(new IdentityHashMap<>());
     while (iterator.hasNext()) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSingleParameterFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSingleParameterFunction.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import scala.Option;
@@ -40,17 +41,20 @@ public class TaintSingleParameterFunction<Magnet>
       value = option.get();
     }
 
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     if (value instanceof Iterable) {
-      final IastContext ctx = IastContext.Provider.get();
       Iterator<?> iterator = ((Iterable<?>) value).iterator();
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint((String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUnmarshaller.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUnmarshaller.java
@@ -2,8 +2,10 @@ package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import akka.http.scaladsl.unmarshalling.Unmarshaller;
 import akka.stream.Materializer;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.instrumentation.akkahttp.iast.UnmarshallerInstrumentation;
 import scala.Function1;
 import scala.PartialFunction;
@@ -28,7 +30,10 @@ public class TaintUnmarshaller<A, B> implements Unmarshaller<A, B> {
 
   @Override
   public Future<B> apply(A value, ExecutionContext ec, Materializer materializer) {
-    propagationModule.taint(value, SourceTypes.REQUEST_BODY);
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx != null) {
+      propagationModule.taint(ctx, value, SourceTypes.REQUEST_BODY);
+    }
     return delegate.apply(value, ec, materializer);
   }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.akkahttp.iast.helpers;
 
 import akka.http.scaladsl.model.Uri;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
 
@@ -18,7 +20,11 @@ public class TaintUriFunction implements JFunction1<Tuple1<Uri>, Tuple1<Uri>> {
     if (mod == null) {
       return v1;
     }
-    mod.taint(uri, SourceTypes.REQUEST_QUERY);
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
+    mod.taint(ctx, uri, SourceTypes.REQUEST_QUERY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/ParameterDirectivesImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/ParameterDirectivesImplInstrumentation.java
@@ -11,9 +11,14 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import akka.http.scaladsl.server.Directive;
 import akka.http.scaladsl.server.util.Tupler$;
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.instrumentation.akkahttp102.iast.helpers.TaintParametersFunction;
@@ -68,30 +73,38 @@ public class ParameterDirectivesImplInstrumentation extends InstrumenterModule.I
         ParameterDirectivesImplInstrumentation.class.getName() + "$RepeatedFilterAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class FilterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Argument(0) String paramName,
-        @Advice.Return(readOnly = false) Directive /*<Tuple1<?>>*/ retval) {
+        @Advice.Return(readOnly = false) Directive /*<Tuple1<?>>*/ retval,
+        @ActiveRequestContext RequestContext reqCtx) {
       try {
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         retval =
-            retval.tmap(new TaintParametersFunction(paramName), Tupler$.MODULE$.forTuple(null));
+            retval.tmap(
+                new TaintParametersFunction(ctx, paramName), Tupler$.MODULE$.forTuple(null));
       } catch (Exception e) {
         throw new RuntimeException(e); // propagate so it's logged
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class RepeatedFilterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     static void after(
         @Advice.Argument(0) String paramName,
-        @Advice.Return(readOnly = false) Directive /*<Tuple1<Iterable<?>>>*/ retval) {
+        @Advice.Return(readOnly = false) Directive /*<Tuple1<Iterable<?>>>*/ retval,
+        @ActiveRequestContext RequestContext reqCtx) {
       try {
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         retval =
-            retval.tmap(new TaintParametersFunction(paramName), Tupler$.MODULE$.forTuple(null));
+            retval.tmap(
+                new TaintParametersFunction(ctx, paramName), Tupler$.MODULE$.forTuple(null));
       } catch (Exception e) {
         throw new RuntimeException(e); // propagate so it's logged
       }

--- a/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/helpers/TaintParametersFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/helpers/TaintParametersFunction.java
@@ -11,9 +11,12 @@ import scala.collection.Iterable;
 import scala.collection.Iterator;
 
 public class TaintParametersFunction<T> implements Function1<Tuple1<T>, Tuple1<T>> {
+
+  private final IastContext ctx;
   private final String paramName;
 
-  public TaintParametersFunction(String paramName) {
+  public TaintParametersFunction(IastContext ctx, String paramName) {
+    this.ctx = ctx;
     this.paramName = paramName;
   }
 
@@ -34,16 +37,15 @@ public class TaintParametersFunction<T> implements Function1<Tuple1<T>, Tuple1<T
     }
 
     if (value instanceof Iterable) {
-      final IastContext ctx = IastContext.Provider.get();
       Iterator<?> iterator = ((Iterable<?>) value).iterator();
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint((String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
@@ -7,8 +7,12 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -44,14 +48,16 @@ public class CommonsFileuploadInstrumenter extends InstrumenterModule.Iast
     };
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class ParseAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
-    public static Map<String, String> onExit(@Advice.Return final Map<String, String> map) {
+    public static Map<String, String> onExit(
+        @Advice.Return final Map<String, String> map, @ActiveRequestContext RequestContext reqCtx) {
       if (!map.isEmpty()) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          final IastContext ctx = IastContext.Provider.get();
+          final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
           for (final Map.Entry<String, String> entry : map.entrySet()) {
             if (entry.getValue() != null) {
               module.taint(

--- a/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/MultipartInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/MultipartInstrumentationTest.groovy
@@ -1,13 +1,24 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 
 
 class MultipartInstrumentationTest extends AgentTestRunner {
+
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  @Override
+  void setup() {
+    iastCtx = Stub(IastContext)
   }
 
   @Override
@@ -23,18 +34,30 @@ class MultipartInstrumentationTest extends AgentTestRunner {
     final parser = clazz.newInstance()
 
     when:
-    parser.parse(content, new char[]{
-      ',', ';'
-    })
+    runUnderIastTrace {
+      parser.parse(content, new char[]{
+        ',', ';'
+      })
+    }
 
     then:
-    1 * module.taint(null, 'file', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'name')
-    1 * module.taint(null, _, SourceTypes.REQUEST_MULTIPART_PARAMETER, 'filename')
+    1 * module.taint(iastCtx, 'file', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'name')
+    1 * module.taint(iastCtx, _, SourceTypes.REQUEST_MULTIPART_PARAMETER, 'filename')
     0 * _
 
     where:
     clazz | _
     org.apache.commons.fileupload.ParameterParser | _
     org.apache.tomcat.util.http.fileupload.ParameterParser | _
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
+    }
   }
 }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
@@ -5,8 +5,12 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -36,15 +40,18 @@ public class AbstractFormProviderInstrumentation extends InstrumenterModule.Iast
     return "org.glassfish.jersey.message.internal.AbstractFormProvider";
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class InstrumenterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
-    public static void onExit(@Advice.Return Map<String, List<String>> result) {
+    public static void onExit(
+        @Advice.Return Map<String, List<String>> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule prop = InstrumentationBridge.PROPAGATION;
       if (prop == null || result == null || result.isEmpty()) {
         return;
       }
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (Map.Entry<String, List<String>> entry : result.entrySet()) {
         final String name = entry.getKey();
         prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
@@ -5,8 +5,13 @@ import static net.bytebuddy.matcher.ElementMatchers.isProtected;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -37,15 +42,19 @@ public class AbstractParamValueExtractorInstrumentation extends InstrumenterModu
     return "org.glassfish.jersey.server.internal.inject.AbstractParamValueExtractor";
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class InstrumenterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void onExit(
-        @Advice.Return Object result, @Advice.FieldValue("parameterName") String parameterName) {
+        @Advice.Return Object result,
+        @Advice.FieldValue("parameterName") String parameterName,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (result instanceof String) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taint(result, ThreadLocalSourceType.get(), parameterName);
+          IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+          module.taint(ctx, result, ThreadLocalSourceType.get(), parameterName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
@@ -1,19 +1,27 @@
 package datadog.trace.instrumentation.jersey;
 
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
 
+@RequiresRequestContext(RequestContextSlot.IAST)
 public class AbstractStringReaderAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
-  public static void onExit(@Advice.Return Object result) {
+  public static void onExit(
+      @Advice.Return Object result, @ActiveRequestContext RequestContext reqCtx) {
     if (result instanceof String) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(result, SourceTypes.REQUEST_PARAMETER_VALUE);
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, result, SourceTypes.REQUEST_PARAMETER_VALUE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieInstrumentation.java
@@ -6,8 +6,13 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -37,27 +42,35 @@ public class CookieInstrumentation extends InstrumenterModule.Iast
     return new String[] {"jakarta.ws.rs.core.Cookie", "javax.ws.rs.core.Cookie"};
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class InstrumenterAdviceGetName {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_NAME)
-    public static void onExit(@Advice.Return String cookieName, @Advice.This Object self) {
+    public static void onExit(
+        @Advice.Return String cookieName,
+        @Advice.This Object self,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(cookieName, self, SourceTypes.REQUEST_COOKIE_NAME, cookieName);
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taintIfTainted(ctx, cookieName, self, SourceTypes.REQUEST_COOKIE_NAME, cookieName);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetValueAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void onExit(
         @Advice.Return String cookieValue,
         @Advice.FieldValue("name") String name,
-        @Advice.This Object self) {
+        @Advice.This Object self,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(cookieValue, self, SourceTypes.REQUEST_COOKIE_VALUE, name);
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taintIfTainted(ctx, cookieValue, self, SourceTypes.REQUEST_COOKIE_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
@@ -5,8 +5,12 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -41,13 +45,16 @@ public class InboundMessageContextInstrumentation extends InstrumenterModule.Ias
     return "org.glassfish.jersey.message.internal.InboundMessageContext";
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class InstrumenterAdviceGetHeaders {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
-    public static void onExit(@Advice.Return Map<String, List<String>> headers) {
+    public static void onExit(
+        @Advice.Return Map<String, List<String>> headers,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule prop = InstrumentationBridge.PROPAGATION;
       if (prop != null && headers != null && !headers.isEmpty()) {
-        final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
           final String name = entry.getKey();
           prop.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
@@ -59,13 +66,15 @@ public class InboundMessageContextInstrumentation extends InstrumenterModule.Ias
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class InstrumenterAdviceGetRequestCookies {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
-    public static void onExit(@Advice.Return Map<String, Object> cookies) {
+    public static void onExit(
+        @Advice.Return Map<String, Object> cookies, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null && cookies != null && !cookies.isEmpty()) {
-        final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (Map.Entry<String, Object> entry : cookies.entrySet()) {
           final String name = entry.getKey();
           module.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ReaderInterceptorExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ReaderInterceptorExecutorInstrumentation.java
@@ -4,8 +4,13 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -32,12 +37,15 @@ public class ReaderInterceptorExecutorInstrumentation extends InstrumenterModule
         getClass().getName() + "$InstrumenterAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class InstrumenterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    static void after(@Advice.Return final InputStream inputStream) {
+    static void after(
+        @Advice.Return final InputStream inputStream, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(inputStream, SourceTypes.REQUEST_BODY);
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, inputStream, SourceTypes.REQUEST_BODY);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
@@ -5,8 +5,13 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -34,21 +39,24 @@ public class JSONObjectUtilsInstrumentation extends InstrumenterModule.Iast
     return "com.nimbusds.jose.util.JSONObjectUtils";
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class InstrumenterAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
-    public static void onEnter(@Advice.Return Map<String, Object> map) {
+    public static void onEnter(
+        @Advice.Return Map<String, Object> map, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
 
       if (module != null) {
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (Map.Entry<String, Object> entry : map.entrySet()) {
           final String name = entry.getKey();
           final Object value = entry.getValue();
           if (value instanceof String) {
             // TODO: We could represent this source more accurately, perhaps tracking the original
             // source, or using a special name.
-            module.taint(value, SourceTypes.REQUEST_HEADER_VALUE, name);
+            module.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
           }
         }
       }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
@@ -5,8 +5,13 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -33,17 +38,20 @@ public class JWTParserInstrumentation extends InstrumenterModule.Iast
     return "com.auth0.jwt.impl.JWTParser";
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class InstrumenterAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
-    public static void onEnter(@Advice.Argument(0) String json) {
+    public static void onEnter(
+        @Advice.Argument(0) String json, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
 
       if (module != null) {
         // TODO: We could represent this source more accurately, perhaps tracking the original
         // source, or using a special name.
-        module.taint(json, SourceTypes.REQUEST_HEADER_VALUE);
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, json, SourceTypes.REQUEST_HEADER_VALUE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
@@ -1,25 +1,35 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 
-class JWTParserInstrumentationTest  extends AgentTestRunner {
+class JWTParserInstrumentationTest extends AgentTestRunner {
+
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
   }
 
-  void 'oauth jwt parser'(){
+  void setup() {
+    iastCtx = Stub(IastContext)
+  }
+
+  void 'oauth jwt parser'() {
     setup:
     final propagationModule = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(propagationModule)
     final String payload = "{}"
 
     when:
-    new com.auth0.jwt.impl.JWTParser().parsePayload(payload)
+    runUnderIastTrace { new com.auth0.jwt.impl.JWTParser().parsePayload(payload) }
 
     then:
-    1 * propagationModule.taint(payload, SourceTypes.REQUEST_HEADER_VALUE)
+    1 * propagationModule.taint(iastCtx, payload, SourceTypes.REQUEST_HEADER_VALUE)
     0 * _
   }
 
@@ -30,14 +40,24 @@ class JWTParserInstrumentationTest  extends AgentTestRunner {
     InstrumentationBridge.registerIastModule(propagationModule)
 
     when:
-    com.nimbusds.jose.util.JSONObjectUtils.parse(json)
+    runUnderIastTrace { com.nimbusds.jose.util.JSONObjectUtils.parse(json) }
 
     then:
-    1 * propagationModule.taint('http://foobar.com', SourceTypes.REQUEST_HEADER_VALUE, 'iss')
-    1 * propagationModule.taint('foo', SourceTypes.REQUEST_HEADER_VALUE, 'sub')
-    1 * propagationModule.taint('foobar', SourceTypes.REQUEST_HEADER_VALUE, 'aud')
-    1 * propagationModule.taint('Mr Foo Bar', SourceTypes.REQUEST_HEADER_VALUE, 'name')
-    1 * propagationModule.taint('read', SourceTypes.REQUEST_HEADER_VALUE, 'scope')
+    1 * propagationModule.taint(iastCtx, 'http://foobar.com', SourceTypes.REQUEST_HEADER_VALUE, 'iss')
+    1 * propagationModule.taint(iastCtx, 'foo', SourceTypes.REQUEST_HEADER_VALUE, 'sub')
+    1 * propagationModule.taint(iastCtx, 'foobar', SourceTypes.REQUEST_HEADER_VALUE, 'aud')
+    1 * propagationModule.taint(iastCtx, 'Mr Foo Bar', SourceTypes.REQUEST_HEADER_VALUE, 'name')
+    1 * propagationModule.taint(iastCtx, 'read', SourceTypes.REQUEST_HEADER_VALUE, 'scope')
     0 * _
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
+    }
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/CookieHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/CookieHeaderInstrumentation.java
@@ -8,8 +8,12 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -50,16 +54,19 @@ public class CookieHeaderInstrumentation extends InstrumenterModule.Iast
         CookieHeaderInstrumentation.class.getName() + "$TaintAllCookiesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class TaintAllCookiesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     static void after(
-        @Advice.This HttpHeader cookie, @Advice.Return Seq<HttpCookiePair> cookiePairs) {
+        @Advice.This HttpHeader cookie,
+        @Advice.Return Seq<HttpCookiePair> cookiePairs,
+        @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule prop = InstrumentationBridge.PROPAGATION;
       if (prop == null || cookiePairs == null || cookiePairs.isEmpty()) {
         return;
       }
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       if (!prop.isTainted(ctx, cookie)) {
         return;
       }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HeaderNameCallSite.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.pekkohttp.iast;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -27,7 +28,11 @@ public class HeaderNameCallSite {
       return result;
     }
     try {
-      module.taintIfTainted(result, header, SourceTypes.REQUEST_HEADER_NAME, result);
+      final IastContext ctx = IastContext.Provider.get();
+      if (ctx == null) {
+        return result;
+      }
+      module.taintIfTainted(ctx, result, header, SourceTypes.REQUEST_HEADER_NAME, result);
     } catch (final Throwable e) {
       module.onUnexpectedException("onHeaderNames threw", e);
     }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HeaderNameCallSite.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import org.apache.pekko.http.javadsl.model.HttpHeader;
 
 /**
@@ -28,7 +29,7 @@ public class HeaderNameCallSite {
       return result;
     }
     try {
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
       if (ctx == null) {
         return result;
       }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpHeaderSubclassesInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpHeaderSubclassesInstrumentation.java
@@ -9,8 +9,13 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -53,17 +58,21 @@ public class HttpHeaderSubclassesInstrumentation extends InstrumenterModule.Iast
         HttpHeaderSubclassesInstrumentation.class.getName() + "$HttpHeaderSubclassesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class HttpHeaderSubclassesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
-    static void onExit(@Advice.This HttpHeader h, @Advice.Return String retVal) {
+    static void onExit(
+        @Advice.This HttpHeader h,
+        @Advice.Return String retVal,
+        @ActiveRequestContext RequestContext reqCtx) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation == null) {
         return;
       }
-
-      propagation.taintIfTainted(retVal, h);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      propagation.taintIfTainted(ctx, retVal, h);
     }
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/PathMatcherInstrumentation.java
@@ -12,6 +12,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -63,14 +64,15 @@ public class PathMatcherInstrumentation extends InstrumenterModule.Iast
       scala.Tuple1 tuple = (scala.Tuple1) extractions;
       Object value = tuple._1();
 
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+
       // in the test, 4 instances of PathMatcher$Match are created, all with the same value
-      if (module.isTainted(value)) {
+      if (module.isTainted(ctx, value)) {
         return;
       }
 
       if (value instanceof String) {
-        module.taint(
-            reqCtx.getData(RequestContextSlot.IAST), value, SourceTypes.REQUEST_PATH_PARAMETER);
+        module.taint(ctx, value, SourceTypes.REQUEST_PATH_PARAMETER);
       }
     }
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/RequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/RequestContextInstrumentation.java
@@ -8,8 +8,12 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -43,18 +47,27 @@ public class RequestContextInstrumentation extends InstrumenterModule.Iast
   }
 
   @SuppressFBWarnings("BC_IMPOSSIBLE_INSTANCEOF")
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class GetRequestAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     static void onExit(
-        @Advice.This RequestContext requestContext, @Advice.Return HttpRequest request) {
+        @Advice.This RequestContext requestContext,
+        @Advice.Return HttpRequest request,
+        @ActiveRequestContext datadog.trace.api.gateway.RequestContext reqCtx) {
 
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
-      if (propagation == null || propagation.isTainted(request)) {
+      if (propagation == null) {
         return;
       }
 
-      propagation.taintIfTainted(request, requestContext);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+
+      if (propagation.isTainted(ctx, request)) {
+        return;
+      }
+
+      propagation.taintIfTainted(ctx, request, requestContext);
     }
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/UriInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/UriInstrumentation.java
@@ -9,8 +9,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
@@ -63,30 +67,39 @@ public class UriInstrumentation extends InstrumenterModule.Iast
         UriInstrumentation.class.getName() + "$TaintQueryAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   static class TaintQueryStringAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
-    static void after(@Advice.This Uri uri, @Advice.Return scala.Option<String> ret) {
+    static void after(
+        @Advice.This Uri uri,
+        @Advice.Return scala.Option<String> ret,
+        @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule mod = InstrumentationBridge.PROPAGATION;
       if (mod == null || ret.isEmpty()) {
         return;
       }
-      mod.taintIfTainted(ret.get(), uri);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      mod.taintIfTainted(ctx, ret.get(), uri);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class TaintQueryAdvice {
     // bind uri to a variable of type Object so that this advice can also
     // be used from FromDataInstrumentaton
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
-    static void after(@Advice.This /*Uri*/ Object uri, @Advice.Return Uri.Query ret) {
+    static void after(
+        @Advice.This /*Uri*/ Object uri,
+        @Advice.Return Uri.Query ret,
+        @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule prop = InstrumentationBridge.PROPAGATION;
       if (prop == null || ret.isEmpty()) {
         return;
       }
 
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       if (!prop.isTainted(ctx, uri)) {
         return;
       }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintCookieFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintCookieFunction.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import org.apache.pekko.http.scaladsl.model.headers.HttpCookiePair;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
@@ -19,10 +21,14 @@ public class TaintCookieFunction
     if (mod == null || httpCookiePair == null) {
       return v1;
     }
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     final String name = httpCookiePair.name();
     final String value = httpCookiePair.value();
-    mod.taint(name, SourceTypes.REQUEST_COOKIE_NAME, name);
-    mod.taint(value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+    mod.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+    mod.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintFutureHelper.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintFutureHelper.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.compat.java8.JFunction1;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
@@ -10,7 +12,10 @@ public class TaintFutureHelper {
       Future<T> f, Object input, PropagationModule mod, ExecutionContext ec) {
     JFunction1<T, T> mapf =
         t -> {
-          mod.taintIfTainted(t, input);
+          IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+          if (ctx != null) {
+            mod.taintIfTainted(ctx, t, input);
+          }
           return t;
         };
     return f.map(mapf, ec);

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintMapFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintMapFunction.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.Tuple1;
 import scala.Tuple2;
 import scala.collection.Iterator;
@@ -23,7 +24,10 @@ public class TaintMapFunction
       return v1;
     }
 
-    final IastContext ctx = IastContext.Provider.get();
+    final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     Iterator<Tuple2<String, String>> iterator = m.iterator();
     while (iterator.hasNext()) {
       Tuple2<String, String> e = iterator.next();

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintMultiMapFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintMultiMapFunction.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import scala.Tuple1;
 import scala.Tuple2;
 import scala.collection.Iterator;
@@ -24,7 +25,10 @@ public class TaintMultiMapFunction
       return v1;
     }
 
-    final IastContext ctx = IastContext.Provider.get();
+    final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     Iterator<Tuple2<String, List<String>>> entriesIterator = m.iterator();
     while (entriesIterator.hasNext()) {
       Tuple2<String, List<String>> e = entriesIterator.next();

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintOptionalCookieFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintOptionalCookieFunction.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import org.apache.pekko.http.scaladsl.model.headers.HttpCookiePair;
 import scala.Option;
 import scala.Tuple1;
@@ -20,11 +22,15 @@ public class TaintOptionalCookieFunction
     if (mod == null || httpCookiePair.isEmpty()) {
       return v1;
     }
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     final HttpCookiePair cookie = httpCookiePair.get();
     final String name = cookie.name();
     final String value = cookie.value();
-    mod.taint(name, SourceTypes.REQUEST_COOKIE_NAME, name);
-    mod.taint(value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+    mod.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+    mod.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestContextFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestContextFunction.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import org.apache.pekko.http.scaladsl.server.RequestContext;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
@@ -19,7 +21,11 @@ public class TaintRequestContextFunction
     if (mod == null) {
       return v1;
     }
-    mod.taint(reqCtx, SourceTypes.REQUEST_BODY);
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
+    mod.taint(ctx, reqCtx, SourceTypes.REQUEST_BODY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestFunction.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
 import scala.Tuple1;
@@ -20,7 +22,11 @@ public class TaintRequestFunction implements JFunction1<Tuple1<HttpRequest>, Tup
     if (mod == null) {
       return v1;
     }
-    mod.taint(httpRequest, SourceTypes.REQUEST_BODY);
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
+    mod.taint(ctx, httpRequest, SourceTypes.REQUEST_BODY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSeqFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSeqFunction.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
@@ -27,7 +28,10 @@ public class TaintSeqFunction
       return v1;
     }
 
-    final IastContext ctx = IastContext.Provider.get();
+    final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
     Iterator<Tuple2<String, String>> iterator = seq.iterator();
     Set<String> seenKeys = Collections.newSetFromMap(new IdentityHashMap<>());
     while (iterator.hasNext()) {

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSingleParameterFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSingleParameterFunction.java
@@ -4,6 +4,7 @@ import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import scala.Option;
@@ -40,17 +41,21 @@ public class TaintSingleParameterFunction<Magnet>
       value = option.get();
     }
 
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
+
     if (value instanceof Iterable) {
-      final IastContext ctx = IastContext.Provider.get();
       Iterator<?> iterator = ((Iterable<?>) value).iterator();
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint((String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUnmarshaller.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUnmarshaller.java
@@ -1,7 +1,9 @@
 package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.instrumentation.pekkohttp.iast.UnmarshallerInstrumentation;
 import org.apache.pekko.http.scaladsl.unmarshalling.Unmarshaller;
 import org.apache.pekko.stream.Materializer;
@@ -28,7 +30,10 @@ public class TaintUnmarshaller<A, B> implements Unmarshaller<A, B> {
 
   @Override
   public Future<B> apply(A value, ExecutionContext ec, Materializer materializer) {
-    propagationModule.taint(value, SourceTypes.REQUEST_BODY);
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx != null) {
+      propagationModule.taint(ctx, value, SourceTypes.REQUEST_BODY);
+    }
     return delegate.apply(value, ec, materializer);
   }
 

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUriFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUriFunction.java
@@ -1,8 +1,10 @@
 package datadog.trace.instrumentation.pekkohttp.iast.helpers;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import org.apache.pekko.http.scaladsl.model.Uri;
 import scala.Tuple1;
 import scala.compat.java8.JFunction1;
@@ -18,7 +20,11 @@ public class TaintUriFunction implements JFunction1<Tuple1<Uri>, Tuple1<Uri>> {
     if (mod == null) {
       return v1;
     }
-    mod.taint(uri, SourceTypes.REQUEST_QUERY);
+    IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
+    if (ctx == null) {
+      return v1;
+    }
+    mod.taint(ctx, uri, SourceTypes.REQUEST_QUERY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
@@ -1,5 +1,9 @@
 package datadog.trace.instrumentation.resteasy;
 
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -8,24 +12,27 @@ import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
 
+@RequiresRequestContext(RequestContextSlot.IAST)
 public class CookieParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_COOKIE_VALUE)
   public static void onExit(
-      @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
+      @Advice.Return Object result,
+      @Advice.FieldValue("paramName") String paramName,
+      @ActiveRequestContext RequestContext reqCtx) {
     if (result instanceof String || result instanceof Collection) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (result instanceof Collection) {
           Collection<?> collection = (Collection<?>) result;
-          final IastContext ctx = IastContext.Provider.get();
           for (Object o : collection) {
             if (o instanceof String) {
               module.taint(ctx, o, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
             }
           }
         } else {
-          module.taint(result, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
+          module.taint(ctx, result, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
@@ -1,5 +1,9 @@
 package datadog.trace.instrumentation.resteasy;
 
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -8,16 +12,19 @@ import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
 
+@RequiresRequestContext(RequestContextSlot.IAST)
 public class FormParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   public static void onExit(
-      @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
+      @Advice.Return Object result,
+      @Advice.FieldValue("paramName") String paramName,
+      @ActiveRequestContext RequestContext reqCtx) {
     if (result instanceof String || result instanceof Collection) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (result instanceof Collection) {
-          final IastContext ctx = IastContext.Provider.get();
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
@@ -25,7 +32,7 @@ public class FormParamInjectorAdvice {
             }
           }
         } else {
-          module.taint(result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          module.taint(ctx, result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
@@ -1,5 +1,9 @@
 package datadog.trace.instrumentation.resteasy;
 
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -8,25 +12,28 @@ import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
 
+@RequiresRequestContext(RequestContextSlot.IAST)
 public class HeaderParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_HEADER_VALUE)
   public static void onExit(
-      @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
+      @Advice.Return Object result,
+      @Advice.FieldValue("paramName") String paramName,
+      @ActiveRequestContext RequestContext reqCtx) {
     if (result instanceof String || result instanceof Collection) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
+          IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
           if (result instanceof Collection) {
             Collection<?> collection = (Collection<?>) result;
-            final IastContext ctx = IastContext.Provider.get();
             for (Object o : collection) {
               if (o instanceof String) {
                 module.taint(ctx, o, SourceTypes.REQUEST_HEADER_VALUE, paramName);
               }
             }
           } else {
-            module.taint(result, SourceTypes.REQUEST_HEADER_VALUE, paramName);
+            module.taint(ctx, result, SourceTypes.REQUEST_HEADER_VALUE, paramName);
           }
         } catch (final Throwable e) {
           module.onUnexpectedException("HeaderParamInjectorAdvice.onExit threw", e);

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
@@ -1,5 +1,9 @@
 package datadog.trace.instrumentation.resteasy;
 
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -8,24 +12,27 @@ import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
 
+@RequiresRequestContext(RequestContextSlot.IAST)
 public class PathParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   public static void onExit(
-      @Advice.Return Object result, @Advice.FieldValue("paramName") String paramName) {
+      @Advice.Return Object result,
+      @Advice.FieldValue("paramName") String paramName,
+      @ActiveRequestContext RequestContext reqCtx) {
     if (result instanceof String || result instanceof Collection) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (result instanceof Collection) {
           Collection<?> collection = (Collection<?>) result;
-          final IastContext ctx = IastContext.Provider.get();
           for (Object o : collection) {
             if (o instanceof String) {
               module.taint(ctx, o, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
             }
           }
         } else {
-          module.taint(result, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
+          module.taint(ctx, result, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
@@ -1,5 +1,9 @@
 package datadog.trace.instrumentation.resteasy;
 
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -8,24 +12,27 @@ import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.Collection;
 import net.bytebuddy.asm.Advice;
 
+@RequiresRequestContext(RequestContextSlot.IAST)
 public class QueryParamInjectorAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
   public static void onExit(
-      @Advice.Return Object result, @Advice.FieldValue("encodedName") String paramName) {
+      @Advice.Return Object result,
+      @Advice.FieldValue("encodedName") String paramName,
+      @ActiveRequestContext RequestContext reqCtx) {
     if (result instanceof String || result instanceof Collection) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (result instanceof Collection) {
           Collection<?> collection = (Collection<?>) result;
-          final IastContext ctx = IastContext.Provider.get();
           for (Object o : collection) {
             if (o instanceof String) {
               module.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
             }
           }
         } else {
-          module.taint(result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          module.taint(ctx, result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/MultipartInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/MultipartInstrumentation.java
@@ -6,8 +6,12 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -56,43 +60,52 @@ public class MultipartInstrumentation extends InstrumenterModule.Iast
         getClass().getName() + "$GetHeaderNamesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetNameAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
-    public static String onExit(@Advice.Return final String name) {
+    public static String onExit(
+        @Advice.Return final String name, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(name, SourceTypes.REQUEST_MULTIPART_PARAMETER, "Content-Disposition");
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER, "Content-Disposition");
       }
       return name;
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static String onExit(
-        @Advice.Return final String value, @Advice.Argument(0) final String name) {
+        @Advice.Return final String value,
+        @Advice.Argument(0) final String name,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(value, SourceTypes.REQUEST_MULTIPART_PARAMETER, name);
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, name);
       }
       return value;
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static void onExit(
         @Advice.Argument(0) final String headerName,
-        @Advice.Return Collection<String> headerValues) {
+        @Advice.Return Collection<String> headerValues,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (null == headerValues || headerValues.isEmpty()) {
         return;
       }
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final String value : headerValues) {
           module.taint(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, headerName);
         }
@@ -100,16 +113,19 @@ public class MultipartInstrumentation extends InstrumenterModule.Iast
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeaderNamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
-    public static void onExit(@Advice.Return final Collection<String> headerNames) {
+    public static void onExit(
+        @Advice.Return final Collection<String> headerNames,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (null == headerNames || headerNames.isEmpty()) {
         return;
       }
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final String name : headerNames) {
           module.taint(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER);
         }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/MultipartInstrumentationForkedTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/MultipartInstrumentationForkedTest.groovy
@@ -1,13 +1,24 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import foo.bar.smoketest.MockPart
 
 class MultipartInstrumentationForkedTest extends AgentTestRunner {
+
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  @Override
+  void setup() {
+    iastCtx = Stub(IastContext)
   }
 
   @Override
@@ -22,10 +33,10 @@ class MultipartInstrumentationForkedTest extends AgentTestRunner {
     final part = new MockPart('partName', 'headerName', 'headerValue')
 
     when:
-    part.getName()
+    runUnderIastTrace { part.getName() }
 
     then:
-    1 * module.taint('partName', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'Content-Disposition')
+    1 * module.taint(iastCtx, 'partName', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'Content-Disposition')
     0 * _
   }
 
@@ -36,10 +47,10 @@ class MultipartInstrumentationForkedTest extends AgentTestRunner {
     final part = new MockPart('partName', 'headerName', 'headerValue')
 
     when:
-    part.getHeader('headerName')
+    runUnderIastTrace { part.getHeader('headerName') }
 
     then:
-    1 * module.taint('headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
+    1 * module.taint(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
     0 * _
   }
 
@@ -50,10 +61,10 @@ class MultipartInstrumentationForkedTest extends AgentTestRunner {
     final part = new MockPart('partName', 'headerName', 'headerValue')
 
     when:
-    part.getHeaders('headerName')
+    runUnderIastTrace { part.getHeaders('headerName') }
 
     then:
-    1 * module.taint(_, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
+    1 * module.taint(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
     0 * _
   }
 
@@ -64,10 +75,20 @@ class MultipartInstrumentationForkedTest extends AgentTestRunner {
     final part = new MockPart('partName', 'headerName', 'headerValue')
 
     when:
-    part.getHeaderNames()
+    runUnderIastTrace { part.getHeaderNames() }
 
     then:
-    1 * module.taint(_, 'headerName', SourceTypes.REQUEST_MULTIPART_PARAMETER)
+    1 * module.taint(iastCtx, 'headerName', SourceTypes.REQUEST_MULTIPART_PARAMETER)
     0 * _
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
+    }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import jakarta.servlet.http.HttpServletRequest;
 
 /**
@@ -30,7 +31,7 @@ public class JakartaHttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          final IastContext ctx = IastContext.Provider.get();
+          final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
             module.taint(ctx, retValue, SourceTypes.REQUEST_PATH);
           }
@@ -52,7 +53,7 @@ public class JakartaHttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          final IastContext ctx = IastContext.Provider.get();
+          final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
             module.taint(ctx, retValue, SourceTypes.REQUEST_URI);
           }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.servlet5;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -29,7 +30,10 @@ public class JakartaHttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taint(retValue, SourceTypes.REQUEST_PATH);
+          final IastContext ctx = IastContext.Provider.get();
+          if (ctx != null) {
+            module.taint(ctx, retValue, SourceTypes.REQUEST_PATH);
+          }
         } catch (final Throwable e) {
           module.onUnexpectedException("afterPath threw", e);
         }
@@ -48,7 +52,10 @@ public class JakartaHttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taint(retValue, SourceTypes.REQUEST_URI);
+          final IastContext ctx = IastContext.Provider.get();
+          if (ctx != null) {
+            module.taint(ctx, retValue, SourceTypes.REQUEST_URI);
+          }
         } catch (final Throwable e) {
           module.onUnexpectedException("afterGetRequestURL threw", e);
         }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInstrumentation.java
@@ -9,9 +9,13 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.iast.TaintableEnumeration;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Sink;
@@ -94,11 +98,14 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
         CLASS_NAME + "$GetRequestDispatcherAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(
-        @Advice.Argument(0) final String name, @Advice.Return final String value) {
+        @Advice.Argument(0) final String name,
+        @Advice.Return final String value,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (value == null) {
         return;
       }
@@ -106,16 +113,19 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
-      module.taint(value, SourceTypes.REQUEST_HEADER_VALUE, name);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      module.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(
         @Advice.Argument(0) final String name,
-        @Advice.Return(readOnly = false) Enumeration<String> enumeration) {
+        @Advice.Return(readOnly = false) Enumeration<String> enumeration,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (enumeration == null) {
         return;
       }
@@ -123,15 +133,20 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       enumeration =
-          TaintableEnumeration.wrap(enumeration, module, SourceTypes.REQUEST_HEADER_VALUE, name);
+          TaintableEnumeration.wrap(
+              ctx, enumeration, module, SourceTypes.REQUEST_HEADER_VALUE, name);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeaderNamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_NAME)
-    public static void onExit(@Advice.Return(readOnly = false) Enumeration<String> enumeration) {
+    public static void onExit(
+        @Advice.Return(readOnly = false) Enumeration<String> enumeration,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (enumeration == null) {
         return;
       }
@@ -139,16 +154,21 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       enumeration =
-          TaintableEnumeration.wrap(enumeration, module, SourceTypes.REQUEST_HEADER_NAME, true);
+          TaintableEnumeration.wrap(
+              ctx, enumeration, module, SourceTypes.REQUEST_HEADER_NAME, true);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetParameterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
-        @Advice.Argument(0) final String name, @Advice.Return final String value) {
+        @Advice.Argument(0) final String name,
+        @Advice.Return final String value,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (value == null) {
         return;
       }
@@ -156,15 +176,19 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
-      module.taint(value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetParameterValuesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
-        @Advice.Argument(0) final String name, @Advice.Return final String[] values) {
+        @Advice.Argument(0) final String name,
+        @Advice.Return final String[] values,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (values == null || values.length == 0) {
         return;
       }
@@ -172,17 +196,20 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final String value : values) {
         module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetParameterMapAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
-    public static void onExit(@Advice.Return final Map<String, String[]> parameters) {
+    public static void onExit(
+        @Advice.Return final Map<String, String[]> parameters,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (parameters == null || parameters.isEmpty()) {
         return;
       }
@@ -190,7 +217,7 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final Map.Entry<String, String[]> entry : parameters.entrySet()) {
         final String name = entry.getKey();
         module.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
@@ -204,10 +231,13 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetParameterNamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_NAME)
-    public static void onExit(@Advice.Return(readOnly = false) Enumeration<String> enumeration) {
+    public static void onExit(
+        @Advice.Return(readOnly = false) Enumeration<String> enumeration,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (enumeration == null) {
         return;
       }
@@ -215,16 +245,20 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       enumeration =
-          TaintableEnumeration.wrap(enumeration, module, SourceTypes.REQUEST_PARAMETER_NAME, true);
+          TaintableEnumeration.wrap(
+              ctx, enumeration, module, SourceTypes.REQUEST_PARAMETER_NAME, true);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetCookiesAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
-    public static void onExit(@Advice.Return final Cookie[] cookies) {
+    public static void onExit(
+        @Advice.Return final Cookie[] cookies, @ActiveRequestContext RequestContext reqCtx) {
       if (cookies == null || cookies.length == 0) {
         return;
       }
@@ -232,17 +266,19 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final Cookie cookie : cookies) {
         module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetQueryStringAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_QUERY)
-    public static void onExit(@Advice.Return final String queryString) {
+    public static void onExit(
+        @Advice.Return final String queryString, @ActiveRequestContext RequestContext reqCtx) {
       if (queryString == null) {
         return;
       }
@@ -250,14 +286,17 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
-      module.taint(queryString, SourceTypes.REQUEST_QUERY);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      module.taint(ctx, queryString, SourceTypes.REQUEST_QUERY);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetBodyAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_BODY)
-    public static void onExit(@Advice.Return final Object body) {
+    public static void onExit(
+        @Advice.Return final Object body, @ActiveRequestContext RequestContext reqCtx) {
       if (body == null) {
         return;
       }
@@ -265,7 +304,8 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       if (module == null) {
         return;
       }
-      module.taint(body, SourceTypes.REQUEST_BODY);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      module.taint(ctx, body, SourceTypes.REQUEST_BODY);
     }
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaMultipartInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaMultipartInstrumentation.java
@@ -6,8 +6,12 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -52,43 +56,52 @@ public class JakartaMultipartInstrumentation extends InstrumenterModule.Iast
         getClass().getName() + "$GetHeaderNamesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetNameAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
-    public static String onExit(@Advice.Return final String name) {
+    public static String onExit(
+        @Advice.Return final String name, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(name, SourceTypes.REQUEST_MULTIPART_PARAMETER, "Content-Disposition");
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER, "Content-Disposition");
       }
       return name;
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static String onExit(
-        @Advice.Return final String value, @Advice.Argument(0) final String name) {
+        @Advice.Return final String value,
+        @Advice.Argument(0) final String name,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(value, SourceTypes.REQUEST_MULTIPART_PARAMETER, name);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, name);
       }
       return value;
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
     public static void onExit(
         @Advice.Argument(0) final String headerName,
-        @Advice.Return Collection<String> headerValues) {
+        @Advice.Return Collection<String> headerValues,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (null == headerValues || headerValues.isEmpty()) {
         return;
       }
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final String value : headerValues) {
           module.taint(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, headerName);
         }
@@ -96,16 +109,19 @@ public class JakartaMultipartInstrumentation extends InstrumenterModule.Iast
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeaderNamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_MULTIPART_PARAMETER)
-    public static void onExit(@Advice.Return final Collection<String> headerNames) {
+    public static void onExit(
+        @Advice.Return final Collection<String> headerNames,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (null == headerNames || headerNames.isEmpty()) {
         return;
       }
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final String name : headerNames) {
           module.taint(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER);
         }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletRequestInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletRequestInstrumentationTest.groovy
@@ -1,8 +1,11 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import foo.bar.smoketest.JakartaHttpServletRequestTestSuite
 import foo.bar.smoketest.JakartaHttpServletRequestWrapperTestSuite
 import foo.bar.smoketest.ServletRequestTestSuite
@@ -16,9 +19,15 @@ import datadog.trace.agent.tooling.iast.TaintableEnumeration
 
 class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
 
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void setup() {
+    iastCtx = Stub(IastContext)
   }
 
   void cleanup() {
@@ -33,12 +42,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getHeader('header')
+    final result = runUnderIastTrace { request.getHeader('header') }
 
     then:
     result == 'value'
     1 * mock.getHeader('header') >> 'value'
-    1 * iastModule.taint('value', SourceTypes.REQUEST_HEADER_VALUE, 'header')
+    1 * iastModule.taint(iastCtx, 'value', SourceTypes.REQUEST_HEADER_VALUE, 'header')
     0 * _
 
     where:
@@ -54,12 +63,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getHeaders('headers').collect()
+    final result = runUnderIastTrace { request.getHeaders('headers').collect() }
 
     then:
     result == headers
     1 * mock.getHeaders('headers') >> Collections.enumeration(headers)
-    headers.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_HEADER_VALUE, 'headers') }
+    headers.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_VALUE, 'headers') }
     0 * _
 
     where:
@@ -75,12 +84,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getHeaderNames().collect()
+    final result = runUnderIastTrace { request.getHeaderNames().collect() }
 
     then:
     result == headers
     1 * mock.getHeaderNames() >> Collections.enumeration(headers)
-    headers.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_HEADER_NAME, it) }
+    headers.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) }
     0 * _
 
     where:
@@ -95,12 +104,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getParameter('parameter')
+    final result = runUnderIastTrace { request.getParameter('parameter') }
 
     then:
     result == 'value'
     1 * mock.getParameter('parameter') >> 'value'
-    1 * iastModule.taint('value', SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter')
+    1 * iastModule.taint(iastCtx, 'value', SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter')
     0 * _
 
     where:
@@ -116,12 +125,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getParameterValues('parameter').collect()
+    final result = runUnderIastTrace { request.getParameterValues('parameter').collect() }
 
     then:
     result == values
     1 * mock.getParameterValues('parameter') >> { values as String[] }
-    values.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter') }
+    values.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter') }
     0 * _
 
     where:
@@ -137,15 +146,15 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getParameterMap()
+    final result = runUnderIastTrace { request.getParameterMap() }
 
     then:
     result == parameters
     1 * mock.getParameterMap() >> parameters
     parameters.each { key, values ->
-      1 * iastModule.taint(_, key, SourceTypes.REQUEST_PARAMETER_NAME, key)
+      1 * iastModule.taint(iastCtx, key, SourceTypes.REQUEST_PARAMETER_NAME, key)
       values.each { value ->
-        1 * iastModule.taint(_, value, SourceTypes.REQUEST_PARAMETER_VALUE, key)
+        1 * iastModule.taint(iastCtx, value, SourceTypes.REQUEST_PARAMETER_VALUE, key)
       }
     }
     0 * _
@@ -164,12 +173,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getParameterNames().collect()
+    final result = runUnderIastTrace { request.getParameterNames().collect() }
 
     then:
     result == parameters
     1 * mock.getParameterNames() >> Collections.enumeration(parameters)
-    parameters.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_PARAMETER_NAME, it) }
+    parameters.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it) }
     0 * _
 
     where:
@@ -185,12 +194,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getCookies()
+    final result = runUnderIastTrace { request.getCookies() }
 
     then:
     result == cookies
     1 * mock.getCookies() >> cookies
-    cookies.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_COOKIE_VALUE) }
+    cookies.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_COOKIE_VALUE) }
     0 * _
 
     where:
@@ -208,7 +217,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final headers = request.getHeaders('header')
+    final headers = runUnderIastTrace { request.getHeaders('header') }
 
     then:
     1 * mock.getHeaders('header') >> enumeration
@@ -236,7 +245,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getHeaderNames()
+    final result = runUnderIastTrace { request.getHeaderNames() }
 
     then:
     1 * mock.getHeaderNames() >> enumeration
@@ -262,12 +271,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final String result = request.getQueryString()
+    final String result = runUnderIastTrace { request.getQueryString() }
 
     then:
     result == queryString
     1 * mock.getQueryString() >> queryString
-    1 * iastModule.taint(queryString, SourceTypes.REQUEST_QUERY)
+    1 * iastModule.taint(iastCtx, queryString, SourceTypes.REQUEST_QUERY)
     0 * _
 
     where:
@@ -283,12 +292,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getInputStream()
+    final result = runUnderIastTrace { request.getInputStream() }
 
     then:
     result == is
     1 * mock.getInputStream() >> is
-    1 * iastModule.taint(is, SourceTypes.REQUEST_BODY)
+    1 * iastModule.taint(iastCtx, is, SourceTypes.REQUEST_BODY)
     0 * _
 
     where:
@@ -304,12 +313,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getReader()
+    final result = runUnderIastTrace { request.getReader() }
 
     then:
     result == reader
     1 * mock.getReader() >> reader
-    1 * iastModule.taint(reader, SourceTypes.REQUEST_BODY)
+    1 * iastModule.taint(iastCtx, reader, SourceTypes.REQUEST_BODY)
     0 * _
 
     where:
@@ -326,7 +335,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getRequestDispatcher(path)
+    final result = runUnderIastTrace { request.getRequestDispatcher(path) }
 
     then:
     result == dispatcher
@@ -347,12 +356,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getRequestURI()
+    final result = runUnderIastTrace { request.getRequestURI() }
 
     then:
     result == uri
     1 * mock.getRequestURI() >> uri
-    1 * iastModule.taint(uri, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taint(iastCtx, uri, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -368,12 +377,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getPathInfo()
+    final result = runUnderIastTrace { request.getPathInfo() }
 
     then:
     result == pathInfo
     1 * mock.getPathInfo() >> pathInfo
-    1 * iastModule.taint(pathInfo, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taint(iastCtx, pathInfo, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -389,12 +398,12 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getPathTranslated()
+    final result = runUnderIastTrace { request.getPathTranslated() }
 
     then:
     result == pathTranslated
     1 * mock.getPathTranslated() >> pathTranslated
-    1 * iastModule.taint(pathTranslated, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taint(iastCtx, pathTranslated, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -410,16 +419,26 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getRequestURL()
+    final result = runUnderIastTrace { request.getRequestURL() }
 
     then:
     result == url
     1 * mock.getRequestURL() >> url
-    1 * iastModule.taint(url, SourceTypes.REQUEST_URI)
+    1 * iastModule.taint(iastCtx, url, SourceTypes.REQUEST_URI)
     0 * _
 
     where:
     suite << testSuiteCallSites()
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
+    }
   }
 
   private List<Closure<? extends HttpServletRequest>> testSuite() {

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaMultipartInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaMultipartInstrumentationTest.groovy
@@ -1,13 +1,23 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import foo.bar.smoketest.MockPart
 
 class JakartaMultipartInstrumentationTest extends AgentTestRunner {
+
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void setup() {
+    iastCtx = Stub(IastContext)
   }
 
   @Override
@@ -22,10 +32,10 @@ class JakartaMultipartInstrumentationTest extends AgentTestRunner {
     final part = new MockPart('partName', 'headerName', 'headerValue')
 
     when:
-    part.getName()
+    runUnderIastTrace { part.getName() }
 
     then:
-    1 * module.taint('partName', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'Content-Disposition')
+    1 * module.taint(iastCtx, 'partName', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'Content-Disposition')
     0 * _
   }
 
@@ -36,10 +46,10 @@ class JakartaMultipartInstrumentationTest extends AgentTestRunner {
     final part = new MockPart('partName', 'headerName', 'headerValue')
 
     when:
-    part.getHeader('headerName')
+    runUnderIastTrace { part.getHeader('headerName') }
 
     then:
-    1 * module.taint('headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
+    1 * module.taint(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
     0 * _
   }
 
@@ -50,10 +60,10 @@ class JakartaMultipartInstrumentationTest extends AgentTestRunner {
     final part = new MockPart('partName', 'headerName', 'headerValue')
 
     when:
-    part.getHeaders('headerName')
+    runUnderIastTrace { part.getHeaders('headerName') }
 
     then:
-    1 * module.taint(_, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
+    1 * module.taint(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
     0 * _
   }
 
@@ -64,10 +74,20 @@ class JakartaMultipartInstrumentationTest extends AgentTestRunner {
     final part = new MockPart('partName', 'headerName', 'headerValue')
 
     when:
-    part.getHeaderNames()
+    runUnderIastTrace { part.getHeaderNames() }
 
     then:
-    1 * module.taint(_, 'headerName', SourceTypes.REQUEST_MULTIPART_PARAMETER)
+    1 * module.taint(iastCtx, 'headerName', SourceTypes.REQUEST_MULTIPART_PARAMETER)
     0 * _
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
+    }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestCallSite.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.servlet.http;
 
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -29,7 +30,10 @@ public class HttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taint(retValue, SourceTypes.REQUEST_PATH);
+          final IastContext ctx = IastContext.Provider.get();
+          if (ctx != null) {
+            module.taint(ctx, retValue, SourceTypes.REQUEST_PATH);
+          }
         } catch (final Throwable e) {
           module.onUnexpectedException("afterPath threw", e);
         }
@@ -48,7 +52,10 @@ public class HttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taint(retValue, SourceTypes.REQUEST_URI);
+          final IastContext ctx = IastContext.Provider.get();
+          if (ctx != null) {
+            module.taint(ctx, retValue, SourceTypes.REQUEST_URI);
+          }
         } catch (final Throwable e) {
           module.onUnexpectedException("afterGetRequestURL threw", e);
         }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestCallSite.java
@@ -7,6 +7,7 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -30,7 +31,7 @@ public class HttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          final IastContext ctx = IastContext.Provider.get();
+          final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
             module.taint(ctx, retValue, SourceTypes.REQUEST_PATH);
           }
@@ -52,7 +53,7 @@ public class HttpServletRequestCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          final IastContext ctx = IastContext.Provider.get();
+          final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
             module.taint(ctx, retValue, SourceTypes.REQUEST_URI);
           }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestInstrumentation.java
@@ -9,9 +9,13 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.iast.TaintableEnumeration;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Sink;
@@ -94,11 +98,14 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
         CLASS_NAME + "$GetRequestDispatcherAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeaderAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(
-        @Advice.Argument(0) final String name, @Advice.Return final String value) {
+        @Advice.Argument(0) final String name,
+        @Advice.Return final String value,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (value == null) {
         return;
       }
@@ -106,16 +113,19 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
-      module.taint(value, SourceTypes.REQUEST_HEADER_VALUE, name);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      module.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(
         @Advice.Argument(0) final String name,
-        @Advice.Return(readOnly = false) Enumeration<String> enumeration) {
+        @Advice.Return(readOnly = false) Enumeration<String> enumeration,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (enumeration == null) {
         return;
       }
@@ -123,15 +133,20 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       enumeration =
-          TaintableEnumeration.wrap(enumeration, module, SourceTypes.REQUEST_HEADER_VALUE, name);
+          TaintableEnumeration.wrap(
+              ctx, enumeration, module, SourceTypes.REQUEST_HEADER_VALUE, name);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetHeaderNamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_NAME)
-    public static void onExit(@Advice.Return(readOnly = false) Enumeration<String> enumeration) {
+    public static void onExit(
+        @Advice.Return(readOnly = false) Enumeration<String> enumeration,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (enumeration == null) {
         return;
       }
@@ -139,16 +154,21 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       enumeration =
-          TaintableEnumeration.wrap(enumeration, module, SourceTypes.REQUEST_HEADER_NAME, true);
+          TaintableEnumeration.wrap(
+              ctx, enumeration, module, SourceTypes.REQUEST_HEADER_NAME, true);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetParameterAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
-        @Advice.Argument(0) final String name, @Advice.Return final String value) {
+        @Advice.Argument(0) final String name,
+        @Advice.Return final String value,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (value == null) {
         return;
       }
@@ -156,15 +176,19 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
-      module.taint(value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetParameterValuesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
-        @Advice.Argument(0) final String name, @Advice.Return final String[] values) {
+        @Advice.Argument(0) final String name,
+        @Advice.Return final String[] values,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (values == null || values.length == 0) {
         return;
       }
@@ -172,17 +196,20 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final String value : values) {
         module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetParameterMapAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
-    public static void onExit(@Advice.Return final Map<String, String[]> parameters) {
+    public static void onExit(
+        @Advice.Return final Map<String, String[]> parameters,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (parameters == null || parameters.isEmpty()) {
         return;
       }
@@ -190,7 +217,7 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final Map.Entry<String, String[]> entry : parameters.entrySet()) {
         final String name = entry.getKey();
         module.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
@@ -204,10 +231,13 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetParameterNamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_NAME)
-    public static void onExit(@Advice.Return(readOnly = false) Enumeration<String> enumeration) {
+    public static void onExit(
+        @Advice.Return(readOnly = false) Enumeration<String> enumeration,
+        @ActiveRequestContext RequestContext reqCtx) {
       if (enumeration == null) {
         return;
       }
@@ -215,16 +245,20 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       enumeration =
-          TaintableEnumeration.wrap(enumeration, module, SourceTypes.REQUEST_PARAMETER_NAME, true);
+          TaintableEnumeration.wrap(
+              ctx, enumeration, module, SourceTypes.REQUEST_PARAMETER_NAME, true);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetCookiesAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
-    public static void onExit(@Advice.Return final Cookie[] cookies) {
+    public static void onExit(
+        @Advice.Return final Cookie[] cookies, @ActiveRequestContext RequestContext reqCtx) {
       if (cookies == null || cookies.length == 0) {
         return;
       }
@@ -232,17 +266,19 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
-      final IastContext ctx = IastContext.Provider.get();
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final Cookie cookie : cookies) {
         module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetQueryStringAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_QUERY)
-    public static void onExit(@Advice.Return final String queryString) {
+    public static void onExit(
+        @Advice.Return final String queryString, @ActiveRequestContext RequestContext reqCtx) {
       if (queryString == null) {
         return;
       }
@@ -250,14 +286,17 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
-      module.taint(queryString, SourceTypes.REQUEST_QUERY);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      module.taint(ctx, queryString, SourceTypes.REQUEST_QUERY);
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetBodyAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_BODY)
-    public static void onExit(@Advice.Return final Object body) {
+    public static void onExit(
+        @Advice.Return final Object body, @ActiveRequestContext RequestContext reqCtx) {
       if (body == null) {
         return;
       }
@@ -265,7 +304,8 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       if (module == null) {
         return;
       }
-      module.taint(body, SourceTypes.REQUEST_BODY);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      module.taint(ctx, body, SourceTypes.REQUEST_BODY);
     }
   }
 

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/CookieInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/CookieInstrumentationTest.groovy
@@ -1,7 +1,10 @@
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import groovy.transform.CompileDynamic
 
 import javax.servlet.http.Cookie
@@ -12,9 +15,16 @@ class CookieInstrumentationTest extends AgentTestRunner {
   private static final String NAME = 'name'
   private static final String VALUE = 'value'
 
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig("dd.iast.enabled", "true")
+  }
+
+  @Override
+  void setup() {
+    iastCtx = Stub(IastContext)
   }
 
   void 'test getName'() {
@@ -24,11 +34,11 @@ class CookieInstrumentationTest extends AgentTestRunner {
     final cookie = new Cookie(NAME, VALUE)
 
     when:
-    final result = cookie.getName()
+    final result = runUnderIastTrace { cookie.getName() }
 
     then:
     result == NAME
-    1 * iastModule.taintIfTainted(NAME, cookie, SourceTypes.REQUEST_COOKIE_NAME, NAME)
+    1 * iastModule.taintIfTainted(iastCtx, NAME, cookie, SourceTypes.REQUEST_COOKIE_NAME, NAME)
   }
 
   void 'test getValue'() {
@@ -38,10 +48,20 @@ class CookieInstrumentationTest extends AgentTestRunner {
     final cookie = new Cookie(NAME, VALUE)
 
     when:
-    final result = cookie.getValue()
+    final result = runUnderIastTrace { cookie.getValue() }
 
     then:
     result == VALUE
-    1 * iastModule.taintIfTainted(VALUE, cookie, SourceTypes.REQUEST_COOKIE_VALUE, NAME)
+    1 * iastModule.taintIfTainted(iastCtx, VALUE, cookie, SourceTypes.REQUEST_COOKIE_VALUE, NAME)
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
+    }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestTest.groovy
@@ -2,10 +2,13 @@ import datadog.smoketest.controller.JavaxHttpServletRequestTestSuite
 import datadog.smoketest.controller.JavaxHttpServletRequestWrapperTestSuite
 import datadog.smoketest.controller.ServletRequestTestSuite
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.api.iast.sink.UnvalidatedRedirectModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 
 import javax.servlet.RequestDispatcher
 import javax.servlet.ServletInputStream
@@ -17,10 +20,17 @@ import datadog.trace.agent.tooling.iast.TaintableEnumeration
 
 class HttpServletRequestTest extends AgentTestRunner {
 
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
   }
+
+  void setup() {
+    iastCtx = Stub(IastContext)
+  }
+
 
   void cleanup() {
     InstrumentationBridge.clearIastModules()
@@ -34,12 +44,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getHeader('header')
+    final result = runUnderIastTrace { request.getHeader('header') }
 
     then:
     result == 'value'
     1 * mock.getHeader('header') >> 'value'
-    1 * iastModule.taint('value', SourceTypes.REQUEST_HEADER_VALUE, 'header')
+    1 * iastModule.taint(iastCtx, 'value', SourceTypes.REQUEST_HEADER_VALUE, 'header')
     0 * _
 
     where:
@@ -55,12 +65,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getHeaders('headers').collect()
+    final result = runUnderIastTrace { request.getHeaders('headers').collect() }
 
     then:
     result == headers
     1 * mock.getHeaders('headers') >> Collections.enumeration(headers)
-    headers.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_HEADER_VALUE, 'headers') }
+    headers.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_VALUE, 'headers') }
     0 * _
 
     where:
@@ -76,12 +86,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getHeaderNames().collect()
+    final result = runUnderIastTrace { request.getHeaderNames().collect() }
 
     then:
     result == headers
     1 * mock.getHeaderNames() >> Collections.enumeration(headers)
-    headers.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_HEADER_NAME, it) }
+    headers.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) }
     0 * _
 
     where:
@@ -96,12 +106,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getParameter('parameter')
+    final result = runUnderIastTrace { request.getParameter('parameter') }
 
     then:
     result == 'value'
     1 * mock.getParameter('parameter') >> 'value'
-    1 * iastModule.taint('value', SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter')
+    1 * iastModule.taint(iastCtx, 'value', SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter')
     0 * _
 
     where:
@@ -117,12 +127,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getParameterValues('parameter').collect()
+    final result = runUnderIastTrace { request.getParameterValues('parameter').collect() }
 
     then:
     result == values
     1 * mock.getParameterValues('parameter') >> { values as String[] }
-    values.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter') }
+    values.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter') }
     0 * _
 
     where:
@@ -138,15 +148,15 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getParameterMap()
+    final result = runUnderIastTrace { request.getParameterMap() }
 
     then:
     result == parameters
     1 * mock.getParameterMap() >> parameters
     parameters.each { key, values ->
-      1 * iastModule.taint(_, key, SourceTypes.REQUEST_PARAMETER_NAME, key)
+      1 * iastModule.taint(iastCtx, key, SourceTypes.REQUEST_PARAMETER_NAME, key)
       values.each { value ->
-        1 * iastModule.taint(_, value, SourceTypes.REQUEST_PARAMETER_VALUE, key)
+        1 * iastModule.taint(iastCtx, value, SourceTypes.REQUEST_PARAMETER_VALUE, key)
       }
     }
     0 * _
@@ -164,12 +174,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getParameterNames().collect()
+    final result = runUnderIastTrace { request.getParameterNames().collect() }
 
     then:
     result == parameters
     1 * mock.getParameterNames() >> Collections.enumeration(parameters)
-    parameters.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_PARAMETER_NAME, it) }
+    parameters.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it) }
     0 * _
 
     where:
@@ -185,12 +195,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getCookies()
+    final result = runUnderIastTrace { request.getCookies() }
 
     then:
     result == cookies
     1 * mock.getCookies() >> cookies
-    cookies.each { 1 * iastModule.taint(_, it, SourceTypes.REQUEST_COOKIE_VALUE) }
+    cookies.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_COOKIE_VALUE) }
     0 * _
 
     where:
@@ -208,7 +218,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final headers = request.getHeaders('header')
+    final headers = runUnderIastTrace { request.getHeaders('header') }
 
     then:
     1 * mock.getHeaders('header') >> enumeration
@@ -236,7 +246,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getHeaderNames()
+    final result = runUnderIastTrace { request.getHeaderNames() }
 
     then:
     1 * mock.getHeaderNames() >> enumeration
@@ -262,12 +272,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final String result = request.getQueryString()
+    final String result = runUnderIastTrace { request.getQueryString() }
 
     then:
     result == queryString
     1 * mock.getQueryString() >> queryString
-    1 * iastModule.taint(queryString, SourceTypes.REQUEST_QUERY)
+    1 * iastModule.taint(iastCtx, queryString, SourceTypes.REQUEST_QUERY)
     0 * _
 
     where:
@@ -283,12 +293,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getInputStream()
+    final result = runUnderIastTrace { request.getInputStream() }
 
     then:
     result == is
     1 * mock.getInputStream() >> is
-    1 * iastModule.taint(is, SourceTypes.REQUEST_BODY)
+    1 * iastModule.taint(iastCtx, is, SourceTypes.REQUEST_BODY)
     0 * _
 
     where:
@@ -304,12 +314,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getReader()
+    final result = runUnderIastTrace { request.getReader() }
 
     then:
     result == reader
     1 * mock.getReader() >> reader
-    1 * iastModule.taint(reader, SourceTypes.REQUEST_BODY)
+    1 * iastModule.taint(iastCtx, reader, SourceTypes.REQUEST_BODY)
     0 * _
 
     where:
@@ -326,7 +336,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getRequestDispatcher(path)
+    final result = runUnderIastTrace { request.getRequestDispatcher(path) }
 
     then:
     result == dispatcher
@@ -347,12 +357,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getRequestURI()
+    final result = runUnderIastTrace { request.getRequestURI() }
 
     then:
     result == uri
     1 * mock.getRequestURI() >> uri
-    1 * iastModule.taint(uri, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taint(iastCtx, uri, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -368,12 +378,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getPathInfo()
+    final result = runUnderIastTrace { request.getPathInfo() }
 
     then:
     result == pathInfo
     1 * mock.getPathInfo() >> pathInfo
-    1 * iastModule.taint(pathInfo, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taint(iastCtx, pathInfo, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -389,12 +399,12 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getPathTranslated()
+    final result = runUnderIastTrace { request.getPathTranslated() }
 
     then:
     result == pathTranslated
     1 * mock.getPathTranslated() >> pathTranslated
-    1 * iastModule.taint(pathTranslated, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taint(iastCtx, pathTranslated, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -410,16 +420,26 @@ class HttpServletRequestTest extends AgentTestRunner {
     final request = suite.call(mock)
 
     when:
-    final result = request.getRequestURL()
+    final result = runUnderIastTrace { request.getRequestURL() }
 
     then:
     result == url
     1 * mock.getRequestURL() >> url
-    1 * iastModule.taint(url, SourceTypes.REQUEST_URI)
+    1 * iastModule.taint(iastCtx, url, SourceTypes.REQUEST_URI)
     0 * _
 
     where:
     suite << testSuiteCallSites()
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
+    }
   }
 
   private List<Closure<? extends HttpServletRequest>> testSuite() {

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/AbstractServerHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/AbstractServerHttpRequestInstrumentation.java
@@ -6,9 +6,15 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -33,14 +39,18 @@ public class AbstractServerHttpRequestInstrumentation extends InstrumenterModule
         getClass().getName() + "$TaintHeadersAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class TaintHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void after(@Advice.Return Object object) {
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    public static void after(
+        @Advice.Return Object object, @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation == null) {
         return;
       }
-      propagation.taint(object, SourceTypes.REQUEST_HEADER_VALUE);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      propagation.taint(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/DataBufferAsInputStreamAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/DataBufferAsInputStreamAdvice.java
@@ -1,7 +1,5 @@
 package datadog.trace.instrumentation.springwebflux.server.iast;
 
-import datadog.trace.advice.RequiresRequestContext;
-import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -9,7 +7,6 @@ import java.io.InputStream;
 import net.bytebuddy.asm.Advice;
 import org.springframework.core.io.buffer.DataBuffer;
 
-@RequiresRequestContext(RequestContextSlot.IAST)
 public class DataBufferAsInputStreamAdvice {
 
   @Advice.OnMethodExit(suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HttpMessageInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HttpMessageInstrumentation.java
@@ -7,9 +7,15 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
@@ -41,14 +47,18 @@ public class HttpMessageInstrumentation extends InstrumenterModule.Iast
         getClass().getName() + "$TaintHeadersAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class TaintHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void after(@Advice.Return Object object) {
+    @Source(SourceTypes.REQUEST_HEADER_VALUE)
+    public static void after(
+        @Advice.Return Object object, @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation == null) {
         return;
       }
-      propagation.taint(object, SourceTypes.REQUEST_HEADER_VALUE);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      propagation.taint(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ReactorServerHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ReactorServerHttpRequestInstrumentation.java
@@ -6,8 +6,13 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -33,14 +38,17 @@ public class ReactorServerHttpRequestInstrumentation extends InstrumenterModule.
         getClass().getName() + "$TaintHeadersAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class TaintHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void after(@Advice.Return Object object) {
+    public static void after(
+        @Advice.Return Object object, @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation == null) {
         return;
       }
-      propagation.taint(object, SourceTypes.REQUEST_HEADER_VALUE);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      propagation.taint(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ServerServletHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ServerServletHttpRequestInstrumentation.java
@@ -6,8 +6,13 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -33,14 +38,17 @@ public class ServerServletHttpRequestInstrumentation extends InstrumenterModule.
         getClass().getName() + "$TaintHeadersAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class TaintHeadersAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void after(@Advice.Return Object object) {
+    public static void after(
+        @Advice.Return Object object, @ActiveRequestContext RequestContext reqCtx) {
       PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation == null) {
         return;
       }
-      propagation.taint(object, SourceTypes.REQUEST_HEADER_VALUE);
+      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      propagation.taint(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintCookiesAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintCookiesAdvice.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.springwebflux.server.iast;
 
+import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
@@ -15,13 +17,15 @@ import org.springframework.util.MultiValueMap;
 class TaintCookiesAdvice {
 
   @Advice.OnMethodExit(suppress = Throwable.class)
-  public static void after(@Advice.Return MultiValueMap<String, HttpCookie> cookies) {
+  public static void after(
+      @Advice.Return MultiValueMap<String, HttpCookie> cookies,
+      @ActiveRequestContext RequestContext reqCtx) {
     PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || cookies.isEmpty()) {
       return;
     }
 
-    final IastContext ctx = IastContext.Provider.get();
+    final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
     for (List<HttpCookie> cookieList : cookies.values()) {
       for (HttpCookie cookie : cookieList) {
         final String name = cookie.getName();

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintFluxElementsFunction.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintFluxElementsFunction.java
@@ -1,19 +1,23 @@
 package datadog.trace.instrumentation.springwebflux.server.iast;
 
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.util.function.Function;
 
 public class TaintFluxElementsFunction<T> implements Function<T, T> {
+
+  final IastContext ctx;
   final PropagationModule propagation;
 
-  public TaintFluxElementsFunction(PropagationModule propagationModule) {
+  public TaintFluxElementsFunction(IastContext ctx, PropagationModule propagationModule) {
+    this.ctx = ctx;
     this.propagation = propagationModule;
   }
 
   @Override
   public T apply(T t) {
-    propagation.taint(t, SourceTypes.REQUEST_BODY);
+    propagation.taint(ctx, t, SourceTypes.REQUEST_BODY);
     return t;
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintGetBodyAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintGetBodyAdvice.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.springwebflux.server.iast;
 
+import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.SourceTypes;
 import datadog.trace.api.iast.propagation.PropagationModule;
@@ -14,14 +17,17 @@ import reactor.core.publisher.Flux;
 @RequiresRequestContext(RequestContextSlot.IAST)
 class TaintGetBodyAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
-  public static void after(@Advice.Return(readOnly = false) Flux<DataBuffer> flux) {
+  public static void after(
+      @Advice.Return(readOnly = false) Flux<DataBuffer> flux,
+      @ActiveRequestContext RequestContext reqCtx) {
     PropagationModule propagation = InstrumentationBridge.PROPAGATION;
     if (propagation == null || flux == null) {
       return;
     }
 
     // taint both the flux and the individual DataBuffers
-    propagation.taint(flux, SourceTypes.REQUEST_BODY);
-    flux = flux.map(new TaintFluxElementsFunction<>(propagation));
+    IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+    propagation.taint(ctx, flux, SourceTypes.REQUEST_BODY);
+    flux = flux.map(new TaintFluxElementsFunction<>(ctx, propagation));
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.springwebflux.server.iast;
 
+import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
@@ -19,7 +21,8 @@ class TaintHttpHeadersGetAdvice {
   public static void after(
       @Advice.This Object self,
       @Advice.Argument(0) Object arg,
-      @Advice.Return List<String> values) {
+      @Advice.Return List<String> values,
+      @ActiveRequestContext RequestContext reqCtx) {
 
     PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || values == null || values.isEmpty()) {
@@ -28,7 +31,7 @@ class TaintHttpHeadersGetAdvice {
     if (!(arg instanceof String)) {
       return;
     }
-    final IastContext ctx = IastContext.Provider.get();
+    final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
     String lc = ((String) arg).toLowerCase(Locale.ROOT);
     for (String value : values) {
       module.taintIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, lc);

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.springwebflux.server.iast;
 
+import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -14,12 +17,16 @@ class TaintHttpHeadersGetFirstAdvice {
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_HEADER_VALUE)
   public static void after(
-      @Advice.This Object self, @Advice.Argument(0) String arg, @Advice.Return String value) {
+      @Advice.This Object self,
+      @Advice.Argument(0) String arg,
+      @Advice.Return String value,
+      @ActiveRequestContext RequestContext reqCtx) {
 
     PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module == null || arg == null || value == null) {
       return;
     }
-    module.taintIfTainted(value, self, SourceTypes.REQUEST_HEADER_VALUE, arg);
+    IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+    module.taintIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, arg);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintQueryParamsAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintQueryParamsAdvice.java
@@ -1,6 +1,8 @@
 package datadog.trace.instrumentation.springwebflux.server.iast;
 
+import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
@@ -18,13 +20,15 @@ class TaintQueryParamsAdvice {
   @SuppressWarnings("Duplicates")
   @Advice.OnMethodExit(suppress = Throwable.class)
   @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
-  public static void after(@Advice.Return MultiValueMap<String, String> queryParams) {
+  public static void after(
+      @Advice.Return MultiValueMap<String, String> queryParams,
+      @ActiveRequestContext RequestContext reqCtx) {
     final PropagationModule prop = InstrumentationBridge.PROPAGATION;
     if (prop == null || queryParams == null || queryParams.isEmpty()) {
       return;
     }
 
-    final IastContext ctx = IastContext.Provider.get();
+    final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
     for (Map.Entry<String, List<String>> e : queryParams.entrySet()) {
       String name = e.getKey();
       prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/HeadersAdviceForkedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/HeadersAdviceForkedTest.groovy
@@ -1,16 +1,27 @@
 package dd.trace.instrumentation.springwebflux.client
 
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import foo.bar.DummyRequest
 import org.springframework.http.server.ServletServerHttpRequest
 
 class HeadersAdviceForkedTest extends AgentTestRunner {
+
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  @Override
+  void setup() {
+    iastCtx = Stub(IastContext)
   }
 
   void 'Headers instrumentation'() {
@@ -21,10 +32,20 @@ class HeadersAdviceForkedTest extends AgentTestRunner {
 
 
     when:
-    request.getHeaders()
+    runUnderIastTrace { request.getHeaders() }
 
     then:
-    2 * module.taint(_ as Object, SourceTypes.REQUEST_HEADER_VALUE)
+    2 * module.taint(iastCtx , _ as Object, SourceTypes.REQUEST_HEADER_VALUE)
     0 * _
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
+    }
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/CaseInsensitiveHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/CaseInsensitiveHeadersInstrumentation.java
@@ -10,10 +10,14 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -75,31 +79,36 @@ public class CaseInsensitiveHeadersInstrumentation extends InstrumenterModule.Ia
         className + "$NamesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final String name,
-        @Advice.Return final String result) {
+        @Advice.Return final String result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null) {
-        propagation.taintIfTainted(result, self, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        propagation.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetAllAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final String name,
-        @Advice.Return final Collection<String> result) {
+        @Advice.Return final Collection<String> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        if (propagation.isTainted(self)) {
-          final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        if (propagation.isTainted(ctx, self)) {
           for (final String value : result) {
             propagation.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
           }
@@ -108,16 +117,18 @@ public class CaseInsensitiveHeadersInstrumentation extends InstrumenterModule.Ia
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class EntriesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void afterEntries(
         @Advice.This final Object self,
-        @Advice.Return final List<Map.Entry<String, String>> result) {
+        @Advice.Return final List<Map.Entry<String, String>> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        if (propagation.isTainted(self)) {
-          final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        if (propagation.isTainted(ctx, self)) {
           final Set<String> names = new HashSet<>();
           for (final Map.Entry<String, String> entry : result) {
             final String name = entry.getKey();
@@ -132,15 +143,18 @@ public class CaseInsensitiveHeadersInstrumentation extends InstrumenterModule.Ia
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class NamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_PARAMETER_NAME)
     public static void afterNames(
-        @Advice.This final Object self, @Advice.Return final Set<String> result) {
+        @Advice.This final Object self,
+        @Advice.Return final Set<String> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        if (propagation.isTainted(self)) {
-          final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        if (propagation.isTainted(ctx, self)) {
           for (final String name : result) {
             propagation.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
           }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HeadersAdaptorInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HeadersAdaptorInstrumentation.java
@@ -8,10 +8,14 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -67,31 +71,36 @@ public class HeadersAdaptorInstrumentation extends InstrumenterModule.Iast
         className + "$NamesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
-        @Advice.Return final String result) {
+        @Advice.Return final String result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null) {
-        propagation.taintIfTainted(result, self, SourceTypes.REQUEST_HEADER_VALUE, name);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        propagation.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_HEADER_VALUE, name);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetAllAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
-        @Advice.Return final Collection<String> result) {
+        @Advice.Return final Collection<String> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        if (propagation.isTainted(self)) {
-          final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        if (propagation.isTainted(ctx, self)) {
           final String headerName = name == null ? null : name.toString();
           for (final String value : result) {
             propagation.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, headerName);
@@ -101,16 +110,18 @@ public class HeadersAdaptorInstrumentation extends InstrumenterModule.Iast
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class EntriesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void afterEntries(
         @Advice.This final Object self,
-        @Advice.Return final List<Map.Entry<String, String>> result) {
+        @Advice.Return final List<Map.Entry<String, String>> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        if (propagation.isTainted(self)) {
-          final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        if (propagation.isTainted(ctx, self)) {
           final Set<String> names = new HashSet<>();
           for (Map.Entry<String, String> entry : result) {
             final String name = entry.getKey();
@@ -125,15 +136,18 @@ public class HeadersAdaptorInstrumentation extends InstrumenterModule.Iast
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class NamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_NAME)
     public static void afterNames(
-        @Advice.This final Object self, @Advice.Return final Set<String> result) {
+        @Advice.This final Object self,
+        @Advice.Return final Set<String> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        if (propagation.isTainted(self)) {
-          final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        if (propagation.isTainted(ctx, self)) {
           for (final String name : result) {
             propagation.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
           }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
@@ -6,7 +6,12 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -36,6 +41,7 @@ public class Http2ServerRequestInstrumentation extends AbstractHttpServerRequest
         Http2ServerRequestInstrumentation.class.getName() + "$HeadersAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class HeadersAdvice {
 
     @Advice.OnMethodEnter
@@ -49,12 +55,14 @@ public class Http2ServerRequestInstrumentation extends AbstractHttpServerRequest
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(
         @Advice.Local("beforeHeaders") final Object beforeHeaders,
-        @Advice.Return final Object multiMap) {
+        @Advice.Return final Object multiMap,
+        @ActiveRequestContext RequestContext reqCtx) {
       // only taint the map the first time
       if (beforeHeaders != multiMap) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taint(multiMap, SourceTypes.REQUEST_HEADER_VALUE);
+          final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+          module.taint(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
         }
       }
     }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
@@ -7,7 +7,12 @@ import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -37,6 +42,7 @@ public class HttpServerRequestInstrumentation extends AbstractHttpServerRequestI
         HttpServerRequestInstrumentation.class.getName() + "$HeadersAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class HeadersAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
@@ -50,12 +56,14 @@ public class HttpServerRequestInstrumentation extends AbstractHttpServerRequestI
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
     public static void onExit(
         @Advice.Local("beforeHeaders") final Object beforeHeaders,
-        @Advice.Return final Object multiMap) {
+        @Advice.Return final Object multiMap,
+        @ActiveRequestContext RequestContext reqCtx) {
       // only taint the map the first time
       if (beforeHeaders != multiMap) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taint(multiMap, SourceTypes.REQUEST_HEADER_VALUE);
+          final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+          module.taint(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
         }
       }
     }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/CookieImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/CookieImplInstrumentation.java
@@ -7,10 +7,15 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -51,28 +56,36 @@ public class CookieImplInstrumentation extends InstrumenterModule.Iast
         isMethod().and(named("getValue")).and(takesArguments(0)), className + "$GetValueAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetNameAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_NAME)
     public static void afterGetName(
-        @Advice.This final Cookie self, @Advice.Return final String result) {
+        @Advice.This final Cookie self,
+        @Advice.Return final String result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetValueAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void afterGetValue(
-        @Advice.This final Cookie self, @Advice.Return final String result) {
+        @Advice.This final Cookie self,
+        @Advice.Return final String result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         // TODO calling self.getName() actually taints the name of the cookie
-        module.taintIfTainted(result, self, SourceTypes.REQUEST_COOKIE_VALUE, self.getName());
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_VALUE, self.getName());
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/CaseInsensitiveHeadersInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/CaseInsensitiveHeadersInstrumentationTest.groovy
@@ -1,9 +1,12 @@
 package core
 
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import groovy.transform.CompileDynamic
 import io.vertx.core.MultiMap
 import io.vertx.core.http.CaseInsensitiveHeaders
@@ -12,9 +15,15 @@ import org.junit.Assume
 @CompileDynamic
 class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
 
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void setup() {
+    iastCtx = Stub(IastContext)
   }
 
   void 'test that get() is instrumented'() {
@@ -25,10 +34,10 @@ class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
     addAll([key: 'value'], headers)
 
     when:
-    headers.get('key')
+    runUnderIastTrace { headers.get('key') }
 
     then:
-    1 * module.taintIfTainted('value', headers, SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
+    1 * module.taintIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
   }
 
   void 'test that getAll() is instrumented'() {
@@ -39,19 +48,19 @@ class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
     addAll([[key: 'value1'], [key: 'value2']], headers)
 
     when:
-    headers.getAll('key')
+    runUnderIastTrace { headers.getAll('key') }
 
     then:
-    1 * module.isTainted(headers) >> { false }
+    1 * module.isTainted(iastCtx, headers) >> { false }
     0 * _
 
     when:
-    headers.getAll('key')
+    runUnderIastTrace { headers.getAll('key') }
 
     then:
-    1 * module.isTainted(headers) >> { true }
-    1 * module.taint(_, 'value1', SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
-    1 * module.taint(_, 'value2', SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
+    1 * module.isTainted(iastCtx, headers) >> { true }
+    1 * module.taint(iastCtx, 'value1', SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
+    1 * module.taint(iastCtx, 'value2', SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
   }
 
   void 'test that names() is instrumented'() {
@@ -62,18 +71,18 @@ class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
     addAll([[key: 'value1'], [key: 'value2']], headers)
 
     when:
-    headers.names()
+    runUnderIastTrace { headers.names() }
 
     then:
-    1 * module.isTainted(headers) >> { false }
+    1 * module.isTainted(iastCtx, headers) >> { false }
     0 * _
 
     when:
-    headers.names()
+    runUnderIastTrace { headers.names() }
 
     then:
-    1 * module.isTainted(headers) >> { true }
-    1 * module.taint(_, 'key', SourceTypes.REQUEST_PARAMETER_NAME, 'key')
+    1 * module.isTainted(iastCtx, headers) >> { true }
+    1 * module.taint(iastCtx, 'key', SourceTypes.REQUEST_PARAMETER_NAME, 'key')
   }
 
   void 'test that entries() is instrumented'() {
@@ -86,22 +95,32 @@ class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
     addAll([[key: 'value1'], [key: 'value2']], headers)
 
     when:
-    final result = headers.entries()
+    final result = runUnderIastTrace { headers.entries() }
 
     then:
-    1 * module.isTainted(headers) >> { false }
+    1 * module.isTainted(iastCtx, headers) >> { false }
     0 * _
 
     when:
-    headers.entries()
+    runUnderIastTrace { headers.entries() }
 
     then:
-    1 * module.isTainted(headers) >> { true }
+    1 * module.isTainted(iastCtx, headers) >> { true }
     result.collect { it.key }.unique().each {
-      1 * module.taint(_, it, SourceTypes.REQUEST_PARAMETER_NAME, it)
+      1 * module.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it)
     }
     result.each {
-      1 * module.taint(_, it.value, SourceTypes.REQUEST_PARAMETER_VALUE, it.key)
+      1 * module.taint(iastCtx, it.value, SourceTypes.REQUEST_PARAMETER_VALUE, it.key)
+    }
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
     }
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
@@ -41,7 +41,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_, SourceTypes.REQUEST_COOKIE_VALUE)
+    (1.._) * module.taint(_ as IastContext, _, SourceTypes.REQUEST_COOKIE_VALUE)
   }
 
   void 'test that cookie getName is instrumented'() {
@@ -55,7 +55,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintIfTainted('cookieName', _, SourceTypes.REQUEST_COOKIE_NAME, 'cookieName')
+    1 * module.taintIfTainted(_ as IastContext, 'cookieName', _, SourceTypes.REQUEST_COOKIE_NAME, 'cookieName')
   }
 
   void 'test that cookie getValue is instrumented'() {
@@ -69,8 +69,8 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintIfTainted('cookieName', _, SourceTypes.REQUEST_COOKIE_NAME, 'cookieName')
-    1 * module.taintIfTainted('cookieValue', _, SourceTypes.REQUEST_COOKIE_VALUE, 'cookieName')
+    1 * module.taintIfTainted(_ as IastContext, 'cookieName', _, SourceTypes.REQUEST_COOKIE_NAME, 'cookieName')
+    1 * module.taintIfTainted(_ as IastContext, 'cookieValue', _, SourceTypes.REQUEST_COOKIE_VALUE, 'cookieName')
   }
 
   void 'test that headers() is instrumented'() {
@@ -84,7 +84,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_, SourceTypes.REQUEST_HEADER_VALUE)
+    1 * module.taint(_ as IastContext, _, SourceTypes.REQUEST_HEADER_VALUE)
   }
 
   void 'test that params() is instrumented'() {
@@ -98,7 +98,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_, SourceTypes.REQUEST_PARAMETER_VALUE)
+    1 * module.taint(_ as IastContext, _, SourceTypes.REQUEST_PARAMETER_VALUE)
   }
 
   void 'test that formAttributes() is instrumented'() {
@@ -113,9 +113,9 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE) // once for formAttributes()
-    1 * module.taint(_ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE) // once for params()
-    1 * module.taintIfTainted('form', _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE, 'formAttribute')
+    1 * module.taint(_ as IastContext, _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE) // once for formAttributes()
+    1 * module.taint(_ as IastContext, _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE) // once for params()
+    1 * module.taintIfTainted(_ as IastContext, 'form', _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE, 'formAttribute')
   }
 
   void 'test that handleData()/onData() is instrumented'() {
@@ -130,7 +130,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_ as Buffer, SourceTypes.REQUEST_BODY)
+    1 * module.taint(_ as IastContext, _ as Buffer, SourceTypes.REQUEST_BODY)
     1 * module.taintIfTainted('{ "my_key": "my_value" }', _ as Buffer)
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-3.5/src/test/groovy/core/VertxHttpHeadersInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.5/src/test/groovy/core/VertxHttpHeadersInstrumentationTest.groovy
@@ -1,9 +1,12 @@
 package core
 
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.TagContext
 import groovy.transform.CompileDynamic
 import io.vertx.core.MultiMap
 import io.vertx.core.http.impl.headers.VertxHttpHeaders
@@ -11,9 +14,15 @@ import io.vertx.core.http.impl.headers.VertxHttpHeaders
 @CompileDynamic
 class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
 
+  private Object iastCtx
+
   @Override
   protected void configurePreAgent() {
     injectSysConfig('dd.iast.enabled', 'true')
+  }
+
+  void setup() {
+    iastCtx = Stub(IastContext)
   }
 
   void 'test that get() is instrumented'() {
@@ -24,10 +33,10 @@ class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
     addAll([key: 'value'], headers)
 
     when:
-    headers.get('key')
+    runUnderIastTrace { headers.get('key') }
 
     then:
-    1 * module.taintIfTainted('value', headers, SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.taintIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_HEADER_VALUE, 'key')
   }
 
   void 'test that getAll() is instrumented'() {
@@ -38,19 +47,19 @@ class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
     addAll([[key: 'value1'], [key: 'value2']], headers)
 
     when:
-    headers.getAll('key')
+    runUnderIastTrace { headers.getAll('key') }
 
     then:
-    1 * module.isTainted(headers) >> { false }
+    1 * module.isTainted(iastCtx, headers) >> { false }
     0 * _
 
     when:
-    headers.getAll('key')
+    runUnderIastTrace { headers.getAll('key') }
 
     then:
-    1 * module.isTainted(headers) >> { true }
-    1 * module.taint(_, 'value1', SourceTypes.REQUEST_HEADER_VALUE, 'key')
-    1 * module.taint(_, 'value2', SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.isTainted(iastCtx, headers) >> { true }
+    1 * module.taint(iastCtx, 'value1', SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.taint(iastCtx, 'value2', SourceTypes.REQUEST_HEADER_VALUE, 'key')
   }
 
   void 'test that names() is instrumented'() {
@@ -61,18 +70,18 @@ class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
     addAll([[key: 'value1'], [key: 'value2']], headers)
 
     when:
-    headers.names()
+    runUnderIastTrace { headers.names() }
 
     then:
-    1 * module.isTainted(headers) >> { false }
+    1 * module.isTainted(iastCtx, headers) >> { false }
     0 * _
 
     when:
-    headers.names()
+    runUnderIastTrace { headers.names() }
 
     then:
-    1 * module.isTainted(headers) >> { true }
-    1 * module.taint(_, 'key', SourceTypes.REQUEST_HEADER_NAME, 'key')
+    1 * module.isTainted(iastCtx, headers) >> { true }
+    1 * module.taint(iastCtx, 'key', SourceTypes.REQUEST_HEADER_NAME, 'key')
   }
 
   void 'test that entries() is instrumented'() {
@@ -83,22 +92,32 @@ class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
     addAll([[key: 'value1'], [key: 'value2']], headers)
 
     when:
-    final result = headers.entries()
+    final result = runUnderIastTrace { headers.entries() }
 
     then:
-    module.isTainted(headers) >> { false }
+    module.isTainted(iastCtx, headers) >> { false }
     0 * _
 
     when:
-    headers.entries()
+    runUnderIastTrace { headers.entries() }
 
     then:
-    module.isTainted(headers) >> { true }
+    module.isTainted(iastCtx, headers) >> { true }
     result.collect { it.key }.unique().each {
-      (1.._) * module.taint(_, it, SourceTypes.REQUEST_HEADER_NAME, it) // entries relies on names() on some impls
+      (1.._) * module.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) // entries relies on names() on some impls
     }
     result.each {
-      1 * module.taint(_, it.value, SourceTypes.REQUEST_HEADER_VALUE, it.key)
+      1 * module.taint(iastCtx, it.value, SourceTypes.REQUEST_HEADER_VALUE, it.key)
+    }
+  }
+
+  protected <E> E runUnderIastTrace(Closure<E> cl) {
+    final ddctx = new TagContext().withRequestContextDataIast(iastCtx)
+    final span = TEST_TRACER.startSpan("test", "test-iast-span", ddctx)
+    try {
+      return AgentTracer.activateSpan(span).withCloseable(cl)
+    } finally {
+      span.finish()
     }
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
@@ -9,8 +9,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
@@ -60,6 +64,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         className + "$GetCookieAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class ParamsAdvice {
 
     @Advice.OnMethodEnter
@@ -73,17 +78,20 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
         @Advice.Local("beforeParams") final Object beforeParams,
-        @Advice.Return final Object multiMap) {
+        @Advice.Return final Object multiMap,
+        @ActiveRequestContext RequestContext reqCtx) {
       // only taint the map the first time
       if (beforeParams != multiMap) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taint(multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
+          final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+          module.taint(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
         }
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class AttributesAdvice {
 
     @Advice.OnMethodEnter
@@ -97,49 +105,59 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     @Source(SourceTypes.REQUEST_PARAMETER_VALUE)
     public static void onExit(
         @Advice.Local("beforeAttributes") final Object beforeAttributes,
-        @Advice.Return final Object multiMap) {
+        @Advice.Return final Object multiMap,
+        @ActiveRequestContext RequestContext reqCtx) {
       // only taint the map the first time
       if (beforeAttributes != multiMap) {
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
-          module.taint(multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
+          final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+          module.taint(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
         }
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class HeadersAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_HEADER_VALUE)
-    public static void onExit(@Advice.Return final Object multiMap) {
+    public static void onExit(
+        @Advice.Return final Object multiMap, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(multiMap, SourceTypes.REQUEST_HEADER_VALUE);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class DataAdvice {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_BODY)
-    public static void onExit(@Advice.Argument(0) final Object data) {
+    public static void onExit(
+        @Advice.Argument(0) final Object data, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(data, SourceTypes.REQUEST_BODY);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, data, SourceTypes.REQUEST_BODY);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class CookiesAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
-    public static void onExit(@Advice.Return final Set<Object> cookies) {
+    public static void onExit(
+        @Advice.Return final Set<Object> cookies, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null && cookies != null && !cookies.isEmpty()) {
-        final IastContext ctx = IastContext.Provider.get();
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final Object cookie : cookies) {
           module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
         }
@@ -147,14 +165,17 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetCookieAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
-    public static void onExit(@Advice.Return final Object cookie) {
+    public static void onExit(
+        @Advice.Return final Object cookie, @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taint(cookie, SourceTypes.REQUEST_COOKIE_VALUE);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/MultiMapInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/MultiMapInstrumentation.java
@@ -7,10 +7,14 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
@@ -68,35 +72,40 @@ public abstract class MultiMapInstrumentation extends InstrumenterModule.Iast
         className + "$NamesAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterGet(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
-        @Advice.Return final String result) {
+        @Advice.Return final String result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null) {
-        final Source source = propagation.findSource(self);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        final Source source = propagation.findSource(ctx, self);
         if (source != null) {
-          propagation.taint(result, source.getOrigin(), name);
+          propagation.taint(ctx, result, source.getOrigin(), name);
         }
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetAllAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterGetAll(
         @Advice.This final Object self,
         @Advice.Argument(0) final CharSequence name,
-        @Advice.Return final Collection<String> result) {
+        @Advice.Return final Collection<String> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        final Source source = propagation.findSource(self);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        final Source source = propagation.findSource(ctx, self);
         if (source != null) {
-          final IastContext ctx = IastContext.Provider.get();
           for (final String value : result) {
             propagation.taint(ctx, value, source.getOrigin(), name);
           }
@@ -105,17 +114,19 @@ public abstract class MultiMapInstrumentation extends InstrumenterModule.Iast
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class EntriesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterEntries(
         @Advice.This final Object self,
-        @Advice.Return final List<Map.Entry<String, String>> result) {
+        @Advice.Return final List<Map.Entry<String, String>> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        final Source source = propagation.findSource(self);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        final Source source = propagation.findSource(ctx, self);
         if (source != null) {
-          final IastContext ctx = IastContext.Provider.get();
           final byte nameOrigin = namedSource(source.getOrigin());
           final Set<String> keys = new HashSet<>();
           for (final Map.Entry<String, String> entry : result) {
@@ -131,16 +142,19 @@ public abstract class MultiMapInstrumentation extends InstrumenterModule.Iast
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class NamesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterNames(
-        @Advice.This final Object self, @Advice.Return final Set<String> result) {
+        @Advice.This final Object self,
+        @Advice.Return final Set<String> result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null && result != null && !result.isEmpty()) {
-        final Source source = propagation.findSource(self);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        final Source source = propagation.findSource(ctx, self);
         if (source != null) {
-          final IastContext ctx = IastContext.Provider.get();
           final byte nameOrigin = namedSource(source.getOrigin());
           for (final String name : result) {
             propagation.taint(ctx, name, nameOrigin, name);

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/CookieImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/CookieImplInstrumentation.java
@@ -6,10 +6,15 @@ import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor;
 import datadog.trace.agent.tooling.muzzle.Reference;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Source;
 import datadog.trace.api.iast.SourceTypes;
@@ -49,27 +54,35 @@ public class CookieImplInstrumentation extends InstrumenterModule.Iast
         isMethod().and(named("getValue")).and(takesArguments(0)), className + "$GetValueAdvice");
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetNameAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_NAME)
     public static void afterGetName(
-        @Advice.This final Cookie self, @Advice.Return final String result) {
+        @Advice.This final Cookie self,
+        @Advice.Return final String result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
       }
     }
   }
 
+  @RequiresRequestContext(RequestContextSlot.IAST)
   public static class GetValueAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Source(SourceTypes.REQUEST_COOKIE_VALUE)
     public static void afterGetValue(
-        @Advice.This final Cookie self, @Advice.Return final String result) {
+        @Advice.This final Cookie self,
+        @Advice.Return final String result,
+        @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, self, SourceTypes.REQUEST_COOKIE_VALUE, self.getName());
+        final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_VALUE, self.getName());
       }
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastContext.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastContext.java
@@ -62,25 +62,13 @@ public interface IastContext {
       return INSTANCE.resolve();
     }
 
-    /**
-     * Gets the current IAST context associated with the request context inside the span
-     *
-     * @see #get(RequestContext)
-     */
+    /** Gets the current IAST context associated with the request context inside the span */
     @Nullable
     public static IastContext get(@Nullable final AgentSpan span) {
       if (span == null) {
         return null;
       }
-      return get(span.getRequestContext());
-    }
-
-    /**
-     * Gets the current IAST context associated with the request context, if the request context is
-     * {@code null} then it returns {@code null}
-     */
-    @Nullable
-    public static IastContext get(@Nullable final RequestContext reqCtx) {
+      final RequestContext reqCtx = span.getRequestContext();
       if (reqCtx == null) {
         return null;
       }

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/IastContextTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/IastContextTest.groovy
@@ -57,14 +57,6 @@ class IastContextTest extends DDSpecification {
     context == iastCtx
   }
 
-  void 'test get context with request context'() {
-    when:
-    final context = IastContext.Provider.get(reqCtx)
-
-    then:
-    context == iastCtx
-  }
-
   void 'test get context with provider instance'() {
     given:
     final provider = Mock(IastContext.Provider)


### PR DESCRIPTION
# What Does This Do
Adds sampling back to HTTP sources so there will be no tainting if no active IAST context is present. The way it's done is by checking for the presence of an `IastRequestContext` in the current span at the callsite/addvice level. It brings two benefits:

- In `REQUEST` mode the tainting operation happens sooner so less code is run when a request is sampled
- In `GLOBAL` mode now sources are sampled too bringing less load to services.

# Motivation
When using `DD_IAST_CONTEXT_MODE=GLOBAL`, tainting all incoming HTTP data is starting to hurt in terms of performance, this PR reduces the amount of work done by IAST ending in less CPU consumption.
