### PR TITLE
Report via telemetry if _dd.iast.json tag exceeds max tag size

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
@@ -1,5 +1,7 @@
 package com.datadog.iast.model.json;
 
+import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
+
 import com.datadog.iast.model.VulnerabilityBatch;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -33,7 +35,7 @@ public class VulnerabilityEncoding {
   }
 
   static String getExceededTagSizeJson(final TruncatedVulnerabilities truncatedVulnerabilities) {
-    // TODO report via telemetry
+    log.debug(SEND_TELEMETRY, "_dd.iast.json tag exceeded the maximum tag size");
     return TRUNCATED_VULNERABILITIES_ADAPTER.toJson(truncatedVulnerabilities);
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/json/VulnerabilityEncoding.java
@@ -1,10 +1,10 @@
 package com.datadog.iast.model.json;
 
-import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
-
 import com.datadog.iast.model.VulnerabilityBatch;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import datadog.trace.api.iast.telemetry.IastMetric;
+import datadog.trace.api.iast.telemetry.IastMetricCollector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,7 @@ public class VulnerabilityEncoding {
   }
 
   static String getExceededTagSizeJson(final TruncatedVulnerabilities truncatedVulnerabilities) {
-    log.debug(SEND_TELEMETRY, "_dd.iast.json tag exceeded the maximum tag size");
+    IastMetricCollector.add(IastMetric.JSON_TAG_SIZE_EXCEED, 1);
     return TRUNCATED_VULNERABILITIES_ADAPTER.toJson(truncatedVulnerabilities);
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
@@ -14,6 +14,7 @@ import datadog.trace.api.iast.telemetry.IastMetricCollector
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
 import org.skyscreamer.jsonassert.JSONAssert
+import spock.lang.Shared
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -22,9 +23,17 @@ import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED
 
 class VulnerabilityEncodingTest extends DDSpecification {
 
+  @Shared
+  final IastMetricCollector defaultCollector = IastMetricCollector.get()
+
   @Override
   void setup() {
     injectSysConfig(IastConfig.IAST_REDACTION_ENABLED, 'false')
+  }
+
+  @Override
+  void cleanupSpec() {
+    IastMetricCollector.register(defaultCollector)
   }
 
   void 'null vulnerability'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/json/VulnerabilityEncodingTest.groovy
@@ -9,6 +9,8 @@ import com.datadog.iast.model.VulnerabilityBatch
 import com.datadog.iast.model.VulnerabilityType
 import datadog.trace.api.config.IastConfig
 import datadog.trace.api.iast.SourceTypes
+import datadog.trace.api.iast.telemetry.IastMetric
+import datadog.trace.api.iast.telemetry.IastMetricCollector
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
 import org.skyscreamer.jsonassert.JSONAssert
@@ -484,6 +486,8 @@ class VulnerabilityEncodingTest extends DDSpecification {
 
   void 'when json is greater than 25kb VulnerabilityEncoding#getExceededTagSizeJson is called'(){
     given:
+    final metricCollector = Mock(IastMetricCollector)
+    IastMetricCollector.register(metricCollector)
     final span = Stub(AgentSpan)
     final spanId = 123456
     span.getSpanId() >> spanId
@@ -498,6 +502,7 @@ class VulnerabilityEncodingTest extends DDSpecification {
     then: 'all sources have been removed and all vulnerabilities have generic evidence'
     !result.contains("source") //sources have been removed
     countGenericEvidenceOccurrences(result) == value.getVulnerabilities().size() //All the vulnerabilities have generic evidence
+    1 * metricCollector.addMetric(IastMetric.JSON_TAG_SIZE_EXCEED, -1, 1)
 
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetric.java
@@ -19,7 +19,7 @@ public enum IastMetric {
   EXECUTED_TAINTED("executed.tainted", true, Scope.REQUEST, Verbosity.DEBUG),
   REQUEST_TAINTED("request.tainted", true, Scope.REQUEST, Verbosity.INFORMATION),
   TAINTED_FLAT_MODE("tainted.flat.mode", false, Scope.GLOBAL, Verbosity.INFORMATION),
-  JSON_TAG_SIZE_EXCEED("json.tag.size.exceed", false, Scope.GLOBAL, Verbosity.INFORMATION);
+  JSON_TAG_SIZE_EXCEED("json.tag.size.exceeded", true, Scope.GLOBAL, Verbosity.INFORMATION);
 
   private static final int COUNT;
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/telemetry/IastMetric.java
@@ -18,7 +18,8 @@ public enum IastMetric {
       "executed.sink", true, Scope.REQUEST, Tag.VULNERABILITY_TYPE, Verbosity.INFORMATION),
   EXECUTED_TAINTED("executed.tainted", true, Scope.REQUEST, Verbosity.DEBUG),
   REQUEST_TAINTED("request.tainted", true, Scope.REQUEST, Verbosity.INFORMATION),
-  TAINTED_FLAT_MODE("tainted.flat.mode", false, Scope.GLOBAL, Verbosity.INFORMATION);
+  TAINTED_FLAT_MODE("tainted.flat.mode", false, Scope.GLOBAL, Verbosity.INFORMATION),
+  JSON_TAG_SIZE_EXCEED("json.tag.size.exceed", false, Scope.GLOBAL, Verbosity.INFORMATION);
 
   private static final int COUNT;
 


### PR DESCRIPTION
# What Does This Do

Add a new telemetry metric to mesure how many times iast-json tag exceeds max tag size

# Motivation

We need metrics related with how many times source code vulnerabilities information exceeds the maximum size allowed


# Additional Notes

Jira ticket: [APPSEC-11540]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-11540]: https://datadoghq.atlassian.net/browse/APPSEC-11540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ