### PR TITLE
Upgrade to libddwaf-java 9.1.1

### DIFF
--- a/dd-java-agent/appsec/build.gradle
+++ b/dd-java-agent/appsec/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation project(':internal-api')
   implementation project(':communication')
   implementation project(':telemetry')
-  implementation group: 'io.sqreen', name: 'libsqreen', version: '9.0.2'
+  implementation group: 'io.sqreen', name: 'libsqreen', version: '9.1.1'
   implementation group: 'com.squareup.moshi', name: 'moshi', version: versions.moshi
 
   testImplementation deps.bytebuddy


### PR DESCRIPTION
# What Does This Do

* Upgrade to libddwaf-java 9.1.0. There are no changes to libddwaf itself or bindings code here, only build changes. libc++ was upgraded too.
* These builds are smaller, saving 535KB on our final dd-java-agent.jar. Also resulting in faster initialization.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
