### PR TITLE
Mark Spring Webflux 5 integration test as flaky

### DIFF
--- a/dd-java-agent/instrumentation/spring-webflux-5/src/bootTest/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/bootTest/groovy/SpringWebfluxTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.bootstrap.instrumentation.api.URIUtils
 import datadog.trace.core.DDSpan
+import datadog.trace.test.util.Flaky
 import dd.trace.instrumentation.springwebflux.server.EchoHandlerFunction
 import dd.trace.instrumentation.springwebflux.server.FooModel
 import dd.trace.instrumentation.springwebflux.server.SpringWebFluxTestApplication
@@ -489,6 +490,7 @@ class SpringWebfluxTest extends AgentTestRunner {
     "annotation API fail Mono" | "/foo-failmono/1"   | "/foo-failmono/{id}"   | "getFooFailMono"
   }
 
+  @Flaky("https://github.com/DataDog/dd-trace-java/issues/6909")
   def "Redirect test"() {
     setup:
     String url = "http://localhost:$port/double-greet-redirect"


### PR DESCRIPTION
# What Does This Do

This PR marks Spring Webflux 5 integration test as flaky.

# Motivation

See #6909

# Additional Notes

Jira ticket: [AIDM-11]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
