### PR TITLE
Mark Grizzly HTTP integration test as flaky

### DIFF
--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyTest.groovy
@@ -1,5 +1,6 @@
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.grizzlyhttp232.GrizzlyDecorator
+import datadog.trace.test.util.Flaky
 import org.glassfish.grizzly.http.server.HttpServer
 
 class GrizzlyTest extends HttpServerTest<HttpServer> {
@@ -53,9 +54,10 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
     true
   }
 
+  @Flaky("https://github.com/DataDog/dd-trace-java/issues/6933")
   @Override
   boolean testBlocking() {
-    true
+    "false" != System.getProperty("run.flaky.tests") // Set when using -PskipFlakyTests gradle parameter
   }
 
   //@Ignore("https://github.com/DataDog/dd-trace-java/pull/5213")


### PR DESCRIPTION
# What Does This Do

This PR marks Grizzly HTTP  integration test as flaky.

# Motivation

See #6933

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
