### PR TITLE
Fix AppSec without IAST petclinic benchmark variant

### DIFF
--- a/benchmark/load/petclinic/benchmark.json
+++ b/benchmark/load/petclinic/benchmark.json
@@ -32,7 +32,7 @@
     },
     "appsec_no_iast": {
       "env": {
-        "VARIANT": "appsec",
+        "VARIANT": "appsec_no_iast",
         "JAVA_OPTS": "-javaagent:${TRACER} -Ddd.appsec.enabled=true -Ddd.iast.enabled=false"
       }
     },


### PR DESCRIPTION
# What Does This Do
Changes the variant name for the petclinic benchmark in the scenario where AppSec starts with IAST completely disabled.