### PR TITLE
Improve IAST metric unwrapping logic

### DIFF
--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricCollectorTest.groovy
@@ -226,8 +226,14 @@ class IastMetricCollectorTest extends DDSpecification {
     IastMetric.INSTRUMENTED_SINK   | VulnerabilityTypes.SPRING_RESPONSE // wrapped spring response
     IastMetric.EXECUTED_SINK       | VulnerabilityTypes.SPRING_RESPONSE
 
+    IastMetric.INSTRUMENTED_SINK   | VulnerabilityTypes.APPLICATION // wrapped application vuls
+    IastMetric.EXECUTED_SINK       | VulnerabilityTypes.APPLICATION
+
     IastMetric.INSTRUMENTED_SOURCE | SourceTypes.REQUEST_HEADER_NAME
     IastMetric.EXECUTED_SOURCE     | SourceTypes.REQUEST_HEADER_NAME
+
+    IastMetric.INSTRUMENTED_SOURCE | SourceTypes.KAFKA_MESSAGE // wrapped kafka sources
+    IastMetric.EXECUTED_SOURCE     | SourceTypes.KAFKA_MESSAGE
 
     IastMetric.EXECUTED_TAINTED    | null
   }


### PR DESCRIPTION
# What Does This Do
Improves the handling of wrapped metrics from two fronts:

- Removes the Function to check if a metric is wrapped that was causing unnecessary wrapped types conversion
- Removes the wrapping logic from the happy path so most tags are not affected by the wrapping 