### PR TITLE
Lint produced deb and rpm packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,12 +86,14 @@ package:
   when: on_success # this can't use 'needs: [build]', since build is not available in the scheduled pipeline
   script:
     - ../.gitlab/build_java_package.sh
+    - find . -iregex '.*\.\(deb\|rpm\)' -printf '%f\0' | xargs -0 dd-pkg lint
 
 package-arm:
   extends: .package-arm
   when: on_success # this can't use 'needs: [build]', since build is not available in the scheduled pipeline
   script:
     - ../.gitlab/build_java_package.sh
+    - find . -iregex '.*\.\(deb\|rpm\)' -printf '%f\0' | xargs -0 dd-pkg lint
 
 package-oci:
   stage: package


### PR DESCRIPTION
# What Does This Do

The latest stable version of the packaging template now includes a tool `dd-pkg`. This PR uses this tool to lint the produced DEB and RPM packages.

# Motivation

This lint has been run at the time of package promotion, this change moves this step to the left and lets teams identify issues _before_ they're trying to release to production.

# Additional Notes

Jira ticket: [BARX-245](https://datadoghq.atlassian.net/browse/BARX-245)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[BARX-245]: https://datadoghq.atlassian.net/browse/BARX-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ