### PR TITLE
Skip auto user events when sign-up logic fails

### DIFF
--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/SpringSecurityUserEventDecorator.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/SpringSecurityUserEventDecorator.java
@@ -18,7 +18,13 @@ public class SpringSecurityUserEventDecorator extends AppSecUserEventDecorator {
   public static final SpringSecurityUserEventDecorator DECORATE =
       new SpringSecurityUserEventDecorator();
 
-  public void onSignup(UserDetails user) {
+  public void onSignup(UserDetails user, Throwable throwable) {
+    // skip failures while signing up a user, later on, we might want to generate a separate event
+    // for this case
+    if (throwable != null) {
+      return;
+    }
+
     UserEventTrackingMode mode = Config.get().getAppSecUserEventsTrackingMode();
     String userId = null;
     Map<String, String> metadata = null;

--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/UserDetailsManagerAdvice.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/UserDetailsManagerAdvice.java
@@ -7,9 +7,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 public class UserDetailsManagerAdvice {
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-  public static void onExit(@Advice.Argument(value = 0, readOnly = false) UserDetails user) {
+  public static void onExit(
+      @Advice.Argument(value = 0, readOnly = false) UserDetails user,
+      @Advice.Thrown Throwable throwable) {
     if (ActiveSubsystems.APPSEC_ACTIVE) {
-      SpringSecurityUserEventDecorator.DECORATE.onSignup(user);
+      SpringSecurityUserEventDecorator.DECORATE.onSignup(user, throwable);
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
Skip generating `appsec.events.users.signup.*` events in case there is an error in the sign up process.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
