### PR TITLE
Fix CI Visibility Gradle plugin to be compatible with Gradle build scans

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -131,9 +131,7 @@ public final class CombiningTransformerBuilder
     helperTransformer =
         helperClassNames.length > 0
             ? new HelperTransformer(
-                module.injectHelperClassesWithAgentCodeSource(),
-                module.getClass().getSimpleName(),
-                helperClassNames)
+                module.useAgentCodeSource(), module.getClass().getSimpleName(), helperClassNames)
             : null;
 
     muzzle = new MuzzleCheck(module, instrumentationId);

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -130,7 +130,10 @@ public final class CombiningTransformerBuilder
     }
     helperTransformer =
         helperClassNames.length > 0
-            ? new HelperTransformer(module.getClass().getSimpleName(), helperClassNames)
+            ? new HelperTransformer(
+                module.injectHelperClassesWithAgentCodeSource(),
+                module.getClass().getSimpleName(),
+                helperClassNames)
             : null;
 
     muzzle = new MuzzleCheck(module, instrumentationId);
@@ -347,8 +350,9 @@ public final class CombiningTransformerBuilder
   }
 
   static final class HelperTransformer extends HelperInjector implements AgentBuilder.Transformer {
-    HelperTransformer(String requestingName, String... helperClassNames) {
-      super(requestingName, helperClassNames);
+    HelperTransformer(
+        boolean useAgentCodeSource, String requestingName, String... helperClassNames) {
+      super(useAgentCodeSource, requestingName, helperClassNames);
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -20,6 +20,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.dynamic.DynamicType;
 import net.bytebuddy.dynamic.loading.ClassInjector;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.utility.JavaModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,7 +161,7 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
       CodeSource codeSource = HelperInjector.class.getProtectionDomain().getCodeSource();
       return new ProtectionDomain(codeSource, null, classLoader, null);
     } else {
-      return null;
+      return ClassLoadingStrategy.NO_PROTECTION_DOMAIN;
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -5,6 +5,7 @@ import static datadog.trace.bootstrap.AgentClassLoading.INJECTING_HELPERS;
 import datadog.trace.util.Strings;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 public class HelperInjector implements Instrumenter.TransformingAdvice {
   private static final Logger log = LoggerFactory.getLogger(HelperInjector.class);
 
+  private final boolean useAgentCodeSource;
   private final String requestingName;
 
   private final Set<String> helperClassNames;
@@ -39,19 +41,29 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
   /**
    * Construct HelperInjector.
    *
+   * @param useAgentCodeSource whether helper classes should be injected with the agent's {@link
+   *     CodeSource}.
    * @param helperClassNames binary names of the helper classes to inject. These class names must be
    *     resolvable by the classloader returned by
    *     datadog.trace.agent.tooling.Utils#getAgentClassLoader(). Classes are injected in the order
    *     provided. This is important if there is interdependency between helper classes that
    *     requires them to be injected in a specific order.
    */
-  public HelperInjector(final String requestingName, final String... helperClassNames) {
+  public HelperInjector(
+      final boolean useAgentCodeSource,
+      final String requestingName,
+      final String... helperClassNames) {
+    this.useAgentCodeSource = useAgentCodeSource;
     this.requestingName = requestingName;
 
     this.helperClassNames = new LinkedHashSet<>(Arrays.asList(helperClassNames));
   }
 
-  public HelperInjector(final String requestingName, final Map<String, byte[]> helperMap) {
+  public HelperInjector(
+      final boolean useAgentCodeSource,
+      final String requestingName,
+      final Map<String, byte[]> helperMap) {
+    this.useAgentCodeSource = useAgentCodeSource;
     this.requestingName = requestingName;
 
     helperClassNames = helperMap.keySet();
@@ -135,9 +147,20 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
       final ClassLoader classLoader, final Map<String, byte[]> classnameToBytes) {
     INJECTING_HELPERS.begin();
     try {
-      return new ClassInjector.UsingReflection(classLoader).injectRaw(classnameToBytes);
+      ProtectionDomain protectionDomain = createProtectionDomain(classLoader);
+      return new ClassInjector.UsingReflection(classLoader, protectionDomain)
+          .injectRaw(classnameToBytes);
     } finally {
       INJECTING_HELPERS.end();
+    }
+  }
+
+  private ProtectionDomain createProtectionDomain(final ClassLoader classLoader) {
+    if (useAgentCodeSource) {
+      CodeSource codeSource = HelperInjector.class.getProtectionDomain().getCodeSource();
+      return new ProtectionDomain(codeSource, null, classLoader, null);
+    } else {
+      return null;
     }
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -16,6 +16,7 @@ import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.util.Strings;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -106,6 +107,13 @@ public abstract class InstrumenterModule implements Instrumenter {
   /** @return Class names of helpers to inject into the user's classloader */
   public String[] helperClassNames() {
     return new String[0];
+  }
+
+  /**
+   * @return {@code true} if helper classes should be injected with the agent's {@link CodeSource}
+   */
+  public boolean injectHelperClassesWithAgentCodeSource() {
+    return false;
   }
 
   /** Override this to automatically inject all (non-bootstrap) helper dependencies. */

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -112,7 +112,7 @@ public abstract class InstrumenterModule implements Instrumenter {
   /**
    * @return {@code true} if helper classes should be injected with the agent's {@link CodeSource}
    */
-  public boolean injectHelperClassesWithAgentCodeSource() {
+  public boolean useAgentCodeSource() {
     return false;
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteTransformer.java
@@ -46,7 +46,7 @@ public class CallSiteTransformer implements Instrumenter.TransformingAdvice {
     this.helperInjector =
         helpers == null || helpers.length == 0
             ? NO_OP
-            : new HelperInjector(name, advices.getHelpers());
+            : new HelperInjector(false, name, advices.getHelpers());
   }
 
   @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -73,7 +73,9 @@ public class MuzzleVersionScanPlugin {
           final String[] helperClassNames = module.helperClassNames();
           if (helperClassNames.length > 0) {
             new HelperInjector(
-                    MuzzleVersionScanPlugin.class.getSimpleName(), createHelperMap(module))
+                    module.injectHelperClassesWithAgentCodeSource(),
+                    MuzzleVersionScanPlugin.class.getSimpleName(),
+                    createHelperMap(module))
                 .transform(null, null, testApplicationLoader, null, null);
           }
         } catch (final Exception e) {

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -73,7 +73,7 @@ public class MuzzleVersionScanPlugin {
           final String[] helperClassNames = module.helperClassNames();
           if (helperClassNames.length > 0) {
             new HelperInjector(
-                    module.injectHelperClassesWithAgentCodeSource(),
+                    module.useAgentCodeSource(),
                     MuzzleVersionScanPlugin.class.getSimpleName(),
                     createHelperMap(module))
                 .transform(null, null, testApplicationLoader, null, null);

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/test/HelperInjectionTest.groovy
@@ -19,7 +19,7 @@ class HelperInjectionTest extends DDSpecification {
   //@Flaky("awaitGC usage is flaky")
   def "helpers injected to non-delegating classloader"() {
     setup:
-    HelperInjector injector = new HelperInjector("test", HELPER_CLASS_NAME)
+    HelperInjector injector = new HelperInjector(false, "test", HELPER_CLASS_NAME)
     AtomicReference<URLClassLoader> emptyLoader = new AtomicReference<>(new URLClassLoader(new URL[0], (ClassLoader) null))
 
     when:

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradlePluginInjectorInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradlePluginInjectorInstrumentation.java
@@ -59,5 +59,10 @@ public class GradlePluginInjectorInstrumentation extends InstrumenterModule.CiVi
   }
 
   @Override
+  public boolean injectHelperClassesWithAgentCodeSource() {
+    return true;
+  }
+
+  @Override
   public void methodAdvice(MethodTransformer transformer) {}
 }

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradlePluginInjectorInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradlePluginInjectorInstrumentation.java
@@ -59,7 +59,7 @@ public class GradlePluginInjectorInstrumentation extends InstrumenterModule.CiVi
   }
 
   @Override
-  public boolean injectHelperClassesWithAgentCodeSource() {
+  public boolean useAgentCodeSource() {
     return true;
   }
 


### PR DESCRIPTION
# What Does This Do
Fixes the Gradle plugin injected by CI Visibility so that it does not cause Gradle build scans to fail.

# Additional Notes
Attaching tracer with CI Visibility to a Gradle build that has scanning enabled causes the following error (the code is obfuscated since build scans are part of Gradle Enterprise):
```
Gradle version: 8.6
23562Plugin version: 3.15.1
23563
23564com.gradle.scan.plugin.internal.operations.a: Build operation dispatch of started notification failed.
23565Operation context:
23566 org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor$1 (1): {}
23567 org.gradle.configuration.BuildOperationFiringProjectsPreparer$ConfigureBuild$1 (104): {getBuildPath=:}
23568 org.gradle.initialization.buildsrc.BuildSourceBuilder$2$1 (169): {getBuildPath=:}
23569 org.gradle.configuration.BuildOperationFiringProjectsPreparer$ConfigureBuild$1 (178): {getBuildPath=:buildSrc}
23570 org.gradle.initialization.ProjectsEvaluatedNotifier$NotifyProjectsEvaluatedListeners$1 (293): {getBuildPath=:buildSrc}
23571 org.gradle.api.internal.plugins.DefaultPluginManager$OperationDetails (294): {pluginId=null, targetPath=:, pluginClass=datadog.trace.instrumentation.gradle.CiVisibilityPlugin, targetType=project, applicationId=32, buildPath=:buildSrc}
23572Caused by: java.lang.NullPointerException: Cannot invoke "java.net.URL.getProtocol()" because "<local4>" is null
23573 at com.gradle.scan.plugin.internal.c.ae.a.a.b.a(SourceFile:62)
23574 at com.gradle.scan.plugin.internal.c.ae.a.a.e.a(SourceFile:47)
23575 at com.gradle.scan.plugin.internal.c.ae.a.b.a(SourceFile:59)
23576 at com.gradle.scan.plugin.internal.c.ae.a.b.a(SourceFile:47)
23577 at com.gradle.scan.plugin.internal.operations.b$c.started(SourceFile:140)
23578 at com.gradle.scan.plugin.internal.operations.b.a(SourceFile:55)
23579 at com.gradle.scan.plugin.internal.operations.n.a(SourceFile:33)
23580 at com.gradle.scan.plugin.internal.operations.d.a(SourceFile:60)
23581 at com.gradle.scan.plugin.internal.operations.h.a(SourceFile:39)
23582 at com.gradle.scan.plugin.internal.r.a$a.a(SourceFile:31)
23583 at com.gradle.scan.plugin.internal.r.a$a.a(SourceFile:20)
23584 at com.gradle.scan.plugin.internal.r.a.c(SourceFile:67)
23585----------
```

The reason the error occurs is that Gradle build scan tries to determine the location of all the plugins that the build uses, including the plugin injected by CI Visibility.
The code is roughly:
```
ProtectionDomain domain = pluginClass.getProtectionDomain();
CodeSource codeSource = var2.getCodeSource();
if (codeSource != null) {
    URL locationUrl = var3.getLocation();
    String protocol = locationUrl.getProtocol(); // this is where the NPE happens
    // ...
}
```

The CI Visibility Gradle plugin is injected by the tracer as a helper class.
Currently all the helper classes are injected with no protection domain specified.
As the result, they get assigned `java.lang.ClassLoader#defaultDomain` - `new ProtectionDomain(new CodeSource(null, (Certificate[]) null), null, this, null)`: the default domain has a code source that returns `null` as its location, which causes the NPE above.

The proposed fix is to allow instrumentation modules to define the protection domain that will be assigned to the injected classes.

The protection domain for the Gradle plugin module has code source that points to the tracer JAR and class loader that is the CL where the plugin is injected.

Jira ticket: [SCV-157]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SCV-157]: https://datadoghq.atlassian.net/browse/SCV-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ