### PR TITLE
Add frame tags and send snapshots on addThrowable

### DIFF
--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -17,7 +17,10 @@ excludedClassesCoverage += [
   'com.datadog.debugger.agent.DebuggerAgent',
   // too old for this coverage (JDK 1.2)
   'antlr.*',
-  'com.datadog.debugger.util.MoshiSnapshotHelper' // only static classes
+  // only static classes
+  'com.datadog.debugger.util.MoshiSnapshotHelper',
+  // based on JDK WeakHashMap
+  'com.datadog.debugger.util.WeakIdentityHashMap*'
 ]
 
 dependencies {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -2,6 +2,7 @@ package datadog.trace.bootstrap.debugger;
 
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -63,7 +64,7 @@ public class DebuggerContext {
   }
 
   public interface ExceptionDebugger {
-    void handleException(Throwable t);
+    void handleException(Throwable t, AgentSpan span);
   }
 
   private static volatile ProbeResolver probeResolver;
@@ -331,11 +332,15 @@ public class DebuggerContext {
     }
   }
 
-  public static void handleException(Throwable t) {
-    ExceptionDebugger exDebugger = exceptionDebugger;
-    if (exDebugger == null) {
-      return;
+  public static void handleException(Throwable t, AgentSpan span) {
+    try {
+      ExceptionDebugger exDebugger = exceptionDebugger;
+      if (exDebugger == null) {
+        return;
+      }
+      exDebugger.handleException(t, span);
+    } catch (Exception ex) {
+      LOGGER.debug("Error in handleException: ", ex);
     }
-    exDebugger.handleException(t);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -1,10 +1,17 @@
 package com.datadog.debugger.exception;
 
 import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.EXCEPTION;
+import static com.datadog.debugger.util.ExceptionHelper.createThrowableMapping;
 
 import com.datadog.debugger.agent.ConfigurationUpdater;
+import com.datadog.debugger.agent.DebuggerAgent;
+import com.datadog.debugger.exception.ExceptionProbeManager.ThrowableState;
+import com.datadog.debugger.sink.Snapshot;
 import com.datadog.debugger.util.ClassNameFiltering;
+import com.datadog.debugger.util.ExceptionHelper;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +21,10 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugger {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExceptionDebugger.class);
+  public static final String DD_DEBUG_ERROR_EXCEPTION_ID = "_dd.debug.error.exception_id";
+  public static final String ERROR_DEBUG_INFO_CAPTURED = "error.debug_info_captured";
+  public static final String SNAPSHOT_ID_TAG_FMT = "_dd.debug.error.%d.snapshot_id";
+
   private final ExceptionProbeManager exceptionProbeManager;
   private final ConfigurationUpdater configurationUpdater;
   private final ClassNameFiltering classNameFiltering;
@@ -33,16 +44,66 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
   }
 
   @Override
-  public void handleException(Throwable t) {
+  public void handleException(Throwable t, AgentSpan span) {
     String fingerprint = Fingerprinter.fingerprint(t, classNameFiltering);
     if (fingerprint == null) {
       LOGGER.debug("Unable to fingerprint exception", t);
       return;
     }
+    Throwable innerMostException = ExceptionHelper.getInnerMostThrowable(t);
+    if (innerMostException == null) {
+      LOGGER.debug("Unable to find root cause of exception");
+      return;
+    }
     if (exceptionProbeManager.isAlreadyInstrumented(fingerprint)) {
-      // TODO trigger send snapshots already captured
+      ThrowableState state = exceptionProbeManager.getSateByThrowable(innerMostException);
+      if (state == null) {
+        LOGGER.debug("Unable to find state for throwable: {}", innerMostException.toString());
+        return;
+      }
+      span.setTag(ERROR_DEBUG_INFO_CAPTURED, true);
+      if (span.getTag(DD_DEBUG_ERROR_EXCEPTION_ID) != null) {
+        LOGGER.debug("Clear previous frame tags");
+        // already set for this span, clear the frame tags
+        span.getTags()
+            .forEach(
+                (k, v) -> {
+                  if (k.startsWith("_dd.debug.error.")) {
+                    span.setTag(k, (String) null);
+                  }
+                });
+      }
+      span.setTag(DD_DEBUG_ERROR_EXCEPTION_ID, state.getExceptionId());
+      LOGGER.debug(
+          "add tag to span[{}]: {}: {}",
+          span.getSpanId(),
+          DD_DEBUG_ERROR_EXCEPTION_ID,
+          state.getExceptionId());
+      int[] mapping = createThrowableMapping(innerMostException, t);
+      StackTraceElement[] innerTrace = innerMostException.getStackTrace();
+      int currentIdx = 0;
+      List<Snapshot> snapshots = state.getSnapshots();
+      for (int i = 0; i < snapshots.size(); i++) {
+        Snapshot snapshot = snapshots.get(i);
+        String className = snapshot.getProbe().getLocation().getType();
+        String methodName = snapshot.getProbe().getLocation().getMethod();
+        while (currentIdx < innerTrace.length
+            && !innerTrace[currentIdx].getClassName().equals(className)
+            && !innerTrace[currentIdx].getMethodName().equals(methodName)) {
+          currentIdx++;
+        }
+        int frameIndex = mapping[currentIdx++];
+        if (frameIndex == -1) {
+          continue;
+        }
+        String tagName = String.format(SNAPSHOT_ID_TAG_FMT, frameIndex);
+        span.setTag(tagName, snapshot.getId());
+        LOGGER.debug("add tag to span[{}]: {}: {}", span.getSpanId(), tagName, snapshot.getId());
+        DebuggerAgent.getSink().addSnapshot(snapshot);
+      }
     } else {
-      exceptionProbeManager.createProbesForException(fingerprint, t.getStackTrace());
+      exceptionProbeManager.createProbesForException(
+          fingerprint, innerMostException.getStackTrace());
       // TODO make it async
       configurationUpdater.accept(EXCEPTION, exceptionProbeManager.getProbes());
     }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -2,19 +2,32 @@ package com.datadog.debugger.exception;
 
 import com.datadog.debugger.probe.ExceptionProbe;
 import com.datadog.debugger.probe.Where;
+import com.datadog.debugger.sink.Snapshot;
 import com.datadog.debugger.util.ClassNameFiltering;
+import com.datadog.debugger.util.ExceptionHelper;
+import com.datadog.debugger.util.WeakIdentityHashMap;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Manages the probes used for instrumentation of exception stacktraces. */
 public class ExceptionProbeManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionProbeManager.class);
+
   private final Set<String> fingerprints = ConcurrentHashMap.newKeySet();
   private final Map<String, ExceptionProbe> probes = new ConcurrentHashMap<>();
   private final ClassNameFiltering classNameFiltering;
+  // FIXME: if this becomes a bottleneck, find a way to make it concurrent weak identity hashmap
+  private final Map<Throwable, ThrowableState> snapshotsByThrowable =
+      Collections.synchronizedMap(new WeakIdentityHashMap<>());
 
   public ExceptionProbeManager(ClassNameFiltering classNameFiltering) {
     this.classNameFiltering = classNameFiltering;
@@ -63,5 +76,50 @@ public class ExceptionProbeManager {
 
   public boolean shouldCaptureException(String fingerprint) {
     return fingerprints.contains(fingerprint);
+  }
+
+  boolean containsFingerprint(String fingerprint) {
+    return fingerprints.contains(fingerprint);
+  }
+
+  public void addSnapshot(Snapshot snapshot) {
+    Throwable throwable = snapshot.getCaptures().getReturn().getCapturedThrowable().getThrowable();
+    throwable = ExceptionHelper.getInnerMostThrowable(throwable);
+    if (throwable == null) {
+      LOGGER.debug(
+          "Unable to find root cause of exception: {}",
+          snapshot.getCaptures().getReturn().getCapturedThrowable().getThrowable().toString());
+      return;
+    }
+    ThrowableState state =
+        snapshotsByThrowable.computeIfAbsent(
+            throwable, key -> new ThrowableState(UUID.randomUUID().toString()));
+    snapshot.setExceptionId(state.getExceptionId());
+    state.addSnapshot(snapshot);
+  }
+
+  public ThrowableState getSateByThrowable(Throwable throwable) {
+    return snapshotsByThrowable.get(throwable);
+  }
+
+  public static class ThrowableState {
+    private final String exceptionId;
+    private final List<Snapshot> snapshots = new ArrayList<>();
+
+    private ThrowableState(String exceptionId) {
+      this.exceptionId = exceptionId;
+    }
+
+    public String getExceptionId() {
+      return exceptionId;
+    }
+
+    public List<Snapshot> getSnapshots() {
+      return snapshots;
+    }
+
+    public void addSnapshot(Snapshot snapshot) {
+      snapshots.add(snapshot);
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/Fingerprinter.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.exception;
 
+import static com.datadog.debugger.util.ExceptionHelper.getInnerMostThrowable;
+
 import com.datadog.debugger.util.ClassNameFiltering;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -39,18 +41,6 @@ public class Fingerprinter {
     }
     byte[] bytes = digest.digest();
     return bytesToHex(bytes);
-  }
-
-  private static Throwable getInnerMostThrowable(Throwable t) {
-    int i = 100;
-    while (t.getCause() != null && i > 0) {
-      t = t.getCause();
-      i--;
-    }
-    if (i == 0) {
-      return null;
-    }
-    return t;
   }
 
   // convert byte[] to hex string

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -186,9 +186,6 @@ public class ASMHelper {
         returnType,
         targetType,
         Types.STRING_TYPE);
-    if (sort == org.objectweb.asm.Type.OBJECT || sort == org.objectweb.asm.Type.ARRAY) {
-      insnList.add(new TypeInsnNode(Opcodes.CHECKCAST, fieldType.getMainType().getInternalName()));
-    }
     // stack: [field_value]
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -889,7 +889,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
               ldc(insnList, fieldNode.name);
               // stack: [capturedcontext, capturedcontext, array, array, int, string, type_name,
               // this, string]
-              ASMHelper.emitReflectiveCall(
+              emitReflectiveCall(
                   insnList, new ASMHelper.Type(Type.getType(fieldNode.desc)), OBJECT_TYPE);
               // stack: [capturedcontext, capturedcontext, array, array, int, string, type_name,
               // this, string]

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -772,6 +772,11 @@ public class MetricInstrumentor extends Instrumentor {
           ldc(insnList, fieldName);
           // stack: [target_object, string]
           emitReflectiveCall(insnList, returnType, OBJECT_TYPE);
+          int sort = returnType.getMainType().getSort();
+          if (sort == org.objectweb.asm.Type.OBJECT || sort == org.objectweb.asm.Type.ARRAY) {
+            insnList.add(
+                new TypeInsnNode(Opcodes.CHECKCAST, returnType.getMainType().getInternalName()));
+          }
         }
         // build null branch which will be added later after the call to emit metric
         LabelNode gotoNode = new LabelNode();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -85,7 +85,15 @@ public class ExceptionProbe extends LogProbe {
     Snapshot snapshot = createSnapshot();
     boolean shouldCommit = fillSnapshot(entryContext, exitContext, caughtExceptions, snapshot);
     if (shouldCommit) {
-      snapshot.recordStackTrace(5);
+      /*
+       * Record stack trace having the caller of this method as 'top' frame.
+       * For this it is necessary to discard:
+       * - Thread.currentThread().getStackTrace()
+       * - Snapshot.recordStackTrace()
+       * - ExceptionProbe.commit()
+       * - DebuggerContext.commit()
+       */
+      snapshot.recordStackTrace(4);
       // add snapshot for later to wait for triggering point (ExceptionDebugger::handleException)
       exceptionProbeManager.addSnapshot(snapshot);
       LOGGER.debug(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -6,6 +6,7 @@ import com.datadog.debugger.el.ProbeCondition;
 import com.datadog.debugger.exception.ExceptionProbeManager;
 import com.datadog.debugger.exception.Fingerprinter;
 import com.datadog.debugger.instrumentation.InstrumentationResult;
+import com.datadog.debugger.sink.Snapshot;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
@@ -17,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class ExceptionProbe extends LogProbe {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionProbe.class);
-  private final ExceptionProbeManager exceptionProbeManager;
+  private final transient ExceptionProbeManager exceptionProbeManager;
 
   public ExceptionProbe(
       ProbeId probeId,
@@ -64,14 +65,14 @@ public class ExceptionProbe extends LogProbe {
     if (context.getCapturedThrowable() == null) {
       return;
     }
+    Throwable throwable = context.getCapturedThrowable().getThrowable();
     String fingerprint =
-        Fingerprinter.fingerprint(
-            context.getCapturedThrowable().getThrowable(),
-            exceptionProbeManager.getClassNameFiltering());
+        Fingerprinter.fingerprint(throwable, exceptionProbeManager.getClassNameFiltering());
     if (exceptionProbeManager.shouldCaptureException(fingerprint)) {
       LOGGER.debug("Capturing exception matching fingerprint: {}", fingerprint);
       // capture only on uncaught exception matching the fingerprint
-      ((ExceptionProbeStatus) status).setCapture(true);
+      ExceptionProbeStatus exceptionStatus = (ExceptionProbeStatus) status;
+      exceptionStatus.setCapture(true);
       super.evaluate(context, status, methodLocation);
     }
   }
@@ -81,8 +82,18 @@ public class ExceptionProbe extends LogProbe {
       CapturedContext entryContext,
       CapturedContext exitContext,
       List<CapturedContext.CapturedThrowable> caughtExceptions) {
-    LOGGER.debug("committing exception probe id={}", id);
-    super.commit(entryContext, exitContext, caughtExceptions);
+    Snapshot snapshot = createSnapshot();
+    boolean shouldCommit = fillSnapshot(entryContext, exitContext, caughtExceptions, snapshot);
+    if (shouldCommit) {
+      snapshot.recordStackTrace(5);
+      // add snapshot for later to wait for triggering point (ExceptionDebugger::handleException)
+      exceptionProbeManager.addSnapshot(snapshot);
+      LOGGER.debug(
+          "committing exception probe id={}, snapshot id={}, exception id={}",
+          id,
+          snapshot.getId(),
+          snapshot.getExceptionId());
+    }
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -440,6 +440,26 @@ public class LogProbe extends ProbeDefinition {
       CapturedContext entryContext,
       CapturedContext exitContext,
       List<CapturedContext.CapturedThrowable> caughtExceptions) {
+    Snapshot snapshot = createSnapshot();
+    boolean shouldCommit = fillSnapshot(entryContext, exitContext, caughtExceptions, snapshot);
+    DebuggerSink sink = DebuggerAgent.getSink();
+    if (shouldCommit) {
+      commitSnapshot(snapshot, sink);
+    } else {
+      sink.skipSnapshot(id, DebuggerContext.SkipCause.CONDITION);
+    }
+  }
+
+  protected Snapshot createSnapshot() {
+    int maxDepth = capture != null ? capture.maxReferenceDepth : -1;
+    return new Snapshot(Thread.currentThread(), this, maxDepth);
+  }
+
+  protected boolean fillSnapshot(
+      CapturedContext entryContext,
+      CapturedContext exitContext,
+      List<CapturedContext.CapturedThrowable> caughtExceptions,
+      Snapshot snapshot) {
     LogStatus entryStatus = convertStatus(entryContext.getStatus(probeId.getEncodedId()));
     LogStatus exitStatus = convertStatus(exitContext.getStatus(probeId.getEncodedId()));
     String message = null;
@@ -458,10 +478,7 @@ public class LogProbe extends ProbeDefinition {
         spanId = exitContext.getSpanId();
         break;
     }
-    DebuggerSink sink = DebuggerAgent.getSink();
     boolean shouldCommit = false;
-    int maxDepth = capture != null ? capture.maxReferenceDepth : -1;
-    Snapshot snapshot = new Snapshot(Thread.currentThread(), this, maxDepth);
     if (entryStatus.shouldSend() && exitStatus.shouldSend()) {
       snapshot.setTraceId(traceId);
       snapshot.setSpanId(spanId);
@@ -490,11 +507,7 @@ public class LogProbe extends ProbeDefinition {
       snapshot.addEvaluationErrors(exitStatus.getErrors());
       shouldCommit = true;
     }
-    if (shouldCommit) {
-      commitSnapshot(snapshot, sink);
-    } else {
-      sink.skipSnapshot(id, DebuggerContext.SkipCause.CONDITION);
-    }
+    return shouldCommit;
   }
 
   private LogStatus convertStatus(CapturedContext.Status status) {
@@ -507,7 +520,7 @@ public class LogProbe extends ProbeDefinition {
     return (LogStatus) status;
   }
 
-  private void commitSnapshot(Snapshot snapshot, DebuggerSink sink) {
+  protected void commitSnapshot(Snapshot snapshot, DebuggerSink sink) {
     /*
      * Record stack trace having the caller of this method as 'top' frame.
      * For this it is necessary to discard:
@@ -528,8 +541,7 @@ public class LogProbe extends ProbeDefinition {
       return;
     }
     DebuggerSink sink = DebuggerAgent.getSink();
-    int maxDepth = capture != null ? capture.maxReferenceDepth : -1;
-    Snapshot snapshot = new Snapshot(Thread.currentThread(), this, maxDepth);
+    Snapshot snapshot = createSnapshot();
     boolean shouldCommit = false;
     if (status.shouldSend()) {
       snapshot.setTraceId(lineContext.getTraceId());

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Snapshot.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Snapshot.java
@@ -31,6 +31,7 @@ public class Snapshot {
   private List<EvaluationError> evaluationErrors;
   private transient String message;
   private final transient int maxDepth;
+  private String exceptionId;
 
   public Snapshot(java.lang.Thread thread, ProbeImplementation probeImplementation, int maxDepth) {
     this.id = UUID.randomUUID().toString();
@@ -84,6 +85,10 @@ public class Snapshot {
 
   public void setMessage(String message) {
     this.message = message;
+  }
+
+  public void setExceptionId(String exceptionId) {
+    this.exceptionId = exceptionId;
   }
 
   public void addLine(CapturedContext context, int line) {
@@ -163,6 +168,10 @@ public class Snapshot {
 
   public int getMaxDepth() {
     return maxDepth;
+  }
+
+  public String getExceptionId() {
+    return exceptionId;
   }
 
   public void recordStackTrace(int offset) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/WeakIdentityHashMap.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/WeakIdentityHashMap.java
@@ -1,0 +1,1075 @@
+package com.datadog.debugger.util;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+/**
+ * This class merges the properties of {@link java.util.WeakHashMap} and {@link
+ * java.util.IdentityHashMap}. Keys are weak and are compared using reference equality (==). The
+ * implementation is a modified version of {@link java.util.WeakHashMap} that uses reference
+ * equality and identity hashcode
+ */
+public class WeakIdentityHashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
+
+  /** The default initial capacity -- MUST be a power of two. */
+  private static final int DEFAULT_INITIAL_CAPACITY = 16;
+
+  /**
+   * The maximum capacity, used if a higher value is implicitly specified by either of the
+   * constructors with arguments. MUST be a power of two <= 1<<30.
+   */
+  private static final int MAXIMUM_CAPACITY = 1 << 30;
+
+  /** The load factor used when none specified in constructor. */
+  private static final float DEFAULT_LOAD_FACTOR = 0.75f;
+
+  /** The table, resized as necessary. Length MUST Always be a power of two. */
+  Entry<K, V>[] table;
+
+  /** The number of key-value mappings contained in this weak hash map. */
+  private int size;
+
+  /** The next size value at which to resize (capacity * load factor). */
+  private int threshold;
+
+  /** The load factor for the hash table. */
+  private final float loadFactor;
+
+  /** Reference queue for cleared WeakEntries */
+  private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+
+  /**
+   * The number of times this WeakHashMap has been structurally modified. Structural modifications
+   * are those that change the number of mappings in the map or otherwise modify its internal
+   * structure (e.g., rehash). This field is used to make iterators on Collection-views of the map
+   * fail-fast.
+   *
+   * @see ConcurrentModificationException
+   */
+  int modCount;
+
+  @SuppressWarnings("unchecked")
+  private Entry<K, V>[] newTable(int n) {
+    return (Entry<K, V>[]) new Entry<?, ?>[n];
+  }
+
+  /**
+   * Constructs a new, empty {@code WeakHashMap} with the given initial capacity and the given load
+   * factor.
+   *
+   * @param initialCapacity The initial capacity of the {@code WeakHashMap}
+   * @param loadFactor The load factor of the {@code WeakHashMap}
+   * @throws IllegalArgumentException if the initial capacity is negative, or if the load factor is
+   *     nonpositive.
+   */
+  public WeakIdentityHashMap(int initialCapacity, float loadFactor) {
+    if (initialCapacity < 0)
+      throw new IllegalArgumentException("Illegal Initial Capacity: " + initialCapacity);
+    if (initialCapacity > MAXIMUM_CAPACITY) initialCapacity = MAXIMUM_CAPACITY;
+
+    if (loadFactor <= 0 || Float.isNaN(loadFactor))
+      throw new IllegalArgumentException("Illegal Load factor: " + loadFactor);
+    int capacity = 1;
+    while (capacity < initialCapacity) capacity <<= 1;
+    table = newTable(capacity);
+    this.loadFactor = loadFactor;
+    threshold = (int) (capacity * loadFactor);
+  }
+
+  /**
+   * Constructs a new, empty {@code WeakHashMap} with the given initial capacity and the default
+   * load factor (0.75).
+   *
+   * @param initialCapacity The initial capacity of the {@code WeakHashMap}
+   * @throws IllegalArgumentException if the initial capacity is negative
+   */
+  public WeakIdentityHashMap(int initialCapacity) {
+    this(initialCapacity, DEFAULT_LOAD_FACTOR);
+  }
+
+  /**
+   * Constructs a new, empty {@code WeakHashMap} with the default initial capacity (16) and load
+   * factor (0.75).
+   */
+  public WeakIdentityHashMap() {
+    this(DEFAULT_INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR);
+  }
+
+  /**
+   * Constructs a new {@code WeakHashMap} with the same mappings as the specified map. The {@code
+   * WeakHashMap} is created with the default load factor (0.75) and an initial capacity sufficient
+   * to hold the mappings in the specified map.
+   *
+   * @param m the map whose mappings are to be placed in this map
+   * @throws NullPointerException if the specified map is null
+   * @since 1.3
+   */
+  public WeakIdentityHashMap(Map<? extends K, ? extends V> m) {
+    this(
+        Math.max((int) (m.size() / DEFAULT_LOAD_FACTOR) + 1, DEFAULT_INITIAL_CAPACITY),
+        DEFAULT_LOAD_FACTOR);
+    putAll(m);
+  }
+
+  // internal utilities
+
+  /** Value representing null keys inside tables. */
+  private static final Object NULL_KEY = new Object();
+
+  /** Use NULL_KEY for key if it is null. */
+  private static Object maskNull(Object key) {
+    return (key == null) ? NULL_KEY : key;
+  }
+
+  /** Returns internal representation of null key back to caller as null. */
+  static Object unmaskNull(Object key) {
+    return (key == NULL_KEY) ? null : key;
+  }
+
+  /** Checks for reference equality of non-null reference x and possibly-null y. */
+  private static boolean eq(Object x, Object y) {
+    return x == y;
+  }
+
+  /**
+   * Retrieve object hash code and applies a supplemental hash function to the result hash, which
+   * defends against poor quality hash functions. This is critical because HashMap uses power-of-two
+   * length hash tables, that otherwise encounter collisions for hashCodes that do not differ in
+   * lower bits.
+   */
+  final int hash(Object k) {
+    int h = System.identityHashCode(k);
+
+    // This function ensures that hashCodes that differ only by
+    // constant multiples at each bit position have a bounded
+    // number of collisions (approximately 8 at default load factor).
+    h ^= (h >>> 20) ^ (h >>> 12);
+    return h ^ (h >>> 7) ^ (h >>> 4);
+  }
+
+  /** Returns index for hash code h. */
+  private static int indexFor(int h, int length) {
+    return h & (length - 1);
+  }
+
+  /** Expunges stale entries from the table. */
+  private void expungeStaleEntries() {
+    for (Object x; (x = queue.poll()) != null; ) {
+      synchronized (queue) {
+        @SuppressWarnings("unchecked")
+        Entry<K, V> e = (Entry<K, V>) x;
+        int i = indexFor(e.hash, table.length);
+
+        Entry<K, V> prev = table[i];
+        Entry<K, V> p = prev;
+        while (p != null) {
+          Entry<K, V> next = p.next;
+          if (p == e) {
+            if (prev == e) table[i] = next;
+            else prev.next = next;
+            // Must not null out e.next;
+            // stale entries may be in use by a HashIterator
+            e.value = null; // Help GC
+            size--;
+            break;
+          }
+          prev = p;
+          p = next;
+        }
+      }
+    }
+  }
+
+  /** Returns the table after first expunging stale entries. */
+  private Entry<K, V>[] getTable() {
+    expungeStaleEntries();
+    return table;
+  }
+
+  /**
+   * Returns the number of key-value mappings in this map. This result is a snapshot, and may not
+   * reflect unprocessed entries that will be removed before next attempted access because they are
+   * no longer referenced.
+   */
+  public int size() {
+    if (size == 0) return 0;
+    expungeStaleEntries();
+    return size;
+  }
+
+  /**
+   * Returns {@code true} if this map contains no key-value mappings. This result is a snapshot, and
+   * may not reflect unprocessed entries that will be removed before next attempted access because
+   * they are no longer referenced.
+   */
+  public boolean isEmpty() {
+    return size() == 0;
+  }
+
+  /**
+   * Returns the value to which the specified key is mapped, or {@code null} if this map contains no
+   * mapping for the key.
+   *
+   * <p>More formally, if this map contains a mapping from a key {@code k} to a value {@code v} such
+   * that {@code Objects.equals(key, k)}, then this method returns {@code v}; otherwise it returns
+   * {@code null}. (There can be at most one such mapping.)
+   *
+   * <p>A return value of {@code null} does not <i>necessarily</i> indicate that the map contains no
+   * mapping for the key; it's also possible that the map explicitly maps the key to {@code null}.
+   * The {@link #containsKey containsKey} operation may be used to distinguish these two cases.
+   *
+   * @see #put(Object, Object)
+   */
+  public V get(Object key) {
+    Object k = maskNull(key);
+    int h = hash(k);
+    Entry<K, V>[] tab = getTable();
+    int index = indexFor(h, tab.length);
+    Entry<K, V> e = tab[index];
+    while (e != null) {
+      if (e.hash == h && eq(k, e.get())) return e.value;
+      e = e.next;
+    }
+    return null;
+  }
+
+  /**
+   * Returns {@code true} if this map contains a mapping for the specified key.
+   *
+   * @param key The key whose presence in this map is to be tested
+   * @return {@code true} if there is a mapping for {@code key}; {@code false} otherwise
+   */
+  public boolean containsKey(Object key) {
+    return getEntry(key) != null;
+  }
+
+  /**
+   * Returns the entry associated with the specified key in this map. Returns null if the map
+   * contains no mapping for this key.
+   */
+  Entry<K, V> getEntry(Object key) {
+    Object k = maskNull(key);
+    int h = hash(k);
+    Entry<K, V>[] tab = getTable();
+    int index = indexFor(h, tab.length);
+    Entry<K, V> e = tab[index];
+    while (e != null && !(e.hash == h && eq(k, e.get()))) e = e.next;
+    return e;
+  }
+
+  /**
+   * Associates the specified value with the specified key in this map. If the map previously
+   * contained a mapping for this key, the old value is replaced.
+   *
+   * @param key key with which the specified value is to be associated.
+   * @param value value to be associated with the specified key.
+   * @return the previous value associated with {@code key}, or {@code null} if there was no mapping
+   *     for {@code key}. (A {@code null} return can also indicate that the map previously
+   *     associated {@code null} with {@code key}.)
+   */
+  public V put(K key, V value) {
+    Object k = maskNull(key);
+    int h = hash(k);
+    Entry<K, V>[] tab = getTable();
+    int i = indexFor(h, tab.length);
+
+    for (Entry<K, V> e = tab[i]; e != null; e = e.next) {
+      if (h == e.hash && eq(k, e.get())) {
+        V oldValue = e.value;
+        if (value != oldValue) e.value = value;
+        return oldValue;
+      }
+    }
+
+    modCount++;
+    Entry<K, V> e = tab[i];
+    tab[i] = new Entry<>(k, value, queue, h, e);
+    if (++size >= threshold) resize(tab.length * 2);
+    return null;
+  }
+
+  /**
+   * Rehashes the contents of this map into a new array with a larger capacity. This method is
+   * called automatically when the number of keys in this map reaches its threshold.
+   *
+   * <p>If current capacity is MAXIMUM_CAPACITY, this method does not resize the map, but sets
+   * threshold to Integer.MAX_VALUE. This has the effect of preventing future calls.
+   *
+   * @param newCapacity the new capacity, MUST be a power of two; must be greater than current
+   *     capacity unless current capacity is MAXIMUM_CAPACITY (in which case value is irrelevant).
+   */
+  void resize(int newCapacity) {
+    Entry<K, V>[] oldTable = getTable();
+    int oldCapacity = oldTable.length;
+    if (oldCapacity == MAXIMUM_CAPACITY) {
+      threshold = Integer.MAX_VALUE;
+      return;
+    }
+
+    Entry<K, V>[] newTable = newTable(newCapacity);
+    transfer(oldTable, newTable);
+    table = newTable;
+
+    /*
+     * If ignoring null elements and processing ref queue caused massive
+     * shrinkage, then restore old table.  This should be rare, but avoids
+     * unbounded expansion of garbage-filled tables.
+     */
+    if (size >= threshold / 2) {
+      threshold = (int) (newCapacity * loadFactor);
+    } else {
+      expungeStaleEntries();
+      transfer(newTable, oldTable);
+      table = oldTable;
+    }
+  }
+
+  /** Transfers all entries from src to dest tables */
+  private void transfer(Entry<K, V>[] src, Entry<K, V>[] dest) {
+    for (int j = 0; j < src.length; ++j) {
+      Entry<K, V> e = src[j];
+      src[j] = null;
+      while (e != null) {
+        Entry<K, V> next = e.next;
+        Object key = e.get();
+        if (key == null) {
+          e.next = null; // Help GC
+          e.value = null; //  "   "
+          size--;
+        } else {
+          int i = indexFor(e.hash, dest.length);
+          e.next = dest[i];
+          dest[i] = e;
+        }
+        e = next;
+      }
+    }
+  }
+
+  /**
+   * Copies all of the mappings from the specified map to this map. These mappings will replace any
+   * mappings that this map had for any of the keys currently in the specified map.
+   *
+   * @param m mappings to be stored in this map.
+   * @throws NullPointerException if the specified map is null.
+   */
+  public void putAll(Map<? extends K, ? extends V> m) {
+    int numKeysToBeAdded = m.size();
+    if (numKeysToBeAdded == 0) return;
+
+    /*
+     * Expand the map if the map if the number of mappings to be added
+     * is greater than or equal to threshold.  This is conservative; the
+     * obvious condition is (m.size() + size) >= threshold, but this
+     * condition could result in a map with twice the appropriate capacity,
+     * if the keys to be added overlap with the keys already in this map.
+     * By using the conservative calculation, we subject ourself
+     * to at most one extra resize.
+     */
+    if (numKeysToBeAdded > threshold) {
+      int targetCapacity = (int) (numKeysToBeAdded / loadFactor + 1);
+      if (targetCapacity > MAXIMUM_CAPACITY) targetCapacity = MAXIMUM_CAPACITY;
+      int newCapacity = table.length;
+      while (newCapacity < targetCapacity) newCapacity <<= 1;
+      if (newCapacity > table.length) resize(newCapacity);
+    }
+
+    for (Map.Entry<? extends K, ? extends V> e : m.entrySet()) put(e.getKey(), e.getValue());
+  }
+
+  /**
+   * Removes the mapping for a key from this weak hash map if it is present. More formally, if this
+   * map contains a mapping from key {@code k} to value {@code v} such that <code>
+   * (key==null ?  k==null :
+   * key.equals(k))</code>, that mapping is removed. (The map can contain at most one such mapping.)
+   *
+   * <p>Returns the value to which this map previously associated the key, or {@code null} if the
+   * map contained no mapping for the key. A return value of {@code null} does not
+   * <i>necessarily</i> indicate that the map contained no mapping for the key; it's also possible
+   * that the map explicitly mapped the key to {@code null}.
+   *
+   * <p>The map will not contain a mapping for the specified key once the call returns.
+   *
+   * @param key key whose mapping is to be removed from the map
+   * @return the previous value associated with {@code key}, or {@code null} if there was no mapping
+   *     for {@code key}
+   */
+  public V remove(Object key) {
+    Object k = maskNull(key);
+    int h = hash(k);
+    Entry<K, V>[] tab = getTable();
+    int i = indexFor(h, tab.length);
+    Entry<K, V> prev = tab[i];
+    Entry<K, V> e = prev;
+
+    while (e != null) {
+      Entry<K, V> next = e.next;
+      if (h == e.hash && eq(k, e.get())) {
+        modCount++;
+        size--;
+        if (prev == e) tab[i] = next;
+        else prev.next = next;
+        return e.value;
+      }
+      prev = e;
+      e = next;
+    }
+
+    return null;
+  }
+
+  /** Special version of remove needed by Entry set */
+  boolean removeMapping(Object o) {
+    if (!(o instanceof Map.Entry)) return false;
+    Entry<K, V>[] tab = getTable();
+    Map.Entry<?, ?> entry = (Map.Entry<?, ?>) o;
+    Object k = maskNull(entry.getKey());
+    int h = hash(k);
+    int i = indexFor(h, tab.length);
+    Entry<K, V> prev = tab[i];
+    Entry<K, V> e = prev;
+
+    while (e != null) {
+      Entry<K, V> next = e.next;
+      if (h == e.hash && e.equals(entry)) {
+        modCount++;
+        size--;
+        if (prev == e) tab[i] = next;
+        else prev.next = next;
+        return true;
+      }
+      prev = e;
+      e = next;
+    }
+
+    return false;
+  }
+
+  /** Removes all of the mappings from this map. The map will be empty after this call returns. */
+  public void clear() {
+    // clear out ref queue. We don't need to expunge entries
+    // since table is getting cleared.
+    while (queue.poll() != null) ;
+
+    modCount++;
+    Arrays.fill(table, null);
+    size = 0;
+
+    // Allocation of array may have caused GC, which may have caused
+    // additional entries to go stale.  Removing these entries from the
+    // reference queue will make them eligible for reclamation.
+    while (queue.poll() != null) ;
+  }
+
+  /**
+   * Returns {@code true} if this map maps one or more keys to the specified value.
+   *
+   * @param value value whose presence in this map is to be tested
+   * @return {@code true} if this map maps one or more keys to the specified value
+   */
+  public boolean containsValue(Object value) {
+    if (value == null) return containsNullValue();
+
+    Entry<K, V>[] tab = getTable();
+    for (int i = tab.length; i-- > 0; )
+      for (Entry<K, V> e = tab[i]; e != null; e = e.next) if (value.equals(e.value)) return true;
+    return false;
+  }
+
+  /** Special-case code for containsValue with null argument */
+  private boolean containsNullValue() {
+    Entry<K, V>[] tab = getTable();
+    for (int i = tab.length; i-- > 0; )
+      for (Entry<K, V> e = tab[i]; e != null; e = e.next) if (e.value == null) return true;
+    return false;
+  }
+
+  /** The entries in this hash table extend WeakReference, using its main ref field as the key. */
+  private static class Entry<K, V> extends WeakReference<Object> implements Map.Entry<K, V> {
+    V value;
+    final int hash;
+    Entry<K, V> next;
+
+    /** Creates new entry. */
+    Entry(Object key, V value, ReferenceQueue<Object> queue, int hash, Entry<K, V> next) {
+      super(key, queue);
+      this.value = value;
+      this.hash = hash;
+      this.next = next;
+    }
+
+    @SuppressWarnings("unchecked")
+    public K getKey() {
+      return (K) unmaskNull(get());
+    }
+
+    public V getValue() {
+      return value;
+    }
+
+    public V setValue(V newValue) {
+      V oldValue = value;
+      value = newValue;
+      return oldValue;
+    }
+
+    public boolean equals(Object o) {
+      if (!(o instanceof Map.Entry)) return false;
+      Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+      K k1 = getKey();
+      Object k2 = e.getKey();
+      if (k1 == k2 || (k1 != null && k1.equals(k2))) {
+        V v1 = getValue();
+        Object v2 = e.getValue();
+        if (v1 == v2 || (v1 != null && v1.equals(v2))) return true;
+      }
+      return false;
+    }
+
+    public int hashCode() {
+      K k = getKey();
+      V v = getValue();
+      return Objects.hashCode(k) ^ Objects.hashCode(v);
+    }
+
+    public String toString() {
+      return getKey() + "=" + getValue();
+    }
+  }
+
+  private abstract class HashIterator<T> implements Iterator<T> {
+    private int index;
+    private Entry<K, V> entry;
+    private Entry<K, V> lastReturned;
+    private int expectedModCount = modCount;
+
+    /** Strong reference needed to avoid disappearance of key between hasNext and next */
+    private Object nextKey;
+
+    /**
+     * Strong reference needed to avoid disappearance of key between nextEntry() and any use of the
+     * entry
+     */
+    private Object currentKey;
+
+    HashIterator() {
+      index = isEmpty() ? 0 : table.length;
+    }
+
+    public boolean hasNext() {
+      Entry<K, V>[] t = table;
+
+      while (nextKey == null) {
+        Entry<K, V> e = entry;
+        int i = index;
+        while (e == null && i > 0) e = t[--i];
+        entry = e;
+        index = i;
+        if (e == null) {
+          currentKey = null;
+          return false;
+        }
+        nextKey = e.get(); // hold on to key in strong ref
+        if (nextKey == null) entry = entry.next;
+      }
+      return true;
+    }
+
+    /** The common parts of next() across different types of iterators */
+    protected Entry<K, V> nextEntry() {
+      if (modCount != expectedModCount) throw new ConcurrentModificationException();
+      if (nextKey == null && !hasNext()) throw new NoSuchElementException();
+
+      lastReturned = entry;
+      entry = entry.next;
+      currentKey = nextKey;
+      nextKey = null;
+      return lastReturned;
+    }
+
+    public void remove() {
+      if (lastReturned == null) throw new IllegalStateException();
+      if (modCount != expectedModCount) throw new ConcurrentModificationException();
+
+      WeakIdentityHashMap.this.remove(currentKey);
+      expectedModCount = modCount;
+      lastReturned = null;
+      currentKey = null;
+    }
+  }
+
+  private class ValueIterator extends HashIterator<V> {
+    public V next() {
+      return nextEntry().value;
+    }
+  }
+
+  private class KeyIterator extends HashIterator<K> {
+    public K next() {
+      return nextEntry().getKey();
+    }
+  }
+
+  private class EntryIterator extends HashIterator<Map.Entry<K, V>> {
+    public Map.Entry<K, V> next() {
+      return nextEntry();
+    }
+  }
+
+  // Views
+
+  private transient Set<Map.Entry<K, V>> entrySet;
+  private transient volatile Set<K> keySet;
+
+  /**
+   * Returns a {@link Set} view of the keys contained in this map. The set is backed by the map, so
+   * changes to the map are reflected in the set, and vice-versa. If the map is modified while an
+   * iteration over the set is in progress (except through the iterator's own {@code remove}
+   * operation), the results of the iteration are undefined. The set supports element removal, which
+   * removes the corresponding mapping from the map, via the {@code Iterator.remove}, {@code
+   * Set.remove}, {@code removeAll}, {@code retainAll}, and {@code clear} operations. It does not
+   * support the {@code add} or {@code addAll} operations.
+   */
+  public Set<K> keySet() {
+    Set<K> ks = keySet;
+    if (ks == null) {
+      ks = new KeySet();
+      keySet = ks;
+    }
+    return ks;
+  }
+
+  private class KeySet extends AbstractSet<K> {
+    public Iterator<K> iterator() {
+      return new KeyIterator();
+    }
+
+    public int size() {
+      return WeakIdentityHashMap.this.size();
+    }
+
+    public boolean contains(Object o) {
+      return containsKey(o);
+    }
+
+    public boolean remove(Object o) {
+      if (containsKey(o)) {
+        WeakIdentityHashMap.this.remove(o);
+        return true;
+      } else return false;
+    }
+
+    public void clear() {
+      WeakIdentityHashMap.this.clear();
+    }
+
+    public Spliterator<K> spliterator() {
+      return new KeySpliterator<>(WeakIdentityHashMap.this, 0, -1, 0, 0);
+    }
+  }
+
+  private transient volatile Collection<V> values;
+
+  /**
+   * Returns a {@link Collection} view of the values contained in this map. The collection is backed
+   * by the map, so changes to the map are reflected in the collection, and vice-versa. If the map
+   * is modified while an iteration over the collection is in progress (except through the
+   * iterator's own {@code remove} operation), the results of the iteration are undefined. The
+   * collection supports element removal, which removes the corresponding mapping from the map, via
+   * the {@code Iterator.remove}, {@code Collection.remove}, {@code removeAll}, {@code retainAll}
+   * and {@code clear} operations. It does not support the {@code add} or {@code addAll} operations.
+   */
+  public Collection<V> values() {
+    Collection<V> vs = values;
+    if (vs == null) {
+      vs = new Values();
+      values = vs;
+    }
+    return vs;
+  }
+
+  private class Values extends AbstractCollection<V> {
+    public Iterator<V> iterator() {
+      return new ValueIterator();
+    }
+
+    public int size() {
+      return WeakIdentityHashMap.this.size();
+    }
+
+    public boolean contains(Object o) {
+      return containsValue(o);
+    }
+
+    public void clear() {
+      WeakIdentityHashMap.this.clear();
+    }
+
+    public Spliterator<V> spliterator() {
+      return new ValueSpliterator<>(WeakIdentityHashMap.this, 0, -1, 0, 0);
+    }
+  }
+
+  /**
+   * Returns a {@link Set} view of the mappings contained in this map. The set is backed by the map,
+   * so changes to the map are reflected in the set, and vice-versa. If the map is modified while an
+   * iteration over the set is in progress (except through the iterator's own {@code remove}
+   * operation, or through the {@code setValue} operation on a map entry returned by the iterator)
+   * the results of the iteration are undefined. The set supports element removal, which removes the
+   * corresponding mapping from the map, via the {@code Iterator.remove}, {@code Set.remove}, {@code
+   * removeAll}, {@code retainAll} and {@code clear} operations. It does not support the {@code add}
+   * or {@code addAll} operations.
+   */
+  public Set<Map.Entry<K, V>> entrySet() {
+    Set<Map.Entry<K, V>> es = entrySet;
+    return es != null ? es : (entrySet = new EntrySet());
+  }
+
+  private class EntrySet extends AbstractSet<Map.Entry<K, V>> {
+    public Iterator<Map.Entry<K, V>> iterator() {
+      return new EntryIterator();
+    }
+
+    public boolean contains(Object o) {
+      if (!(o instanceof Map.Entry)) return false;
+      Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+      Entry<K, V> candidate = getEntry(e.getKey());
+      return candidate != null && candidate.equals(e);
+    }
+
+    public boolean remove(Object o) {
+      return removeMapping(o);
+    }
+
+    public int size() {
+      return WeakIdentityHashMap.this.size();
+    }
+
+    public void clear() {
+      WeakIdentityHashMap.this.clear();
+    }
+
+    private List<Map.Entry<K, V>> deepCopy() {
+      List<Map.Entry<K, V>> list = new ArrayList<>(size());
+      for (Map.Entry<K, V> e : this) list.add(new AbstractMap.SimpleEntry<>(e));
+      return list;
+    }
+
+    public Object[] toArray() {
+      return deepCopy().toArray();
+    }
+
+    public <T> T[] toArray(T[] a) {
+      return deepCopy().toArray(a);
+    }
+
+    public Spliterator<Map.Entry<K, V>> spliterator() {
+      return new EntrySpliterator<>(WeakIdentityHashMap.this, 0, -1, 0, 0);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void forEach(BiConsumer<? super K, ? super V> action) {
+    Objects.requireNonNull(action);
+    int expectedModCount = modCount;
+
+    Entry<K, V>[] tab = getTable();
+    for (Entry<K, V> entry : tab) {
+      while (entry != null) {
+        Object key = entry.get();
+        if (key != null) {
+          action.accept((K) unmaskNull(key), entry.value);
+        }
+        entry = entry.next;
+
+        if (expectedModCount != modCount) {
+          throw new ConcurrentModificationException();
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+    Objects.requireNonNull(function);
+    int expectedModCount = modCount;
+
+    Entry<K, V>[] tab = getTable();
+    ;
+    for (Entry<K, V> entry : tab) {
+      while (entry != null) {
+        Object key = entry.get();
+        if (key != null) {
+          entry.value = function.apply((K) unmaskNull(key), entry.value);
+        }
+        entry = entry.next;
+
+        if (expectedModCount != modCount) {
+          throw new ConcurrentModificationException();
+        }
+      }
+    }
+  }
+
+  /** Similar form as other hash Spliterators, but skips dead elements. */
+  static class WeakHashMapSpliterator<K, V> {
+    final WeakIdentityHashMap<K, V> map;
+    Entry<K, V> current; // current node
+    int index; // current index, modified on advance/split
+    int fence; // -1 until first use; then one past last index
+    int est; // size estimate
+    int expectedModCount; // for comodification checks
+
+    WeakHashMapSpliterator(
+        WeakIdentityHashMap<K, V> m, int origin, int fence, int est, int expectedModCount) {
+      this.map = m;
+      this.index = origin;
+      this.fence = fence;
+      this.est = est;
+      this.expectedModCount = expectedModCount;
+    }
+
+    final int getFence() { // initialize fence and size on first use
+      int hi;
+      if ((hi = fence) < 0) {
+        WeakIdentityHashMap<K, V> m = map;
+        est = m.size();
+        expectedModCount = m.modCount;
+        hi = fence = m.table.length;
+      }
+      return hi;
+    }
+
+    public final long estimateSize() {
+      getFence(); // force init
+      return (long) est;
+    }
+  }
+
+  static final class KeySpliterator<K, V> extends WeakHashMapSpliterator<K, V>
+      implements Spliterator<K> {
+    KeySpliterator(
+        WeakIdentityHashMap<K, V> m, int origin, int fence, int est, int expectedModCount) {
+      super(m, origin, fence, est, expectedModCount);
+    }
+
+    public KeySpliterator<K, V> trySplit() {
+      int hi = getFence(), lo = index, mid = (lo + hi) >>> 1;
+      return (lo >= mid)
+          ? null
+          : new KeySpliterator<>(map, lo, index = mid, est >>>= 1, expectedModCount);
+    }
+
+    public void forEachRemaining(Consumer<? super K> action) {
+      int i, hi, mc;
+      if (action == null) throw new NullPointerException();
+      WeakIdentityHashMap<K, V> m = map;
+      Entry<K, V>[] tab = m.table;
+      if ((hi = fence) < 0) {
+        mc = expectedModCount = m.modCount;
+        hi = fence = tab.length;
+      } else mc = expectedModCount;
+      if (tab.length >= hi && (i = index) >= 0 && (i < (index = hi) || current != null)) {
+        Entry<K, V> p = current;
+        current = null; // exhaust
+        do {
+          if (p == null) p = tab[i++];
+          else {
+            Object x = p.get();
+            p = p.next;
+            if (x != null) {
+              @SuppressWarnings("unchecked")
+              K k = (K) unmaskNull(x);
+              action.accept(k);
+            }
+          }
+        } while (p != null || i < hi);
+      }
+      if (m.modCount != mc) throw new ConcurrentModificationException();
+    }
+
+    public boolean tryAdvance(Consumer<? super K> action) {
+      int hi;
+      if (action == null) throw new NullPointerException();
+      Entry<K, V>[] tab = map.table;
+      if (tab.length >= (hi = getFence()) && index >= 0) {
+        while (current != null || index < hi) {
+          if (current == null) current = tab[index++];
+          else {
+            Object x = current.get();
+            current = current.next;
+            if (x != null) {
+              @SuppressWarnings("unchecked")
+              K k = (K) unmaskNull(x);
+              action.accept(k);
+              if (map.modCount != expectedModCount) throw new ConcurrentModificationException();
+              return true;
+            }
+          }
+        }
+      }
+      return false;
+    }
+
+    public int characteristics() {
+      return Spliterator.DISTINCT;
+    }
+  }
+
+  static final class ValueSpliterator<K, V> extends WeakHashMapSpliterator<K, V>
+      implements Spliterator<V> {
+    ValueSpliterator(
+        WeakIdentityHashMap<K, V> m, int origin, int fence, int est, int expectedModCount) {
+      super(m, origin, fence, est, expectedModCount);
+    }
+
+    public ValueSpliterator<K, V> trySplit() {
+      int hi = getFence(), lo = index, mid = (lo + hi) >>> 1;
+      return (lo >= mid)
+          ? null
+          : new ValueSpliterator<>(map, lo, index = mid, est >>>= 1, expectedModCount);
+    }
+
+    public void forEachRemaining(Consumer<? super V> action) {
+      int i, hi, mc;
+      if (action == null) throw new NullPointerException();
+      WeakIdentityHashMap<K, V> m = map;
+      Entry<K, V>[] tab = m.table;
+      if ((hi = fence) < 0) {
+        mc = expectedModCount = m.modCount;
+        hi = fence = tab.length;
+      } else mc = expectedModCount;
+      if (tab.length >= hi && (i = index) >= 0 && (i < (index = hi) || current != null)) {
+        Entry<K, V> p = current;
+        current = null; // exhaust
+        do {
+          if (p == null) p = tab[i++];
+          else {
+            Object x = p.get();
+            V v = p.value;
+            p = p.next;
+            if (x != null) action.accept(v);
+          }
+        } while (p != null || i < hi);
+      }
+      if (m.modCount != mc) throw new ConcurrentModificationException();
+    }
+
+    public boolean tryAdvance(Consumer<? super V> action) {
+      int hi;
+      if (action == null) throw new NullPointerException();
+      Entry<K, V>[] tab = map.table;
+      if (tab.length >= (hi = getFence()) && index >= 0) {
+        while (current != null || index < hi) {
+          if (current == null) current = tab[index++];
+          else {
+            Object x = current.get();
+            V v = current.value;
+            current = current.next;
+            if (x != null) {
+              action.accept(v);
+              if (map.modCount != expectedModCount) throw new ConcurrentModificationException();
+              return true;
+            }
+          }
+        }
+      }
+      return false;
+    }
+
+    public int characteristics() {
+      return 0;
+    }
+  }
+
+  static final class EntrySpliterator<K, V> extends WeakHashMapSpliterator<K, V>
+      implements Spliterator<Map.Entry<K, V>> {
+    EntrySpliterator(
+        WeakIdentityHashMap<K, V> m, int origin, int fence, int est, int expectedModCount) {
+      super(m, origin, fence, est, expectedModCount);
+    }
+
+    public EntrySpliterator<K, V> trySplit() {
+      int hi = getFence(), lo = index, mid = (lo + hi) >>> 1;
+      return (lo >= mid)
+          ? null
+          : new EntrySpliterator<>(map, lo, index = mid, est >>>= 1, expectedModCount);
+    }
+
+    public void forEachRemaining(Consumer<? super Map.Entry<K, V>> action) {
+      int i, hi, mc;
+      if (action == null) throw new NullPointerException();
+      WeakIdentityHashMap<K, V> m = map;
+      Entry<K, V>[] tab = m.table;
+      if ((hi = fence) < 0) {
+        mc = expectedModCount = m.modCount;
+        hi = fence = tab.length;
+      } else mc = expectedModCount;
+      if (tab.length >= hi && (i = index) >= 0 && (i < (index = hi) || current != null)) {
+        Entry<K, V> p = current;
+        current = null; // exhaust
+        do {
+          if (p == null) p = tab[i++];
+          else {
+            Object x = p.get();
+            V v = p.value;
+            p = p.next;
+            if (x != null) {
+              @SuppressWarnings("unchecked")
+              K k = (K) unmaskNull(x);
+              action.accept(new AbstractMap.SimpleImmutableEntry<>(k, v));
+            }
+          }
+        } while (p != null || i < hi);
+      }
+      if (m.modCount != mc) throw new ConcurrentModificationException();
+    }
+
+    public boolean tryAdvance(Consumer<? super Map.Entry<K, V>> action) {
+      int hi;
+      if (action == null) throw new NullPointerException();
+      Entry<K, V>[] tab = map.table;
+      if (tab.length >= (hi = getFence()) && index >= 0) {
+        while (current != null || index < hi) {
+          if (current == null) current = tab[index++];
+          else {
+            Object x = current.get();
+            V v = current.value;
+            current = current.next;
+            if (x != null) {
+              @SuppressWarnings("unchecked")
+              K k = (K) unmaskNull(x);
+              action.accept(new AbstractMap.SimpleImmutableEntry<>(k, v));
+              if (map.modCount != expectedModCount) throw new ConcurrentModificationException();
+              return true;
+            }
+          }
+        }
+      }
+      return false;
+    }
+
+    public int characteristics() {
+      return Spliterator.DISTINCT;
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -42,6 +42,7 @@ import com.datadog.debugger.util.MoshiHelper;
 import com.datadog.debugger.util.MoshiSnapshotTestHelper;
 import com.datadog.debugger.util.SerializerWithLimits;
 import com.datadog.debugger.util.TestSnapshotListener;
+import com.datadog.debugger.util.TestTraceInterceptor;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
@@ -2107,8 +2108,7 @@ public class CapturedSnapshotTest {
 
     CoreTracer tracer = CoreTracer.builder().build();
     TracerInstaller.forceInstallGlobalTracer(tracer);
-    SpanDecorationProbeInstrumentationTest.TestTraceInterceptor traceInterceptor =
-        new SpanDecorationProbeInstrumentationTest.TestTraceInterceptor();
+    TestTraceInterceptor traceInterceptor = new TestTraceInterceptor();
     tracer.addTraceInterceptor(traceInterceptor);
     try {
       TestSnapshotListener snapshotListener = installProbes(CLASS_NAME, configuration);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -28,10 +28,10 @@ import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.sink.Snapshot;
+import com.datadog.debugger.util.TestTraceInterceptor;
 import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
 import datadog.trace.api.interceptor.MutableSpan;
-import datadog.trace.api.interceptor.TraceInterceptor;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.MethodLocation;
@@ -41,9 +41,7 @@ import datadog.trace.bootstrap.debugger.util.Redaction;
 import datadog.trace.core.CoreTracer;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import org.joor.Reflect;
 import org.junit.jupiter.api.AfterEach;
@@ -665,38 +663,5 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
       }
     }
     return null;
-  }
-
-  static class TestTraceInterceptor implements TraceInterceptor {
-    private Collection<? extends MutableSpan> currentTrace;
-    private List<List<? extends MutableSpan>> allTraces = new ArrayList<>();
-
-    @Override
-    public Collection<? extends MutableSpan> onTraceComplete(
-        Collection<? extends MutableSpan> trace) {
-      currentTrace = trace;
-      allTraces.add(new ArrayList<>(trace));
-      return trace;
-    }
-
-    @Override
-    public int priority() {
-      return 0;
-    }
-
-    public Collection<? extends MutableSpan> getTrace() {
-      return currentTrace;
-    }
-
-    public MutableSpan getFirstSpan() {
-      if (currentTrace == null) {
-        return null;
-      }
-      return currentTrace.iterator().next();
-    }
-
-    public List<List<? extends MutableSpan>> getAllTraces() {
-      return allTraces;
-    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -1,30 +1,228 @@
 package com.datadog.debugger.exception;
 
+import static com.datadog.debugger.exception.DefaultExceptionDebugger.SNAPSHOT_ID_TAG_FMT;
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.datadog.debugger.agent.ConfigurationAcceptor;
 import com.datadog.debugger.agent.ConfigurationUpdater;
+import com.datadog.debugger.agent.DebuggerAgentHelper;
+import com.datadog.debugger.probe.ExceptionProbe;
+import com.datadog.debugger.sink.ProbeStatusSink;
+import com.datadog.debugger.sink.Snapshot;
 import com.datadog.debugger.util.ClassNameFiltering;
+import com.datadog.debugger.util.ExceptionHelper;
+import com.datadog.debugger.util.TestSnapshotListener;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.MethodLocation;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class DefaultExceptionDebuggerTest {
 
+  private ClassNameFiltering classNameFiltering;
+  private ConfigurationUpdater configurationUpdater;
+  private DefaultExceptionDebugger exceptionDebugger;
+  private TestSnapshotListener listener;
+
+  @BeforeEach
+  public void setUp() {
+    configurationUpdater = mock(ConfigurationUpdater.class);
+    classNameFiltering = new ClassNameFiltering(emptyList());
+    exceptionDebugger = new DefaultExceptionDebugger(configurationUpdater, classNameFiltering);
+    listener = new TestSnapshotListener(createConfig(), mock(ProbeStatusSink.class));
+    DebuggerAgentHelper.injectSink(listener);
+  }
+
   @Test
-  public void test() {
-    ClassNameFiltering classNameFiltering = new ClassNameFiltering(emptyList());
-    ConfigurationUpdater configurationUpdater = mock(ConfigurationUpdater.class);
-    DefaultExceptionDebugger exceptionDebugger =
-        new DefaultExceptionDebugger(configurationUpdater, classNameFiltering);
+  public void simpleException() {
     RuntimeException exception = new RuntimeException("test");
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
-    exceptionDebugger.handleException(exception);
-    exceptionDebugger.handleException(exception);
+    AgentSpan span = mock(AgentSpan.class);
+    exceptionDebugger.handleException(exception, span);
+    exceptionDebugger.handleException(exception, span);
     assertTrue(exceptionDebugger.getExceptionProbeManager().isAlreadyInstrumented(fingerprint));
     verify(configurationUpdater).accept(eq(ConfigurationAcceptor.Source.EXCEPTION), any());
+  }
+
+  @Test
+  public void nestedException() {
+    RuntimeException exception = createNestException();
+    AgentSpan span = mock(AgentSpan.class);
+    Map<String, String> tags = new HashMap<>();
+    doAnswer(
+            invocationOnMock -> {
+              Object[] args = invocationOnMock.getArguments();
+              String key = (String) args[0];
+              String value = (String) args[1];
+              tags.put(key, value);
+              return null;
+            })
+        .when(span)
+        .setTag(anyString(), anyString());
+    exceptionDebugger.handleException(exception, span);
+    generateSnapshots(exception);
+    exception.printStackTrace();
+    exceptionDebugger.handleException(exception, span);
+    ExceptionProbeManager.ThrowableState state =
+        exceptionDebugger
+            .getExceptionProbeManager()
+            .getSateByThrowable(ExceptionHelper.getInnerMostThrowable(exception));
+    assertEquals(
+        state.getExceptionId(), tags.get(DefaultExceptionDebugger.DD_DEBUG_ERROR_EXCEPTION_ID));
+    Map<String, Snapshot> snapshotMap =
+        listener.snapshots.stream().collect(toMap(Snapshot::getId, Function.identity()));
+    List<String> lines = parseStackTrace(exception);
+    int expectedFrameIndex =
+        findLine(
+            lines,
+            "com.datadog.debugger.exception.DefaultExceptionDebuggerTest.createNestException");
+    assertSnapshot(
+        tags,
+        snapshotMap,
+        expectedFrameIndex,
+        "com.datadog.debugger.exception.DefaultExceptionDebuggerTest",
+        "createNestException");
+    expectedFrameIndex =
+        findLine(
+            lines, "com.datadog.debugger.exception.DefaultExceptionDebuggerTest.nestedException");
+    assertSnapshot(
+        tags,
+        snapshotMap,
+        expectedFrameIndex,
+        "com.datadog.debugger.exception.DefaultExceptionDebuggerTest",
+        "nestedException");
+    expectedFrameIndex =
+        findLine(
+            lines,
+            "com.datadog.debugger.exception.DefaultExceptionDebuggerTest.createTest1Exception");
+    assertSnapshot(
+        tags,
+        snapshotMap,
+        expectedFrameIndex,
+        "com.datadog.debugger.exception.DefaultExceptionDebuggerTest",
+        "createTest1Exception");
+  }
+
+  private static int findLine(List<String> lines, String str) {
+    for (int i = 0; i < lines.size(); i++) {
+      if (lines.get(i).contains(str)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static List<String> parseStackTrace(RuntimeException exception) {
+    StringWriter writer = new StringWriter();
+    exception.printStackTrace(new PrintWriter(writer));
+    writer.flush();
+    BufferedReader reader = new BufferedReader(new StringReader(writer.toString()));
+    List<String> results = new ArrayList<>();
+    try {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        results.add(line);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return results;
+  }
+
+  private static void assertSnapshot(
+      Map<String, String> tags,
+      Map<String, Snapshot> snapshotMap,
+      int frameIndex,
+      String className,
+      String methodName) {
+    String snapshotId = tags.get(String.format(SNAPSHOT_ID_TAG_FMT, frameIndex));
+    Snapshot snapshot = snapshotMap.get(snapshotId);
+    assertEquals(className, snapshot.getProbe().getLocation().getType());
+    assertEquals(methodName, snapshot.getProbe().getLocation().getMethod());
+  }
+
+  private void generateSnapshots(RuntimeException exception) {
+    BinaryOperator<ExceptionProbe> dropMerger = (oldValue, newValue) -> oldValue;
+    Map<String, ExceptionProbe> probesByLocation =
+        exceptionDebugger.getExceptionProbeManager().getProbes().stream()
+            .collect(
+                toMap(
+                    probe ->
+                        probe.getWhere().getTypeName()
+                            + "::"
+                            + probe.getWhere().getMethodName()
+                            + ":"
+                            + probe.getWhere().getLines()[0],
+                    Function.identity(),
+                    dropMerger));
+    Throwable innerMost = ExceptionHelper.getInnerMostThrowable(exception);
+    for (StackTraceElement element : innerMost.getStackTrace()) {
+      ExceptionProbe exceptionProbe =
+          probesByLocation.get(
+              element.getClassName()
+                  + "::"
+                  + element.getMethodName()
+                  + ":"
+                  + element.getLineNumber());
+      if (exceptionProbe == null) {
+        continue;
+      }
+      exceptionProbe.buildLocation(null);
+      CapturedContext capturedContext = new CapturedContext();
+      capturedContext.addThrowable(exception);
+      capturedContext.evaluate(
+          exceptionProbe.getProbeId().getEncodedId(),
+          exceptionProbe,
+          "",
+          System.currentTimeMillis(),
+          MethodLocation.EXIT);
+      exceptionProbe.commit(CapturedContext.EMPTY_CAPTURING_CONTEXT, capturedContext, emptyList());
+    }
+  }
+
+  private RuntimeException createNestException() {
+    return new RuntimeException("test3", createTest2Exception(createTest1Exception()));
+  }
+
+  private RuntimeException createTest1Exception() {
+    return new RuntimeException("test1");
+  }
+
+  private RuntimeException createTest2Exception(Throwable cause) {
+    return new RuntimeException("test2", cause);
+  }
+
+  private static Config createConfig() {
+    Config config = mock(Config.class);
+    when(config.isDebuggerEnabled()).thenReturn(true);
+    when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
+    when(config.isDebuggerVerifyByteCode()).thenReturn(true);
+    when(config.getFinalDebuggerSnapshotUrl())
+        .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
+    when(config.getDebuggerUploadBatchSize()).thenReturn(100);
+    return config;
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -27,6 +27,7 @@ import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
 import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.debugger.ProbeLocation;
 import datadog.trace.core.CoreTracer;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
@@ -100,6 +101,9 @@ public class ExceptionProbeInstrumentationTest {
     assertProbeId(probeIdsByMethodName, "processWithException", snapshot0.getProbe().getId());
     assertEquals("oops", snapshot0.getCaptures().getReturn().getCapturedThrowable().getMessage());
     assertTrue(snapshot0.getCaptures().getReturn().getLocals().containsKey("@exception"));
+    ProbeLocation location = snapshot0.getProbe().getLocation();
+    assertEquals(
+        location.getType() + "." + location.getMethod(), snapshot0.getStack().get(0).getFunction());
     MutableSpan span = traceInterceptor.getFirstSpan();
     assertEquals(snapshot0.getExceptionId(), span.getTags().get(DD_DEBUG_ERROR_EXCEPTION_ID));
     assertEquals(Boolean.TRUE, span.getTags().get(ERROR_DEBUG_INFO_CAPTURED));

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -1,6 +1,9 @@
 package com.datadog.debugger.exception;
 
 import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CONFIG;
+import static com.datadog.debugger.exception.DefaultExceptionDebugger.DD_DEBUG_ERROR_EXCEPTION_ID;
+import static com.datadog.debugger.exception.DefaultExceptionDebugger.ERROR_DEBUG_INFO_CAPTURED;
+import static com.datadog.debugger.exception.DefaultExceptionDebugger.SNAPSHOT_ID_TAG_FMT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -19,8 +22,10 @@ import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.sink.Snapshot;
 import com.datadog.debugger.util.ClassNameFiltering;
 import com.datadog.debugger.util.TestSnapshotListener;
+import com.datadog.debugger.util.TestTraceInterceptor;
 import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
+import datadog.trace.api.interceptor.MutableSpan;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.core.CoreTracer;
 import java.lang.instrument.ClassFileTransformer;
@@ -38,6 +43,7 @@ import org.junit.jupiter.api.Test;
 
 public class ExceptionProbeInstrumentationTest {
   private final Instrumentation instr = ByteBuddyAgent.install();
+  private final TestTraceInterceptor traceInterceptor = new TestTraceInterceptor();
   private ClassFileTransformer currentTransformer;
   private final ClassNameFiltering classNameFiltering =
       new ClassNameFiltering(
@@ -52,6 +58,7 @@ public class ExceptionProbeInstrumentationTest {
   public void before() {
     CoreTracer tracer = CoreTracer.builder().build();
     TracerInstaller.forceInstallGlobalTracer(tracer);
+    tracer.addTraceInterceptor(traceInterceptor);
   }
 
   @AfterEach
@@ -88,15 +95,15 @@ public class ExceptionProbeInstrumentationTest {
     callMethodThrowingRuntimeException(testClass); // generate snapshots
     Map<String, Set<String>> probeIdsByMethodName =
         extractProbeIdsByMethodName(exceptionProbeManager);
-    assertEquals(2, listener.snapshots.size());
+    assertEquals(1, listener.snapshots.size());
     Snapshot snapshot0 = listener.snapshots.get(0);
     assertProbeId(probeIdsByMethodName, "processWithException", snapshot0.getProbe().getId());
     assertEquals("oops", snapshot0.getCaptures().getReturn().getCapturedThrowable().getMessage());
     assertTrue(snapshot0.getCaptures().getReturn().getLocals().containsKey("@exception"));
-    Snapshot snapshot1 = listener.snapshots.get(1);
-    assertProbeId(probeIdsByMethodName, "main", snapshot1.getProbe().getId());
-    assertEquals("oops", snapshot1.getCaptures().getReturn().getCapturedThrowable().getMessage());
-    assertTrue(snapshot1.getCaptures().getReturn().getLocals().containsKey("@exception"));
+    MutableSpan span = traceInterceptor.getFirstSpan();
+    assertEquals(snapshot0.getExceptionId(), span.getTags().get(DD_DEBUG_ERROR_EXCEPTION_ID));
+    assertEquals(Boolean.TRUE, span.getTags().get(ERROR_DEBUG_INFO_CAPTURED));
+    assertEquals(snapshot0.getId(), span.getTags().get(String.format(SNAPSHOT_ID_TAG_FMT, 1)));
   }
 
   @Test
@@ -107,32 +114,35 @@ public class ExceptionProbeInstrumentationTest {
         setupExceptionDebugging(config, exceptionProbeManager, classNameFiltering);
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
-    callMethodThrowingRuntimeException(testClass); // instrument RuntimeException  stacktrace
+    // instrument RuntimeException stacktrace
+    callMethodThrowingRuntimeException(testClass);
     assertEquals(2, exceptionProbeManager.getProbes().size());
-    callMethodThrowingIllegalArgException(
-        testClass); // instrument IllegalArgumentException stacktrace
+    // instrument IllegalArgumentException stacktrace
+    callMethodThrowingIllegalArgException(testClass);
     assertEquals(4, exceptionProbeManager.getProbes().size());
     Map<String, Set<String>> probeIdsByMethodName =
         extractProbeIdsByMethodName(exceptionProbeManager);
-    // snapshot  generated for main method when leaving it with last uncaught exception
-    // and after registering the Illegal exception into ExceptionProbeManager
-    assertEquals(1, listener.snapshots.size());
-    listener.snapshots.clear();
-    callMethodThrowingRuntimeException(testClass); // generate snapshots RuntimeException
-    callMethodThrowingIllegalArgException(testClass); // generate snapshots IllegalArgumentException
-    assertEquals(4, listener.snapshots.size());
+    // clear traces from instrumenting calls
+    traceInterceptor.getAllTraces().clear();
+    // generate snapshots RuntimeException
+    callMethodThrowingRuntimeException(testClass);
+    // generate snapshots IllegalArgumentException
+    callMethodThrowingIllegalArgException(testClass);
+    assertEquals(2, listener.snapshots.size());
     Snapshot snapshot0 = listener.snapshots.get(0);
     assertProbeId(probeIdsByMethodName, "processWithException", snapshot0.getProbe().getId());
     assertExceptionMsg("oops", snapshot0);
     Snapshot snapshot1 = listener.snapshots.get(1);
-    assertProbeId(probeIdsByMethodName, "main", snapshot1.getProbe().getId());
-    assertExceptionMsg("oops", snapshot1);
-    Snapshot snapshot2 = listener.snapshots.get(2);
-    assertProbeId(probeIdsByMethodName, "processWithException", snapshot2.getProbe().getId());
-    assertExceptionMsg("illegal argument", snapshot2);
-    Snapshot snapshot3 = listener.snapshots.get(3);
-    assertProbeId(probeIdsByMethodName, "main", snapshot3.getProbe().getId());
-    assertExceptionMsg("illegal argument", snapshot3);
+    assertProbeId(probeIdsByMethodName, "processWithException", snapshot1.getProbe().getId());
+    assertExceptionMsg("illegal argument", snapshot1);
+    MutableSpan span0 = traceInterceptor.getAllTraces().get(0).get(0);
+    assertEquals(snapshot0.getExceptionId(), span0.getTags().get(DD_DEBUG_ERROR_EXCEPTION_ID));
+    assertEquals(Boolean.TRUE, span0.getTags().get(ERROR_DEBUG_INFO_CAPTURED));
+    assertEquals(snapshot0.getId(), span0.getTags().get(String.format(SNAPSHOT_ID_TAG_FMT, 1)));
+    MutableSpan span1 = traceInterceptor.getAllTraces().get(1).get(0);
+    assertEquals(snapshot1.getExceptionId(), span1.getTags().get(DD_DEBUG_ERROR_EXCEPTION_ID));
+    assertEquals(Boolean.TRUE, span1.getTags().get(ERROR_DEBUG_INFO_CAPTURED));
+    assertEquals(snapshot1.getId(), span1.getTags().get(String.format(SNAPSHOT_ID_TAG_FMT, 1)));
   }
 
   private static void assertExceptionMsg(String expectedMsg, Snapshot snapshot) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
@@ -78,6 +78,80 @@ public class ExceptionHelperTest {
     assertFalse(strStackTrace.contains("\r"));
   }
 
+  @Test
+  public void innerMostException() {
+    Exception ex = new RuntimeException("test1");
+    Throwable innerMost = ExceptionHelper.getInnerMostThrowable(ex);
+    assertEquals(ex, innerMost);
+    Exception nested = new RuntimeException("test3", new RuntimeException("test2", ex));
+    innerMost = ExceptionHelper.getInnerMostThrowable(nested);
+    assertEquals(ex, innerMost);
+  }
+
+  @Test
+  public void flattenStackTrace() {
+    Throwable simpleException =
+        new MockException(
+            "oops!",
+            new StackTraceElement[] {
+              new StackTraceElement("MyClass1", "myMethod1", "file1.java", 1)
+            });
+    Throwable nestedException =
+        new MockException(
+            "oops!",
+            new StackTraceElement[] {
+              new StackTraceElement("MyClass2", "myMethod2", "file2.java", 2)
+            },
+            simpleException);
+    StackTraceElement[] stack = ExceptionHelper.flattenStackTrace(simpleException);
+    assertEquals(2, stack.length); // message + frame
+    stack = ExceptionHelper.flattenStackTrace(nestedException);
+    assertEquals(4, stack.length); // message + frame + message + frame
+  }
+
+  @Test
+  public void createThrowableMapping() {
+    Throwable nestedException = createNestException();
+    Throwable innerMostThrowable = ExceptionHelper.getInnerMostThrowable(nestedException);
+    int[] mapping = ExceptionHelper.createThrowableMapping(innerMostThrowable, nestedException);
+    StackTraceElement[] flattenedTrace = ExceptionHelper.flattenStackTrace(nestedException);
+    for (int i = 0; i < mapping.length; i++) {
+      assertEquals(
+          flattenedTrace[mapping[i]].getClassName(),
+          innerMostThrowable.getStackTrace()[i].getClassName());
+    }
+  }
+
+  private RuntimeException createNestException() {
+    return new RuntimeException("test3", createTest2Exception(createTest1Exception()));
+  }
+
+  private RuntimeException createTest1Exception() {
+    return new RuntimeException("test1");
+  }
+
+  private RuntimeException createTest2Exception(Throwable cause) {
+    return new RuntimeException("test2", cause);
+  }
+
+  private static class MockException extends Exception {
+    private final StackTraceElement[] stackTrace;
+
+    public MockException(String message, StackTraceElement[] stackTrace) {
+      this(message, stackTrace, null);
+    }
+
+    public MockException(String message, StackTraceElement[] stackTrace, Throwable cause) {
+      super(message, cause);
+      this.stackTrace = stackTrace;
+    }
+
+    @Override
+    public StackTraceElement[] getStackTrace() {
+      return stackTrace;
+    }
+  }
+
   private Object logDebug(InvocationOnMock invocation) {
     Object[] args = invocation.getArguments();
     assertEquals(4, args.length);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TestTraceInterceptor.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TestTraceInterceptor.java
@@ -1,0 +1,40 @@
+package com.datadog.debugger.util;
+
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.TraceInterceptor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class TestTraceInterceptor implements TraceInterceptor {
+  private Collection<? extends MutableSpan> currentTrace;
+  private List<List<? extends MutableSpan>> allTraces = new ArrayList<>();
+
+  @Override
+  public Collection<? extends MutableSpan> onTraceComplete(
+      Collection<? extends MutableSpan> trace) {
+    currentTrace = trace;
+    allTraces.add(new ArrayList<>(trace));
+    return trace;
+  }
+
+  @Override
+  public int priority() {
+    return 0;
+  }
+
+  public Collection<? extends MutableSpan> getTrace() {
+    return currentTrace;
+  }
+
+  public MutableSpan getFirstSpan() {
+    if (currentTrace == null) {
+      return null;
+    }
+    return currentTrace.iterator().next();
+  }
+
+  public List<List<? extends MutableSpan>> getAllTraces() {
+    return allTraces;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/WeakIdentityHashMapTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/WeakIdentityHashMapTest.java
@@ -1,0 +1,46 @@
+package com.datadog.debugger.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.concurrent.locks.LockSupport;
+import org.junit.jupiter.api.Test;
+
+class WeakIdentityHashMapTest {
+
+  @Test
+  public void referenceEq() {
+    WeakIdentityHashMap<Object, Object> map = new WeakIdentityHashMap<>();
+    Object key = new BadClass();
+    Object value = new Object();
+    map.put(key, value);
+    assertTrue(map.containsKey(key));
+    assertEquals(value, map.get(key));
+  }
+
+  @Test
+  public void weakKey() {
+    WeakIdentityHashMap<Object, Object> map = new WeakIdentityHashMap<>();
+    map.put(new BadClass(), new Object());
+    System.gc(); // clear weak reference
+    int count = 0;
+    // size method will trigger a check on the reference queue and eventually purge the stale entry
+    while (map.size() > 0 && count < 1000) {
+      LockSupport.parkNanos(Duration.ofMillis(1).toNanos());
+      count++;
+    }
+    assertEquals(0, map.size());
+  }
+
+  static class BadClass extends Object {
+    @Override
+    public int hashCode() {
+      return 1;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return false;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -366,7 +366,7 @@ public class DDSpan
       setTag(DDTags.ERROR_MSG, message);
       setTag(DDTags.ERROR_TYPE, error.getClass().getName());
       if (isLocalRootSpan()) {
-        DebuggerContext.handleException(error);
+        DebuggerContext.handleException(error, this);
       }
     }
     return this;

--- a/gradle/spotbugFilters/exclude.xml
+++ b/gradle/spotbugFilters/exclude.xml
@@ -2,6 +2,7 @@
 <FindBugsFilter>
   <Match>
     <Or>
+      <Class name="~com.datadog.debugger.util.WeakIdentityHashMap.*" />
       <Package name="io.sqreen.testapp.sampleapp" />
       <Package name="datadog.trace.bootstrap.instrumentation.decorator.http.utils" />
       <!-- these are auto-generated -->


### PR DESCRIPTION
# What Does This Do
Collect snapshot generated by an exception probe frame in ThrowableState class that is generated by exception instance. Those exception instances are tracked by a WeakIdentityHashMap in ExceptionProbeManager. Key is directly the exception instance. The Weak nature of the hash map allow to remove the entry upon the exception is no longer reachable.

When unwinding, once the exception reaches the frame level where it is added to the span (DDSpan::addThrowable) we process all the collected snapshots and and add tags with frame index for each snapshot id. The frame index is computed based on the generated mapping between original exception (the one added to the span) and the inner most exception which was used to generated exception probes and snapshots.

An instrumentation bug is also fixed:
casting when calling CapturedValue.of is not necessary as the method is accepting any objects. On the other side, some return types could not be used as cast target because not visible from the current frame. inherited field with a type not visible from the inherited class.

# Motivation
Exception debugging feature

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ