### PR TITLE
System-tests: new k8s lib injection tests

### DIFF
--- a/.github/workflows/lib-injection.yaml
+++ b/.github/workflows/lib-injection.yaml
@@ -65,26 +65,16 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      matrix:
-        lib-injection-connection: [ 'network','uds']
-        lib-injection-use-admission-controller: ['', 'use-admission-controller']
-        weblog-variant: [ 'dd-lib-java-init-test-app']
-      fail-fast: false
     env:
       TEST_LIBRARY: java
-      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
-      LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
-      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-use-admission-controller }}
+      WEBLOG_VARIANT: dd-lib-java-init-test-app
       DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
       DOCKER_IMAGE_TAG: ${{ github.sha }}
-      MODE: manual
-    steps:     
-      - name: lib-injection test runner
-        id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@89d754340046eafcc72dc5c5fd6ea651ca7b920e # main
-        with:
-          docker-registry: ghcr.io
-          docker-registry-username: ${{ github.repository_owner }}
-          docker-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          test-script: ./lib-injection/run-manual-lib-injection.sh
+      BUILDX_PLATFORMS: linux/amd64
+    steps:
+    - name: Checkout system tests
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
+      with:
+          repository: 'DataDog/system-tests'
+    - name: Run K8s Lib Injection Tests
+      run: ./run.sh K8S_LIB_INJECTION 

--- a/.github/workflows/lib-injection.yaml
+++ b/.github/workflows/lib-injection.yaml
@@ -76,5 +76,7 @@ jobs:
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
       with:
           repository: 'DataDog/system-tests'
+    - name: Install runner
+      uses: ./.github/actions/install_runner   
     - name: Run K8s Lib Injection Tests
       run: ./run.sh K8S_LIB_INJECTION 

--- a/.github/workflows/lib-injection.yaml
+++ b/.github/workflows/lib-injection.yaml
@@ -76,7 +76,21 @@ jobs:
       uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # 2.3.4
       with:
           repository: 'DataDog/system-tests'
+
     - name: Install runner
-      uses: ./.github/actions/install_runner   
+      uses: ./.github/actions/install_runner 
+
     - name: Run K8s Lib Injection Tests
-      run: ./run.sh K8S_LIB_INJECTION 
+      run: ./run.sh K8S_LIB_INJECTION_BASIC
+
+    - name: Compress logs
+      id: compress_logs
+      if: always()
+      run: tar -czvf artifact.tar.gz $(ls | grep logs)
+
+    - name: Upload artifact
+      if: always()
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # 2.3.1
+      with:
+        name: logs_k8s_lib_injection
+        path: artifact.tar.gz


### PR DESCRIPTION
# What Does This Do
Migrate the system-tests lib injection test to the new approach
# Motivation
Lib Injection tests were build using bash scripting, new tests use kubernetes python client
# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
