### PR TITLE
Gitlab build cache improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
-  - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
+  - remote: https://gitlab-templates.ddbuild.io/apm/wip/packaging.yml
   - local: ".gitlab/benchmarks.yml"
   - local: ".gitlab/exploration-tests.yml"
   - local: ".gitlab/ci-visibility-tests.yml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ default:
     policy: pull
 
 cache:
-  - key: '$CI_SERVER_VERSION' # Dependencies cache. Reset the cache every time gitlab is upgraded.  ~Every couple months
+  - key: '$CI_SERVER_VERSION-dne' # Dependencies cache. Reset the cache every time gitlab is upgraded.  ~Every couple months
     paths:
       # Cached dependencies and wrappers for gradle
       - .gradle/wrapper

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,6 +63,9 @@ cache:
 
 .gradle_build: &gradle_build
   image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
+  variables:
+    GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
+    GRADLE_ARGS: "--build-cache --stacktrace --no-daemon"
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
     # for weird reasons, gradle will always "chmod 700" the .gradle folder
@@ -85,7 +88,7 @@ build: &build
       when: never
     - when: on_success
   script:
-    - GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M" ./gradlew clean :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+    - ./gradlew clean :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --parallel --max-workers=8 $GRADLE_ARGS
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
     - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
     - echo "BUILD_JOB_ID=$CI_JOB_ID" >> build.env
@@ -104,7 +107,7 @@ build_again: &build
   needs: [ build ]
   script:
     - ls -laR workspace/dd-java-agent/instrumentation/
-    - ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+    - ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --parallel --max-workers=8 $GRADLE_ARGS
 
 build_with_cache:
   <<: *build
@@ -218,7 +221,7 @@ deploy_to_sonatype:
     - export SONATYPE_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.sonatype_password --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
-    - ./gradlew -PbuildInfo.build.number=$CI_JOB_ID publishToSonatype closeSonatypeStagingRepository --max-workers=1 --build-cache --stacktrace --no-daemon
+    - ./gradlew -PbuildInfo.build.number=$CI_JOB_ID publishToSonatype closeSonatypeStagingRepository --max-workers=1 $GRADLE_ARGS
 
 deploy_artifacts_to_github:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,10 @@ build_just_api:
   needs: [ build ]
   script:
     - ls -laR workspace/dd-trace-api
-    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 --info $GRADLE_ARGS
+    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 --debug $GRADLE_ARGS > gradlelogs
+  artifacts:
+    paths:
+      - gradlelogs
 
 build_with_cache:
   extends: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ build_just_api:
   needs: [ build ]
   script:
     - ls -laR workspace/dd-trace-api
-    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 $GRADLE_ARGS
+    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 --info $GRADLE_ARGS
 
 build_with_cache:
   extends: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,13 +83,9 @@ build: &build
       when: never
     - when: on_success
   script:
-#    - ls -la
-#    - pwd
-#    - ls -la .gradle
     - GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M" ./gradlew clean :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
-    - ls -la workspace
-    - ls -la workspace/dd-java-agent
+    - ls -la -R workspace/dd-java-agent
     - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
     - echo "BUILD_JOB_ID=$CI_JOB_ID" >> build.env
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ variables:
   SONATYPE_USERNAME: robot-sonatype-apm-java
   DEPENDENCY_CACHE_POLICY: pull
   BUILD_CACHE_POLICY: pull
-  GRADLE_VERSION: 8.4 # must match gradle-wrapper.properties
+  GRADLE_VERSION: "8.4" # must match gradle-wrapper.properties
   DOWNSTREAM_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,8 +106,16 @@ build_again:
   stage: build
   needs: [ build ]
   script:
-    - ls -laR workspace/dd-java-agent/instrumentation/
+    - ls -laR workspace/
     - ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --parallel --max-workers=8 $GRADLE_ARGS
+
+build_just_api:
+  extends: .gradle_build
+  stage: build
+  needs: [ build ]
+  script:
+    - ls -laR workspace/dd-trace-api
+    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 $GRADLE_ARGS
 
 build_with_cache:
   extends: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,8 +92,7 @@ build:
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
     - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
     - echo "BUILD_JOB_ID=$CI_JOB_ID" >> build.env
-    - echo "Building again"
-    - ./gradlew :dd-trace-api:jar
+    - ls -laR .gradle
   artifacts:
     paths:
       - 'workspace/dd-java-agent/build/libs/*.jar'
@@ -108,6 +107,8 @@ build_again:
   stage: build
   needs: [ build ]
   script:
+    - ls -la .gradle
+    - ls -la .gradle/$GRADLE_VERSION
     - ls -laR workspace/
     - ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --parallel --max-workers=8 $GRADLE_ARGS
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,6 +98,14 @@ build: &build
     reports:
       dotenv: build.env
 
+build_again: &build
+  <<: *gradle_build
+  stage: build
+  needs: [ build ]
+  script:
+    - ls -laR workspace/dd-java-agent/instrumentation/
+    - ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
+
 build_with_cache:
   <<: *build
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ cache:
   - key: $CI_PIPELINE_ID # Incremental build cache. Shared by all jobs in the pipeline
     paths:
       - .gradle/caches/$GRADLE_VERSION
-      - .gradle/$GRADLE_VERSION/executionHistory.bin
+      - .gradle/$GRADLE_VERSION/executionHistory/executionHistory.bin
       - workspace
     policy: $BUILD_CACHE_POLICY
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ build_just_api:
   needs: [ build ]
   script:
     - ls -laR workspace/dd-trace-api
-    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 --debug $GRADLE_ARGS
+    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 --info $GRADLE_ARGS
 
 build_with_cache:
   extends: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,11 +28,10 @@ variables:
     value: "false"
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
 
-.common: &common
-  tags: [ "runner:main", "size:large" ]
+default:
+  tags: [ "arch:amd64" ]
 
 .docker: &docker
-  tags: [ "arch:amd64", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.13
   cache:
     key: no-cache
@@ -57,10 +56,10 @@ cache:
     paths:
       - .gradle/caches/8.4 # must match gradle-wrapper.properties
       - workspace/.gradle
+      - workspace/**/build/**
     policy: $BUILD_CACHE_POLICY
 
 .gradle_build: &gradle_build
-  <<: *common
   image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
   before_script:
     - export GRADLE_USER_HOME=`pwd`/.gradle
@@ -78,6 +77,7 @@ build: &build
   stage: build
   variables:
     BUILD_CACHE_POLICY: push
+    DEPENDENCY_CACHE_POLICY: pull
   rules:
     - if: '$POPULATE_CACHE'
       when: never
@@ -213,7 +213,6 @@ deploy_to_sonatype:
 deploy_artifacts_to_github:
   stage: deploy
   image: registry.ddbuild.io/github-cli:v27480869-eafb11d-2.43.0
-  tags: [ "arch:amd64" ]
   rules:
     - if: '$POPULATE_CACHE'
       when: never
@@ -276,7 +275,6 @@ create_key:
   stage: generate-signing-key
   when: manual
   needs: [ ]
-  tags: [ "arch:amd64", "size:large" ]
   variables:
     PROJECT_NAME: "dd-trace-java"
     EXPORT_TO_KEYSERVER: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,10 @@
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
   - remote: https://gitlab-templates.ddbuild.io/apm/wip/packaging.yml
-  - local: ".gitlab/benchmarks.yml"
-  - local: ".gitlab/exploration-tests.yml"
-  - local: ".gitlab/ci-visibility-tests.yml"
-  - local: ".gitlab/single-step-instrumentation-tests.yml"
+#  - local: ".gitlab/benchmarks.yml"
+#  - local: ".gitlab/exploration-tests.yml"
+#  - local: ".gitlab/ci-visibility-tests.yml"
+#  - local: ".gitlab/single-step-instrumentation-tests.yml"
 
 stages:
   - build
@@ -21,6 +21,7 @@ variables:
   SONATYPE_USERNAME: robot-sonatype-apm-java
   DEPENDENCY_CACHE_POLICY: pull
   BUILD_CACHE_POLICY: pull
+  GRADLE_VERSION: 8.4 # must match gradle-wrapper.properties
   DOWNSTREAM_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
@@ -55,7 +56,8 @@ cache:
     policy: $DEPENDENCY_CACHE_POLICY
   - key: $CI_PIPELINE_ID # Incremental build cache. Shared by all jobs in the pipeline
     paths:
-      - .gradle/caches/8.4 # must match gradle-wrapper.properties
+      - .gradle/caches/$GRADLE_VERSION
+      - .gradle/$GRADLE_VERSION/executionHistory.bin
       - workspace
     policy: $BUILD_CACHE_POLICY
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,10 @@
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
   - remote: https://gitlab-templates.ddbuild.io/apm/wip/packaging.yml
-  - local: ".gitlab/benchmarks.yml"
-  - local: ".gitlab/exploration-tests.yml"
-  - local: ".gitlab/ci-visibility-tests.yml"
-  - local: ".gitlab/single-step-instrumentation-tests.yml"
+#  - local: ".gitlab/benchmarks.yml"
+#  - local: ".gitlab/exploration-tests.yml"
+#  - local: ".gitlab/ci-visibility-tests.yml"
+#  - local: ".gitlab/single-step-instrumentation-tests.yml"
 
 stages:
   - build
@@ -55,8 +55,7 @@ cache:
   - key: $CI_PIPELINE_ID # Incremental build cache. Shared by all jobs in the pipeline
     paths:
       - .gradle/caches/8.4 # must match gradle-wrapper.properties
-      - workspace/.gradle
-      - workspace/**/build/**
+      - workspace
     policy: $BUILD_CACHE_POLICY
 
 .gradle_build: &gradle_build
@@ -83,8 +82,13 @@ build: &build
       when: never
     - when: on_success
   script:
+    - ls -la
+    - pwd
+    - ls -la .gradle
     - GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M" ./gradlew clean :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
+    - ls -la workspace
+    - ls -la workspace/dd-java-agent
     - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
     - echo "BUILD_JOB_ID=$CI_JOB_ID" >> build.env
   artifacts:
@@ -205,6 +209,10 @@ deploy_to_sonatype:
     - when: manual
       allow_failure: true
   script:
+    - ls -la
+    - pwd
+    - ls -la .gradle
+    - ls -la workspace
     - export SONATYPE_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.sonatype_password --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,8 @@ stages:
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   SONATYPE_USERNAME: robot-sonatype-apm-java
+  DEPENDENCY_CACHE_POLICY: pull
+  BUILD_CACHE_POLICY: pull
   DOWNSTREAM_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
@@ -36,12 +38,26 @@ variables:
     key: no-cache
     policy: pull
 
-cache: &default_cache
-  key: '$CI_SERVER_VERSION' # Reset the cache every time gitlab is upgraded.  ~Every couple months
-  paths:
-    - .gradle/wrapper
-    - .gradle/caches
-  policy: pull
+cache:
+  - key: '$CI_SERVER_VERSION' # Dependencies cache. Reset the cache every time gitlab is upgraded.  ~Every couple months
+    paths:
+      # Cached dependencies and wrappers for gradle
+      - .gradle/wrapper
+      - .gradle/caches
+      # Cached dependencies for maven
+      - .m2
+      # Cached launchers and compilers for sbt
+      - .sbt
+      # Cached dependencies for sbt handled by ivy
+      - .ivy2
+      # Cached dependencies for sbt handled by coursier
+      - .cache/coursier
+    policy: $DEPENDENCY_CACHE_POLICY
+  - key: $CI_PIPELINE_ID # Incremental build cache. Shared by all jobs in the pipeline
+    paths:
+      - .gradle/caches/8.4 # must match gradle-wrapper.properties
+      - workspace/.gradle
+    policy: $BUILD_CACHE_POLICY
 
 .gradle_build: &gradle_build
   <<: *common
@@ -60,6 +76,8 @@ cache: &default_cache
 build: &build
   <<: *gradle_build
   stage: build
+  variables:
+    BUILD_CACHE_POLICY: push
   rules:
     - if: '$POPULATE_CACHE'
       when: never
@@ -80,14 +98,14 @@ build: &build
 
 build_with_cache:
   <<: *build
+  variables:
+    BUILD_CACHE_POLICY: push
+    DEPENDENCY_CACHE_POLICY: push
   rules:
     - if: '$POPULATE_CACHE'
       when: on_success
     - when: manual
       allow_failure: true
-  cache:
-    <<: *default_cache
-    policy: push
 
 package:
   extends: .package

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,10 @@
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
   - remote: https://gitlab-templates.ddbuild.io/apm/wip/packaging.yml
-#  - local: ".gitlab/benchmarks.yml"
-#  - local: ".gitlab/exploration-tests.yml"
-#  - local: ".gitlab/ci-visibility-tests.yml"
-#  - local: ".gitlab/single-step-instrumentation-tests.yml"
+  - local: ".gitlab/benchmarks.yml"
+  - local: ".gitlab/exploration-tests.yml"
+  - local: ".gitlab/ci-visibility-tests.yml"
+  - local: ".gitlab/single-step-instrumentation-tests.yml"
 
 stages:
   - build
@@ -85,7 +85,6 @@ build: &build
   script:
     - GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M" ./gradlew clean :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
-    - ls -la -R workspace/dd-java-agent
     - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
     - echo "BUILD_JOB_ID=$CI_JOB_ID" >> build.env
   artifacts:
@@ -206,10 +205,6 @@ deploy_to_sonatype:
     - when: manual
       allow_failure: true
   script:
-    - ls -la
-    - pwd
-    - ls -la .gradle
-    - ls -la workspace
     - export SONATYPE_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.sonatype_password --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ build_just_api:
   needs: [ build ]
   script:
     - ls -laR workspace/dd-trace-api
-    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 --info $GRADLE_ARGS
+    - ./gradlew :dd-trace-api:jar --parallel --max-workers=8 --debug $GRADLE_ARGS
 
 build_with_cache:
   extends: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,19 +45,11 @@ cache:
       - .gradle/wrapper
       - .gradle/caches
       - .gradle/notifications
-      # Cached dependencies for maven
-      - .m2
-      # Cached launchers and compilers for sbt
-      - .sbt
-      # Cached dependencies for sbt handled by ivy
-      - .ivy2
-      # Cached dependencies for sbt handled by coursier
-      - .cache/coursier
     policy: $DEPENDENCY_CACHE_POLICY
   - key: $CI_PIPELINE_ID # Incremental build cache. Shared by all jobs in the pipeline
     paths:
-      - .gradle/caches/$GRADLE_VERSION
-      - .gradle/$GRADLE_VERSION/executionHistory
+      - .gradle/caches
+      - .gradle/$GRADLE_VERSION
       - workspace
     policy: $BUILD_CACHE_POLICY
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ cache:
   - key: $CI_PIPELINE_ID # Incremental build cache. Shared by all jobs in the pipeline
     paths:
       - .gradle/caches/$GRADLE_VERSION
-      - .gradle/$GRADLE_VERSION/executionHistory/executionHistory.bin
+      - .gradle/$GRADLE_VERSION/executionHistory
       - workspace
     policy: $BUILD_CACHE_POLICY
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,11 +38,12 @@ default:
     policy: pull
 
 cache:
-  - key: '$CI_SERVER_VERSION-dne' # Dependencies cache. Reset the cache every time gitlab is upgraded.  ~Every couple months
+  - key: '$CI_SERVER_VERSION-v2' # Dependencies cache. Reset the cache every time gitlab is upgraded.  ~Every couple months
     paths:
       # Cached dependencies and wrappers for gradle
       - .gradle/wrapper
       - .gradle/caches
+      - .gradle/notifications
       # Cached dependencies for maven
       - .m2
       # Cached launchers and compilers for sbt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
 default:
   tags: [ "arch:amd64" ]
 
-.docker: &docker
+.docker:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.13
   cache:
     key: no-cache
@@ -61,7 +61,7 @@ cache:
       - workspace
     policy: $BUILD_CACHE_POLICY
 
-.gradle_build: &gradle_build
+.gradle_build:
   image: ghcr.io/datadog/dd-trace-java-docker-build:v23.10-base
   variables:
     GRADLE_OPTS: "-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M"
@@ -77,8 +77,8 @@ cache:
     - mv .gradle-copy .gradle
     - ls -la
 
-build: &build
-  <<: *gradle_build
+build:
+  extends: .gradle_build
   stage: build
   variables:
     BUILD_CACHE_POLICY: push
@@ -101,8 +101,8 @@ build: &build
     reports:
       dotenv: build.env
 
-build_again: &build
-  <<: *gradle_build
+build_again:
+  extends: .gradle_build
   stage: build
   needs: [ build ]
   script:
@@ -110,7 +110,7 @@ build_again: &build
     - ./gradlew :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --parallel --max-workers=8 $GRADLE_ARGS
 
 build_with_cache:
-  <<: *build
+  extends: build
   variables:
     BUILD_CACHE_POLICY: push
     DEPENDENCY_CACHE_POLICY: push
@@ -208,7 +208,7 @@ deploy_to_di_backend:manual:
     UPSTREAM_COMMIT_SHORT_SHA: $CI_COMMIT_SHORT_SHA
 
 deploy_to_sonatype:
-  <<: *gradle_build
+  extends: .gradle_build
   stage: deploy
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
-  - remote: https://gitlab-templates.ddbuild.io/apm/wip/packaging.yml
+  - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
 #  - local: ".gitlab/benchmarks.yml"
 #  - local: ".gitlab/exploration-tests.yml"
 #  - local: ".gitlab/ci-visibility-tests.yml"
@@ -92,6 +92,8 @@ build:
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
     - echo "BUILD_JOB_NAME=$CI_JOB_NAME" >> build.env
     - echo "BUILD_JOB_ID=$CI_JOB_ID" >> build.env
+    - echo "Building again"
+    - ./gradlew :dd-trace-api:jar
   artifacts:
     paths:
       - 'workspace/dd-java-agent/build/libs/*.jar'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,9 +82,9 @@ build: &build
       when: never
     - when: on_success
   script:
-    - ls -la
-    - pwd
-    - ls -la .gradle
+#    - ls -la
+#    - pwd
+#    - ls -la .gradle
     - GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1900M -Xms512M' -Ddatadog.forkedMaxHeapSize=512M -Ddatadog.forkedMinHeapSize=128M" ./gradlew clean :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar --build-cache --parallel --stacktrace --no-daemon --max-workers=8
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env
     - ls -la workspace

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -20,6 +20,6 @@ tasks.register("writeVersionNumberFile") {
   }
 }
 
-tasks.withType(JavaCompile).configureEach {
-  dependsOn "writeVersionNumberFile"
-}
+//tasks.withType(JavaCompile).configureEach {
+//  dependsOn "writeVersionNumberFile"
+//}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # Please note that the version specific cache directory in
-# .circleci/config.continue.yml.j2 needs to match this version.
+# .circleci/config.continue.yml.j2 and .gitlab-ci needs to match this version.
 distributionSha256Sum=f2b9ed0faf8472cbe469255ae6c86eddb77076c75191741b4a462f33128dd419
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 networkTimeout=10000


### PR DESCRIPTION
# What Does This Do
Improves the gradle build cache when running the build in gitlab.  The setup closely matches that of CircleCI. 

There are 2 caches: a dependency cache and build cache. The dependency cache contains the gradle wrapper and all maven dependencies. The build cache is a cache of the currently running pipeline. Both caches can be controlled on a per-job basis using variables.

# Motivation
Fixing the cache is important for #6837 .

# Additional Notes
https://github.com/DataDog/auto_inject/pull/172 must be merged before this to use the proper gitlab runners.
