### PR TITLE
use real time threshold for queue times

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -29,7 +29,6 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_T
 
 import com.datadog.profiling.controller.OngoingRecording;
 import com.datadog.profiling.utils.ProfilingMode;
-import com.datadog.profiling.utils.Timestamper;
 import com.datadoghq.profiler.ContextSetter;
 import com.datadoghq.profiler.JavaProfiler;
 import datadog.trace.api.profiling.RecordingData;
@@ -97,7 +96,7 @@ public final class DatadogProfiler {
 
   private final List<String> orderedContextAttributes;
 
-  private final double queueTimeThresholdNanos;
+  private final long queueTimeThresholdMillis;
 
   private DatadogProfiler(ConfigProvider configProvider) {
     this(configProvider, getContextAttributes(configProvider));
@@ -134,11 +133,10 @@ public final class DatadogProfiler {
       orderedContextAttributes.add(RESOURCE);
     }
     this.contextSetter = new ContextSetter(profiler, orderedContextAttributes);
-    this.queueTimeThresholdNanos =
-        1_000_000D
-            * configProvider.getLong(
-                PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS,
-                PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS_DEFAULT);
+    this.queueTimeThresholdMillis =
+        configProvider.getLong(
+            PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS,
+            PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS_DEFAULT);
   }
 
   void addThread() {
@@ -377,34 +375,21 @@ public final class DatadogProfiler {
   }
 
   public QueueTimeTracker newQueueTimeTracker() {
-    return new QueueTimeTracker(this, timestamper().timestamp());
+    return new QueueTimeTracker(this, profiler.getCurrentTicks());
   }
 
-  void recordQueueTimeEvent(long startTicks, Object task, Class<?> scheduler, Thread origin) {
+  void recordQueueTimeEvent(
+      long startMillis, long startTicks, Object task, Class<?> scheduler, Thread origin) {
     if (profiler != null) {
-      Timestamper timestamper = timestamper();
-      long endTicks = timestamper.timestamp();
-      double durationNanos = timestamper.toNanosConversionFactor() * (endTicks - startTicks);
-      if (durationNanos >= queueTimeThresholdNanos) {
+      if (System.currentTimeMillis() - startMillis >= queueTimeThresholdMillis) {
         // note: because this type traversal can update secondary_super_cache (see JDK-8180450)
         // we avoid doing this unless we are absolutely certain we will record the event
         Class<?> taskType = TaskWrapper.getUnwrappedType(task);
         if (taskType != null) {
+          long endTicks = profiler.getCurrentTicks();
           profiler.recordQueueTime(startTicks, endTicks, taskType, scheduler, origin);
         }
       }
     }
-  }
-
-  private Timestamper timestamper() {
-    // FIXME intended to be injectable, but still a singleton for currently pragmatic reasons.
-    //  We need a way to make the Controller responsible for creating the context integration
-    //  for the tracer, which also allows the context integration to be constant in the tracer,
-    //  as well as allowing for the various late initialisation needs for JFR on certain JDK
-    // versions
-    // note that this access does not risk using the default version so long as queue time is
-    // guarded
-    // by checking if JFR is ready (this currently happens in QueueTimeHelper, so this is safe)
-    return Timestamper.timestamper();
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/QueueTimeTracker.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/QueueTimeTracker.java
@@ -8,6 +8,7 @@ public class QueueTimeTracker implements QueueTiming {
   private final DatadogProfiler profiler;
   private final Thread origin;
   private final long startTicks;
+  private final long startMillis;
   private WeakReference<Object> weakTask;
   // FIXME this can be eliminated by altering the instrumentation
   //  since it is known when the item is polled from the queue
@@ -16,8 +17,8 @@ public class QueueTimeTracker implements QueueTiming {
   public QueueTimeTracker(DatadogProfiler profiler, long startTicks) {
     this.profiler = profiler;
     this.origin = Thread.currentThread();
-    // TODO get this from JFR if available instead of making a JNI call
     this.startTicks = startTicks;
+    this.startMillis = System.currentTimeMillis();
   }
 
   @Override
@@ -36,7 +37,7 @@ public class QueueTimeTracker implements QueueTiming {
     Object task = this.weakTask.get();
     if (task != null) {
       // indirection reduces shallow size of the tracker instance
-      profiler.recordQueueTimeEvent(startTicks, task, scheduler, origin);
+      profiler.recordQueueTimeEvent(startMillis, startTicks, task, scheduler, origin);
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

This fixes a design flaw where RDTSC derived values are compared across cores which can have frequency scaling applied differently, and just uses the system time instead for the sake of computing the threshold.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
