### PR TITLE
Use stack depth to do snapshot assignment

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -91,12 +91,11 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
     }
     int[] mapping = createThrowableMapping(innerMostException, t);
     StackTraceElement[] innerTrace = innerMostException.getStackTrace();
-    int currentIdx = 0;
     boolean snapshotAssigned = false;
     List<Snapshot> snapshots = state.getSnapshots();
     for (int i = 0; i < snapshots.size(); i++) {
       Snapshot snapshot = snapshots.get(i);
-      currentIdx = innerTrace.length - snapshot.getStack().size();
+      int currentIdx = innerTrace.length - snapshot.getStack().size();
       if (!sanityCheckSnapshotAssignment(snapshot, innerTrace, currentIdx)) {
         continue;
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
@@ -97,6 +97,8 @@ public class ExceptionHelper {
     }
   }
 
+  // Because flattened stack traces are organized with first frames at the bottom I need to follow
+  // the order of the first frame and wrap around the array with a modulo to continue the matching
   public static int[] createThrowableMapping(Throwable innerMost, Throwable current) {
     StackTraceElement[] innerTrace = innerMost.getStackTrace();
     StackTraceElement[] currentTrace = flattenStackTrace(current);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
@@ -98,16 +98,22 @@ public class ExceptionHelper {
   }
 
   public static int[] createThrowableMapping(Throwable innerMost, Throwable current) {
-    StackTraceElement[] trace = innerMost.getStackTrace();
+    StackTraceElement[] innerTrace = innerMost.getStackTrace();
     StackTraceElement[] currentTrace = flattenStackTrace(current);
-    int[] mapping = new int[trace.length];
-    for (int i = 0; i < trace.length; i++) {
+    int[] mapping = new int[innerTrace.length];
+    int currentIdx = 0;
+    for (int i = 0; i < innerTrace.length; i++) {
       mapping[i] = -1;
-      for (int j = 0; j < currentTrace.length; j++) {
-        if (trace[i].equals(currentTrace[j])) {
-          mapping[i] = j;
+      int count = currentTrace.length;
+      int idx = currentIdx;
+      while (count > 0) {
+        if (innerTrace[i].equals(currentTrace[idx])) {
+          mapping[i] = idx;
+          currentIdx = (idx + 1) % currentTrace.length;
           break;
         }
+        idx = (idx + 1) % currentTrace.length;
+        count--;
       }
     }
     return mapping;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -238,7 +238,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   public void lineActiveSpanSimpleTag() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration = createDecoration("tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 44);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 47);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(84, result);
@@ -271,7 +271,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
         createDecoration(eq(ref("arg"), value("5")), "arg == '5'", "tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 44);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 47);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 10; i++) {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
@@ -287,7 +287,7 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
         createDecoration(eq(ref("noarg"), value("5")), "arg == '5'", "tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 44);
+    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 47);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "5").get();
     assertEquals(84, result);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 public class ExceptionProbeInstrumentationTest {
   private final Instrumentation instr = ByteBuddyAgent.install();
@@ -163,6 +164,9 @@ public class ExceptionProbeInstrumentationTest {
   }
 
   @Test
+  @DisabledIf(
+      value = "datadog.trace.api.Platform#isJ9",
+      disabledReason = "Bug in J9: no LocalVariableTable for ClassFileTransformer")
   public void recursive() throws Exception {
     Config config = createConfig();
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CON
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.DD_DEBUG_ERROR_EXCEPTION_ID;
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.ERROR_DEBUG_INFO_CAPTURED;
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.SNAPSHOT_ID_TAG_FMT;
+import static com.datadog.debugger.util.MoshiSnapshotTestHelper.getValue;
 import static com.datadog.debugger.util.TestHelper.assertWithTimeout;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -161,6 +162,37 @@ public class ExceptionProbeInstrumentationTest {
     assertEquals(snapshot1.getId(), span1.getTags().get(String.format(SNAPSHOT_ID_TAG_FMT, 0)));
   }
 
+  @Test
+  public void recursive() throws Exception {
+    Config config = createConfig();
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
+    TestSnapshotListener listener =
+        setupExceptionDebugging(config, exceptionProbeManager, classNameFiltering);
+    final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    // instrument RuntimeException stacktrace
+    String fingerprint = callMethodFiboException(testClass);
+    assertWithTimeout(
+        () -> exceptionProbeManager.isAlreadyInstrumented(fingerprint), Duration.ofSeconds(30));
+    assertEquals(11, exceptionProbeManager.getProbes().size());
+    callMethodFiboException(testClass); // generate snapshots
+    Map<String, Set<String>> probeIdsByMethodName =
+        extractProbeIdsByMethodName(exceptionProbeManager);
+    assertEquals(10, listener.snapshots.size());
+    Snapshot snapshot0 = listener.snapshots.get(0);
+    assertProbeId(probeIdsByMethodName, "fiboException", snapshot0.getProbe().getId());
+    assertEquals(
+        "oops fibo", snapshot0.getCaptures().getReturn().getCapturedThrowable().getMessage());
+    assertTrue(snapshot0.getCaptures().getReturn().getLocals().containsKey("@exception"));
+    assertEquals("1", getValue(snapshot0.getCaptures().getReturn().getArguments().get("n")));
+    Snapshot snapshot1 = listener.snapshots.get(1);
+    assertEquals("2", getValue(snapshot1.getCaptures().getReturn().getArguments().get("n")));
+    Snapshot snapshot2 = listener.snapshots.get(2);
+    assertEquals("3", getValue(snapshot2.getCaptures().getReturn().getArguments().get("n")));
+    Snapshot snapshot9 = listener.snapshots.get(9);
+    assertEquals("10", getValue(snapshot9.getCaptures().getReturn().getArguments().get("n")));
+  }
+
   private static void assertExceptionMsg(String expectedMsg, Snapshot snapshot) {
     assertEquals(
         expectedMsg, snapshot.getCaptures().getReturn().getCapturedThrowable().getMessage());
@@ -174,7 +206,7 @@ public class ExceptionProbeInstrumentationTest {
 
   private String callMethodThrowingRuntimeException(Class<?> testClass) {
     try {
-      Reflect.on(testClass).call("main", "exception").get();
+      Reflect.onClass(testClass).call("main", "exception").get();
       Assertions.fail("should not reach this code");
     } catch (RuntimeException ex) {
       assertEquals("oops", ex.getCause().getCause().getMessage());
@@ -185,7 +217,7 @@ public class ExceptionProbeInstrumentationTest {
 
   private String callMethodThrowingIllegalArgException(Class<?> testClass) {
     try {
-      Reflect.on(testClass).call("main", "illegal").get();
+      Reflect.onClass(testClass).call("main", "illegal").get();
       Assertions.fail("should not reach this code");
     } catch (RuntimeException ex) {
       assertEquals("illegal argument", ex.getCause().getCause().getMessage());
@@ -195,8 +227,19 @@ public class ExceptionProbeInstrumentationTest {
   }
 
   private static void callMethodNoException(Class<?> testClass) {
-    int result = Reflect.on(testClass).call("main", "1").get();
+    int result = Reflect.onClass(testClass).call("main", "1").get();
     assertEquals(84, result);
+  }
+
+  private String callMethodFiboException(Class<?> testClass) {
+    try {
+      Reflect.onClass(testClass).call("main", "recursive").get();
+      Assertions.fail("should not reach this code");
+    } catch (RuntimeException ex) {
+      assertEquals("oops fibo", ex.getCause().getCause().getMessage());
+      return Fingerprinter.fingerprint(ex, classNameFiltering);
+    }
+    return null;
   }
 
   private static Map<String, Set<String>> extractProbeIdsByMethodName(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
@@ -122,6 +122,26 @@ public class ExceptionHelperTest {
     }
   }
 
+  @Test
+  public void createThrowableMappingRecursive() {
+    Throwable nestedException = createNestExceptionRecursive(4);
+    Throwable innerMostThrowable = ExceptionHelper.getInnerMostThrowable(nestedException);
+    int[] mapping = ExceptionHelper.createThrowableMapping(innerMostThrowable, nestedException);
+    StackTraceElement[] flattenedTrace = ExceptionHelper.flattenStackTrace(nestedException);
+    for (int i = 0; i < mapping.length; i++) {
+      assertEquals(
+          flattenedTrace[mapping[i]].getClassName(),
+          innerMostThrowable.getStackTrace()[i].getClassName());
+    }
+  }
+
+  private RuntimeException createNestExceptionRecursive(int depth) {
+    if (depth == 0) {
+      return createNestException();
+    }
+    return createNestExceptionRecursive(depth - 1);
+  }
+
   private RuntimeException createNestException() {
     return new RuntimeException("test3", createTest2Exception(createTest1Exception()));
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/MoshiSnapshotTestHelper.java
@@ -36,13 +36,39 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Assertions;
 
 public class MoshiSnapshotTestHelper {
+
+  public static final JsonAdapter<CapturedContext.CapturedValue> VALUE_ADAPTER =
+      new MoshiSnapshotTestHelper.CapturedValueAdapter();
+
+  public static String getValue(CapturedContext.CapturedValue capturedValue) {
+    CapturedContext.CapturedValue valued = null;
+    try {
+      valued = VALUE_ADAPTER.fromJson(capturedValue.getStrValue());
+      if (valued.getNotCapturedReason() != null) {
+        Assertions.fail("NotCapturedReason: " + valued.getNotCapturedReason());
+      }
+      Object obj = valued.getValue();
+      if (obj != null && obj.getClass().isArray()) {
+        if (obj.getClass().getComponentType().isPrimitive()) {
+          return primitiveArrayToString(obj);
+        }
+        return Arrays.toString((Object[]) obj);
+      }
+      return obj != null ? String.valueOf(obj) : null;
+    } catch (IOException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
 
   public static class SnapshotJsonFactory implements JsonAdapter.Factory {
     @Override
@@ -72,6 +98,35 @@ public class MoshiSnapshotTestHelper {
             DebuggerScript.class,
             new ProbeCondition.ProbeConditionJsonAdapter()) // ProbeDetails in Snapshot
         .build();
+  }
+
+  private static String primitiveArrayToString(Object obj) {
+    Class<?> componentType = obj.getClass().getComponentType();
+    if (componentType == long.class) {
+      return Arrays.toString((long[]) obj);
+    }
+    if (componentType == int.class) {
+      return Arrays.toString((int[]) obj);
+    }
+    if (componentType == short.class) {
+      return Arrays.toString((short[]) obj);
+    }
+    if (componentType == char.class) {
+      return Arrays.toString((char[]) obj);
+    }
+    if (componentType == byte.class) {
+      return Arrays.toString((byte[]) obj);
+    }
+    if (componentType == boolean.class) {
+      return Arrays.toString((boolean[]) obj);
+    }
+    if (componentType == float.class) {
+      return Arrays.toString((float[]) obj);
+    }
+    if (componentType == double.class) {
+      return Arrays.toString((double[]) obj);
+    }
+    return null;
   }
 
   private static class CapturesAdapter extends MoshiSnapshotHelper.CapturesAdapter {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -30,6 +30,9 @@ public class CapturedSnapshot20 {
       if (arg.equals("exception") || arg.equals("illegal")) {
         return new CapturedSnapshot20().processWithException(arg);
       }
+      if (arg.equals("recursive")) {
+        return new CapturedSnapshot20().fiboException(10);
+      }
       return new CapturedSnapshot20().process(arg);
     } catch (Exception ex) {
       span.addThrowable(ex);
@@ -50,5 +53,16 @@ public class CapturedSnapshot20 {
       throw new IllegalArgumentException("illegal argument");
     }
     throw new RuntimeException("oops");
+  }
+
+  private int fiboException(int n) {
+    if (n <= 1) {
+      throw new RuntimeException("oops fibo");
+    }
+    try {
+      return fiboException(n - 1) + fiboException(n - 2);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex.getMessage(), ex);
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do
Instead of relying solely on matching class and method name for snapshot assignment on exception debugging we are using the stack depth of the snapshot of the current frame. It allows to support recursive calls

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ