### PR TITLE
create SpanLink from spark.streaming_batch span to databricks.task.execution span for spark instrumentation if applicable.

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -9,6 +9,7 @@ import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.SpanLink;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -260,12 +261,14 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
       builder.withTag("databricks_job_run_id", databricksJobRunId);
       builder.withTag("databricks_task_run_id", databricksTaskRunId);
 
-      if (withParentContext) {
-        AgentSpan.Context parentContext =
-            new DatabricksParentContext(databricksJobId, databricksJobRunId, databricksTaskRunId);
+      AgentSpan.Context parentContext =
+          new DatabricksParentContext(databricksJobId, databricksJobRunId, databricksTaskRunId);
 
-        if (parentContext.getTraceId() != DDTraceId.ZERO) {
+      if (parentContext.getTraceId() != DDTraceId.ZERO) {
+        if (withParentContext) {
           builder.asChildOf(parentContext);
+        } else {
+          builder.withLink(SpanLink.from(parentContext));
         }
       }
     }

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/java/datadog/trace/instrumentation/spark/TestSparkComputation.java
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/java/datadog/trace/instrumentation/spark/TestSparkComputation.java
@@ -38,19 +38,6 @@ public class TestSparkComputation {
         .start();
   }
 
-  public static StreamingQuery generateTestStreamingComputation(Dataset<String> dataSet) {
-    return dataSet
-        .selectExpr("value", "current_timestamp() as event_time")
-        .withWatermark("event_time", "0 seconds")
-        .groupBy("value")
-        .count()
-        .writeStream()
-        .queryName("test-query")
-        .outputMode("complete")
-        .format("console")
-        .start();
-  }
-
   static class IdentityMapFunction implements MapFunction<String, String> {
     @Override
     public String call(String s) {
@@ -64,25 +51,5 @@ public class TestSparkComputation {
 
   public static String getSparkVersion() {
     return org.apache.spark.package$.MODULE$.SPARK_VERSION();
-  }
-
-  public static SparkSession createSparkSession(String appName) {
-    return SparkSession.builder()
-        .appName(appName)
-        .config("spark.master", "local[2]")
-        .config("spark.sql.shuffle.partitions", "2")
-        .getOrCreate();
-  }
-
-  public static SparkSession createDatabricksWorkflowsSparkSession(String appName) {
-    return SparkSession.builder()
-        .appName(appName)
-        .config("spark.master", "local[2]")
-        .config("spark.sql.shuffle.partitions", "2")
-        .config("spark.databricks.sparkContextId", "3291395623902517763")
-        .config("spark.databricks.job.id", "3822225623902514353")
-        .config("spark.databricks.job.parentRunId", "3851395623902519743")
-        .config("spark.databricks.job.runId", "3851395623902519743")
-        .getOrCreate();
   }
 }

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/java/datadog/trace/instrumentation/spark/TestSparkComputation.java
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/java/datadog/trace/instrumentation/spark/TestSparkComputation.java
@@ -38,6 +38,19 @@ public class TestSparkComputation {
         .start();
   }
 
+  public static StreamingQuery generateTestStreamingComputation(Dataset<String> dataSet) {
+    return dataSet
+        .selectExpr("value", "current_timestamp() as event_time")
+        .withWatermark("event_time", "0 seconds")
+        .groupBy("value")
+        .count()
+        .writeStream()
+        .queryName("test-query")
+        .outputMode("complete")
+        .format("console")
+        .start();
+  }
+
   static class IdentityMapFunction implements MapFunction<String, String> {
     @Override
     public String call(String s) {
@@ -51,5 +64,25 @@ public class TestSparkComputation {
 
   public static String getSparkVersion() {
     return org.apache.spark.package$.MODULE$.SPARK_VERSION();
+  }
+
+  public static SparkSession createSparkSession(String appName) {
+    return SparkSession.builder()
+        .appName(appName)
+        .config("spark.master", "local[2]")
+        .config("spark.sql.shuffle.partitions", "2")
+        .getOrCreate();
+  }
+
+  public static SparkSession createDatabricksWorkflowsSparkSession(String appName) {
+    return SparkSession.builder()
+        .appName(appName)
+        .config("spark.master", "local[2]")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.databricks.sparkContextId", "3291395623902517763")
+        .config("spark.databricks.job.id", "3822225623902514353")
+        .config("spark.databricks.job.parentRunId", "3851395623902519743")
+        .config("spark.databricks.job.runId", "3851395623902519743")
+        .getOrCreate();
   }
 }


### PR DESCRIPTION
# What Does This Do
Add support for [SpanLinks](https://docs.datadoghq.com/tracing/trace_collection/span_links/) in spark instrumentation to correlate `spark.streaming_batch` span with its parent `databricks.task.execution` span from a different trace. 

# Motivation
`spark.streaming_batch` spans are not linked to the parent `databricks.task.execution` span as this would have created traces with too many spans. 

However, without such casual relationship tracked inside the same trace, it's cumbersome to navigate from the `spark.streaming_batch` span to its parent span in order to understand larger context. Instead, users need to manually narrow down parent trace by filtering [Databricks Workflows](https://docs.databricks.com/en/workflows/index.html) related tags common to both `spark.streaming_batch` span and `databricks.task.execution` span, such as `databricks_task_run_id` tag.

We improve the user experience by adding the support of [SpanLinks](https://docs.datadoghq.com/tracing/trace_collection/span_links/) for `spark.streaming_batch` spans.

# Additional Notes
Check [this](https://docs.datadoghq.com/tracing/trace_explorer/trace_view/?tab=spanlinksbeta#more-information) for more information on SpanLinks in the Trace View.

Jira ticket: [DJM-65]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DJM-65]: https://datadoghq.atlassian.net/browse/DJM-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ