### PR TITLE
Fix Datadog-Entity-ID detection by skipping a root inode

### DIFF
--- a/utils/container-utils/src/test/groovy/datadog/common/container/ContainerInfoTest.groovy
+++ b/utils/container-utils/src/test/groovy/datadog/common/container/ContainerInfoTest.groovy
@@ -231,10 +231,10 @@ class ContainerInfoTest extends DDSpecification {
     Path path = f.toPath()
 
     then:
-    ContainerInfo.getIno(path) == readInode(path)
+    ContainerInfo.readInode(path) == readInode(path)
   }
 
-  private Long readInode(Path path) {
+  private long readInode(Path path) {
     ProcessBuilder pb = new ProcessBuilder("ls", "-id", path.toString())
     Process ps = pb.start()
     BufferedReader reader = new BufferedReader(new InputStreamReader(ps.getInputStream()))


### PR DESCRIPTION
# What Does This Do

Fixes Datadog-Entity-ID detection by skipping a root inode

# Motivation

It was returning the root inode

# Additional Notes

Jira ticket: [APMJAVA-1283]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1283]: https://datadoghq.atlassian.net/browse/APMJAVA-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ