### PR TITLE
Hack to send traces via rust data-pipeline

### DIFF
--- a/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
+++ b/communication/src/main/java/datadog/communication/serialization/FlushingBuffer.java
@@ -1,8 +1,11 @@
 package datadog.communication.serialization;
 
 import java.nio.ByteBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class FlushingBuffer implements StreamingBuffer {
+  Logger log = LoggerFactory.getLogger(FlushingBuffer.class);
 
   private final ByteBuffer buffer;
   private final ByteBufferConsumer consumer;
@@ -11,6 +14,7 @@ public final class FlushingBuffer implements StreamingBuffer {
   private int mark;
 
   public FlushingBuffer(int capacity, ByteBufferConsumer consumer) {
+    log.debug("Creating FlushingBuffer with capacity {}", capacity);
     this.buffer = ByteBuffer.allocate(capacity);
     this.consumer = consumer;
   }
@@ -39,6 +43,7 @@ public final class FlushingBuffer implements StreamingBuffer {
     buffer.limit(mark);
     buffer.flip();
     ByteBuffer toPublish = buffer.slice();
+    log.debug("Flushing {} messages with {} bytes", messageCount, toPublish.remaining());
     consumer.accept(messageCount, toPublish);
     reset();
     return true;

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/server/http/TestHttpServer.groovy
@@ -500,16 +500,23 @@ class TestHttpServer implements AutoCloseable {
 
   static class Headers {
     private final Map<String, String> headers
+    private final Map<String, String> lc_headers
 
     private Headers(Request request) {
       this.headers = [:]
+      this.lc_headers = [:]
       request.getHeaderNames().each {
         headers.put(it, request.getHeader(it))
+        lc_headers.put(it.toLowerCase(), request.getHeader(it))
       }
     }
 
     def get(String header) {
-      return headers[header]
+      return lc_headers[header.toLowerCase()]
+    }
+
+    def getIterator() {
+      return headers.iterator()
     }
   }
 

--- a/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/build.gradle
@@ -24,6 +24,6 @@ dependencies {
 
 tasks.withType(Test).configureEach {
   dependsOn "shadowJar"
-
+  testLogging.showStandardStreams = true
   jvmArgs "-Ddatadog.smoketest.springboot.shadowJar.path=${tasks.shadowJar.archiveFile.get()}"
 }

--- a/dd-smoke-tests/spring-boot-2.4-webflux/src/test/groovy/datadog/smoketest/SpringBootWebfluxIntegrationTest.groovy
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/src/test/groovy/datadog/smoketest/SpringBootWebfluxIntegrationTest.groovy
@@ -13,9 +13,7 @@ class SpringBootWebfluxIntegrationTest extends AbstractServerSmokeTest {
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
     command.addAll((String[]) [
-      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter",
-      // decoding received traces is only available for v05 right now
-      "-Ddd.trace.agent.v0.5.enabled=true",
+      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDNativeWriter",
       "-jar",
       springBootShadowJar,
       "--server.port=${httpPort}"
@@ -38,6 +36,11 @@ class SpringBootWebfluxIntegrationTest extends AbstractServerSmokeTest {
   Closure decodedTracesCallback() {
     // we don't want to do anything special with the decoded traces
     return {}
+  }
+
+  @Override
+  def logLevel() {
+    return "debug"
   }
 
   def "put docs and find all docs"() {

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 
   implementation group: 'com.google.re2j', name: 're2j', version: '1.7'
 
+  implementation group: 'com.datadoghq', name: 'dd-data-pipline', version: '0.0.1'
+
   compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.2.0'
 
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -24,7 +24,7 @@ public class DDAgentWriter extends RemoteWriter {
     return new DDAgentWriterBuilder();
   }
 
-  private static final int BUFFER_SIZE = 1024;
+  static final int BUFFER_SIZE = 1024;
 
   public static class DDAgentWriterBuilder {
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDNativeWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDNativeWriter.java
@@ -1,0 +1,282 @@
+package datadog.trace.common.writer;
+
+import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_HOST;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_AGENT_PORT;
+import static datadog.trace.common.writer.DDAgentWriter.BUFFER_SIZE;
+import static datadog.trace.common.writer.ddagent.DDAgentApi.RESPONSE_ADAPTER;
+
+import datadog.communication.ddagent.DroppingPolicy;
+import datadog.communication.monitor.Monitoring;
+import datadog.data_pipeline.TraceExporter;
+import datadog.trace.common.sampling.Sampler;
+import datadog.trace.common.sampling.SingleSpanSampler;
+import datadog.trace.common.writer.ddagent.Prioritization;
+import datadog.trace.common.writer.ddagent.TraceMapper;
+import datadog.trace.common.writer.ddagent.TraceMapperV0_4;
+import datadog.trace.core.DDTraceCoreInfo;
+import datadog.trace.core.monitor.HealthMetrics;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DDNativeWriter extends RemoteWriter {
+
+  public static DDNativeWriterBuilder builder() {
+    return new DDNativeWriterBuilder();
+  }
+
+  public static final class DDNativeWriterBuilder {
+    private static Logger log = LoggerFactory.getLogger(DDNativeWriterBuilder.class);
+
+    private String agentHost = DEFAULT_AGENT_HOST;
+    private int traceAgentPort = DEFAULT_TRACE_AGENT_PORT;
+    private int traceBufferSize = BUFFER_SIZE;
+    private HealthMetrics healthMetrics = HealthMetrics.NO_OP;
+    private Sampler sampler;
+    private boolean proxy = true;
+    private int flushTimeoutMillis = 1000;
+    private Prioritization prioritization = Prioritization.FAST_LANE;
+    private DroppingPolicy droppingPolicy = DroppingPolicy.DISABLED;
+    private SingleSpanSampler singleSpanSampler;
+    private Monitoring monitoring = Monitoring.DISABLED;
+
+    public DDNativeWriterBuilder agentHost(String agentHost) {
+      this.agentHost = agentHost;
+      return this;
+    }
+
+    public DDNativeWriterBuilder traceAgentPort(int traceAgentPort) {
+      this.traceAgentPort = traceAgentPort;
+      return this;
+    }
+
+    public DDNativeWriterBuilder traceBufferSize(int traceBufferSize) {
+      this.traceBufferSize = traceBufferSize;
+      return this;
+    }
+
+    public DDNativeWriterBuilder healthMetrics(HealthMetrics healthMetrics) {
+      this.healthMetrics = healthMetrics;
+      return this;
+    }
+
+    public DDNativeWriterBuilder sampler(Sampler sampler) {
+      this.sampler = sampler;
+      return this;
+    }
+
+    public DDNativeWriterBuilder proxy(boolean proxy) {
+      this.proxy = proxy;
+      return this;
+    }
+
+    public DDNativeWriterBuilder flushTimeoutMillis(int flushTimeoutMillis) {
+      this.flushTimeoutMillis = flushTimeoutMillis;
+      return this;
+    }
+
+    public DDNativeWriterBuilder prioritization(Prioritization prioritization) {
+      this.prioritization = prioritization;
+      return this;
+    }
+
+    public DDNativeWriterBuilder droppingPolicy(DroppingPolicy droppingPolicy) {
+      this.droppingPolicy = droppingPolicy;
+      return this;
+    }
+
+    public DDNativeWriterBuilder singleSpanSampler(SingleSpanSampler singleSpanSampler) {
+      this.singleSpanSampler = singleSpanSampler;
+      return this;
+    }
+
+    public DDNativeWriterBuilder monitoring(Monitoring monitoring) {
+      this.monitoring = monitoring;
+      return this;
+    }
+
+    public DDNativeWriter build() {
+      log.debug("Building DDNativeWriter");
+      DDNativeMapperDiscovery mapperDiscovery = new DDNativeMapperDiscovery();
+      int endBufferSize = mapperDiscovery.getMapper().messageBufferSize();
+      log.debug("DDNativeMapperDiscovery built");
+      DDNativeApi api =
+          new DDNativeApi(
+              endBufferSize,
+              sampler,
+              agentHost,
+              traceAgentPort,
+              DDTraceCoreInfo.VERSION,
+              "jvm",
+              DDTraceCoreInfo.JAVA_VERSION,
+              DDTraceCoreInfo.JAVA_VM_NAME,
+              proxy);
+      log.debug("DDNativeApi built");
+      PayloadDispatcher dispatcher =
+          new PayloadDispatcherImpl(mapperDiscovery, api, healthMetrics, monitoring);
+      log.debug("PayloadDispatcher built");
+      TraceProcessingWorker worker =
+          new TraceProcessingWorker(
+              traceBufferSize,
+              healthMetrics,
+              dispatcher,
+              droppingPolicy,
+              prioritization,
+              flushTimeoutMillis,
+              TimeUnit.MILLISECONDS,
+              singleSpanSampler);
+      log.debug("TraceProcessingWorker built");
+      return new DDNativeWriter(
+          worker, dispatcher, healthMetrics, flushTimeoutMillis, TimeUnit.MILLISECONDS, false);
+    }
+  }
+
+  private DDNativeWriter(
+      final TraceProcessingWorker traceProcessingWorker,
+      final PayloadDispatcher dispatcher,
+      final HealthMetrics healthMetrics,
+      final int flushTimeout,
+      final TimeUnit flushTimeoutUnit,
+      final boolean alwaysFlush) {
+    super(
+        traceProcessingWorker,
+        dispatcher,
+        healthMetrics,
+        flushTimeout,
+        flushTimeoutUnit,
+        alwaysFlush);
+  }
+
+  private static final class DDNativeApi extends RemoteApi {
+    private static final Logger log = LoggerFactory.getLogger(DDNativeApi.class);
+
+    private final TraceExporter exporter;
+    private final ByteBuffer buffer;
+    private final WritableByteChannel channel;
+    private final RemoteResponseListener listener;
+
+    private DDNativeApi(
+        int bufferSize,
+        Sampler sampler,
+        String host,
+        int port,
+        String tracerVersion,
+        String language,
+        String languageVersion,
+        String interpreter,
+        boolean proxy) {
+      super(false);
+      try {
+        log.debug("Initializing DDNativeApi");
+        TraceExporter.initialize();
+        log.debug("TraceExporter initialized");
+        if (sampler instanceof RemoteResponseListener) {
+          listener = (RemoteResponseListener) sampler;
+        } else {
+          listener = null;
+        }
+        // TODO size up the buffer to a 1KB increment
+        buffer = ByteBuffer.allocateDirect(bufferSize);
+        channel = new ByteBufferWritableByteChannel(buffer);
+        exporter =
+            TraceExporter.builder()
+                .withHost(host)
+                .withPort(port)
+                .withTracerVersion(tracerVersion)
+                .withLanguage(language)
+                .withLanguageVersion(languageVersion)
+                .withInterpreter(interpreter)
+                .withProxy(proxy)
+                .build();
+        log.debug("TraceExporter built");
+      } catch (final Exception e) {
+        log.debug("Failed to initialize DDNativeApi", e);
+        throw new ExceptionInInitializerError(e);
+      }
+    }
+
+    @Override
+    protected Response sendSerializedTraces(Payload payload) {
+      int count = payload.traceCount();
+      int size = payload.sizeInBytes();
+      log.debug("Sending {} traces ({} bytes)", count, size);
+      try {
+        payload.writeTo(channel);
+        buffer.flip();
+        String response = "";
+        try {
+          response = exporter.sendTraces(buffer, size, count);
+          log.debug("Received response: {}", response);
+          countAndLogSuccessfulSend(count, size);
+          if (!"".equals(response) && !"OK".equalsIgnoreCase(response)) {
+            final Map<String, Map<String, Number>> parsedResponse =
+                RESPONSE_ADAPTER.fromJson(response);
+            if (listener != null) {
+              // TODO faking the endpoint
+              listener.onResponse("http://only.used.for.debug/", parsedResponse);
+            }
+          }
+          // TODO faking the response code
+          return Response.success(200, response);
+        } catch (final IOException e) {
+          log.debug("Failed to parse DD agent response: {}", response, e);
+          // TODO faking the response code
+          return Response.success(200, e);
+        }
+      } catch (final Exception e) {
+        countAndLogFailedSend(count, size, null, e);
+        return Response.failed(e);
+      } finally {
+        buffer.clear();
+      }
+    }
+
+    @Override
+    protected Logger getLogger() {
+      return log;
+    }
+  }
+
+  private static final class ByteBufferWritableByteChannel implements WritableByteChannel {
+    private static final Logger log = LoggerFactory.getLogger(ByteBufferWritableByteChannel.class);
+    private final ByteBuffer buffer;
+
+    private ByteBufferWritableByteChannel(ByteBuffer buffer) {
+      this.buffer = buffer;
+    }
+
+    @Override
+    public int write(ByteBuffer src) {
+      log.debug("Writing {} bytes", src.remaining());
+      int remaining = src.remaining();
+      buffer.put(src);
+      return remaining;
+    }
+
+    @Override
+    public boolean isOpen() {
+      return true;
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  private static final class DDNativeMapperDiscovery implements RemoteMapperDiscovery {
+    private static final Logger log = LoggerFactory.getLogger(DDNativeMapperDiscovery.class);
+    private final TraceMapper traceMapper = new TraceMapperV0_4();
+
+    @Override
+    public void discover() {}
+
+    @Override
+    public RemoteMapper getMapper() {
+      log.debug("Returning {}", traceMapper);
+      return traceMapper;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/RemoteApi.java
@@ -35,7 +35,7 @@ public abstract class RemoteApi {
       final int traceCount,
       final int sizeInBytes,
       final okhttp3.Response response,
-      final IOException outer) {
+      final Exception outer) {
     // count the failed traces
     failedTraces += traceCount;
     // these are used to catch and log if there is a failure in debug logging the response body

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -3,6 +3,7 @@ package datadog.trace.common.writer;
 import static datadog.trace.api.config.TracerConfig.PRIORITIZATION_TYPE;
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.DD_AGENT_WRITER_TYPE;
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.DD_INTAKE_WRITER_TYPE;
+import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.DD_NATIVE_WRITER_TYPE;
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.LOGGING_WRITER_TYPE;
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.MULTI_WRITER_TYPE;
 import static datadog.trace.bootstrap.instrumentation.api.WriterConstants.PRINTING_WRITER_TYPE;
@@ -63,7 +64,8 @@ public class WriterFactory {
     }
 
     if (!DD_AGENT_WRITER_TYPE.equals(configuredType)
-        && !DD_INTAKE_WRITER_TYPE.equals(configuredType)) {
+        && !DD_INTAKE_WRITER_TYPE.equals(configuredType)
+        && !DD_NATIVE_WRITER_TYPE.equals(configuredType)) {
       log.warn(
           "Writer type not configured correctly: Type {} not recognized. Ignoring", configuredType);
       configuredType = datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_WRITER_TYPE;
@@ -113,6 +115,19 @@ public class WriterFactory {
 
       remoteWriter = builder.build();
 
+    } else if (DD_NATIVE_WRITER_TYPE.equals(configuredType)) {
+      log.debug("Creating DDNativeWriter");
+      remoteWriter =
+          DDNativeWriter.builder()
+              .agentHost(config.getAgentHost())
+              .traceAgentPort(config.getAgentPort())
+              .healthMetrics(healthMetrics)
+              .sampler(sampler)
+              .monitoring(commObjects.monitoring)
+              .singleSpanSampler(singleSpanSampler)
+              .prioritization(prioritization)
+              .flushTimeoutMillis(flushIntervalMilliseconds)
+              .build();
     } else { // configuredType == DDAgentWriter
       boolean alwaysFlush = false;
       if (config.isAgentConfiguredUsingDefault()

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/DDAgentApi.java
@@ -47,7 +47,7 @@ public class DDAgentApi extends RemoteApi {
   private final Recording sendPayloadTimer;
   private final Counter agentErrorCounter;
 
-  private static final JsonAdapter<Map<String, Map<String, Number>>> RESPONSE_ADAPTER =
+  public static final JsonAdapter<Map<String, Map<String, Number>>> RESPONSE_ADAPTER =
       new Moshi.Builder()
           .build()
           .adapter(

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/WriterConstants.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/WriterConstants.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 public final class WriterConstants {
   public static final String DD_AGENT_WRITER_TYPE = "DDAgentWriter";
   public static final String DD_INTAKE_WRITER_TYPE = "DDIntakeWriter";
+  public static final String DD_NATIVE_WRITER_TYPE = "DDNativeWriter";
   public static final String LOGGING_WRITER_TYPE = "LoggingWriter";
   public static final String PRINTING_WRITER_TYPE = "PrintingWriter";
   public static final String TRACE_STRUCTURE_WRITER_TYPE = "TraceStructureWriter";


### PR DESCRIPTION
# What Does This Do

Hack to try out native bindings for rust data pipeline in Java. See DataDog/libdatadog#360

# Motivation

R&D week.

# Additional Notes

Currently only works on Mac, and you have to publish the bindings locally. Runs the `dd-smoke-tests:spring-boot-2.4-webflux` tests successfully with the `NativeWriter`
