### PR TITLE
Add DSM checkpoint for S3 calls in aws-sdk-1

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/build.gradle
@@ -91,8 +91,10 @@ dependencies {
   dsmTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '1.12.366'
   // no batch publish before v1.12
   dsmTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-sns', version: '1.12.366'
+  dsmTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.366'
   latestDsmTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-kinesis', version: '+'
   latestDsmTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-sns', version: '+'
+  latestDsmTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '+'
 
   latestDepTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '+'
   latestDepTestImplementation group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: '+'

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/dsmTest/groovy/AWS1S3ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/dsmTest/groovy/AWS1S3ClientTest.groovy
@@ -1,0 +1,113 @@
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.AnonymousAWSCredentials
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.UploadPartRequest
+import datadog.trace.agent.test.naming.VersionedNamingTestBase
+import datadog.trace.core.datastreams.StatsGroup
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+abstract class AWS1S3ClientTest extends VersionedNamingTestBase {
+
+  @Shared
+  def credentialsProvider = new AWSStaticCredentialsProvider(new AnonymousAWSCredentials())
+  @Shared
+  def responseBody = new AtomicReference<String>()
+  @AutoCleanup
+  @Shared
+  def server = httpServer {
+    handlers {
+      all {
+        response.status(200).send(responseBody.get())
+      }
+    }
+  }
+  @Shared
+  def endpoint = new AwsClientBuilder.EndpointConfiguration("http://localhost:$server.address.port", "us-west-2")
+
+  @Override
+  protected boolean isDataStreamsEnabled() {
+    return true
+  }
+
+  @Override
+  protected long dataStreamsBucketDuration() {
+    TimeUnit.MILLISECONDS.toNanos(250)
+  }
+
+  @Override
+  String operation() {
+    null
+  }
+
+  @Override
+  String service() {
+    null
+  }
+
+  def "send s3 request #testName with mocked response produces DSM checkpoints"() {
+    setup:
+    def conditions = new PollingConditions(timeout: 1)
+    responseBody.set(body)
+    AmazonS3 client = AmazonS3ClientBuilder.standard()
+      .withPathStyleAccessEnabled(true)
+      .withEndpointConfiguration(endpoint)
+      .withCredentials(credentialsProvider)
+      .build()
+
+    when:
+    def response = call.call(client)
+
+    TEST_WRITER.waitForTraces(1)
+    TEST_DATA_STREAMS_WRITER.waitForGroups(1)
+
+    then:
+    response != null
+
+    conditions.eventually {
+      List<StatsGroup> results = TEST_DATA_STREAMS_WRITER.groups.findAll { it.parentHash == 0 }
+      assert results.size() >= 1
+      results.each { group ->
+        verifyAll(group) {
+          edgeTags.containsAll([
+            "direction:" + dsmDirection,
+            "ds.name:somekey",
+            "ds.namespace:somebucket",
+            "topic:somebucket",
+            "type:s3"
+          ])
+          edgeTags.size() == 5
+          payloadSize.getCount() == 1
+        }
+      }
+    }
+
+    where:
+    testName      | dsmDirection | call                                                                         | body
+    "get object"  | "in"         | { AmazonS3 s3 -> s3.getObject("somebucket", "somekey") }                     | "somereponse"
+    "put object"  | "out"        | { AmazonS3 s3 -> s3.putObject("somebucket", "somekey", "somecontent") }      | ""
+    "upload part" | "out"        | { AmazonS3 s3 -> s3.uploadPart(new UploadPartRequest().withBucketName("somebucket").withKey("somekey").withUploadId("someid").withPartNumber(1).withPartSize(11).withInputStream(new ByteArrayInputStream("somecontent".getBytes()))) } | ""
+  }
+}
+
+class AWS1S3ClientV0Test extends AWS1S3ClientTest {
+  @Override
+  int version() {
+    0
+  }
+}
+
+class AWS1S3ClientV1ForkedTest extends AWS1S3ClientTest {
+  @Override
+  int version() {
+    1
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/TagsProcessor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/TagsProcessor.java
@@ -69,6 +69,9 @@ public class TagsProcessor {
   private static final Function<String, String> KAFKA_CLUSTER_ID_TAG_PREFIX =
       new StringPrefix("kafka_cluster_id:");
 
+  public static final String DATASET_NAME_TAG = "ds.name";
+  public static final String DATASET_NAMESPACE_TAG = "ds.namespace";
+
   private static final Map<String, DDCache<String, String>> TAG_TO_CACHE = createTagToCacheMap();
   private static final Map<String, Function<String, String>> TAG_TO_PREFIX = createTagToPrefixMap();
 


### PR DESCRIPTION
# What Does This Do

Add DSM checkpoint when reading/writing to S3 using `aws-sdk-1`

# Motivation

Connect services based on which data they are reading/writing in S3

# Additional Notes

Using the [Content-Length](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length) header in order to get the payload size

Adding two new DSM tags:
- `ds.name`: full path to the object
- `ds.namespace` bucket of the object 

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
