### PR TITLE
Increase default timeout for requests made to CI Visibility backend through EVP proxy

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -44,7 +44,7 @@ public class SharedCommunicationObjects {
   }
 
   private static long getHttpClientTimeout(Config config) {
-    if (!config.isCiVisibilityEnabled() || !config.isCiVisibilityAgentlessEnabled()) {
+    if (!config.isCiVisibilityEnabled()) {
       return TimeUnit.SECONDS.toMillis(config.getAgentTimeout());
     } else {
       return config.getCiVisibilityBackendApiTimeoutMillis();


### PR DESCRIPTION
# What Does This Do
When setting the timeout for the tracer's default HTTP client, an increased value is used if CI Visibility is enabled (30 seconds vs 10 seconds).

# Motivation
CI Visibility has a "get skippable tests" endpoint that might take more than 15 seconds to respond in some cases.

Jira ticket: [CIVIS-9601]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9601]: https://datadoghq.atlassian.net/browse/CIVIS-9601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ