### PR TITLE
Fix Selenium instrumentation to avoid trying to set cookies for about:blank and other similar pages

### DIFF
--- a/dd-java-agent/instrumentation/selenium/src/test/groovy/datadog/trace/instrumentation/selenium/SeleniumUtilsTest.groovy
+++ b/dd-java-agent/instrumentation/selenium/src/test/groovy/datadog/trace/instrumentation/selenium/SeleniumUtilsTest.groovy
@@ -29,8 +29,6 @@ class SeleniumUtilsTest extends AgentTestRunner {
 
     where:
     host                                                  | expectedValue
-    null                                                  | null
-    "malformed-url"                                       | null
     "http://192.168.0.1"                                  | null
     "http://localhost:8080"                               | null
     "http://website.com"                                  | null


### PR DESCRIPTION
# What Does This Do
Updates Selenium instrumentation to avoid setting cookies for pages whose URL cannot be parsed (`about:blank` is one example of such page).

# Motivation
Some Selenium tests explicitly open `about:blank` before starting a test case.
Trying to set a cookie for this page will lead to a Selenium driver exception.

# Additional Notes
Selenium instrumentation adds cookies for loaded pages in order to integrate with DD RUM (if the page has RUM instrumentation configured, RUM will use the cookie to establish correspondence between a RUM session and a CI Visibility test case).

Jira ticket: [CIVIS-9921]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-9921]: https://datadoghq.atlassian.net/browse/CIVIS-9921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ