### PR TITLE
java-dogstatsd-client 4.3.0

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -275,7 +275,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 29 : 28
+    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 30 : 29
     assert shadowJar.archiveFile.get().getAsFile().length() <= megs * 1024 * 1024
   }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ final class CachedData {
     truth         : "1.1.3",
     kotlin        : "1.6.21",
     coroutines    : "1.3.0",
-    dogstatsd     : "4.2.0",
+    dogstatsd     : "4.3.0",
     jnr_unixsocket: "0.38.22",
     jnr_posix     : '3.1.19',
     commons       : "3.2",


### PR DESCRIPTION
[Send in-{inode} using the cgroup controller when container-id cannot be retrieved](https://github.com/DataDog/java-dogstatsd-client/pull/232)

[Don't send partial messages when the utf8 encoder overflows ](https://github.com/DataDog/java-dogstatsd-client/pull/224)

[Fix a bug in address resolution order](https://github.com/DataDog/java-dogstatsd-client/commit/87832f03f3471985f335e16f9926bd189ce39f31) 