### PR TITLE
Disable retry instrumentations if both Early Flakiness Detection and Flaky Test Retries are turned off

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ModuleExecutionSettingsFactoryImpl.java
@@ -66,7 +66,7 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
     boolean earlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled(ciVisibilitySettings);
     Map<String, String> systemProperties =
         getPropertiesPropagatedToChildProcess(
-            codeCoverageEnabled, itrEnabled, flakyTestRetriesEnabled);
+            codeCoverageEnabled, itrEnabled, flakyTestRetriesEnabled, earlyFlakeDetectionEnabled);
 
     LOGGER.info(
         "CI Visibility settings ({}, {}):\n"
@@ -196,7 +196,10 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
   }
 
   private Map<String, String> getPropertiesPropagatedToChildProcess(
-      boolean codeCoverageEnabled, boolean itrEnabled, boolean flakyTestRetriesEnabled) {
+      boolean codeCoverageEnabled,
+      boolean itrEnabled,
+      boolean flakyTestRetriesEnabled,
+      boolean earlyFlakeDetectionEnabled) {
     Map<String, String> propagatedSystemProperties = new HashMap<>();
     Properties systemProperties = System.getProperties();
     for (Map.Entry<Object, Object> e : systemProperties.entrySet()) {
@@ -222,6 +225,11 @@ public class ModuleExecutionSettingsFactoryImpl implements ModuleExecutionSettin
         Strings.propertyNameToSystemPropertyName(
             CiVisibilityConfig.CIVISIBILITY_FLAKY_RETRY_ENABLED),
         Boolean.toString(flakyTestRetriesEnabled));
+
+    propagatedSystemProperties.put(
+        Strings.propertyNameToSystemPropertyName(
+            CiVisibilityConfig.CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED),
+        Boolean.toString(earlyFlakeDetectionEnabled));
 
     // explicitly disable build instrumentation in child processes,
     // because some projects run "embedded" Maven/Gradle builds as part of their integration tests,


### PR DESCRIPTION
# What Does This Do
Disables instrumentations that are related to CI Visibility's test retry functionality in case both test retry features (Early Flakiness Detection and Failed Test Retries) are turned off.

# Motivation
Applying those instrumentations if test retries are not going to be used is redundant: even though it does not break anyhing, it adds some unnecessary overhead.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
