### PR TITLE
Fix publishing to local sonatype

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,12 +91,14 @@ nexusPublishing {
     if (forceLocal && !isCI) {
       local {
         // For testing use with https://hub.docker.com/r/sonatype/nexus
-        // docker run --rm -d -p 8081:8081 --name nexus sonatype/nexus
+        // docker run --rm -d -p 8081:8081 --name nexus sonatype/nexus:oss
+        // ./gradlew publishToLocal
         // Doesn't work for testing releases though... (due to staging)
         nexusUrl = uri("http://localhost:8081/nexus/content/repositories/releases/")
         snapshotRepositoryUrl = uri("http://localhost:8081/nexus/content/repositories/snapshots/")
         username = "admin"
         password = "admin123"
+        allowInsecureProtocol = true
       }
     } else {
       sonatype {


### PR DESCRIPTION
# What Does This Do
Adds `allowInsecureProtocol` so that publishing to a dockerized maven repo works. Also updates the comment

# Motivation

I was testing local sonatype publishing and it was broken