### PR TITLE
Optionally prevent undertow from setting http.route

### DIFF
--- a/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
+++ b/dd-java-agent/instrumentation/undertow/src/main/java/datadog/trace/instrumentation/undertow/UndertowDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.undertow;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.gateway.BlockResponseFunction;
 import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.ContextStore;
@@ -33,6 +34,8 @@ public class UndertowDecorator
   public static final UndertowDecorator DECORATE = new UndertowDecorator();
   public static final CharSequence UNDERTOW_REQUEST =
       UTF8BytesString.create(DECORATE.operationName());
+  public static final boolean UNDERTOW_LEGACY_TRACING =
+      Config.get().isLegacyTracingEnabled(true, "undertow");
 
   @Override
   protected String[] instrumentationNames() {

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
@@ -70,7 +70,8 @@ public final class ServletInstrumentation extends InstrumenterModule.Tracing
         String relativePath = exchange.getRelativePath();
 
         ServletPathMatch servletPathMatch = servletRequestContext.getServletPathMatch();
-        if (servletPathMatch != null
+        if (UndertowDecorator.UNDERTOW_LEGACY_TRACING
+            && servletPathMatch != null
             && servletPathMatch.getMappingMatch() != MappingMatch.DEFAULT) {
           // Set the route unless the mapping match is default, this way we prevent setting route
           // for a non-existing resource. Otherwise, it'd set a non-existing resource name with

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/test/groovy/UndertowDispatcherTest.groovy
@@ -207,7 +207,7 @@ abstract class UndertowDispatcherTest extends HttpServerTest<Undertow> {
   }
 }
 
-class UndertowDispatcherV0ForkedTest extends UndertowDispatcherTest {
+class UndertowDispatcherV0Test extends UndertowDispatcherTest {
   @Override
   int version() {
     return 0


### PR DESCRIPTION
# What Does This Do

Undertow  is today setting `http.route` from `HttpServletMapping#getMappingMatch()`. There few issues with that:
* Other servlet/application server instrumentations are not doing this hence we have an incoherent behaviour
* It's only happening on undertow < 2.2. For more recent versions of undertow based on jakarta servlet, that's not happening
* `http.route` should be set by more specific frameworks (i.e. jax-rs, spring mvc) and should not contain a part of the relative uri that can lead to high cardinality resources

This PR allows preventing undertow instrumentation from setting  the`http.route` tag by explicitly setting:
* The env `DD_UNDERTOW_LEGACY_TRACING_ENABLED=false`
* The sysprop `-Ddd.undertow.legacy.tracing.enabled=false`

This cannot be done as an easy change this it will break the resource name.

# Motivation

We received customer complaints about having servlet URI in http.route

# Additional Notes

Jira ticket: [AIT-10012]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIT-10012]: https://datadoghq.atlassian.net/browse/AIT-10012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ