### PR TITLE
Flush pending traces synchronously before terminating child process

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestSession.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.config.ModuleExecutionSettings;
 import datadog.trace.api.civisibility.coverage.CoverageDataSupplier;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.coverage.CoverageProbeStoreFactory;
 import datadog.trace.civisibility.decorator.TestDecorator;
@@ -63,7 +64,10 @@ public class ProxyTestSession implements TestFrameworkSession {
 
   @Override
   public void end(Long startTime) {
-    // no op
+    // flushing written traces synchronously:
+    // as soon as all tests have been executed,
+    // the process can be killed by the build system
+    AgentTracer.get().flush();
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Adds a synchronous flush of pending traces to `TestFrameworkSession#end` invocation.
`TestFrameworkSession` is used by CI Vis children processes (JVMs that a build system forks for tests execution).
The `end` method is invoked by a shutdown hook when a child process terminates.

# Motivation
As soon as all the tests have executed, the build system can terminate the child process that it previously forked to run the tests.
We need to ensure that all the pending traces have been flushed before the process shuts down, otherwise test events may be lost.

Jira ticket: [CIVIS-9567]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9567]: https://datadoghq.atlassian.net/browse/CIVIS-9567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ