### PR TITLE
Increase spark listener max collection size

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -60,8 +60,8 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
   public static volatile boolean finishTraceOnApplicationEnd = true;
   public static volatile boolean isPysparkShell = false;
 
-  private final int MAX_COLLECTION_SIZE = 1000;
-  private final int MAX_ACCUMULATOR_SIZE = 10000;
+  private final int MAX_COLLECTION_SIZE = 5000;
+  private final int MAX_ACCUMULATOR_SIZE = 50000;
   private final String RUNTIME_TAGS_PREFIX = "spark.datadog.tags.";
 
   private final SparkConf sparkConf;


### PR DESCRIPTION
# What Does This Do

Increase the maximum number of retained events for the injected spark listener

Assuming spans are taking up to ~2kB of memory, going from 1000 to 5000 events can increase the memory impact from 2MB up to 10MB. This should be acceptable since only one listener is injected per spark driver

# Motivation

Customer with some big spark clusters reaching this limit

# Additional Notes

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
