### PR TITLE
Added Http Route to AppSec

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/http/HttpResourceDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/http/HttpResourceDecorator.java
@@ -1,12 +1,20 @@
 package datadog.trace.bootstrap.instrumentation.decorator.http;
 
+import static datadog.trace.api.gateway.Events.EVENTS;
+
 import datadog.trace.api.Config;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.normalize.HttpResourceNames;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIUtils;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import java.util.function.BiConsumer;
+import javax.annotation.Nonnull;
 
 public class HttpResourceDecorator {
   public static final HttpResourceDecorator HTTP_RESOURCE_DECORATOR = new HttpResourceDecorator();
@@ -17,6 +25,11 @@ public class HttpResourceDecorator {
       Config.get().isRuleEnabled("URLAsResourceNameRule");
 
   private HttpResourceDecorator() {}
+
+  // Extract this to allow for easier testing
+  protected AgentTracer.TracerAPI tracer() {
+    return AgentTracer.get();
+  }
 
   public final AgentSpan withClientPath(AgentSpan span, CharSequence method, CharSequence path) {
     return HttpResourceNames.setForClient(span, method, path, false);
@@ -46,7 +59,24 @@ public class HttpResourceDecorator {
     if (Config.get().isHttpServerRouteBasedNaming()) {
       final CharSequence resourceName = HttpResourceNames.join(method, route);
       span.setResourceName(resourceName, ResourceNamePriorities.HTTP_FRAMEWORK_ROUTE);
+      callIGCallbackRoute(span, route);
     }
     return span;
+  }
+
+  private void callIGCallbackRoute(@Nonnull final AgentSpan span, final CharSequence resourceName) {
+    CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
+    RequestContext requestContext = span.getRequestContext();
+
+    if (requestContext == null || cbp == null || resourceName == null) {
+      return;
+    }
+
+    BiConsumer<RequestContext, String> callback = cbp.getCallback(EVENTS.requestRoute());
+    if (callback == null) {
+      return;
+    }
+
+    callback.accept(requestContext, resourceName.toString());
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -64,6 +64,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private String peerAddress;
   private int peerPort;
   private String inferredClientIp;
+  private String route;
 
   private volatile StoredBodySupplier storedRequestBodySupplier;
 
@@ -304,6 +305,14 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   String getInferredClientIp() {
     return inferredClientIp;
+  }
+
+  public String getRoute() {
+    return route;
+  }
+
+  public void setRoute(String route) {
+    this.route = route;
   }
 
   void setStoredRequestBodySupplier(StoredBodySupplier storedRequestBodySupplier) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -419,6 +419,15 @@ public class GatewayBridge {
             }
           }
         });
+
+    subscriptionService.registerCallback(
+        EVENTS.requestRoute(),
+        (ctx_, route) -> {
+          AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
+          if (ctx != null) {
+            ctx.setRoute(route);
+          }
+        });
   }
 
   public void stop() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -24,6 +24,7 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase
 import datadog.trace.test.util.DDSpecification
 
+import java.util.function.BiConsumer
 import java.util.function.BiFunction
 import java.util.function.Function
 import java.util.function.Supplier
@@ -78,6 +79,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   Function<RequestContext, Flow<Void>> respHeadersDoneCB
   BiFunction<RequestContext, Object, Flow<Void>> grpcServerRequestMessageCB
   BiFunction<RequestContext, Map<String, Object>, Flow<Void>> graphqlServerRequestMessageCB
+  BiConsumer<RequestContext, String> reqRouteCB
 
   void setup() {
     callInitAndCaptureCBs()
@@ -245,6 +247,14 @@ class GatewayBridgeSpecification extends DDSpecification {
     thrown(IllegalStateException)
     def data = bundle.get(KnownAddresses.HEADERS_NO_COOKIES)
     assert data == null || data.isEmpty()
+  }
+
+  void 'bridge can collect the route'() {
+    when:
+    reqRouteCB.accept(ctx, '/id/{id}/name/{name}')
+
+    then:
+    assert ctx.data.route == '/id/{id}/name/{name}'
   }
 
   void 'the socket address is distributed'() {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -6,6 +6,7 @@ import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -200,6 +201,16 @@ public final class Events<D> {
       graphqlServerRequestMessage() {
     return (EventType<BiFunction<RequestContext, Map<String, ?>, Flow<Void>>>)
         GRAPHQL_SERVER_REQUEST_MESSAGE;
+  }
+
+  static final int REQUEST_ROUTE_ID = 16;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType REQUEST_ROUTE = new ET<>("server.request.route", REQUEST_ROUTE_ID);
+  /** The route for the request */
+  @SuppressWarnings("unchecked")
+  public EventType<BiConsumer<RequestContext, String>> requestRoute() {
+    return (EventType<BiConsumer<RequestContext, String>>) REQUEST_ROUTE;
   }
 
   static final int MAX_EVENTS = nextId.get();

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -13,6 +13,7 @@ import static datadog.trace.api.gateway.Events.REQUEST_HEADER_ID;
 import static datadog.trace.api.gateway.Events.REQUEST_INFERRED_CLIENT_ADDRESS_ID;
 import static datadog.trace.api.gateway.Events.REQUEST_METHOD_URI_RAW_ID;
 import static datadog.trace.api.gateway.Events.REQUEST_PATH_PARAMS_ID;
+import static datadog.trace.api.gateway.Events.REQUEST_ROUTE_ID;
 import static datadog.trace.api.gateway.Events.REQUEST_STARTED_ID;
 import static datadog.trace.api.gateway.Events.RESPONSE_HEADER_DONE_ID;
 import static datadog.trace.api.gateway.Events.RESPONSE_HEADER_ID;
@@ -24,6 +25,7 @@ import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -357,6 +359,18 @@ public class InstrumentationGateway {
                 } catch (Throwable t) {
                   log.warn("Callback for {} threw.", eventType, t);
                   return Flow.ResultFlow.empty();
+                }
+              }
+            };
+      case REQUEST_ROUTE_ID:
+        return (C)
+            new BiConsumer<RequestContext, String>() {
+              @Override
+              public void accept(RequestContext ctx, String route) {
+                try {
+                  ((BiConsumer<RequestContext, String>) callback).accept(ctx, route);
+                } catch (Throwable t) {
+                  log.warn("Callback for {} threw.", eventType, t);
                 }
               }
             };


### PR DESCRIPTION
# What Does This Do
Added functionality to provide HTTP Route to AppSec (`AppSecRequestContext`)

# Motivation
This is preparation work for API Security Sampling. 

# Additional Notes

<!--Jira ticket: [PROJ-IDENT]-->

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
