### PR TITLE
Process 'sampling.priority' tags

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/RuleFlags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/taginterceptor/RuleFlags.java
@@ -14,6 +14,7 @@ public class RuleFlags {
     DB_STATEMENT("DBStatementRule"),
     FORCE_MANUAL_DROP("ForceManualDropTagInterceptor"),
     FORCE_MANUAL_KEEP("ForceManualKeepTagInterceptor"),
+    FORCE_SAMPLING_PRIORITY("ForceSamplingPriorityTagInterceptor"),
     PEER_SERVICE("PeerServiceTagInterceptor", false),
     SERVICE_NAME("ServiceNameTagInterceptor"),
     SERVLET_CONTEXT("ServletContextTagInterceptor");

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/taginterceptor/TagInterceptorTest.groovy
@@ -408,18 +408,28 @@ class TagInterceptorTest extends DDCoreSpecification {
     tracer.close()
 
     where:
-    tag                | value   | expected
-    DDTags.MANUAL_KEEP | true    | PrioritySampling.USER_KEEP
-    DDTags.MANUAL_KEEP | false   | null
-    DDTags.MANUAL_KEEP | "true"  | PrioritySampling.USER_KEEP
-    DDTags.MANUAL_KEEP | "false" | null
-    DDTags.MANUAL_KEEP | "asdf"  | null
+    tag                    | value   | expected
+    DDTags.MANUAL_KEEP     | true    | PrioritySampling.USER_KEEP
+    DDTags.MANUAL_KEEP     | false   | null
+    DDTags.MANUAL_KEEP     | "true"  | PrioritySampling.USER_KEEP
+    DDTags.MANUAL_KEEP     | "false" | null
+    DDTags.MANUAL_KEEP     | "asdf"  | null
 
-    DDTags.MANUAL_DROP | true    | PrioritySampling.USER_DROP
-    DDTags.MANUAL_DROP | false   | null
-    DDTags.MANUAL_DROP | "true"  | PrioritySampling.USER_DROP
-    DDTags.MANUAL_DROP | "false" | null
-    DDTags.MANUAL_DROP | "asdf"  | null
+    DDTags.MANUAL_DROP     | true    | PrioritySampling.USER_DROP
+    DDTags.MANUAL_DROP     | false   | null
+    DDTags.MANUAL_DROP     | "true"  | PrioritySampling.USER_DROP
+    DDTags.MANUAL_DROP     | "false" | null
+    DDTags.MANUAL_DROP     | "asdf"  | null
+
+    Tags.SAMPLING_PRIORITY | -1      | PrioritySampling.USER_DROP
+    Tags.SAMPLING_PRIORITY | 0       | PrioritySampling.USER_DROP
+    Tags.SAMPLING_PRIORITY | 1       | PrioritySampling.USER_KEEP
+    Tags.SAMPLING_PRIORITY | 2       | PrioritySampling.USER_KEEP
+    Tags.SAMPLING_PRIORITY | "-1"    | PrioritySampling.USER_DROP
+    Tags.SAMPLING_PRIORITY | "0"     | PrioritySampling.USER_DROP
+    Tags.SAMPLING_PRIORITY | "1"     | PrioritySampling.USER_KEEP
+    Tags.SAMPLING_PRIORITY | "2"     | PrioritySampling.USER_KEEP
+    Tags.SAMPLING_PRIORITY | "asdf"  | null
   }
 
   def "set error flag when error tag reported"() {


### PR DESCRIPTION
# What Does This Do

Processes `sampling.priority` tags as defined by [OpenTracing](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#span-tags-table):
> If greater than 0, a hint to the Tracer to do its best to capture the trace. If 0, a hint to the trace to not-capture the trace. If absent, the Tracer should use its default sampling mechanism.

# Motivation

Improves consistency with other tracers that process `sampling.priority` tags. 

Jira ticket: [PROJ-IDENT]