### PR TITLE
Add possibility to retry every failed test when retries are enabled

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
@@ -95,7 +95,9 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
     }
 
     Collection<TestIdentifier> flakyTests =
-        flakyTestRetriesEnabled ? getFlakyTests(tracerEnvironment) : Collections.emptyList();
+        flakyTestRetriesEnabled && config.isCiVisibilityFlakyRetryOnlyKnownFlakes()
+            ? getFlakyTests(tracerEnvironment)
+            : null;
 
     Map<String, Collection<TestIdentifier>> knownTestsByModuleName =
         earlyFlakeDetectionEnabled ? getKnownTests(tracerEnvironment) : null;
@@ -169,9 +171,7 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
       }
 
     } catch (Exception e) {
-      LOGGER.warn(
-          "Could not obtain CI Visibility settings, will default to disabled code coverage and tests skipping");
-      LOGGER.debug("Error while obtaining CI Visibility settings", e);
+      LOGGER.warn("Error while obtaining CI Visibility settings", e);
       return CiVisibilitySettings.DEFAULT;
     }
   }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ModuleExecutionSettingsSerializerTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/config/ModuleExecutionSettingsSerializerTest.groovy
@@ -17,7 +17,7 @@ class ModuleExecutionSettingsSerializerTest extends Specification {
 
     where:
     settings << [
-      new ModuleExecutionSettings(false, false, false, EarlyFlakeDetectionSettings.DEFAULT, [:], null, [:], [], [:], []),
+      new ModuleExecutionSettings(false, false, false, EarlyFlakeDetectionSettings.DEFAULT, [:], null, [:], null, [:], []),
       new ModuleExecutionSettings(true, false, true,
       new EarlyFlakeDetectionSettings(true, [], 10),
       ["a": "b", "propName": "propValue"],

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -220,7 +220,8 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_SOURCE_DATA_ROOT_CHECK_ENABLED)}=false," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_GIT_UPLOAD_ENABLED)}=false," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_COMPILER_PLUGIN_VERSION)}=${JAVAC_PLUGIN_VERSION}," +
-        "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL)}=${intakeServer.address.toString()},"
+        "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL)}=${intakeServer.address.toString()}," +
+        "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_FLAKY_RETRY_ONLY_KNOWN_FLAKES)}=true," // to cover flaky test retrieval logic
 
       if (injectJacoco) {
         agentArgument += "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_SEGMENTS_ENABLED)}=true," +

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -53,6 +53,8 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_RESOURCE_FOLDER_NAMES =
       "civisibility.resource.folder.names";
   public static final String CIVISIBILITY_FLAKY_RETRY_ENABLED = "civisibility.flaky.retry.enabled";
+  public static final String CIVISIBILITY_FLAKY_RETRY_ONLY_KNOWN_FLAKES =
+      "civisibility.flaky.retry.only.known.flakes";
   public static final String CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED =
       "civisibility.early.flake.detection.enabled";
   public static final String CIVISIBILITY_EARLY_FLAKE_DETECTION_LOWER_LIMIT =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -170,6 +170,7 @@ import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_EARLY_FLA
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_EARLY_FLAKE_DETECTION_LOWER_LIMIT;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_FLAKY_RETRY_COUNT;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_FLAKY_RETRY_ENABLED;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_FLAKY_RETRY_ONLY_KNOWN_FLAKES;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_GIT_COMMAND_TIMEOUT_MILLIS;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_GIT_REMOTE_NAME;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_GIT_UNSHALLOW_DEFER;
@@ -780,6 +781,7 @@ public class Config {
   private final String ciVisibilityInjectedTracerVersion;
   private final List<String> ciVisibilityResourceFolderNames;
   private final boolean ciVisibilityFlakyRetryEnabled;
+  private final boolean ciVisibilityFlakyRetryOnlyKnownFlakes;
   private final int ciVisibilityFlakyRetryCount;
   private final boolean ciVisibilityEarlyFlakeDetectionEnabled;
   private final int ciVisibilityEarlyFlakeDetectionLowerLimit;
@@ -1778,6 +1780,8 @@ public class Config {
             CIVISIBILITY_RESOURCE_FOLDER_NAMES, DEFAULT_CIVISIBILITY_RESOURCE_FOLDER_NAMES);
     ciVisibilityFlakyRetryEnabled =
         configProvider.getBoolean(CIVISIBILITY_FLAKY_RETRY_ENABLED, true);
+    ciVisibilityFlakyRetryOnlyKnownFlakes =
+        configProvider.getBoolean(CIVISIBILITY_FLAKY_RETRY_ONLY_KNOWN_FLAKES, false);
     ciVisibilityEarlyFlakeDetectionEnabled =
         configProvider.getBoolean(CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED, true);
     ciVisibilityEarlyFlakeDetectionLowerLimit =
@@ -3009,6 +3013,10 @@ public class Config {
 
   public boolean isCiVisibilityFlakyRetryEnabled() {
     return ciVisibilityFlakyRetryEnabled;
+  }
+
+  public boolean isCiVisibilityFlakyRetryOnlyKnownFlakes() {
+    return ciVisibilityFlakyRetryOnlyKnownFlakes;
   }
 
   public boolean isCiVisibilityEarlyFlakeDetectionEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/config/ModuleExecutionSettings.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/config/ModuleExecutionSettings.java
@@ -29,7 +29,7 @@ public class ModuleExecutionSettings {
   private final Map<String, String> systemProperties;
   private final String itrCorrelationId;
   private final Map<String, Collection<TestIdentifier>> skippableTestsByModule;
-  private final Collection<TestIdentifier> flakyTests;
+  @Nullable private final Collection<TestIdentifier> flakyTests;
   @Nullable private final Map<String, Collection<TestIdentifier>> knownTestsByModule;
   private final List<String> coverageEnabledPackages;
 
@@ -102,6 +102,7 @@ public class ModuleExecutionSettings {
     return skippableTestsByModule.getOrDefault(moduleName, Collections.emptyList());
   }
 
+  @Nullable
   public Collection<TestIdentifier> getFlakyTests(String moduleName) {
     // backend does not store module info for flaky tests yet
     return flakyTests;


### PR DESCRIPTION
# What Does This Do
When flaky test retries are enabled in CI Visibility, by default every failed test will be retried up to N times.
A config property is added to switch the tracer to its previous behaviour: only retry the tests that are known to be flaky.

Jira ticket: [CIVIS-9432]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9432]: https://datadoghq.atlassian.net/browse/CIVIS-9432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ