### PR TITLE
Fix Datadog-Entity-ID detection paths joining

### DIFF
--- a/utils/container-utils/src/main/java/datadog/common/container/ContainerInfo.java
+++ b/utils/container-utils/src/main/java/datadog/common/container/ContainerInfo.java
@@ -126,7 +126,7 @@ public class ContainerInfo {
     for (String controller : Arrays.asList(CGROUPV1_BASE_CONTROLLER, CGROUPV2_BASE_CONTROLLER)) {
       for (CGroupInfo cgroup : cgroups) {
         if (cgroup.getControllers().contains(controller)) {
-          Path path = cgroupMountPath.resolve(controller).resolve(cgroup.getPath());
+          Path path = Paths.get(cgroupMountPath.toString(), controller, cgroup.getPath());
           long inode = readInode(path);
           // ignore invalid and root inode
           if (inode > 2) {

--- a/utils/container-utils/src/test/groovy/datadog/common/container/ContainerInfoTest.groovy
+++ b/utils/container-utils/src/test/groovy/datadog/common/container/ContainerInfoTest.groovy
@@ -327,4 +327,24 @@ class ContainerInfoTest extends DDSpecification {
     Arrays.asList("memory")     | true
     Arrays.asList("")           | false
   }
+
+  def "readEntityID return id-<ino> for a parent when path is /"() {
+    setup:
+    File mountPath = File.createTempDir("container-info-test-", "-sys-fs-cgroup")
+    mountPath.deleteOnExit()
+    File memoryController = Files.createDirectory(mountPath.toPath().resolve("memory")).toFile()
+    memoryController.deleteOnExit()
+    Long ino = readInode(memoryController.toPath())
+
+    when:
+    ContainerInfo containerInfo = new ContainerInfo()
+    ContainerInfo.CGroupInfo cGroupInfo = new ContainerInfo.CGroupInfo()
+    cGroupInfo.setControllers(Arrays.asList("memory"))
+    cGroupInfo.setPath("/")
+    List<ContainerInfo.CGroupInfo> cGroups = Arrays.asList(cGroupInfo)
+    containerInfo.setcGroups(cGroups)
+
+    then:
+    containerInfo.readEntityID(containerInfo, false, mountPath.toPath()) == "in-" + ino
+  }
 }


### PR DESCRIPTION
# What Does This Do

Fixes Datadog-Entity-ID detection by joining paths properly.

# Motivation

It used Path.resolve that clears path when joined with '/'.

# Additional Notes

Jira ticket: [APMJAVA-1283]

This is continuation of previously merged PR: #6858

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMJAVA-1283]: https://datadoghq.atlassian.net/browse/APMJAVA-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ