### PR TITLE
Add CPU and memory metrics to benchmarks

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -11,7 +11,7 @@ benchmarks:
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && mkdir -p "${ARTIFACTS_DIR}"
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
-    - git clone --branch dd-trace-java/tracer-benchmarks https://github.com/DataDog/benchmarking-platform.git /platform && cd /platform
+    - git clone --branch malvarez/dd-trace-java-cpu-mem https://github.com/DataDog/benchmarking-platform.git /platform && cd /platform
     - ./steps/capture-hardware-software-info.sh
     - ./steps/run-benchmarks.sh
     - ./steps/analyze-results.sh

--- a/benchmark/load/insecure-bank/k6.js
+++ b/benchmark/load/insecure-bank/k6.js
@@ -6,7 +6,7 @@ const baseUrl = 'http://localhost:8080';
 export const options = {
   discardResponseBodies: true,
   vus: 5,
-  iterations: 40000
+  iterations: 60000
 };
 
 export default function () {

--- a/benchmark/load/petclinic/k6.js
+++ b/benchmark/load/petclinic/k6.js
@@ -6,7 +6,7 @@ const baseUrl = 'http://localhost:8080';
 export const options = {
   discardResponseBodies: true,
   vus: 5,
-  iterations: 80000
+  iterations: 100000
 };
 
 export default function () {

--- a/benchmark/utils/cpu_usage_ps.sh
+++ b/benchmark/utils/cpu_usage_ps.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu
+
+PNAME="$1"
+LOG_FILE="$2"
+
+while true ; do
+    echo ":: $(date +"%a %b %d %H:%M:%S %Z %Y")" >> $LOG_FILE
+    ps -C ${PNAME} -o %cpu,rss,pid,command >> $LOG_FILE
+    sleep 1
+done

--- a/benchmark/utils/run-k6-load-test.sh
+++ b/benchmark/utils/run-k6-load-test.sh
@@ -4,9 +4,12 @@ set -eu
 url=$1
 output=$2
 command=$3
+ps_pid=0
 exit_code=0
 
 cleanup() {
+  # stop ps commands
+  kill "${ps_pid}" 2>/dev/null
   # run the exit command
   bash -c "${command}"
   exit $exit_code
@@ -20,6 +23,9 @@ while true; do
     break
   fi
 done
+
+"${UTILS_DIR}/cpu_usage_ps.sh" java "${output}/cpu_usage.log" &
+ps_pid=$!
 
 # run the k6 benchmark and store the result as JSON
 k6 run k6.js --out "json=${output}/k6_$(date +%s).json" &>>"${output}/k6.log"


### PR DESCRIPTION
# What Does This Do
Use PS to track CPU and RSS usage during the run of the load benchmarks

# Motivation
From IAST we've noticed some regressions that do not affect latency but impacting CPU usage on the target applications. 