### PR TITLE
Add remote config tracing_sample_rules.sample_rate ingestion capability to Java trace agent

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 53ff0c13dbf3d46d5832d3381407566a0ed583f2  
+default_system_tests_commit: &default_system_tests_commit 53ff0c13dbf3d46d5832d3381407566a0ed583f2
 
 parameters:
   nightly:

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 454b41b414ba9e4b534893c2fe77477428d3bdca
+default_system_tests_commit: &default_system_tests_commit 53ff0c13dbf3d46d5832d3381407566a0ed583f2  
 
 parameters:
   nightly:

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,11 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 53ff0c13dbf3d46d5832d3381407566a0ed583f2
+# prod
+default_system_tests_commit: &default_system_tests_commit 454b41b414ba9e4b534893c2fe77477428d3bdca
+
+# dev
+# default_system_tests_commit: &default_system_tests_commit 53ff0c13dbf3d46d5832d3381407566a0ed583f2
 
 parameters:
   nightly:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
   id 'com.github.spotbugs' version '5.0.14'
   id "de.thetaphi.forbiddenapis" version "3.5.1"
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -19,6 +19,7 @@ import datadog.remoteconfig.state.ParsedConfigKey;
 import datadog.remoteconfig.state.ProductListener;
 import datadog.trace.api.Config;
 import datadog.trace.api.DynamicConfig;
+import datadog.trace.api.sampling.SamplingRule;
 import datadog.trace.logging.GlobalLogLevelSwitcher;
 import datadog.trace.logging.LogLevel;
 import java.io.ByteArrayInputStream;
@@ -168,6 +169,8 @@ final class TracingConfigPoller {
 
     maybeOverride(builder::setTraceSampleRate, libConfig.traceSampleRate);
     maybeOverride(builder::setTracingTags, parseTagListToMap(libConfig.tracingTags));
+
+   // maybeOverride(builder::setTraceSamplingRules, libConfig.tracingSamplingRules);
     builder.apply();
   }
 
@@ -231,7 +234,6 @@ final class TracingConfigPoller {
 
     @Json(name = "sample_rate")
     public Double sampleRate;
-
   }
 
   static final class LibConfig {

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -219,9 +219,30 @@ final class TracingConfigPoller {
     public String env;
   }
 
+  static final class TracingSamplingRules {
+    @Json(name = "tracing_sampling_rules")
+    public List<String> tracingSamplingRules;
+
+    @Json(name = "service")
+    public String service;
+
+    @Json(name = "provenance")
+    public String provenance;
+
+    @Json(name = "resource")
+    public String resource;
+
+    @Json(name = "sample_rate")
+    public Double sampleRate;
+
+  }
+
   static final class LibConfig {
     @Json(name = "tracing_enabled")
     public Boolean tracingEnabled;
+
+    @Json(name = "tracing_sampling_rules")
+    public List<TracingSamplingRules> tracingSamplingRules;
 
     @Json(name = "tracing_debug")
     public Boolean debugEnabled;

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -5,6 +5,7 @@ import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_LOGS_INJECTION;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_TRACING_DATA_STREAMS_ENABLED;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_TRACING_SAMPLE_RATE;
+import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_TRACING_SAMPLE_RULES;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_TRACING_TRACING_ENABLED;
 
 import com.squareup.moshi.Json;
@@ -55,7 +56,8 @@ final class TracingConfigPoller {
               | CAPABILITY_APM_LOGS_INJECTION
               | CAPABILITY_APM_HTTP_HEADER_TAGS
               | CAPABILITY_APM_CUSTOM_TAGS
-              | CAPABILITY_APM_TRACING_DATA_STREAMS_ENABLED);
+              | CAPABILITY_APM_TRACING_DATA_STREAMS_ENABLED
+              | CAPABILITY_APM_TRACING_SAMPLE_RULES);
     }
     stopPolling = new Updater().register(config, configPoller);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -220,9 +220,6 @@ final class TracingConfigPoller {
   }
 
   static final class TracingSamplingRules {
-    @Json(name = "tracing_sampling_rules")
-    public List<String> tracingSamplingRules;
-
     @Json(name = "service")
     public String service;
 

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -14,7 +14,6 @@ import static datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
 
 import datadog.trace.api.sampling.SamplingRule.SpanSamplingRule;
 import datadog.trace.api.sampling.SamplingRule.TraceSamplingRule;
-
 import datadog.trace.util.Strings;
 import java.util.Collection;
 import java.util.Collections;
@@ -130,7 +129,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
       this.tracingTags = snapshot.tracingTags;
       this.preferredServiceName = snapshot.preferredServiceName;
 
-      this.traceSamplingRules=snapshot.traceSamplingRules;
+      this.traceSamplingRules = snapshot.traceSamplingRules;
     }
 
     public Builder setRuntimeMetricsEnabled(boolean runtimeMetricsEnabled) {

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -9,10 +9,12 @@ import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE;
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_RULES;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
 
 import datadog.trace.api.sampling.SamplingRule.SpanSamplingRule;
 import datadog.trace.api.sampling.SamplingRule.TraceSamplingRule;
+
 import datadog.trace.util.Strings;
 import java.util.Collection;
 import java.util.Collections;
@@ -127,6 +129,8 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
       this.traceSampleRate = snapshot.traceSampleRate;
       this.tracingTags = snapshot.tracingTags;
       this.preferredServiceName = snapshot.preferredServiceName;
+
+      this.traceSamplingRules=snapshot.traceSamplingRules;
     }
 
     public Builder setRuntimeMetricsEnabled(boolean runtimeMetricsEnabled) {
@@ -282,6 +286,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     update.put(RESPONSE_HEADER_TAGS, newSnapshot.responseHeaderTags);
     update.put(BAGGAGE_MAPPING, newSnapshot.baggageMapping);
 
+    maybePut(update, TRACE_SAMPLING_RULES, newSnapshot.traceSamplingRules);
     maybePut(update, TRACE_SAMPLE_RATE, newSnapshot.traceSampleRate);
 
     ConfigCollector.get().putAll(update, ConfigOrigin.REMOTE);


### PR DESCRIPTION
# What Does This Do

Enables sampling rules to be applied to the Java trace agent using Remote Config.  

Manual testing process documented here:
https://docs.google.com/document/d/1M7KLbV7q8mskVJxbT0fdRrgM0qNZjvF8mzuWJM_R4Q0/edit?usp=sharing

1. advise dd agent that this client is interested in CAPABILITY_APM_TRACING_SAMPLE_RULES using client.products field of the ClientGetConfigsRequest
2. expect corresponding incoming ClientGetConfigsResponse msg
3. deserialize the incoming configuration
4. retain the existing default configuration
5. in TracingConfigPoller, applyConfigOverrides maybeOverride() any default or local data values with new lib_config values arriving from incoming remote config, matching on service+env (ServiceTarget )to DynamicConfig.setTraceSampleRate. e.g.:

```
"lib_config": {
    "library_language": "all",
    "library_version": "latest",
    "service_name": "datadog-demo",
    "env": "staging",
    "tracing_enabled": true,
    "tracing_sampling_rules": [
      {
        "service": "datadog-demo",
        "provenance": "customer",
        "resource": "mariadb.query",
        "sample_rate": 0.4
      }
    ]
  },
  "service_target": {
    "service": "datadog-demo",
    "env": "dev"
  }
```

# Motivation

Jira ticket: [PROJ-IDENT]
