### PR TITLE
Reduce logging noise in CI Visibility

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
@@ -202,7 +202,8 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
     for (Map.Entry<Object, Object> e : systemProperties.entrySet()) {
       String propertyName = (String) e.getKey();
       Object propertyValue = e.getValue();
-      if ((propertyName.startsWith(Config.PREFIX) || propertyName.startsWith("datadog."))
+      if ((propertyName.startsWith(Config.PREFIX)
+              || propertyName.startsWith("datadog.slf4j.simpleLogger.defaultLogLevel"))
           && propertyValue != null) {
         propagatedSystemProperties.put(propertyName, propertyValue.toString());
       }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
@@ -160,7 +160,7 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
     try {
       CiVisibilitySettings settings = configurationApi.getSettings(tracerEnvironment);
       if (settings.isGitUploadRequired()) {
-        LOGGER.info("Git data upload needs to finish before remote settings can be retrieved");
+        LOGGER.debug("Git data upload needs to finish before remote settings can be retrieved");
         gitDataUploader
             .startOrObserveGitDataUpload()
             .get(config.getCiVisibilityGitUploadTimeoutMillis(), TimeUnit.MILLISECONDS);
@@ -202,7 +202,8 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
     for (Map.Entry<Object, Object> e : systemProperties.entrySet()) {
       String propertyName = (String) e.getKey();
       Object propertyValue = e.getValue();
-      if (propertyName.startsWith(Config.PREFIX) && propertyValue != null) {
+      if ((propertyName.startsWith(Config.PREFIX) || propertyName.startsWith("datadog."))
+          && propertyValue != null) {
         propagatedSystemProperties.put(propertyName, propertyValue.toString());
       }
     }
@@ -247,7 +248,7 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
           .get(config.getCiVisibilityGitUploadTimeoutMillis(), TimeUnit.MILLISECONDS);
 
       SkippableTests skippableTests = configurationApi.getSkippableTests(tracerEnvironment);
-      LOGGER.info(
+      LOGGER.debug(
           "Received {} skippable tests in total for {}",
           skippableTests.getIdentifiers().size(),
           repositoryRoot);
@@ -282,7 +283,7 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
   private Collection<TestIdentifier> getFlakyTests(TracerEnvironment tracerEnvironment) {
     try {
       Collection<TestIdentifier> flakyTests = configurationApi.getFlakyTests(tracerEnvironment);
-      LOGGER.info("Received {} flaky tests in total for {}", flakyTests.size(), repositoryRoot);
+      LOGGER.debug("Received {} flaky tests in total for {}", flakyTests.size(), repositoryRoot);
       return flakyTests;
 
     } catch (Exception e) {
@@ -297,7 +298,7 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
     try {
       Map<String, Collection<TestIdentifier>> knownTestsByModuleName =
           configurationApi.getKnownTestsByModuleName(tracerEnvironment);
-      LOGGER.info(
+      LOGGER.debug(
           "Received known tests for {} modules for {}",
           knownTestsByModuleName.size(),
           repositoryRoot);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/CoverageUtils.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/CoverageUtils.java
@@ -71,7 +71,7 @@ public abstract class CoverageUtils {
   public static void dumpCoverageReport(
       IBundleCoverage coverageBundle, RepoIndex repoIndex, String repoRoot, File reportFolder) {
     if (!reportFolder.exists() && !reportFolder.mkdirs()) {
-      LOGGER.info("Skipping report generation, could not create report dir: {}", reportFolder);
+      LOGGER.debug("Skipping report generation, could not create report dir: {}", reportFolder);
       return;
     }
     try {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
@@ -86,7 +86,7 @@ public class GitDataUploaderImpl implements GitDataUploader {
 
   private void uploadGitData() {
     try {
-      LOGGER.info("Starting git data upload, {}", gitClient);
+      LOGGER.debug("Starting git data upload, {}", gitClient);
 
       if (config.isCiVisibilityGitUnshallowEnabled()
           && !config.isCiVisibilityGitUnshallowDefer()
@@ -98,14 +98,14 @@ public class GitDataUploaderImpl implements GitDataUploader {
       String remoteUrl = gitInfo.getRepositoryURL();
       List<String> latestCommits = gitClient.getLatestCommits();
       if (latestCommits.isEmpty()) {
-        LOGGER.info("No commits in the last month, skipping git data upload");
+        LOGGER.debug("No commits in the last month, skipping git data upload");
         callback.complete(null);
         return;
       }
 
       Collection<String> commitsToSkip = gitDataApi.searchCommits(remoteUrl, latestCommits);
       if (commitsToSkip.size() == latestCommits.size()) {
-        LOGGER.info(
+        LOGGER.debug(
             "Backend already knows of the {} local commits, skipping git data upload",
             latestCommits.size());
         callback.complete(null);
@@ -130,7 +130,7 @@ public class GitDataUploaderImpl implements GitDataUploader {
 
       List<String> objectHashes = gitClient.getObjects(commitsToSkip, commitsToInclude);
       if (objectHashes.isEmpty()) {
-        LOGGER.info("No git objects to upload");
+        LOGGER.debug("No git objects to upload");
         callback.complete(null);
         return;
       }
@@ -160,7 +160,7 @@ public class GitDataUploaderImpl implements GitDataUploader {
         FileUtils.delete(packFilesDirectory);
       }
 
-      LOGGER.info("Git data upload finished");
+      LOGGER.debug("Git data upload finished");
       callback.complete(null);
 
     } catch (Exception e) {
@@ -191,7 +191,7 @@ public class GitDataUploaderImpl implements GitDataUploader {
           e);
       gitClient.unshallow(null);
     }
-    LOGGER.info("Repository unshallowing took {} ms", System.currentTimeMillis() - unshallowStart);
+    LOGGER.debug("Repository unshallowing took {} ms", System.currentTimeMillis() - unshallowStart);
   }
 
   private void waitForUploadToFinish() {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalServerRunnable.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ipc/SignalServerRunnable.java
@@ -48,7 +48,7 @@ class SignalServerRunnable implements Runnable {
         LOGGER.error("Error while executing signal server polling loop", e);
       }
     }
-    LOGGER.info("Signal server stopped");
+    LOGGER.debug("Signal server stopped");
   }
 
   private void processSelectableKeys() throws IOException {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -59,7 +59,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
   }
 
   private RepoIndex doGetIndex() {
-    log.warn("Building index of source files in {}, repo root is {}", scanRoot, repoRoot);
+    log.debug("Building index of source files in {}, repo root is {}", scanRoot, repoRoot);
 
     Path repoRootPath = toRealPath(fileSystem.getPath(repoRoot));
     Path scanRootPath = toRealPath(fileSystem.getPath(scanRoot));
@@ -80,7 +80,7 @@ public class RepoIndexBuilder implements RepoIndexProvider {
     long duration = System.currentTimeMillis() - startTime;
     RepoIndexingStats stats = repoIndexingFileVisitor.indexingStats;
     RepoIndex index = repoIndexingFileVisitor.getIndex();
-    log.info(
+    log.debug(
         "Indexing took {} ms. Files visited: {}, source files visited: {}, resource files visited: {}, source roots found: {}, root packages found: {}",
         duration,
         stats.filesVisited,


### PR DESCRIPTION
# What Does This Do
Decreases log level of `INFO` logs to `DEBUG`.
The only log statement with level `INFO` left is the one that prints CI Visibility settings when the tracer is initialised.

Also updates logic that propagates system properties from parent process (Maven/Gradle) to children processes: not only `dd.*` properties are now propagated, but also `datadog.*` properties.
This is needed to ensure that `datadog.slf4j.simpleLogger.defaultLogLevel` property is propagated from parent to children.

# Motivation
There is a CI Visibility customer complaining about the logs being too noisy.

Jira ticket: [APMS-11714]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-11714]: https://datadoghq.atlassian.net/browse/APMS-11714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ