### PR TITLE
More JDBC injection fixes

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.core.DDSpan
 import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.containers.PostgreSQLContainer
 import spock.lang.Requires
@@ -496,6 +497,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
 
     then:
     assert upperProc.getString(1) == "HELLO WORLD"
+
     cleanup:
     upperProc.close()
     connection.close()
@@ -550,6 +552,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     TEST_WRITER.waitForTraces(1)
 
     then:
+    List<DDSpan> trace = TEST_WRITER.firstTrace()
     assert true
 
     cleanup:
@@ -573,7 +576,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     if (driver == "postgresql") {
       createSql =
         """
-    CREATE OR REPLACE PROCEDURE dummy(inout res integer)
+    CREATE OR REPLACE PROCEDURE dummy2(inout res integer)
     LANGUAGE SQL
     AS \$\$
         SELECT 1;
@@ -582,7 +585,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     } else if (driver == "mysql") {
       createSql =
         """
-    CREATE PROCEDURE IF NOT EXISTS dummy(inout res int)
+    CREATE PROCEDURE IF NOT EXISTS dummy2(inout res int)
     BEGIN
         SELECT 1;
     END
@@ -620,14 +623,14 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
 
     where:
     driver       | connection                                              | query
-    "postgresql" | cpDatasources.get("hikari").get(driver).getConnection() | "CALL dummy(?)"
-    "mysql"      | cpDatasources.get("hikari").get(driver).getConnection() | "CALL dummy(?)"
-    "postgresql" | cpDatasources.get("tomcat").get(driver).getConnection() | "   CALL dummy(?)"
-    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | "CALL dummy(?)"
-    "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "  CALL dummy(?)"
-    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | "CALL dummy(?)"
-    "postgresql" | connectTo(driver, peerConnectionProps)                  | " CALL dummy(?)"
-    "mysql"      | connectTo(driver, peerConnectionProps)                  | "CALL dummy(?)"
+    "postgresql" | cpDatasources.get("hikari").get(driver).getConnection() | "CALL dummy2(?)"
+    "mysql"      | cpDatasources.get("hikari").get(driver).getConnection() | "CALL dummy2(?)"
+    "postgresql" | cpDatasources.get("tomcat").get(driver).getConnection() | "   CALL dummy2(?)"
+    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | "CALL dummy2(?)"
+    "postgresql" | cpDatasources.get("c3p0").get(driver).getConnection()   | "  CALL dummy2(?)"
+    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | "CALL dummy2(?)"
+    "postgresql" | connectTo(driver, peerConnectionProps)                  | " CALL dummy2(?)"
+    "mysql"      | connectTo(driver, peerConnectionProps)                  | "CALL dummy2(?)"
   }
 
 

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -164,7 +164,6 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     PortUtils.waitForPortToOpen(mysql.getHost(), mysql.getMappedPort(MySQLContainer.MYSQL_PORT), 5, TimeUnit.SECONDS)
     jdbcUrls.put("mysql", "${mysql.getJdbcUrl()}")
 
-
     prepareConnectionPoolDatasources()
   }
 
@@ -562,9 +561,9 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     where:
     driver       | connection                                              | query
     "mysql"      | cpDatasources.get("hikari").get(driver).getConnection() | "{CALL dummy(?)}"
-    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | "{CALL dummy(?)}"
-    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | "{CALL dummy(?)}"
-    "mysql"      | connectTo(driver, peerConnectionProps)                  | "{CALL dummy(?)}"
+    "mysql"      | cpDatasources.get("tomcat").get(driver).getConnection() | "{ CALL dummy(?)}"
+    "mysql"      | cpDatasources.get("c3p0").get(driver).getConnection()   | " { CALL dummy(?)}"
+    "mysql"      | connectTo(driver, peerConnectionProps)                  | " {CALL dummy(?)}"
   }
 
   def "prepared procedure call with return value on #driver with #connection.getClass().getCanonicalName() does not hang"() {

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/SQLCommenterTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/SQLCommenterTest.groovy
@@ -3,26 +3,6 @@ import datadog.trace.instrumentation.jdbc.SQLCommenter
 
 class SQLCommenterTest extends AgentTestRunner {
 
-  def "test find first word"() {
-    setup:
-
-    when:
-    String word = SQLCommenter.getFirstWord(sql)
-
-    then:
-    word == firstWord
-
-    where:
-    sql               | firstWord
-    "SELECT *"        | "SELECT"
-    "  { "            | "{"
-    "{"               | "{"
-    "CALL ( ? )"      | "CALL"
-    ""                | ""
-    "   "             | ""
-  }
-
-
   def "test encode Sql Comment"() {
     setup:
     injectSysConfig("dd.service", ddService)
@@ -50,10 +30,11 @@ class SQLCommenterTest extends AgentTestRunner {
     query                                                                                                         | ddService      | ddEnv  | dbService    | dbType     | host | dbName | ddVersion     | injectTrace | appendComment | traceParent                                               | expected
     "SELECT * FROM foo"                                                                                           | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
     "SELECT * FROM foo"                                                                                           | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
-    "{call dogshelterProc(?, ?)}"                                                                                 | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{call dogshelterProc(?, ?)} /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
-    "{call dogshelterProc(?, ?)}"                                                                                 | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{call dogshelterProc(?, ?)}"
-    "CALL dogshelterProc(?, ?)"                                                                                   | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "CALL dogshelterProc(?, ?) /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
-    "CALL dogshelterProc(?, ?)"                                                                                   | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "CALL dogshelterProc(?, ?) /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
+    "{ call dogshelterProc(?, ?)}"                                                                                | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{ call dogshelterProc(?, ?)} /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
+    "{call dogshelterProc(?, ?)}"                                                                                 | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{call dogshelterProc(?, ?)} /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
+    "{call dogshelterProc(?, ?)}"                                                                                 | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{call dogshelterProc(?, ?)}"
+    "CALL dogshelterProc(?, ?)"                                                                                   | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "CALL dogshelterProc(?, ?) /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
+    "CALL dogshelterProc(?, ?)"                                                                                   | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "CALL dogshelterProc(?, ?) /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
     "SELECT * FROM foo"                                                                                           | ""             | "Test" | ""           | "mysql"    | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
     "SELECT * FROM foo"                                                                                           | ""             | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
     "SELECT * FROM foo"                                                                                           | "SqlCommenter" | "Test" | "my-service" | "mysql"    | ""   | ""     | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*ddps='SqlCommenter',dddbs='my-service',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/SQLCommenterTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/SQLCommenterTest.groovy
@@ -3,6 +3,49 @@ import datadog.trace.instrumentation.jdbc.SQLCommenter
 
 class SQLCommenterTest extends AgentTestRunner {
 
+  def "test isProcedureCall"() {
+    setup:
+
+    when:
+    boolean isCall = SQLCommenter.isProcedureCall(sql)
+
+    then:
+    isCall == isProcedureCall
+
+    where:
+    sql               | isProcedureCall
+    "SELECT *"        | false
+    "  { "            | false
+    "{"               | false
+    "{call"           | true
+    "{  call"         | true
+    "CALL ( ? )"      | true
+    ""                | false
+    "   "             | false
+  }
+
+
+  def "test isJDBCStatement"() {
+    setup:
+
+    when:
+    boolean isJDBC = SQLCommenter.isJDBCStatement(sql)
+
+    then:
+    isJDBC == isJDBCStatement
+
+    where:
+    sql               | isJDBCStatement
+    "SELECT *"        | false
+    "  { "            | true
+    "{"               | true
+    "{call"           | true
+    "{  call"         | true
+    "CALL ( ? )"      | false
+    ""                | false
+    "   "             | false
+  }
+
   def "test encode Sql Comment"() {
     setup:
     injectSysConfig("dd.service", ddService)
@@ -30,11 +73,11 @@ class SQLCommenterTest extends AgentTestRunner {
     query                                                                                                         | ddService      | ddEnv  | dbService    | dbType     | host | dbName | ddVersion     | injectTrace | appendComment | traceParent                                               | expected
     "SELECT * FROM foo"                                                                                           | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
     "SELECT * FROM foo"                                                                                           | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
-    "{ call dogshelterProc(?, ?)}"                                                                                | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{ call dogshelterProc(?, ?)} /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
-    "{call dogshelterProc(?, ?)}"                                                                                 | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{call dogshelterProc(?, ?)} /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
-    "{call dogshelterProc(?, ?)}"                                                                                 | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{call dogshelterProc(?, ?)}"
-    "CALL dogshelterProc(?, ?)"                                                                                   | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "CALL dogshelterProc(?, ?) /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
-    "CALL dogshelterProc(?, ?)"                                                                                   | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false         | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "CALL dogshelterProc(?, ?) /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
+    "{ call dogshelterProc(?, ?)}"                                                                                | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{ call dogshelterProc(?, ?)} /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
+    "{  call dogshelterProc(?, ?)}"                                                                                 | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{  call dogshelterProc(?, ?)} /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
+    "{call dogshelterProc(?, ?)}"                                                                                 | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | false          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "{call dogshelterProc(?, ?)}"
+    "CALL dogshelterProc(?, ?)"                                                                                   | "SqlCommenter" | "Test" | "my-service" | "postgres" | "h"  | "n"    | "TestVersion" | true        | false          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "CALL dogshelterProc(?, ?) /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
+    "CALL dogshelterProc(?, ?)"                                                                                   | "SqlCommenter" | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | false          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "CALL dogshelterProc(?, ?) /*ddps='SqlCommenter',dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
     "SELECT * FROM foo"                                                                                           | ""             | "Test" | ""           | "mysql"    | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
     "SELECT * FROM foo"                                                                                           | ""             | "Test" | "my-service" | "mysql"    | "h"  | "n"    | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*dddbs='my-service',ddh='h',dddb='n',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"
     "SELECT * FROM foo"                                                                                           | "SqlCommenter" | "Test" | "my-service" | "mysql"    | ""   | ""     | "TestVersion" | true        | true          | "00-00000000000000007fffffffffffffff-000000024cb016ea-00" | "SELECT * FROM foo /*ddps='SqlCommenter',dddbs='my-service',dde='Test',ddpv='TestVersion',traceparent='00-00000000000000007fffffffffffffff-000000024cb016ea-00'*/"


### PR DESCRIPTION
# What Does This Do
Moves SQL injection to the end of queries for any JDBC call statement.

# Motivation
MySQL is particular about comment injection for more CALL syntaxes than we originally thought.

# Additional Notes

Jira ticket: https://datadoghq.atlassian.net/browse/DBMON-3771

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
