### PR TITLE
Avoid touching Config in InstrumenterMetrics

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterMetrics.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterMetrics.java
@@ -1,6 +1,6 @@
 package datadog.trace.agent.tooling;
 
-import datadog.trace.api.Config;
+import datadog.trace.api.InstrumenterConfig;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class InstrumenterMetrics {
@@ -33,7 +33,7 @@ public final class InstrumenterMetrics {
     static final AtomicLong missingClassFile = new AtomicLong();
   }
 
-  private static final boolean ENABLED = Config.get().isTriageEnabled();
+  private static final boolean ENABLED = InstrumenterConfig.get().isTriageEnabled();
 
   public static long tick() {
     if (ENABLED) {

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1935,14 +1935,12 @@ public class Config {
     servletAsyncTimeoutError = configProvider.getBoolean(SERVLET_ASYNC_TIMEOUT_ERROR, true);
 
     debugEnabled = configProvider.getBoolean(TRACE_DEBUG, false);
+    triageEnabled = configProvider.getBoolean(TRACE_TRIAGE, instrumenterConfig.isTriageEnabled());
     triageReportTrigger = configProvider.getString(TRIAGE_REPORT_TRIGGER);
     if (null != triageReportTrigger) {
-      // setting a trigger implies the triage directory and triage mode should be enabled
       triageReportDir = configProvider.getString(TRIAGE_REPORT_DIR, getProp("java.io.tmpdir"));
-      triageEnabled = true;
     } else {
       triageReportDir = null;
-      triageEnabled = configProvider.getBoolean(TRACE_TRIAGE, debugEnabled);
     }
 
     startupLogsEnabled =

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -21,6 +21,9 @@ import static datadog.trace.api.config.AppSecConfig.APPSEC_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.INTERNAL_EXIT_ON_FAILURE;
 import static datadog.trace.api.config.GeneralConfig.TELEMETRY_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.TRACE_DEBUG;
+import static datadog.trace.api.config.GeneralConfig.TRACE_TRIAGE;
+import static datadog.trace.api.config.GeneralConfig.TRIAGE_REPORT_TRIGGER;
 import static datadog.trace.api.config.IastConfig.IAST_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_DIRECT_ALLOCATION_ENABLED_DEFAULT;
@@ -86,6 +89,8 @@ import java.util.Set;
 public class InstrumenterConfig {
   private final ConfigProvider configProvider;
 
+  private final boolean triageEnabled;
+
   private final boolean integrationsEnabled;
 
   private final boolean traceEnabled;
@@ -141,6 +146,14 @@ public class InstrumenterConfig {
 
   InstrumenterConfig(ConfigProvider configProvider) {
     this.configProvider = configProvider;
+
+    if (null != configProvider.getString(TRIAGE_REPORT_TRIGGER)) {
+      triageEnabled = true; // explicitly setting a trigger implies triage mode
+    } else {
+      // default to same state as debug mode, unless explicitly overridden
+      boolean debugEnabled = configProvider.getBoolean(TRACE_DEBUG, false);
+      triageEnabled = configProvider.getBoolean(TRACE_TRIAGE, debugEnabled);
+    }
 
     integrationsEnabled =
         configProvider.getBoolean(INTEGRATIONS_ENABLED, DEFAULT_INTEGRATIONS_ENABLED);
@@ -228,6 +241,10 @@ public class InstrumenterConfig {
 
     this.additionalJaxRsAnnotations =
         tryMakeImmutableSet(configProvider.getList(JAX_RS_ADDITIONAL_ANNOTATIONS));
+  }
+
+  public boolean isTriageEnabled() {
+    return triageEnabled;
   }
 
   public boolean isIntegrationsEnabled() {


### PR DESCRIPTION
# What Does This Do

Moves initial calculation of the `triageEnabled` flag to `InstrumenterConfig` so `InstrumenterMetrics` can check it without triggering load of the larger `Config` object. The triage section of `Config` is updated to use that initial calculation.

# Motivation

Avoids performance cost of loading `Config` early on during instrumentation, also avoids potentially loading additional JDK types if debug is enabled (since loading `Config` while debug is turned on can trigger a process call to `hostname`)