### PR TITLE
Mark Spark integration test as flaky

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSpark32SqlTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSpark32SqlTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.spark
 
 import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.test.util.Flaky
 import org.apache.spark.sql.SparkSession
 
 abstract class AbstractSpark32SqlTest extends AgentTestRunner {
@@ -97,6 +98,7 @@ abstract class AbstractSpark32SqlTest extends AgentTestRunner {
     }
   }
 
+  @Flaky("https://github.com/DataDog/dd-trace-java/issues/6957")
   def "compute a JOIN sql query plan"() {
     def sparkSession = SparkSession.builder()
       .config("spark.master", "local[2]")


### PR DESCRIPTION
# What Does This Do

This PR marks Spark integration test as flaky.

# Motivation

See #6957

# Additional Notes

Jira ticket: [DJM-206]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DJM-206]: https://datadoghq.atlassian.net/browse/DJM-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ