### PR TITLE
Report servlet misconfiguration vulnerabilities with opt-out configuration

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/IastServlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/IastServlet2Instrumentation.java
@@ -64,4 +64,9 @@ public final class IastServlet2Instrumentation extends InstrumenterModule.Iast
             .and(isPublic()),
         packageName + ".IastServlet2Advice");
   }
+
+  @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
 }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/IastServlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/IastServlet3Instrumentation.java
@@ -59,4 +59,9 @@ public final class IastServlet3Instrumentation extends InstrumenterModule.Iast
             .and(isPublic()),
         packageName + ".IastServlet3Advice");
   }
+
+  @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
 }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/IastJakartaServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/main/java/datadog/trace/instrumentation/servlet5/IastJakartaServletInstrumentation.java
@@ -58,6 +58,11 @@ public class IastJakartaServletInstrumentation extends InstrumenterModule.Iast
         getClass().getName() + "$IastAdvice");
   }
 
+  @Override
+  protected boolean isOptOutEnabled() {
+    return true;
+  }
+
   public static class IastAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class)


### PR DESCRIPTION
# What Does This Do

Enable opt-out for instrumentations that calls ApplicationModule

# Motivation

We are not reporting servlet misconfiguration vulnerabilities with opt-out configuration

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
