### PR TITLE
Admin Console Active vulnerability hash calculation

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -64,7 +64,7 @@ public interface VulnerabilityType {
   VulnerabilityType VERB_TAMPERING = new VulnerabilityTypeImpl(VulnerabilityTypes.VERB_TAMPERING);
 
   VulnerabilityType ADMIN_CONSOLE_ACTIVE =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE);
+      new ServiceVulnerabilityType(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE);
 
   VulnerabilityType DEFAULT_HTML_ESCAPE_INVALID =
       new VulnerabilityTypeImpl(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -64,7 +64,7 @@ public interface VulnerabilityType {
   VulnerabilityType VERB_TAMPERING = new VulnerabilityTypeImpl(VulnerabilityTypes.VERB_TAMPERING);
 
   VulnerabilityType ADMIN_CONSOLE_ACTIVE =
-      new ServiceVulnerabilityType(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE);
+      new ServiceVulnerabilityType(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE, false);
 
   VulnerabilityType DEFAULT_HTML_ESCAPE_INVALID =
       new VulnerabilityTypeImpl(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID);

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -91,6 +91,11 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     super(dependencies);
   }
 
+  /**
+   * Overhead is not checked here as it's called once per application context
+   *
+   * @param realPath the real path of the application
+   */
   @Override
   public void onRealPath(final @Nullable String realPath) {
     if (realPath == null) {
@@ -105,13 +110,17 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
     checkWebXmlVulnerabilities(root, span);
   }
 
+  /**
+   * Overhead is not checked here as it's called once per application context
+   *
+   * @param sessionTrackingModes the session tracking modes
+   */
   @Override
   public void checkSessionTrackingModes(@Nonnull Set<String> sessionTrackingModes) {
     if (!sessionTrackingModes.contains("URL")) {
       return;
     }
     final AgentSpan span = AgentTracer.activeSpan();
-    // overhead is not checked here as it's called once per application context
     // No deduplication is needed as same service can have multiple applications
     reporter.report(
         span,
@@ -188,7 +197,13 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
   }
 
   private void reportAdminConsoleActive(AgentSpan span) {
-    report(span, VulnerabilityType.ADMIN_CONSOLE_ACTIVE, "Tomcat Manager Application", NO_LINE);
+    // No deduplication is needed as same service can have multiple applications
+    reporter.noDedupReport(
+        span,
+        new Vulnerability(
+            VulnerabilityType.ADMIN_CONSOLE_ACTIVE,
+            Location.forSpan(span),
+            new Evidence("Tomcat Manager Application")));
   }
 
   private void checkDirectoryListingLeak(

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/ApplicationModuleImpl.java
@@ -198,7 +198,7 @@ public class ApplicationModuleImpl extends SinkModuleBase implements Application
 
   private void reportAdminConsoleActive(AgentSpan span) {
     // No deduplication is needed as same service can have multiple applications
-    reporter.noDedupReport(
+    reporter.report(
         span,
         new Vulnerability(
             VulnerabilityType.ADMIN_CONSOLE_ACTIVE,

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -50,28 +50,28 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
 
     then:
     if (expectedVulnType != null) {
-      1 * reporter.report(_, _) >> { assertEvidence(it[1], expectedVulnType, expectedEvidence, line) }
+      1 * reporter."$method"(_, _) >> { assertEvidence(it[1], expectedVulnType, expectedEvidence, line) }
     } else {
       0 * reporter._
     }
 
     where:
-    path                                              | expectedVulnType            | expectedEvidence                                           | line
-    'application/insecurejsplayout/secure'            | null                        | null                                                       | _
-    'application/insecurejsplayout/insecure'          | INSECURE_JSP_LAYOUT         | ['/nestedinsecure', '/nestedinsecure/nestedinsecure', '/'] | NO_LINE
-    'application/verbtampering/secure'                | null                        | null                                                       | _
-    'application/verbtampering/insecure'              | VERB_TAMPERING              | 'http-method not defined in web.xml'                       | 6
-    'application/sessiontimeout/secure'               | null                        | null                                                       | _
-    'application/sessiontimeout/insecure'             | SESSION_TIMEOUT             | 'Found vulnerable timeout value: 80'                       | 7
-    'application/directorylistingleak/secure'         | null                        | null                                                       | _
-    'application/directorylistingleak/insecure'       | DIRECTORY_LISTING_LEAK      | 'Directory listings configured'                            | 14
-    'application/adminconsoleactive/secure'           | null                        | null                                                       | _
-    'application/adminconsoleactive/insecure'         | ADMIN_CONSOLE_ACTIVE        | 'Tomcat Manager Application'                               | NO_LINE
-    'application/defaulthtmlescapeinvalid/secure'     | null                        | null                                                       | _
-    'application/defaulthtmlescapeinvalid/secure_tag' | null                        | null                                                       | _
-    'application/defaulthtmlescapeinvalid/false_tag'  | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be true'                     | 8
-    'application/defaulthtmlescapeinvalid/no_tag_1'   | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'                      | NO_LINE
-    'application/defaulthtmlescapeinvalid/no_tag_2'   | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'                      | NO_LINE
+    method           | path                                              | expectedVulnType            | expectedEvidence                                           | line
+    'report'         | 'application/insecurejsplayout/secure'            | null                        | null                                                       | _
+    'report'         | 'application/insecurejsplayout/insecure'          | INSECURE_JSP_LAYOUT         | ['/nestedinsecure', '/nestedinsecure/nestedinsecure', '/'] | NO_LINE
+    'report'         | 'application/verbtampering/secure'                | null                        | null                                                       | _
+    'report'         | 'application/verbtampering/insecure'              | VERB_TAMPERING              | 'http-method not defined in web.xml'                       | 6
+    'report'         | 'application/sessiontimeout/secure'               | null                        | null                                                       | _
+    'report'         | 'application/sessiontimeout/insecure'             | SESSION_TIMEOUT             | 'Found vulnerable timeout value: 80'                       | 7
+    'report'         | 'application/directorylistingleak/secure'         | null                        | null                                                       | _
+    'report'         | 'application/directorylistingleak/insecure'       | DIRECTORY_LISTING_LEAK      | 'Directory listings configured'                            | 14
+    'noDedupReport'  | 'application/adminconsoleactive/secure'           | null                        | null                                                       | _
+    'noDedupReport'  | 'application/adminconsoleactive/insecure'         | ADMIN_CONSOLE_ACTIVE        | 'Tomcat Manager Application'                               | NO_LINE
+    'report'         | 'application/defaulthtmlescapeinvalid/secure'     | null                        | null                                                       | _
+    'report'         | 'application/defaulthtmlescapeinvalid/secure_tag' | null                        | null                                                       | _
+    'report'         | 'application/defaulthtmlescapeinvalid/false_tag'  | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be true'                     | 8
+    'report'         | 'application/defaulthtmlescapeinvalid/no_tag_1'   | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'                      | NO_LINE
+    'report'         | 'application/defaulthtmlescapeinvalid/no_tag_2'   | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'                      | NO_LINE
   }
 
   void 'iast module detects session rewriting on sessionTrackingModes'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/ApplicationModuleTest.groovy
@@ -50,28 +50,28 @@ class ApplicationModuleTest extends IastModuleImplTestBase {
 
     then:
     if (expectedVulnType != null) {
-      1 * reporter."$method"(_, _) >> { assertEvidence(it[1], expectedVulnType, expectedEvidence, line) }
+      1 * reporter.report(_, _) >> { assertEvidence(it[1], expectedVulnType, expectedEvidence, line) }
     } else {
       0 * reporter._
     }
 
     where:
-    method           | path                                              | expectedVulnType            | expectedEvidence                                           | line
-    'report'         | 'application/insecurejsplayout/secure'            | null                        | null                                                       | _
-    'report'         | 'application/insecurejsplayout/insecure'          | INSECURE_JSP_LAYOUT         | ['/nestedinsecure', '/nestedinsecure/nestedinsecure', '/'] | NO_LINE
-    'report'         | 'application/verbtampering/secure'                | null                        | null                                                       | _
-    'report'         | 'application/verbtampering/insecure'              | VERB_TAMPERING              | 'http-method not defined in web.xml'                       | 6
-    'report'         | 'application/sessiontimeout/secure'               | null                        | null                                                       | _
-    'report'         | 'application/sessiontimeout/insecure'             | SESSION_TIMEOUT             | 'Found vulnerable timeout value: 80'                       | 7
-    'report'         | 'application/directorylistingleak/secure'         | null                        | null                                                       | _
-    'report'         | 'application/directorylistingleak/insecure'       | DIRECTORY_LISTING_LEAK      | 'Directory listings configured'                            | 14
-    'noDedupReport'  | 'application/adminconsoleactive/secure'           | null                        | null                                                       | _
-    'noDedupReport'  | 'application/adminconsoleactive/insecure'         | ADMIN_CONSOLE_ACTIVE        | 'Tomcat Manager Application'                               | NO_LINE
-    'report'         | 'application/defaulthtmlescapeinvalid/secure'     | null                        | null                                                       | _
-    'report'         | 'application/defaulthtmlescapeinvalid/secure_tag' | null                        | null                                                       | _
-    'report'         | 'application/defaulthtmlescapeinvalid/false_tag'  | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be true'                     | 8
-    'report'         | 'application/defaulthtmlescapeinvalid/no_tag_1'   | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'                      | NO_LINE
-    'report'         | 'application/defaulthtmlescapeinvalid/no_tag_2'   | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'                      | NO_LINE
+    path                                              | expectedVulnType            | expectedEvidence                                           | line
+    'application/insecurejsplayout/secure'            | null                        | null                                                       | _
+    'application/insecurejsplayout/insecure'          | INSECURE_JSP_LAYOUT         | ['/nestedinsecure', '/nestedinsecure/nestedinsecure', '/'] | NO_LINE
+    'application/verbtampering/secure'                | null                        | null                                                       | _
+    'application/verbtampering/insecure'              | VERB_TAMPERING              | 'http-method not defined in web.xml'                       | 6
+    'application/sessiontimeout/secure'               | null                        | null                                                       | _
+    'application/sessiontimeout/insecure'             | SESSION_TIMEOUT             | 'Found vulnerable timeout value: 80'                       | 7
+    'application/directorylistingleak/secure'         | null                        | null                                                       | _
+    'application/directorylistingleak/insecure'       | DIRECTORY_LISTING_LEAK      | 'Directory listings configured'                            | 14
+    'application/adminconsoleactive/secure'           | null                        | null                                                       | _
+    'application/adminconsoleactive/insecure'         | ADMIN_CONSOLE_ACTIVE        | 'Tomcat Manager Application'                               | NO_LINE
+    'application/defaulthtmlescapeinvalid/secure'     | null                        | null                                                       | _
+    'application/defaulthtmlescapeinvalid/secure_tag' | null                        | null                                                       | _
+    'application/defaulthtmlescapeinvalid/false_tag'  | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be true'                     | 8
+    'application/defaulthtmlescapeinvalid/no_tag_1'   | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'                      | NO_LINE
+    'application/defaulthtmlescapeinvalid/no_tag_2'   | DEFAULT_HTML_ESCAPE_INVALID | 'defaultHtmlEscape tag should be set'                      | NO_LINE
   }
 
   void 'iast module detects session rewriting on sessionTrackingModes'() {


### PR DESCRIPTION
# What Does This Do

The current implementation uses the default  VulnerabilityTypeImpl but this is conceptually wrong as there is no error in a file. 

Change VulnerabilityType ADMIN_CONSOLE_ACTIVE implementation to  ServiceVulnerabilityType

# Motivation

# Additional Notes

Jira ticket: [APPSEC-52435]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-52435]: https://datadoghq.atlassian.net/browse/APPSEC-52435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ