### PR TITLE
Fix test names to be unique

### DIFF
--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -357,7 +357,7 @@ class ReactorCoreTest extends AgentTestRunner {
     "basic flux" | 2         | { -> Flux.fromIterable([1, 2]).map(addOne) }
   }
 
-  def "Fluxes produce the right number of results '#scheduler'"() {
+  def "Fluxes produce the right number of results on '#schedulerName' scheduler"() {
     when:
     List<String> values = Flux.fromIterable(Arrays.asList(1, 2, 3, 4))
       .parallel()
@@ -371,12 +371,11 @@ class ReactorCoreTest extends AgentTestRunner {
     values.size() == 4
 
     where:
-    scheduler << [
-      Schedulers.parallel(),
-      Schedulers.elastic(),
-      Schedulers.single(),
-      Schedulers.immediate()
-    ]
+    schedulerName | scheduler
+    "parallel"    | Schedulers.parallel()
+    "elastic"     | Schedulers.elastic()
+    "single"      | Schedulers.single()
+    "immediate"   | Schedulers.immediate()
   }
 
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")

--- a/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2Test.groovy
+++ b/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2Test.groovy
@@ -359,7 +359,7 @@ class RxJava2Test extends AgentTestRunner {
     "basic flowable" | 2         | { -> Flowable.fromIterable([1, 2]).map(addOne) }
   }
 
-  def "Flowables produce the right number of results '#scheduler'"() {
+  def "Flowables produce the right number of results on '#schedulerName' scheduler"() {
     when:
     List<String> values = Flowable.fromIterable(Arrays.asList(1, 2, 3, 4))
       .parallel()
@@ -373,12 +373,11 @@ class RxJava2Test extends AgentTestRunner {
     values.size() == 4
 
     where:
-    scheduler << [
-      Schedulers.newThread(),
-      Schedulers.computation(),
-      Schedulers.single(),
-      Schedulers.trampoline()
-    ]
+    schedulerName | scheduler
+    "new-thread"   | Schedulers.newThread()
+    "computation" | Schedulers.computation()
+    "single"      | Schedulers.single()
+    "trampoline"  | Schedulers.trampoline()
   }
 
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")

--- a/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
+++ b/remote-config/src/test/groovy/datadog/remoteconfig/ConfigurationPollerSpecification.groovy
@@ -1,12 +1,8 @@
+package datadog.remoteconfig
+
 import cafe.cryptography.ed25519.Ed25519PrivateKey
 import cafe.cryptography.ed25519.Ed25519PublicKey
 import cafe.cryptography.ed25519.Ed25519Signature
-import datadog.remoteconfig.ConfigurationChangesListener
-import datadog.remoteconfig.ConfigurationChangesTypedListener
-import datadog.remoteconfig.ConfigurationDeserializer
-import datadog.remoteconfig.ConfigurationPoller
-import datadog.remoteconfig.JsonCanonicalizer
-import datadog.remoteconfig.Product
 import datadog.remoteconfig.state.ProductListener
 import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
@@ -1108,7 +1104,7 @@ class ConfigurationPollerSpecification extends DDSpecification {
     ]
   }
 
-  void 'reportable errors'() {
+  void 'reportable errors #errorMsg'() {
     when:
     poller.addListener(Product.ASM_DD,
       { throw new RuntimeException('should not be called') } as ConfigurationDeserializer,


### PR DESCRIPTION
# What Does This Do

This PR fix few test names to not rely on toString() for generated names, making them unique across runs.

# Motivation

This will help identify tests in CI visibility.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
