### PR TITLE
Update byte-buddy to 1.14.13

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.12")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.13")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   implementation("org.ow2.asm", "asm-tree", "9.0")
   implementation("com.github.javaparser", "javaparser-symbol-solver-core", "3.24.4")
 
-  testImplementation("net.bytebuddy", "byte-buddy", "1.14.12")
+  testImplementation("net.bytebuddy", "byte-buddy", "1.14.13")
   testImplementation("org.spockframework", "spock-core", "2.0-groovy-3.0")
   testImplementation("org.objenesis", "objenesis", "3.0.1")
   testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")

--- a/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
+++ b/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
@@ -27,7 +27,7 @@ class CallSiteInstrumentationPluginTest extends Specification {
     }
     
     dependencies {
-      implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.12'
+      implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.13'
       implementation group: 'com.google.auto.service', name: 'auto-service-annotations', version: '1.0-rc7'
     }
   '''

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.12' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.13' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.9.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.14.12",
+    bytebuddy     : "1.14.13",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",


### PR DESCRIPTION
Changes of note since last upgrade (1.14.12)

- Avoid resolving type variables when generic type processing is disabled.
- Improve error message for Byte Buddy agent external attach.
- Fix build for modular jars when using later version than Java 8.

There is a [commit](https://github.com/raphw/byte-buddy/commit/aa5c04a2b5c7fc6d71a257b19952f8817e828706) included in this release that affects IAST, it fixes this [issue](https://github.com/DataDog/dd-trace-java/issues/6723)