### PR TITLE
Exclude oracle.j2ee from vulnerability locations

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -183,6 +183,7 @@
 2 okhttp3.Request
 2 okhttp3.Request$*
 1 ognl.*
+2 oracle.j2ee.*
 1 oracle.jdbc.*
 1 oracle.sql.*
 1 org.ajax4jsf.*


### PR DESCRIPTION
# What Does This Do
Exclude `oracle.j2ee.*` packages from being selected as vulnerability locations.

# Motivation

# Additional Notes

Jira ticket: [APPSEC-52409](https://datadoghq.atlassian.net/browse/APPSEC-52409)

[APPSEC-52409]: https://datadoghq.atlassian.net/browse/APPSEC-52409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ