### PR TITLE
fix spurious context clear when thread detached from wallclock profiling

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilingIntegration.java
@@ -32,7 +32,9 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
       new Stateful() {
         @Override
         public void close() {
-          // this implementation is stateless so nothing to do here
+          DDPROF.clearSpanContext();
+          DDPROF.clearContextValue(SPAN_NAME_INDEX);
+          DDPROF.clearContextValue(RESOURCE_NAME_INDEX);
         }
 
         @Override
@@ -60,7 +62,6 @@ public class DatadogProfilingIntegration implements ProfilingContextIntegration 
 
   @Override
   public void onDetach() {
-    clearContext();
     if (WALLCLOCK_ENABLED) {
       DDPROF.removeThread();
     }


### PR DESCRIPTION
# What Does This Do

#6261 introduced a regression by conflating detachment from wallclock profiling with clearing profiling context, but sometimes we have to detach the current thread to avoid signalling it when it goes off CPU in certain states (e.g. to workaround a JDK bug where interrupted socket connects do not reduce the timeout before resuming) but the current thread should retain its context for all purposes.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
