### PR TITLE
update spotless to v6.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
   id 'com.github.spotbugs' version '5.0.14'
   id "de.thetaphi.forbiddenapis" version "3.5.1"
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   groovy
   `java-gradle-plugin`
-  id("com.diffplug.spotless") version "6.11.0"
+  id("com.diffplug.spotless") version "6.13.0"
 }
 
 gradlePlugin {

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
   java
   groovy
-  id("com.diffplug.spotless") version "6.11.0"
+  id("com.diffplug.spotless") version "6.13.0"
   id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 

--- a/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
+++ b/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
@@ -10,7 +10,7 @@ class CallSiteInstrumentationPluginTest extends Specification {
     plugins {
       id 'java'
       id 'call-site-instrumentation'
-      id("com.diffplug.spotless") version "6.11.0"
+      id("com.diffplug.spotless") version "6.13.0"
     }
     
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/dd-smoke-tests/armeria-grpc/application/build.gradle
+++ b/dd-smoke-tests/armeria-grpc/application/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 plugins {
   id 'application'
   id 'java'
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
   id "com.github.johnrengelman.shadow" version "7.1.2"
   id 'com.google.protobuf' version '0.9.3'
 }

--- a/dd-smoke-tests/kafka-3/application/build.gradle
+++ b/dd-smoke-tests/kafka-3/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.2.2'
   id 'io.spring.dependency-management' version '1.1.4'
-  id 'com.diffplug.spotless' version '6.11.0'
+  id 'com.diffplug.spotless' version '6.13.0'
 }
 
 java {

--- a/dd-smoke-tests/quarkus/application/build.gradle
+++ b/dd-smoke-tests/quarkus/application/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java'
   id 'io.quarkus'
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-2.7-webflux/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-2.7-webflux/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '2.7.4'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-native/application/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
   id 'org.graalvm.buildtools.native' version '0.9.28'
-  id 'com.diffplug.spotless' version "6.11.0"
+  id 'com.diffplug.spotless' version "6.13.0"
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.0-webflux/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webflux/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/spring-boot-3.0-webmvc/application/build.gradle
+++ b/dd-smoke-tests/spring-boot-3.0-webmvc/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'org.springframework.boot' version '3.0.0'
   id 'io.spring.dependency-management' version '1.0.14.RELEASE'
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/dd-smoke-tests/wildfly/spring-ear/build.gradle
+++ b/dd-smoke-tests/wildfly/spring-ear/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'java'
   id 'ear'
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
 }
 
 def sharedRootDir = "$rootDir/../../../"

--- a/test-published-dependencies/build.gradle
+++ b/test-published-dependencies/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.diffplug.spotless" version "6.11.0"
+  id "com.diffplug.spotless" version "6.13.0"
 }
 
 def sharedConfigDirectory = "$rootDir/../gradle"


### PR DESCRIPTION
# What Does This Do
Updates spotless plugin v6.11.0 -> v6.13.0

# Motivation

v6.13.0 is the last version usable w/JDK-8.  v6.14.1 requires JDK-11+

v6.11.0 was showing this NPE which v6.13.0 fixes:
```
$ ./gradlew :dd-smoke-tests:java9-modules:spotlessGroovyGradle

> Task :dd-smoke-tests:java9-modules:spotlessGroovyGradle
internal error
java.lang.NullPointerException
        at org.codehaus.groovy.eclipse.refactoring.formatter.GroovyIndentation.isLastClosureArg(GroovyIndentation.java:405)
        at org.codehaus.groovy.eclipse.refactoring.formatter.GroovyIndentation.setAdditionalIndentation(GroovyIndentation.java:372)
        at org.codehaus.groovy.eclipse.refactoring.formatter.GroovyIndentation.getIndentationEdits(GroovyIndentation.java:135)
        at org.codehaus.groovy.eclipse.refactoring.formatter.DefaultGroovyFormatter.format(DefaultGroovyFormatter.java:128)
        at com.diffplug.spotless.extra.eclipse.groovy.GrEclipseFormatterStepImpl.format(GrEclipseFormatterStepImpl.java:86)
```
 
