### PR TITLE
Remove deduplication for session rewriting vulnerability report

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -52,6 +52,15 @@ public class Reporter {
     if (duplicated.test(vulnerability)) {
       return;
     }
+    noDedupReport(span, vulnerability);
+  }
+
+  /**
+   * Report a vulnerability without deduplication. This should be used when the caller is sure that
+   * no deduplication is needed, otherwise use {@link #report(AgentSpan, Vulnerability)}.
+   */
+  public void noDedupReport(
+      @Nullable final AgentSpan span, @Nonnull final Vulnerability vulnerability) {
     if (span == null) {
       final AgentSpan newSpan = startNewSpan();
       try (final AgentScope autoClosed = tracer().activateSpan(newSpan, ScopeSource.MANUAL)) {

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/Reporter.java
@@ -52,15 +52,6 @@ public class Reporter {
     if (duplicated.test(vulnerability)) {
       return;
     }
-    noDedupReport(span, vulnerability);
-  }
-
-  /**
-   * Report a vulnerability without deduplication. This should be used when the caller is sure that
-   * no deduplication is needed, otherwise use {@link #report(AgentSpan, Vulnerability)}.
-   */
-  public void noDedupReport(
-      @Nullable final AgentSpan span, @Nonnull final Vulnerability vulnerability) {
     if (span == null) {
       final AgentSpan newSpan = startNewSpan();
       try (final AgentScope autoClosed = tracer().activateSpan(newSpan, ScopeSource.MANUAL)) {
@@ -161,6 +152,9 @@ public class Reporter {
 
     @Override
     public boolean test(final Vulnerability vulnerability) {
+      if (!vulnerability.getType().isDeduplicable()) {
+        return false;
+      }
       final boolean newVulnerability = hashes.add(vulnerability.getHash());
       if (newVulnerability && hashes.size() > maxSize) {
         hashes.clear();

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -87,7 +87,7 @@ public interface VulnerabilityType {
           VulnerabilityTypes.REFLECTION_INJECTION, VulnerabilityMarks.REFLECTION_INJECTION_MARK);
 
   VulnerabilityType SESSION_REWRITING =
-      new ServiceVulnerabilityType(VulnerabilityTypes.SESSION_REWRITING);
+      new ServiceVulnerabilityType(VulnerabilityTypes.SESSION_REWRITING, false);
 
   String name();
 
@@ -109,14 +109,26 @@ public interface VulnerabilityType {
 
     private final int mark;
 
+    private final boolean deduplicable;
+
     public VulnerabilityTypeImpl(final byte type, final int... marks) {
       this(type, ' ', marks);
     }
 
+    public VulnerabilityTypeImpl(final byte type, boolean deduplicable, final int... marks) {
+      this(type, ' ', deduplicable, marks);
+    }
+
     public VulnerabilityTypeImpl(final byte type, final char separator, final int... marks) {
+      this(type, separator, true, marks);
+    }
+
+    public VulnerabilityTypeImpl(
+        final byte type, final char separator, final boolean deduplicable, final int... marks) {
       this.type = type;
       this.separator = separator;
       mark = computeMarks(marks);
+      this.deduplicable = deduplicable;
     }
 
     @Override
@@ -153,7 +165,7 @@ public interface VulnerabilityType {
 
     @Override
     public boolean isDeduplicable() {
-      return true;
+      return deduplicable;
     }
 
     protected void update(final CRC32 crc, final String value) {
@@ -205,13 +217,8 @@ public interface VulnerabilityType {
   }
 
   class ServiceVulnerabilityType extends VulnerabilityTypeImpl {
-    public ServiceVulnerabilityType(byte type, int... marks) {
-      super(type, marks);
-    }
-
-    @Override
-    public boolean isDeduplicable() {
-      return false;
+    public ServiceVulnerabilityType(byte type, boolean deduplicable, int... marks) {
+      super(type, deduplicable, marks);
     }
 
     @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -98,6 +98,9 @@ public interface VulnerabilityType {
 
   long calculateHash(@Nonnull final Vulnerability vulnerability);
 
+  /** A flag to indicate if the vulnerability is deduplicable. */
+  boolean isDeduplicable();
+
   class VulnerabilityTypeImpl implements VulnerabilityType {
 
     private final byte type;
@@ -146,6 +149,11 @@ public interface VulnerabilityType {
         }
       }
       return crc.getValue();
+    }
+
+    @Override
+    public boolean isDeduplicable() {
+      return true;
     }
 
     protected void update(final CRC32 crc, final String value) {
@@ -199,6 +207,11 @@ public interface VulnerabilityType {
   class ServiceVulnerabilityType extends VulnerabilityTypeImpl {
     public ServiceVulnerabilityType(byte type, int... marks) {
       super(type, marks);
+    }
+
+    @Override
+    public boolean isDeduplicable() {
+      return false;
     }
 
     @Override

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -112,7 +112,8 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     }
     final AgentSpan span = AgentTracer.activeSpan();
     // overhead is not checked here as it's called once per application context
-    reporter.report(
+    // No deduplication is needed as same service can have multiple applications
+    reporter.noDedupReport(
         span,
         new Vulnerability(
             VulnerabilityType.SESSION_REWRITING,

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -113,7 +113,7 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     final AgentSpan span = AgentTracer.activeSpan();
     // overhead is not checked here as it's called once per application context
     // No deduplication is needed as same service can have multiple applications
-    reporter.noDedupReport(
+    reporter.report(
         span,
         new Vulnerability(
             VulnerabilityType.SESSION_REWRITING,

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -449,6 +449,30 @@ class ReporterTest extends DDSpecification {
     0 * _
   }
 
+  void 'Reporter when noDedupReport is called does not prevent duplicates'() {
+    given:
+    final Reporter reporter = new Reporter()
+    final batch = new VulnerabilityBatch()
+    final span = spanWithBatch(batch)
+    final vulnerability = new Vulnerability(
+      VulnerabilityType.WEAK_HASH,
+      Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
+      new Evidence("GOOD")
+      )
+
+    when: 'first time a vulnerability is reported'
+    reporter.noDedupReport(span, vulnerability)
+
+    then:
+    batch.vulnerabilities.size() == 1
+
+    when: 'second time the a vulnerability is reported'
+    reporter.noDedupReport(span, vulnerability)
+
+    then:
+    batch.vulnerabilities.size() == 2
+  }
+
   private AgentSpan spanWithBatch(final VulnerabilityBatch batch) {
     final traceSegment = Mock(TraceSegment) {
       getDataTop('iast') >> batch

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -449,25 +449,25 @@ class ReporterTest extends DDSpecification {
     0 * _
   }
 
-  void 'Reporter when noDedupReport is called does not prevent duplicates'() {
+  void 'Reporter when vulnerability is no deduplicable does not prevent duplicates'() {
     given:
     final Reporter reporter = new Reporter()
     final batch = new VulnerabilityBatch()
     final span = spanWithBatch(batch)
     final vulnerability = new Vulnerability(
-      VulnerabilityType.WEAK_HASH,
-      Location.forSpanAndStack(span, new StackTraceElement("foo", "foo", "foo", 1)),
-      new Evidence("GOOD")
+      VulnerabilityType.SESSION_REWRITING,
+      Location.forSpan(span),
+      new Evidence("SESSION_REWRITING")
       )
 
     when: 'first time a vulnerability is reported'
-    reporter.noDedupReport(span, vulnerability)
+    reporter.report(span, vulnerability)
 
     then:
     batch.vulnerabilities.size() == 1
 
     when: 'second time the a vulnerability is reported'
-    reporter.noDedupReport(span, vulnerability)
+    reporter.report(span, vulnerability)
 
     then:
     batch.vulnerabilities.size() == 2

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -80,9 +80,9 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
 
     then:
     if (expected != null) {
-      1 * reporter.noDedupReport(_, _) >> { args -> assertSessionRewriting(args[1] as Vulnerability, expected) }
+      1 * reporter.report(_, _) >> { args -> assertSessionRewriting(args[1] as Vulnerability, expected) }
     } else {
-      0 * reporter.noDedupReport(_, _)
+      0 * reporter.report(_, _)
     }
     0 * reporter.report(_, _)
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -80,10 +80,11 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
 
     then:
     if (expected != null) {
-      1 * reporter.report(_, _) >> { args -> assertSessionRewriting(args[1] as Vulnerability, expected) }
+      1 * reporter.noDedupReport(_, _) >> { args -> assertSessionRewriting(args[1] as Vulnerability, expected) }
     } else {
-      0 * reporter.report(_, _)
+      0 * reporter.noDedupReport(_, _)
     }
+    0 * reporter.report(_, _)
 
     where:
     sessionTrackingModes        | expected


### PR DESCRIPTION
# What Does This Do

- Add a new method Reporter#noDepupReport to allow report vulnerabilities without deduplication
- Remove deduplication for session rewriting vulnerability report

# Motivation

If several apps are deployed in the same server  only the first one session rewriting vulnerability find will be reported 

# Additional Notes

Jira ticket: [APPSEC-52434]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-52434]: https://datadoghq.atlassian.net/browse/APPSEC-52434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ