### PR TITLE
Keep track of public classes in compact filter

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/IsPublicFilter.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/outline/IsPublicFilter.java
@@ -1,0 +1,11 @@
+package datadog.trace.agent.tooling.bytebuddy.outline;
+
+import datadog.trace.agent.tooling.bytebuddy.ClassCodeFilter;
+import datadog.trace.api.InstrumenterConfig;
+
+/** Compact filter that records public types. */
+final class IsPublicFilter extends ClassCodeFilter {
+  IsPublicFilter() {
+    super(InstrumenterConfig.get().getResolverVisibilitySize());
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -350,6 +350,10 @@ public class InstrumenterConfig {
     return resolverCacheConfig.noMatchesSize();
   }
 
+  public int getResolverVisibilitySize() {
+    return resolverCacheConfig.visibilitySize();
+  }
+
   public boolean isResolverMemoizingEnabled() {
     return resolverCacheConfig.memoPoolSize() > 0;
   }

--- a/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/ResolverCacheConfig.java
@@ -11,6 +11,11 @@ public enum ResolverCacheConfig {
     }
 
     @Override
+    public int visibilitySize() {
+      return 4096;
+    }
+
+    @Override
     public int memoPoolSize() {
       return 4096;
     }
@@ -34,6 +39,11 @@ public enum ResolverCacheConfig {
     }
 
     @Override
+    public int visibilitySize() {
+      return 1024;
+    }
+
+    @Override
     public int memoPoolSize() {
       return 2048;
     }
@@ -53,6 +63,11 @@ public enum ResolverCacheConfig {
   NO_MEMOS {
     @Override
     public int noMatchesSize() {
+      return 0;
+    }
+
+    @Override
+    public int visibilitySize() {
       return 0;
     }
 
@@ -80,6 +95,11 @@ public enum ResolverCacheConfig {
     }
 
     @Override
+    public int visibilitySize() {
+      return 0;
+    }
+
+    @Override
     public int memoPoolSize() {
       return 0;
     }
@@ -103,6 +123,11 @@ public enum ResolverCacheConfig {
     }
 
     @Override
+    public int visibilitySize() {
+      return 0;
+    }
+
+    @Override
     public int memoPoolSize() {
       return 0;
     }
@@ -119,6 +144,8 @@ public enum ResolverCacheConfig {
   };
 
   public abstract int noMatchesSize();
+
+  public abstract int visibilitySize();
 
   public abstract int memoPoolSize();
 


### PR DESCRIPTION
# Motivation

Reduces the number of class-file lookups needed when byte-buddy checks which types are visible from other types.

(cuts the number of additional class-file lookups by almost 50% - most of the remaining lookups relate to muzzle)