### PR TITLE
Fix inaccessible fields capture

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
@@ -1,12 +1,13 @@
 package datadog.trace.bootstrap.debugger.el;
 
+import datadog.trace.bootstrap.debugger.CapturedContext;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
 /** A helper class to resolve a reference path using reflection. */
 public class ReflectiveFieldValueResolver {
   public static Object resolve(Object target, Class<?> targetType, String fldName) {
-    Field fld = getField(targetType, fldName);
+    Field fld = safeGetField(targetType, fldName);
     if (fld == null) {
       return Values.UNDEFINED_OBJECT;
     }
@@ -22,9 +23,41 @@ public class ReflectiveFieldValueResolver {
     return getField(target, fieldName).get(target);
   }
 
+  public static CapturedContext.CapturedValue getFieldAsCapturedValue(
+      Object target, String fieldName) {
+    if (target == null) {
+      return CapturedContext.CapturedValue.of(fieldName, Object.class.getTypeName(), null);
+    }
+    return getFieldAsCapturedValue(target.getClass(), target, fieldName);
+  }
+
+  public static CapturedContext.CapturedValue getFieldAsCapturedValue(
+      Class<?> clazz, Object target, String fieldName) {
+    Field field;
+    try {
+      field = getField(clazz, fieldName);
+      if (field == null) {
+        return CapturedContext.CapturedValue.notCapturedReason(
+            fieldName, Object.class.getTypeName(), "Field not found");
+      }
+    } catch (Exception ex) {
+      return CapturedContext.CapturedValue.notCapturedReason(
+          fieldName, Object.class.getTypeName(), ex.toString());
+    }
+    String declaredFieldType = Object.class.getTypeName();
+    try {
+      declaredFieldType = field.getType().getTypeName();
+      Object fieldValue = field.get(target);
+      return CapturedContext.CapturedValue.of(fieldName, declaredFieldType, fieldValue);
+    } catch (Exception ex) {
+      return CapturedContext.CapturedValue.notCapturedReason(
+          fieldName, declaredFieldType, ex.toString());
+    }
+  }
+
   public static Object getFieldValue(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).get(null);
+    return safeGetField(targetClass, fieldName).get(null);
   }
 
   public static long getFieldValueAsLong(Object target, String fieldName)
@@ -34,7 +67,7 @@ public class ReflectiveFieldValueResolver {
 
   public static long getFieldValueAsLong(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).getLong(null);
+    return safeGetField(targetClass, fieldName).getLong(null);
   }
 
   public static int getFieldValueAsInt(Object target, String fieldName)
@@ -44,7 +77,7 @@ public class ReflectiveFieldValueResolver {
 
   public static int getFieldValueAsInt(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).getInt(null);
+    return safeGetField(targetClass, fieldName).getInt(null);
   }
 
   public static double getFieldValueAsDouble(Object target, String fieldName)
@@ -54,7 +87,7 @@ public class ReflectiveFieldValueResolver {
 
   public static double getFieldValueAsDouble(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).getDouble(null);
+    return safeGetField(targetClass, fieldName).getDouble(null);
   }
 
   public static float getFieldValueAsFloat(Object target, String fieldName)
@@ -64,7 +97,7 @@ public class ReflectiveFieldValueResolver {
 
   public static float getFieldValueAsFloat(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).getFloat(null);
+    return safeGetField(targetClass, fieldName).getFloat(null);
   }
 
   public static float getFieldValueAsShort(Object target, String fieldName)
@@ -74,7 +107,7 @@ public class ReflectiveFieldValueResolver {
 
   public static float getFieldValueAsShort(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).getShort(null);
+    return safeGetField(targetClass, fieldName).getShort(null);
   }
 
   public static char getFieldValueAsChar(Object target, String fieldName)
@@ -84,7 +117,7 @@ public class ReflectiveFieldValueResolver {
 
   public static char getFieldValueAsChar(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).getChar(null);
+    return safeGetField(targetClass, fieldName).getChar(null);
   }
 
   public static byte getFieldValueAsByte(Object target, String fieldName)
@@ -94,7 +127,7 @@ public class ReflectiveFieldValueResolver {
 
   public static byte getFieldValueAsByte(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).getByte(null);
+    return safeGetField(targetClass, fieldName).getByte(null);
   }
 
   public static boolean getFieldValueAsBoolean(Object target, String fieldName)
@@ -104,18 +137,30 @@ public class ReflectiveFieldValueResolver {
 
   public static boolean getFieldValueAsBoolean(Class<?> targetClass, String fieldName)
       throws IllegalAccessException {
-    return getField(targetClass, fieldName).getBoolean(null);
+    return safeGetField(targetClass, fieldName).getBoolean(null);
   }
 
   private static Field getField(Object target, String name) throws NoSuchFieldException {
     if (target == null) {
       throw new NullPointerException();
     }
-    Field field = getField(target.getClass(), name);
+    Field field = safeGetField(target.getClass(), name);
     if (field == null) {
       throw new NoSuchFieldException(name);
     }
     return field;
+  }
+
+  private static Field safeGetField(Class<?> container, String name) {
+    try {
+      return getField(container, name);
+    } catch (SecurityException ignored) {
+      return null;
+    } catch (Exception e) {
+      // The only other exception allowed here is InaccessibleObjectException but since we compile
+      // against JDK 8 we can not use that type in the exception handler
+      return null;
+    }
   }
 
   private static Field getField(Class<?> container, String name) {
@@ -126,12 +171,6 @@ public class ReflectiveFieldValueResolver {
         return fld;
       } catch (NoSuchFieldException ignored) {
         container = container.getSuperclass();
-      } catch (SecurityException ignored) {
-        return null;
-      } catch (Exception ignored) {
-        // The only other exception allowed here is InaccessibleObjectException but since we compile
-        // against JDK 8 we can not use that type in the exception handler
-        return null;
       }
     }
     return null;

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot30.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot30.java
@@ -1,0 +1,66 @@
+package com.datadog.debugger;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.HttpURLConnection;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Objects;
+
+public class CapturedSnapshot30 {
+
+  private InetAddress inetAddress;
+
+  public CapturedSnapshot30() throws UnknownHostException {
+    this.inetAddress = Inet4Address.getLocalHost();
+  }
+
+  public static int main(String arg) throws Exception {
+    if ("static".equals(arg)) {
+      return new MyHttpURLConnection().process();
+    }
+    return new MyObjectInputStream().process();
+  }
+
+  private static class MyObjectInputStream extends ObjectInputStream {
+    private final int intField = 42;
+
+    public MyObjectInputStream() throws IOException {
+      super();
+    }
+
+    public int process() {
+      return intField;
+    }
+  }
+
+  private static class MyHttpURLConnection extends HttpURLConnection {
+    private final int intField = 42;
+
+    public MyHttpURLConnection() {
+      super(null);
+    }
+
+    @Override
+    public void connect() throws IOException {
+
+    }
+
+    @Override
+    public void disconnect() {
+
+    }
+
+    @Override
+    public boolean usingProxy() {
+      return false;
+    }
+
+    public int process() {
+      return intField;
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
To fix this we need to catch eventual exception thrown by accessing field values. For that we continue to try to access directly to field when possible because it will be faster, but when we detect fields are not accessible we use another method that try to access it through reflection but could catch exception if not and returns a CapturedValue instance filled with the reason of this exception.

# Motivation
NoSuchFieldException can be thrown if we try to capture, through reflection, (static) fields from JDK classes or from another module. 

# Additional Notes

Jira ticket: [DEBUG-2270]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2270]: https://datadoghq.atlassian.net/browse/DEBUG-2270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ