### PR TITLE
Update buildscan plugin to latest version

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,18 +1,15 @@
 plugins {
-  id 'com.gradle.enterprise' version '3.0'
+  id 'com.gradle.develocity' version '3.17.2'
 }
 
 def isCI = System.getenv("CI") != null
 def skipBuildscan = Boolean.valueOf(System.getenv("SKIP_BUILDSCAN"))
-gradleEnterprise {
+develocity {
   buildScan {
-    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-    termsOfServiceAgree = 'yes'
+    termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+    termsOfUseAgree = "yes"
 
-    if (isCI && !skipBuildscan) {
-      publishAlways()
-      tag 'CI'
-    }
+    publishing.onlyIf { isCI && !skipBuildscan }
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,8 +6,8 @@ def isCI = System.getenv("CI") != null
 def skipBuildscan = Boolean.valueOf(System.getenv("SKIP_BUILDSCAN"))
 develocity {
   buildScan {
-    termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
-    termsOfUseAgree = "yes"
+    termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+    termsOfUseAgree = 'yes'
 
     publishing.onlyIf { isCI && !skipBuildscan }
   }


### PR DESCRIPTION
# What Does This Do

Updates the build scan plugin to the latest artifact coodinates.

# Motivation
The previous version, `3.0`, was 17 minor version old. It failed constantly in Gitlab, likely due to incompatibilities with the latest Gradle versions. Gradle has moved the plugin from `com.gradle.enterprise` to `com.gradle.develocity`. See [Migration guide](https://docs.gradle.com/develocity/gradle-plugin/legacy/#develocity_migration)
