### PR TITLE
Installation of CoreTracer implies tracing submission is on initially

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -540,7 +540,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     this.dynamicConfig =
         DynamicConfig.create(ConfigSnapshot::new)
-            .setTracingEnabled(config.isTraceEnabled())
+            .setTracingEnabled(true) // implied by installation of CoreTracer
             .setRuntimeMetricsEnabled(config.isRuntimeMetricsEnabled())
             .setLogsInjectionEnabled(config.isLogsInjectionEnabled())
             .setDataStreamsEnabled(config.isDataStreamsEnabled())
@@ -726,7 +726,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   public void rebuildTraceConfig(Config config) {
     dynamicConfig
         .initial()
-        .setTracingEnabled(config.isTraceEnabled())
+        .setTracingEnabled(true) // implied by installation of CoreTracer
         .setRuntimeMetricsEnabled(config.isRuntimeMetricsEnabled())
         .setLogsInjectionEnabled(config.isLogsInjectionEnabled())
         .setDataStreamsEnabled(config.isDataStreamsEnabled())


### PR DESCRIPTION
This PR allows setups which turn off trace instrumentation, but enable CI-Vis instrumentation (which creates spans independently and doesn't rely on trace instrumentation)

We can't just use `config.isTraceEnabled()` because that is historically used to control whether trace instrumentation is applied and there are other products (CI-Vis) which generate spans and don't rely on `isTraceEnabled` being `true`.

We could create a new method which tells us whether the tracer should be installed, which uses the same logic as in [TracerInstaller](https://github.com/DataDog/dd-trace-java/blob/v1.31.2/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/TracerInstaller.java#L18) but I think a simpler approach is to always default it to `true` if the `CoreTracer` is installed.

(The general reasoning being that `CoreTracer` being installed implies we want traces submitted because that's the logic implied by [TracerInstaller](https://github.com/DataDog/dd-trace-java/blob/v1.31.2/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/TracerInstaller.java#L18) - if that changes then a new helper method like `shouldInstallTracer` might be the way to go, as then we only have one place to update when new products become independent of core tracing)

Jira ticket: [APMJAVA-1248]


[APMJAVA-1248]: https://datadoghq.atlassian.net/browse/APMJAVA-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ