### PR TITLE
unwrap akka `TaskInvocation` and scala `CallbackRunnable`

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskUnwrappingInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskUnwrappingInstrumentation.java
@@ -51,7 +51,9 @@ public class TaskUnwrappingInstrumentation extends InstrumenterModule.Profiling
     "io.grpc.netty.shaded.io.netty.util.concurrent.PromiseTask$RunnableAdapter",
     "task",
     "io.grpc.netty.shaded.io.netty.util.concurrent.PromiseTask",
-    "task"
+    "task",
+    "akka.dispatch.TaskInvocation",
+    "runnable"
   };
 
   @Override

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskUnwrappingInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/TaskUnwrappingInstrumentation.java
@@ -53,7 +53,9 @@ public class TaskUnwrappingInstrumentation extends InstrumenterModule.Profiling
     "io.grpc.netty.shaded.io.netty.util.concurrent.PromiseTask",
     "task",
     "akka.dispatch.TaskInvocation",
-    "runnable"
+    "runnable",
+    "scala.concurrent.impl.CallbackRunnable",
+    "onComplete"
   };
 
   @Override


### PR DESCRIPTION
# What Does This Do

Makes akka `TaskInvocation` instances unwrappable so we can access the name of the `Runnable` they carry. 

```scala
final case class TaskInvocation(eventStream: _root_.akka.event.EventStream, runnable: _root_.java.lang.Runnable, cleanup: () => _root_.scala.Unit) extends _root_.akka.dispatch.Batchable {
  override final def isBatchable: _root_.scala.Boolean = ???

  def run(): _root_.scala.Unit = ???
}
```

Also allows access to Scala's `CalbackRunnable`'s `onComplete` field.

# Motivation

This will allow the time spent queueing by `TaskInvocation`s to be disaggregated.
<img width="377" alt="Screenshot 2024-04-30 at 14 05 58" src="https://github.com/DataDog/dd-trace-java/assets/16439049/9f226588-8bf3-461c-a44f-56bd8b752910">


# Additional Notes

Jira ticket: [PROF-9696]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-9696]: https://datadoghq.atlassian.net/browse/PROF-9696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ