### PR TITLE
Fix profiling integration test app startup

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
@@ -1,8 +1,8 @@
 package datadog.smoketest;
 
 import static datadog.smoketest.SmokeTestUtils.buildDirectory;
+import static datadog.smoketest.SmokeTestUtils.checkProcessSuccessfullyEnd;
 import static datadog.smoketest.SmokeTestUtils.createProcessBuilder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -136,9 +136,7 @@ public final class CodeHotspotsTest {
                 Long.toString(arrivalRate),
                 Integer.toString(timeout))
             .start();
-
-    int ret = targetProcess.waitFor();
-    assertEquals(0, ret);
+    checkProcessSuccessfullyEnd(targetProcess, logFilePath);
 
     long serviceRate = (long) (workers * 1_000_000_000d) / meanServiceTime.toNanos();
     double idleness = Math.max(0d, (serviceRate - arrivalRate) / (double) serviceRate);
@@ -179,9 +177,7 @@ public final class CodeHotspotsTest {
                 Long.toString(meanServiceTimeNs),
                 Integer.toString(timeout))
             .start();
-
-    int ret = targetProcess.waitFor();
-    assertEquals(0, ret);
+    checkProcessSuccessfullyEnd(targetProcess, logFilePath);
 
     Files.walk(dumpDir)
         .filter(Files::isRegularFile)
@@ -213,9 +209,7 @@ public final class CodeHotspotsTest {
                 Long.toString(meanServiceTimeNs),
                 Integer.toString(timeout))
             .start();
-
-    int ret = targetProcess.waitFor();
-    assertEquals(0, ret);
+    checkProcessSuccessfullyEnd(targetProcess, logFilePath);
 
     Files.walk(dumpDir)
         .filter(Files::isRegularFile)
@@ -240,9 +234,7 @@ public final class CodeHotspotsTest {
                 logFilePath,
                 libraryName)
             .start();
-
-    int ret = targetProcess.waitFor();
-    assertEquals(0, ret);
+    checkProcessSuccessfullyEnd(targetProcess, logFilePath);
 
     Files.walk(dumpDir)
         .filter(Files::isRegularFile)
@@ -287,9 +279,7 @@ public final class CodeHotspotsTest {
                 "1000",
                 mode)
             .start();
-
-    int ret = targetProcess.waitFor();
-    assertEquals(0, ret);
+    checkProcessSuccessfullyEnd(targetProcess, logFilePath);
 
     Files.walk(dumpDir)
         .filter(Files::isRegularFile)


### PR DESCRIPTION
# What Does This Do

Fix system property declared after classname.
Also dump for log file if the application failed to run.

# Motivation

Dumping the application log file when run failed should helps to identify flaky tests with `255` exit code.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
