### PR TITLE
Register SpanLinkAdapter and SpanLinkJson for reflection 

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
+++ b/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
@@ -48,6 +48,19 @@
     ]
   },
   {
+    "name" : "datadog.trace.agent.core.DDSpanLink$SpanLinkAdapter",
+    "methods": [
+      {"name": "toSpanLinkJson"}
+    ]
+  },
+  {
+    "name" : "datadog.trace.agent.core.DDSpanLink$SpanLinkJson",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
     "name" : "datadog.trace.instrumentation.springweb.HandlerMappingResourceNameFilter",
     "methods": [
       {"name": "<init>", "parameterTypes": []}


### PR DESCRIPTION
# What Does This Do
Uses a initialization-on-demand holder idiom for the DDSpanLink encoder to make sure that it is not initialized more than once, so it is thread safe. During debugging we saw a bunch of
```
java.lang.IllegalArgumentException: Expected at least one @ToJson or @FromJson method on datadog.trace.agent.core.DDSpanLink$SpanLinkAdapter
	at com.squareup.moshi.AdapterMethodsFactory.get(AdapterMethodsFactory.java:153)
	at com.squareup.moshi.Moshi$Builder.add(Moshi.java:223)
	at datadog.trace.agent.core.DDSpanLink.getEncoder(DDSpanLink.java:99)
	at datadog.trace.agent.core.DDSpanLink.toTag(DDSpanLink.java:77)
	at datadog.trace.agent.core.DDSpanContext.processTagsAndBaggage(DDSpanContext.java:789)
	at datadog.trace.agent.core.DDSpan.processTagsAndBaggage(DDSpan.java:703)
	at datadog.trace.agent.common.writer.ddagent.TraceMapperV0_4.map(TraceMapperV0_4.java:219)
	at datadog.trace.agent.common.writer.ddagent.TraceMapperV0_4.map(TraceMapperV0_4.java:20)
	at datadog.communication.serialization.msgpack.MsgPackWriter.format(MsgPackWriter.java:84)
	at datadog.trace.agent.common.writer.PayloadDispatcherImpl.addTrace(PayloadDispatcherImpl.java:80)
	at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.onEvent(TraceProcessingWorker.java:239)
	at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.consumeFromPrimaryQueue(TraceProcessingWorker.java:258)
	at datadog.trace.agent.common.writer.TraceProcessingWorker$DaemonTraceSerializingHandler.runDutyCycle(TraceProcessingWorker.java:155)
	at datadog.trace.agent.common.writer.TraceProcessingWorker$DaemonTraceSerializingHandler.run(TraceProcessingWorker.java:145)
	at java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
	at java.base@21.0.2/java.lang.Thread.run(Thread.java:1583)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:838)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.posix.thread.PosixPlatformThreads.pthreadStartRoutine(PosixPlatformThreads.java:211)
```

which means that SpanLinkAdapter and SpanLinkJson were not registered for reflection to be used on GraalVM.

Registration for SpanLinkAdapter is required so Moshi is able to build the adapter during runtime, and for SpanLinkJson as well, since this is lazy init GraalVM can't auto infer reflections.

# Motivation
SpanLinkAdapter was failing, thus producing invalid payloads (we also raised support request number 1631888)... there you can see the payload and logs for the auto instrumentation and DD side car.

We've have conducted load tests with the change in our environments and with the change the`Cannot decode v0.4 traces payload: msgp: attempted to decode type "array" with method for "str` error message is gone, and we didn't see any error whatsoever.

# Fixes
https://github.com/DataDog/dd-trace-java/issues/6889
