### PR TITLE
Refactor propagation module to introduce better naming for methods

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/iast/NamedContext.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/iast/NamedContext.java
@@ -64,7 +64,7 @@ public abstract class NamedContext {
 
     @Override
     public void taintValue(@Nullable final String value) {
-      module.taint(iastCtx(), value, source.getOrigin(), currentName, source.getValue());
+      module.taintString(iastCtx(), value, source.getOrigin(), currentName, source.getValue());
     }
 
     @Override
@@ -74,7 +74,7 @@ public abstract class NamedContext {
       // prevent tainting the same name more than once
       if (currentName != name) {
         currentName = name;
-        module.taint(iastCtx(), name, source.getOrigin(), name, source.getValue());
+        module.taintString(iastCtx(), name, source.getOrigin(), name, source.getValue());
       }
     }
 

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/iast/NamedContextTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/iast/NamedContextTest.groovy
@@ -38,7 +38,7 @@ class NamedContextTest extends DDSpecification {
     context.taintName(name)
 
     then:
-    1 * module.taint(_, name, source.origin, name, source.value)
+    1 * module.taintString(_, name, source.origin, name, source.value)
 
     when:
     context.taintName(name)
@@ -50,7 +50,7 @@ class NamedContextTest extends DDSpecification {
     context.taintValue(value)
 
     then:
-    1 * module.taint(_, value, source.origin, name, source.value)
+    1 * module.taintString(_, value, source.origin, name, source.value)
     0 * _
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/GrpcRequestMessageHandler.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/GrpcRequestMessageHandler.java
@@ -35,7 +35,8 @@ public class GrpcRequestMessageHandler implements BiFunction<RequestContext, Obj
       final IastContext iastCtx = ctx.getData(RequestContextSlot.IAST);
       final byte source = SourceTypes.GRPC_BODY;
       final int tainted =
-          module.taintDeeply(iastCtx, o, source, GrpcRequestMessageHandler::isProtobufArtifact);
+          module.taintObjectDeeply(
+              iastCtx, o, source, GrpcRequestMessageHandler::isProtobufArtifact);
       if (tainted > 0) {
         IastMetricCollector.add(IastMetric.EXECUTED_SOURCE, source, tainted, iastCtx);
       }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/FastCodecModule.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/FastCodecModule.java
@@ -11,7 +11,7 @@ public class FastCodecModule extends PropagationModuleImpl implements CodecModul
   @Override
   public void onUrlDecode(
       @Nonnull final String value, @Nullable final String encoding, @Nonnull final String result) {
-    taintIfTainted(result, value);
+    taintStringIfTainted(result, value);
   }
 
   @Override
@@ -22,22 +22,22 @@ public class FastCodecModule extends PropagationModuleImpl implements CodecModul
       @Nullable final String charset,
       @Nonnull final String result) {
     // create a new range shifted to the result string coordinates
-    taintIfTainted(result, value, offset, length, false, NOT_MARKED);
+    taintStringIfRangeTainted(result, value, offset, length, false, NOT_MARKED);
   }
 
   @Override
   public void onStringGetBytes(
       @Nonnull final String value, @Nullable final String charset, @Nonnull final byte[] result) {
-    taintIfTainted(result, value);
+    taintObjectIfTainted(result, value);
   }
 
   @Override
   public void onBase64Encode(@Nullable byte[] value, @Nullable byte[] result) {
-    taintIfTainted(result, value);
+    taintObjectIfTainted(result, value);
   }
 
   @Override
   public void onBase64Decode(@Nullable byte[] value, @Nullable byte[] result) {
-    taintIfTainted(result, value);
+    taintObjectIfTainted(result, value);
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -28,55 +28,55 @@ public class PropagationModuleImpl implements PropagationModule {
   private static final int MAX_VALUE_LENGTH = Config.get().getIastTruncationMaxValueLength();
 
   @Override
-  public void taint(@Nullable Object target, byte origin) {
-    taint(target, origin, null);
+  public void taintObject(@Nullable Object target, byte origin) {
+    taintObject(target, origin, null);
   }
 
   @Override
-  public void taint(@Nullable IastContext ctx, @Nullable Object target, byte origin) {
-    taint(ctx, target, origin, null);
+  public void taintObject(@Nullable IastContext ctx, @Nullable Object target, byte origin) {
+    taintObject(ctx, target, origin, null);
   }
 
   @Override
-  public void taint(@Nullable String target, byte origin) {
-    taint(target, origin, null);
+  public void taintString(@Nullable String target, byte origin) {
+    taintString(target, origin, null);
   }
 
   @Override
-  public void taint(@Nullable IastContext ctx, @Nullable String target, byte origin) {
-    taint(ctx, target, origin, null);
+  public void taintString(@Nullable IastContext ctx, @Nullable String target, byte origin) {
+    taintString(ctx, target, origin, null);
   }
 
   @Override
-  public void taint(@Nullable Object target, byte origin, @Nullable CharSequence name) {
-    taint(target, origin, name, target);
+  public void taintObject(@Nullable Object target, byte origin, @Nullable CharSequence name) {
+    taintObject(target, origin, name, target);
   }
 
   @Override
-  public void taint(
+  public void taintObject(
       @Nullable IastContext ctx,
       @Nullable Object target,
       byte origin,
       @Nullable CharSequence name) {
-    taint(ctx, target, origin, name, target);
+    taintObject(ctx, target, origin, name, target);
   }
 
   @Override
-  public void taint(@Nullable String target, byte origin, @Nullable CharSequence name) {
-    taint(target, origin, name, target);
+  public void taintString(@Nullable String target, byte origin, @Nullable CharSequence name) {
+    taintString(target, origin, name, target);
   }
 
   @Override
-  public void taint(
+  public void taintString(
       @Nullable IastContext ctx,
       @Nullable String target,
       byte origin,
       @Nullable CharSequence name) {
-    taint(ctx, target, origin, name, target);
+    taintString(ctx, target, origin, name, target);
   }
 
   @Override
-  public void taint(
+  public void taintObjectRange(
       @Nullable final Object target, final byte origin, final int start, final int length) {
     if (target == null || length == 0) {
       return;
@@ -85,11 +85,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taint(ctx, target, origin, start, length);
+    taintObjectRange(ctx, target, origin, start, length);
   }
 
   @Override
-  public void taint(
+  public void taintObjectRange(
       @Nullable final IastContext ctx,
       @Nullable final Object target,
       final byte origin,
@@ -105,7 +105,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taint(
+  public void taintStringRange(
       @Nullable final String target, final byte origin, final int start, final int length) {
     if (target == null || length == 0) {
       return;
@@ -114,11 +114,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taint(ctx, target, origin, start, length);
+    taintStringRange(ctx, target, origin, start, length);
   }
 
   @Override
-  public void taint(
+  public void taintStringRange(
       @Nullable final IastContext ctx,
       @Nullable final String target,
       final byte origin,
@@ -134,7 +134,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taint(
+  public void taintObject(
       @Nullable final Object target,
       final byte origin,
       @Nullable final CharSequence name,
@@ -146,11 +146,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taint(ctx, target, origin, name, value);
+    taintObject(ctx, target, origin, name, value);
   }
 
   @Override
-  public void taint(
+  public void taintObject(
       @Nullable final IastContext ctx,
       @Nullable final Object target,
       final byte origin,
@@ -164,7 +164,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taint(
+  public void taintString(
       @Nullable final String target,
       final byte origin,
       @Nullable final CharSequence name,
@@ -176,11 +176,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taint(ctx, target, origin, name, value);
+    taintString(ctx, target, origin, name, value);
   }
 
   @Override
-  public void taint(
+  public void taintString(
       @Nullable final IastContext ctx,
       @Nullable final String target,
       final byte origin,
@@ -194,29 +194,29 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintIfTainted(@Nullable Object target, @Nullable Object input) {
-    taintIfTainted(target, input, false, NOT_MARKED);
+  public void taintObjectIfTainted(@Nullable Object target, @Nullable Object input) {
+    taintObjectIfTainted(target, input, false, NOT_MARKED);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfTainted(
       @Nullable IastContext ctx, @Nullable Object target, @Nullable Object input) {
-    taintIfTainted(ctx, target, input, false, NOT_MARKED);
+    taintObjectIfTainted(ctx, target, input, false, NOT_MARKED);
   }
 
   @Override
-  public void taintIfTainted(@Nullable String target, @Nullable Object input) {
-    taintIfTainted(target, input, false, NOT_MARKED);
+  public void taintStringIfTainted(@Nullable String target, @Nullable Object input) {
+    taintStringIfTainted(target, input, false, NOT_MARKED);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfTainted(
       @Nullable IastContext ctx, @Nullable String target, @Nullable Object input) {
-    taintIfTainted(ctx, target, input, false, NOT_MARKED);
+    taintStringIfTainted(ctx, target, input, false, NOT_MARKED);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfTainted(
       @Nullable final Object target, @Nullable final Object input, boolean keepRanges, int mark) {
     if (target == null || input == null) {
       return;
@@ -225,11 +225,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taintIfTainted(ctx, target, input, keepRanges, mark);
+    taintObjectIfTainted(ctx, target, input, keepRanges, mark);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfTainted(
       @Nullable final IastContext ctx,
       @Nullable final Object target,
       @Nullable final Object input,
@@ -247,7 +247,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfTainted(
       @Nullable final String target, @Nullable final Object input, boolean keepRanges, int mark) {
     if (target == null || input == null) {
       return;
@@ -256,11 +256,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taintIfTainted(ctx, target, input, keepRanges, mark);
+    taintStringIfTainted(ctx, target, input, keepRanges, mark);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfTainted(
       @Nullable final IastContext ctx,
       @Nullable final String target,
       @Nullable final Object input,
@@ -278,7 +278,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfRangeTainted(
       @Nullable final Object target,
       @Nullable final Object input,
       final int start,
@@ -292,11 +292,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taintIfTainted(ctx, target, input, start, length, keepRanges, mark);
+    taintObjectIfRangeTainted(ctx, target, input, start, length, keepRanges, mark);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfRangeTainted(
       @Nullable final IastContext ctx,
       @Nullable final Object target,
       @Nullable final Object input,
@@ -325,7 +325,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfRangeTainted(
       @Nullable final String target,
       @Nullable final Object input,
       final int start,
@@ -339,11 +339,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taintIfTainted(ctx, target, input, start, length, keepRanges, mark);
+    taintStringIfRangeTainted(ctx, target, input, start, length, keepRanges, mark);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfRangeTainted(
       @Nullable final IastContext ctx,
       @Nullable final String target,
       @Nullable final Object input,
@@ -372,61 +372,61 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintIfTainted(@Nullable Object target, @Nullable Object input, byte origin) {
-    taintIfTainted(target, input, origin, null, target);
+  public void taintObjectIfTainted(@Nullable Object target, @Nullable Object input, byte origin) {
+    taintObjectIfTainted(target, input, origin, null, target);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfTainted(
       @Nullable IastContext ctx, @Nullable Object target, @Nullable Object input, byte origin) {
-    taintIfTainted(ctx, target, input, origin, null, target);
+    taintObjectIfTainted(ctx, target, input, origin, null, target);
   }
 
   @Override
-  public void taintIfTainted(@Nullable String target, @Nullable Object input, byte origin) {
-    taintIfTainted(target, input, origin, null, target);
+  public void taintStringIfTainted(@Nullable String target, @Nullable Object input, byte origin) {
+    taintStringIfTainted(target, input, origin, null, target);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfTainted(
       @Nullable IastContext ctx, @Nullable String target, @Nullable Object input, byte origin) {
-    taintIfTainted(ctx, target, input, origin, null, target);
+    taintStringIfTainted(ctx, target, input, origin, null, target);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfTainted(
       @Nullable Object target, @Nullable Object input, byte origin, @Nullable CharSequence name) {
-    taintIfTainted(target, input, origin, name, target);
+    taintObjectIfTainted(target, input, origin, name, target);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfTainted(
       @Nullable IastContext ctx,
       @Nullable Object target,
       @Nullable Object input,
       byte origin,
       @Nullable CharSequence name) {
-    taintIfTainted(ctx, target, input, origin, name, target);
+    taintObjectIfTainted(ctx, target, input, origin, name, target);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfTainted(
       @Nullable String target, @Nullable Object input, byte origin, @Nullable CharSequence name) {
-    taintIfTainted(target, input, origin, name, target);
+    taintStringIfTainted(target, input, origin, name, target);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfTainted(
       @Nullable IastContext ctx,
       @Nullable String target,
       @Nullable Object input,
       byte origin,
       @Nullable CharSequence name) {
-    taintIfTainted(ctx, target, input, origin, name, target);
+    taintStringIfTainted(ctx, target, input, origin, name, target);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfTainted(
       @Nullable final Object target,
       @Nullable final Object input,
       final byte origin,
@@ -439,11 +439,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taintIfTainted(ctx, target, input, origin, name, value);
+    taintObjectIfTainted(ctx, target, input, origin, name, value);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintObjectIfTainted(
       @Nullable final IastContext ctx,
       @Nullable final Object target,
       @Nullable final Object input,
@@ -460,7 +460,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfTainted(
       @Nullable final String target,
       @Nullable final Object input,
       final byte origin,
@@ -473,11 +473,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taintIfTainted(ctx, target, input, origin, name, value);
+    taintStringIfTainted(ctx, target, input, origin, name, value);
   }
 
   @Override
-  public void taintIfTainted(
+  public void taintStringIfTainted(
       @Nullable final IastContext ctx,
       @Nullable final String target,
       @Nullable final Object input,
@@ -494,29 +494,29 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintIfAnyTainted(@Nullable Object target, @Nullable Object[] inputs) {
-    taintIfAnyTainted(target, inputs, false, NOT_MARKED);
+  public void taintObjectIfAnyTainted(@Nullable Object target, @Nullable Object[] inputs) {
+    taintObjectIfAnyTainted(target, inputs, false, NOT_MARKED);
   }
 
   @Override
-  public void taintIfAnyTainted(
+  public void taintObjectIfAnyTainted(
       @Nullable IastContext ctx, @Nullable Object target, @Nullable Object[] inputs) {
-    taintIfAnyTainted(ctx, target, inputs, false, NOT_MARKED);
+    taintObjectIfAnyTainted(ctx, target, inputs, false, NOT_MARKED);
   }
 
   @Override
-  public void taintIfAnyTainted(@Nullable String target, @Nullable Object[] inputs) {
-    taintIfAnyTainted(target, inputs, false, NOT_MARKED);
+  public void taintStringIfAnyTainted(@Nullable String target, @Nullable Object[] inputs) {
+    taintStringIfAnyTainted(target, inputs, false, NOT_MARKED);
   }
 
   @Override
-  public void taintIfAnyTainted(
+  public void taintStringIfAnyTainted(
       @Nullable IastContext ctx, @Nullable String target, @Nullable Object[] inputs) {
-    taintIfAnyTainted(ctx, target, inputs, false, NOT_MARKED);
+    taintStringIfAnyTainted(ctx, target, inputs, false, NOT_MARKED);
   }
 
   @Override
-  public void taintIfAnyTainted(
+  public void taintObjectIfAnyTainted(
       @Nullable final Object target,
       @Nullable final Object[] inputs,
       final boolean keepRanges,
@@ -528,11 +528,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taintIfAnyTainted(ctx, target, inputs, keepRanges, mark);
+    taintObjectIfAnyTainted(ctx, target, inputs, keepRanges, mark);
   }
 
   @Override
-  public void taintIfAnyTainted(
+  public void taintObjectIfAnyTainted(
       @Nullable final IastContext ctx,
       @Nullable final Object target,
       @Nullable final Object[] inputs,
@@ -556,7 +556,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public void taintIfAnyTainted(
+  public void taintStringIfAnyTainted(
       @Nullable final String target,
       @Nullable final Object[] inputs,
       final boolean keepRanges,
@@ -568,11 +568,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return;
     }
-    taintIfAnyTainted(ctx, target, inputs, keepRanges, mark);
+    taintStringIfAnyTainted(ctx, target, inputs, keepRanges, mark);
   }
 
   @Override
-  public void taintIfAnyTainted(
+  public void taintStringIfAnyTainted(
       @Nullable final IastContext ctx,
       @Nullable final String target,
       @Nullable final Object[] inputs,
@@ -596,7 +596,7 @@ public class PropagationModuleImpl implements PropagationModule {
   }
 
   @Override
-  public int taintDeeply(
+  public int taintObjectDeeply(
       @Nullable final Object target, final byte origin, final Predicate<Class<?>> classFilter) {
     if (target == null) {
       return 0;
@@ -605,11 +605,11 @@ public class PropagationModuleImpl implements PropagationModule {
     if (ctx == null) {
       return 0;
     }
-    return taintDeeply(ctx, target, origin, classFilter);
+    return taintObjectDeeply(ctx, target, origin, classFilter);
   }
 
   @Override
-  public int taintDeeply(
+  public int taintObjectDeeply(
       @Nullable final IastContext ctx,
       @Nullable final Object target,
       final byte origin,

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/GrpcRequestMessageHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/GrpcRequestMessageHandlerTest.groovy
@@ -3,16 +3,12 @@ package com.datadog.iast
 import com.datadog.iast.propagation.PropagationModuleImpl
 import com.datadog.iast.protobuf.Test2
 import com.datadog.iast.protobuf.Test3
-import com.datadog.iast.taint.TaintedObjects
 import com.datadog.iast.util.ObjectVisitor
-import datadog.trace.api.gateway.RequestContext
-import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.SourceTypes
 import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.api.iast.telemetry.IastMetric
 import datadog.trace.api.iast.telemetry.IastMetricCollector
-import datadog.trace.test.util.DDSpecification
 import foo.bar.VisitableClass
 
 import java.util.function.Predicate
@@ -63,7 +59,7 @@ class GrpcRequestMessageHandlerTest extends IastModuleImplTestBase {
     handler.apply(reqCtx, target)
 
     then:
-    1 * propagation.taintDeeply(ctx, target, SourceTypes.GRPC_BODY, _ as Predicate<Class<?>>)
+    1 * propagation.taintObjectDeeply(ctx, target, SourceTypes.GRPC_BODY, _ as Predicate<Class<?>>)
   }
 
   void 'the handler only takes into account protobuf v.#protobufVersion related messages'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/PropagationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/PropagationModuleTest.groovy
@@ -54,37 +54,54 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     0 * _
 
     where:
-    method              | args
-    'taint'             | [null, SourceTypes.REQUEST_PARAMETER_VALUE]
-    'taint'             | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
-    'taint'             | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
-    'taint'             | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 0, 10]
-    'taintIfTainted'    | [null, 'test']
-    'taintIfTainted'    | ['test', null]
-    'taintIfTainted'    | [null, 'test', false, NOT_MARKED]
-    'taintIfTainted'    | ['test', null, false, NOT_MARKED]
-    'taintIfTainted'    | [null, 'test']
-    'taintIfTainted'    | ['test', null]
-    'taintIfTainted'    | [null, 'test', 0, 4, false, NOT_MARKED]
-    'taintIfTainted'    | ['test', null, 0, 4, false, NOT_MARKED]
-    'taintIfTainted'    | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE]
-    'taintIfTainted'    | ['test', null, SourceTypes.REQUEST_PARAMETER_VALUE]
-    'taintIfTainted'    | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
-    'taintIfTainted'    | ['test', null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
-    'taintIfTainted'    | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
-    'taintIfTainted'    | ['test', null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
-    'taintIfAnyTainted' | [null, ['test'] as Object[]]
-    'taintIfAnyTainted' | ['test', null]
-    'taintIfAnyTainted' | ['test', [] as Object[]]
-    'taintDeeply'       | [
+    method                      | args
+    'taintObject'               | [null, SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintString'               | [null, SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintObject'               | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintString'               | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintObject'               | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintString'               | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintObjectRange'          | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 0, 10]
+    'taintStringRange'          | [null, SourceTypes.REQUEST_PARAMETER_VALUE, 0, 10]
+    'taintObjectIfTainted'      | [null, 'test']
+    'taintStringIfTainted'      | [null, 'test']
+    'taintObjectIfTainted'      | [date(), null]
+    'taintStringIfTainted'      | ['test', null]
+    'taintObjectIfTainted'      | [null, 'test', false, NOT_MARKED]
+    'taintStringIfTainted'      | [null, 'test', false, NOT_MARKED]
+    'taintObjectIfTainted'      | [date(), null, false, NOT_MARKED]
+    'taintStringIfTainted'      | ['test', null, false, NOT_MARKED]
+    'taintObjectIfRangeTainted' | [null, 'test', 0, 4, false, NOT_MARKED]
+    'taintStringIfRangeTainted' | [null, 'test', 0, 4, false, NOT_MARKED]
+    'taintObjectIfRangeTainted' | [date(), null, 0, 4, false, NOT_MARKED]
+    'taintStringIfRangeTainted' | ['test', null, 0, 4, false, NOT_MARKED]
+    'taintObjectIfTainted'      | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintStringIfTainted'      | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintObjectIfTainted'      | [date(), null, SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintStringIfTainted'      | ['test', null, SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintObjectIfTainted'      | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintStringIfTainted'      | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintObjectIfTainted'      | [date(), null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintStringIfTainted'      | ['test', null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintObjectIfTainted'      | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintStringIfTainted'      | [null, 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintObjectIfTainted'      | [date(), null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintStringIfTainted'      | ['test', null, SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintObjectIfAnyTainted'   | [null, ['test'] as Object[]]
+    'taintStringIfAnyTainted'   | [null, ['test'] as Object[]]
+    'taintObjectIfAnyTainted'   | [date(), null]
+    'taintStringIfAnyTainted'   | ['test', null]
+    'taintObjectIfAnyTainted'   | [date(), [] as Object[]]
+    'taintStringIfAnyTainted'   | ['test', [] as Object[]]
+    'taintObjectDeeply'         | [
       null,
       SourceTypes.REQUEST_PARAMETER_VALUE,
       {
         true
       }
     ]
-    'findSource'        | [null]
-    'isTainted'         | [null]
+    'findSource'                | [null]
+    'isTainted'                 | [null]
   }
 
   void '#method without span'() {
@@ -96,27 +113,38 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     0 * _
 
     where:
-    method              | args
-    'taint'             | ['test', SourceTypes.REQUEST_PARAMETER_VALUE]
-    'taint'             | ['test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
-    'taint'             | ['test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
-    'taint'             | ['test', SourceTypes.REQUEST_PARAMETER_VALUE, 0, 10]
-    'taintIfTainted'    | ['test', 'test']
-    'taintIfTainted'    | ['test', 'test', 0, 4, false, NOT_MARKED]
-    'taintIfTainted'    | ['test', 'test', false, NOT_MARKED]
-    'taintIfTainted'    | ['test', 'test', SourceTypes.REQUEST_PARAMETER_VALUE]
-    'taintIfTainted'    | ['test', 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
-    'taintIfTainted'    | ['test', 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
-    'taintIfAnyTainted' | ['test', ['test']]
-    'taintDeeply'       | [
+    method                      | args
+    'taintObject'               | [date(), SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintString'               | ['test', SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintObject'               | [date(), SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintString'               | ['test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintObject'               | [date(), SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintString'               | ['test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintObjectRange'          | [date(), SourceTypes.REQUEST_PARAMETER_VALUE, 0, 10]
+    'taintStringRange'          | ['test', SourceTypes.REQUEST_PARAMETER_VALUE, 0, 10]
+    'taintObjectIfTainted'      | [date(), 'test']
+    'taintStringIfTainted'      | ['test', 'test']
+    'taintObjectIfRangeTainted' | [date(), 'test', 0, 4, false, NOT_MARKED]
+    'taintStringIfRangeTainted' | ['test', 'test', 0, 4, false, NOT_MARKED]
+    'taintObjectIfTainted'      | [date(), 'test', false, NOT_MARKED]
+    'taintStringIfTainted'      | ['test', 'test', false, NOT_MARKED]
+    'taintObjectIfTainted'      | [date(), 'test', SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintStringIfTainted'      | ['test', 'test', SourceTypes.REQUEST_PARAMETER_VALUE]
+    'taintObjectIfTainted'      | [date(), 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintStringIfTainted'      | ['test', 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name']
+    'taintObjectIfTainted'      | [date(), 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintStringIfTainted'      | ['test', 'test', SourceTypes.REQUEST_PARAMETER_VALUE, 'name', 'value']
+    'taintObjectIfAnyTainted'   | [date(), ['test']]
+    'taintStringIfAnyTainted'   | ['test', ['test']]
+    'taintObjectDeeply'         | [
       'test',
       SourceTypes.REQUEST_PARAMETER_VALUE,
       {
         true
       }
     ]
-    'findSource'        | ['test']
-    'isTainted'         | ['test']
+    'findSource'                | ['test']
+    'isTainted'                 | ['test']
   }
 
   void 'test taint'() {
@@ -126,7 +154,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     final ranges = Ranges.forObject(source)
 
     when:
-    module.taint(target, source.origin, source.name, source.value)
+    module."$method"(target, source.origin, source.name, source.value)
 
     then:
     final tainted = getTaintedObject(target)
@@ -137,11 +165,11 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     }
 
     where:
-    target                         | shouldTaint
-    string('string')               | true
-    stringBuilder('stringBuilder') | true
-    date()                         | true
-    taintable()                    | true
+    method        | target                         | shouldTaint
+    'taintString' | string('string')               | true
+    'taintObject' | stringBuilder('stringBuilder') | true
+    'taintObject' | date()                         | true
+    'taintObject' | taintable()                    | true
   }
 
   void 'test taint with range'() {
@@ -151,35 +179,36 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     final ranges = [new Range(start, length, source, NOT_MARKED)] as Range[]
 
     when:
-    module.taint(target, source.origin, start, length)
+    module."$method"(target, source.origin, start, length)
 
     then:
     final tainted = getTaintedObject(target)
     assertTainted(tainted, ranges)
 
     where:
-    target                         | start | length
-    string('string')               | 0     | 2
-    stringBuilder('stringBuilder') | 0     | 2
-    date()                         | 0     | 2
-    taintable()                    | 0     | 2
+    method             | target                         | start | length
+    'taintStringRange' | string('string')               | 0     | 2
+    'taintObjectRange' | stringBuilder('stringBuilder') | 0     | 2
+    'taintObjectRange' | date()                         | 0     | 2
+    'taintObjectRange' | taintable()                    | 0     | 2
   }
 
   void 'test taintIfTainted keeping ranges'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
+    final method = "taint${type}IfTainted"
     final source = taintedSource()
     final ranges = [new Range(0, 1, source, NOT_MARKED), new Range(1, 1, source, NOT_MARKED)] as Range[]
 
     when: 'input is not tainted'
-    module.taintIfTainted(target, input, true, NOT_MARKED)
+    module."$method"(target, input, true, NOT_MARKED)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input is tainted'
     final taintedFrom = taintObject(input, ranges)
-    module.taintIfTainted(target, input, true, NOT_MARKED)
+    module."$method"(target, input, true, NOT_MARKED)
 
     then:
     final tainted = getTaintedObject(target)
@@ -196,19 +225,20 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   void 'test taintIfTainted with ranges'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
+    final method = "taint${type}IfRangeTainted"
     final source = taintedSource()
     final ranges = [new Range(0, 2, source, NOT_MARKED)] as Range[]
 
     when: 'input is not tainted'
-    module.taintIfTainted(target, input, 0, 2, false, NOT_MARKED)
+    module."$method"(target, input, 0, 2, false, NOT_MARKED)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input tainted but range does not overlap'
     final firstTaintedForm = taintObject(input, ranges)
-    module.taintIfTainted(target, input, 4, 3, false, NOT_MARKED)
+    module."$method"(target, input, 4, 3, false, NOT_MARKED)
 
     then:
     final firstTainted = getTaintedObject(target)
@@ -222,7 +252,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     when: 'input is tainted and range overlaps'
     ctx.taintedObjects.clear()
     final secondTaintedFrom = taintObject(input, ranges)
-    module.taintIfTainted(target, input, 0, 2, false, NOT_MARKED)
+    module."$method"(target, input, 0, 2, false, NOT_MARKED)
 
     then:
     final secondTainted = getTaintedObject(target)
@@ -239,21 +269,22 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   void 'test taintIfTainted keeping ranges with a mark'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
     Assume.assumeFalse(target instanceof Taintable) // taintable does not support multiple ranges or marks
+    final method = "taint${type}IfTainted"
     final source = taintedSource()
     final ranges = [new Range(0, 1, source, NOT_MARKED), new Range(1, 1, source, NOT_MARKED)] as Range[]
     final mark = VulnerabilityMarks.UNVALIDATED_REDIRECT_MARK
 
     when: 'input is not tainted'
-    module.taintIfTainted(target, input, true, mark)
+    module."$method"(target, input, true, mark)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input is tainted'
     final taintedFrom = taintObject(input, ranges)
-    module.taintIfTainted(target, input, true, mark)
+    module."$method"(target, input, true, mark)
 
     then:
     final tainted = getTaintedObject(target)
@@ -265,19 +296,20 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   void 'test taintIfTainted not keeping ranges'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
+    final method = "taint${type}IfTainted"
     final source = taintedSource()
     final ranges = [new Range(0, 1, source, NOT_MARKED), new Range(1, 1, source, NOT_MARKED)] as Range[]
 
     when: 'input is not tainted'
-    module.taintIfTainted(target, input, false, NOT_MARKED)
+    module."$method"(target, input, false, NOT_MARKED)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input is tainted'
     final taintedFrom = taintObject(input, ranges)
-    module.taintIfTainted(target, input, false, NOT_MARKED)
+    module."$method"(target, input, false, NOT_MARKED)
 
     then:
     final tainted = getTaintedObject(target)
@@ -289,21 +321,22 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   void 'test taintIfTainted not keeping ranges with a mark'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
     Assume.assumeFalse(target instanceof Taintable) // taintable does not support marks
+    final method = "taint${type}IfTainted"
     final source = taintedSource()
     final ranges = [new Range(0, 1, source, NOT_MARKED), new Range(1, 1, source, NOT_MARKED)] as Range[]
     final mark = VulnerabilityMarks.LDAP_INJECTION_MARK
 
     when: 'input is not tainted'
-    module.taintIfTainted(target, input, false, mark)
+    module."$method"(target, input, false, mark)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input is tainted'
     final taintedFrom = taintObject(input, ranges)
-    module.taintIfTainted(target, input, false, mark)
+    module."$method"(target, input, false, mark)
 
     then:
     final tainted = getTaintedObject(target)
@@ -315,20 +348,21 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   void 'test taintIfAnyTainted keeping ranges'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
+    final method = "taint${type}IfAnyTainted"
     final inputs = ['test', input].toArray()
     final source = taintedSource()
     final ranges = [new Range(0, 1, source, NOT_MARKED), new Range(1, 1, source, NOT_MARKED)] as Range[]
 
     when: 'input is not tainted'
-    module.taintIfAnyTainted(target, inputs, true, NOT_MARKED)
+    module."$method"(target, inputs, true, NOT_MARKED)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input is tainted'
     final taintedFrom = taintObject(input, ranges)
-    module.taintIfAnyTainted(target, inputs, true, NOT_MARKED)
+    module."$method"(target, inputs, true, NOT_MARKED)
 
     then:
     final tainted = getTaintedObject(target)
@@ -345,22 +379,23 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   void 'test taintIfAnyTainted keeping ranges with a mark'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
     Assume.assumeFalse(target instanceof Taintable) // taintable does not support multiple ranges or marks
+    final method = "taint${type}IfAnyTainted"
     final inputs = ['test', input].toArray()
     final source = taintedSource()
     final ranges = [new Range(0, 1, source, NOT_MARKED), new Range(1, 1, source, NOT_MARKED)] as Range[]
     final mark = VulnerabilityMarks.UNVALIDATED_REDIRECT_MARK
 
     when: 'input is not tainted'
-    module.taintIfAnyTainted(target, inputs, true, mark)
+    module."$method"(target, inputs, true, mark)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input is tainted'
     final taintedFrom = taintObject(input, ranges)
-    module.taintIfAnyTainted(target, inputs, true, mark)
+    module."$method"(target, inputs, true, mark)
 
     then:
     final tainted = getTaintedObject(target)
@@ -372,20 +407,21 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   void 'test taintIfAnyTainted not keeping ranges'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
+    final method = "taint${type}IfAnyTainted"
     final inputs = ['test', input].toArray()
     final source = taintedSource()
     final ranges = [new Range(0, 1, source, NOT_MARKED), new Range(1, 1, source, NOT_MARKED)] as Range[]
 
     when: 'input is not tainted'
-    module.taintIfAnyTainted(target, inputs, false, NOT_MARKED)
+    module."$method"(target, inputs, false, NOT_MARKED)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input is tainted'
     final taintedFrom = taintObject(input, ranges)
-    module.taintIfAnyTainted(target, inputs, false, NOT_MARKED)
+    module."$method"(target, inputs, false, NOT_MARKED)
 
     then:
     final tainted = getTaintedObject(target)
@@ -397,22 +433,23 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   void 'test taintIfAnyTainted not keeping ranges with a mark'() {
     given:
-    def (target, input) = suite
+    def (type, target, input) = suite
     Assume.assumeFalse(target instanceof Taintable) // taintable does not support marks
+    final method = "taint${type}IfAnyTainted"
     final inputs = ['test', input].toArray()
     final source = taintedSource()
     final ranges = [new Range(0, 1, source, NOT_MARKED), new Range(1, 1, source, NOT_MARKED)] as Range[]
     final mark = VulnerabilityMarks.LDAP_INJECTION_MARK
 
     when: 'input is not tainted'
-    module.taintIfAnyTainted(target, inputs, false, mark)
+    module."$method"(target, inputs, false, mark)
 
     then:
     assert getTaintedObject(target) == null
 
     when: 'input is tainted'
     final taintedFrom = taintObject(input, ranges)
-    module.taintIfAnyTainted(target, inputs, false, mark)
+    module."$method"(target, inputs, false, mark)
 
     then:
     final tainted = getTaintedObject(target)
@@ -427,7 +464,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     final target = [Hello: " World!", Age: 25]
 
     when:
-    module.taintDeeply(target, SourceTypes.GRPC_BODY, { true })
+    module.taintObjectDeeply(target, SourceTypes.GRPC_BODY, { true })
 
     then:
     final taintedObjects = ctx.taintedObjects
@@ -443,7 +480,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     final target = stringBuilder('taint me')
 
     when:
-    module.taintDeeply(target, SourceTypes.GRPC_BODY, { true })
+    module.taintObjectDeeply(target, SourceTypes.GRPC_BODY, { true })
 
     then:
     final taintedObjects = ctx.taintedObjects
@@ -488,9 +525,10 @@ class PropagationModuleTest extends IastModuleImplTestBase {
   void 'test source names over threshold'() {
     given:
     assert target.length() > maxValueLength
+    final method = target instanceof String ? 'taintString' : 'taintObject'
 
     when:
-    module.taint(target, SourceTypes.REQUEST_PARAMETER_VALUE)
+    module."$method"(target, SourceTypes.REQUEST_PARAMETER_VALUE)
 
     then:
     final tainted = ctx.getTaintedObjects().get(target)
@@ -509,8 +547,11 @@ class PropagationModuleTest extends IastModuleImplTestBase {
   }
 
   void 'test that source names/values should not make a strong reference over the value'() {
+    given:
+    final method = toTaint instanceof String ? 'taintString' : 'taintObject'
+
     when:
-    module.taint(toTaint, SourceTypes.REQUEST_PARAMETER_NAME, name, value)
+    module."$method"(toTaint, SourceTypes.REQUEST_PARAMETER_NAME, name, value)
 
     then:
     final tainted = ctx.getTaintedObjects().get(toTaint)
@@ -557,7 +598,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     final baos = toTaint.bytes
 
     when: 'tainting a non char sequence object'
-    module.taint(baos, SourceTypes.KAFKA_MESSAGE_KEY)
+    module.taintObject(baos, SourceTypes.KAFKA_MESSAGE_KEY)
 
     then:
     with(ctx.taintedObjects.get(baos)) {
@@ -569,7 +610,7 @@ class PropagationModuleTest extends IastModuleImplTestBase {
     }
 
     when: 'the object is propagated'
-    module.taintIfTainted(toTaint, baos)
+    module.taintStringIfTainted(toTaint, baos)
 
     then:
     with(ctx.taintedObjects.get(toTaint)) {
@@ -582,22 +623,22 @@ class PropagationModuleTest extends IastModuleImplTestBase {
 
   private List<Tuple<Object>> taintIfSuite() {
     return [
-      Tuple.tuple(string('string'), string('string')),
-      Tuple.tuple(string('string'), stringBuilder('stringBuilder')),
-      Tuple.tuple(string('string'), date()),
-      Tuple.tuple(string('string'), taintable()),
-      Tuple.tuple(stringBuilder('stringBuilder'), string('string')),
-      Tuple.tuple(stringBuilder('stringBuilder'), stringBuilder('stringBuilder')),
-      Tuple.tuple(stringBuilder('stringBuilder'), date()),
-      Tuple.tuple(stringBuilder('stringBuilder'), taintable()),
-      Tuple.tuple(date(), string('string')),
-      Tuple.tuple(date(), stringBuilder('stringBuilder')),
-      Tuple.tuple(date(), date()),
-      Tuple.tuple(date(), taintable()),
-      Tuple.tuple(taintable(), string('string')),
-      Tuple.tuple(taintable(), stringBuilder('stringBuilder')),
-      Tuple.tuple(taintable(), date()),
-      Tuple.tuple(taintable(), taintable())
+      Tuple.tuple("String", string('string'), string('string')),
+      Tuple.tuple("String", string('string'), stringBuilder('stringBuilder')),
+      Tuple.tuple("String", string('string'), date()),
+      Tuple.tuple("String", string('string'), taintable()),
+      Tuple.tuple("Object", stringBuilder('stringBuilder'), string('string')),
+      Tuple.tuple("Object", stringBuilder('stringBuilder'), stringBuilder('stringBuilder')),
+      Tuple.tuple("Object", stringBuilder('stringBuilder'), date()),
+      Tuple.tuple("Object", stringBuilder('stringBuilder'), taintable()),
+      Tuple.tuple("Object", date(), string('string')),
+      Tuple.tuple("Object", date(), stringBuilder('stringBuilder')),
+      Tuple.tuple("Object", date(), date()),
+      Tuple.tuple("Object", date(), taintable()),
+      Tuple.tuple("Object", taintable(), string('string')),
+      Tuple.tuple("Object", taintable(), stringBuilder('stringBuilder')),
+      Tuple.tuple("Object", taintable(), date()),
+      Tuple.tuple("Object", taintable(), taintable())
     ]
   }
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/AbstractSinkModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/AbstractSinkModuleTest.groovy
@@ -58,7 +58,7 @@ class AbstractSinkModuleTest extends IastModuleImplTestBase {
     ctx.getTaintedObjects().taint(input, Ranges.forCharSequence(input, source))
 
     when:
-    propagation.taintIfTainted(toReport, input)
+    propagation.taintObjectIfTainted(toReport, input)
     final evidence = sink.checkInjection(SSRF, toReport)
 
     then:

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/iast/TaintableEnumeration.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/iast/TaintableEnumeration.java
@@ -58,7 +58,7 @@ public class TaintableEnumeration implements Enumeration<String> {
       throw e;
     }
     try {
-      module.taint(context, next, origin, name(next));
+      module.taintString(context, next, origin, name(next));
     } catch (final Throwable e) {
       module.onUnexpectedException("Failed to taint enumeration", e);
     }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/iast/TaintableEnumerationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/iast/TaintableEnumerationTest.groovy
@@ -36,7 +36,7 @@ class TaintableEnumerationTest extends DDSpecification {
 
     then:
     result == values
-    values.each { 1 * module.taint(iastCtx, it, origin, name) }
+    values.each { 1 * module.taintString(iastCtx, it, origin, name) }
   }
 
   void 'underlying enumerated values are tainted with the value as a name'() {
@@ -50,7 +50,7 @@ class TaintableEnumerationTest extends DDSpecification {
 
     then:
     result == values
-    values.each { 1 * module.taint(iastCtx, it, origin, it) }
+    values.each { 1 * module.taintString(iastCtx, it, origin, it) }
   }
 
   void 'taintable enumeration leaves no trace in case of error'() {

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/CookieHeaderInstrumentation.java
@@ -75,8 +75,8 @@ public class CookieHeaderInstrumentation extends InstrumenterModule.Iast
       while (iterator.hasNext()) {
         HttpCookiePair pair = iterator.next();
         final String name = pair.name(), value = pair.value();
-        prop.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
-        prop.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+        prop.taintString(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HeaderNameCallSite.java
@@ -32,7 +32,7 @@ public class HeaderNameCallSite {
       if (ctx == null) {
         return result;
       }
-      module.taintIfTainted(ctx, result, header, SourceTypes.REQUEST_HEADER_NAME, result);
+      module.taintStringIfTainted(ctx, result, header, SourceTypes.REQUEST_HEADER_NAME, result);
     } catch (final Throwable e) {
       module.onUnexpectedException("onHeaderNames threw", e);
     }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpHeaderSubclassesInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpHeaderSubclassesInstrumentation.java
@@ -72,7 +72,7 @@ public class HttpHeaderSubclassesInstrumentation extends InstrumenterModule.Iast
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      propagation.taintIfTainted(ctx, retVal, h);
+      propagation.taintStringIfTainted(ctx, retVal, h);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/HttpRequestInstrumentation.java
@@ -88,7 +88,7 @@ public class HttpRequestInstrumentation extends InstrumenterModule.Iast
         }
         // unfortunately, the call to h.value() is instrumented, but
         // because the call to taint() only happens after, the call is a noop
-        propagation.taint(ctx, h, SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value());
+        propagation.taintObject(ctx, h, SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value());
       }
     }
   }
@@ -112,7 +112,7 @@ public class HttpRequestInstrumentation extends InstrumenterModule.Iast
         return;
       }
 
-      propagation.taintIfTainted(ctx, entity, thiz);
+      propagation.taintObjectIfTainted(ctx, entity, thiz);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/PathMatcherInstrumentation.java
@@ -72,7 +72,7 @@ public class PathMatcherInstrumentation extends InstrumenterModule.Iast
         return;
       }
 
-      module.taint(ctx, stringValue, SourceTypes.REQUEST_PATH_PARAMETER);
+      module.taintString(ctx, stringValue, SourceTypes.REQUEST_PATH_PARAMETER);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/RequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/RequestContextInstrumentation.java
@@ -67,7 +67,7 @@ public class RequestContextInstrumentation extends InstrumenterModule.Iast
         return;
       }
 
-      propagation.taintIfTainted(ctx, request, requestContext);
+      propagation.taintObjectIfTainted(ctx, request, requestContext);
     }
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/UriInstrumentation.java
@@ -80,7 +80,7 @@ public class UriInstrumentation extends InstrumenterModule.Iast
         return;
       }
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      mod.taintIfTainted(ctx, ret.get(), uri);
+      mod.taintStringIfTainted(ctx, ret.get(), uri);
     }
   }
 
@@ -109,8 +109,8 @@ public class UriInstrumentation extends InstrumenterModule.Iast
       while (iterator.hasNext()) {
         Tuple2<String, String> pair = iterator.next();
         final String name = pair._1(), value = pair._2();
-        prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
-        prop.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+        prop.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintCookieFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintCookieFunction.java
@@ -27,8 +27,8 @@ public class TaintCookieFunction
     }
     final String name = httpCookiePair.name();
     final String value = httpCookiePair.value();
-    mod.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
-    mod.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+    mod.taintString(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+    mod.taintString(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintFutureHelper.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintFutureHelper.java
@@ -14,7 +14,7 @@ public class TaintFutureHelper {
         t -> {
           IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
-            mod.taintIfTainted(ctx, t, input);
+            mod.taintObjectIfTainted(ctx, t, input);
           }
           return t;
         };

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMapFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMapFunction.java
@@ -32,8 +32,8 @@ public class TaintMapFunction
     while (iterator.hasNext()) {
       Tuple2<String, String> e = iterator.next();
       final String name = e._1(), value = e._2();
-      prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
-      prop.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+      prop.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+      prop.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMultiMapFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintMultiMapFunction.java
@@ -33,10 +33,10 @@ public class TaintMultiMapFunction
     while (entriesIterator.hasNext()) {
       Tuple2<String, List<String>> e = entriesIterator.next();
       final String name = e._1();
-      mod.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+      mod.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
       List<String> values = e._2();
       for (final String value : ScalaToJava.listAsList(values)) {
-        mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        mod.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
 

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintOptionalCookieFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintOptionalCookieFunction.java
@@ -29,8 +29,8 @@ public class TaintOptionalCookieFunction
     final HttpCookiePair cookie = httpCookiePair.get();
     final String name = cookie.name();
     final String value = cookie.value();
-    mod.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
-    mod.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+    mod.taintString(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+    mod.taintString(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestContextFunction.java
@@ -25,7 +25,7 @@ public class TaintRequestContextFunction
     if (ctx == null) {
       return v1;
     }
-    mod.taint(ctx, reqCtx, SourceTypes.REQUEST_BODY);
+    mod.taintObject(ctx, reqCtx, SourceTypes.REQUEST_BODY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintRequestFunction.java
@@ -26,7 +26,7 @@ public class TaintRequestFunction implements JFunction1<Tuple1<HttpRequest>, Tup
     if (ctx == null) {
       return v1;
     }
-    mod.taint(ctx, httpRequest, SourceTypes.REQUEST_BODY);
+    mod.taintObject(ctx, httpRequest, SourceTypes.REQUEST_BODY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSeqFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSeqFunction.java
@@ -39,9 +39,9 @@ public class TaintSeqFunction
       String name = t._1();
       String value = t._2();
       if (seenKeys.add(name)) {
-        prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
       }
-      prop.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+      prop.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSingleParameterFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintSingleParameterFunction.java
@@ -50,11 +50,11 @@ public class TaintSingleParameterFunction<Magnet>
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taintString(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taintString(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUnmarshaller.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUnmarshaller.java
@@ -32,7 +32,7 @@ public class TaintUnmarshaller<A, B> implements Unmarshaller<A, B> {
   public Future<B> apply(A value, ExecutionContext ec, Materializer materializer) {
     IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
     if (ctx != null) {
-      propagationModule.taint(ctx, value, SourceTypes.REQUEST_BODY);
+      propagationModule.taintObject(ctx, value, SourceTypes.REQUEST_BODY);
     }
     return delegate.apply(value, ec, materializer);
   }

--- a/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/iast/helpers/TaintUriFunction.java
@@ -24,7 +24,7 @@ public class TaintUriFunction implements JFunction1<Tuple1<Uri>, Tuple1<Uri>> {
     if (ctx == null) {
       return v1;
     }
-    mod.taint(ctx, uri, SourceTypes.REQUEST_QUERY);
+    mod.taintObject(ctx, uri, SourceTypes.REQUEST_QUERY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/helpers/TaintParametersFunction.java
+++ b/dd-java-agent/instrumentation/akka-http-10.2-iast/src/main/java/datadog/trace/instrumentation/akkahttp102/iast/helpers/TaintParametersFunction.java
@@ -41,11 +41,11 @@ public class TaintParametersFunction<T> implements Function1<Tuple1<T>, Tuple1<T
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taintString(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taintString(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/apache-httpcore-4/src/main/java/datadog/trace/instrumentation/apachehttpcore/IastHttpHostInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpcore-4/src/main/java/datadog/trace/instrumentation/apachehttpcore/IastHttpHostInstrumentation.java
@@ -38,7 +38,7 @@ public class IastHttpHostInstrumentation extends InstrumenterModule.Iast
         @Advice.This final Object self, @Advice.Argument(0) final Object argument) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(self, argument);
+        module.taintObjectIfTainted(self, argument);
       }
     }
   }

--- a/dd-java-agent/instrumentation/apache-httpcore-4/src/test/groovy/datadog/trace/instrumentation/apachehttpcore/IastHttpHostInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpcore-4/src/test/groovy/datadog/trace/instrumentation/apachehttpcore/IastHttpHostInstrumentationTest.groovy
@@ -21,7 +21,7 @@ class IastHttpHostInstrumentationTest extends AgentTestRunner {
     HttpHost.newInstance(*args)
 
     then:
-    1 * module.taintIfTainted( _ as HttpHost, 'localhost')
+    1 * module.taintObjectIfTainted( _ as HttpHost, 'localhost')
 
     where:
     args | _

--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumenter.java
@@ -60,7 +60,7 @@ public class CommonsFileuploadInstrumenter extends InstrumenterModule.Iast
           final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
           for (final Map.Entry<String, String> entry : map.entrySet()) {
             if (entry.getValue() != null) {
-              module.taint(
+              module.taintString(
                   ctx, entry.getValue(), SourceTypes.REQUEST_MULTIPART_PARAMETER, entry.getKey());
             }
           }

--- a/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/MultipartInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/MultipartInstrumentationTest.groovy
@@ -41,8 +41,8 @@ class MultipartInstrumentationTest extends AgentTestRunner {
     }
 
     then:
-    1 * module.taint(iastCtx, 'file', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'name')
-    1 * module.taint(iastCtx, _, SourceTypes.REQUEST_MULTIPART_PARAMETER, 'filename')
+    1 * module.taintString(iastCtx, 'file', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'name')
+    1 * module.taintString(iastCtx, _, SourceTypes.REQUEST_MULTIPART_PARAMETER, 'filename')
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastHttpMethodBaseInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/main/java/datadog/trace/instrumentation/commonshttpclient/IastHttpMethodBaseInstrumentation.java
@@ -52,7 +52,7 @@ public class IastHttpMethodBaseInstrumentation extends InstrumenterModule.Iast
         @Advice.This final Object self, @Advice.Argument(0) final Object argument) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(self, argument);
+        module.taintObjectIfTainted(self, argument);
       }
     }
   }

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/test/groovy/IastCommonsHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/test/groovy/IastCommonsHttpClientInstrumentationTest.groovy
@@ -51,7 +51,7 @@ class IastCommonsHttpClientInstrumentationTest extends AgentTestRunner {
 
   private void mockPropagation() {
     final propagation = Mock(PropagationModule) {
-      taintIfTainted(_, _) >> {
+      taintObjectIfTainted(_, _) >> {
         if (tainteds.containsKey(it[1])) {
           tainteds.put(it[0], null)
         }

--- a/dd-java-agent/instrumentation/commons-lang-2/src/main/java/datadog/trace/instrumentation/commonslang/StringEscapeUtilsCallSite.java
+++ b/dd-java-agent/instrumentation/commons-lang-2/src/main/java/datadog/trace/instrumentation/commonslang/StringEscapeUtilsCallSite.java
@@ -25,7 +25,7 @@ public class StringEscapeUtilsCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEscape threw", e);
       }
@@ -40,7 +40,7 @@ public class StringEscapeUtilsCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.SQL_INJECTION_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.SQL_INJECTION_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEscapeSQL threw", e);
       }

--- a/dd-java-agent/instrumentation/commons-lang-2/src/test/groovy/datadog/trace/instrumentation/commonslang/StringEscapeUtilsCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/commons-lang-2/src/test/groovy/datadog/trace/instrumentation/commonslang/StringEscapeUtilsCallSiteTest.groovy
@@ -27,7 +27,7 @@ class StringEscapeUtilsCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * module.taintIfTainted(_ as String, args[0], false, mark)
+    1 * module.taintStringIfTainted(_ as String, args[0], false, mark)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/commons-lang-3/src/main/java/datadog/trace/instrumentation/commonslang3/StringEscapeUtilsCallSite.java
+++ b/dd-java-agent/instrumentation/commons-lang-3/src/main/java/datadog/trace/instrumentation/commonslang3/StringEscapeUtilsCallSite.java
@@ -27,7 +27,7 @@ public class StringEscapeUtilsCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEscape threw", e);
       }
@@ -42,7 +42,7 @@ public class StringEscapeUtilsCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input);
+        module.taintStringIfTainted(result, input);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEscapeJson threw", e);
       }

--- a/dd-java-agent/instrumentation/commons-lang-3/src/test/groovy/datadog/trace/instrumentation/commonslang3/StringEscapeUtilsCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/commons-lang-3/src/test/groovy/datadog/trace/instrumentation/commonslang3/StringEscapeUtilsCallSiteTest.groovy
@@ -25,7 +25,7 @@ class StringEscapeUtilsCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * module.taintIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
+    1 * module.taintStringIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
     0 * _
 
     where:
@@ -47,7 +47,7 @@ class StringEscapeUtilsCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * module.taintIfTainted(_ as String, args[0])
+    1 * module.taintStringIfTainted(_ as String, args[0])
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/commons-text/src/main/java/datadog/trace/instrumentation/commonstext/StringEscapeUtilsCallSite.java
+++ b/dd-java-agent/instrumentation/commons-text/src/main/java/datadog/trace/instrumentation/commonstext/StringEscapeUtilsCallSite.java
@@ -29,7 +29,7 @@ public class StringEscapeUtilsCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEscape threw", e);
       }
@@ -44,7 +44,7 @@ public class StringEscapeUtilsCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input);
+        module.taintStringIfTainted(result, input);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEscapeJson threw", e);
       }

--- a/dd-java-agent/instrumentation/commons-text/src/test/groovy/datadog/trace/instrumentation/commonstext/StringEscapeUtilsCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/commons-text/src/test/groovy/datadog/trace/instrumentation/commonstext/StringEscapeUtilsCallSiteTest.groovy
@@ -25,7 +25,7 @@ class StringEscapeUtilsCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * module.taintIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
+    1 * module.taintStringIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
     0 * _
 
     where:
@@ -48,7 +48,7 @@ class StringEscapeUtilsCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * module.taintIfTainted(_ as String, args[0])
+    1 * module.taintStringIfTainted(_ as String, args[0])
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/freemarker/src/main/java/datadog/trace/instrumentation/freemarker/StringUtilCallSite.java
+++ b/dd-java-agent/instrumentation/freemarker/src/main/java/datadog/trace/instrumentation/freemarker/StringUtilCallSite.java
@@ -29,7 +29,7 @@ public class StringUtilCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEscape threw", e);
       }

--- a/dd-java-agent/instrumentation/freemarker/src/test/groovy/datadog/trace/instrumentation/freemarker/StringUtilCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/freemarker/src/test/groovy/datadog/trace/instrumentation/freemarker/StringUtilCallSiteTest.groovy
@@ -23,7 +23,7 @@ class StringUtilCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * module.taintIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
+    1 * module.taintStringIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/gson-1.6/src/main/java/datadog/trace/instrumentation/gson/JsonReaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/gson-1.6/src/main/java/datadog/trace/instrumentation/gson/JsonReaderInstrumentation.java
@@ -59,7 +59,7 @@ public class JsonReaderInstrumentation extends InstrumenterModule.Iast
         @Advice.This Object self, @Advice.Argument(0) final java.io.Reader input) {
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null && input != null) {
-        iastModule.taintIfTainted(self, input);
+        iastModule.taintObjectIfTainted(self, input);
       }
     }
   }
@@ -70,7 +70,7 @@ public class JsonReaderInstrumentation extends InstrumenterModule.Iast
     public static void afterMethod(@Advice.This Object self, @Advice.Return final String result) {
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null && result != null) {
-        iastModule.taintIfTainted(result, self);
+        iastModule.taintStringIfTainted(result, self);
       }
     }
   }

--- a/dd-java-agent/instrumentation/gson-1.6/src/test/groovy/datadog/trace/instrumentation/gson/JsonReaderInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/gson-1.6/src/test/groovy/datadog/trace/instrumentation/gson/JsonReaderInstrumentationTest.groovy
@@ -23,13 +23,13 @@ class JsonReaderInstrumentationTest extends AgentTestRunner {
     final reader = new JsonReader(new StringReader(json))
 
     then:
-    1 * module.taintIfTainted(_ as JsonReader, _ as StringReader)
+    1 * module.taintObjectIfTainted(_ as JsonReader, _ as StringReader)
 
     when:
     gson.fromJson(reader, clazz)
 
     then:
-    calls * module.taintIfTainted(_ as String, _ as JsonReader)
+    calls * module.taintStringIfTainted(_ as String, _ as JsonReader)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/main/java/datadog/trace/instrumentation/jackson/codehouse/core/Json1FactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/main/java/datadog/trace/instrumentation/jackson/codehouse/core/Json1FactoryInstrumentation.java
@@ -61,7 +61,7 @@ public class Json1FactoryInstrumentation extends InstrumenterModule.Iast
       if (input != null) {
         final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
         if (propagation != null) {
-          propagation.taintIfTainted(parser, input);
+          propagation.taintObjectIfTainted(parser, input);
         }
         if (input instanceof URL) {
           final SsrfModule ssrf = InstrumentationBridge.SSRF;
@@ -85,7 +85,7 @@ public class Json1FactoryInstrumentation extends InstrumenterModule.Iast
       if (input != null || length <= 0) {
         final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
         if (propagation != null) {
-          propagation.taintIfTainted(parser, input, offset, length, false, NOT_MARKED);
+          propagation.taintObjectIfRangeTainted(parser, input, offset, length, false, NOT_MARKED);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/test/groovy/Json1FactoryInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/test/groovy/Json1FactoryInstrumentationTest.groovy
@@ -41,7 +41,7 @@ class Json1FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     result != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, content)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, content)
     0 * _
   }
 
@@ -56,7 +56,7 @@ class Json1FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     result != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, is)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, is)
     2 * is.read(_, _, _)
     0 * _
   }
@@ -73,7 +73,7 @@ class Json1FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     result != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, reader)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, reader)
     0 * _
   }
 
@@ -89,7 +89,7 @@ class Json1FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     parser != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, url)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, url)
     1 * ssrfModule.onURLConnection(url)
     0 * _
   }
@@ -107,7 +107,7 @@ class Json1FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     result != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, bytes)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, bytes)
     0 * _
   }
 
@@ -122,7 +122,7 @@ class Json1FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     parser != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, bytes, 0, 2, false, VulnerabilityMarks.NOT_MARKED)
+    1 * propagationModule.taintObjectIfRangeTainted(_ as JsonParser, bytes, 0, 2, false, VulnerabilityMarks.NOT_MARKED)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/test/groovy/Json1ParserInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jackson-core/jackson-core-1/src/test/groovy/Json1ParserInstrumentationTest.groovy
@@ -31,14 +31,14 @@ class Json1ParserInstrumentationTest extends AgentTestRunner {
 
     then:
     JsonOutput.toJson(taintedResult) == JSON_STRING
-    _ * module.taintIfTainted(_, _)
+    _ * module.taintObjectIfTainted(_, _)
     _ * module.findSource(_) >> source
-    1 * module.taint(_, 'root', source.origin, 'root', JSON_STRING)
-    1 * module.taint(_, 'root_value', source.origin, 'root', JSON_STRING)
-    1 * module.taint(_, 'nested', source.origin, 'nested', JSON_STRING)
-    1 * module.taint(_, 'nested_array', source.origin, 'nested_array', JSON_STRING)
-    1 * module.taint(_, 'array_0', source.origin, 'nested_array', JSON_STRING)
-    1 * module.taint(_, 'array_1', source.origin, 'nested_array', JSON_STRING)
+    1 * module.taintString(_, 'root', source.origin, 'root', JSON_STRING)
+    1 * module.taintString(_, 'root_value', source.origin, 'root', JSON_STRING)
+    1 * module.taintString(_, 'nested', source.origin, 'nested', JSON_STRING)
+    1 * module.taintString(_, 'nested_array', source.origin, 'nested_array', JSON_STRING)
+    1 * module.taintString(_, 'array_0', source.origin, 'nested_array', JSON_STRING)
+    1 * module.taintString(_, 'array_1', source.origin, 'nested_array', JSON_STRING)
     0 * _
 
     where:
@@ -58,7 +58,7 @@ class Json1ParserInstrumentationTest extends AgentTestRunner {
 
     then:
     JsonOutput.toJson(taintedResult) == JSON_STRING
-    _ * module.taintIfTainted(_, _)
+    _ * module.taintObjectIfTainted(_, _)
     _ * module.findSource(_) >> null
     0 * _
 

--- a/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/Json2FactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/Json2FactoryInstrumentation.java
@@ -63,7 +63,7 @@ public class Json2FactoryInstrumentation extends InstrumenterModule.Iast
       if (input != null) {
         final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
         if (propagation != null) {
-          propagation.taintIfTainted(parser, input);
+          propagation.taintObjectIfTainted(parser, input);
         }
         if (input instanceof URL) {
           final SsrfModule ssrf = InstrumentationBridge.SSRF;
@@ -87,7 +87,7 @@ public class Json2FactoryInstrumentation extends InstrumenterModule.Iast
       if (input != null || length <= 0) {
         final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
         if (propagation != null) {
-          propagation.taintIfTainted(parser, input, offset, length, false, NOT_MARKED);
+          propagation.taintObjectIfRangeTainted(parser, input, offset, length, false, NOT_MARKED);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/TokenBufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/jackson-core/src/main/java/datadog/trace/instrumentation/jackson/core/TokenBufferInstrumentation.java
@@ -50,7 +50,7 @@ public class TokenBufferInstrumentation extends InstrumenterModule.Iast
         @Advice.This TokenBuffer tokenBuffer, @Advice.Return JsonParser parser) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(parser, tokenBuffer);
+        module.taintObjectIfTainted(parser, tokenBuffer);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jackson-core/src/test/groovy/Json2FactoryInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jackson-core/src/test/groovy/Json2FactoryInstrumentationTest.groovy
@@ -44,7 +44,7 @@ class Json2FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     result != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, content)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, content)
     0 * _
   }
 
@@ -60,7 +60,7 @@ class Json2FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     result != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, is)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, is)
     2 * is.read(_, _, _)
     0 * _
   }
@@ -77,7 +77,7 @@ class Json2FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     result != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, reader)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, reader)
     0 * _
   }
 
@@ -93,7 +93,7 @@ class Json2FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     result != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, bytes)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, bytes)
     0 * _
   }
 
@@ -108,7 +108,7 @@ class Json2FactoryInstrumentationTest extends AgentTestRunner {
 
     then:
     parser != null
-    1 * propagationModule.taintIfTainted(_ as JsonParser, bytes, 0, 2, false, VulnerabilityMarks.NOT_MARKED)
+    1 * propagationModule.taintObjectIfRangeTainted(_ as JsonParser, bytes, 0, 2, false, VulnerabilityMarks.NOT_MARKED)
     0 * _
   }
 
@@ -127,7 +127,7 @@ class Json2FactoryInstrumentationTest extends AgentTestRunner {
     then:
     parser != null
     json == [key: 'value']
-    1 * propagationModule.taintIfTainted(_ as JsonParser, url)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, url)
     1 * propagationModule.findSource(_ as JsonParser) >> null
     1 * ssrfModule.onURLConnection(url)
     0 * _

--- a/dd-java-agent/instrumentation/jackson-core/src/test/groovy/Json2ParserInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jackson-core/src/test/groovy/Json2ParserInstrumentationTest.groovy
@@ -31,14 +31,14 @@ class Json2ParserInstrumentationTest extends AgentTestRunner {
 
     then:
     JsonOutput.toJson(taintedResult) == JSON_STRING
-    _ * module.taintIfTainted(_, _)
+    _ * module.taintObjectIfTainted(_, _)
     _ * module.findSource(_) >> source
-    1 * module.taint(_, 'root', source.origin, 'root', JSON_STRING)
-    1 * module.taint(_, 'root_value', source.origin, 'root', JSON_STRING)
-    1 * module.taint(_, 'nested', source.origin, 'nested', JSON_STRING)
-    1 * module.taint(_, 'nested_array', source.origin, 'nested_array', JSON_STRING)
-    1 * module.taint(_, 'array_0', source.origin, 'nested_array', JSON_STRING)
-    1 * module.taint(_, 'array_1', source.origin, 'nested_array', JSON_STRING)
+    1 * module.taintString(_, 'root', source.origin, 'root', JSON_STRING)
+    1 * module.taintString(_, 'root_value', source.origin, 'root', JSON_STRING)
+    1 * module.taintString(_, 'nested', source.origin, 'nested', JSON_STRING)
+    1 * module.taintString(_, 'nested_array', source.origin, 'nested_array', JSON_STRING)
+    1 * module.taintString(_, 'array_0', source.origin, 'nested_array', JSON_STRING)
+    1 * module.taintString(_, 'array_1', source.origin, 'nested_array', JSON_STRING)
     0 * _
 
     where:
@@ -58,7 +58,7 @@ class Json2ParserInstrumentationTest extends AgentTestRunner {
 
     then:
     JsonOutput.toJson(taintedResult) == JSON_STRING
-    _ * module.taintIfTainted(_, _)
+    _ * module.taintObjectIfTainted(_, _)
     _ * module.findSource(_) >> null
     0 * _
 

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/ByteBufferCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/ByteBufferCallSite.java
@@ -26,7 +26,7 @@ public class ByteBufferCallSite {
       return result;
     }
     try {
-      module.taintIfTainted(result, bytes, true, NOT_MARKED); // keep ranges
+      module.taintObjectIfTainted(result, bytes, true, NOT_MARKED); // keep ranges
     } catch (final Throwable e) {
       module.onUnexpectedException("beforeConstructor threw", e);
     }
@@ -44,7 +44,7 @@ public class ByteBufferCallSite {
       return bytes;
     }
     try {
-      module.taintIfTainted(bytes, buffer, true, NOT_MARKED); // keep ranges
+      module.taintObjectIfTainted(bytes, buffer, true, NOT_MARKED); // keep ranges
     } catch (final Throwable e) {
       module.onUnexpectedException("afterArray threw", e);
     }

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/InputStreamInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/InputStreamInstrumentation.java
@@ -57,7 +57,7 @@ public class InputStreamInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       try {
         if (module != null) {
-          module.taintIfTainted(self, param);
+          module.taintObjectIfTainted(self, param);
         }
       } catch (final Throwable e) {
         module.onUnexpectedException("InputStreamAdvice onExit threw", e);

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/InputStreamReaderCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/InputStreamReaderCallSite.java
@@ -20,7 +20,7 @@ public class InputStreamReaderCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, params[0]);
+        module.taintObjectIfTainted(result, params[0]);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterInit threw", e);
       }

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/StringReaderCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/StringReaderCallSite.java
@@ -19,7 +19,7 @@ public class StringReaderCallSite {
     final PropagationModule propagationModule = InstrumentationBridge.PROPAGATION;
     if (propagationModule != null) {
       try {
-        propagationModule.taintIfTainted(result, params[0]);
+        propagationModule.taintObjectIfTainted(result, params[0]);
       } catch (Throwable e) {
         propagationModule.onUnexpectedException("afterInit threw", e);
       }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ByteBufferTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ByteBufferTest.groovy
@@ -25,7 +25,7 @@ class ByteBufferTest extends AgentTestRunner {
     TestByteBufferSuite.wrap(message)
 
     then:
-    1 * module.taintIfTainted(_ as ByteBuffer, message, true, VulnerabilityMarks.NOT_MARKED)
+    1 * module.taintObjectIfTainted(_ as ByteBuffer, message, true, VulnerabilityMarks.NOT_MARKED)
   }
 
   void 'test array method'() {
@@ -39,6 +39,6 @@ class ByteBufferTest extends AgentTestRunner {
 
     then:
     result == message.array()
-    1 * module.taintIfTainted(_ as byte[], message, true, VulnerabilityMarks.NOT_MARKED)
+    1 * module.taintObjectIfTainted(_ as byte[], message, true, VulnerabilityMarks.NOT_MARKED)
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/InputStreamInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/InputStreamInstrumentationTest.groovy
@@ -23,6 +23,6 @@ class InputStreamInstrumentationTest extends AgentTestRunner {
     TestInputStreamSuite.pushbackInputStreamFromIS(is)
 
     then:
-    (1.._) * propagationModule.taintIfTainted(_ as InputStream, is)
+    (1.._) * propagationModule.taintObjectIfTainted(_ as InputStream, is)
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/InputStreamReaderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/InputStreamReaderCallSiteTest.groovy
@@ -17,7 +17,7 @@ class InputStreamReaderCallSiteTest extends  BaseIoCallSiteTest{
     TestInputStreamReaderSuite.init(new ByteArrayInputStream("test".getBytes()), Charset.defaultCharset())
 
     then:
-    1 * iastModule.taintIfTainted(_ as InputStreamReader, _ as InputStream)
+    1 * iastModule.taintObjectIfTainted(_ as InputStreamReader, _ as InputStream)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/StringReaderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/StringReaderCallSiteTest.groovy
@@ -16,6 +16,6 @@ class StringReaderCallSiteTest extends  BaseIoCallSiteTest{
     TestStringReaderSuite.init(input)
 
     then:
-    1 * iastModule.taintIfTainted(_ as StringReader, input)
+    1 * iastModule.taintObjectIfTainted(_ as StringReader, input)
   }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -384,7 +384,7 @@ public class StringCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, self, true, NOT_MARKED);
+        module.taintObjectIfTainted(result, self, true, NOT_MARKED);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterToCharArray threw", e);
       }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
@@ -276,7 +276,7 @@ class StringCallSiteTest extends AgentTestRunner {
 
     then:
     result != null && result.length > 0
-    1 * module.taintIfTainted(_ as char[], string, true, VulnerabilityMarks.NOT_MARKED)
+    1 * module.taintObjectIfTainted(_ as char[], string, true, VulnerabilityMarks.NOT_MARKED)
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URICallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URICallSite.java
@@ -20,7 +20,7 @@ public class URICallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taintIfTainted(result, value);
+          module.taintObjectIfTainted(result, value);
         } catch (final Throwable e) {
           module.onUnexpectedException("create threw", e);
         }
@@ -43,7 +43,7 @@ public class URICallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taintIfAnyTainted(result, args);
+          module.taintObjectIfAnyTainted(result, args);
         } catch (final Throwable e) {
           module.onUnexpectedException("ctor threw", e);
         }
@@ -59,7 +59,7 @@ public class URICallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, url);
+        module.taintStringIfTainted(result, url);
       } catch (final Throwable e) {
         module.onUnexpectedException("After toString threw", e);
       }
@@ -73,7 +73,7 @@ public class URICallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, url);
+        module.taintObjectIfTainted(result, url);
       } catch (final Throwable e) {
         module.onUnexpectedException("After toString threw", e);
       }

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLCallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLCallSite.java
@@ -32,7 +32,7 @@ public class URLCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taintIfAnyTainted(result, args);
+          module.taintObjectIfAnyTainted(result, args);
         } catch (final Throwable e) {
           module.onUnexpectedException("ctor threw", e);
         }
@@ -49,7 +49,7 @@ public class URLCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, url);
+        module.taintStringIfTainted(result, url);
       } catch (final Throwable e) {
         module.onUnexpectedException("After toString threw", e);
       }
@@ -63,7 +63,7 @@ public class URLCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, url);
+        module.taintObjectIfTainted(result, url);
       } catch (final Throwable e) {
         module.onUnexpectedException("After toURI threw", e);
       }

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLEncoderCallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLEncoderCallSite.java
@@ -32,7 +32,7 @@ public class URLEncoderCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taintIfTainted(result, value, false, VulnerabilityMarks.XSS_MARK);
+          module.taintStringIfTainted(result, value, false, VulnerabilityMarks.XSS_MARK);
         } catch (final Throwable e) {
           module.onUnexpectedException("afterEncode threw", e);
         }

--- a/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URICallSIteTest.groovy
+++ b/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URICallSIteTest.groovy
@@ -24,7 +24,7 @@ class URICallSIteTest extends AgentTestRunner {
 
     then:
     uri.toString() == expected
-    1 * module.taintIfAnyTainted(_ as URI, args as Object[])
+    1 * module.taintObjectIfAnyTainted(_ as URI, args as Object[])
 
     where:
     method | args                                                                          | expected
@@ -45,7 +45,7 @@ class URICallSIteTest extends AgentTestRunner {
 
     then:
     uri.toString() == expected
-    1 * module.taintIfTainted(_ as URI, args[0])
+    1 * module.taintObjectIfTainted(_ as URI, args[0])
 
     where:
     method   | args                                          | expected
@@ -61,12 +61,12 @@ class URICallSIteTest extends AgentTestRunner {
     TestURICallSiteSuite.&"$method".call(args as Object[])
 
     then:
-    1 * module.taintIfTainted(_, _ as URI)
+    1 * module."taint${target}IfTainted"(_, _ as URI)
 
     where:
-    method          | args
-    'normalize'     | [new URI('http://test.com/index?name=value#fragment')]
-    'toString'      | [new URI('http://test.com/index?name=value#fragment')]
-    'toASCIIString' | [new URI('http://test.com/index?name=value#fragment')]
+    method          | target   | args
+    'normalize'     | 'Object' | [new URI('http://test.com/index?name=value#fragment')]
+    'toString'      | 'String' | [new URI('http://test.com/index?name=value#fragment')]
+    'toASCIIString' | 'String' | [new URI('http://test.com/index?name=value#fragment')]
   }
 }

--- a/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URLCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URLCallSiteTest.groovy
@@ -23,7 +23,7 @@ class URLCallSiteTest extends AgentTestRunner {
 
     then:
     uri.toString() == expected
-    1 * module.taintIfAnyTainted(_ as URL, args as Object[])
+    1 * module.taintObjectIfAnyTainted(_ as URL, args as Object[])
 
     where:
     method | args                                                                             | expected
@@ -44,13 +44,13 @@ class URLCallSiteTest extends AgentTestRunner {
     TestURLCallSiteSuite.&"$method".call(args as Object[])
 
     then:
-    1 * module.taintIfTainted(_, _ as URL)
+    1 * module."taint${target}IfTainted"(_, _ as URL)
 
     where:
-    method           | args
-    'toURI'          | [new URL('http://test.com/index?name=value#fragment')]
-    'toString'       | [new URL('http://test.com/index?name=value#fragment')]
-    'toExternalForm' | [new URL('http://test.com/index?name=value#fragment')]
+    method           | target   | args
+    'toURI'          | 'Object' | [new URL('http://test.com/index?name=value#fragment')]
+    'toString'       | 'String' | [new URL('http://test.com/index?name=value#fragment')]
+    'toExternalForm' | 'String' | [new URL('http://test.com/index?name=value#fragment')]
   }
 
   void 'test ssrf endpoints'() {

--- a/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URLEncoderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URLEncoderCallSiteTest.groovy
@@ -23,7 +23,7 @@ class URLEncoderCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * iastModule.taintIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
+    1 * iastModule.taintStringIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractFormProviderInstrumentation.java
@@ -54,9 +54,9 @@ public class AbstractFormProviderInstrumentation extends InstrumenterModule.Iast
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (Map.Entry<String, List<String>> entry : result.entrySet()) {
         final String name = entry.getKey();
-        prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
         for (String value : entry.getValue()) {
-          prop.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+          prop.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractParamValueExtractorInstrumentation.java
@@ -54,7 +54,7 @@ public class AbstractParamValueExtractorInstrumentation extends InstrumenterModu
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taint(ctx, (String) result, ThreadLocalSourceType.get(), parameterName);
+          module.taintString(ctx, (String) result, ThreadLocalSourceType.get(), parameterName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/AbstractStringReaderAdvice.java
@@ -21,7 +21,7 @@ public class AbstractStringReaderAdvice {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE);
+        module.taintString(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/CookieInstrumentation.java
@@ -53,7 +53,8 @@ public class CookieInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taintIfTainted(ctx, cookieName, self, SourceTypes.REQUEST_COOKIE_NAME, cookieName);
+        module.taintStringIfTainted(
+            ctx, cookieName, self, SourceTypes.REQUEST_COOKIE_NAME, cookieName);
       }
     }
   }
@@ -70,7 +71,7 @@ public class CookieInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taintIfTainted(ctx, cookieValue, self, SourceTypes.REQUEST_COOKIE_VALUE, name);
+        module.taintStringIfTainted(ctx, cookieValue, self, SourceTypes.REQUEST_COOKIE_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/InboundMessageContextInstrumentation.java
@@ -57,9 +57,9 @@ public class InboundMessageContextInstrumentation extends InstrumenterModule.Ias
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
           final String name = entry.getKey();
-          prop.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
+          prop.taintString(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
           for (String value : entry.getValue()) {
-            prop.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+            prop.taintString(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
           }
         }
       }
@@ -77,8 +77,8 @@ public class InboundMessageContextInstrumentation extends InstrumenterModule.Ias
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (Map.Entry<String, Object> entry : cookies.entrySet()) {
           final String name = entry.getKey();
-          module.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
-          module.taint(ctx, entry.getValue(), SourceTypes.REQUEST_COOKIE_VALUE, name);
+          module.taintString(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+          module.taintObject(ctx, entry.getValue(), SourceTypes.REQUEST_COOKIE_VALUE, name);
         }
       }
     }

--- a/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ReaderInterceptorExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/jersey/src/main/java/datadog/trace/instrumentation/jersey/ReaderInterceptorExecutorInstrumentation.java
@@ -45,7 +45,7 @@ public class ReaderInterceptorExecutorInstrumentation extends InstrumenterModule
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, inputStream, SourceTypes.REQUEST_BODY);
+        module.taintObject(ctx, inputStream, SourceTypes.REQUEST_BODY);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JSONObjectUtilsInstrumentation.java
@@ -56,7 +56,7 @@ public class JSONObjectUtilsInstrumentation extends InstrumenterModule.Iast
           if (value instanceof String) {
             // TODO: We could represent this source more accurately, perhaps tracking the original
             // source, or using a special name.
-            module.taint(ctx, (String) value, SourceTypes.REQUEST_HEADER_VALUE, name);
+            module.taintString(ctx, (String) value, SourceTypes.REQUEST_HEADER_VALUE, name);
           }
         }
       }

--- a/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
+++ b/dd-java-agent/instrumentation/jose-jwt/src/main/java/datadog/trace/instrumentation/josejwt/JWTParserInstrumentation.java
@@ -51,7 +51,7 @@ public class JWTParserInstrumentation extends InstrumenterModule.Iast
         // TODO: We could represent this source more accurately, perhaps tracking the original
         // source, or using a special name.
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, json, SourceTypes.REQUEST_HEADER_VALUE);
+        module.taintString(ctx, json, SourceTypes.REQUEST_HEADER_VALUE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jose-jwt/src/test/groovy/JWTParserInstrumentationTest.groovy
@@ -29,7 +29,7 @@ class JWTParserInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { new com.auth0.jwt.impl.JWTParser().parsePayload(payload) }
 
     then:
-    1 * propagationModule.taint(iastCtx, payload, SourceTypes.REQUEST_HEADER_VALUE)
+    1 * propagationModule.taintString(iastCtx, payload, SourceTypes.REQUEST_HEADER_VALUE)
     0 * _
   }
 
@@ -43,11 +43,11 @@ class JWTParserInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { com.nimbusds.jose.util.JSONObjectUtils.parse(json) }
 
     then:
-    1 * propagationModule.taint(iastCtx, 'http://foobar.com', SourceTypes.REQUEST_HEADER_VALUE, 'iss')
-    1 * propagationModule.taint(iastCtx, 'foo', SourceTypes.REQUEST_HEADER_VALUE, 'sub')
-    1 * propagationModule.taint(iastCtx, 'foobar', SourceTypes.REQUEST_HEADER_VALUE, 'aud')
-    1 * propagationModule.taint(iastCtx, 'Mr Foo Bar', SourceTypes.REQUEST_HEADER_VALUE, 'name')
-    1 * propagationModule.taint(iastCtx, 'read', SourceTypes.REQUEST_HEADER_VALUE, 'scope')
+    1 * propagationModule.taintString(iastCtx, 'http://foobar.com', SourceTypes.REQUEST_HEADER_VALUE, 'iss')
+    1 * propagationModule.taintString(iastCtx, 'foo', SourceTypes.REQUEST_HEADER_VALUE, 'sub')
+    1 * propagationModule.taintString(iastCtx, 'foobar', SourceTypes.REQUEST_HEADER_VALUE, 'aud')
+    1 * propagationModule.taintString(iastCtx, 'Mr Foo Bar', SourceTypes.REQUEST_HEADER_VALUE, 'name')
+    1 * propagationModule.taintString(iastCtx, 'read', SourceTypes.REQUEST_HEADER_VALUE, 'scope')
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/iastLatestDepTest3/groovy/iast/KafkaIastDeserializerTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/iastLatestDepTest3/groovy/iast/KafkaIastDeserializerTest.groovy
@@ -45,21 +45,21 @@ class KafkaIastDeserializerTest extends AgentTestRunner {
     then:
     switch (test.method) {
       case Method.DEFAULT:
-        1 * propagationModule.taint(payload, source) // taint byte[]
+        1 * propagationModule.taintObject(payload, source) // taint byte[]
         1 * codecModule.onStringFromBytes(payload, 0, payload.length, _, _ as String) // taint byte[] => string
         break
       case Method.WITH_HEADERS:
-        1 * propagationModule.taint(payload, source) // taint byte[]
+        1 * propagationModule.taintObject(payload, source) // taint byte[]
         1 * codecModule.onStringFromBytes(payload, 0, payload.length, _, _ as String) // taint byte[] => string
         break
       case Method.WITH_BYTE_BUFFER:
-        1 * propagationModule.taint(_ as ByteBuffer, source, 0, payload.length) // taint ByteBuffer
-        1 * propagationModule.taintIfTainted(payload, _ as ByteBuffer, 0, payload.length, false, NOT_MARKED) // taint ByteBuffer => byte[]
+        1 * propagationModule.taintObjectRange(_ as ByteBuffer, source, 0, payload.length) // taint ByteBuffer
+        1 * propagationModule.taintObjectIfRangeTainted(payload, _ as ByteBuffer, 0, payload.length, false, NOT_MARKED) // taint ByteBuffer => byte[]
         1 * codecModule.onStringFromBytes(payload, 0, payload.length, _, _ as String) // taint byte[] => string
         break
       case Method.WITH_BYTE_BUFFER_OFFSET:
-        1 * propagationModule.taint(_ as ByteBuffer, source, BUFF_OFFSET, payload.length) // taint ByteBuffer
-        1 * propagationModule.taintIfTainted(_ as byte[], _ as ByteBuffer, true, NOT_MARKED) // taint ByteBuffer => byte[]
+        1 * propagationModule.taintObjectRange(_ as ByteBuffer, source, BUFF_OFFSET, payload.length) // taint ByteBuffer
+        1 * propagationModule.taintObjectIfTainted(_ as byte[], _ as ByteBuffer, true, NOT_MARKED) // taint ByteBuffer => byte[]
         1 * codecModule.onStringFromBytes(_ as byte[], BUFF_OFFSET, payload.length, _, _ as String) // taint byte[] => string
         break
     }
@@ -86,18 +86,18 @@ class KafkaIastDeserializerTest extends AgentTestRunner {
     then:
     switch (test.method) {
       case Method.DEFAULT:
-        1 * propagationModule.taint(payload, source) // taint byte[]
+        1 * propagationModule.taintObject(payload, source) // taint byte[]
         break
       case Method.WITH_HEADERS:
-        1 * propagationModule.taint(payload, source) // taint byte[]
+        1 * propagationModule.taintObject(payload, source) // taint byte[]
         break
       case Method.WITH_BYTE_BUFFER:
-        1 * propagationModule.taint(_ as ByteBuffer, source, 0, payload.length) // taint ByteBuffer
-        1 * propagationModule.taintIfTainted(payload, _ as ByteBuffer, 0, payload.length, false, NOT_MARKED) // taint ByteBuffer => byte[]
+        1 * propagationModule.taintObjectRange(_ as ByteBuffer, source, 0, payload.length) // taint ByteBuffer
+        1 * propagationModule.taintObjectIfRangeTainted(payload, _ as ByteBuffer, 0, payload.length, false, NOT_MARKED) // taint ByteBuffer => byte[]
         break
       case Method.WITH_BYTE_BUFFER_OFFSET:
-        1 * propagationModule.taint(_ as ByteBuffer, source, BUFF_OFFSET, payload.length) // taint ByteBuffer
-        1 * propagationModule.taintIfTainted(payload, _ as ByteBuffer, BUFF_OFFSET, payload.length, false, NOT_MARKED) // taint ByteBuffer => byte[]
+        1 * propagationModule.taintObjectRange(_ as ByteBuffer, source, BUFF_OFFSET, payload.length) // taint ByteBuffer
+        1 * propagationModule.taintObjectIfRangeTainted(payload, _ as ByteBuffer, BUFF_OFFSET, payload.length, false, NOT_MARKED) // taint ByteBuffer => byte[]
         break
     }
     0 * _
@@ -123,18 +123,18 @@ class KafkaIastDeserializerTest extends AgentTestRunner {
     then:
     switch (test.method) {
       case Method.DEFAULT:
-        1 * propagationModule.taint(payload, source) // taint byte[]
-        1 * propagationModule.taintIfTainted(_ as ByteBuffer, payload, true, NOT_MARKED) // taint byte[] => ByteBuffer
+        1 * propagationModule.taintObject(payload, source) // taint byte[]
+        1 * propagationModule.taintObjectIfTainted(_ as ByteBuffer, payload, true, NOT_MARKED) // taint byte[] => ByteBuffer
         break
       case Method.WITH_HEADERS:
-        1 * propagationModule.taint(payload, source) // taint byte[]
-        1 * propagationModule.taintIfTainted(_ as ByteBuffer, payload, true, NOT_MARKED) // taint byte[] => ByteBuffer
+        1 * propagationModule.taintObject(payload, source) // taint byte[]
+        1 * propagationModule.taintObjectIfTainted(_ as ByteBuffer, payload, true, NOT_MARKED) // taint byte[] => ByteBuffer
         break
       case Method.WITH_BYTE_BUFFER:
-        1 * propagationModule.taint(_ as ByteBuffer, source, 0, payload.length) // taint ByteBuffer
+        1 * propagationModule.taintObjectRange(_ as ByteBuffer, source, 0, payload.length) // taint ByteBuffer
         break
       case Method.WITH_BYTE_BUFFER_OFFSET:
-        1 * propagationModule.taint(_ as ByteBuffer, source, BUFF_OFFSET, payload.length) // taint ByteBuffer
+        1 * propagationModule.taintObjectRange(_ as ByteBuffer, source, BUFF_OFFSET, payload.length) // taint ByteBuffer
         break
     }
     0 * _
@@ -161,28 +161,28 @@ class KafkaIastDeserializerTest extends AgentTestRunner {
     then:
     switch (test.method) {
       case Method.DEFAULT:
-        1 * propagationModule.taint(payload, source) // taint byte[]
+        1 * propagationModule.taintObject(payload, source) // taint byte[]
         break
       case Method.WITH_HEADERS:
-        1 * propagationModule.taint(payload, source) // taint byte[]
+        1 * propagationModule.taintObject(payload, source) // taint byte[]
         break
       case Method.WITH_BYTE_BUFFER:
-        1 * propagationModule.taint(_ as ByteBuffer, source, 0, payload.length) // taint ByteBuffer
-        1 * propagationModule.taintIfTainted(payload, _ as ByteBuffer, 0, payload.length, false, NOT_MARKED) // taint byte[] => ByteBuffer
+        1 * propagationModule.taintObjectRange(_ as ByteBuffer, source, 0, payload.length) // taint ByteBuffer
+        1 * propagationModule.taintObjectIfRangeTainted(payload, _ as ByteBuffer, 0, payload.length, false, NOT_MARKED) // taint byte[] => ByteBuffer
         break
       case Method.WITH_BYTE_BUFFER_OFFSET:
-        1 * propagationModule.taint(_ as ByteBuffer, source, BUFF_OFFSET, payload.length) // taint ByteBuffer
-        1 * propagationModule.taintIfTainted(payload, _ as ByteBuffer, BUFF_OFFSET, payload.length, false, NOT_MARKED) // taint byte[] => ByteBuffer
+        1 * propagationModule.taintObjectRange(_ as ByteBuffer, source, BUFF_OFFSET, payload.length) // taint ByteBuffer
+        1 * propagationModule.taintObjectIfRangeTainted(payload, _ as ByteBuffer, BUFF_OFFSET, payload.length, false, NOT_MARKED) // taint byte[] => ByteBuffer
         break
     }
     // taint JSON
-    1 * propagationModule.taintIfTainted(_ as JsonParser, payload)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, payload)
     1 * propagationModule.findSource(_) >> Stub(Taintable.Source) {
       getOrigin() >> source
       getValue() >> json
     }
-    1 * propagationModule.taint(_, 'name', source, 'name', json)
-    1 * propagationModule.taint(_, 'Mr Bean', source, 'name', json)
+    1 * propagationModule.taintString(_, 'name', source, 'name', json)
+    1 * propagationModule.taintString(_, 'Mr Bean', source, 'name', json)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaIastHelper.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaIastHelper.java
@@ -37,7 +37,7 @@ public class KafkaIastHelper {
       return;
     }
     final byte source = getSource(store, deserializer);
-    module.taint(data, source);
+    module.taintObject(data, source);
   }
 
   public static void taint(
@@ -59,7 +59,7 @@ public class KafkaIastHelper {
     if (data.hasArray()) {
       start += data.arrayOffset();
     }
-    module.taint(data, source, start, data.remaining());
+    module.taintObjectRange(data, source, start, data.remaining());
   }
 
   public static void afterDeserialize() {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/UtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/UtilsInstrumentation.java
@@ -63,7 +63,7 @@ public class UtilsInstrumentation extends InstrumenterModule.Iast
         start += buffer.arrayOffset();
       }
       // create a new range shifted to the result byte array coordinates
-      propagation.taintIfTainted(bytes, buffer, start, length, false, NOT_MARKED);
+      propagation.taintObjectIfRangeTainted(bytes, buffer, start, length, false, NOT_MARKED);
     }
   }
 
@@ -79,7 +79,7 @@ public class UtilsInstrumentation extends InstrumenterModule.Iast
       if (propagation == null) {
         return;
       }
-      propagation.taintIfTainted(buffer, bytes, true, NOT_MARKED);
+      propagation.taintObjectIfTainted(buffer, bytes, true, NOT_MARKED);
     }
   }
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/iast/KafkaIastDeserializerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/iast/KafkaIastDeserializerForkedTest.groovy
@@ -35,7 +35,7 @@ class KafkaIastDeserializerForkedTest extends AgentTestRunner {
     deserializer.deserialize("test", payload)
 
     then:
-    1 * propagationModule.taint(payload, source)
+    1 * propagationModule.taintObject(payload, source)
     1 * codecModule.onStringFromBytes(payload, _, _, _, _)
     0 * _
 
@@ -59,7 +59,7 @@ class KafkaIastDeserializerForkedTest extends AgentTestRunner {
     deserializer.deserialize("test", payload)
 
     then:
-    1 * propagationModule.taint(payload, source)
+    1 * propagationModule.taintObject(payload, source)
     0 * _
 
     where:
@@ -82,8 +82,8 @@ class KafkaIastDeserializerForkedTest extends AgentTestRunner {
     deserializer.deserialize("test", payload)
 
     then:
-    1 * propagationModule.taint(payload, source)
-    1 * propagationModule.taintIfTainted(_, payload, true, VulnerabilityMarks.NOT_MARKED)
+    1 * propagationModule.taintObject(payload, source)
+    1 * propagationModule.taintObjectIfTainted(_, payload, true, VulnerabilityMarks.NOT_MARKED)
     0 * _
 
     where:
@@ -107,14 +107,14 @@ class KafkaIastDeserializerForkedTest extends AgentTestRunner {
     deserializer.deserialize('test', payload)
 
     then:
-    1 * propagationModule.taint(payload, source)
-    1 * propagationModule.taintIfTainted(_ as JsonParser, payload)
+    1 * propagationModule.taintObject(payload, source)
+    1 * propagationModule.taintObjectIfTainted(_ as JsonParser, payload)
     1 * propagationModule.findSource(_) >> Stub(Source) {
       getOrigin() >> source
       getValue() >> json
     }
-    1 * propagationModule.taint(_, 'name', source, 'name', json)
-    1 * propagationModule.taint(_, 'Mr Bean', source, 'name', json)
+    1 * propagationModule.taintString(_, 'name', source, 'name', json)
+    1 * propagationModule.taintString(_, 'Mr Bean', source, 'name', json)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/iast/UtilsInstrumentationForkedTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/iast/UtilsInstrumentationForkedTest.groovy
@@ -26,7 +26,7 @@ class UtilsInstrumentationForkedTest extends AgentTestRunner {
 
     then:
     bytes != null
-    1 * propagationModule.taintIfTainted(_ as byte[], buffer, offset, length, false, VulnerabilityMarks.NOT_MARKED)
+    1 * propagationModule.taintObjectIfRangeTainted(_ as byte[], buffer, offset, length, false, VulnerabilityMarks.NOT_MARKED)
     0 * _
 
     where:
@@ -51,7 +51,7 @@ class UtilsInstrumentationForkedTest extends AgentTestRunner {
 
     then:
     buffer != null
-    1 * propagationModule.taintIfTainted(_ as ByteBuffer, bytes, true, VulnerabilityMarks.NOT_MARKED)
+    1 * propagationModule.taintObjectIfTainted(_ as ByteBuffer, bytes, true, VulnerabilityMarks.NOT_MARKED)
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/netty-buffer-4/src/main/java/datadog/trace/instrumentation/netty40/buffer/ByteBufInputStreamInstrumentation.java
+++ b/dd-java-agent/instrumentation/netty-buffer-4/src/main/java/datadog/trace/instrumentation/netty40/buffer/ByteBufInputStreamInstrumentation.java
@@ -54,7 +54,7 @@ public class ByteBufInputStreamInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       try {
         if (module != null) {
-          module.taintIfTainted(self, buffer);
+          module.taintObjectIfTainted(self, buffer);
         }
       } catch (final Throwable e) {
         module.onUnexpectedException("ByteBufInputStream ctor threw", e);

--- a/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastHttpUrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-2/src/main/java/datadog/trace/instrumentation/okhttp2/IastHttpUrlInstrumentation.java
@@ -77,7 +77,7 @@ public class IastHttpUrlInstrumentation extends InstrumenterModule.Iast
         @Advice.Argument(0) final Object argument, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, argument);
+        module.taintObjectIfTainted(result, argument);
       }
     }
   }
@@ -90,7 +90,7 @@ public class IastHttpUrlInstrumentation extends InstrumenterModule.Iast
         @Advice.This final Object self, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, self);
+        module.taintObjectIfTainted(result, self);
       }
     }
   }

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/IastOkHttp2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/IastOkHttp2InstrumentationTest.groovy
@@ -62,12 +62,12 @@ class IastOkHttp2InstrumentationTest extends AgentTestRunner {
 
   private void mockPropagation() {
     final propagation = Mock(PropagationModule) {
-      taintIfAnyTainted(_, _) >> {
+      taintObjectIfAnyTainted(_, _) >> {
         if ((it[1] as List).any { input -> tainteds.containsKey(input) }) {
           tainteds.put(it[0], null)
         }
       }
-      taintIfTainted(_, _) >> {
+      taintObjectIfTainted(_, _) >> {
         if (tainteds.containsKey(it[1])) {
           tainteds.put(it[0], null)
         }

--- a/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastHttpUrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/okhttp-3/src/main/java/datadog/trace/instrumentation/okhttp3/IastHttpUrlInstrumentation.java
@@ -77,7 +77,7 @@ public class IastHttpUrlInstrumentation extends InstrumenterModule.Iast
         @Advice.Argument(0) final Object arg, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, arg);
+        module.taintObjectIfTainted(result, arg);
       }
     }
   }

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/IastOkHttp3InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/IastOkHttp3InstrumentationTest.groovy
@@ -66,12 +66,14 @@ class IastOkHttp3InstrumentationTest extends AgentTestRunner {
   }
 
   private void mockPropagation() {
-    final propagation = Mock(PropagationModule) {
-      taintIfTainted(_, _) >> {
-        if (tainteds.containsKey(it[1])) {
-          tainteds.put(it[0], null)
-        }
+    final Closure taint = { target, input ->
+      if (tainteds.containsKey(input)) {
+        tainteds.put(target, null)
       }
+    }
+    final propagation = Mock(PropagationModule) {
+      taintObjectIfTainted(_, _) >> { taint(it[0], it[1]) }
+      taintStringIfTainted(_, _) >> { taint(it[0], it[1]) }
     }
     InstrumentationBridge.registerIastModule(propagation)
   }

--- a/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONArrayInstrumentation.java
+++ b/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONArrayInstrumentation.java
@@ -53,7 +53,7 @@ public class JSONArrayInstrumentation extends InstrumenterModule.Iast
     public static void afterInit(@Advice.This Object self, @Advice.Argument(0) final Object input) {
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null && input != null) {
-        iastModule.taintIfTainted(self, input);
+        iastModule.taintObjectIfTainted(self, input);
       }
     }
   }
@@ -70,9 +70,9 @@ public class JSONArrayInstrumentation extends InstrumenterModule.Iast
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null) {
         if (isString) {
-          iastModule.taintIfTainted((String) result, self);
+          iastModule.taintStringIfTainted((String) result, self);
         } else {
-          iastModule.taintIfTainted(result, self);
+          iastModule.taintObjectIfTainted(result, self);
         }
       }
     }
@@ -90,9 +90,9 @@ public class JSONArrayInstrumentation extends InstrumenterModule.Iast
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null) {
         if (isString) {
-          iastModule.taintIfTainted((String) result, self);
+          iastModule.taintStringIfTainted((String) result, self);
         } else {
-          iastModule.taintIfTainted(result, self);
+          iastModule.taintObjectIfTainted(result, self);
         }
       }
     }

--- a/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONCookieInstrumentation.java
+++ b/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONCookieInstrumentation.java
@@ -38,7 +38,7 @@ public class JSONCookieInstrumentation extends InstrumenterModule.Iast
         @Advice.Return Object retValue, @Advice.Argument(0) final String input) {
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null && input != null) {
-        iastModule.taintIfTainted(retValue, input);
+        iastModule.taintObjectIfTainted(retValue, input);
       }
     }
   }

--- a/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONObjectInstrumentation.java
+++ b/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONObjectInstrumentation.java
@@ -55,7 +55,7 @@ public class JSONObjectInstrumentation extends InstrumenterModule.Iast
     public static void afterInit(@Advice.This Object self, @Advice.Argument(0) final Object input) {
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null && input != null) {
-        iastModule.taintIfTainted(self, input);
+        iastModule.taintObjectIfTainted(self, input);
       }
     }
   }
@@ -72,9 +72,9 @@ public class JSONObjectInstrumentation extends InstrumenterModule.Iast
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null) {
         if (isString) {
-          iastModule.taintIfTainted((String) result, self);
+          iastModule.taintStringIfTainted((String) result, self);
         } else {
-          iastModule.taintIfTainted(result, self);
+          iastModule.taintObjectIfTainted(result, self);
         }
       }
     }
@@ -92,9 +92,9 @@ public class JSONObjectInstrumentation extends InstrumenterModule.Iast
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null) {
         if (isString) {
-          iastModule.taintIfTainted((String) result, self);
+          iastModule.taintStringIfTainted((String) result, self);
         } else {
-          iastModule.taintIfTainted(result, self);
+          iastModule.taintObjectIfTainted(result, self);
         }
       }
     }

--- a/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONTokenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/org-json/src/main/java/datadog/trace/instrumentation/json/JSONTokenerInstrumentation.java
@@ -37,7 +37,7 @@ public class JSONTokenerInstrumentation extends InstrumenterModule.Iast
     public static void afterInit(@Advice.This Object self, @Advice.Argument(0) final Object input) {
       final PropagationModule iastModule = InstrumentationBridge.PROPAGATION;
       if (iastModule != null && input != null) {
-        iastModule.taintIfTainted(self, input);
+        iastModule.taintObjectIfTainted(self, input);
       }
     }
   }

--- a/dd-java-agent/instrumentation/org-json/src/test/groovy/JSONArrayInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/org-json/src/test/groovy/JSONArrayInstrumentationTest.groovy
@@ -32,12 +32,12 @@ class JSONArrayInstrumentationTest extends AgentTestRunner {
 
     then:
     name == "File"
-    1 * module.taintIfTainted(_ as JSONObject, json)
-    2 * module.taintIfTainted(_ as JSONObject, _ as JSONTokener)
-    2 * module.taintIfTainted(_ as JSONObject, _ as JSONObject)
-    1 * module.taintIfTainted(_ as JSONTokener, json)
-    2 * module.taintIfTainted(_ as JSONArray, _ as JSONObject)
-    2 * module.taintIfTainted("File", _ as JSONArray)
+    1 * module.taintObjectIfTainted(_ as JSONObject, json)
+    2 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONTokener)
+    2 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONObject)
+    1 * module.taintObjectIfTainted(_ as JSONTokener, json)
+    2 * module.taintObjectIfTainted(_ as JSONArray, _ as JSONObject)
+    2 * module.taintStringIfTainted("File", _ as JSONArray)
     0 * _
   }
 
@@ -61,12 +61,12 @@ class JSONArrayInstrumentationTest extends AgentTestRunner {
 
     then:
     name == "File"
-    1 * module.taintIfTainted(_ as JSONObject, json)
-    2 * module.taintIfTainted(_ as JSONObject, _ as JSONTokener)
-    2 * module.taintIfTainted(_ as JSONObject, _ as JSONObject)
-    1 * module.taintIfTainted(_ as JSONTokener, json)
-    2 * module.taintIfTainted(_ as JSONArray, _ as JSONObject)
-    1 * module.taintIfTainted("File", _ as JSONArray)
+    1 * module.taintObjectIfTainted(_ as JSONObject, json)
+    2 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONTokener)
+    2 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONObject)
+    1 * module.taintObjectIfTainted(_ as JSONTokener, json)
+    2 * module.taintObjectIfTainted(_ as JSONArray, _ as JSONObject)
+    1 * module.taintStringIfTainted("File", _ as JSONArray)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/org-json/src/test/groovy/JSONCookieInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/org-json/src/test/groovy/JSONCookieInstrumentationTest.groovy
@@ -22,8 +22,8 @@ class JSONCookieInstrumentationTest extends AgentTestRunner {
 
 
     then:
-    1 * module.taintIfTainted(_ as JSONObject, cookie)
-    1 * module.taintIfTainted(_ as JSONTokener, cookie)
+    1 * module.taintObjectIfTainted(_ as JSONObject, cookie)
+    1 * module.taintObjectIfTainted(_ as JSONTokener, cookie)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/org-json/src/test/groovy/JSONObjectInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/org-json/src/test/groovy/JSONObjectInstrumentationTest.groovy
@@ -30,11 +30,11 @@ class JSONObjectInstrumentationTest extends AgentTestRunner {
 
     then:
     name == "nameTest"
-    1 * module.taintIfTainted(_ as JSONObject, json)
-    2 * module.taintIfTainted(_ as JSONObject, _ as JSONTokener)
-    2 * module.taintIfTainted(_ as JSONObject, _ as JSONObject)
-    1 * module.taintIfTainted(_ as JSONTokener, json)
-    2 * module.taintIfTainted("nameTest", _ as JSONObject)
+    1 * module.taintObjectIfTainted(_ as JSONObject, json)
+    2 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONTokener)
+    2 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONObject)
+    1 * module.taintObjectIfTainted(_ as JSONTokener, json)
+    2 * module.taintStringIfTainted("nameTest", _ as JSONObject)
     0 * _
   }
 
@@ -58,11 +58,11 @@ class JSONObjectInstrumentationTest extends AgentTestRunner {
 
     then:
     name == "nameTest"
-    1 * module.taintIfTainted(_ as JSONObject, json)
-    2 * module.taintIfTainted(_ as JSONObject, _ as JSONTokener)
-    2 * module.taintIfTainted(_ as JSONObject, _ as JSONObject)
-    1 * module.taintIfTainted(_ as JSONTokener, json)
-    1 * module.taintIfTainted("nameTest", _ as JSONObject)
+    1 * module.taintObjectIfTainted(_ as JSONObject, json)
+    2 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONTokener)
+    2 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONObject)
+    1 * module.taintObjectIfTainted(_ as JSONTokener, json)
+    1 * module.taintStringIfTainted("nameTest", _ as JSONObject)
     0 * _
   }
 
@@ -80,9 +80,9 @@ class JSONObjectInstrumentationTest extends AgentTestRunner {
 
     then:
     name == "nameTest"
-    1 * module.taintIfTainted(_ as JSONObject, _ as JSONTokener)
-    1 * module.taintIfTainted(_ as JSONTokener, json)
-    2 * module.taintIfTainted("nameTest", _ as JSONObject)
+    1 * module.taintObjectIfTainted(_ as JSONObject, _ as JSONTokener)
+    1 * module.taintObjectIfTainted(_ as JSONTokener, json)
+    2 * module.taintStringIfTainted("nameTest", _ as JSONObject)
     0 * _
   }
 
@@ -100,8 +100,8 @@ class JSONObjectInstrumentationTest extends AgentTestRunner {
     jsonObject.get("name")
 
     then:
-    1 * module.taintIfTainted(_ as JSONObject, map)
-    2 * module.taintIfTainted("nameTest", _ as JSONObject)
+    1 * module.taintObjectIfTainted(_ as JSONObject, map)
+    2 * module.taintStringIfTainted("nameTest", _ as JSONObject)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/org-json/src/test/groovy/JSONTokenerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/org-json/src/test/groovy/JSONTokenerInstrumentationTest.groovy
@@ -19,7 +19,7 @@ class JSONTokenerInstrumentationTest extends AgentTestRunner {
     new JSONTokener(json)
 
     then:
-    1 * module.taintIfTainted(_ as JSONTokener, json)
+    1 * module.taintObjectIfTainted(_ as JSONTokener, json)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/owasp-esapi-2/src/main/java/datadog/trace/instrumentation/owasp/esapi/EncoderCallSite.java
+++ b/dd-java-agent/instrumentation/owasp-esapi-2/src/main/java/datadog/trace/instrumentation/owasp/esapi/EncoderCallSite.java
@@ -22,7 +22,7 @@ public class EncoderCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEncodeForHTML threw", e);
       }
@@ -38,7 +38,7 @@ public class EncoderCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterCanonicalize1 threw", e);
       }
@@ -56,7 +56,7 @@ public class EncoderCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterCanonicalize2 threw", e);
       }
@@ -75,7 +75,7 @@ public class EncoderCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterCanonicalize3 threw", e);
       }
@@ -91,7 +91,7 @@ public class EncoderCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.LDAP_INJECTION_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.LDAP_INJECTION_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEncodeForLDAP threw", e);
       }
@@ -109,7 +109,8 @@ public class EncoderCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.COMMAND_INJECTION_MARK);
+        module.taintStringIfTainted(
+            result, input, false, VulnerabilityMarks.COMMAND_INJECTION_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEncodeForOS threw", e);
       }
@@ -127,7 +128,7 @@ public class EncoderCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.SQL_INJECTION_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.SQL_INJECTION_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEncodeForSQL threw", e);
       }

--- a/dd-java-agent/instrumentation/owasp-esapi-2/src/test/groovy/datadog/trace/instrumentation/owasp/esapi/EncoderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/owasp-esapi-2/src/test/groovy/datadog/trace/instrumentation/owasp/esapi/EncoderCallSiteTest.groovy
@@ -25,7 +25,7 @@ class EncoderCallSiteTest extends AgentTestRunner {
     testSuite.&"$method".call(args)
 
     then:
-    1 * module.taintIfTainted(_, _, false, mark)
+    1 * module.taintObjectIfTainted(_, _, false, mark)
     0 * module._
 
     where:

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/CookieHeaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/CookieHeaderInstrumentation.java
@@ -75,8 +75,8 @@ public class CookieHeaderInstrumentation extends InstrumenterModule.Iast
       while (iterator.hasNext()) {
         HttpCookiePair pair = iterator.next();
         final String name = pair.name(), value = pair.value();
-        prop.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
-        prop.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+        prop.taintString(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HeaderNameCallSite.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HeaderNameCallSite.java
@@ -33,7 +33,7 @@ public class HeaderNameCallSite {
       if (ctx == null) {
         return result;
       }
-      module.taintIfTainted(ctx, result, header, SourceTypes.REQUEST_HEADER_NAME, result);
+      module.taintStringIfTainted(ctx, result, header, SourceTypes.REQUEST_HEADER_NAME, result);
     } catch (final Throwable e) {
       module.onUnexpectedException("onHeaderNames threw", e);
     }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpHeaderSubclassesInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpHeaderSubclassesInstrumentation.java
@@ -72,7 +72,7 @@ public class HttpHeaderSubclassesInstrumentation extends InstrumenterModule.Iast
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      propagation.taintIfTainted(ctx, retVal, h);
+      propagation.taintStringIfTainted(ctx, retVal, h);
     }
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/HttpRequestInstrumentation.java
@@ -89,7 +89,7 @@ public class HttpRequestInstrumentation extends InstrumenterModule.Iast
         }
         // unfortunately, the call to h.value() is instrumented, but
         // because the call to taint() only happens after, the call is a noop
-        propagation.taint(ctx, h, SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value());
+        propagation.taintObject(ctx, h, SourceTypes.REQUEST_HEADER_VALUE, h.name(), h.value());
       }
     }
   }
@@ -113,7 +113,7 @@ public class HttpRequestInstrumentation extends InstrumenterModule.Iast
         return;
       }
 
-      propagation.taintIfTainted(ctx, entity, thiz);
+      propagation.taintObjectIfTainted(ctx, entity, thiz);
     }
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/PathMatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/PathMatcherInstrumentation.java
@@ -72,7 +72,7 @@ public class PathMatcherInstrumentation extends InstrumenterModule.Iast
         return;
       }
 
-      module.taint(ctx, stringValue, SourceTypes.REQUEST_PATH_PARAMETER);
+      module.taintString(ctx, stringValue, SourceTypes.REQUEST_PATH_PARAMETER);
     }
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/RequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/RequestContextInstrumentation.java
@@ -67,7 +67,7 @@ public class RequestContextInstrumentation extends InstrumenterModule.Iast
         return;
       }
 
-      propagation.taintIfTainted(ctx, request, requestContext);
+      propagation.taintObjectIfTainted(ctx, request, requestContext);
     }
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/UriInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/UriInstrumentation.java
@@ -80,7 +80,7 @@ public class UriInstrumentation extends InstrumenterModule.Iast
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      mod.taintIfTainted(ctx, ret.get(), uri);
+      mod.taintStringIfTainted(ctx, ret.get(), uri);
     }
   }
 
@@ -108,8 +108,8 @@ public class UriInstrumentation extends InstrumenterModule.Iast
       while (iterator.hasNext()) {
         Tuple2<String, String> pair = iterator.next();
         final String name = pair._1(), value = pair._2();
-        prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
-        prop.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+        prop.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintCookieFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintCookieFunction.java
@@ -27,8 +27,8 @@ public class TaintCookieFunction
     }
     final String name = httpCookiePair.name();
     final String value = httpCookiePair.value();
-    mod.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
-    mod.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+    mod.taintString(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+    mod.taintString(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintFutureHelper.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintFutureHelper.java
@@ -14,7 +14,7 @@ public class TaintFutureHelper {
         t -> {
           IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
-            mod.taintIfTainted(ctx, t, input);
+            mod.taintObjectIfTainted(ctx, t, input);
           }
           return t;
         };

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintMapFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintMapFunction.java
@@ -32,8 +32,8 @@ public class TaintMapFunction
     while (iterator.hasNext()) {
       Tuple2<String, String> e = iterator.next();
       final String name = e._1(), value = e._2();
-      prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
-      prop.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+      prop.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+      prop.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintMultiMapFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintMultiMapFunction.java
@@ -33,10 +33,10 @@ public class TaintMultiMapFunction
     while (entriesIterator.hasNext()) {
       Tuple2<String, List<String>> e = entriesIterator.next();
       final String name = e._1();
-      mod.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+      mod.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
       List<String> values = e._2();
       for (final String value : ScalaToJava.listAsList(values)) {
-        mod.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        mod.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
 

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintOptionalCookieFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintOptionalCookieFunction.java
@@ -29,8 +29,8 @@ public class TaintOptionalCookieFunction
     final HttpCookiePair cookie = httpCookiePair.get();
     final String name = cookie.name();
     final String value = cookie.value();
-    mod.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
-    mod.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+    mod.taintString(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+    mod.taintString(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
     return v1;
   }
 }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintParametersFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintParametersFunction.java
@@ -44,11 +44,11 @@ public class TaintParametersFunction<T> implements Function1<Tuple1<T>, Tuple1<T
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taintString(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taintString(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestContextFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestContextFunction.java
@@ -25,7 +25,7 @@ public class TaintRequestContextFunction
     if (ctx == null) {
       return v1;
     }
-    mod.taint(ctx, reqCtx, SourceTypes.REQUEST_BODY);
+    mod.taintObject(ctx, reqCtx, SourceTypes.REQUEST_BODY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintRequestFunction.java
@@ -26,7 +26,7 @@ public class TaintRequestFunction implements JFunction1<Tuple1<HttpRequest>, Tup
     if (ctx == null) {
       return v1;
     }
-    mod.taint(ctx, httpRequest, SourceTypes.REQUEST_BODY);
+    mod.taintObject(ctx, httpRequest, SourceTypes.REQUEST_BODY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSeqFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSeqFunction.java
@@ -39,9 +39,9 @@ public class TaintSeqFunction
       String name = t._1();
       String value = t._2();
       if (seenKeys.add(name)) {
-        prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
       }
-      prop.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+      prop.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSingleParameterFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintSingleParameterFunction.java
@@ -51,11 +51,11 @@ public class TaintSingleParameterFunction<Magnet>
       while (iterator.hasNext()) {
         Object o = iterator.next();
         if (o instanceof String) {
-          mod.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          mod.taintString(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     } else if (value instanceof String) {
-      mod.taint(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+      mod.taintString(ctx, (String) value, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
     }
 
     return v1;

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUnmarshaller.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUnmarshaller.java
@@ -32,7 +32,7 @@ public class TaintUnmarshaller<A, B> implements Unmarshaller<A, B> {
   public Future<B> apply(A value, ExecutionContext ec, Materializer materializer) {
     IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
     if (ctx != null) {
-      propagationModule.taint(ctx, value, SourceTypes.REQUEST_BODY);
+      propagationModule.taintObject(ctx, value, SourceTypes.REQUEST_BODY);
     }
     return delegate.apply(value, ec, materializer);
   }

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUriFunction.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/iast/helpers/TaintUriFunction.java
@@ -24,7 +24,7 @@ public class TaintUriFunction implements JFunction1<Tuple1<Uri>, Tuple1<Uri>> {
     if (ctx == null) {
       return v1;
     }
-    mod.taint(ctx, uri, SourceTypes.REQUEST_QUERY);
+    mod.taintObject(ctx, uri, SourceTypes.REQUEST_QUERY);
 
     return v1;
   }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/CookieParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class CookieParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, (String) o, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
+              module.taintString(ctx, (String) o, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
             }
           }
         } else {
-          module.taint(ctx, (String) result, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
+          module.taintString(ctx, (String) result, SourceTypes.REQUEST_COOKIE_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/FormParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class FormParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+              module.taintString(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
             }
           }
         } else {
-          module.taint(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          module.taintString(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/HeaderParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class HeaderParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, (String) o, SourceTypes.REQUEST_HEADER_VALUE, paramName);
+              module.taintString(ctx, (String) o, SourceTypes.REQUEST_HEADER_VALUE, paramName);
             }
           }
         } else {
-          module.taint(ctx, (String) result, SourceTypes.REQUEST_HEADER_VALUE, paramName);
+          module.taintString(ctx, (String) result, SourceTypes.REQUEST_HEADER_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/PathParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class PathParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, (String) o, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
+              module.taintString(ctx, (String) o, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
             }
           }
         } else {
-          module.taint(ctx, (String) result, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
+          module.taintString(ctx, (String) result, SourceTypes.REQUEST_PATH_PARAMETER, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
+++ b/dd-java-agent/instrumentation/resteasy-appsec/src/main/java/datadog/trace/instrumentation/resteasy/QueryParamInjectorAdvice.java
@@ -28,11 +28,11 @@ public class QueryParamInjectorAdvice {
           Collection<?> collection = (Collection<?>) result;
           for (Object o : collection) {
             if (o instanceof String) {
-              module.taint(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+              module.taintString(ctx, (String) o, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
             }
           }
         } else {
-          module.taint(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
+          module.taintString(ctx, (String) result, SourceTypes.REQUEST_PARAMETER_VALUE, paramName);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet-common/src/main/java/datadog/trace/instrumentation/servlet/HttpServletResponseInstrumentation.java
@@ -121,7 +121,7 @@ public final class HttpServletResponseInstrumentation extends InstrumenterModule
     public static void onExit(@Advice.Argument(0) final String url, @Advice.Return String encoded) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (encoded != null && module != null) {
-        module.taintIfTainted(encoded, url);
+        module.taintStringIfTainted(encoded, url);
       }
     }
   }

--- a/dd-java-agent/instrumentation/servlet-common/src/test/groovy/HttpServletResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet-common/src/test/groovy/HttpServletResponseInstrumentationTest.groovy
@@ -182,7 +182,7 @@ class HttpServletResponseInstrumentationTest extends AgentTestRunner {
 
     then:
     noExceptionThrown()
-    1 * module.taintIfTainted(_, "http://dummy.url.com")
+    1 * module.taintStringIfTainted(_, "http://dummy.url.com")
     0 * _
   }
 
@@ -197,7 +197,7 @@ class HttpServletResponseInstrumentationTest extends AgentTestRunner {
 
     then:
     noExceptionThrown()
-    1 * module.taintIfTainted(_, "http://dummy.url.com")
+    1 * module.taintStringIfTainted(_, "http://dummy.url.com")
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/MultipartInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/MultipartInstrumentation.java
@@ -69,7 +69,8 @@ public class MultipartInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER, "Content-Disposition");
+        module.taintString(
+            ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER, "Content-Disposition");
       }
       return name;
     }
@@ -86,7 +87,7 @@ public class MultipartInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, name);
+        module.taintString(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, name);
       }
       return value;
     }
@@ -107,7 +108,7 @@ public class MultipartInstrumentation extends InstrumenterModule.Iast
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final String value : headerValues) {
-          module.taint(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, headerName);
+          module.taintString(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, headerName);
         }
       }
     }
@@ -127,7 +128,7 @@ public class MultipartInstrumentation extends InstrumenterModule.Iast
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final String name : headerNames) {
-          module.taint(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER);
+          module.taintString(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/MultipartInstrumentationForkedTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/MultipartInstrumentationForkedTest.groovy
@@ -36,7 +36,7 @@ class MultipartInstrumentationForkedTest extends AgentTestRunner {
     runUnderIastTrace { part.getName() }
 
     then:
-    1 * module.taint(iastCtx, 'partName', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'Content-Disposition')
+    1 * module.taintString(iastCtx, 'partName', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'Content-Disposition')
     0 * _
   }
 
@@ -50,7 +50,7 @@ class MultipartInstrumentationForkedTest extends AgentTestRunner {
     runUnderIastTrace { part.getHeader('headerName') }
 
     then:
-    1 * module.taint(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
+    1 * module.taintString(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
     0 * _
   }
 
@@ -64,7 +64,7 @@ class MultipartInstrumentationForkedTest extends AgentTestRunner {
     runUnderIastTrace { part.getHeaders('headerName') }
 
     then:
-    1 * module.taint(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
+    1 * module.taintString(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
     0 * _
   }
 
@@ -78,7 +78,7 @@ class MultipartInstrumentationForkedTest extends AgentTestRunner {
     runUnderIastTrace { part.getHeaderNames() }
 
     then:
-    1 * module.taint(iastCtx, 'headerName', SourceTypes.REQUEST_MULTIPART_PARAMETER)
+    1 * module.taintString(iastCtx, 'headerName', SourceTypes.REQUEST_MULTIPART_PARAMETER)
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestCallSite.java
@@ -33,7 +33,7 @@ public class JakartaHttpServletRequestCallSite {
         try {
           final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
-            module.taint(ctx, retValue, SourceTypes.REQUEST_PATH);
+            module.taintString(ctx, retValue, SourceTypes.REQUEST_PATH);
           }
         } catch (final Throwable e) {
           module.onUnexpectedException("afterPath threw", e);
@@ -55,7 +55,7 @@ public class JakartaHttpServletRequestCallSite {
         try {
           final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
-            module.taint(ctx, retValue, SourceTypes.REQUEST_URI);
+            module.taintObject(ctx, retValue, SourceTypes.REQUEST_URI);
           }
         } catch (final Throwable e) {
           module.onUnexpectedException("afterGetRequestURL threw", e);

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletRequestInstrumentation.java
@@ -114,7 +114,7 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      module.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+      module.taintString(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
     }
   }
 
@@ -177,7 +177,7 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+      module.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
     }
   }
 
@@ -198,7 +198,7 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       }
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final String value : values) {
-        module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        module.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }
@@ -220,11 +220,11 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final Map.Entry<String, String[]> entry : parameters.entrySet()) {
         final String name = entry.getKey();
-        module.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+        module.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
         final String[] values = entry.getValue();
         if (values != null) {
           for (final String value : entry.getValue()) {
-            module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+            module.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
           }
         }
       }
@@ -268,7 +268,7 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
       }
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final Cookie cookie : cookies) {
-        module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
+        module.taintObject(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
       }
     }
   }
@@ -287,7 +287,7 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      module.taint(ctx, queryString, SourceTypes.REQUEST_QUERY);
+      module.taintString(ctx, queryString, SourceTypes.REQUEST_QUERY);
     }
   }
 
@@ -305,7 +305,7 @@ public class JakartaHttpServletRequestInstrumentation extends InstrumenterModule
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      module.taint(ctx, body, SourceTypes.REQUEST_BODY);
+      module.taintObject(ctx, body, SourceTypes.REQUEST_BODY);
     }
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaHttpServletResponseInstrumentation.java
@@ -120,7 +120,7 @@ public final class JakartaHttpServletResponseInstrumentation extends Instrumente
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         if (null != url && !url.isEmpty() && null != encoded && !encoded.isEmpty()) {
-          module.taintIfTainted(encoded, url);
+          module.taintStringIfTainted(encoded, url);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaMultipartInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/JakartaMultipartInstrumentation.java
@@ -65,7 +65,8 @@ public class JakartaMultipartInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER, "Content-Disposition");
+        module.taintString(
+            ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER, "Content-Disposition");
       }
       return name;
     }
@@ -82,7 +83,7 @@ public class JakartaMultipartInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, name);
+        module.taintString(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, name);
       }
       return value;
     }
@@ -103,7 +104,7 @@ public class JakartaMultipartInstrumentation extends InstrumenterModule.Iast
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final String value : headerValues) {
-          module.taint(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, headerName);
+          module.taintString(ctx, value, SourceTypes.REQUEST_MULTIPART_PARAMETER, headerName);
         }
       }
     }
@@ -123,7 +124,7 @@ public class JakartaMultipartInstrumentation extends InstrumenterModule.Iast
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final String name : headerNames) {
-          module.taint(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER);
+          module.taintString(ctx, name, SourceTypes.REQUEST_MULTIPART_PARAMETER);
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletRequestInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletRequestInstrumentationTest.groovy
@@ -47,7 +47,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == 'value'
     1 * mock.getHeader('header') >> 'value'
-    1 * iastModule.taint(iastCtx, 'value', SourceTypes.REQUEST_HEADER_VALUE, 'header')
+    1 * iastModule.taintString(iastCtx, 'value', SourceTypes.REQUEST_HEADER_VALUE, 'header')
     0 * _
 
     where:
@@ -68,7 +68,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == headers
     1 * mock.getHeaders('headers') >> Collections.enumeration(headers)
-    headers.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_VALUE, 'headers') }
+    headers.each { 1 * iastModule.taintString(iastCtx, it, SourceTypes.REQUEST_HEADER_VALUE, 'headers') }
     0 * _
 
     where:
@@ -89,7 +89,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == headers
     1 * mock.getHeaderNames() >> Collections.enumeration(headers)
-    headers.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) }
+    headers.each { 1 * iastModule.taintString(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) }
     0 * _
 
     where:
@@ -109,7 +109,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == 'value'
     1 * mock.getParameter('parameter') >> 'value'
-    1 * iastModule.taint(iastCtx, 'value', SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter')
+    1 * iastModule.taintString(iastCtx, 'value', SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter')
     0 * _
 
     where:
@@ -130,7 +130,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == values
     1 * mock.getParameterValues('parameter') >> { values as String[] }
-    values.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter') }
+    values.each { 1 * iastModule.taintString(iastCtx, it, SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter') }
     0 * _
 
     where:
@@ -152,9 +152,9 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     result == parameters
     1 * mock.getParameterMap() >> parameters
     parameters.each { key, values ->
-      1 * iastModule.taint(iastCtx, key, SourceTypes.REQUEST_PARAMETER_NAME, key)
+      1 * iastModule.taintString(iastCtx, key, SourceTypes.REQUEST_PARAMETER_NAME, key)
       values.each { value ->
-        1 * iastModule.taint(iastCtx, value, SourceTypes.REQUEST_PARAMETER_VALUE, key)
+        1 * iastModule.taintString(iastCtx, value, SourceTypes.REQUEST_PARAMETER_VALUE, key)
       }
     }
     0 * _
@@ -178,7 +178,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == parameters
     1 * mock.getParameterNames() >> Collections.enumeration(parameters)
-    parameters.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it) }
+    parameters.each { 1 * iastModule.taintString(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it) }
     0 * _
 
     where:
@@ -199,7 +199,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == cookies
     1 * mock.getCookies() >> cookies
-    cookies.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_COOKIE_VALUE) }
+    cookies.each { 1 * iastModule.taintObject(iastCtx, it, SourceTypes.REQUEST_COOKIE_VALUE) }
     0 * _
 
     where:
@@ -276,7 +276,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == queryString
     1 * mock.getQueryString() >> queryString
-    1 * iastModule.taint(iastCtx, queryString, SourceTypes.REQUEST_QUERY)
+    1 * iastModule.taintString(iastCtx, queryString, SourceTypes.REQUEST_QUERY)
     0 * _
 
     where:
@@ -297,7 +297,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == is
     1 * mock.getInputStream() >> is
-    1 * iastModule.taint(iastCtx, is, SourceTypes.REQUEST_BODY)
+    1 * iastModule.taintObject(iastCtx, is, SourceTypes.REQUEST_BODY)
     0 * _
 
     where:
@@ -318,7 +318,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == reader
     1 * mock.getReader() >> reader
-    1 * iastModule.taint(iastCtx, reader, SourceTypes.REQUEST_BODY)
+    1 * iastModule.taintObject(iastCtx, reader, SourceTypes.REQUEST_BODY)
     0 * _
 
     where:
@@ -361,7 +361,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == uri
     1 * mock.getRequestURI() >> uri
-    1 * iastModule.taint(iastCtx, uri, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taintString(iastCtx, uri, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -382,7 +382,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == pathInfo
     1 * mock.getPathInfo() >> pathInfo
-    1 * iastModule.taint(iastCtx, pathInfo, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taintString(iastCtx, pathInfo, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -403,7 +403,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == pathTranslated
     1 * mock.getPathTranslated() >> pathTranslated
-    1 * iastModule.taint(iastCtx, pathTranslated, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taintString(iastCtx, pathTranslated, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -424,7 +424,7 @@ class JakartaHttpServletRequestInstrumentationTest extends AgentTestRunner {
     then:
     result == url
     1 * mock.getRequestURL() >> url
-    1 * iastModule.taint(iastCtx, url, SourceTypes.REQUEST_URI)
+    1 * iastModule.taintObject(iastCtx, url, SourceTypes.REQUEST_URI)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletResponseInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaHttpServletResponseInstrumentationTest.groovy
@@ -219,7 +219,7 @@ class JakartaHttpServletResponseInstrumentationTest extends AgentTestRunner {
     result = response.encodeRedirectURL(url)
 
     then:
-    1 * module.taintIfTainted(_, url) >> { args -> expected = args[0] }
+    1 * module.taintStringIfTainted(_, url) >> { args -> expected = args[0] }
     0 * _
     result == expected
   }
@@ -236,7 +236,7 @@ class JakartaHttpServletResponseInstrumentationTest extends AgentTestRunner {
     result = response.encodeURL(url)
 
     then:
-    1 * module.taintIfTainted(_, url) >> { args -> expected = args[0] }
+    1 * module.taintStringIfTainted(_, url) >> { args -> expected = args[0] }
     0 * _
     expected == result
   }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaMultipartInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/test/groovy/JakartaMultipartInstrumentationTest.groovy
@@ -35,7 +35,7 @@ class JakartaMultipartInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { part.getName() }
 
     then:
-    1 * module.taint(iastCtx, 'partName', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'Content-Disposition')
+    1 * module.taintString(iastCtx, 'partName', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'Content-Disposition')
     0 * _
   }
 
@@ -49,7 +49,7 @@ class JakartaMultipartInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { part.getHeader('headerName') }
 
     then:
-    1 * module.taint(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
+    1 * module.taintString(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
     0 * _
   }
 
@@ -63,7 +63,7 @@ class JakartaMultipartInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { part.getHeaders('headerName') }
 
     then:
-    1 * module.taint(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
+    1 * module.taintString(iastCtx, 'headerValue', SourceTypes.REQUEST_MULTIPART_PARAMETER, 'headerName')
     0 * _
   }
 
@@ -77,7 +77,7 @@ class JakartaMultipartInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { part.getHeaderNames() }
 
     then:
-    1 * module.taint(iastCtx, 'headerName', SourceTypes.REQUEST_MULTIPART_PARAMETER)
+    1 * module.taintString(iastCtx, 'headerName', SourceTypes.REQUEST_MULTIPART_PARAMETER)
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/CookieInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/CookieInstrumentation.java
@@ -59,7 +59,7 @@ public class CookieInstrumentation extends InstrumenterModule.Iast
       if (module != null) {
         try {
           IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
+          module.taintStringIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
         } catch (final Throwable e) {
           module.onUnexpectedException("afterGetName threw", e);
         }
@@ -81,7 +81,7 @@ public class CookieInstrumentation extends InstrumenterModule.Iast
       if (module != null) {
         try {
           IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_VALUE, name);
+          module.taintStringIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_VALUE, name);
         } catch (final Throwable e) {
           module.onUnexpectedException("getValue threw", e);
         }

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestCallSite.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestCallSite.java
@@ -33,7 +33,7 @@ public class HttpServletRequestCallSite {
         try {
           final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
-            module.taint(ctx, retValue, SourceTypes.REQUEST_PATH);
+            module.taintString(ctx, retValue, SourceTypes.REQUEST_PATH);
           }
         } catch (final Throwable e) {
           module.onUnexpectedException("afterPath threw", e);
@@ -55,7 +55,7 @@ public class HttpServletRequestCallSite {
         try {
           final IastContext ctx = IastContext.Provider.get(AgentTracer.activeSpan());
           if (ctx != null) {
-            module.taint(ctx, retValue, SourceTypes.REQUEST_URI);
+            module.taintObject(ctx, retValue, SourceTypes.REQUEST_URI);
           }
         } catch (final Throwable e) {
           module.onUnexpectedException("afterGetRequestURL threw", e);

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletRequestInstrumentation.java
@@ -114,7 +114,7 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      module.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+      module.taintString(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
     }
   }
 
@@ -177,7 +177,7 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+      module.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
     }
   }
 
@@ -198,7 +198,7 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       }
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final String value : values) {
-        module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        module.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }
@@ -220,11 +220,11 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final Map.Entry<String, String[]> entry : parameters.entrySet()) {
         final String name = entry.getKey();
-        module.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+        module.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
         final String[] values = entry.getValue();
         if (values != null) {
           for (final String value : entry.getValue()) {
-            module.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+            module.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
           }
         }
       }
@@ -268,7 +268,7 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
       }
       final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
       for (final Cookie cookie : cookies) {
-        module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
+        module.taintObject(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
       }
     }
   }
@@ -287,7 +287,7 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      module.taint(ctx, queryString, SourceTypes.REQUEST_QUERY);
+      module.taintString(ctx, queryString, SourceTypes.REQUEST_QUERY);
     }
   }
 
@@ -305,7 +305,7 @@ public class HttpServletRequestInstrumentation extends InstrumenterModule.Iast
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      module.taint(ctx, body, SourceTypes.REQUEST_BODY);
+      module.taintObject(ctx, body, SourceTypes.REQUEST_BODY);
     }
   }
 

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/CookieInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/CookieInstrumentationTest.groovy
@@ -38,7 +38,7 @@ class CookieInstrumentationTest extends AgentTestRunner {
 
     then:
     result == NAME
-    1 * iastModule.taintIfTainted(iastCtx, NAME, cookie, SourceTypes.REQUEST_COOKIE_NAME, NAME)
+    1 * iastModule.taintStringIfTainted(iastCtx, NAME, cookie, SourceTypes.REQUEST_COOKIE_NAME, NAME)
   }
 
   void 'test getValue'() {
@@ -52,7 +52,7 @@ class CookieInstrumentationTest extends AgentTestRunner {
 
     then:
     result == VALUE
-    1 * iastModule.taintIfTainted(iastCtx, VALUE, cookie, SourceTypes.REQUEST_COOKIE_VALUE, NAME)
+    1 * iastModule.taintStringIfTainted(iastCtx, VALUE, cookie, SourceTypes.REQUEST_COOKIE_VALUE, NAME)
   }
 
   protected <E> E runUnderIastTrace(Closure<E> cl) {

--- a/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestTest.groovy
+++ b/dd-java-agent/instrumentation/servlet/src/test/groovy/HttpServletRequestTest.groovy
@@ -49,7 +49,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == 'value'
     1 * mock.getHeader('header') >> 'value'
-    1 * iastModule.taint(iastCtx, 'value', SourceTypes.REQUEST_HEADER_VALUE, 'header')
+    1 * iastModule.taintString(iastCtx, 'value', SourceTypes.REQUEST_HEADER_VALUE, 'header')
     0 * _
 
     where:
@@ -70,7 +70,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == headers
     1 * mock.getHeaders('headers') >> Collections.enumeration(headers)
-    headers.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_VALUE, 'headers') }
+    headers.each { 1 * iastModule.taintString(iastCtx, it, SourceTypes.REQUEST_HEADER_VALUE, 'headers') }
     0 * _
 
     where:
@@ -91,7 +91,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == headers
     1 * mock.getHeaderNames() >> Collections.enumeration(headers)
-    headers.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) }
+    headers.each { 1 * iastModule.taintString(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) }
     0 * _
 
     where:
@@ -111,7 +111,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == 'value'
     1 * mock.getParameter('parameter') >> 'value'
-    1 * iastModule.taint(iastCtx, 'value', SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter')
+    1 * iastModule.taintString(iastCtx, 'value', SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter')
     0 * _
 
     where:
@@ -132,7 +132,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == values
     1 * mock.getParameterValues('parameter') >> { values as String[] }
-    values.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter') }
+    values.each { 1 * iastModule.taintString(iastCtx, it, SourceTypes.REQUEST_PARAMETER_VALUE, 'parameter') }
     0 * _
 
     where:
@@ -154,9 +154,9 @@ class HttpServletRequestTest extends AgentTestRunner {
     result == parameters
     1 * mock.getParameterMap() >> parameters
     parameters.each { key, values ->
-      1 * iastModule.taint(iastCtx, key, SourceTypes.REQUEST_PARAMETER_NAME, key)
+      1 * iastModule.taintString(iastCtx, key, SourceTypes.REQUEST_PARAMETER_NAME, key)
       values.each { value ->
-        1 * iastModule.taint(iastCtx, value, SourceTypes.REQUEST_PARAMETER_VALUE, key)
+        1 * iastModule.taintString(iastCtx, value, SourceTypes.REQUEST_PARAMETER_VALUE, key)
       }
     }
     0 * _
@@ -179,7 +179,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == parameters
     1 * mock.getParameterNames() >> Collections.enumeration(parameters)
-    parameters.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it) }
+    parameters.each { 1 * iastModule.taintString(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it) }
     0 * _
 
     where:
@@ -200,7 +200,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == cookies
     1 * mock.getCookies() >> cookies
-    cookies.each { 1 * iastModule.taint(iastCtx, it, SourceTypes.REQUEST_COOKIE_VALUE) }
+    cookies.each { 1 * iastModule.taintObject(iastCtx, it, SourceTypes.REQUEST_COOKIE_VALUE) }
     0 * _
 
     where:
@@ -277,7 +277,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == queryString
     1 * mock.getQueryString() >> queryString
-    1 * iastModule.taint(iastCtx, queryString, SourceTypes.REQUEST_QUERY)
+    1 * iastModule.taintString(iastCtx, queryString, SourceTypes.REQUEST_QUERY)
     0 * _
 
     where:
@@ -298,7 +298,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == is
     1 * mock.getInputStream() >> is
-    1 * iastModule.taint(iastCtx, is, SourceTypes.REQUEST_BODY)
+    1 * iastModule.taintObject(iastCtx, is, SourceTypes.REQUEST_BODY)
     0 * _
 
     where:
@@ -319,7 +319,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == reader
     1 * mock.getReader() >> reader
-    1 * iastModule.taint(iastCtx, reader, SourceTypes.REQUEST_BODY)
+    1 * iastModule.taintObject(iastCtx, reader, SourceTypes.REQUEST_BODY)
     0 * _
 
     where:
@@ -362,7 +362,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == uri
     1 * mock.getRequestURI() >> uri
-    1 * iastModule.taint(iastCtx, uri, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taintString(iastCtx, uri, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -383,7 +383,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == pathInfo
     1 * mock.getPathInfo() >> pathInfo
-    1 * iastModule.taint(iastCtx, pathInfo, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taintString(iastCtx, pathInfo, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -404,7 +404,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == pathTranslated
     1 * mock.getPathTranslated() >> pathTranslated
-    1 * iastModule.taint(iastCtx, pathTranslated, SourceTypes.REQUEST_PATH)
+    1 * iastModule.taintString(iastCtx, pathTranslated, SourceTypes.REQUEST_PATH)
     0 * _
 
     where:
@@ -425,7 +425,7 @@ class HttpServletRequestTest extends AgentTestRunner {
     then:
     result == url
     1 * mock.getRequestURL() >> url
-    1 * iastModule.taint(iastCtx, url, SourceTypes.REQUEST_URI)
+    1 * iastModule.taintObject(iastCtx, url, SourceTypes.REQUEST_URI)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/spring-core/src/main/java/datadog/trace/instrumentation/springcore/StreamUtilsInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-core/src/main/java/datadog/trace/instrumentation/springcore/StreamUtilsInstrumentation.java
@@ -50,7 +50,7 @@ public final class StreamUtilsInstrumentation extends InstrumenterModule.Iast
         @Advice.Return String string, @Advice.Argument(0) final InputStream in) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (string != null && module != null) {
-        module.taintIfTainted(string, in);
+        module.taintStringIfTainted(string, in);
       }
     }
 

--- a/dd-java-agent/instrumentation/spring-core/src/test/groovy/datadog/trace/instrumentation/springcore/StreamUtilsInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/spring-core/src/test/groovy/datadog/trace/instrumentation/springcore/StreamUtilsInstrumentationTest.groovy
@@ -24,7 +24,7 @@ class StreamUtilsInstrumentationTest extends AgentTestRunner {
     StreamUtils.copyToString(new ByteArrayInputStream("test".getBytes()), StandardCharsets.ISO_8859_1)
 
     then:
-    1 * module.taintIfTainted(_ as String, _ as InputStream)
+    1 * module.taintStringIfTainted(_ as String, _ as InputStream)
     0 * _
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/AbstractServerHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/AbstractServerHttpRequestInstrumentation.java
@@ -50,7 +50,7 @@ public class AbstractServerHttpRequestInstrumentation extends InstrumenterModule
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      propagation.taint(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
+      propagation.taintObject(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/DataBufferAsInputStreamAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/DataBufferAsInputStreamAdvice.java
@@ -18,6 +18,6 @@ public class DataBufferAsInputStreamAdvice {
       return;
     }
 
-    mod.taintIfTainted(is, dataBuffer);
+    mod.taintObjectIfTainted(is, dataBuffer);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HandleMatchAdvice.java
@@ -40,7 +40,7 @@ public class HandleMatchAdvice {
           if (parameterName == null || value == null) {
             continue; // should not happen
           }
-          module.taint(
+          module.taintString(
               iastRequestContext, value, SourceTypes.REQUEST_PATH_PARAMETER, parameterName);
         }
       }
@@ -57,7 +57,7 @@ public class HandleMatchAdvice {
           for (Map.Entry<String, Iterable<String>> ie : value.entrySet()) {
             String innerKey = ie.getKey();
             if (innerKey != null) {
-              module.taint(
+              module.taintString(
                   iastRequestContext,
                   innerKey,
                   SourceTypes.REQUEST_MATRIX_PARAMETER,
@@ -66,7 +66,7 @@ public class HandleMatchAdvice {
             Iterable<String> innerValues = ie.getValue();
             if (innerValues != null) {
               for (String iv : innerValues) {
-                module.taint(
+                module.taintString(
                     iastRequestContext, iv, SourceTypes.REQUEST_MATRIX_PARAMETER, parameterName);
               }
             }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HttpMessageInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/HttpMessageInstrumentation.java
@@ -58,7 +58,7 @@ public class HttpMessageInstrumentation extends InstrumenterModule.Iast
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      propagation.taint(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
+      propagation.taintObject(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ReactorServerHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ReactorServerHttpRequestInstrumentation.java
@@ -48,7 +48,7 @@ public class ReactorServerHttpRequestInstrumentation extends InstrumenterModule.
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      propagation.taint(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
+      propagation.taintObject(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/RequestHeaderMapResolveAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/RequestHeaderMapResolveAdvice.java
@@ -32,17 +32,17 @@ public class RequestHeaderMapResolveAdvice {
       for (Map.Entry<String, List<String>> e :
           ((MultiValueMap<String, String>) values).entrySet()) {
         final String name = e.getKey();
-        prop.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
         for (String v : e.getValue()) {
-          prop.taint(ctx, v, SourceTypes.REQUEST_HEADER_VALUE, name);
+          prop.taintString(ctx, v, SourceTypes.REQUEST_HEADER_VALUE, name);
         }
       }
     } else {
       for (Map.Entry<String, String> e : ((Map<String, String>) values).entrySet()) {
         final String name = e.getKey();
         final String value = e.getValue();
-        prop.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
-        prop.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+        prop.taintString(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
+        prop.taintString(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ServerServletHttpRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/ServerServletHttpRequestInstrumentation.java
@@ -48,7 +48,7 @@ public class ServerServletHttpRequestInstrumentation extends InstrumenterModule.
         return;
       }
       IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-      propagation.taint(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
+      propagation.taintObject(ctx, object, SourceTypes.REQUEST_HEADER_VALUE);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintCookiesAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintCookiesAdvice.java
@@ -30,8 +30,8 @@ class TaintCookiesAdvice {
       for (HttpCookie cookie : cookieList) {
         final String name = cookie.getName();
         final String value = cookie.getValue();
-        module.taint(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
-        module.taint(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
+        module.taintString(ctx, name, SourceTypes.REQUEST_COOKIE_NAME, name);
+        module.taintString(ctx, value, SourceTypes.REQUEST_COOKIE_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintFluxElementsFunction.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintFluxElementsFunction.java
@@ -17,7 +17,7 @@ public class TaintFluxElementsFunction<T> implements Function<T, T> {
 
   @Override
   public T apply(T t) {
-    propagation.taint(ctx, t, SourceTypes.REQUEST_BODY);
+    propagation.taintObject(ctx, t, SourceTypes.REQUEST_BODY);
     return t;
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintGetBodyAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintGetBodyAdvice.java
@@ -27,7 +27,7 @@ class TaintGetBodyAdvice {
 
     // taint both the flux and the individual DataBuffers
     IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-    propagation.taint(ctx, flux, SourceTypes.REQUEST_BODY);
+    propagation.taintObject(ctx, flux, SourceTypes.REQUEST_BODY);
     flux = flux.map(new TaintFluxElementsFunction<>(ctx, propagation));
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetAdvice.java
@@ -34,7 +34,7 @@ class TaintHttpHeadersGetAdvice {
     final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
     String lc = ((String) arg).toLowerCase(Locale.ROOT);
     for (String value : values) {
-      module.taintIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, lc);
+      module.taintStringIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, lc);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersGetFirstAdvice.java
@@ -27,6 +27,6 @@ class TaintHttpHeadersGetFirstAdvice {
       return;
     }
     IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-    module.taintIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, arg);
+    module.taintStringIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, arg);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintHttpHeadersToSingleValueMapAdvice.java
@@ -31,8 +31,8 @@ class TaintHttpHeadersToSingleValueMapAdvice {
     for (Map.Entry<String, String> e : values.entrySet()) {
       final String name = e.getKey();
       final String value = e.getValue();
-      module.taintIfTainted(ctx, name, self, SourceTypes.REQUEST_HEADER_NAME, name);
-      module.taintIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, name);
+      module.taintStringIfTainted(ctx, name, self, SourceTypes.REQUEST_HEADER_NAME, name);
+      module.taintStringIfTainted(ctx, value, self, SourceTypes.REQUEST_HEADER_VALUE, name);
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintQueryParamsAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintQueryParamsAdvice.java
@@ -31,9 +31,9 @@ class TaintQueryParamsAdvice {
     final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
     for (Map.Entry<String, List<String>> e : queryParams.entrySet()) {
       String name = e.getKey();
-      prop.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+      prop.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
       for (String value : e.getValue()) {
-        prop.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        prop.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintReadOnlyHttpHeadersAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/iast/TaintReadOnlyHttpHeadersAdvice.java
@@ -26,6 +26,6 @@ class TaintReadOnlyHttpHeadersAdvice {
       return;
     }
     final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-    module.taintIfTainted(ctx, retValue, headers);
+    module.taintObjectIfTainted(ctx, retValue, headers);
   }
 }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/HeadersAdviceForkedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/HeadersAdviceForkedTest.groovy
@@ -35,7 +35,7 @@ class HeadersAdviceForkedTest extends AgentTestRunner {
     runUnderIastTrace { request.getHeaders() }
 
     then:
-    2 * module.taint(iastCtx , _ as Object, SourceTypes.REQUEST_HEADER_VALUE)
+    2 * module.taintObject(iastCtx , _ as Object, SourceTypes.REQUEST_HEADER_VALUE)
     0 * _
   }
 

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
@@ -196,7 +196,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends InstrumenterModul
                 if (parameterName == null || value == null) {
                   continue; // should not happen
                 }
-                module.taint(
+                module.taintString(
                     iastRequestContext, value, SourceTypes.REQUEST_PATH_PARAMETER, parameterName);
               }
             }
@@ -213,7 +213,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends InstrumenterModul
                 for (Map.Entry<String, Iterable<String>> ie : value.entrySet()) {
                   String innerKey = ie.getKey();
                   if (innerKey != null) {
-                    module.taint(
+                    module.taintString(
                         iastRequestContext,
                         innerKey,
                         SourceTypes.REQUEST_MATRIX_PARAMETER,
@@ -222,7 +222,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends InstrumenterModul
                   Iterable<String> innerValues = ie.getValue();
                   if (innerValues != null) {
                     for (String iv : innerValues) {
-                      module.taint(
+                      module.taintString(
                           iastRequestContext,
                           iv,
                           SourceTypes.REQUEST_MATRIX_PARAMETER,

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -154,7 +154,7 @@ public class TemplateVariablesUrlHandlerInstrumentation extends InstrumenterModu
               if (parameterName == null || value == null) {
                 continue; // should not happen
               }
-              module.taint(
+              module.taintString(
                   iastRequestContext, value, SourceTypes.REQUEST_PATH_PARAMETER, parameterName);
             }
           }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/boot/SpringBootBasedTest.groovy
@@ -259,7 +259,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     TEST_WRITER.waitForTraces(1)
 
     then:
-    1 * mod.taint(_ as IastContext, '123', SourceTypes.REQUEST_PATH_PARAMETER, 'id')
+    1 * mod.taintString(_ as IastContext, '123', SourceTypes.REQUEST_PATH_PARAMETER, 'id')
     0 * mod._
 
     cleanup:
@@ -295,11 +295,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
     TEST_WRITER.waitForTraces(1)
 
     then:
-    1 * mod.taint(_ as IastContext, 'a=x,y;a=z', SourceTypes.REQUEST_PATH_PARAMETER, 'var')
-    1 * mod.taint(_ as IastContext, 'a', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
-    1 * mod.taint(_ as IastContext, 'x', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
-    1 * mod.taint(_ as IastContext, 'y', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
-    1 * mod.taint(_ as IastContext, 'z', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
+    1 * mod.taintString(_ as IastContext, 'a=x,y;a=z', SourceTypes.REQUEST_PATH_PARAMETER, 'var')
+    1 * mod.taintString(_ as IastContext, 'a', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
+    1 * mod.taintString(_ as IastContext, 'x', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
+    1 * mod.taintString(_ as IastContext, 'y', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
+    1 * mod.taintString(_ as IastContext, 'z', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
     0 * mod._
 
     cleanup:

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/urlhandlermapping/UrlHandlerMappingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/test/groovy/test/urlhandlermapping/UrlHandlerMappingTest.groovy
@@ -203,7 +203,7 @@ class UrlHandlerMappingTest extends HttpServerTest<ConfigurableApplicationContex
     TEST_WRITER.waitForTraces(1)
 
     then:
-    1 * mod.taint(_ as IastContext, '123', SourceTypes.REQUEST_PATH_PARAMETER, 'id')
+    1 * mod.taintString(_ as IastContext, '123', SourceTypes.REQUEST_PATH_PARAMETER, 'id')
     0 * mod._
 
     cleanup:

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/EscapeUtilsCallSite.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/EscapeUtilsCallSite.java
@@ -21,7 +21,7 @@ public class EscapeUtilsCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterEscape threw", e);
       }
@@ -38,7 +38,7 @@ public class EscapeUtilsCallSite {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+        module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
       } catch (final Throwable e) {
         module.onUnexpectedException("afterHtmlEscape2 threw", e);
       }

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/test/groovy/EscapeUtilsCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/test/groovy/EscapeUtilsCallSiteTest.groovy
@@ -21,7 +21,7 @@ class EscapeUtilsCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * module.taintIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
+    1 * module.taintStringIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/HandleMatchAdvice.java
@@ -124,7 +124,7 @@ public class HandleMatchAdvice {
               if (parameterName == null || value == null) {
                 continue; // should not happen
               }
-              module.taint(
+              module.taintString(
                   iastRequestContext, value, SourceTypes.REQUEST_PATH_PARAMETER, parameterName);
             }
           }
@@ -141,7 +141,7 @@ public class HandleMatchAdvice {
               for (Map.Entry<String, Iterable<String>> ie : value.entrySet()) {
                 String innerKey = ie.getKey();
                 if (innerKey != null) {
-                  module.taint(
+                  module.taintString(
                       iastRequestContext,
                       innerKey,
                       SourceTypes.REQUEST_MATRIX_PARAMETER,
@@ -150,7 +150,7 @@ public class HandleMatchAdvice {
                 Iterable<String> innerValues = ie.getValue();
                 if (innerValues != null) {
                   for (String iv : innerValues) {
-                    module.taint(
+                    module.taintString(
                         iastRequestContext,
                         iv,
                         SourceTypes.REQUEST_MATRIX_PARAMETER,

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/InterceptorPreHandleAdvice.java
@@ -91,7 +91,7 @@ public class InterceptorPreHandleAdvice {
             if (parameterName == null || value == null) {
               continue; // should not happen
             }
-            module.taint(
+            module.taintString(
                 iastRequestContext, value, SourceTypes.REQUEST_PATH_PARAMETER, parameterName);
           }
         }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/boot/SpringBootBasedTest.groovy
@@ -305,7 +305,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
     then:
     // spring-security filter causes uri matching to happen twice
-    (1.._) * mod.taint(_, '123', SourceTypes.REQUEST_PATH_PARAMETER, 'id')
+    (1.._) * mod.taintString(_ as IastContext, '123', SourceTypes.REQUEST_PATH_PARAMETER, 'id')
     0 * mod._
 
     cleanup:
@@ -344,11 +344,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
 
     then:
     // spring-security filter (AuthorizationFilter.java:95) causes uri matching to happen twice (or three times in recent spring (6.1+) versions)
-    (1.._) * mod.taint(_ as IastContext, 'a=x,y', SourceTypes.REQUEST_PATH_PARAMETER, 'var') // this version of spring removes ;a=z
-    (1.._) * mod.taint(_ as IastContext, 'a', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
-    (1.._) * mod.taint(_ as IastContext, 'x', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
-    (1.._) * mod.taint(_ as IastContext, 'y', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
-    (1.._) * mod.taint(_ as IastContext, 'z', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
+    (1.._) * mod.taintString(_ as IastContext, 'a=x,y', SourceTypes.REQUEST_PATH_PARAMETER, 'var') // this version of spring removes ;a=z
+    (1.._) * mod.taintString(_ as IastContext, 'a', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
+    (1.._) * mod.taintString(_ as IastContext, 'x', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
+    (1.._) * mod.taintString(_ as IastContext, 'y', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
+    (1.._) * mod.taintString(_ as IastContext, 'z', SourceTypes.REQUEST_MATRIX_PARAMETER, 'var')
     0 * mod._
 
     cleanup:

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/urlhandlermapping/UrlHandlerMappingTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/urlhandlermapping/UrlHandlerMappingTest.groovy
@@ -207,7 +207,7 @@ class UrlHandlerMappingTest extends HttpServerTest<ConfigurableApplicationContex
     TEST_WRITER.waitForTraces(1)
 
     then:
-    1 * mod.taint(_, '123', SourceTypes.REQUEST_PATH_PARAMETER, 'id')
+    1 * mod.taintString(_, '123', SourceTypes.REQUEST_PATH_PARAMETER, 'id')
     0 * mod._
 
     cleanup:

--- a/dd-java-agent/instrumentation/unbescape/src/main/java/datadog/trace/instrumentation/unbescape/EscapeUtilsCallSite.java
+++ b/dd-java-agent/instrumentation/unbescape/src/main/java/datadog/trace/instrumentation/unbescape/EscapeUtilsCallSite.java
@@ -24,7 +24,7 @@ public class EscapeUtilsCallSite {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         try {
-          module.taintIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
+          module.taintStringIfTainted(result, input, false, VulnerabilityMarks.XSS_MARK);
         } catch (final Throwable e) {
           module.onUnexpectedException("afterEscape threw", e);
         }

--- a/dd-java-agent/instrumentation/unbescape/src/test/groovy/datadog/trace/instrumentation/unbescape/EscapeUtilsCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/unbescape/src/test/groovy/datadog/trace/instrumentation/unbescape/EscapeUtilsCallSiteTest.groovy
@@ -23,7 +23,7 @@ class EscapeUtilsCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * module.taintIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
+    1 * module.taintStringIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/AbstractHttpServerRequestInstrumentation.java
@@ -77,7 +77,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taint(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
+          module.taintObject(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
         }
       }
     }
@@ -104,7 +104,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taint(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
+          module.taintObject(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
         }
       }
     }
@@ -120,7 +120,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, data, SourceTypes.REQUEST_BODY);
+        module.taintObject(ctx, data, SourceTypes.REQUEST_BODY);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/BufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/BufferInstrumentation.java
@@ -65,7 +65,7 @@ public class BufferInstrumentation extends InstrumenterModule.Iast
     public static void get(@Advice.This final Object self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (result != null && module != null) {
-        module.taintIfTainted(result, self);
+        module.taintStringIfTainted(result, self);
       }
     }
   }
@@ -76,7 +76,7 @@ public class BufferInstrumentation extends InstrumenterModule.Iast
     public static void get(@Advice.This final Object self, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (result != null && module != null) {
-        module.taintIfTainted(result, self);
+        module.taintObjectIfTainted(result, self);
       }
     }
   }
@@ -88,7 +88,7 @@ public class BufferInstrumentation extends InstrumenterModule.Iast
         @Advice.Argument(0) final Object buffer, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (result != null && module != null) {
-        module.taintIfTainted(result, buffer);
+        module.taintObjectIfTainted(result, buffer);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/CaseInsensitiveHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/CaseInsensitiveHeadersInstrumentation.java
@@ -91,7 +91,8 @@ public class CaseInsensitiveHeadersInstrumentation extends InstrumenterModule.Ia
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null) {
         IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        propagation.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+        propagation.taintStringIfTainted(
+            ctx, result, self, SourceTypes.REQUEST_PARAMETER_VALUE, name);
       }
     }
   }
@@ -110,7 +111,7 @@ public class CaseInsensitiveHeadersInstrumentation extends InstrumenterModule.Ia
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (propagation.isTainted(ctx, self)) {
           for (final String value : result) {
-            propagation.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+            propagation.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
           }
         }
       }
@@ -134,9 +135,9 @@ public class CaseInsensitiveHeadersInstrumentation extends InstrumenterModule.Ia
             final String name = entry.getKey();
             final String value = entry.getValue();
             if (names.add(name)) {
-              propagation.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+              propagation.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
             }
-            propagation.taint(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
+            propagation.taintString(ctx, value, SourceTypes.REQUEST_PARAMETER_VALUE, name);
           }
         }
       }
@@ -156,7 +157,7 @@ public class CaseInsensitiveHeadersInstrumentation extends InstrumenterModule.Ia
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (propagation.isTainted(ctx, self)) {
           for (final String name : result) {
-            propagation.taint(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
+            propagation.taintString(ctx, name, SourceTypes.REQUEST_PARAMETER_NAME, name);
           }
         }
       }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HeadersAdaptorInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HeadersAdaptorInstrumentation.java
@@ -83,7 +83,7 @@ public class HeadersAdaptorInstrumentation extends InstrumenterModule.Iast
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        propagation.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_HEADER_VALUE, name);
+        propagation.taintStringIfTainted(ctx, result, self, SourceTypes.REQUEST_HEADER_VALUE, name);
       }
     }
   }
@@ -103,7 +103,7 @@ public class HeadersAdaptorInstrumentation extends InstrumenterModule.Iast
         if (propagation.isTainted(ctx, self)) {
           final String headerName = name == null ? null : name.toString();
           for (final String value : result) {
-            propagation.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, headerName);
+            propagation.taintString(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, headerName);
           }
         }
       }
@@ -127,9 +127,9 @@ public class HeadersAdaptorInstrumentation extends InstrumenterModule.Iast
             final String name = entry.getKey();
             final String value = entry.getValue();
             if (names.add(name)) {
-              propagation.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
+              propagation.taintString(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
             }
-            propagation.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+            propagation.taintString(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
           }
         }
       }
@@ -149,7 +149,7 @@ public class HeadersAdaptorInstrumentation extends InstrumenterModule.Iast
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (propagation.isTainted(ctx, self)) {
           for (final String name : result) {
-            propagation.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
+            propagation.taintString(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
           }
         }
       }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/Http2ServerRequestInstrumentation.java
@@ -62,7 +62,7 @@ public class Http2ServerRequestInstrumentation extends AbstractHttpServerRequest
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taint(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
+          module.taintObject(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
         }
       }
     }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/core/HttpServerRequestInstrumentation.java
@@ -63,7 +63,7 @@ public class HttpServerRequestInstrumentation extends AbstractHttpServerRequestI
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taint(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
+          module.taintObject(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
         }
       }
     }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/CookieImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/CookieImplInstrumentation.java
@@ -67,7 +67,7 @@ public class CookieImplInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
+        module.taintStringIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
       }
     }
   }
@@ -85,7 +85,8 @@ public class CookieImplInstrumentation extends InstrumenterModule.Iast
       if (module != null) {
         // TODO calling self.getName() actually taints the name of the cookie
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_VALUE, self.getName());
+        module.taintStringIfTainted(
+            ctx, result, self, SourceTypes.REQUEST_COOKIE_VALUE, self.getName());
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/IastRoutingContextImplInstrumentation.java
@@ -66,7 +66,7 @@ public class IastRoutingContextImplInstrumentation extends InstrumenterModule.Ia
       if (module != null && cookies != null && !cookies.isEmpty()) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final Object cookie : cookies) {
-          module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
+          module.taintObject(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
         }
       }
     }
@@ -81,7 +81,7 @@ public class IastRoutingContextImplInstrumentation extends InstrumenterModule.Ia
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
+        module.taintObject(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/PathParameterPublishingHelper.java
@@ -72,7 +72,7 @@ public class PathParameterPublishingHelper {
             if (parameterName == null || value == null) {
               continue; // should not happen
             }
-            module.taint(
+            module.taintString(
                 iastRequestContext, value, SourceTypes.REQUEST_PATH_PARAMETER, parameterName);
           }
         }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/BufferInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/BufferInstrumentationTest.groovy
@@ -27,7 +27,7 @@ class BufferInstrumentationTest extends AgentTestRunner {
     method.call(buffer)
 
     then:
-    1 * module.taintIfTainted(_, buffer)
+    1 * module.taintStringIfTainted(_, buffer)
 
     where:
     methodName         | method
@@ -46,7 +46,7 @@ class BufferInstrumentationTest extends AgentTestRunner {
     method.call(buffer, tainted)
 
     then:
-    1 * module.taintIfTainted(buffer, tainted)
+    1 * module.taintObjectIfTainted(buffer, tainted)
 
     where:
     methodName                       | method

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/CaseInsensitiveHeadersInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/CaseInsensitiveHeadersInstrumentationTest.groovy
@@ -37,7 +37,7 @@ class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { headers.get('key') }
 
     then:
-    1 * module.taintIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
+    1 * module.taintStringIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
   }
 
   void 'test that getAll() is instrumented'() {
@@ -59,8 +59,8 @@ class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.isTainted(iastCtx, headers) >> { true }
-    1 * module.taint(iastCtx, 'value1', SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
-    1 * module.taint(iastCtx, 'value2', SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
+    1 * module.taintString(iastCtx, 'value1', SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
+    1 * module.taintString(iastCtx, 'value2', SourceTypes.REQUEST_PARAMETER_VALUE, 'key')
   }
 
   void 'test that names() is instrumented'() {
@@ -82,7 +82,7 @@ class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.isTainted(iastCtx, headers) >> { true }
-    1 * module.taint(iastCtx, 'key', SourceTypes.REQUEST_PARAMETER_NAME, 'key')
+    1 * module.taintString(iastCtx, 'key', SourceTypes.REQUEST_PARAMETER_NAME, 'key')
   }
 
   void 'test that entries() is instrumented'() {
@@ -107,10 +107,10 @@ class CaseInsensitiveHeadersInstrumentationTest extends AgentTestRunner {
     then:
     1 * module.isTainted(iastCtx, headers) >> { true }
     result.collect { it.key }.unique().each {
-      1 * module.taint(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it)
+      1 * module.taintString(iastCtx, it, SourceTypes.REQUEST_PARAMETER_NAME, it)
     }
     result.each {
-      1 * module.taint(iastCtx, it.value, SourceTypes.REQUEST_PARAMETER_VALUE, it.key)
+      1 * module.taintString(iastCtx, it.value, SourceTypes.REQUEST_PARAMETER_VALUE, it.key)
     }
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/HeadersAdaptorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/core/HeadersAdaptorInstrumentationTest.groovy
@@ -39,7 +39,7 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { headers.get('key') }
 
     then:
-    1 * module.taintIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.taintStringIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_HEADER_VALUE, 'key')
 
     where:
     headers        | name
@@ -65,8 +65,8 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.isTainted(iastCtx, headers) >> { true }
-    1 * module.taint(iastCtx, 'value1', SourceTypes.REQUEST_HEADER_VALUE, 'key')
-    1 * module.taint(iastCtx, 'value2', SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.taintString(iastCtx, 'value1', SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.taintString(iastCtx, 'value2', SourceTypes.REQUEST_HEADER_VALUE, 'key')
 
     where:
     headers        | name
@@ -92,7 +92,7 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.isTainted(iastCtx, headers) >> { true }
-    1 * module.taint(iastCtx, 'key', SourceTypes.REQUEST_HEADER_NAME, 'key')
+    1 * module.taintString(iastCtx, 'key', SourceTypes.REQUEST_HEADER_NAME, 'key')
 
     where:
     headers        | name
@@ -121,10 +121,10 @@ class HeadersAdaptorInstrumentationTest extends AgentTestRunner {
     then:
     1 * module.isTainted(iastCtx, headers) >> { true }
     result.collect { it.key }.unique().each {
-      1 * module.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it)
+      1 * module.taintString(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it)
     }
     result.each {
-      1 * module.taint(iastCtx, it.value, SourceTypes.REQUEST_HEADER_VALUE, it.key)
+      1 * module.taintString(iastCtx, it.value, SourceTypes.REQUEST_HEADER_VALUE, it.key)
     }
 
     where:

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/server/IastSourceTest.groovy
@@ -27,7 +27,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    (1.._) * module.taint(_ as IastContext, _, SourceTypes.REQUEST_COOKIE_VALUE)
+    (1.._) * module.taintObject(_ as IastContext, _, SourceTypes.REQUEST_COOKIE_VALUE)
   }
 
   void 'test that getCookie is instrumented'() {
@@ -41,7 +41,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    (1.._) * module.taint(_ as IastContext, _, SourceTypes.REQUEST_COOKIE_VALUE)
+    (1.._) * module.taintObject(_ as IastContext, _, SourceTypes.REQUEST_COOKIE_VALUE)
   }
 
   void 'test that cookie getName is instrumented'() {
@@ -55,7 +55,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintIfTainted(_ as IastContext, 'cookieName', _, SourceTypes.REQUEST_COOKIE_NAME, 'cookieName')
+    1 * module.taintStringIfTainted(_ as IastContext, 'cookieName', _, SourceTypes.REQUEST_COOKIE_NAME, 'cookieName')
   }
 
   void 'test that cookie getValue is instrumented'() {
@@ -69,8 +69,8 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taintIfTainted(_ as IastContext, 'cookieName', _, SourceTypes.REQUEST_COOKIE_NAME, 'cookieName')
-    1 * module.taintIfTainted(_ as IastContext, 'cookieValue', _, SourceTypes.REQUEST_COOKIE_VALUE, 'cookieName')
+    1 * module.taintStringIfTainted(_ as IastContext, 'cookieName', _, SourceTypes.REQUEST_COOKIE_NAME, 'cookieName')
+    1 * module.taintStringIfTainted(_ as IastContext, 'cookieValue', _, SourceTypes.REQUEST_COOKIE_VALUE, 'cookieName')
   }
 
   void 'test that headers() is instrumented'() {
@@ -84,7 +84,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_ as IastContext, _, SourceTypes.REQUEST_HEADER_VALUE)
+    1 * module.taintObject(_ as IastContext, _, SourceTypes.REQUEST_HEADER_VALUE)
   }
 
   void 'test that params() is instrumented'() {
@@ -98,7 +98,7 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_ as IastContext, _, SourceTypes.REQUEST_PARAMETER_VALUE)
+    1 * module.taintObject(_ as IastContext, _, SourceTypes.REQUEST_PARAMETER_VALUE)
   }
 
   void 'test that formAttributes() is instrumented'() {
@@ -113,9 +113,9 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_ as IastContext, _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE) // once for formAttributes()
-    1 * module.taint(_ as IastContext, _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE) // once for params()
-    1 * module.taintIfTainted(_ as IastContext, 'form', _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE, 'formAttribute')
+    1 * module.taintObject(_ as IastContext, _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE) // once for formAttributes()
+    1 * module.taintObject(_ as IastContext, _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE) // once for params()
+    1 * module.taintStringIfTainted(_ as IastContext, 'form', _ as MultiMap, SourceTypes.REQUEST_PARAMETER_VALUE, 'formAttribute')
   }
 
   void 'test that handleData()/onData() is instrumented'() {
@@ -130,8 +130,8 @@ class IastSourceTest extends IastVertx34Server {
     client.newCall(request).execute()
 
     then:
-    1 * module.taint(_ as IastContext, _ as Buffer, SourceTypes.REQUEST_BODY)
-    1 * module.taintIfTainted('{ "my_key": "my_value" }', _ as Buffer)
+    1 * module.taintObject(_ as IastContext, _ as Buffer, SourceTypes.REQUEST_BODY)
+    1 * module.taintStringIfTainted('{ "my_key": "my_value" }', _ as Buffer)
   }
 
 

--- a/dd-java-agent/instrumentation/vertx-web-3.5/src/main/java/datadog/trace/instrumentation/vertx_3_5/core/VertxHttpHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.5/src/main/java/datadog/trace/instrumentation/vertx_3_5/core/VertxHttpHeadersInstrumentation.java
@@ -89,7 +89,7 @@ public class VertxHttpHeadersInstrumentation extends InstrumenterModule.Iast
       final PropagationModule propagation = InstrumentationBridge.PROPAGATION;
       if (propagation != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        propagation.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_HEADER_VALUE, name);
+        propagation.taintStringIfTainted(ctx, result, self, SourceTypes.REQUEST_HEADER_VALUE, name);
       }
     }
   }
@@ -108,7 +108,7 @@ public class VertxHttpHeadersInstrumentation extends InstrumenterModule.Iast
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (propagation.isTainted(ctx, self)) {
           for (final String value : result) {
-            propagation.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+            propagation.taintString(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
           }
         }
       }
@@ -132,9 +132,9 @@ public class VertxHttpHeadersInstrumentation extends InstrumenterModule.Iast
             final String name = entry.getKey();
             final String value = entry.getValue();
             if (names.add(name)) {
-              propagation.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
+              propagation.taintString(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
             }
-            propagation.taint(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
+            propagation.taintString(ctx, value, SourceTypes.REQUEST_HEADER_VALUE, name);
           }
         }
       }
@@ -154,7 +154,7 @@ public class VertxHttpHeadersInstrumentation extends InstrumenterModule.Iast
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         if (propagation.isTainted(ctx, self)) {
           for (final String name : result) {
-            propagation.taint(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
+            propagation.taintString(ctx, name, SourceTypes.REQUEST_HEADER_NAME, name);
           }
         }
       }

--- a/dd-java-agent/instrumentation/vertx-web-3.5/src/test/groovy/core/VertxHttpHeadersInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.5/src/test/groovy/core/VertxHttpHeadersInstrumentationTest.groovy
@@ -36,7 +36,7 @@ class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
     runUnderIastTrace { headers.get('key') }
 
     then:
-    1 * module.taintIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.taintStringIfTainted(iastCtx, 'value', headers, SourceTypes.REQUEST_HEADER_VALUE, 'key')
   }
 
   void 'test that getAll() is instrumented'() {
@@ -58,8 +58,8 @@ class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.isTainted(iastCtx, headers) >> { true }
-    1 * module.taint(iastCtx, 'value1', SourceTypes.REQUEST_HEADER_VALUE, 'key')
-    1 * module.taint(iastCtx, 'value2', SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.taintString(iastCtx, 'value1', SourceTypes.REQUEST_HEADER_VALUE, 'key')
+    1 * module.taintString(iastCtx, 'value2', SourceTypes.REQUEST_HEADER_VALUE, 'key')
   }
 
   void 'test that names() is instrumented'() {
@@ -81,7 +81,7 @@ class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.isTainted(iastCtx, headers) >> { true }
-    1 * module.taint(iastCtx, 'key', SourceTypes.REQUEST_HEADER_NAME, 'key')
+    1 * module.taintString(iastCtx, 'key', SourceTypes.REQUEST_HEADER_NAME, 'key')
   }
 
   void 'test that entries() is instrumented'() {
@@ -104,10 +104,10 @@ class VertxHttpHeadersInstrumentationTest extends AgentTestRunner {
     then:
     module.isTainted(iastCtx, headers) >> { true }
     result.collect { it.key }.unique().each {
-      (1.._) * module.taint(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) // entries relies on names() on some impls
+      (1.._) * module.taintString(iastCtx, it, SourceTypes.REQUEST_HEADER_NAME, it) // entries relies on names() on some impls
     }
     result.each {
-      1 * module.taint(iastCtx, it.value, SourceTypes.REQUEST_HEADER_VALUE, it.key)
+      1 * module.taintString(iastCtx, it.value, SourceTypes.REQUEST_HEADER_VALUE, it.key)
     }
   }
 

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/AbstractHttpServerRequestInstrumentation.java
@@ -85,7 +85,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taint(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
+          module.taintObject(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
         }
       }
     }
@@ -112,7 +112,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
         final PropagationModule module = InstrumentationBridge.PROPAGATION;
         if (module != null) {
           final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-          module.taint(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
+          module.taintObject(ctx, multiMap, SourceTypes.REQUEST_PARAMETER_VALUE);
         }
       }
     }
@@ -128,7 +128,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
+        module.taintObject(ctx, multiMap, SourceTypes.REQUEST_HEADER_VALUE);
       }
     }
   }
@@ -143,7 +143,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, data, SourceTypes.REQUEST_BODY);
+        module.taintObject(ctx, data, SourceTypes.REQUEST_BODY);
       }
     }
   }
@@ -159,7 +159,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       if (module != null && cookies != null && !cookies.isEmpty()) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         for (final Object cookie : cookies) {
-          module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
+          module.taintObject(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
         }
       }
     }
@@ -175,7 +175,7 @@ public abstract class AbstractHttpServerRequestInstrumentation extends Instrumen
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taint(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
+        module.taintObject(ctx, cookie, SourceTypes.REQUEST_COOKIE_VALUE);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/BufferInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/BufferInstrumentation.java
@@ -64,7 +64,7 @@ public class BufferInstrumentation extends InstrumenterModule.Iast
     public static void get(@Advice.This final Object self, @Advice.Return final String result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, self);
+        module.taintStringIfTainted(result, self);
       }
     }
   }
@@ -75,7 +75,7 @@ public class BufferInstrumentation extends InstrumenterModule.Iast
     public static void get(@Advice.This final Object self, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, self);
+        module.taintObjectIfTainted(result, self);
       }
     }
   }
@@ -87,7 +87,7 @@ public class BufferInstrumentation extends InstrumenterModule.Iast
         @Advice.Argument(0) final Object buffer, @Advice.Return final Object result) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
-        module.taintIfTainted(result, buffer);
+        module.taintObjectIfTainted(result, buffer);
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/MultiMapInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/core/MultiMapInstrumentation.java
@@ -86,7 +86,7 @@ public abstract class MultiMapInstrumentation extends InstrumenterModule.Iast
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
         final Source source = propagation.findSource(ctx, self);
         if (source != null) {
-          propagation.taint(ctx, result, source.getOrigin(), name);
+          propagation.taintString(ctx, result, source.getOrigin(), name);
         }
       }
     }
@@ -107,7 +107,7 @@ public abstract class MultiMapInstrumentation extends InstrumenterModule.Iast
         final Source source = propagation.findSource(ctx, self);
         if (source != null) {
           for (final String value : result) {
-            propagation.taint(ctx, value, source.getOrigin(), name);
+            propagation.taintString(ctx, value, source.getOrigin(), name);
           }
         }
       }
@@ -133,9 +133,9 @@ public abstract class MultiMapInstrumentation extends InstrumenterModule.Iast
             final String name = entry.getKey();
             final String value = entry.getValue();
             if (keys.add(name)) {
-              propagation.taint(ctx, name, nameOrigin, name);
+              propagation.taintString(ctx, name, nameOrigin, name);
             }
-            propagation.taint(ctx, value, source.getOrigin(), name);
+            propagation.taintString(ctx, value, source.getOrigin(), name);
           }
         }
       }
@@ -157,7 +157,7 @@ public abstract class MultiMapInstrumentation extends InstrumenterModule.Iast
         if (source != null) {
           final byte nameOrigin = namedSource(source.getOrigin());
           for (final String name : result) {
-            propagation.taint(ctx, name, nameOrigin, name);
+            propagation.taintString(ctx, name, nameOrigin, name);
           }
         }
       }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/CookieImplInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/CookieImplInstrumentation.java
@@ -65,7 +65,7 @@ public class CookieImplInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
+        module.taintStringIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_NAME, result);
       }
     }
   }
@@ -82,7 +82,8 @@ public class CookieImplInstrumentation extends InstrumenterModule.Iast
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {
         final IastContext ctx = reqCtx.getData(RequestContextSlot.IAST);
-        module.taintIfTainted(ctx, result, self, SourceTypes.REQUEST_COOKIE_VALUE, self.getName());
+        module.taintStringIfTainted(
+            ctx, result, self, SourceTypes.REQUEST_COOKIE_VALUE, self.getName());
       }
     }
   }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/PathParameterPublishingHelper.java
@@ -70,7 +70,7 @@ public class PathParameterPublishingHelper {
             if (parameterName == null || value == null) {
               continue; // should not happen
             }
-            module.taint(
+            module.taintString(
                 iastRequestContext, value, SourceTypes.REQUEST_PATH_PARAMETER, parameterName);
           }
         }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/BufferInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/BufferInstrumentationTest.groovy
@@ -27,7 +27,7 @@ class BufferInstrumentationTest extends AgentTestRunner {
     method.call(buffer)
 
     then:
-    1 * module.taintIfTainted(_, buffer)
+    1 * module.taintStringIfTainted(_, buffer)
 
     where:
     methodName         | method
@@ -46,7 +46,7 @@ class BufferInstrumentationTest extends AgentTestRunner {
     method.call(buffer, tainted)
 
     then:
-    1 * module.taintIfTainted(buffer, tainted)
+    1 * module.taintObjectIfTainted(buffer, tainted)
 
     where:
     methodName                       | method

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/MultiMapInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/core/MultiMapInstrumentationTest.groovy
@@ -52,7 +52,7 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.findSource(iastCtx, instance) >> { mockedSource(origin) }
-    1 * module.taint(iastCtx, 'value', origin, 'key')
+    1 * module.taintString(iastCtx, 'value', origin, 'key')
 
     where:
     instance << multiMaps()
@@ -78,8 +78,8 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.findSource(iastCtx, instance) >> { mockedSource(origin) }
-    1 * module.taint(iastCtx, 'value1', origin, 'key')
-    1 * module.taint(iastCtx, 'value2', origin, 'key')
+    1 * module.taintString(iastCtx, 'value1', origin, 'key')
+    1 * module.taintString(iastCtx, 'value2', origin, 'key')
 
     where:
     instance << multiMaps()
@@ -105,7 +105,7 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.findSource(iastCtx, instance) >> { mockedSource(origin) }
-    1 * module.taint(iastCtx, 'key', namedSource(origin), 'key')
+    1 * module.taintString(iastCtx, 'key', namedSource(origin), 'key')
 
     where:
     instance << multiMaps()
@@ -133,9 +133,9 @@ class MultiMapInstrumentationTest extends AgentTestRunner {
 
     then:
     1 * module.findSource(iastCtx, instance) >> { mockedSource(origin) }
-    1 * module.taint(iastCtx, 'key', namedSource(origin), 'key')
-    1 * module.taint(iastCtx, 'value1', origin, 'key')
-    1 * module.taint(iastCtx, 'value2', origin, 'key')
+    1 * module.taintString(iastCtx, 'key', namedSource(origin), 'key')
+    1 * module.taintString(iastCtx, 'value1', origin, 'key')
+    1 * module.taintString(iastCtx, 'value2', origin, 'key')
 
     where:
     instance << multiMaps()

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/PropagationModule.java
@@ -10,67 +10,67 @@ import javax.annotation.Nullable;
 @SuppressWarnings("unused")
 public interface PropagationModule extends IastModule {
 
-  /** @see #taint(IastContext, Object, byte) */
-  void taint(@Nullable Object target, byte origin);
+  /** @see #taintObject(IastContext, Object, byte) */
+  void taintObject(@Nullable Object target, byte origin);
 
   /**
    * Taints the object with a source with the selected origin and no name, if target is a char
    * sequence it will be used as value
    */
-  void taint(@Nullable IastContext ctx, @Nullable Object target, byte origin);
+  void taintObject(@Nullable IastContext ctx, @Nullable Object target, byte origin);
 
-  /** @see #taint(IastContext, String, byte) */
-  void taint(@Nullable String target, byte origin);
+  /** @see #taintString(IastContext, String, byte) */
+  void taintString(@Nullable String target, byte origin);
 
-  /** @see #taint(IastContext, Object, byte) */
-  void taint(@Nullable IastContext ctx, @Nullable String target, byte origin);
+  /** @see #taintObject(IastContext, Object, byte) */
+  void taintString(@Nullable IastContext ctx, @Nullable String target, byte origin);
 
   /**
    * Taints the object with a source with the selected origin and name, if target is a char sequence
    * it will be used as value
    */
-  void taint(
+  void taintObject(
       @Nullable IastContext ctx, @Nullable Object target, byte origin, @Nullable CharSequence name);
 
-  /** @see #taint(IastContext, Object, byte, CharSequence) */
-  void taint(@Nullable Object target, byte origin, @Nullable CharSequence name);
+  /** @see #taintObject(IastContext, Object, byte, CharSequence) */
+  void taintObject(@Nullable Object target, byte origin, @Nullable CharSequence name);
 
-  /** @see #taint(IastContext, Object, byte, CharSequence) */
-  void taint(
+  /** @see #taintObject(IastContext, Object, byte, CharSequence) */
+  void taintString(
       @Nullable IastContext ctx, @Nullable String target, byte origin, @Nullable CharSequence name);
 
-  /** @see #taint(IastContext, String, byte, CharSequence) */
-  void taint(@Nullable String target, byte origin, @Nullable CharSequence name);
+  /** @see #taintString(IastContext, String, byte, CharSequence) */
+  void taintString(@Nullable String target, byte origin, @Nullable CharSequence name);
 
-  /** @see #taint(IastContext, Object, byte, CharSequence, Object) */
-  void taint(
+  /** @see #taintObject(IastContext, Object, byte, CharSequence, Object) */
+  void taintObject(
       @Nullable Object target, byte origin, @Nullable CharSequence name, @Nullable Object value);
 
   /** Taints the object with a source with the selected origin, name and value */
-  void taint(
+  void taintObject(
       @Nullable IastContext ctx,
       @Nullable Object target,
       byte origin,
       @Nullable CharSequence name,
       @Nullable Object value);
 
-  /** @see #taint(IastContext, String, byte, CharSequence, CharSequence) */
-  void taint(
+  /** @see #taintString(IastContext, String, byte, CharSequence, CharSequence) */
+  void taintString(
       @Nullable String target,
       byte origin,
       @Nullable CharSequence name,
       @Nullable CharSequence value);
 
-  /** @see #taint(IastContext, Object, byte, CharSequence, Object) */
-  void taint(
+  /** @see #taintObject(IastContext, Object, byte, CharSequence, Object) */
+  void taintString(
       @Nullable IastContext ctx,
       @Nullable String target,
       byte origin,
       @Nullable CharSequence name,
       @Nullable CharSequence value);
 
-  /** @see #taint(IastContext, Object, byte, int, int) */
-  void taint(@Nullable Object target, byte origin, int start, int length);
+  /** @see #taintObjectRange(IastContext, Object, byte, int, int) */
+  void taintObjectRange(@Nullable Object target, byte origin, int start, int length);
 
   /**
    * Taints the object with a source with the selected origin, range and no name. If target is a
@@ -78,33 +78,35 @@ public interface PropagationModule extends IastModule {
    *
    * <p>If the value is already tainted this method will append a new range.
    */
-  void taint(
+  void taintObjectRange(
       @Nullable IastContext ctx, @Nullable Object target, byte origin, int start, int length);
 
-  /** @see #taint(IastContext, String, byte, int, int) */
-  void taint(@Nullable String target, byte origin, int start, int length);
+  /** @see #taintStringRange(IastContext, String, byte, int, int) */
+  void taintStringRange(@Nullable String target, byte origin, int start, int length);
 
-  /** @see #taint(IastContext, Object, byte, int, int) */
-  void taint(
+  /** @see #taintObjectRange(IastContext, Object, byte, int, int) */
+  void taintStringRange(
       @Nullable IastContext ctx, @Nullable String target, byte origin, int start, int length);
 
-  /** @see #taintIfTainted(IastContext, Object, Object) */
-  void taintIfTainted(@Nullable Object target, @Nullable Object input);
+  /** @see #taintObjectIfTainted(IastContext, Object, Object) */
+  void taintObjectIfTainted(@Nullable Object target, @Nullable Object input);
 
   /**
    * Taints the object only if the input value is tainted. If tainted, it will use the highest
    * priority source of the input to taint the object.
    */
-  void taintIfTainted(@Nullable IastContext ctx, @Nullable Object target, @Nullable Object input);
+  void taintObjectIfTainted(
+      @Nullable IastContext ctx, @Nullable Object target, @Nullable Object input);
 
-  /** @see #taintIfTainted(IastContext, String, Object) */
-  void taintIfTainted(@Nullable String target, @Nullable Object input);
+  /** @see #taintStringIfTainted(IastContext, String, Object) */
+  void taintStringIfTainted(@Nullable String target, @Nullable Object input);
 
-  /** @see #taintIfTainted(IastContext, Object, Object) */
-  void taintIfTainted(@Nullable IastContext ctx, @Nullable String target, @Nullable Object input);
+  /** @see #taintObjectIfTainted(IastContext, Object, Object) */
+  void taintStringIfTainted(
+      @Nullable IastContext ctx, @Nullable String target, @Nullable Object input);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, boolean, int) */
+  void taintObjectIfTainted(
       @Nullable Object target, @Nullable Object input, boolean keepRanges, int mark);
 
   /**
@@ -116,27 +118,27 @@ public interface PropagationModule extends IastModule {
    *   <li>keepRanges=false will use the highest priority source from the input ranges and mark it
    * </ul>
    */
-  void taintIfTainted(
+  void taintObjectIfTainted(
       @Nullable IastContext ctx,
       @Nullable Object target,
       @Nullable Object input,
       boolean keepRanges,
       int mark);
 
-  /** @see #taintIfTainted(IastContext, String, Object, boolean, int) */
-  void taintIfTainted(
+  /** @see #taintStringIfTainted(IastContext, String, Object, boolean, int) */
+  void taintStringIfTainted(
       @Nullable String target, @Nullable Object input, boolean keepRanges, int mark);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, boolean, int) */
+  void taintStringIfTainted(
       @Nullable IastContext ctx,
       @Nullable String target,
       @Nullable Object input,
       boolean keepRanges,
       int mark);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, boolean, int) */
+  void taintObjectIfRangeTainted(
       @Nullable Object target,
       @Nullable Object input,
       int start,
@@ -153,7 +155,7 @@ public interface PropagationModule extends IastModule {
    *   <li>keepRanges=false will use the highest priority source from the intersection and mark it
    * </ul>
    */
-  void taintIfTainted(
+  void taintObjectIfRangeTainted(
       @Nullable IastContext ctx,
       @Nullable Object target,
       @Nullable Object input,
@@ -162,8 +164,8 @@ public interface PropagationModule extends IastModule {
       boolean keepRanges,
       int mark);
 
-  /** @see #taintIfTainted(IastContext, String, Object, boolean, int) */
-  void taintIfTainted(
+  /** @see #taintStringIfTainted(IastContext, String, Object, boolean, int) */
+  void taintStringIfRangeTainted(
       @Nullable String target,
       @Nullable Object input,
       int start,
@@ -171,8 +173,8 @@ public interface PropagationModule extends IastModule {
       boolean keepRanges,
       int mark);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, boolean, int) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, boolean, int) */
+  void taintStringIfRangeTainted(
       @Nullable IastContext ctx,
       @Nullable String target,
       @Nullable Object input,
@@ -181,26 +183,26 @@ public interface PropagationModule extends IastModule {
       boolean keepRanges,
       int mark);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, byte) */
-  void taintIfTainted(@Nullable Object target, @Nullable Object input, byte origin);
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, byte) */
+  void taintObjectIfTainted(@Nullable Object target, @Nullable Object input, byte origin);
 
   /**
    * Taints the object only if the input value is tainted, the resulting value will be tainted using
    * a source with the specified origin and no name, if target is a char sequence it will be used as
    * value
    */
-  void taintIfTainted(
+  void taintObjectIfTainted(
       @Nullable IastContext ctx, @Nullable Object target, @Nullable Object input, byte origin);
 
-  /** @see #taintIfTainted(IastContext, String, Object, byte) */
-  void taintIfTainted(@Nullable String target, @Nullable Object input, byte origin);
+  /** @see #taintStringIfTainted(IastContext, String, Object, byte) */
+  void taintStringIfTainted(@Nullable String target, @Nullable Object input, byte origin);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, byte) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, byte) */
+  void taintStringIfTainted(
       @Nullable IastContext ctx, @Nullable String target, @Nullable Object input, byte origin);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, byte, CharSequence) */
+  void taintObjectIfTainted(
       @Nullable Object target, @Nullable Object input, byte origin, @Nullable CharSequence name);
 
   /**
@@ -208,27 +210,27 @@ public interface PropagationModule extends IastModule {
    * a source with the specified origin and name, if target is a char sequence it will be used as
    * value
    */
-  void taintIfTainted(
+  void taintObjectIfTainted(
       @Nullable IastContext ctx,
       @Nullable Object target,
       @Nullable Object input,
       byte origin,
       @Nullable CharSequence name);
 
-  /** @see #taintIfTainted(IastContext, String, Object, byte, CharSequence) */
-  void taintIfTainted(
+  /** @see #taintStringIfTainted(IastContext, String, Object, byte, CharSequence) */
+  void taintStringIfTainted(
       @Nullable String target, @Nullable Object input, byte origin, @Nullable CharSequence name);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, byte, CharSequence) */
+  void taintStringIfTainted(
       @Nullable IastContext ctx,
       @Nullable String target,
       @Nullable Object input,
       byte origin,
       @Nullable CharSequence name);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence, Object) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, byte, CharSequence, Object) */
+  void taintObjectIfTainted(
       @Nullable Object target,
       @Nullable Object input,
       byte origin,
@@ -239,7 +241,7 @@ public interface PropagationModule extends IastModule {
    * Taints the object only if the input value is tainted, the resulting value will be tainted using
    * a source with the specified origin, name and value.
    */
-  void taintIfTainted(
+  void taintObjectIfTainted(
       @Nullable IastContext ctx,
       @Nullable Object target,
       @Nullable Object input,
@@ -247,16 +249,16 @@ public interface PropagationModule extends IastModule {
       @Nullable CharSequence name,
       @Nullable Object value);
 
-  /** @see #taintIfTainted(IastContext, String, Object, byte, CharSequence, Object) */
-  void taintIfTainted(
+  /** @see #taintStringIfTainted(IastContext, String, Object, byte, CharSequence, Object) */
+  void taintStringIfTainted(
       @Nullable String target,
       @Nullable Object input,
       byte origin,
       @Nullable CharSequence name,
       @Nullable Object value);
 
-  /** @see #taintIfTainted(IastContext, Object, Object, byte, CharSequence, Object) */
-  void taintIfTainted(
+  /** @see #taintObjectIfTainted(IastContext, Object, Object, byte, CharSequence, Object) */
+  void taintStringIfTainted(
       @Nullable IastContext ctx,
       @Nullable String target,
       @Nullable Object input,
@@ -264,56 +266,56 @@ public interface PropagationModule extends IastModule {
       @Nullable CharSequence name,
       @Nullable Object value);
 
-  /** @see #taintIfAnyTainted(IastContext, Object, Object[]) */
-  void taintIfAnyTainted(@Nullable Object target, @Nullable Object[] inputs);
+  /** @see #taintObjectIfAnyTainted(IastContext, Object, Object[]) */
+  void taintObjectIfAnyTainted(@Nullable Object target, @Nullable Object[] inputs);
 
   /**
    * Taints the object if any of the inputs is tainted. When a tainted input is found the logic is
-   * the same as in {@link #taintIfTainted(IastContext, Object, Object)}
+   * the same as in {@link #taintObjectIfTainted(IastContext, Object, Object)}
    *
-   * @see #taintIfTainted(IastContext, Object, Object)
+   * @see #taintObjectIfTainted(IastContext, Object, Object)
    */
-  void taintIfAnyTainted(
+  void taintObjectIfAnyTainted(
       @Nullable IastContext ctx, @Nullable Object target, @Nullable Object[] inputs);
 
-  /** @see #taintIfAnyTainted(IastContext, String, Object[]) */
-  void taintIfAnyTainted(@Nullable String target, @Nullable Object[] inputs);
+  /** @see #taintStringIfAnyTainted(IastContext, String, Object[]) */
+  void taintStringIfAnyTainted(@Nullable String target, @Nullable Object[] inputs);
 
-  /** @see #taintIfAnyTainted(IastContext, Object, Object[]) */
-  void taintIfAnyTainted(
+  /** @see #taintObjectIfAnyTainted(IastContext, Object, Object[]) */
+  void taintStringIfAnyTainted(
       @Nullable IastContext ctx, @Nullable String target, @Nullable Object[] inputs);
 
-  /** @see #taintIfAnyTainted(IastContext, Object, Object[], boolean, int) */
-  void taintIfAnyTainted(
+  /** @see #taintObjectIfAnyTainted(IastContext, Object, Object[], boolean, int) */
+  void taintObjectIfAnyTainted(
       @Nullable Object target, @Nullable Object[] inputs, boolean keepRanges, int mark);
 
   /**
    * Taints the object if any of the inputs is tainted. When a tainted input is found the logic is
-   * the same as in {@link #taintIfTainted(IastContext, Object, Object, boolean, int)}
+   * the same as in {@link #taintObjectIfTainted(IastContext, Object, Object, boolean, int)}
    *
-   * @see #taintIfTainted(IastContext, Object, Object, boolean, int)
+   * @see #taintObjectIfTainted(IastContext, Object, Object, boolean, int)
    */
-  void taintIfAnyTainted(
+  void taintObjectIfAnyTainted(
       @Nullable IastContext ctx,
       @Nullable Object target,
       @Nullable Object[] inputs,
       boolean keepRanges,
       int mark);
 
-  /** @see #taintIfAnyTainted(IastContext, String, Object[], boolean, int) */
-  void taintIfAnyTainted(
+  /** @see #taintStringIfAnyTainted(IastContext, String, Object[], boolean, int) */
+  void taintStringIfAnyTainted(
       @Nullable String target, @Nullable Object[] inputs, boolean keepRanges, int mark);
 
-  /** @see #taintIfAnyTainted(IastContext, Object, Object[], boolean, int) */
-  void taintIfAnyTainted(
+  /** @see #taintObjectIfAnyTainted(IastContext, Object, Object[], boolean, int) */
+  void taintStringIfAnyTainted(
       @Nullable IastContext ctx,
       @Nullable String target,
       @Nullable Object[] inputs,
       boolean keepRanges,
       int mark);
 
-  /** @see #taintDeeply(IastContext, Object, byte, Predicate) */
-  int taintDeeply(@Nullable Object target, byte origin, Predicate<Class<?>> classFilter);
+  /** @see #taintObjectDeeply(IastContext, Object, byte, Predicate) */
+  int taintObjectDeeply(@Nullable Object target, byte origin, Predicate<Class<?>> classFilter);
 
   /**
    * Visit the graph of the object and taints all the string properties found using a source with
@@ -322,7 +324,7 @@ public interface PropagationModule extends IastModule {
    * @param classFilter filter for types that should be included in the visiting process
    * @return number of tainted elements
    */
-  int taintDeeply(
+  int taintObjectDeeply(
       @Nullable IastContext ctx,
       @Nullable Object target,
       byte origin,


### PR DESCRIPTION
# What Does This Do
Renames the methods in the `PropagationModule` so they adhere to the following patterns:

- `taintObject`/`taintString`: taints an object/string specifying its source properties
- `taintObjectRange`/`taintStringRange`: taints a range of an object/string or appends a new range if already tainted
- `taintObjectIfTainted`/`taintStringIfTainted`: taints an object/string if the input argument is tainted
- `taintObjectIfAnyTainted`/`taintStringIfAnyTainted`: taints an object/string if the any of the input arguments is tainted
- `taintObjectIfRangeTainted`/`taintStringIfRangeTainted`: taints an object/string if the input argument has a tainted range that intersects
- `taintObjectDeeply`: visits an object and taints its properties

There are no other changes in this PR but the rename of the previous methods.