### PR TITLE
Mark Play Scala integration test as flaky

### DIFF
--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayScalaRoutesServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/datadog/trace/instrumentation/play25/server/PlayScalaRoutesServerTest.groovy
@@ -8,6 +8,7 @@ import datadog.trace.api.DDTags
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.play25.PlayController
+import datadog.trace.test.util.Flaky
 import groovy.transform.CompileStatic
 import scala.concurrent.ExecutionContext$
 import spock.lang.Shared
@@ -51,6 +52,12 @@ class PlayScalaRoutesServerTest extends PlayServerTest {
   @Override
   String testPathParam() {
     '/path/?/param'
+  }
+
+  @Flaky("https://github.com/DataDog/dd-trace-java/issues/6952")
+  @Override
+  boolean testUserBlocking() {
+    "false" != System.getProperty("run.flaky.tests") // Set when using -PskipFlakyTests gradle parameter
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

This PR marks Play Scala integration test as flaky.

# Motivation

See #6952

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
