### PR TITLE
Add provenance to sampling rules

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
@@ -88,6 +88,7 @@ public class SpanSamplingRules {
     private final Map<String, String> tags;
     private final double sampleRate;
     private final int maxPerSecond;
+    private final String provenance;
 
     private Rule(
         String service,
@@ -95,13 +96,15 @@ public class SpanSamplingRules {
         String resource,
         Map<String, String> tags,
         double sampleRate,
-        int maxPerSecond) {
+        int maxPerSecond,
+        String provenance) {
       this.service = service;
       this.name = name;
       this.resource = resource;
       this.tags = tags;
       this.sampleRate = sampleRate;
       this.maxPerSecond = maxPerSecond;
+      this.provenance = provenance;
     }
 
     /**
@@ -145,7 +148,7 @@ public class SpanSamplingRules {
           return null;
         }
       }
-      return new Rule(service, name, resource, tags, sampleRate, maxPerSecond);
+      return new Rule(service, name, resource, tags, sampleRate, maxPerSecond, CUSTOMER);
     }
 
     private static void logRuleError(JsonRule rule, String error) {
@@ -180,6 +183,11 @@ public class SpanSamplingRules {
     @Override
     public int getMaxPerSecond() {
       return maxPerSecond;
+    }
+
+    @Override
+    public String getProvenance() {
+      return provenance;
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
@@ -69,14 +69,21 @@ public class TraceSamplingRules {
     private final String resource;
     private final Map<String, String> tags;
     private final double sampleRate;
+    private final String provenance;
 
     private Rule(
-        String service, String name, String resource, Map<String, String> tags, double sampleRate) {
+        String service,
+        String name,
+        String resource,
+        Map<String, String> tags,
+        double sampleRate,
+        String provenance) {
       this.service = service;
       this.name = name;
       this.resource = resource;
       this.tags = tags;
       this.sampleRate = sampleRate;
+      this.provenance = provenance;
     }
 
     /**
@@ -106,7 +113,7 @@ public class TraceSamplingRules {
           return null;
         }
       }
-      return new Rule(service, name, resource, tags, sampleRate);
+      return new Rule(service, name, resource, tags, sampleRate, CUSTOMER);
     }
 
     private static void logRuleError(JsonRule rule, String error) {
@@ -136,6 +143,11 @@ public class TraceSamplingRules {
     @Override
     public double getSampleRate() {
       return sampleRate;
+    }
+
+    @Override
+    public String getProvenance() {
+      return provenance;
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/sampling/SamplingRule.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/SamplingRule.java
@@ -11,6 +11,12 @@ public interface SamplingRule {
   /** The "match all" glob pattern . */
   String MATCH_ALL = "*";
 
+  /** The provenance of rules generated from dynamic sampling. */
+  String DYNAMIC = "dynamic";
+
+  /** The provenance of rules supplied by the customer. */
+  String CUSTOMER = "customer";
+
   /**
    * Gets the glob pattern the span service must match to validate the rule.
    *
@@ -49,6 +55,13 @@ public interface SamplingRule {
    *     {@code 1.0}.
    */
   double getSampleRate();
+
+  /**
+   * How this rule was generated; e.g. from {@link #DYNAMIC} sampling or the {@link #CUSTOMER}.
+   *
+   * @return How this rule was generated.
+   */
+  String getProvenance();
 
   /** This interface describes the criteria of a sampling rule that can match against a trace. */
   interface TraceSamplingRule extends SamplingRule {}


### PR DESCRIPTION
Initial change to key data structures; for rules supplied by static config the provenance is "customer"

Jira ticket: [AIT-9975]

[AIT-9975]: https://datadoghq.atlassian.net/browse/AIT-9975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ