### PR TITLE
Fix CI broken sources artifact

### DIFF
--- a/dd-java-agent/agent-tooling/build.gradle
+++ b/dd-java-agent/agent-tooling/build.gradle
@@ -35,7 +35,6 @@ configurations {
 }
 
 compileJava.dependsOn 'generateClassNameTries'
-packageSources.dependsOn 'generateClassNameTries'
 sourcesJar.dependsOn 'generateClassNameTries'
 
 dependencies {

--- a/dd-java-agent/instrumentation/iast-instrumenter/build.gradle
+++ b/dd-java-agent/instrumentation/iast-instrumenter/build.gradle
@@ -10,7 +10,6 @@ apply from: "${rootDir}/gradle/tries.gradle"
 addTestSuiteForDir('latestDepTest', 'test')
 
 compileJava.dependsOn 'generateClassNameTries'
-packageSources.dependsOn 'generateClassNameTries'
 sourcesJar.dependsOn 'generateClassNameTries'
 
 

--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -67,10 +67,6 @@ dependencies {
   testImplementation project(':dd-smoke-tests')
 }
 
-tasks.packageSources {
-  dependsOn 'unzip'
-}
-
 tasks.sourcesJar {
   dependsOn 'unzip'
 }
@@ -92,10 +88,6 @@ tasks.war {
 }
 
 tasks.javadocJar{
-  dependsOn 'unzip'
-}
-
-tasks.packageSources{
   dependsOn 'unzip'
 }
 

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -101,15 +101,7 @@ jar {
    Instead we should 'fail early' and avoid building such Jars.
    */
   duplicatesStrategy = 'fail'
-}
 
-tasks.register("packageSources", Jar) {
-  archiveClassifier = 'sources'
-  from sourceSets.main.allSource
-}
-artifacts.archives packageSources
-
-jar {
   manifest {
     attributes(
       "Implementation-Title": project.name,


### PR DESCRIPTION
# What Does This Do

This PR removes the broken `packageSources` task.
This task creates "-sources.jar" like the `withSourcesJar()` from the [Java gradle plugin](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.plugins/-java-plugin-extension/with-sources-jar.html).

The artifact produced by the `packageSources` tasks were overridden by the Java plugin ones at every build and broke the build cache.

I checked the artifact that should be produced by the `packageSources` task are the same (in size and in file count) that the ones the Java plugin builds. We should be able to safely remove the task without trying to fix it.

# Motivation

This task breaks the build cache by creating artifacts that are always overridden.

![image](https://github.com/DataDog/dd-trace-java/assets/1766222/bacd515d-83e8-4613-867c-4974ddffa4ac)

Fixing it finally makes the all the `gradle assemble` command tasks _up-to-date_:
```bash
BUILD SUCCESSFUL in 10s
2114 actionable tasks: 2114 up-to-date
``` 

# Additional Notes

I also group the two `jar` task configuration into one as clean up.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
