### PR TITLE
Add coordinated sampling for Exception Debugging

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -65,9 +65,9 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
       }
       processSnapshotsAndSetTags(t, span, state, innerMostException);
     } else {
-      exceptionProbeManager.createProbesForException(
-          fingerprint, innerMostException.getStackTrace());
-      AgentTaskScheduler.INSTANCE.execute(() -> applyExceptionConfiguration(fingerprint));
+      if (exceptionProbeManager.createProbesForException(innerMostException.getStackTrace())) {
+        AgentTaskScheduler.INSTANCE.execute(() -> applyExceptionConfiguration(fingerprint));
+      }
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -37,7 +37,8 @@ public class ExceptionProbeManager {
     return classNameFiltering;
   }
 
-  public void createProbesForException(String fingerprint, StackTraceElement[] stackTraceElements) {
+  public boolean createProbesForException(StackTraceElement[] stackTraceElements) {
+    boolean created = false;
     for (StackTraceElement stackTraceElement : stackTraceElements) {
       if (stackTraceElement.isNativeMethod() || stackTraceElement.getLineNumber() < 0) {
         // Skip native methods and lines without line numbers
@@ -54,8 +55,10 @@ public class ExceptionProbeManager {
               null,
               String.valueOf(stackTraceElement.getLineNumber()));
       ExceptionProbe probe = createMethodProbe(this, where);
+      created = true;
       probes.putIfAbsent(probe.getId(), probe);
     }
+    return created;
   }
 
   void addFingerprint(String fingerprint) {
@@ -103,7 +106,7 @@ public class ExceptionProbeManager {
 
   public static class ThrowableState {
     private final String exceptionId;
-    private final List<Snapshot> snapshots = new ArrayList<>();
+    private List<Snapshot> snapshots;
 
     private ThrowableState(String exceptionId) {
       this.exceptionId = exceptionId;
@@ -117,7 +120,14 @@ public class ExceptionProbeManager {
       return snapshots;
     }
 
+    public boolean isSampling() {
+      return snapshots != null && !snapshots.isEmpty();
+    }
+
     public void addSnapshot(Snapshot snapshot) {
+      if (snapshots == null) {
+        snapshots = new ArrayList<>();
+      }
       snapshots.add(snapshot);
     }
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -404,11 +404,15 @@ public class LogProbe extends ProbeDefinition {
   }
 
   private void sample(LogStatus logStatus, MethodLocation methodLocation) {
+    if (logStatus.isForceSampling()) {
+      return;
+    }
     // sample only once and when we need to evaluate
     if (!MethodLocation.isSame(methodLocation, evaluateAt)) {
       return;
     }
     boolean sampled = ProbeRateLimiter.tryProbe(id);
+    LOGGER.debug("Probe[{}] sampled={}", probeId.getId(), sampled);
     logStatus.setSampled(sampled);
     if (!sampled) {
       DebuggerAgent.getSink().skipSnapshot(id, DebuggerContext.SkipCause.RATE);
@@ -586,6 +590,7 @@ public class LogProbe extends ProbeDefinition {
     private boolean hasLogTemplateErrors;
     private boolean hasConditionErrors;
     private boolean sampled = true;
+    private boolean forceSampling;
     private String message;
 
     public LogStatus(ProbeImplementation probeImplementation) {
@@ -653,6 +658,14 @@ public class LogProbe extends ProbeDefinition {
 
     public boolean isSampled() {
       return sampled;
+    }
+
+    public boolean isForceSampling() {
+      return forceSampling;
+    }
+
+    public void setForceSampling(boolean forceSampling) {
+      this.forceSampling = forceSampling;
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -48,7 +48,6 @@ import com.squareup.moshi.JsonAdapter;
 import datadog.trace.agent.tooling.TracerInstaller;
 import datadog.trace.api.Config;
 import datadog.trace.api.interceptor.MutableSpan;
-import datadog.trace.api.sampling.Sampler;
 import datadog.trace.bootstrap.debugger.*;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
 import datadog.trace.bootstrap.debugger.util.Redaction;
@@ -2071,8 +2070,8 @@ public class CapturedSnapshotTest {
     } finally {
       ProbeRateLimiter.setSamplerSupplier(null);
     }
-    assertEquals(expectedGlobalCount, globalSampler.callCount);
-    assertEquals(expectedProbeCount, probeSampler.callCount);
+    assertEquals(expectedGlobalCount, globalSampler.getCallCount());
+    assertEquals(expectedProbeCount, probeSampler.getCallCount());
   }
 
   @Test
@@ -2534,27 +2533,6 @@ public class CapturedSnapshotTest {
     @Override
     public void instrumentationResult(ProbeDefinition definition, InstrumentationResult result) {
       results.put(definition.getId(), result);
-    }
-  }
-
-  static class MockSampler implements Sampler {
-
-    int callCount;
-
-    @Override
-    public boolean sample() {
-      callCount++;
-      return true;
-    }
-
-    @Override
-    public boolean keep() {
-      return false;
-    }
-
-    @Override
-    public boolean drop() {
-      return false;
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MockSampler.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MockSampler.java
@@ -1,0 +1,28 @@
+package com.datadog.debugger.agent;
+
+import datadog.trace.api.sampling.Sampler;
+
+public class MockSampler implements Sampler {
+
+  private int callCount;
+
+  @Override
+  public boolean sample() {
+    callCount++;
+    return true;
+  }
+
+  @Override
+  public boolean keep() {
+    return false;
+  }
+
+  @Override
+  public boolean drop() {
+    return false;
+  }
+
+  public int getCallCount() {
+    return callCount;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -21,7 +21,7 @@ class ExceptionProbeManagerTest {
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     RuntimeException exception = new RuntimeException("test");
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
-    exceptionProbeManager.createProbesForException(fingerprint, exception.getStackTrace());
+    exceptionProbeManager.createProbesForException(exception.getStackTrace());
     assertFalse(exceptionProbeManager.getProbes().isEmpty());
   }
 
@@ -42,7 +42,7 @@ class ExceptionProbeManagerTest {
 
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     assertEquals("d2e9d63e304d95f6435d77bf4d0d387521591e550be21d432339a14ee1cb40", fingerprint);
-    exceptionProbeManager.createProbesForException(fingerprint, exception.getStackTrace());
+    exceptionProbeManager.createProbesForException(exception.getStackTrace());
     assertEquals(1, exceptionProbeManager.getProbes().size());
     ExceptionProbe exceptionProbe = exceptionProbeManager.getProbes().iterator().next();
     assertEquals(
@@ -67,7 +67,7 @@ class ExceptionProbeManagerTest {
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     assertEquals("7a1e5e1bcc64ee26801d1471245eff6b6e8d7c61d0ea36fe85f3f75d79e42c", fingerprint);
-    exceptionProbeManager.createProbesForException("", exception.getStackTrace());
+    exceptionProbeManager.createProbesForException(exception.getStackTrace());
     assertEquals(0, exceptionProbeManager.getProbes().size());
   }
 }


### PR DESCRIPTION
# What Does This Do
if the first stack level generates a snapshot after sampling
 we keep continuing to generate snapshot for next levels by forcing
sampling (not calling the sampler).
For each evaluation of exception probe we query the state by throwable
 instance and based on this state (list of snapshots) we take the
decision keep sampling or drop)

# Motivation
Having complete stacks with all snpashots without depending on the sampling for each stack level

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ