### PR TITLE
Finish pyspark-shell trace using SparkListenerApplicationEnd

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -55,6 +55,7 @@ import scala.collection.JavaConverters;
 public abstract class AbstractDatadogSparkListener extends SparkListener {
   public static volatile AbstractDatadogSparkListener listener = null;
   public static volatile boolean finishTraceOnApplicationEnd = true;
+  public static volatile boolean isPysparkShell = false;
 
   private final int MAX_COLLECTION_SIZE = 1000;
   private final int MAX_ACCUMULATOR_SIZE = 10000;

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractSparkInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractSparkInstrumentation.java
@@ -1,13 +1,12 @@
 package datadog.trace.instrumentation.spark;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
-import static net.bytebuddy.matcher.ElementMatchers.isMethod;
-import static net.bytebuddy.matcher.ElementMatchers.nameEndsWith;
+import static net.bytebuddy.matcher.ElementMatchers.*;
 
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import net.bytebuddy.asm.Advice;
+import org.apache.spark.deploy.SparkSubmitArguments;
 
 public abstract class AbstractSparkInstrumentation extends InstrumenterModule.Tracing
     implements Instrumenter.ForKnownTypes {
@@ -32,6 +31,14 @@ public abstract class AbstractSparkInstrumentation extends InstrumenterModule.Tr
 
   @Override
   public void methodAdvice(MethodTransformer transformer) {
+    // Capture spark submit arguments
+    transformer.applyAdvice(
+        isMethod()
+            .and(named("prepareSubmitEnvironment"))
+            .and(takesArgument(0, named("org.apache.spark.deploy.SparkSubmitArguments")))
+            .and(isDeclaredBy(named("org.apache.spark.deploy.SparkSubmit"))),
+        AbstractSparkInstrumentation.class.getName() + "$PrepareSubmitEnvAdvice");
+
     // SparkSubmit class used for non YARN/Mesos environment
     transformer.applyAdvice(
         isMethod()
@@ -47,10 +54,29 @@ public abstract class AbstractSparkInstrumentation extends InstrumenterModule.Tr
         AbstractSparkInstrumentation.class.getName() + "$YarnFinishAdvice");
   }
 
+  public static class PrepareSubmitEnvAdvice {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void enter(@Advice.Argument(0) SparkSubmitArguments submitArgs) {
+
+      // Using pyspark `python script.py`, spark JVM is launched as PythonGatewayServer, which is
+      // exited using System.exit(0), leading to the exit advice not being called
+      // https://github.com/apache/spark/blob/v3.5.1/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala#L540-L542
+      // https://github.com/apache/spark/blob/v3.5.1/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala#L74
+      if ("pyspark-shell".equals(submitArgs.primaryResource())) {
+        AbstractDatadogSparkListener.isPysparkShell = true;
+
+        // prepareSubmitEnvironment might be called before/after runMain depending on spark version
+        AbstractDatadogSparkListener.finishTraceOnApplicationEnd = true;
+      }
+    }
+  }
+
   public static class RunMainAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void enter() {
-      AbstractDatadogSparkListener.finishTraceOnApplicationEnd = false;
+      if (!AbstractDatadogSparkListener.isPysparkShell) {
+        AbstractDatadogSparkListener.finishTraceOnApplicationEnd = false;
+      }
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractSparkInstrumentation.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractSparkInstrumentation.java
@@ -1,7 +1,10 @@
 package datadog.trace.instrumentation.spark;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.*;
+import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.nameEndsWith;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;


### PR DESCRIPTION
# What Does This Do

Finish pyspark-shell application span when the spark listener is receiving the `SparkListenerApplicationEnd` event

The application span is currently finished [when exiting the runMain](https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractSparkInstrumentation.java#L56-L63) method to capture JVM errors ([from this PR](https://github.com/DataDog/dd-trace-java/pull/5505)), however this function is not exited as expected (System.exit(0)) when executing as pyspark-shell

# Motivation

Pyspark application can be launched [using multiple method](https://spark.apache.org/docs/latest/quick-start.html#self-contained-applications), mainly:
- `spark-submit script.py` 
- `python script.py` 

The spark instrumentation is working as expected in the `spark-submit` case, because this is java/scala code launched behind the scene

However, the `python` case, the listener is being injected as expected, but the `spark.application` span is not being closed properly because the JVM is [launched as PythonGatewayServer](https://github.com/apache/spark/blob/v3.5.1/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala#L540-L542) which is [exited using System.exit(0)](https://github.com/apache/spark/blob/v3.5.1/core/src/main/scala/org/apache/spark/api/python/PythonGatewayServer.scala#L74), leading to the exit advice not being called

# Additional Notes

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
