### PR TITLE
Refactor propagation module with APIs for strings and objects

### DIFF
--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/BaseCodecModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/BaseCodecModuleTest.groovy
@@ -25,7 +25,7 @@ abstract class BaseCodecModuleTest extends IastModuleImplTestBase {
     }
   }
 
-  void '#method null or empty'() {
+  void '#method null'() {
     when:
     module.&"$method".call(args.toArray())
 
@@ -35,15 +35,10 @@ abstract class BaseCodecModuleTest extends IastModuleImplTestBase {
     where:
     method              | args
     'onUrlDecode'       | ['test', 'utf-8', null]
-    'onUrlDecode'       | ['test', 'utf-8', '']
     'onStringGetBytes'  | ['test', 'utf-8', null]
-    'onStringGetBytes'  | ['test', 'utf-8', [] as byte[]]
     'onStringFromBytes' | ['test'.bytes, 0, 2, 'utf-8', null]
-    'onStringFromBytes' | ['test'.bytes, 0, 2, 'utf-8', '']
     'onBase64Encode'    | ['test'.bytes, null]
-    'onBase64Encode'    | ['test'.bytes, [] as byte[]]
     'onBase64Decode'    | ['test'.bytes, null]
-    'onBase64Decode'    | ['test'.bytes, [] as byte[]]
   }
 
   void '#method no context'() {

--- a/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastRequestContextPreparationTrait.groovy
+++ b/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastRequestContextPreparationTrait.groovy
@@ -69,9 +69,14 @@ trait IastRequestContextPreparationTrait {
         return tainted
       }
 
-      private final static Logger LOGGER = LoggerFactory.getLogger("map tainted objects")
-      static {
-        ((ch.qos.logback.classic.Logger) LOGGER).level = ch.qos.logback.classic.Level.DEBUG
+      private final static Logger LOGGER = withLogger("map tainted objects")
+
+      private static Logger withLogger(final String name) {
+        final logger = LoggerFactory.getLogger(name)
+        if (logger instanceof ch.qos.logback.classic.Logger) {
+          ((ch.qos.logback.classic.Logger) logger).level = ch.qos.logback.classic.Level.DEBUG
+        }
+        return logger
       }
 
       private static void logTaint(Object o) {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
@@ -56,24 +56,23 @@ public class PathMatcherInstrumentation extends InstrumenterModule.Iast
         return;
       }
 
-      PropagationModule module = InstrumentationBridge.PROPAGATION;
-      if (module == null) {
-        return;
-      }
-
       scala.Tuple1 tuple = (scala.Tuple1) extractions;
       Object value = tuple._1();
+
+      PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module == null || !(value instanceof String)) {
+        return;
+      }
+      final String stringValue = (String) value;
 
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
 
       // in the test, 4 instances of PathMatcher$Match are created, all with the same value
-      if (module.isTainted(ctx, value)) {
+      if (module.isTainted(ctx, stringValue)) {
         return;
       }
 
-      if (value instanceof String) {
-        module.taint(ctx, value, SourceTypes.REQUEST_PATH_PARAMETER);
-      }
+      module.taint(ctx, stringValue, SourceTypes.REQUEST_PATH_PARAMETER);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSingleParameterFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSingleParameterFunction.java
@@ -50,11 +50,11 @@ public class TaintSingleParameterFunction<Magnet>
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taint(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/helpers/TaintParametersFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/helpers/TaintParametersFunction.java
@@ -41,11 +41,11 @@ public class TaintParametersFunction<T> implements Function1<Tuple1<T>, Tuple1<T
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taint(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/StringReaderCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/StringReaderCallSite.java
@@ -18,7 +18,11 @@ public class StringReaderCallSite {
       @CallSite.Return @Nonnull final StringReader result) {
     final PropagationModule propagationModule = InstrumentationBridge.PROPAGATION;
     if (propagationModule != null) {
-      propagationModule.taintIfTainted(result, params[0]);
+      try {
+        propagationModule.taintIfTainted(result, params[0]);
+      } catch (Throwable e) {
+        propagationModule.onUnexpectedException("afterInit threw", e);
+      }
     }
     return result;
   }

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -123,7 +123,7 @@ public class StringCallSite {
     final StringModule module = InstrumentationBridge.STRING;
     if (module != null) {
       try {
-        module.onStringJoin(result, delimiter, copy.toArray(new CharSequence[copy.size()]));
+        module.onStringJoin(result, delimiter, copy.toArray(new CharSequence[0]));
       } catch (final Throwable e) {
         module.onUnexpectedException("afterSubSequence threw", e);
       }
@@ -412,7 +412,7 @@ public class StringCallSite {
   public static String[] afterSplitWithLimit(
       @CallSite.This @Nonnull final String self,
       @CallSite.Argument(0) @Nonnull final String regex,
-      @CallSite.Argument(1) @Nonnull final int pos,
+      @CallSite.Argument(1) final int pos,
       @CallSite.Return @Nonnull final String[] result) {
     final StringModule module = InstrumentationBridge.STRING;
     if (module != null) {

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
@@ -54,7 +54,7 @@ public class AbstractParamValueExtractorInstrumentation extends InstrumenterModu
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taint(ctx, result, ThreadLocalSourceType.get(), parameterName);
+          module.taint(ctx, (String) result, ThreadLocalSourceType.get(), parameterName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
@@ -21,7 +21,7 @@ public class AbstractStringReaderAdvice {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, result, SourceTypes.REQUEST_PARAMETER_VALUE);
+        module.taint(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
@@ -56,7 +56,7 @@ public class JSONObjectUtilsInstrumentation extends InstrumenterModule.Iast
           if (value instanceof String) {
             // TODO: We could represent this source more accurately, perhaps tracking the original
             // source, or using a special name.
-            module.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+            module.taint(ctx, (String) value, SourceTypes.REQUEST_HEADER_VALUE, name);
           }
         }
       }

--- a/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONArrayInstrumentation.java
+++ b/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONArrayInstrumentation.java
@@ -14,6 +14,8 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 @AutoService(InstrumenterModule.class)
 public class JSONArrayInstrumentation extends InstrumenterModule.Iast
@@ -60,15 +62,18 @@ public class JSONArrayInstrumentation extends InstrumenterModule.Iast
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterMethod(@Advice.This Object self, @Advice.Return final Object result) {
-      if (result instanceof Integer
-          || result instanceof Long
-          || result instanceof Double
-          || result instanceof Boolean) {
+      boolean isString = result instanceof String;
+      boolean isJson = !isString && (result instanceof JSONObject || result instanceof JSONArray);
+      if (!isString && !isJson) {
         return;
       }
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
-      if (iastModule != null && result != null && result instanceof String) {
-        iastModule.taintIfTainted(result, self);
+      if (iastModule != null) {
+        if (isString) {
+          iastModule.taintIfTainted((String) result, self);
+        } else {
+          iastModule.taintIfTainted(result, self);
+        }
       }
     }
   }
@@ -77,15 +82,18 @@ public class JSONArrayInstrumentation extends InstrumenterModule.Iast
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterMethod(@Advice.This Object self, @Advice.Return final Object result) {
-      if (result instanceof Integer
-          || result instanceof Long
-          || result instanceof Double
-          || result instanceof Boolean) {
+      boolean isString = result instanceof String;
+      boolean isJson = !isString && (result instanceof JSONObject || result instanceof JSONArray);
+      if (!isString && !isJson) {
         return;
       }
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
-      if (iastModule != null && result != null) {
-        iastModule.taintIfTainted(result, self);
+      if (iastModule != null) {
+        if (isString) {
+          iastModule.taintIfTainted((String) result, self);
+        } else {
+          iastModule.taintIfTainted(result, self);
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONObjectInstrumentation.java
+++ b/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONObjectInstrumentation.java
@@ -14,6 +14,8 @@ import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import net.bytebuddy.asm.Advice;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 @AutoService(InstrumenterModule.class)
 public class JSONObjectInstrumentation extends InstrumenterModule.Iast
@@ -62,15 +64,18 @@ public class JSONObjectInstrumentation extends InstrumenterModule.Iast
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterMethod(@Advice.This Object self, @Advice.Return final Object result) {
-      if (result instanceof Integer
-          || result instanceof Long
-          || result instanceof Double
-          || result instanceof Boolean) {
+      boolean isString = result instanceof String;
+      boolean isJson = !isString && (result instanceof JSONObject || result instanceof JSONArray);
+      if (!isString && !isJson) {
         return;
       }
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
-      if (iastModule != null && result != null) {
-        iastModule.taintIfTainted(result, self);
+      if (iastModule != null) {
+        if (isString) {
+          iastModule.taintIfTainted((String) result, self);
+        } else {
+          iastModule.taintIfTainted(result, self);
+        }
       }
     }
   }
@@ -79,15 +84,18 @@ public class JSONObjectInstrumentation extends InstrumenterModule.Iast
     @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void afterMethod(@Advice.This Object self, @Advice.Return final Object result) {
-      if (result instanceof Integer
-          || result instanceof Long
-          || result instanceof Double
-          || result instanceof Boolean) {
+      boolean isString = result instanceof String;
+      boolean isJson = !isString && (result instanceof JSONObject || result instanceof JSONArray);
+      if (!isString && !isJson) {
         return;
       }
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
-      if (iastModule != null && result != null) {
-        iastModule.taintIfTainted(result, self);
+      if (iastModule != null) {
+        if (isString) {
+          iastModule.taintIfTainted((String) result, self);
+        } else {
+          iastModule.taintIfTainted(result, self);
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/PathMatcherInstrumentation.java
@@ -56,24 +56,23 @@ public class PathMatcherInstrumentation extends InstrumenterModule.Iast
         return;
       }
 
-      PropagationModule module = InstrumentationBridge.PROPAGATION;
-      if (module == null) {
-        return;
-      }
-
       scala.Tuple1 tuple = (scala.Tuple1) extractions;
       Object value = tuple._1();
 
-      IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+      PropagationModule module = InstrumentationBridge.PROPAGATION;
+      if (module == null || !(value instanceof String)) {
+        return;
+      }
+      final String stringValue = (String) value;
+
+      final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
 
       // in the test, 4 instances of PathMatcher$Match are created, all with the same value
-      if (module.isTainted(ctx, value)) {
+      if (module.isTainted(ctx, stringValue)) {
         return;
       }
 
-      if (value instanceof String) {
-        module.taint(ctx, value, SourceTypes.REQUEST_PATH_PARAMETER);
-      }
+      module.taint(ctx, stringValue, SourceTypes.REQUEST_PATH_PARAMETER);
     }
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintParametersFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintParametersFunction.java
@@ -44,11 +44,11 @@ public class TaintParametersFunction<T> implements Function1<Tuple1<T>, Tuple1<T
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taint(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSingleParameterFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSingleParameterFunction.java
@@ -51,11 +51,11 @@ public class TaintSingleParameterFunction<Magnet>
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taint(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class CookieParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, o, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
+              module.taint(ctx, (String) o, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
             }
           }
         } else {
-          module.taint(ctx, result, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
+          module.taint(ctx, (String) result, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class FormParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+              module.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
             }
           }
         } else {
-          module.taint(ctx, result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          module.taint(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
@@ -23,20 +23,16 @@ public class HeaderParamInjectorAdvice {
     if (result instanceof String || result instanceof Collection) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        try {
-          IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          if (result instanceof Collection) {
-            Collection<?> collection = (Collection<?>) result;
-            for (Object o : collection) {
-              if (o instanceof String) {
-                module.taint(ctx, o, SourceTypes.REQUEST_HEADER_VALUE, paramName);
-              }
+        IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
+        if (result instanceof Collection) {
+          Collection<?> collection = (Collection<?>) result;
+          for (Object o : collection) {
+            if (o instanceof String) {
+              module.taint(ctx, (String) o, SourceTypes.REQUEST_HEADER_VALUE, paramName);
             }
-          } else {
-            module.taint(ctx, result, SourceTypes.REQUEST_HEADER_VALUE, paramName);
           }
-        } catch (final Throwable e) {
-          module.onUnexpectedException("HeaderParamInjectorAdvice.onExit threw", e);
+        } else {
+          module.taint(ctx, (String) result, SourceTypes.REQUEST_HEADER_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class PathParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, o, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
+              module.taint(ctx, (String) o, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
             }
           }
         } else {
-          module.taint(ctx, result, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
+          module.taint(ctx, (String) result, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class QueryParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+              module.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
             }
           }
         } else {
-          module.taint(ctx, result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          module.taint(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -120,10 +120,8 @@ public final class HttpServletResponseInstrumentation extends InstrumenterModule
     @Propagation
     public static void onExit(@Advice.Argument(0) final String url, @Advice.Return String encoded) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
-      if (module != null) {
-        if (null != url && !url.isEmpty() && null != encoded && !encoded.isEmpty()) {
-          module.taintIfTainted(encoded, url);
-        }
+      if (encoded != null && module != null) {
+        module.taintIfTainted(encoded, url);
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-core/src/main/java/datadog/trace/instrumentation/springcore/StreamUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-core/src/main/java/datadog/trace/instrumentation/springcore/StreamUtilsInstrumentation.java
@@ -49,7 +49,7 @@ public final class StreamUtilsInstrumentation extends InstrumenterModule.Iast
     public static void checkReturnedObject(
         @Advice.Return String string, @Advice.Argument(0) final InputStream in) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
-      if (in != null && string != null && !string.isEmpty()) {
+      if (string != null && module != null) {
         module.taintIfTainted(string, in);
       }
     }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/BufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/BufferInstrumentation.java
@@ -60,47 +60,35 @@ public class BufferInstrumentation extends InstrumenterModule.Iast
   }
 
   public static class ToStringAdvice {
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void get(@Advice.This final Object self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
-      if (module != null) {
-        try {
-          module.taintIfTainted(result, self);
-        } catch (final Throwable e) {
-          module.onUnexpectedException("toString threw", e);
-        }
+      if (result != null && module != null) {
+        module.taintIfTainted(result, self);
       }
     }
   }
 
   public static class GetByteBuffAdvice {
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void get(@Advice.This final Object self, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
-      if (module != null) {
-        try {
-          module.taintIfTainted(result, self);
-        } catch (final Throwable e) {
-          module.onUnexpectedException("getByteBuf threw", e);
-        }
+      if (result != null && module != null) {
+        module.taintIfTainted(result, self);
       }
     }
   }
 
   public static class AppendBufferAdvice {
-    @Advice.OnMethodExit
+    @Advice.OnMethodExit(suppress = Throwable.class)
     @Propagation
     public static void get(
         @Advice.Argument(0) final Object buffer, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
-      if (module != null) {
-        try {
-          module.taintIfTainted(result, buffer);
-        } catch (final Throwable e) {
-          module.onUnexpectedException("appendBuffer threw", e);
-        }
+      if (result != null && module != null) {
+        module.taintIfTainted(result, buffer);
       }
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -19,20 +19,11 @@ public interface PropagationModule extends IastModule {
    */
   void taint(@Nullable IastContext ctx, @Nullable Object target, byte origin);
 
-  /** @see #taint(IastContext, Object, byte, int, int) */
-  void taint(@Nullable Object target, byte origin, int start, int length);
+  /** @see #taint(IastContext, String, byte) */
+  void taint(@Nullable String target, byte origin);
 
-  /**
-   * Taints the object with a source with the selected origin, range and no name. If target is a
-   * char sequence it will be used as value.
-   *
-   * <p>If the value is already tainted this method will append a new range.
-   */
-  void taint(
-      @Nullable IastContext ctx, @Nullable Object target, byte origin, int start, int length);
-
-  /** @see #taint(IastContext, Object, byte, CharSequence) */
-  void taint(@Nullable Object target, byte origin, @Nullable CharSequence name);
+  /** @see #taint(IastContext, Object, byte) */
+  void taint(@Nullable IastContext ctx, @Nullable String target, byte origin);
 
   /**
    * Taints the object with a source with the selected origin and name, if target is a char sequence
@@ -40,6 +31,16 @@ public interface PropagationModule extends IastModule {
    */
   void taint(
       @Nullable IastContext ctx, @Nullable Object target, byte origin, @Nullable CharSequence name);
+
+  /** @see #taint(IastContext, Object, byte, CharSequence) */
+  void taint(@Nullable Object target, byte origin, @Nullable CharSequence name);
+
+  /** @see #taint(IastContext, Object, byte, CharSequence) */
+  void taint(
+      @Nullable IastContext ctx, @Nullable String target, byte origin, @Nullable CharSequence name);
+
+  /** @see #taint(IastContext, String, byte, CharSequence) */
+  void taint(@Nullable String target, byte origin, @Nullable CharSequence name);
 
   /** @see #taint(IastContext, Object, byte, CharSequence, Object) */
   void taint(
@@ -53,6 +54,40 @@ public interface PropagationModule extends IastModule {
       @Nullable CharSequence name,
       @Nullable Object value);
 
+  /** @see #taint(IastContext, String, byte, CharSequence, CharSequence) */
+  void taint(
+      @Nullable String target,
+      byte origin,
+      @Nullable CharSequence name,
+      @Nullable CharSequence value);
+
+  /** @see #taint(IastContext, Object, byte, CharSequence, Object) */
+  void taint(
+      @Nullable IastContext ctx,
+      @Nullable String target,
+      byte origin,
+      @Nullable CharSequence name,
+      @Nullable CharSequence value);
+
+  /** @see #taint(IastContext, Object, byte, int, int) */
+  void taint(@Nullable Object target, byte origin, int start, int length);
+
+  /**
+   * Taints the object with a source with the selected origin, range and no name. If target is a
+   * char sequence it will be used as value.
+   *
+   * <p>If the value is already tainted this method will append a new range.
+   */
+  void taint(
+      @Nullable IastContext ctx, @Nullable Object target, byte origin, int start, int length);
+
+  /** @see #taint(IastContext, String, byte, int, int) */
+  void taint(@Nullable String target, byte origin, int start, int length);
+
+  /** @see #taint(IastContext, Object, byte, int, int) */
+  void taint(
+      @Nullable IastContext ctx, @Nullable String target, byte origin, int start, int length);
+
   /** @see #taintIfTainted(IastContext, Object, Object) */
   void taintIfTainted(@Nullable Object target, @Nullable Object input);
 
@@ -62,7 +97,45 @@ public interface PropagationModule extends IastModule {
    */
   void taintIfTainted(@Nullable IastContext ctx, @Nullable Object target, @Nullable Object input);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, int, int, boolean, int) */
+  /** @see #taintIfTainted(IastContext, String, Object) */
+  void taintIfTainted(@Nullable String target, @Nullable Object input);
+
+  /** @see #taintIfTainted(IastContext, Object, Object) */
+  void taintIfTainted(@Nullable IastContext ctx, @Nullable String target, @Nullable Object input);
+
+  /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
+  void taintIfTainted(
+      @Nullable Object target, @Nullable Object input, boolean keepRanges, int mark);
+
+  /**
+   * Taints the object only if the input value is tainted. It will try to reuse sources from the
+   * input value according to:
+   *
+   * <ul>
+   *   <li>keepRanges=true will reuse the ranges from the input tainted value and mark them
+   *   <li>keepRanges=false will use the highest priority source from the input ranges and mark it
+   * </ul>
+   */
+  void taintIfTainted(
+      @Nullable IastContext ctx,
+      @Nullable Object target,
+      @Nullable Object input,
+      boolean keepRanges,
+      int mark);
+
+  /** @see #taintIfTainted(IastContext, String, Object, boolean, int) */
+  void taintIfTainted(
+      @Nullable String target, @Nullable Object input, boolean keepRanges, int mark);
+
+  /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
+  void taintIfTainted(
+      @Nullable IastContext ctx,
+      @Nullable String target,
+      @Nullable Object input,
+      boolean keepRanges,
+      int mark);
+
+  /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
   void taintIfTainted(
       @Nullable Object target,
       @Nullable Object input,
@@ -89,23 +162,22 @@ public interface PropagationModule extends IastModule {
       boolean keepRanges,
       int mark);
 
+  /** @see #taintIfTainted(IastContext, String, Object, boolean, int) */
+  void taintIfTainted(
+      @Nullable String target,
+      @Nullable Object input,
+      int start,
+      int length,
+      boolean keepRanges,
+      int mark);
+
   /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
   void taintIfTainted(
-      @Nullable Object target, @Nullable Object input, boolean keepRanges, int mark);
-
-  /**
-   * Taints the object only if the input value is tainted. It will try to reuse sources from the
-   * input value according to:
-   *
-   * <ul>
-   *   <li>keepRanges=true will reuse the ranges from the input tainted value and mark them
-   *   <li>keepRanges=false will use the highest priority source from the input ranges and mark it
-   * </ul>
-   */
-  void taintIfTainted(
       @Nullable IastContext ctx,
-      @Nullable Object target,
+      @Nullable String target,
       @Nullable Object input,
+      int start,
+      int length,
       boolean keepRanges,
       int mark);
 
@@ -120,6 +192,13 @@ public interface PropagationModule extends IastModule {
   void taintIfTainted(
       @Nullable IastContext ctx, @Nullable Object target, @Nullable Object input, byte origin);
 
+  /** @see #taintIfTainted(IastContext, String, Object, byte) */
+  void taintIfTainted(@Nullable String target, @Nullable Object input, byte origin);
+
+  /** @see #taintIfTainted(IastContext, Object, Object, byte) */
+  void taintIfTainted(
+      @Nullable IastContext ctx, @Nullable String target, @Nullable Object input, byte origin);
+
   /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence) */
   void taintIfTainted(
       @Nullable Object target, @Nullable Object input, byte origin, @Nullable CharSequence name);
@@ -132,6 +211,18 @@ public interface PropagationModule extends IastModule {
   void taintIfTainted(
       @Nullable IastContext ctx,
       @Nullable Object target,
+      @Nullable Object input,
+      byte origin,
+      @Nullable CharSequence name);
+
+  /** @see #taintIfTainted(IastContext, String, Object, byte, CharSequence) */
+  void taintIfTainted(
+      @Nullable String target, @Nullable Object input, byte origin, @Nullable CharSequence name);
+
+  /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence) */
+  void taintIfTainted(
+      @Nullable IastContext ctx,
+      @Nullable String target,
       @Nullable Object input,
       byte origin,
       @Nullable CharSequence name);
@@ -156,6 +247,23 @@ public interface PropagationModule extends IastModule {
       @Nullable CharSequence name,
       @Nullable Object value);
 
+  /** @see #taintIfTainted(IastContext, String, Object, byte, CharSequence, Object) */
+  void taintIfTainted(
+      @Nullable String target,
+      @Nullable Object input,
+      byte origin,
+      @Nullable CharSequence name,
+      @Nullable Object value);
+
+  /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence, Object) */
+  void taintIfTainted(
+      @Nullable IastContext ctx,
+      @Nullable String target,
+      @Nullable Object input,
+      byte origin,
+      @Nullable CharSequence name,
+      @Nullable Object value);
+
   /** @see #taintIfAnyTainted(IastContext, Object, Object[]) */
   void taintIfAnyTainted(@Nullable Object target, @Nullable Object[] inputs);
 
@@ -167,6 +275,13 @@ public interface PropagationModule extends IastModule {
    */
   void taintIfAnyTainted(
       @Nullable IastContext ctx, @Nullable Object target, @Nullable Object[] inputs);
+
+  /** @see #taintIfAnyTainted(IastContext, String, Object[]) */
+  void taintIfAnyTainted(@Nullable String target, @Nullable Object[] inputs);
+
+  /** @see #taintIfAnyTainted(IastContext, Object, Object[]) */
+  void taintIfAnyTainted(
+      @Nullable IastContext ctx, @Nullable String target, @Nullable Object[] inputs);
 
   /** @see #taintIfAnyTainted(IastContext, Object, Object[], boolean, int) */
   void taintIfAnyTainted(
@@ -181,6 +296,18 @@ public interface PropagationModule extends IastModule {
   void taintIfAnyTainted(
       @Nullable IastContext ctx,
       @Nullable Object target,
+      @Nullable Object[] inputs,
+      boolean keepRanges,
+      int mark);
+
+  /** @see #taintIfAnyTainted(IastContext, String, Object[], boolean, int) */
+  void taintIfAnyTainted(
+      @Nullable String target, @Nullable Object[] inputs, boolean keepRanges, int mark);
+
+  /** @see #taintIfAnyTainted(IastContext, Object, Object[], boolean, int) */
+  void taintIfAnyTainted(
+      @Nullable IastContext ctx,
+      @Nullable String target,
       @Nullable Object[] inputs,
       boolean keepRanges,
       int mark);


### PR DESCRIPTION
# What Does This Do
Refactors the ```PropagationModule``` in order to separate the APIs to taint strings and objects. In the process, the `IastContext` is always passed as a parameter to simplify the API.

# Motivation
Tainting objects is more convoluted than tainting simple strings, this PR ensures that the extra overhead does not apply to strings.

# Additional Notes
This is a huge PR as the `PropagationModule` is used extensively around code, feel free to skip the PR as only IAST is affected by it.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
