### PR TITLE
Do not abort CI Visibility spans dispatch on interrupt

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/BackendApiFactory.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/BackendApiFactory.java
@@ -23,7 +23,7 @@ public class BackendApiFactory {
   }
 
   public @Nullable BackendApi createBackendApi() {
-    HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0);
+    HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0, true);
 
     if (config.isCiVisibilityAgentlessEnabled()) {
       HttpUrl agentlessUrl = getAgentlessUrl();

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/EvpProxyApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/EvpProxyApi.java
@@ -81,9 +81,8 @@ public class EvpProxyApi implements BackendApi {
 
     final Request request = requestBuilder.post(requestBody).build();
 
-    HttpRetryPolicy retryPolicy = retryPolicyFactory.create();
     try (okhttp3.Response response =
-        OkHttpUtils.sendWithRetries(httpClient, retryPolicy, request)) {
+        OkHttpUtils.sendWithRetries(httpClient, retryPolicyFactory, request)) {
       if (response.isSuccessful()) {
         log.debug("Request to {} returned successful response: {}", uri, response.code());
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/IntakeApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/communication/IntakeApi.java
@@ -85,9 +85,8 @@ public class IntakeApi implements BackendApi {
     }
 
     Request request = requestBuilder.build();
-    HttpRetryPolicy retryPolicy = retryPolicyFactory.create();
     try (okhttp3.Response response =
-        OkHttpUtils.sendWithRetries(httpClient, retryPolicy, request)) {
+        OkHttpUtils.sendWithRetries(httpClient, retryPolicyFactory, request)) {
       if (response.isSuccessful()) {
         log.debug("Request to {} returned successful response: {}", uri, response.code());
         InputStream responseBodyStream = response.body().byteStream();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDEvpProxyApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDEvpProxyApi.java
@@ -92,7 +92,8 @@ public class DDEvpProxyApi extends RemoteApi {
               ? httpClient
               : OkHttpUtils.buildHttpClient(proxiedApiUrl, timeoutMillis);
 
-      final HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0);
+      final HttpRetryPolicy.Factory retryPolicyFactory =
+          new HttpRetryPolicy.Factory(5, 100, 2.0, true);
 
       log.debug("proxiedApiUrl: {}", proxiedApiUrl);
       return new DDEvpProxyApi(
@@ -141,9 +142,8 @@ public class DDEvpProxyApi extends RemoteApi {
     totalTraces += payload.traceCount();
     receivedTraces += payload.traceCount();
 
-    HttpRetryPolicy retryPolicy = retryPolicyFactory.create();
     try (okhttp3.Response response =
-        OkHttpUtils.sendWithRetries(httpClient, retryPolicy, request)) {
+        OkHttpUtils.sendWithRetries(httpClient, retryPolicyFactory, request)) {
       if (response.isSuccessful()) {
         countAndLogSuccessfulSend(payload.traceCount(), sizeInBytes);
         return Response.success(response.code());

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeApi.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddintake/DDIntakeApi.java
@@ -43,7 +43,7 @@ public class DDIntakeApi extends RemoteApi {
 
     HttpUrl hostUrl = null;
     OkHttpClient httpClient = null;
-    HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0);
+    HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0, true);
 
     private String apiKey;
 
@@ -134,9 +134,8 @@ public class DDIntakeApi extends RemoteApi {
     totalTraces += payload.traceCount();
     receivedTraces += payload.traceCount();
 
-    HttpRetryPolicy retryPolicy = retryPolicyFactory.create();
     try (okhttp3.Response response =
-        OkHttpUtils.sendWithRetries(httpClient, retryPolicy, request)) {
+        OkHttpUtils.sendWithRetries(httpClient, retryPolicyFactory, request)) {
       if (response.isSuccessful()) {
         countAndLogSuccessfulSend(payload.traceCount(), sizeInBytes);
         return Response.success(response.code());


### PR DESCRIPTION
# What Does This Do
Updates utility method that executes (and retries, if necessary) an HTTP request.
The method is used exclusively by CI Visibility logic that sends spans to the backend.

# Motivation
When a child JVM that was forked for tests execution finishes its work, the build system shuts the process down.
As part of this shutdown the tracer threads receive interrupts.
It is possible that when these interrupts are received some tests spans are still being dispatched.
Acting on interrupt results in these spans being lost.

# Additional Notes
The logic is updated in a way that an interrupted request will be reattempted.
If an interrupt is received at any point during request execution, the thread's interrupted flag is restored on method exit.

Jira ticket: [CIVIS-9801]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9801]: https://datadoghq.atlassian.net/browse/CIVIS-9801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ