### PR TITLE
Flush on tracer close if CI Visibility enabled

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -189,7 +189,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   private final boolean disableSamplingMechanismValidation;
   private final TimeSource timeSource;
   private final ProfilingContextIntegration profilingContextIntegration;
-  private boolean injectBaggageAsTags;
+  private final boolean injectBaggageAsTags;
+  private final boolean flushOnClose;
 
   /**
    * JVM shutdown callback, keeping a reference to it to remove this if DDTracer gets destroyed
@@ -280,6 +281,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     private boolean pollForTracerFlareRequests;
     private boolean pollForTracingConfiguration;
     private boolean injectBaggageAsTags;
+    private boolean flushOnClose;
 
     public CoreTracerBuilder serviceName(String serviceName) {
       this.serviceName = serviceName;
@@ -413,6 +415,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       return this;
     }
 
+    public CoreTracerBuilder flushOnClose(boolean flushOnClose) {
+      this.flushOnClose = flushOnClose;
+      return this;
+    }
+
     public CoreTracerBuilder() {
       // Apply the default values from config.
       config(Config.get());
@@ -443,6 +450,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       partialFlushMinSpans(config.getPartialFlushMinSpans());
       strictTraceWrites(config.isTraceStrictWritesEnabled());
       injectBaggageAsTags(config.isInjectBaggageAsTagsEnabled());
+      flushOnClose(config.isCiVisibilityEnabled());
       return this;
     }
 
@@ -473,7 +481,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           profilingContextIntegration,
           pollForTracerFlareRequests,
           pollForTracingConfiguration,
-          injectBaggageAsTags);
+          injectBaggageAsTags,
+          flushOnClose);
     }
   }
 
@@ -504,7 +513,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final ProfilingContextIntegration profilingContextIntegration,
       final boolean pollForTracerFlareRequests,
       final boolean pollForTracingConfiguration,
-      final boolean injectBaggageAsTags) {
+      final boolean injectBaggageAsTags,
+      final boolean flushOnClose) {
 
     assert localRootSpanTags != null;
     assert defaultSpanTags != null;
@@ -712,6 +722,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     propagationTagsFactory = PropagationTags.factory(config);
     this.profilingContextIntegration = profilingContextIntegration;
     this.injectBaggageAsTags = injectBaggageAsTags;
+    this.flushOnClose = flushOnClose;
     this.allowInferredServices = SpanNaming.instance().namingSchema().allowInferredServices();
     if (profilingContextIntegration != ProfilingContextIntegration.NoOp.INSTANCE) {
       Map<String, Object> tmp = new HashMap<>(localRootSpanTags);
@@ -1087,6 +1098,9 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
   @Override
   public void close() {
+    if (flushOnClose) {
+      flush();
+    }
     tracingConfigPoller.stop();
     pendingTraceBuffer.close();
     writer.close();

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -11,11 +11,11 @@ import datadog.trace.api.Config
 import datadog.trace.api.StatsDClient
 import datadog.trace.api.remoteconfig.ServiceNameCollector
 import datadog.trace.api.sampling.PrioritySampling
+import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.sampling.AllSampler
 import datadog.trace.common.sampling.PrioritySampler
 import datadog.trace.common.sampling.RateByServiceTraceSampler
 import datadog.trace.common.sampling.Sampler
-import datadog.trace.api.sampling.SamplingMechanism
 import datadog.trace.common.writer.DDAgentWriter
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.common.writer.LoggingWriter
@@ -27,6 +27,7 @@ import okhttp3.OkHttpClient
 import spock.lang.Timeout
 
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.CopyOnWriteArrayList
 
 import static datadog.trace.api.config.GeneralConfig.ENV
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_ENABLED
@@ -669,6 +670,48 @@ class CoreTracerTest extends DDCoreSpecification {
     "service" | "env" | "service"     | "ENV"
     "service" | "env" | "SERVICE"     | "ENV"
     "SERVICE" | "ENV" | "service"     | "env"
+  }
+
+  def "flushes on tracer close if configured to do so"() {
+    given:
+    def writer = new WriterWithExplicitFlush()
+    def tracer = tracerBuilder().writer(writer).flushOnClose(true).build()
+
+    when:
+    tracer.buildSpan('my_span').start().finish()
+    tracer.close()
+
+    then:
+    !writer.flushedTraces.empty
+  }
+}
+
+class WriterWithExplicitFlush implements datadog.trace.common.writer.Writer {
+  final List<List<DDSpan>> writtenTraces = new CopyOnWriteArrayList<>()
+  final List<List<DDSpan>> flushedTraces = new CopyOnWriteArrayList<>()
+
+  @Override
+  void write(List<DDSpan> trace) {
+    writtenTraces.add(trace)
+  }
+
+  @Override
+  void start() {
+  }
+
+  @Override
+  boolean flush() {
+    flushedTraces.addAll(writtenTraces)
+    writtenTraces.clear()
+    return true
+  }
+
+  @Override
+  void close() {
+  }
+
+  @Override
+  void incrementDropCounts(int spanCount) {
   }
 }
 


### PR DESCRIPTION
# What Does This Do
Calls tracer flush when the tracer is called if CI Visibility is enabled.

# Motivation
Handling the following case:
- a test starts, a corresponding span is created
- before finishing, the test submits an async task that performs some cleanup work. A continuation is registered in the test's trace
- the test finishes, its span finishes too, but is not written yet because of the pending async cleanup work

If this is the last test in the suite, after it finishes the JVM shutdown is initiated. A shutdown hook is run that closes the tracer. Following that the test's async cleanup may either fail to complete before JVM terminates or may complete after the tracer has been closed, which will result in discarding it.

Dropping a trace may be fine for APM products, but for CI Visibility it is a requirement that every test span is reported.

Doing a synchronous flush before tracer close will write all the pending traces. This includes traces with `ROOT_BUFFERED` status, i.e. the ones whose root has finished but whose children are pending (the test trace described above fits this case).

Jira ticket: [CIVIS-9930]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
