### PR TITLE
Support ordering of InstrumenterModules

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterIndex.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterIndex.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -256,6 +257,8 @@ final class InstrumenterIndex {
         log.error("Failed to load instrumentation module {}", moduleName, e);
       }
     }
+    // enforce module ordering (lowest-value first) before indexing
+    modules.sort(Comparator.comparing(InstrumenterModule::order));
     return modules;
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -76,6 +76,11 @@ public abstract class InstrumenterModule implements Instrumenter {
     return instrumentationNames;
   }
 
+  /** Modules with higher order values are applied <i>after</i> those with lower values. */
+  public int order() {
+    return 0;
+  }
+
   public List<Instrumenter> typeInstrumentations() {
     return singletonList(this);
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/InstrumenterIndexTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/InstrumenterIndexTest.groovy
@@ -16,8 +16,8 @@ class InstrumenterIndexTest extends DDSpecification {
     InstrumenterIndex index = InstrumenterIndex.buildIndex()
 
     then:
-    index.instrumentationCount() == 2
-    index.transformationCount() == 6
+    index.instrumentationCount() == 4
+    index.transformationCount() == 8
 
     index.instrumentationId(unknownInstrumentation) == -1
     index.transformationId(unknownTransformation) == -1
@@ -26,19 +26,28 @@ class InstrumenterIndexTest extends DDSpecification {
 
     moduleIterator.hasNext()
 
+    // module with order=-100 is applied first
+    def firstModule = moduleIterator.next()
+    firstModule.class.simpleName == 'TestIndexFirstModule'
+    firstModule.order() == -100
+    index.instrumentationId(firstModule) == 0
+
+    moduleIterator.hasNext()
+
     // multi-module declares several transformations
     def multiModule = moduleIterator.next()
-    index.instrumentationId(multiModule) == 0
+    multiModule.class.simpleName == 'TestIndexMultiModule'
+    index.instrumentationId(multiModule) == 1
 
     def multiItr = multiModule.typeInstrumentations().iterator()
     index.transformationId(unknownTransformation) == -1
-    index.transformationId(multiItr.next()) == 0
     index.transformationId(multiItr.next()) == 1
-    index.transformationId(unknownTransformation) == -1
     index.transformationId(multiItr.next()) == 2
     index.transformationId(unknownTransformation) == -1
     index.transformationId(multiItr.next()) == 3
+    index.transformationId(unknownTransformation) == -1
     index.transformationId(multiItr.next()) == 4
+    index.transformationId(multiItr.next()) == 5
     index.transformationId(unknownTransformation) == -1
     !multiItr.hasNext()
 
@@ -49,11 +58,20 @@ class InstrumenterIndexTest extends DDSpecification {
 
     // self-module just declares itself as a transformation
     def selfModule = moduleIterator.next()
-    index.instrumentationId(selfModule) == 1
+    selfModule.class.simpleName == 'TestIndexSelfModule'
+    index.instrumentationId(selfModule) == 2
 
     def selfItr = selfModule.typeInstrumentations().iterator()
-    index.transformationId(selfItr.next()) == 5
+    index.transformationId(selfItr.next()) == 6
     !selfItr.hasNext()
+
+    moduleIterator.hasNext()
+
+    // module with order=100 is applied last
+    def lastModule = moduleIterator.next()
+    lastModule.class.simpleName == 'TestIndexLastModule'
+    lastModule.order() == 100
+    index.instrumentationId(lastModule) == 3
 
     !moduleIterator.hasNext()
 

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/test/TestIndexFirstModule.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/test/TestIndexFirstModule.java
@@ -1,0 +1,14 @@
+package datadog.trace.agent.test;
+
+import datadog.trace.agent.tooling.InstrumenterModule;
+
+public class TestIndexFirstModule extends InstrumenterModule {
+  public TestIndexFirstModule() {
+    super("test-index-priority");
+  }
+
+  @Override
+  public int order() {
+    return -100; // lower-values applied first
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/test/TestIndexLastModule.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/test/TestIndexLastModule.java
@@ -1,0 +1,14 @@
+package datadog.trace.agent.test;
+
+import datadog.trace.agent.tooling.InstrumenterModule;
+
+public class TestIndexLastModule extends InstrumenterModule {
+  public TestIndexLastModule() {
+    super("test-index-priority");
+  }
+
+  @Override
+  public int order() {
+    return 100; // higher-values applied last
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/resources/META-INF/services/datadog.trace.agent.tooling.InstrumenterModule
+++ b/dd-java-agent/agent-tooling/src/test/resources/META-INF/services/datadog.trace.agent.tooling.InstrumenterModule
@@ -1,2 +1,4 @@
 datadog.trace.agent.test.TestIndexMultiModule
+datadog.trace.agent.test.TestIndexLastModule
+datadog.trace.agent.test.TestIndexFirstModule
 datadog.trace.agent.test.TestIndexSelfModule


### PR DESCRIPTION
# Motivation

Allows modules to be applied in a particular order, rather than just the order they appear in the buiild.

Note: this ordering is applied at build-time before generating the `instrumenter.index` used at runtime.

Jira ticket: [AIT-9441]

[AIT-9441]: https://datadoghq.atlassian.net/browse/AIT-9441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ