### PR TITLE
Fix folder permission interaction with Gitlab and gradle

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,14 @@ cache: &default_cache
   image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
+    # for weird reasons, gradle will always "chmod 700" the .gradle folder
+    # with Gitlab caching, .gradle is always owned by root and thus gradle's chmod invocation fails
+    # This dance is a hack to have .gradle owned by the Gitlab runner user
+    - mkdir -p .gradle
+    - cp -r .gradle .gradle-copy
+    - rm -rf .gradle
+    - mv .gradle-copy .gradle
+    - ls -la
 
 build: &build
   <<: *gradle_build


### PR DESCRIPTION
# What Does This Do

https://github.com/DataDog/dd-trace-java/pull/6931 inadvertently broke Gitlab builds because of the interactions between the Gitlab cache and gradle:

* Gradle always attempts to change permissions of the `.gradle` folder. See [here](https://github.com/gradle/gradle/blob/master/platforms/core-execution/persistent-cache/src/main/java/org/gradle/cache/internal/FileBackedObjectHolder.java#L114)
* With Gitlab caching, `.gradle` is owned by root
* Gradle's attempt fails and the build fails

This PR adds a workaround by copying moving back the cache folder so that it is owned by the gitlab runner user.

Related Gradle issues:
https://github.com/gradle/gradle/issues/14200
https://github.com/gradle/gradle/issues/8673
