### PR TITLE
[DSM] - Fix KStreams with dynamic queue names

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -132,8 +132,8 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
         sortedTags.put(TYPE_TAG, "kafka");
         try {
           propagate().inject(span, record.headers(), SETTER);
-          if (STREAMING_CONTEXT.isDisabledForTopic(record.topic()) ||
-              STREAMING_CONTEXT.isSinkTopic(record.topic())) {
+          if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
+              || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
             // inject the context in the headers, but delay sending the stats until we know the
             // message size.
             // The stats are saved in the pathway context and sent in PayloadSizeAdvice.
@@ -154,8 +154,8 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
                   record.headers());
 
           propagate().inject(span, record.headers(), SETTER);
-          if (STREAMING_CONTEXT.isDisabledForTopic(record.topic()) ||
-              STREAMING_CONTEXT.isSinkTopic(record.topic())) {
+          if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())
+              || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
             propagate()
                 .injectPathwayContextWithoutSendingStats(
                     span, record.headers(), SETTER, sortedTags);

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -132,7 +132,8 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
         sortedTags.put(TYPE_TAG, "kafka");
         try {
           propagate().inject(span, record.headers(), SETTER);
-          if (STREAMING_CONTEXT.empty() || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
+          if (STREAMING_CONTEXT.isDisabledForTopic(record.topic()) ||
+              STREAMING_CONTEXT.isSinkTopic(record.topic())) {
             // inject the context in the headers, but delay sending the stats until we know the
             // message size.
             // The stats are saved in the pathway context and sent in PayloadSizeAdvice.
@@ -153,7 +154,8 @@ public final class KafkaProducerInstrumentation extends InstrumenterModule.Traci
                   record.headers());
 
           propagate().inject(span, record.headers(), SETTER);
-          if (STREAMING_CONTEXT.empty() || STREAMING_CONTEXT.isSinkTopic(record.topic())) {
+          if (STREAMING_CONTEXT.isDisabledForTopic(record.topic()) ||
+              STREAMING_CONTEXT.isSinkTopic(record.topic())) {
             propagate()
                 .injectPathwayContextWithoutSendingStats(
                     span, record.headers(), SETTER, sortedTags);

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TracingIterator.java
@@ -105,7 +105,7 @@ public class TracingIterator implements Iterator<ConsumerRecord<?, ?>> {
 
           final long payloadSize =
               span.traceConfig().isDataStreamsEnabled() ? computePayloadSizeBytes(val) : 0;
-          if (STREAMING_CONTEXT.empty()) {
+          if (STREAMING_CONTEXT.isDisabledForTopic(val.topic())) {
             AgentTracer.get()
                 .getDataStreamsMonitoring()
                 .setCheckpoint(span, sortedTags, val.timestamp(), payloadSize);

--- a/dd-java-agent/instrumentation/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/StreamingContext.java
+++ b/dd-java-agent/instrumentation/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/StreamingContext.java
@@ -64,8 +64,10 @@ public class StreamingContext {
     return Objects.equals(topics.getOrDefault(topic, UNKNOWN_TOPIC), SOURCE_TOPIC);
   }
 
-  public boolean empty() {
-    return topics.isEmpty();
+  // Checks if this topic is a part of a streaming topology
+  public boolean isDisabledForTopic(final String topic) {
+    return topics.isEmpty() ||
+        Objects.equals(topics.getOrDefault(topic, UNKNOWN_TOPIC), UNKNOWN_TOPIC);
   }
 
   private final Set<String> allSourceTopics = ConcurrentHashMap.newKeySet();

--- a/dd-java-agent/instrumentation/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/StreamingContext.java
+++ b/dd-java-agent/instrumentation/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/StreamingContext.java
@@ -66,8 +66,8 @@ public class StreamingContext {
 
   // Checks if this topic is a part of a streaming topology
   public boolean isDisabledForTopic(final String topic) {
-    return topics.isEmpty() ||
-        Objects.equals(topics.getOrDefault(topic, UNKNOWN_TOPIC), UNKNOWN_TOPIC);
+    return topics.isEmpty()
+        || Objects.equals(topics.getOrDefault(topic, UNKNOWN_TOPIC), UNKNOWN_TOPIC);
   }
 
   private final Set<String> allSourceTopics = ConcurrentHashMap.newKeySet();

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamTaskInstrumentation.java
@@ -255,7 +255,7 @@ public class KafkaStreamTaskInstrumentation extends InstrumenterModule.Tracing
 
         final long payloadSize =
             span.traceConfig().isDataStreamsEnabled() ? computePayloadSizeBytes(record.value) : 0;
-        if (STREAMING_CONTEXT.empty()) {
+        if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())) {
           AgentTracer.get()
               .getDataStreamsMonitoring()
               .setCheckpoint(span, sortedTags, record.timestamp, payloadSize);
@@ -337,7 +337,7 @@ public class KafkaStreamTaskInstrumentation extends InstrumenterModule.Tracing
           payloadSize = metadata.serializedKeySize() + metadata.serializedValueSize();
         }
 
-        if (STREAMING_CONTEXT.empty()) {
+        if (STREAMING_CONTEXT.isDisabledForTopic(record.topic())) {
           AgentTracer.get()
               .getDataStreamsMonitoring()
               .setCheckpoint(span, sortedTags, record.timestamp(), payloadSize);


### PR DESCRIPTION
# What Does This Do
This PR fixes a bug reported by KStreams users. See [this](https://datadoghq.atlassian.net/browse/DSMS-12) ticket for context.

# Details
`STREAMING_CONTEXT` relies on topology builder to get all source / sink / system topics. The issue with this approach is that some topics may not be part of the topology when it's created. An example may be `.to(` call which uses some logic to determine the downstream sink. In the example below `RE_KEYED_BACKLOGS` topic will not be added to the streaming context, since it's not resolved when topology builder is invoked. The solution is to allow DSM checkpoints for all topics which are not known at the start of the application.

```
builder
   .<Integer, String>stream(RESOLVED_BACKLOGS)
   .selectKey((key, val) -> key + 1)
   .to((key, value, ctx) -> {
       ctx.headers().add("NEW_HEADER", "VALUE".getBytes(StandardCharsets.UTF_8));
       return RE_KEYED_BACKLOGS;
   });
```
