### PR TITLE
Improve custom Instrumenter Gradle plugin

### DIFF
--- a/buildSrc/src/main/groovy/InstrumentPlugin.groovy
+++ b/buildSrc/src/main/groovy/InstrumentPlugin.groovy
@@ -7,6 +7,13 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.invocation.BuildInvocationDetails
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
@@ -20,8 +27,8 @@ import java.util.regex.Matcher
 /**
  * instrument<Language> task plugin which performs build-time instrumentation of classes.
  */
+@SuppressWarnings('unused')
 class InstrumentPlugin implements Plugin<Project> {
-
   @Override
   void apply(Project project) {
     InstrumentExtension extension = project.extensions.create('instrument', InstrumentExtension)
@@ -34,8 +41,8 @@ class InstrumentPlugin implements Plugin<Project> {
       Matcher versionMatcher = it.name =~ /compileMain_(.+)Java/
       project.afterEvaluate {
         if (!compileTask.source.empty) {
-          String sourceSetSuffix
-          String javaVersion
+          String sourceSetSuffix = null
+          String javaVersion = null
           if (versionMatcher.matches()) {
             sourceSetSuffix = versionMatcher.group(1)
             if (sourceSetSuffix ==~ /java\d+/) {
@@ -51,14 +58,28 @@ class InstrumentPlugin implements Plugin<Project> {
 
           // insert task between compile and jar, and before test*
           String instrumentTaskName = compileTask.name.replace('compile', 'instrument')
-          def instrumentTask = project.task(['type': InstrumentTask], instrumentTaskName) {
-            description = "Instruments the classes compiled by ${compileTask.name}"
-            doLast {
-              instrument(javaVersion, project, extension, rawClassesDir, classesDir, it)
+          def instrumentTask = project.tasks.register(instrumentTaskName, InstrumentTask) {
+            // Task configuration
+            it.group = 'Byte Buddy'
+            it.description = "Instruments the classes compiled by ${compileTask.name}"
+            it.inputs.dir(compileTask.destinationDirectory)
+            it.outputs.dir(classesDir)
+            // Task inputs
+            it.javaVersion = javaVersion
+            def instrumenterConfiguration = project.configurations.named('instrumentPluginClasspath')
+            if (instrumenterConfiguration.present) {
+              it.pluginClassPath.from(instrumenterConfiguration.get())
             }
+            it.plugins = extension.plugins
+            it.instrumentingClassPath.from(
+              findCompileClassPath(project, it.name) +
+                rawClassesDir +
+                findAdditionalClassPath(extension, it.name)
+            )
+            it.sourceDirectory = rawClassesDir
+            // Task output
+            it.targetDirectory = classesDir
           }
-          instrumentTask.inputs.dir(compileTask.destinationDirectory)
-          instrumentTask.outputs.dir(classesDir)
           if (javaVersion) {
             project.tasks.named(project.sourceSets."main_java${javaVersion}".classesTaskName) {
               it.dependsOn(instrumentTask)
@@ -72,6 +93,22 @@ class InstrumentPlugin implements Plugin<Project> {
       }
     }
   }
+
+  static findCompileClassPath(Project project, String taskName) {
+    def matcher = taskName =~ /instrument([A-Z].+)Java/
+    def cfgName = matcher.matches() ? "${matcher.group(1).uncapitalize()}CompileClasspath" : 'compileClasspath'
+    project.configurations.named(cfgName).findAll {
+      it.name != 'previous-compilation-data.bin' && !it.name.endsWith('.gz')
+    }
+  }
+
+  static findAdditionalClassPath(InstrumentExtension extension, String taskName) {
+    extension.additionalClasspath.getOrDefault(taskName, []).collect {
+      // insert intermediate 'raw' directory for unprocessed classes
+      def fileName = it.get().asFile.name
+      it.get().dir("../${fileName.replaceFirst('^main', 'raw')}")
+    }
+  }
 }
 
 abstract class InstrumentExtension {
@@ -80,53 +117,51 @@ abstract class InstrumentExtension {
 }
 
 abstract class InstrumentTask extends DefaultTask {
-  {
-    group = 'Byte Buddy'
-  }
+  @Input @Optional
+  String javaVersion
+  @InputFiles @Classpath
+  abstract ConfigurableFileCollection getPluginClassPath()
+  @Input
+  ListProperty<String> plugins
+  @InputFiles @Classpath
+  abstract ConfigurableFileCollection getInstrumentingClassPath()
+  @InputDirectory
+  Directory sourceDirectory
+
+  @OutputDirectory
+  Directory targetDirectory
 
   @Inject
   abstract JavaToolchainService getJavaToolchainService()
-
   @Inject
   abstract BuildInvocationDetails getInvocationDetails()
-
   @Inject
   abstract WorkerExecutor getWorkerExecutor()
 
-  void instrument(String javaVersion,
-                  Project project,
-                  InstrumentExtension extension,
-                  Directory sourceDirectory,
-                  Directory targetDirectory,
-                  InstrumentTask instrumentTask)
-  {
-    def workQueue = getWorkQueueFor(javaVersion)
-    workQueue.submit(InstrumentAction.class, parameters -> {
-      parameters.buildStartedTime.set(invocationDetails.buildStartedTime)
-      parameters.pluginClassPath.setFrom(project.configurations.findByName('instrumentPluginClasspath') ?: [])
-      parameters.plugins.set(extension.plugins)
-      def matcher = instrumentTask.name =~ /instrument([A-Z].+)Java/
-      def cfgName = matcher.matches() ? "${matcher.group(1).uncapitalize()}CompileClasspath" : 'compileClasspath'
-      parameters.instrumentingClassPath.setFrom(project.configurations[cfgName].findAll {
-        it.name != 'previous-compilation-data.bin' && !it.name.endsWith(".gz")
-      } + sourceDirectory + (extension.additionalClasspath[instrumentTask.name] ?: [])*.get())
-      parameters.sourceDirectory.set(sourceDirectory.asFile)
-      parameters.targetDirectory.set(targetDirectory.asFile)
+  @TaskAction
+  instrument() {
+    workQueue().submit(InstrumentAction.class, parameters -> {
+      parameters.buildStartedTime.set(this.invocationDetails.buildStartedTime)
+      parameters.pluginClassPath.from(this.pluginClassPath)
+      parameters.plugins.set(this.plugins)
+      parameters.instrumentingClassPath.setFrom(this.instrumentingClassPath)
+      parameters.sourceDirectory.set(this.sourceDirectory.asFile)
+      parameters.targetDirectory.set(this.targetDirectory.asFile)
     })
   }
 
-  private getWorkQueueFor(String javaVersion) {
-    if (javaVersion) {
-      def javaLauncher = javaToolchainService.launcherFor { spec ->
-        spec.languageVersion.set(JavaLanguageVersion.of(javaVersion))
+  private workQueue() {
+    if (this.javaVersion) {
+      def javaLauncher = this.javaToolchainService.launcherFor { spec ->
+        spec.languageVersion.set(JavaLanguageVersion.of(this.javaVersion))
       }.get()
-      return workerExecutor.processIsolation { spec ->
+      return this.workerExecutor.processIsolation { spec ->
         spec.forkOptions { fork ->
           fork.executable = javaLauncher.executablePath
         }
       }
     } else {
-      return workerExecutor.noIsolation()
+      return this.workerExecutor.noIsolation()
     }
   }
 }

--- a/buildSrc/src/main/groovy/InstrumentPlugin.groovy
+++ b/buildSrc/src/main/groovy/InstrumentPlugin.groovy
@@ -14,6 +14,7 @@ import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
 
+import javax.inject.Inject
 import java.util.regex.Matcher
 
 /**
@@ -83,13 +84,13 @@ abstract class InstrumentTask extends DefaultTask {
     group = 'Byte Buddy'
   }
 
-  @javax.inject.Inject
+  @Inject
   abstract JavaToolchainService getJavaToolchainService()
 
-  @javax.inject.Inject
+  @Inject
   abstract BuildInvocationDetails getInvocationDetails()
 
-  @javax.inject.Inject
+  @Inject
   abstract WorkerExecutor getWorkerExecutor()
 
   void instrument(String javaVersion,

--- a/buildSrc/src/main/groovy/InstrumentPlugin.groovy
+++ b/buildSrc/src/main/groovy/InstrumentPlugin.groovy
@@ -27,7 +27,7 @@ class InstrumentPlugin implements Plugin<Project> {
 
     project.tasks.matching {
       it.name in ['compileJava', 'compileScala', 'compileKotlin'] ||
-        it.name =~ /compileMain_(?:.+)Java/
+        it.name =~ /compileMain_.+Java/
     }.all {
       AbstractCompile compileTask = it as AbstractCompile
       Matcher versionMatcher = it.name =~ /compileMain_(.+)Java/


### PR DESCRIPTION
# What Does This Do

This PR improves our custom Instrumer plugin by using Gradle plugin development conventions like:
* Late task creation with one-time configuration,
* Using Task action rather than task execution callbacks,
* Properly declare task inputs and outputs to improve cache behavior,
* Build inputs like the instrumenting classpath at task definition rather than execution to avoid passing and serializing heavy objects like `Project` and `Configuration`
* Removing deprecated Gradle API usage

# Motivation

This improves our build performance and cache. It also make the plugin compatible with Gradle configuration cache feature.

# Additional Notes

The commits will be squashed when merging.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
