### PR TITLE
Add Onboarding test on gitlab pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ include:
   - local: ".gitlab/benchmarks.yml"
   - local: ".gitlab/exploration-tests.yml"
   - local: ".gitlab/ci-visibility-tests.yml"
+  - local: ".gitlab/single-step-instrumentation-tests.yml"
 
 stages:
   - build
@@ -12,6 +13,7 @@ stages:
   - benchmarks
   - exploration-tests
   - ci-visibility-tests
+  - onboarding-tests
   - generate-signing-key
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ stages:
   - benchmarks
   - exploration-tests
   - ci-visibility-tests
-  - onboarding-tests
+  - single-step-instrumentation-tests
   - generate-signing-key
 
 variables:

--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -54,4 +54,4 @@ onboarding_tests:
     - ls system-tests/binaries
     - cd system-tests
     - ./build.sh -i runner
-    #- timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env prod --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-skip-branches ubuntu18_amd64
+    - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env prod --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-skip-branches ubuntu18_amd64

--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -37,6 +37,9 @@ onboarding_tests:
   extends: .base_job_onboarding_tests
   stage: single-step-instrumentation-tests
   needs: [ package, package-arm]
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"
+      when: on_success
   allow_failure: false
   variables:
     TEST_LIBRARY: java

--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -45,7 +45,7 @@ onboarding_tests:
       matrix:
         - ONBOARDING_FILTER_WEBLOG: [test-app-java]
           SCENARIO: [SIMPLE_HOST_AUTO_INJECTION]
-        - ONBOARDING_FILTER_WEBLOG: [test-app-java-container]
+        - ONBOARDING_FILTER_WEBLOG: [test-app-java-container,test-app-java-buildpack,test-app-java-alpine]
           SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION]
   script:
     - git clone https://git@github.com/DataDog/system-tests.git system-tests

--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -1,0 +1,57 @@
+.base_job_onboarding_tests:
+
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
+  tags: ["arch:amd64"]
+  before_script:
+    # Setup AWS Credentials for dd-trace-rb.
+    - mkdir -p ~/.aws
+    - aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config
+    - export DD_API_KEY_ONBOARDING=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.dd-api-key-onboarding --with-decryption --query "Parameter.Value" --out text)
+    - export DD_APP_KEY_ONBOARDING=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.dd-app-key-onboarding --with-decryption --query "Parameter.Value" --out text)
+    - export ONBOARDING_AWS_INFRA_SUBNET_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.aws-infra-subnet-id --with-decryption --query "Parameter.Value" --out text)
+    - export ONBOARDING_AWS_INFRA_SECURITY_GROUPS_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.aws-infra-securiy-groups-id --with-decryption --query "Parameter.Value" --out text)
+    - export PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.pulumi-config-passphrase --with-decryption --query "Parameter.Value" --out text) 
+    #Install plugins for PULUMI you need connect to gh. Sometimes this problem arises: GitHub rate limit exceeded
+    - export GITHUB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.gh-token --with-decryption --query "Parameter.Value" --out text) 
+    #Avoid dockerhub rate limits
+    - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.docker-login --with-decryption --query "Parameter.Value" --out text) 
+    - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.docker-login-pass --with-decryption --query "Parameter.Value" --out text) 
+
+    - export AWS_PROFILE=agent-qa-ci
+    - pulumi login --local #"s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
+    - pulumi plugin install resource command 0.7.2
+    - pulumi plugin install resource aws 5.41.0
+
+  after_script:
+    - echo "After onboarding script"
+    - cd system-tests
+    - mkdir -p reports
+    - cp -R logs_*/ reports/
+  
+  artifacts:
+      when: always
+      paths:
+        - system-tests/reports/
+
+onboarding_tests:
+  extends: .base_job_onboarding_tests
+  stage: single-step-instrumentation-tests
+  needs: [ package, package-arm]
+  allow_failure: false
+  variables:
+    TEST_LIBRARY: java
+    ONBOARDING_FILTER_ENV: prod
+  parallel:
+      matrix:
+        - ONBOARDING_FILTER_WEBLOG: [test-app-java]
+          SCENARIO: [SIMPLE_HOST_AUTO_INJECTION]
+        - ONBOARDING_FILTER_WEBLOG: [test-app-java-container]
+          SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION]
+  script:
+    - git clone https://git@github.com/DataDog/system-tests.git system-tests
+    - cp packaging/*.rpm system-tests/binaries
+    - cp packaging/*.deb system-tests/binaries
+    - ls system-tests/binaries
+    - cd system-tests
+    - ./build.sh -i runner
+    #- timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env prod --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-skip-branches ubuntu18_amd64


### PR DESCRIPTION
# What Does This Do

Add the onboarding tests on gitlab pipeline. These tests will be executed after deb and rpm packages generation.
# Motivation
System-tests nightly build pipeline is launching the onboarding tests agains latest released packages.
We need to launch the onboarding tests for current branch generated packages.
These tests are adding for auto-inject and dd-trace-rb repositories. We are trying to expand to all dd-trace-lang repos.
# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
