### PR TITLE
[SINT-1892] Run Datadog SCA in CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,3 +51,6 @@ dd-java-agent/instrumentation/spring-security-5/ @DataDog/asm-java
 # @DataDog/data-jobs-monitoring
 dd-java-agent/instrumentation/spark/            @DataDog/data-jobs-monitoring
 dd-java-agent/instrumentation/spark-executor/   @DataDog/data-jobs-monitoring
+
+# Security
+/.gitlab/software_composition_analysis.yaml  @DataDog/software-integrity-and-trust

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - local: ".gitlab/exploration-tests.yml"
   - local: ".gitlab/ci-visibility-tests.yml"
+  - local: ".gitlab/software_composition_analysis.yaml"
 
 stages:
   - build

--- a/.gitlab/software_composition_analysis.yaml
+++ b/.gitlab/software_composition_analysis.yaml
@@ -1,0 +1,19 @@
+datadog-sca-ci:
+  stage: package
+  tags: ["arch:amd64"]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/datadog-static-analyzer:2024031801
+  when: always
+  # We don't want to disrupt the pipeline so let's fail silently.
+  allow_failure: true
+  # This specifies the job does not have any dependency, meaning it can start as soon as it can.
+  needs: []
+  script:
+    # Disabling tracing to avoid leaking secrets.
+    # See https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin:
+    # "Using ‘+’ rather than ‘-’ causes these options to be turned off"
+    - set +o xtrace
+    - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.dd-trace-java.datadog_api_key_org2" --with-decryption --query "Parameter.Value" --out text)
+    - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name "ci.dd-trace-java.datadog_app_key_org2" --with-decryption --query "Parameter.Value" --out text)
+    - set -o xtrace
+    - osv-scanner --skip-git --recursive --experimental-only-packages --format=cyclonedx-1-4 --output=/tmp/sbom.json .
+    - datadog-ci sbom upload --service integrations-core --env ci /tmp/sbom.json


### PR DESCRIPTION
## What does this PR do?
Add a new Gitlab CI job that dogfoods the Datadog SCA product

## Motivation
@DataDog/software-integrity-and-trust partners with @DataDog/static-analysis to dogfood their SCA product and secure Datadog's supply chain.

Additional Notes
