### PR TITLE
Fix test names to be unique

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/BufferInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/BufferInstrumentationTest.groovy
@@ -17,7 +17,7 @@ class BufferInstrumentationTest extends AgentTestRunner {
     injectSysConfig('dd.iast.enabled', 'true')
   }
 
-  void 'test that toString() is instrumented'() {
+  void 'test that Buffer.#methodName is instrumented'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -30,12 +30,12 @@ class BufferInstrumentationTest extends AgentTestRunner {
     1 * module.taintIfTainted(_, buffer)
 
     where:
-    _ | method
-    _ | { Buffer b -> b.toString() }
-    _ | { Buffer b -> b.toString('UTF-8') }
+    methodName         | method
+    'toString()'       | { Buffer b -> b.toString() }
+    'toString(String)' | { Buffer b -> b.toString('UTF-8') }
   }
 
-  void 'test that append() is instrumented'() {
+  void 'test that Buffer.#methodName is instrumented'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -49,9 +49,9 @@ class BufferInstrumentationTest extends AgentTestRunner {
     1 * module.taintIfTainted(buffer, tainted)
 
     where:
-    _ | method
-    _ | { Buffer b, Buffer taint -> b.appendBuffer(taint) }
-    _ | { Buffer b, Buffer taint -> b.appendBuffer(taint, 0, taint.length()) }
+    methodName                       | method
+    'appendBuffer(Buffer)'           | { Buffer b, Buffer taint -> b.appendBuffer(taint) }
+    'appendBuffer(buffer, int, int)' | { Buffer b, Buffer taint -> b.appendBuffer(taint, 0, taint.length()) }
   }
 
   private Buffer taintedInstance(final byte origin) {

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/HeadersAdaptorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/HeadersAdaptorInstrumentationTest.groovy
@@ -29,7 +29,7 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
     iastCtx = Stub(IastContext)
   }
 
-  void 'test that get() is instrumented'() {
+  void 'test that #name get() is instrumented'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -42,12 +42,12 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
     1 * module.taintIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_HEADER_VALUE, 'key')
 
     where:
-    headers        | _
-    httpAdaptor()  | _
-    http2Adaptor() | _
+    headers        | name
+    httpAdaptor()  | 'HeadersAdaptor'
+    http2Adaptor() | 'Http2HeadersAdaptor'
   }
 
-  void 'test that getAll() is instrumented'() {
+  void 'test that #name getAll() is instrumented'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -69,12 +69,12 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
     1 * module.taint(iastCtx, 'value2', SourceTypes.REQUEST_HEADER_VALUE, 'key')
 
     where:
-    headers        | _
-    httpAdaptor()  | _
-    http2Adaptor() | _
+    headers        | name
+    httpAdaptor()  | 'HeadersAdaptor'
+    http2Adaptor() | 'Http2HeadersAdaptor'
   }
 
-  void 'test that names() is instrumented'() {
+  void 'test that #name names() is instrumented'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -95,12 +95,12 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
     1 * module.taint(iastCtx, 'key', SourceTypes.REQUEST_HEADER_NAME, 'key')
 
     where:
-    headers        | _
-    httpAdaptor()  | _
-    http2Adaptor() | _
+    headers        | name
+    httpAdaptor()  | 'HeadersAdaptor'
+    http2Adaptor() | 'Http2HeadersAdaptor'
   }
 
-  void 'test that entries() is instrumented'() {
+  void 'test that #name entries() is instrumented'() {
     given:
     // latest versions of vertx 3.x define the entries in the MultiMap interface, so we will lose propagation
     Assume.assumeTrue(hasMethod(headers.getClass(), 'entries'))
@@ -128,9 +128,9 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
     }
 
     where:
-    headers        | _
-    httpAdaptor()  | _
-    http2Adaptor() | _
+    headers        | name
+    httpAdaptor()  | 'HeadersAdaptor'
+    http2Adaptor() | 'Http2HeadersAdaptor'
   }
 
   protected <E> E runUnderIastTrace(Closure<E> cl) {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/BufferInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/BufferInstrumentationTest.groovy
@@ -17,7 +17,7 @@ class BufferInstrumentationTest extends AgentTestRunner {
     injectSysConfig('dd.iast.enabled', 'true')
   }
 
-  void 'test that toString() is instrumented'() {
+  void 'test that Buffer.#methodName is instrumented'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -30,12 +30,12 @@ class BufferInstrumentationTest extends AgentTestRunner {
     1 * module.taintIfTainted(_, buffer)
 
     where:
-    _ | method
-    _ | { Buffer b -> b.toString() }
-    _ | { Buffer b -> b.toString('UTF-8') }
+    methodName         | method
+    'toString()'       | { Buffer b -> b.toString() }
+    'toString(String)' | { Buffer b -> b.toString('UTF-8') }
   }
 
-  void 'test that append() is instrumented'() {
+  void 'test that Buffer.#methodName is instrumented'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -49,9 +49,9 @@ class BufferInstrumentationTest extends AgentTestRunner {
     1 * module.taintIfTainted(buffer, tainted)
 
     where:
-    _ | method
-    _ | { Buffer b, Buffer taint -> b.appendBuffer(taint) }
-    _ | { Buffer b, Buffer taint -> b.appendBuffer(taint, 0, taint.length()) }
+    methodName                       | method
+    'appendBuffer(Buffer)'           | { Buffer b, Buffer taint -> b.appendBuffer(taint) }
+    'appendBuffer(buffer, int, int)' | { Buffer b, Buffer taint -> b.appendBuffer(taint, 0, taint.length()) }
   }
 
   private Buffer taintedInstance(final byte origin) {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/MultiMapInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/MultiMapInstrumentationTest.groovy
@@ -33,7 +33,7 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
     iastCtx = Stub(IastContext)
   }
 
-  void 'test that get() is instrumented'() {
+  void 'test that #name get() is instrumented'() {
     given:
     final origin = SourceTypes.REQUEST_PARAMETER_VALUE
     addAll([key: 'value'], instance)
@@ -56,9 +56,10 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     where:
     instance << multiMaps()
+    name = instance.getClass().simpleName
   }
 
-  void 'test that getAll() is instrumented'() {
+  void 'test that #name getAll() is instrumented'() {
     given:
     final origin = SourceTypes.REQUEST_PARAMETER_VALUE
     addAll([[key: 'value1'], [key: 'value2']], instance)
@@ -82,9 +83,10 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     where:
     instance << multiMaps()
+    name = instance.getClass().simpleName
   }
 
-  void 'test that names() is instrumented'() {
+  void 'test that #name names() is instrumented'() {
     given:
     final origin = SourceTypes.REQUEST_PARAMETER_VALUE
     addAll([[key: 'value1'], [key: 'value2']], instance)
@@ -107,11 +109,12 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     where:
     instance << multiMaps()
+    name = instance.getClass().simpleName
   }
 
   // some implementations do not override the entries() method so we will lose propagation in those cases
   @IgnoreIf({ !MultiMapInstrumentationTest.hasMethod(data['instance'].class, 'entries')})
-  void 'test that entries() is instrumented'() {
+  void 'test that #name entries() is instrumented'() {
     given:
     final origin = SourceTypes.REQUEST_PARAMETER_VALUE
     addAll([[key: 'value1'], [key: 'value2']], instance)
@@ -136,6 +139,7 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     where:
     instance << multiMaps()
+    name = instance.getClass().simpleName
   }
 
   protected <E> E runUnderIastTrace(Closure<E> cl) {


### PR DESCRIPTION
# What Does This Do

This PR fix few test names to not rely on toString() for generated names, making them unique across runs.

# Motivation

This will help identify tests in CI visibility.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
