### PR TITLE
Prevent gitlab pipelines from always being "blocked"

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -41,6 +41,7 @@ benchmarks:
         compare_to: "master"
       when: on_success
     - when: manual
+      allow_failure: true
   tags: ["runner:apm-k8s-tweaked-metal"]
   interruptible: true
   timeout: 1h


### PR DESCRIPTION
# What Does This Do
Adds `allow_failure: true` to DSM benchmark jobs. Without it being set, all Gitlab jobs are in the `blocked` state. This is a quirk of Gitlab for pipelines using `rules` config with manual jobs.

# Motivation
I noticed all gitlab pipelines were blocked for months.

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
