### PR TITLE
Record public classes in compact filter

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ClassCodeFilter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ClassCodeFilter.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
  * class name should minimize the probability of collisions without needing to store full names,
  * which would otherwise make the filter overly large.
  */
-public abstract class ClassCodeFilter {
+public class ClassCodeFilter {
 
   private static final int MAX_CAPACITY = 1 << 16;
   private static final int MIN_CAPACITY = 1 << 8;
@@ -19,7 +19,7 @@ public abstract class ClassCodeFilter {
   protected final long[] slots;
   protected final int slotMask;
 
-  protected ClassCodeFilter(int capacity) {
+  public ClassCodeFilter(int capacity) {
     if (capacity < MIN_CAPACITY) {
       capacity = MIN_CAPACITY;
     } else if (capacity > MAX_CAPACITY) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/NoMatchFilter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/memoize/NoMatchFilter.java
@@ -24,7 +24,7 @@ final class NoMatchFilter extends ClassCodeFilter {
   private static final Logger log = LoggerFactory.getLogger(NoMatchFilter.class);
 
   NoMatchFilter() {
-    super(InstrumenterConfig.get().getResolverNoMatchesSize());
+    super(InstrumenterConfig.get().getResolverClassFilterSize());
 
     // seed filter from previously collected results?
     Path noMatchFile = discoverNoMatchFile();

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -329,8 +329,8 @@ public class InstrumenterConfig {
     return excludedCodeSources;
   }
 
-  public int getResolverNoMatchesSize() {
-    return resolverCacheConfig.noMatchesSize();
+  public int getResolverClassFilterSize() {
+    return resolverCacheConfig.classFilterSize();
   }
 
   public boolean isResolverMemoizingEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
@@ -6,7 +6,7 @@ public enum ResolverCacheConfig {
   /** Memoizing and outlining for large enterprise apps. */
   LARGE {
     @Override
-    public int noMatchesSize() {
+    public int classFilterSize() {
       return 65536;
     }
 
@@ -29,7 +29,7 @@ public enum ResolverCacheConfig {
   /** Memoizing and outlining for the average sized app. */
   MEMOS {
     @Override
-    public int noMatchesSize() {
+    public int classFilterSize() {
       return 16384;
     }
 
@@ -52,7 +52,7 @@ public enum ResolverCacheConfig {
   /** Outlining only for the average sized app, no memoizing. */
   NO_MEMOS {
     @Override
-    public int noMatchesSize() {
+    public int classFilterSize() {
       return 0;
     }
 
@@ -75,7 +75,7 @@ public enum ResolverCacheConfig {
   /** Outlining only for small microservice apps. */
   SMALL {
     @Override
-    public int noMatchesSize() {
+    public int classFilterSize() {
       return 0;
     }
 
@@ -98,7 +98,7 @@ public enum ResolverCacheConfig {
   /** No outlining or memoizing. */
   LEGACY {
     @Override
-    public int noMatchesSize() {
+    public int classFilterSize() {
       return 0;
     }
 
@@ -118,7 +118,7 @@ public enum ResolverCacheConfig {
     }
   };
 
-  public abstract int noMatchesSize();
+  public abstract int classFilterSize();
 
   public abstract int memoPoolSize();
 


### PR DESCRIPTION
# Motivation

Avoids several class-file lookups when byte-buddy checks which types are visible from other types.