### PR TITLE
Make Exception debugging instrumentation async

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -56,6 +56,9 @@ public class ExceptionProbeManager {
       ExceptionProbe probe = createMethodProbe(this, where);
       probes.putIfAbsent(probe.getId(), probe);
     }
+  }
+
+  void addFingerprint(String fingerprint) {
     fingerprints.add(fingerprint);
   }
 
@@ -75,10 +78,6 @@ public class ExceptionProbeManager {
   }
 
   public boolean shouldCaptureException(String fingerprint) {
-    return fingerprints.contains(fingerprint);
-  }
-
-  boolean containsFingerprint(String fingerprint) {
     return fingerprints.contains(fingerprint);
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
@@ -73,7 +73,7 @@ public class ExceptionHelper {
 
   public static StackTraceElement[] flattenStackTrace(Throwable t) {
     List<StackTraceElement> result = new ArrayList<>();
-    result.add(null); // add a stack frame representing the exception message
+    // result.add(null); // add a stack frame representing the exception message
     result.addAll(Arrays.asList(t.getStackTrace()));
     if (t.getCause() != null) {
       internalFlattenStackTrace(t.getCause(), t.getStackTrace(), result);
@@ -90,12 +90,8 @@ public class ExceptionHelper {
       m--;
       n--;
     }
-    elements.add(null); // add a stack frame representing the exception message
     for (int i = 0; i <= m; i++) {
       elements.add(trace[i]);
-    }
-    if (trace.length - 1 - m > 0) {
-      elements.add(null); // add a stack frame representing number of common frames ("... n more")
     }
     if (t.getCause() != null) {
       internalFlattenStackTrace(t.getCause(), trace, elements);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
@@ -73,7 +73,6 @@ public class ExceptionHelper {
 
   public static StackTraceElement[] flattenStackTrace(Throwable t) {
     List<StackTraceElement> result = new ArrayList<>();
-    // result.add(null); // add a stack frame representing the exception message
     result.addAll(Arrays.asList(t.getStackTrace()));
     if (t.getCause() != null) {
       internalFlattenStackTrace(t.getCause(), t.getStackTrace(), result);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -1,7 +1,7 @@
 package com.datadog.debugger.exception;
 
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.SNAPSHOT_ID_TAG_FMT;
-import static com.datadog.debugger.exception.ExceptionProbeManagerTest.waitForInstrumentation;
+import static com.datadog.debugger.util.TestHelper.assertWithTimeout;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,7 +63,9 @@ class DefaultExceptionDebuggerTest {
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     AgentSpan span = mock(AgentSpan.class);
     exceptionDebugger.handleException(exception, span);
-    waitForInstrumentation(exceptionDebugger.getExceptionProbeManager(), fingerprint);
+    assertWithTimeout(
+        () -> exceptionDebugger.getExceptionProbeManager().isAlreadyInstrumented(fingerprint),
+        Duration.ofSeconds(30));
     exceptionDebugger.handleException(exception, span);
     verify(configurationUpdater).accept(eq(ConfigurationAcceptor.Source.EXCEPTION), any());
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -4,7 +4,7 @@ import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CON
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.DD_DEBUG_ERROR_EXCEPTION_ID;
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.ERROR_DEBUG_INFO_CAPTURED;
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.SNAPSHOT_ID_TAG_FMT;
-import static com.datadog.debugger.exception.ExceptionProbeManagerTest.waitForInstrumentation;
+import static com.datadog.debugger.util.TestHelper.assertWithTimeout;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -32,6 +32,7 @@ import datadog.trace.bootstrap.debugger.ProbeLocation;
 import datadog.trace.core.CoreTracer;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
@@ -80,7 +81,8 @@ public class ExceptionProbeInstrumentationTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     String fingerprint =
         callMethodThrowingRuntimeException(testClass); // instrument exception stacktrace
-    waitForInstrumentation(exceptionProbeManager, fingerprint);
+    assertWithTimeout(
+        () -> exceptionProbeManager.isAlreadyInstrumented(fingerprint), Duration.ofSeconds(30));
     assertEquals(2, exceptionProbeManager.getProbes().size());
     callMethodNoException(testClass);
     assertEquals(0, listener.snapshots.size());
@@ -96,7 +98,8 @@ public class ExceptionProbeInstrumentationTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     String fingerprint =
         callMethodThrowingRuntimeException(testClass); // instrument exception stacktrace
-    waitForInstrumentation(exceptionProbeManager, fingerprint);
+    assertWithTimeout(
+        () -> exceptionProbeManager.isAlreadyInstrumented(fingerprint), Duration.ofSeconds(30));
     assertEquals(2, exceptionProbeManager.getProbes().size());
     callMethodThrowingRuntimeException(testClass); // generate snapshots
     Map<String, Set<String>> probeIdsByMethodName =
@@ -125,11 +128,13 @@ public class ExceptionProbeInstrumentationTest {
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     // instrument RuntimeException stacktrace
     String fingerprint0 = callMethodThrowingRuntimeException(testClass);
-    waitForInstrumentation(exceptionProbeManager, fingerprint0);
+    assertWithTimeout(
+        () -> exceptionProbeManager.isAlreadyInstrumented(fingerprint0), Duration.ofSeconds(30));
     assertEquals(2, exceptionProbeManager.getProbes().size());
     // instrument IllegalArgumentException stacktrace
     String fingerprint1 = callMethodThrowingIllegalArgException(testClass);
-    waitForInstrumentation(exceptionProbeManager, fingerprint1);
+    assertWithTimeout(
+        () -> exceptionProbeManager.isAlreadyInstrumented(fingerprint1), Duration.ofSeconds(30));
     assertEquals(4, exceptionProbeManager.getProbes().size());
     Map<String, Set<String>> probeIdsByMethodName =
         extractProbeIdsByMethodName(exceptionProbeManager);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.probe.ExceptionProbe;
 import com.datadog.debugger.util.ClassNameFiltering;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -29,7 +28,7 @@ class ExceptionProbeManagerTest {
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
 
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
-    assertEquals("ca4d9f3a1033d7262a89855f4b5cbdc225ed63c592c6cdf83fc5a88589e5fb", fingerprint);
+    assertEquals("aa4a4dd768f6ef0fcc2b39a3bdedcbe44baff2e9dd0a779228db7bd8bf58", fingerprint);
     exceptionProbeManager.createProbesForException(fingerprint, exception.getStackTrace());
     assertEquals(1, exceptionProbeManager.getProbes().size());
     ExceptionProbe exceptionProbe = exceptionProbeManager.getProbes().iterator().next();
@@ -52,20 +51,5 @@ class ExceptionProbeManagerTest {
     assertEquals("7a1e5e1bcc64ee26801d1471245eff6b6e8d7c61d0ea36fe85f3f75d79e42c", fingerprint);
     exceptionProbeManager.createProbesForException("", exception.getStackTrace());
     assertEquals(0, exceptionProbeManager.getProbes().size());
-  }
-
-  static void waitForInstrumentation(
-      ExceptionProbeManager exceptionProbeManager, String fingerprint) {
-    Duration timeout = Duration.ofSeconds(30);
-    Duration sleepTime = Duration.ofMillis(10);
-    long count = timeout.toMillis() / sleepTime.toMillis();
-    while (count-- > 0 && !exceptionProbeManager.isAlreadyInstrumented(fingerprint)) {
-      try {
-        Thread.sleep(sleepTime.toMillis());
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    assertTrue(exceptionProbeManager.isAlreadyInstrumented(fingerprint));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.probe.ExceptionProbe;
 import com.datadog.debugger.util.ClassNameFiltering;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
@@ -18,7 +19,7 @@ class ExceptionProbeManagerTest {
     RuntimeException exception = new RuntimeException("test");
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     exceptionProbeManager.createProbesForException(fingerprint, exception.getStackTrace());
-    assertTrue(exceptionProbeManager.isAlreadyInstrumented(fingerprint));
+    assertFalse(exceptionProbeManager.getProbes().isEmpty());
   }
 
   @Test
@@ -28,7 +29,7 @@ class ExceptionProbeManagerTest {
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
 
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
-    assertEquals("aa4a4dd768f6ef0fcc2b39a3bdedcbe44baff2e9dd0a779228db7bd8bf58", fingerprint);
+    assertEquals("ca4d9f3a1033d7262a89855f4b5cbdc225ed63c592c6cdf83fc5a88589e5fb", fingerprint);
     exceptionProbeManager.createProbesForException(fingerprint, exception.getStackTrace());
     assertEquals(1, exceptionProbeManager.getProbes().size());
     ExceptionProbe exceptionProbe = exceptionProbeManager.getProbes().iterator().next();
@@ -51,5 +52,20 @@ class ExceptionProbeManagerTest {
     assertEquals("7a1e5e1bcc64ee26801d1471245eff6b6e8d7c61d0ea36fe85f3f75d79e42c", fingerprint);
     exceptionProbeManager.createProbesForException("", exception.getStackTrace());
     assertEquals(0, exceptionProbeManager.getProbes().size());
+  }
+
+  static void waitForInstrumentation(
+      ExceptionProbeManager exceptionProbeManager, String fingerprint) {
+    Duration timeout = Duration.ofSeconds(30);
+    Duration sleepTime = Duration.ofMillis(10);
+    long count = timeout.toMillis() / sleepTime.toMillis();
+    while (count-- > 0 && !exceptionProbeManager.isAlreadyInstrumented(fingerprint)) {
+      try {
+        Thread.sleep(sleepTime.toMillis());
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    assertTrue(exceptionProbeManager.isAlreadyInstrumented(fingerprint));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
@@ -104,9 +104,9 @@ public class ExceptionHelperTest {
             },
             simpleException);
     StackTraceElement[] stack = ExceptionHelper.flattenStackTrace(simpleException);
-    assertEquals(2, stack.length); // message + frame
+    assertEquals(1, stack.length);
     stack = ExceptionHelper.flattenStackTrace(nestedException);
-    assertEquals(4, stack.length); // message + frame + message + frame
+    assertEquals(2, stack.length);
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TestHelper.java
@@ -1,7 +1,11 @@
 package com.datadog.debugger.util;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import datadog.trace.api.Config;
 import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
 
 public class TestHelper {
 
@@ -13,5 +17,18 @@ public class TestHelper {
     } catch (Throwable e) {
       e.printStackTrace();
     }
+  }
+
+  public static void assertWithTimeout(BooleanSupplier predicate, Duration timeout) {
+    Duration sleepTime = Duration.ofMillis(10);
+    long count = timeout.toMillis() / sleepTime.toMillis();
+    while (count-- > 0 && !predicate.getAsBoolean()) {
+      try {
+        Thread.sleep(sleepTime.toMillis());
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    assertTrue(predicate.getAsBoolean());
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -29,8 +29,7 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_SYMBOL_FORCE_UPLOAD = "internal.force.symbol.database.upload";
   public static final String DEBUGGER_SYMBOL_INCLUDES = "symbol.database.includes";
   public static final String DEBUGGER_SYMBOL_FLUSH_THRESHOLD = "symbol.database.flush.threshold";
-  public static final String DEBUGGER_EXCEPTION_ENABLED =
-      "dynamic.instrumentation.exception.enabled";
+  public static final String DEBUGGER_EXCEPTION_ENABLED = "exception.debugging.enabled";
 
   private DebuggerConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -116,6 +116,8 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(config.isRemoteConfigEnabled());
     writer.name("debugger_enabled");
     writer.value(config.isDebuggerEnabled());
+    writer.name("debugger_exception_enabled");
+    writer.value(config.isDebuggerExceptionEnabled());
     writer.name("appsec_enabled");
     writer.value(config.getAppSecActivation().toString());
     writer.name("appsec_rules_file_path");


### PR DESCRIPTION

# What Does This Do
Rename config option for exception debugging from
`DD_DYNAMIC_INSTRUMENTATION_EXCEPTION_ENABLED` to `DD_EXCEPTION_DEBUGGING_ENABLED`

Fix frame index following the change in Error Tracking UI

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ