### PR TITLE
Mark Vert.X Redis Client 4 integration test as flaky

### DIFF
--- a/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
+++ b/dd-java-agent/instrumentation/vertx-redis-client-3.9/src/test/groovy/VertxRedisAPITestBase.groovy
@@ -1,3 +1,5 @@
+import datadog.trace.test.util.Flaky
+
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 
 import io.vertx.core.AsyncResult
@@ -98,6 +100,7 @@ abstract class VertxRedisAPITestBase extends VertxRedisTestBase {
     }
   }
 
+  @Flaky("https://github.com/DataDog/dd-trace-java/issues/6910")
   def "linsert (5 args)"() {
     when:
     def rpush = runWithParentAndHandler({ Handler<AsyncResult<Response>> h ->


### PR DESCRIPTION
# What Does This Do

This PR marks Vert.X Redis Client 4 integration test as flaky.

# Motivation

See #6910

# Additional Notes

Jira ticket: [AIDM-12]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIDM-12]: https://datadoghq.atlassian.net/browse/AIDM-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ