### PR TITLE
Amend the runtime version for the AOT native image only

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
+++ b/dd-java-agent/agent-profiling/profiling-uploader/src/main/java/com/datadog/profiling/uploader/ProfileUploader.java
@@ -170,8 +170,8 @@ public final class ProfileUploader {
       tagsMap.put(Tags.GIT_REPOSITORY_URL, gitInfo.getRepositoryURL());
       tagsMap.put(Tags.GIT_COMMIT_SHA, gitInfo.getCommit().getSha());
     }
-    if (Platform.isGraalVM()) {
-      tagsMap.put(DDTags.RUNTIME_VERSION_TAG, tagsMap.get(DDTags.RUNTIME_VERSION_TAG) + "-graalvm");
+    if (Platform.isNativeImage()) {
+      tagsMap.put(DDTags.RUNTIME_VERSION_TAG, tagsMap.get(DDTags.RUNTIME_VERSION_TAG) + "-aot");
     }
 
     // Comma separated tags string for V2.4 format


### PR DESCRIPTION
# What Does This Do
Restricts the runtime version augmentation to AOT native image only

# Motivation
The JIT GraalVM based JFR profiles are fully compatible with the Hotspot ones. Therefore we don't need to have this special distinguishing postfix that allows working around some GraalVM native image JFR implementation quirks in our backend.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
