### PR TITLE
Detect Tomcat's host manager tomcat application as admin console

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -44,32 +44,26 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
 
   private static final String CONTEXT_LOADER_LISTENER =
       "org.springframework.web.context.ContextLoaderListener";
-
   private static final String DISPATCHER_SERVLET =
       "org.springframework.web.servlet.DispatcherServlet";
-
   private static final String DEFAULT_HTML_ESCAPE = "defaultHtmlEscape";
-
-  private static final String TOMCAT_MANAGER_APPLICATION = "Tomcat Manager Application";
-
   private static final String LISTINGS_PATTERN = "<param-name>listings</param-name>";
-
   private static final String SESSION_TIMEOUT_START_TAG = "<session-timeout>";
-
   private static final String SESSION_TIMEOUT_END_TAG = "</session-timeout>";
-
   private static final String SECURITY_CONSTRAINT_START_TAG = "<security-constraint>";
-
   private static final String SECURITY_CONSTRAINT_END_TAG = "</security-constraint>";
-
   public static final String PARAM_VALUE_START_TAG = "<param-value>";
-
   public static final String PARAM_VALUE_END_TAG = "</param-value>";
-
+  public static final String DISPLAY_NAME_START_TAG = "<display-name>";
+  public static final String DISPLAY_NAME_END_TAG = "</display-name>";
+  static final String TOMCAT_MANAGER_APP = "Tomcat Manager Application";
+  private static final String TOMCAT_MANAGER_APP_PATTERN =
+      DISPLAY_NAME_START_TAG + TOMCAT_MANAGER_APP + DISPLAY_NAME_END_TAG;
+  static final String TOMCAT_HOST_MANAGER_APP = "Tomcat Host Manager Application";
+  private static final String TOMCAT_HOST_MANAGER_APP_PATTERN =
+      DISPLAY_NAME_START_TAG + TOMCAT_HOST_MANAGER_APP + DISPLAY_NAME_END_TAG;
   public static final String WEB_INF = "WEB-INF";
-
   public static final String WEB_XML = "web.xml";
-
   static final String SESSION_REWRITING_EVIDENCE_VALUE = "Servlet URL Session Tracking Mode";
 
   private static final Pattern PATTERN =
@@ -78,7 +72,8 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
                   CONTEXT_LOADER_LISTENER,
                   DISPATCHER_SERVLET,
                   DEFAULT_HTML_ESCAPE,
-                  TOMCAT_MANAGER_APPLICATION,
+                  TOMCAT_MANAGER_APP_PATTERN,
+                  TOMCAT_HOST_MANAGER_APP_PATTERN,
                   LISTINGS_PATTERN,
                   SESSION_TIMEOUT_START_TAG,
                   SECURITY_CONSTRAINT_START_TAG)
@@ -150,8 +145,11 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
         case DEFAULT_HTML_ESCAPE:
           defaultHtmlEscapeIndex = matcher.start();
           break;
-        case TOMCAT_MANAGER_APPLICATION:
-          reportAdminConsoleActive(span);
+        case TOMCAT_MANAGER_APP_PATTERN:
+          reportAdminConsoleActive(span, TOMCAT_MANAGER_APP);
+          break;
+        case TOMCAT_HOST_MANAGER_APP_PATTERN:
+          reportAdminConsoleActive(span, TOMCAT_HOST_MANAGER_APP);
           break;
         case LISTINGS_PATTERN:
           checkDirectoryListingLeak(webXmlContent, matcher.start(), span);
@@ -196,14 +194,14 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     }
   }
 
-  private void reportAdminConsoleActive(AgentSpan span) {
+  private void reportAdminConsoleActive(AgentSpan span, final String evidence) {
     // No deduplication is needed as same service can have multiple applications
     reporter.report(
         span,
         new Vulnerability(
             VulnerabilityType.ADMIN_CONSOLE_ACTIVE,
             Location.forSpan(span),
-            new Evidence("Tomcat Manager Application")));
+            new Evidence(evidence)));
   }
 
   private void checkDirectoryListingLeak(

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -66,7 +66,8 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
     'application/directorylistingleak/secure'         | null                        | null                                                       | _
     'application/directorylistingleak/insecure'       | DIRECTORY_LISTING_LEAK      | 'Directory listings configured'                            | 14
     'application/adminconsoleactive/secure'           | null                        | null                                                       | _
-    'application/adminconsoleactive/insecure'         | ADMIN_CONSOLE_ACTIVE        | 'Tomcat Manager Application'                               | NO_LINE
+    'application/adminconsoleactive/insecure/tomcat/manager' | ADMIN_CONSOLE_ACTIVE | ApplicationModuleImpl.TOMCAT_MANAGER_APP                   | NO_LINE
+    'application/adminconsoleactive/insecure/tomcat/host'    | ADMIN_CONSOLE_ACTIVE | ApplicationModuleImpl.TOMCAT_HOST_MANAGER_APP              | NO_LINE
     'application/defaulthtmlescapeinvalid/secure'     | null                        | null                                                       | _
     'application/defaulthtmlescapeinvalid/secure_tag' | null                        | null                                                       | _
     'application/defaulthtmlescapeinvalid/false_tag'  | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be true'                     | 8

--- a/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/insecure/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/insecure/WEB-INF/web.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
-         version="4.0">
-  <display-name>Tomcat Manager Application</display-name>
-</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/insecure/tomcat/host/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/insecure/tomcat/host/WEB-INF/web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+  version="4.0"
+  metadata-complete="true">
+
+  <display-name>Tomcat Host Manager Application</display-name>
+
+</web-app>

--- a/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/insecure/tomcat/manager/WEB-INF/web.xml
+++ b/dd-java-agent/agent-iast/src/test/resources/application/adminconsoleactive/insecure/tomcat/manager/WEB-INF/web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                      http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+  version="4.0"
+  metadata-complete="true">
+
+  <display-name>Tomcat Manager Application</display-name>
+
+</web-app>


### PR DESCRIPTION
# What Does This Do

- Parameterize Admin console active report implementation to be able to report more Admin consoles and not only Tomcat Manager Application

- Report Admin console active vulnerability when `<display-name>Tomcat Host Manager Application</display-name>` is found in application web.xml

# Motivation

Report Admin console active vulnerability if Tomcat Host Manager Application  is deployed in a Tomcat server

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
