### PR TITLE
Fix call-site-plugin build script to avoid rebuilding plugin every time

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   java
   groovy
   id("com.diffplug.spotless") version "6.13.0"
-  id("com.github.johnrengelman.shadow") version "7.1.2"
+  id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 java {
@@ -49,7 +49,7 @@ dependencies {
 sourceSets {
   test {
     java {
-      srcDirs("src/test/java", "$buildDir/generated/sources/csi")
+      srcDirs("src/test/java", "${layout.buildDirectory.get()}/generated/sources/csi")
     }
   }
 }
@@ -77,9 +77,6 @@ tasks {
 
 tasks {
   named<ShadowJar>("shadowJar") {
-    archiveBaseName.set("call-site-instrumentation-plugin")
-    archiveClassifier.set("")
-    archiveVersion.set("")
     mergeServiceFiles()
     manifest {
       attributes(mapOf("Main-Class" to "datadog.trace.plugin.csi.PluginApplication"))

--- a/buildSrc/src/main/groovy/CallSiteInstrumentationPlugin.groovy
+++ b/buildSrc/src/main/groovy/CallSiteInstrumentationPlugin.groovy
@@ -18,8 +18,6 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 import java.nio.file.Paths
 
-import static groovy.io.FileType.FILES
-
 @SuppressWarnings('unused')
 @CompileStatic
 class CallSiteInstrumentationPlugin implements Plugin<Project> {
@@ -79,13 +77,8 @@ class CallSiteInstrumentationPlugin implements Plugin<Project> {
   }
 
   private static File newBuildFolder(final Project target, final String name) {
-    if (folder.exists()) {
-      folder.traverse(type: FILES) {
-        if (!it.delete()) {
-          throw new GradleException("Cannot delete stale file $it")
-        }
-      }
-    } else {
+    final folder = target.layout.buildDirectory.dir(name).get().asFile
+    if (!folder.exists()) {
       if (!folder.mkdirs()) {
         throw new GradleException("Cannot create folder $folder")
       }

--- a/buildSrc/src/main/groovy/CallSiteInstrumentationPlugin.groovy
+++ b/buildSrc/src/main/groovy/CallSiteInstrumentationPlugin.groovy
@@ -88,12 +88,10 @@ class CallSiteInstrumentationPlugin implements Plugin<Project> {
 
   private static File newTempFile(final File folder, final String name) {
     final file = new File(folder, name)
-    file.deleteOnExit()
-    if (file.exists()) {
-      file.text = ''
-    } else if (!file.createNewFile()) {
+    if (!file.exists() && !file.createNewFile()) {
       throw new GradleException("Cannot create temporary file: $file")
     }
+    file.deleteOnExit()
     return file
   }
 

--- a/buildSrc/src/main/groovy/CallSiteInstrumentationPlugin.groovy
+++ b/buildSrc/src/main/groovy/CallSiteInstrumentationPlugin.groovy
@@ -128,7 +128,7 @@ class CallSiteInstrumentationPlugin implements Plugin<Project> {
 
     final rootFolder = extension.rootFolder ?: target.rootDir
     final path = Paths.get(rootFolder.toString(),
-      'buildSrc', 'call-site-instrumentation-plugin', 'build', 'libs', 'call-site-instrumentation-plugin.jar')
+      'buildSrc', 'call-site-instrumentation-plugin', 'build', 'libs', 'call-site-instrumentation-plugin-all.jar')
     callSiteGeneratorTask.jvmArgs(extension.jvmArgs)
     callSiteGeneratorTask.classpath(path.toFile())
     callSiteGeneratorTask.setIgnoreExitValue(true)


### PR DESCRIPTION
# What Does This Do

This PR fixes the CSI (Call Site Plugin) build script which is part of the project build script. 

There are two main fixes:

## Avoid rebuilding CSI plugin jar for every Gradle command

CSI plugin shadowed jar was built for every gradle command runned as part of the project configuration:
![image](https://github.com/DataDog/dd-trace-java/assets/1766222/2dda1ae9-1e72-4b32-91f2-de826a05b433)

With the changes, all plugin gradle tasks are properly cached (`UP-TO-DATE` state):
![image](https://github.com/DataDog/dd-trace-java/assets/1766222/18518ac2-a441-46d9-9740-290275372684)

## Avoid generating call site sources file for every build

CSI plugin drops generated call site source files (from `build/generated/sources/csi/`) for every build, breaking the task cache and making the plugin needed to re-run.

Running `gradlew :dd-java-agent:shadowJar` multiple times shows CSI plugin tasks are not cached and are the slowest taks to run:
![image](https://github.com/DataDog/dd-trace-java/assets/1766222/928aa5a8-0ca1-4a03-981f-6596d144065e)

After the fix, all `generateCallSiteJava` generated tasks are properly cached:
![image](https://github.com/DataDog/dd-trace-java/assets/1766222/c0ec63e7-9d48-46e3-b772-e9feca40cb6a)

The generated source files will still be cleared as part of the `clean` gradle task and will still be updated if the sources files (build/classes/raw) are updated.

## Other changes

* Upgrade deprecated API usage,
* Avoid cleaning every temporary files twice

# Motivation

This should help to run gradle project configuration step faster. 

# Additional Notes

Fixes and upgrades are split in multiple commits to help reviewing the PR.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
