### PR TITLE
Fix agent JAR inde build script cache

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -162,12 +162,13 @@ shadowJar generalShadowJarConfig >> {
 }
 
 tasks.register('generateAgentJarIndex', JavaExec) {
+  def indexName = 'dd-java-agent.index'
   def contentDir = "${sourceSets.main.output.resourcesDir}"
-  def indexFile = "${contentDir}/dd-java-agent.index"
+  def indexFile = "${contentDir}/${indexName}"
 
   it.group = 'Build'
   it.description = "Generate dd-java-agent.index"
-  it.inputs.files(contentDir)
+  it.inputs.files(fileTree(contentDir).exclude(indexName))
   it.outputs.files(indexFile)
   it.mainClass = 'datadog.trace.bootstrap.AgentJarIndex$IndexGenerator'
   it.classpath = project.configurations.shadowInclude


### PR DESCRIPTION
# What Does This Do

This PR fixes the agent JAR index generation Gradle task to avoid breaking build cache.
The task generates an index into its input folder, making the tasks always outdated and mandatory to execute for each build.

# Motivation

This was the last tasks breaking the agent build cache:

```bash
$ ./gradlew :dd-java-agent:shadowJar
…
…
…
BUILD SUCCESSFUL in 9s
1037 actionable tasks: 1037 up-to-date
```

# Additional Notes

An alternative way to fix the issue is to create a dedicated `generated-resources` folder into the module build dir and make sure to is part of resource folder when assembling the artifact. 

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
