### PR TITLE
A prototype to use jfr streaming to produce metrics

### DIFF
--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClient.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClient.java
@@ -1,5 +1,6 @@
 package datadog.communication.monitor;
 
+import com.timgroup.statsd.Event;
 import com.timgroup.statsd.ServiceCheck;
 import datadog.trace.api.StatsDClient;
 import java.util.function.Function;
@@ -64,6 +65,27 @@ final class DDAgentStatsDClient implements StatsDClient {
   public void distribution(String metricName, double value, String... tags) {
     connection.statsd.recordDistributionValue(
         nameMapping.apply(metricName), value, tagMapping.apply(tags));
+  }
+
+  @Override
+  public void event(String title, String message, EventKind kind, String... tags) {
+    Event.Builder builder =
+        Event.builder().withTitle(title).withText(message).withDate(System.currentTimeMillis());
+    switch (kind) {
+      case INFO:
+        builder.withAlertType(Event.AlertType.INFO);
+        break;
+      case WARNING:
+        builder.withAlertType(Event.AlertType.WARNING);
+        break;
+      case ERROR:
+        builder.withAlertType(Event.AlertType.ERROR);
+        break;
+      case SUCCESS:
+        builder.withAlertType(Event.AlertType.SUCCESS);
+        break;
+    }
+    connection.statsd.recordEvent(builder.build(), tags);
   }
 
   @Override

--- a/communication/src/main/java/datadog/communication/monitor/LoggingStatsDClient.java
+++ b/communication/src/main/java/datadog/communication/monitor/LoggingStatsDClient.java
@@ -2,6 +2,7 @@ package datadog.communication.monitor;
 
 import static datadog.communication.monitor.DDAgentStatsDClient.serviceCheckStatus;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.StatsDClient;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
@@ -19,6 +20,7 @@ public final class LoggingStatsDClient implements StatsDClient {
   private static final String HISTOGRAM_FORMAT = "{}:{}|h{}";
   private static final String DISTRIBUTION_FORMAT = "{}:{}|d{}";
   private static final String SERVICE_CHECK_FORMAT = "_sc|{}|{}{}{}";
+  private static final String EVENT_FORMAT = "_e{{},{}}:{}|{}|d:{}|h:{}|p:{}|t:{}{}";
 
   private static final DecimalFormat DECIMAL_FORMAT;
 
@@ -86,6 +88,21 @@ public final class LoggingStatsDClient implements StatsDClient {
         DISTRIBUTION_FORMAT,
         nameMapping.apply(metricName),
         DECIMAL_FORMAT.format(value),
+        join(tagMapping.apply(tags)));
+  }
+
+  @Override
+  public void event(String title, String message, EventKind kind, String... tags) {
+    log.info(
+        EVENT_FORMAT,
+        title.length(),
+        message.length(),
+        title,
+        message,
+        System.currentTimeMillis(),
+        Config.get().getHostName(),
+        "normal",
+        kind.name().toLowerCase(),
         join(tagMapping.apply(tags)));
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/DebuggerMetrics.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/DebuggerMetrics.java
@@ -77,6 +77,11 @@ public class DebuggerMetrics implements StatsDClient {
   }
 
   @Override
+  public void event(String title, String message, EventKind kind, String... tags) {
+    statsd.event(title, message, kind, tags);
+  }
+
+  @Override
   public void serviceCheck(String serviceCheckName, String status, String message, String... tags) {
     statsd.serviceCheck(serviceCheckName, status, message, tags);
   }

--- a/dd-java-agent/agent-jfrmetrics/build.gradle
+++ b/dd-java-agent/agent-jfrmetrics/build.gradle
@@ -1,0 +1,57 @@
+plugins {
+  id "com.github.johnrengelman.shadow"
+}
+
+// Set properties before any plugins get loaded
+ext {
+  minJavaVersionForTests = JavaVersion.VERSION_21
+
+  excludeJdk = ['SEMERU21']
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+apply plugin: 'idea'
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(21)
+  }
+}
+
+tasks.withType(JavaCompile).each {
+  it.configure {
+    setJavaVersion(it, 21)
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+}
+
+dependencies {
+  api project(':internal-api')
+  implementation deps.slf4j
+
+  testImplementation deps.mockito
+  testImplementation deps.junit5
+}
+
+excludedClassesCoverage += ['datadog.trace.agent.jfrmetrics.JFRMetrics*']
+
+forbiddenApisMain {
+  failOnMissingClasses = false
+}
+
+shadowJar {
+  dependencies {
+    exclude(project(":internal-api"))
+    exclude(project(":dd-trace-api"))
+    exclude(project(":utils:time-utils"))
+    exclude(dependency("com.datadoghq:dd-javac-plugin-client:0.1.7"))
+    exclude(dependency(deps.slf4j))
+  }
+}
+
+idea {
+  module {
+    jdkName = '21'
+  }
+}

--- a/dd-java-agent/agent-jfrmetrics/src/main/java/datadog/trace/agent/jfrmetrics/JfrMetricsConfig.java
+++ b/dd-java-agent/agent-jfrmetrics/src/main/java/datadog/trace/agent/jfrmetrics/JfrMetricsConfig.java
@@ -1,0 +1,11 @@
+package datadog.trace.agent.jfrmetrics;
+
+public final class JfrMetricsConfig {
+  public static String JFR_METRICS_ENABLED = "experimental.jfr.metrics.enabled";
+  public static boolean JFR_METRICS_ENABLED_DEFAULT = false;
+  public static String JFR_METRICS_PERIOD_SECONDS = "experimental.jfr.metrics.period.seconds";
+  public static int JFR_METRICS_PERIOD_SECONDS_DEFAULT = 10;
+  public static String JFR_METRICS_EVENT_THRESHOLD_SECONDS =
+      "experimental.jfr.metrics.event.threshold.seconds";
+  public static int JFR_METRICS_EVENT_THRESHOLD_SECONDS_DEFAULT = 30;
+}

--- a/dd-java-agent/agent-jfrmetrics/src/main/java/datadog/trace/agent/jfrmetrics/JfrMetricsEmitter.java
+++ b/dd-java-agent/agent-jfrmetrics/src/main/java/datadog/trace/agent/jfrmetrics/JfrMetricsEmitter.java
@@ -1,0 +1,160 @@
+package datadog.trace.agent.jfrmetrics;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.StatsDClient;
+import datadog.trace.api.StatsDClientManager;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import jdk.jfr.consumer.RecordingStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// Used from datadog.trace.bootstrap.Agent
+public final class JfrMetricsEmitter {
+  private static final Logger log = LoggerFactory.getLogger(JfrMetricsEmitter.class);
+  static final String JVM_RESIDENT_SET_SIZE_KEY = "jvm.resident_set_size";
+  static final String JVM_NATIVE_MEMORY_COMMITTED_KEY = "jvm.native_memory_committed";
+  static final String JVM_NATIVE_MEMORY_RESERVED_KEY = "jvm.native_memory_reserved";
+  static final String JVM_VIRTUAL_THREAD_PINNED_KEY = "jvm.virtual_thread_pinned";
+  static final String JVM_VIRTUAL_THREAD_SUBMIT_FAILED_KEY = "jvm.virtual_thread_submit_failed";
+
+  protected static final class Triggering {
+    private final long threshold;
+    private final AtomicLong lastTs = new AtomicLong(-1);
+
+    Triggering(Duration threshold) {
+      this.threshold = threshold.toMillis();
+    }
+
+    void record(Runnable callback) {
+      long now = System.currentTimeMillis();
+      lastTs.updateAndGet(
+          ts -> {
+            if (ts == -1 || now - ts > threshold) {
+              callback.run();
+              return now;
+            }
+            return ts;
+          });
+    }
+  }
+
+  private static JfrMetricsEmitter instance;
+
+  public static synchronized void run(StatsDClientManager statsdManager) {
+    if (instance != null) {
+      return;
+    }
+
+    Config cfg = Config.get();
+
+    String host = cfg.getJmxFetchStatsdHost();
+    Integer port = cfg.getJmxFetchStatsdPort();
+    String namedPipe = cfg.getDogStatsDNamedPipe();
+
+    instance =
+        new JfrMetricsEmitter(
+            statsdManager.statsDClient(host, port, namedPipe, null, null),
+            ConfigProvider.getInstance());
+    Thread t = new Thread(instance::run, "JfrMetricsEmitter");
+    t.start();
+  }
+
+  private final StatsDClient statsd;
+
+  private final boolean enabled;
+  private final int periodSeconds;
+
+  private final Triggering vtSubmitFailedTrigger;
+  private final Triggering vtPinnedTs;
+
+  JfrMetricsEmitter(StatsDClient statsd, ConfigProvider configProvider) {
+    enabled =
+        configProvider.getBoolean(
+            JfrMetricsConfig.JFR_METRICS_ENABLED, JfrMetricsConfig.JFR_METRICS_ENABLED_DEFAULT);
+    periodSeconds =
+        configProvider.getInteger(
+            JfrMetricsConfig.JFR_METRICS_PERIOD_SECONDS,
+            JfrMetricsConfig.JFR_METRICS_PERIOD_SECONDS_DEFAULT);
+    this.statsd = statsd;
+    Duration threshold =
+        Duration.ofSeconds(
+            configProvider.getInteger(
+                JfrMetricsConfig.JFR_METRICS_EVENT_THRESHOLD_SECONDS,
+                JfrMetricsConfig.JFR_METRICS_EVENT_THRESHOLD_SECONDS_DEFAULT));
+    vtSubmitFailedTrigger = new Triggering(threshold);
+    vtPinnedTs = new Triggering(threshold);
+  };
+
+  void runAsync() {
+    Thread t = new Thread(this::run, "JfrMetricsEmitter");
+    t.setDaemon(true);
+    t.start();
+  }
+
+  public void run() {
+    if (!enabled) {
+      log.info("JFR metrics collection is disabled");
+      return;
+    }
+    try (var rs = new RecordingStream()) {
+      rs.enable("jdk.VirtualThreadSubmitFailed");
+      rs.enable("jdk.VirtualThreadPinned");
+      rs.enable("jdk.ResidentSetSize").withPeriod(Duration.ofSeconds(periodSeconds));
+      rs.enable("jdk.NativeMemoryUsageTotal").withPeriod(Duration.ofSeconds(periodSeconds));
+
+      rs.onEvent(
+          "jdk.VirtualThreadSubmitFailed",
+          event -> {
+            statsd.incrementCounter(JVM_VIRTUAL_THREAD_SUBMIT_FAILED_KEY);
+            vtSubmitFailedTrigger.record(
+                () -> {
+                  statsd.event(
+                      "Virtual Thread Submit Failed",
+                      "Virtual Thread "
+                          + event.getThread().getJavaName()
+                          + "( + "
+                          + event.getThread().getId()
+                          + ") submit failed.",
+                      StatsDClient.EventKind.ERROR,
+                      "thread:" + event.getThread().getJavaName(),
+                      "runtime-id:" + Config.get().getRuntimeId());
+                });
+          });
+      rs.onEvent(
+          "jdk.VirtualThreadPinned",
+          event -> {
+            statsd.distribution(JVM_VIRTUAL_THREAD_PINNED_KEY, event.getDuration().toMillis());
+            vtPinnedTs.record(
+                () -> {
+                  statsd.event(
+                      "Virtual Thread Pinned",
+                      "Virtual Thread "
+                          + event.getThread().getJavaName()
+                          + "( + "
+                          + event.getThread().getId()
+                          + ") was pinned.",
+                      StatsDClient.EventKind.WARNING,
+                      "thread:" + event.getThread().getJavaName(),
+                      "runtime-id:" + Config.get().getRuntimeId());
+                });
+          });
+
+      rs.onEvent(
+          "jdk.ResidentSetSize",
+          event -> {
+            statsd.gauge(JVM_RESIDENT_SET_SIZE_KEY, event.getLong("size"));
+          });
+
+      rs.onEvent(
+          "jdk.NativeMemoryUsageTotal",
+          event -> {
+            statsd.gauge(JVM_NATIVE_MEMORY_COMMITTED_KEY, event.getLong("committed"));
+            statsd.gauge(JVM_NATIVE_MEMORY_RESERVED_KEY, event.getLong("reserved"));
+          });
+
+      rs.start();
+    }
+  }
+}

--- a/dd-java-agent/agent-jfrmetrics/src/test/java/datadog/trace/agent/jfrmetrics/JfrMetricsEmitterTest.java
+++ b/dd-java-agent/agent-jfrmetrics/src/test/java/datadog/trace/agent/jfrmetrics/JfrMetricsEmitterTest.java
@@ -1,0 +1,171 @@
+package datadog.trace.agent.jfrmetrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import datadog.trace.api.StatsDClient;
+import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import org.junit.jupiter.api.Test;
+
+public class JfrMetricsEmitterTest {
+  private static class TestMetricSupport implements StatsDClient {
+    private final Map<String, Long> counterMap = new HashMap<>();
+    private final Map<String, Double> gaugeMap = new HashMap<>();
+    private final Set<String> metricNames = new HashSet<>();
+    private final Set<String> eventNames = new HashSet<>();
+
+    @Override
+    public void incrementCounter(String metricName, String... tags) {
+      counterMap.compute(metricName, (k, v) -> v == null ? 1 : v + 1);
+      metricNames.add(metricName);
+    }
+
+    @Override
+    public void count(String metricName, long delta, String... tags) {
+      counterMap.compute(metricName, (k, v) -> v == null ? 1 : v + delta);
+      metricNames.add(metricName);
+    }
+
+    @Override
+    public void gauge(String metricName, double value, String... tags) {
+      gaugeMap.put(metricName, value);
+      metricNames.add(metricName);
+    }
+
+    @Override
+    public void gauge(String metricName, long value, String... tags) {
+      gaugeMap.put(metricName, (double) value);
+      metricNames.add(metricName);
+    }
+
+    @Override
+    public void histogram(String metricName, long value, String... tags) {
+      metricNames.add(metricName);
+    }
+
+    @Override
+    public void histogram(String metricName, double value, String... tags) {
+      metricNames.add(metricName);
+    }
+
+    @Override
+    public void distribution(String metricName, long value, String... tags) {
+      metricNames.add(metricName);
+    }
+
+    @Override
+    public void distribution(String metricName, double value, String... tags) {
+      metricNames.add(metricName);
+    }
+
+    @Override
+    public void serviceCheck(
+        String serviceCheckName, String status, String message, String... tags) {}
+
+    @Override
+    public void event(String title, String message, EventKind kind, String... tags) {
+      eventNames.add(title);
+    }
+
+    @Override
+    public void error(Exception error) {}
+
+    @Override
+    public int getErrorCount() {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  @Test
+  void testRss() throws Exception {
+    Properties override = new Properties();
+    override.setProperty(JfrMetricsConfig.JFR_METRICS_ENABLED, "true");
+    override.setProperty(JfrMetricsConfig.JFR_METRICS_PERIOD_SECONDS, "1");
+
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(override);
+
+    TestMetricSupport metricSupport = new TestMetricSupport();
+    JfrMetricsEmitter emitter = new JfrMetricsEmitter(metricSupport, configProvider);
+
+    emitter.runAsync();
+    waitFull(1_500);
+
+    assertTrue(metricSupport.gaugeMap.containsKey(JfrMetricsEmitter.JVM_RESIDENT_SET_SIZE_KEY));
+  }
+
+  @Test
+  void testVirtualThreads() throws Exception {
+    // set up the metrics emitter
+    Properties override = new Properties();
+    override.setProperty(JfrMetricsConfig.JFR_METRICS_ENABLED, "true");
+    override.setProperty(JfrMetricsConfig.JFR_METRICS_PERIOD_SECONDS, "1");
+
+    ConfigProvider configProvider = ConfigProvider.withPropertiesOverride(override);
+
+    TestMetricSupport metricSupport = new TestMetricSupport();
+    JfrMetricsEmitter emitter = new JfrMetricsEmitter(metricSupport, configProvider);
+
+    emitter.runAsync();
+
+    // and now we will submit a virtual thread that will be pinned periodically
+    AtomicBoolean done = new AtomicBoolean(false);
+    try (var service = Executors.newVirtualThreadPerTaskExecutor()) {
+      Object monitor = new Object();
+      service.submit(
+          () -> {
+            while (!done.get()) {
+              // pin the thread
+              synchronized (monitor) {
+                LockSupport.parkNanos(30_000L);
+              }
+            }
+          });
+      waitFull(1_500);
+      done.set(true);
+    }
+
+    assertTrue(metricSupport.metricNames.contains(JfrMetricsEmitter.JVM_VIRTUAL_THREAD_PINNED_KEY));
+  }
+
+  @Test
+  void testTriggering() throws Exception {
+    JfrMetricsEmitter.Triggering t = new JfrMetricsEmitter.Triggering(Duration.ofSeconds(1));
+    AtomicInteger triggered = new AtomicInteger(0);
+    long ts = System.currentTimeMillis();
+    t.record(triggered::incrementAndGet);
+    assertEquals(1, triggered.get());
+    t.record(triggered::incrementAndGet);
+    assumeTrue(System.currentTimeMillis() - ts < 950); // less than 1 second
+    assertEquals(1, triggered.get()); // no re-trigger
+    waitFull(1_100); // after 1 second the trigger is reset
+    t.record(triggered::incrementAndGet);
+    assumeTrue(System.currentTimeMillis() - ts < 2_050); // less than 2 seconds
+    assertEquals(2, triggered.get()); // should be re-triggered
+  }
+
+  private static void waitFull(long ms) {
+    long start = System.currentTimeMillis();
+    long end = start + ms;
+    while (System.currentTimeMillis() < end) {
+      try {
+        Thread.sleep(end - System.currentTimeMillis()); // deal with spurious wakeups
+      } catch (InterruptedException e) {
+        // ignore
+      }
+    }
+  }
+}

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -108,6 +108,7 @@ def includeSubprojShadowJar(String projName, String jarname) {
 
 includeSubprojShadowJar ':dd-java-agent:instrumentation', 'inst'
 includeSubprojShadowJar ':dd-java-agent:agent-jmxfetch', 'metrics'
+includeSubprojShadowJar ':dd-java-agent:agent-jfrmetrics', 'metrics-jfr'
 includeSubprojShadowJar ':dd-java-agent:agent-profiling', 'profiling'
 includeSubprojShadowJar ':dd-java-agent:appsec', 'appsec'
 includeSubprojShadowJar ':dd-java-agent:agent-iast', 'iast'

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -506,6 +506,15 @@ class HealthMetricsTest extends DDSpecification {
     }
 
     @Override
+    void event(String title, String message, EventKind kind, String... tags) {
+      try {
+        delegate.event(title, message, kind, tags)
+      } finally {
+        latch.countDown()
+      }
+    }
+
+    @Override
     void error(Exception error) {
       try {
         delegate.error(error)

--- a/internal-api/src/main/java/datadog/trace/api/NoOpStatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/NoOpStatsDClient.java
@@ -34,6 +34,9 @@ final class NoOpStatsDClient implements StatsDClient {
       final String... tags) {}
 
   @Override
+  public void event(String title, String message, EventKind kind, String... tags) {}
+
+  @Override
   public void error(Exception error) {}
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
@@ -3,6 +3,13 @@ package datadog.trace.api;
 import java.io.Closeable;
 
 public interface StatsDClient extends Closeable {
+  enum EventKind {
+    INFO,
+    WARNING,
+    ERROR,
+    SUCCESS
+  }
+
   StatsDClient NO_OP = new NoOpStatsDClient();
 
   void incrementCounter(String metricName, String... tags);
@@ -20,6 +27,8 @@ public interface StatsDClient extends Closeable {
   void distribution(String metricName, long value, String... tags);
 
   void distribution(String metricName, double value, String... tags);
+
+  void event(String title, String message, EventKind kind, String... tags);
 
   void serviceCheck(String serviceCheckName, String status, String message, String... tags);
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -57,6 +57,8 @@ include ':dd-java-agent:agent-profiling:profiling-testing'
 include ':dd-java-agent:agent-profiling:profiling-uploader'
 include ':dd-java-agent:agent-profiling:profiling-utils'
 
+include ':dd-java-agent:agent-jfrmetrics'
+
 include ':dd-java-agent:agent-debugger:debugger-bootstrap'
 include ':dd-java-agent:agent-debugger:debugger-test-scala'
 include ':dd-java-agent:agent-debugger:debugger-el'


### PR DESCRIPTION
# What Does This Do
This is a simple prototype of how to extract JFR data into statsd metrics using JFR streaming.

# Motivation
A PoC of the functionality to verify if this approach is acceptable by our customers.

# Additional Notes
The feature is guarded by an experimental config option and is disabled by default.

Jira ticket: [PROF-9618]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-9618]: https://datadoghq.atlassian.net/browse/PROF-9618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ