### PR TITLE
Ensure no IAST advices are added unless appsec is fully enabled

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastSystem.java
@@ -46,6 +46,7 @@ import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.iast.IastContext;
 import datadog.trace.api.iast.IastModule;
 import datadog.trace.api.iast.InstrumentationBridge;
+import datadog.trace.api.iast.telemetry.IastMetricCollector;
 import datadog.trace.api.iast.telemetry.Verbosity;
 import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.stacktrace.StackWalkerFactory;
@@ -62,6 +63,7 @@ public class IastSystem {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IastSystem.class);
   public static boolean DEBUG = false;
+  public static Verbosity VERBOSITY = Verbosity.OFF;
 
   public static void start(final SubscriptionService ss) {
     start(ss, null);
@@ -77,7 +79,11 @@ public class IastSystem {
       return;
     }
     DEBUG = config.isIastDebugEnabled();
-    LOGGER.debug("IAST is starting: debug={}", DEBUG);
+    VERBOSITY = config.getIastTelemetryVerbosity();
+    LOGGER.debug("IAST is starting: debug={}, verbosity={}", DEBUG, VERBOSITY);
+    if (VERBOSITY != Verbosity.OFF) {
+      IastMetricCollector.register(new IastMetricCollector());
+    }
     final Reporter reporter = new Reporter(config, AgentTaskScheduler.INSTANCE);
     final boolean globalContext = config.getIastContextMode() == GLOBAL;
     final IastContext.Provider contextProvider = contextProvider(iast, globalContext);

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -11,6 +11,7 @@ import datadog.trace.agent.tooling.muzzle.Reference;
 import datadog.trace.agent.tooling.muzzle.ReferenceMatcher;
 import datadog.trace.agent.tooling.muzzle.ReferenceProvider;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.ProductActivation;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.util.Strings;
@@ -240,7 +241,8 @@ public abstract class InstrumenterModule implements Instrumenter {
     @Override
     public boolean isApplicable(Set<TargetSystem> enabledSystems) {
       return enabledSystems.contains(TargetSystem.IAST)
-          || (isOptOutEnabled() && enabledSystems.contains(TargetSystem.APPSEC));
+          || (isOptOutEnabled()
+              && InstrumenterConfig.get().getAppSecActivation() == ProductActivation.FULLY_ENABLED);
     }
 
     /**

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/iast/IastPostProcessorFactoryTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/iast/IastPostProcessorFactoryTest.groovy
@@ -12,8 +12,12 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner
 import net.bytebuddy.jar.asm.MethodVisitor
 import net.bytebuddy.jar.asm.Opcodes
 import net.bytebuddy.jar.asm.Type
+import spock.lang.Shared
 
 class IastPostProcessorFactoryTest extends DDSpecification {
+
+  @Shared
+  protected static final IastMetricCollector ORIGINAL_COLLECTOR = IastMetricCollector.INSTANCE
 
   private static final Type COLLECTOR_TYPE = Type.getType(IastMetricCollector)
   private static final Type METRIC_TYPE = Type.getType(IastMetric)
@@ -21,6 +25,14 @@ class IastPostProcessorFactoryTest extends DDSpecification {
   static class NonAnnotatedAdvice {
     @Advice.OnMethodExit
     static void exit() {}
+  }
+
+  void setup() {
+    IastMetricCollector.register(new IastMetricCollector())
+  }
+
+  void cleanup() {
+    IastMetricCollector.register(ORIGINAL_COLLECTOR)
   }
 
   void 'test factory for non annotated'() {

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
@@ -7,6 +7,8 @@ import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteInstrumentation;
 import datadog.trace.agent.tooling.bytebuddy.csi.CallSiteSupplier;
 import datadog.trace.agent.tooling.csi.CallSites;
 import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.ProductActivation;
 import datadog.trace.api.iast.IastCallSites;
 import datadog.trace.api.iast.telemetry.Verbosity;
 import datadog.trace.instrumentation.iastinstrumenter.telemetry.TelemetryCallSiteSupplier;
@@ -30,7 +32,8 @@ public class IastInstrumentation extends CallSiteInstrumentation {
   @Override
   public boolean isApplicable(final Set<TargetSystem> enabledSystems) {
     return enabledSystems.contains(TargetSystem.IAST)
-        || (isOptOutEnabled() && enabledSystems.contains(TargetSystem.APPSEC));
+        || (isOptOutEnabled()
+            && InstrumenterConfig.get().getAppSecActivation() == ProductActivation.FULLY_ENABLED);
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetricCollector.java
@@ -30,8 +30,11 @@ public class IastMetricCollector implements MetricCollector<IastMetricCollector.
 
   private static final Verbosity VERBOSITY = Config.get().getIastTelemetryVerbosity();
 
-  private static final IastMetricCollector INSTANCE =
-      VERBOSITY != Verbosity.OFF ? new IastMetricCollector() : new NoOpInstance();
+  private static IastMetricCollector INSTANCE = new NoOpInstance();
+
+  public static void register(final IastMetricCollector collector) {
+    INSTANCE = collector;
+  }
 
   public static IastMetricCollector get() {
     return INSTANCE;

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
@@ -24,6 +24,9 @@ class IastMetricCollectorTest extends DDSpecification {
   @Shared
   protected static final AgentTracer.TracerAPI ORIGINAL_TRACER = AgentTracer.get()
 
+  @Shared
+  protected static final IastMetricCollector ORIGINAL_COLLECTOR = IastMetricCollector.INSTANCE
+
   private HasMetricCollector iastCtx
   private RequestContext ctx
   private AgentSpan span
@@ -48,6 +51,7 @@ class IastMetricCollectorTest extends DDSpecification {
   void cleanup() {
     executor.shutdown()
     AgentTracer.forceRegister(ORIGINAL_TRACER)
+    IastMetricCollector.register(ORIGINAL_COLLECTOR)
   }
 
   void 'test empty collector'() {
@@ -68,6 +72,8 @@ class IastMetricCollectorTest extends DDSpecification {
     final value = 5
     final total = times * value
     final latch = new CountDownLatch(1)
+    final globalCollector = new IastMetricCollector()
+    IastMetricCollector.register(globalCollector)
     final requestCollector = new IastMetricCollector()
     final random = new Random()
     final metrics = IastMetric.values()
@@ -89,11 +95,11 @@ class IastMetricCollectorTest extends DDSpecification {
     latch.countDown()
     futures*.get(10, TimeUnit.SECONDS).size()
     requestCollector.prepareMetrics()
-    IastMetricCollector.get().merge(requestCollector.drain())
+    globalCollector.merge(requestCollector.drain())
 
     then:
-    IastMetricCollector.get().prepareMetrics()
-    final result = IastMetricCollector.get().drain()
+    globalCollector.prepareMetrics()
+    final result = globalCollector.drain()
     final computedTotal = result*.value.sum() as long
     computedTotal == total
   }

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/IastMetricPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/IastMetricPeriodicActionTest.groovy
@@ -6,10 +6,22 @@ import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.telemetry.IastMetric
 import datadog.trace.api.iast.telemetry.IastMetricCollector
 import groovy.transform.CompileDynamic
+import spock.lang.Shared
 import spock.lang.Specification
 
 @CompileDynamic
 class IastMetricPeriodicActionTest extends Specification {
+
+  @Shared
+  protected static final IastMetricCollector ORIGINAL_COLLECTOR = IastMetricCollector.INSTANCE
+
+  void setup() {
+    IastMetricCollector.register(new IastMetricCollector())
+  }
+
+  void cleanup() {
+    IastMetricCollector.register(ORIGINAL_COLLECTOR)
+  }
 
   void 'test metric'() {
     given:


### PR DESCRIPTION
# What Does This Do
Removes IAST from triggering inactive opt-out advices when appsec starts in inactive mode, only when appsec is fully enabled IAST opt-out advices will be triggered (also fully enabled).

# Motivation
Since there is no benefit from starting IAST opt-out advices in inactive mode besides testing stability (in fact the advices are no-ops so no vulnerabilities will be discovered), it's better simply to skip them.

