### PR TITLE
Exclude package ibm.security.* from IAST

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -123,6 +123,7 @@
 1 freemarker.*
 1 gnu.*
 1 graphql.*
+1 ibm.security.*
 1 io.dropwizard.*
 1 io.github.lukehutch.fastclasspathscanner.*
 1 io.grpc.*


### PR DESCRIPTION
# What Does This Do
Exclude package `ibm.security.*` from IAST transformations

# Motivation
The clases are loaded in the boot class-path so they cannot be instrumented as helpers cannot be injected there:

```
[dd.trace 2024-04-05 16:19:06:528 -0400] [Default Executor-thread-79] DEBUG datadog.trace.agent.tooling.AgentInstaller$TransformLoggingListener - Transformation failed - instrumentation.target.class=ibm.security.internal.spec.TlsMasterSecretParameterSpec instrumentation.target.classloader=null
java.lang.UnsupportedOperationException: Cannot inject helper classes onto boot-class-path
```

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
