### PR TITLE
Use JDK11 to build javadoc of the internal-api-9 module

### DIFF
--- a/internal-api/internal-api-9/build.gradle
+++ b/internal-api/internal-api-9/build.gradle
@@ -9,6 +9,16 @@ ext {
 apply from: "$rootDir/gradle/java.gradle"
 apply plugin: "idea"
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(11)
+  }
+}
+
+tasks.withType(Javadoc) {
+  javadocTool.set(javaToolchains.javadocToolFor(java.toolchain))
+}
+
 [JavaCompile, GroovyCompile].each {
   tasks.withType(it).configureEach {
     setJavaVersion(it, 11)


### PR DESCRIPTION
# What Does This Do
Removes the error during the assemble of the `internal-api-9` module due to using the wrong JDK to build the JavaDoc documentation.

![image](https://github.com/DataDog/dd-trace-java/assets/4885539/c5227d16-9191-4ce9-9a2b-b3875deb3f48)

