### PR TITLE
Capture exception snapshots only once an hour

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -28,6 +28,7 @@ import java.lang.instrument.Instrumentation;
 import java.lang.ref.WeakReference;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.zip.ZipOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 /** Debugger agent implementation */
 public class DebuggerAgent {
   private static final Logger LOGGER = LoggerFactory.getLogger(DebuggerAgent.class);
+  public static final Duration EXCEPTION_CAPTURE_INTERVAL = Duration.ofHours(1);
   private static ConfigurationPoller configurationPoller;
   private static DebuggerSink sink;
   private static String agentVersion;
@@ -81,7 +83,8 @@ public class DebuggerAgent {
     DebuggerContext.initTracer(new DebuggerTracer(debuggerSink.getProbeStatusSink()));
     if (config.isDebuggerExceptionEnabled()) {
       DefaultExceptionDebugger defaultExceptionDebugger =
-          new DefaultExceptionDebugger(configurationUpdater, classNameFiltering);
+          new DefaultExceptionDebugger(
+              configurationUpdater, classNameFiltering, EXCEPTION_CAPTURE_INTERVAL);
       DebuggerContext.initExceptionDebugger(defaultExceptionDebugger);
     }
     if (config.isDebuggerInstrumentTheWorld()) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -12,6 +12,7 @@ import com.datadog.debugger.util.ExceptionHelper;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.util.AgentTaskScheduler;
+import java.time.Duration;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,8 +33,13 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
   private final ClassNameFiltering classNameFiltering;
 
   public DefaultExceptionDebugger(
-      ConfigurationUpdater configurationUpdater, ClassNameFiltering classNameFiltering) {
-    this(new ExceptionProbeManager(classNameFiltering), configurationUpdater, classNameFiltering);
+      ConfigurationUpdater configurationUpdater,
+      ClassNameFiltering classNameFiltering,
+      Duration captureInterval) {
+    this(
+        new ExceptionProbeManager(classNameFiltering, captureInterval),
+        configurationUpdater,
+        classNameFiltering);
   }
 
   DefaultExceptionDebugger(
@@ -64,6 +70,7 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
         return;
       }
       processSnapshotsAndSetTags(t, span, state, innerMostException);
+      exceptionProbeManager.updateLastCapture(fingerprint);
     } else {
       if (exceptionProbeManager.createProbesForException(innerMostException.getStackTrace())) {
         AgentTaskScheduler.INSTANCE.execute(() -> applyExceptionConfiguration(fingerprint));

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -31,7 +31,7 @@ public class ExceptionProbeManager {
   // FIXME: if this becomes a bottleneck, find a way to make it concurrent weak identity hashmap
   private final Map<Throwable, ThrowableState> snapshotsByThrowable =
       Collections.synchronizedMap(new WeakIdentityHashMap<>());
-  private final long captureIntervalMS;
+  private final long captureIntervalS;
   private final Clock clock;
 
   public ExceptionProbeManager(ClassNameFiltering classNameFiltering, Duration captureInterval) {
@@ -45,7 +45,7 @@ public class ExceptionProbeManager {
   ExceptionProbeManager(
       ClassNameFiltering classNameFiltering, Duration captureInterval, Clock clock) {
     this.classNameFiltering = classNameFiltering;
-    this.captureIntervalMS = captureInterval.toMillis();
+    this.captureIntervalS = captureInterval.getSeconds();
     this.clock = clock;
   }
 
@@ -105,7 +105,7 @@ public class ExceptionProbeManager {
     if (lastCapture == null) {
       return false;
     }
-    return ChronoUnit.MILLIS.between(lastCapture, Instant.now(clock)) >= captureIntervalMS;
+    return ChronoUnit.SECONDS.between(lastCapture, Instant.now(clock)) >= captureIntervalS;
   }
 
   public void addSnapshot(Snapshot snapshot) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -78,7 +78,7 @@ public class ExceptionProbeManager {
   }
 
   void addFingerprint(String fingerprint) {
-    fingerprints.put(fingerprint, Instant.ofEpochSecond(0));
+    fingerprints.put(fingerprint, Instant.MIN);
   }
 
   private static ExceptionProbe createMethodProbe(
@@ -105,7 +105,6 @@ public class ExceptionProbeManager {
     if (lastCapture == null) {
       return false;
     }
-    // only capture once an hour
     return ChronoUnit.MILLIS.between(lastCapture, Instant.now(clock)) >= captureIntervalMS;
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -58,7 +58,8 @@ class DefaultExceptionDebuggerTest {
   public void setUp() {
     configurationUpdater = mock(ConfigurationUpdater.class);
     classNameFiltering = new ClassNameFiltering(emptySet());
-    exceptionDebugger = new DefaultExceptionDebugger(configurationUpdater, classNameFiltering);
+    exceptionDebugger =
+        new DefaultExceptionDebugger(configurationUpdater, classNameFiltering, Duration.ofHours(1));
     listener = new TestSnapshotListener(createConfig(), mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -45,7 +45,7 @@ class ExceptionProbeManagerTest {
 
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     assertEquals("1c27b291764c9d387fb85247bb7c2711f885aadfbf2f64fed34b2e0c64c5a2", fingerprint);
-    exceptionProbeManager.createProbesForException(fingerprint, exception.getStackTrace());
+    exceptionProbeManager.createProbesForException(exception.getStackTrace());
     assertEquals(1, exceptionProbeManager.getProbes().size());
     ExceptionProbe exceptionProbe = exceptionProbeManager.getProbes().iterator().next();
     assertEquals(


### PR DESCRIPTION
# What Does This Do
Keep a timestamp associated to the fingerprint to know when last time we capture snapshots for this exception. Hardcoded once an hour will probably make it a config token for this later

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ