### PR TITLE
[WIP] Merge of remote sampling rules and new sampling mechanism

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -37,6 +37,9 @@ excludedClassesCoverage += [
   'datadog.trace.core.datastreams.DataStreamContextInjector',
   'datadog.trace.common.sampling.TraceSamplingRules.RuleAdapter',
   'datadog.trace.common.sampling.SpanSamplingRules.RuleAdapter',
+  'datadog.trace.core.TracingConfigPoller.SamplingRuleTagEntry',
+  'datadog.trace.core.TracingConfigPoller.TracingSamplingRule',
+  'datadog.trace.core.TracingConfigPoller.Updater',
 ]
 
 addTestSuite('traceAgentTest')

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateSamplingRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateSamplingRule.java
@@ -8,10 +8,10 @@ import datadog.trace.core.util.TagsMatcher;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-public abstract class SamplingRule {
+public abstract class RateSamplingRule {
   private final RateSampler sampler;
 
-  public SamplingRule(final RateSampler sampler) {
+  public RateSamplingRule(final RateSampler sampler) {
     this.sampler = sampler;
   }
 
@@ -25,7 +25,7 @@ public abstract class SamplingRule {
     return sampler;
   }
 
-  public static class AlwaysMatchesSamplingRule extends SamplingRule {
+  public static class AlwaysMatchesSamplingRule extends RateSamplingRule {
 
     public AlwaysMatchesSamplingRule(final RateSampler sampler) {
       super(sampler);
@@ -37,7 +37,7 @@ public abstract class SamplingRule {
     }
   }
 
-  public abstract static class PatternMatchSamplingRule extends SamplingRule {
+  public abstract static class PatternMatchSamplingRule extends RateSamplingRule {
     private final Pattern pattern;
 
     public PatternMatchSamplingRule(final String regex, final RateSampler sampler) {
@@ -76,7 +76,7 @@ public abstract class SamplingRule {
     }
   }
 
-  public static final class TraceSamplingRule extends SamplingRule {
+  public static final class TraceSamplingRule extends RateSamplingRule {
     private final Matcher serviceMatcher;
     private final Matcher operationMatcher;
     private final Matcher resourceMatcher;
@@ -104,7 +104,7 @@ public abstract class SamplingRule {
     }
   }
 
-  public static final class SpanSamplingRule extends SamplingRule {
+  public static final class SpanSamplingRule extends RateSamplingRule {
     private final Matcher serviceMatcher;
     private final Matcher operationMatcher;
     private final SimpleRateLimiter rateLimiter;

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateSamplingRule.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateSamplingRule.java
@@ -1,5 +1,6 @@
 package datadog.trace.common.sampling;
 
+import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.core.CoreSpan;
 import datadog.trace.core.util.Matcher;
 import datadog.trace.core.util.Matchers;
@@ -10,9 +11,16 @@ import java.util.regex.Pattern;
 
 public abstract class RateSamplingRule {
   private final RateSampler sampler;
+  private final byte mechanism;
 
-  public RateSamplingRule(final RateSampler sampler) {
+  public RateSamplingRule(final RateSampler sampler, byte mechanism) {
     this.sampler = sampler;
+    this.mechanism = mechanism;
+  }
+
+  @Deprecated
+  public RateSamplingRule(final RateSampler sampler) {
+    this(sampler, SamplingMechanism.LOCAL_USER_RULE);
   }
 
   public abstract <T extends CoreSpan<T>> boolean matches(T span);
@@ -25,10 +33,13 @@ public abstract class RateSamplingRule {
     return sampler;
   }
 
-  public static class AlwaysMatchesSamplingRule extends RateSamplingRule {
+  public final byte getMechanism() {
+    return mechanism;
+  }
 
-    public AlwaysMatchesSamplingRule(final RateSampler sampler) {
-      super(sampler);
+  public static class AlwaysMatchesSamplingRule extends RateSamplingRule {
+    public AlwaysMatchesSamplingRule(final RateSampler sampler, byte samplingMechanism) {
+      super(sampler, samplingMechanism);
     }
 
     @Override
@@ -87,8 +98,10 @@ public abstract class RateSamplingRule {
         final String operationGlob,
         final String resourceGlob,
         final Map<String, String> tags,
-        final RateSampler sampler) {
-      super(sampler);
+        final RateSampler sampler,
+        final byte samplingMechanism) {
+      super(sampler, samplingMechanism);
+
       serviceMatcher = Matchers.compileGlob(serviceGlob);
       operationMatcher = Matchers.compileGlob(operationGlob);
       resourceMatcher = Matchers.compileGlob(resourceGlob);

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedTraceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedTraceSampler.java
@@ -68,7 +68,7 @@ public class RuleBasedTraceSampler<T extends CoreSpan<T>> implements Sampler, Pr
                 rule.getResource(),
                 rule.getTags(),
                 new DeterministicSampler.TraceSampler(rule.getSampleRate()),
-                SamplingMechanism.LOCAL_USER_RULE);
+                samplingMechanism(rule.getProvenance()));
         samplingRules.add(samplingRule);
       }
     } else {
@@ -114,6 +114,17 @@ public class RuleBasedTraceSampler<T extends CoreSpan<T>> implements Sampler, Pr
     }
 
     return new RuleBasedTraceSampler(samplingRules, rateLimit, new RateByServiceTraceSampler());
+  }
+
+  private static byte samplingMechanism(SamplingRule.Provenance provenance) {
+    switch (provenance) {
+      case DYNAMIC:
+        return SamplingMechanism.REMOTE_ADAPTIVE_RULE;
+      case CUSTOMER:
+        return SamplingMechanism.REMOTE_USER_RULE;
+      default:
+        return SamplingMechanism.LOCAL_USER_RULE;
+    }
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/Sampler.java
@@ -8,7 +8,10 @@ import datadog.trace.api.TraceConfig;
 import datadog.trace.api.config.TracerConfig;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
+import datadog.trace.api.sampling.SamplingRule;
 import datadog.trace.core.CoreSpan;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.slf4j.Logger;
@@ -33,15 +36,19 @@ public interface Sampler {
       if (config != null) {
         final Map<String, String> serviceRules = config.getTraceSamplingServiceRules();
         final Map<String, String> operationRules = config.getTraceSamplingOperationRules();
-        String traceSamplingRulesJson = config.getTraceSamplingRules();
-        TraceSamplingRules traceSamplingRules = TraceSamplingRules.EMPTY;
-        if (traceSamplingRulesJson != null) {
-          traceSamplingRules = TraceSamplingRules.deserialize(traceSamplingRulesJson);
+        List<? extends SamplingRule.TraceSamplingRule> traceSamplingRules;
+        if (null != traceConfig) {
+          traceSamplingRules = traceConfig.getTraceSamplingRules();
+        } else if (null != config.getTraceSamplingRules()) {
+          traceSamplingRules =
+              TraceSamplingRules.deserialize(config.getTraceSamplingRules()).getRules();
+        } else {
+          traceSamplingRules = Collections.emptyList();
         }
         boolean serviceRulesDefined = serviceRules != null && !serviceRules.isEmpty();
         boolean operationRulesDefined = operationRules != null && !operationRules.isEmpty();
-        boolean jsonTraceSamplingRulesDefined = !traceSamplingRules.isEmpty();
-        if ((serviceRulesDefined || operationRulesDefined) && jsonTraceSamplingRulesDefined) {
+        boolean traceSamplingRulesDefined = !traceSamplingRules.isEmpty();
+        if ((serviceRulesDefined || operationRulesDefined) && traceSamplingRulesDefined) {
           log.warn(
               "Both {} and/or {} as well as {} are defined. Only {} will be used for rule-based sampling",
               TracerConfig.TRACE_SAMPLING_SERVICE_RULES,
@@ -53,7 +60,7 @@ public interface Sampler {
             null != traceConfig ? traceConfig.getTraceSampleRate() : config.getTraceSampleRate();
         if (serviceRulesDefined
             || operationRulesDefined
-            || jsonTraceSamplingRulesDefined
+            || traceSamplingRulesDefined
             || traceSampleRate != null) {
           try {
             sampler =

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/SingleSpanSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/SingleSpanSampler.java
@@ -53,7 +53,7 @@ public interface SingleSpanSampler {
   }
 
   final class RuleBasedSingleSpanSampler implements SingleSpanSampler {
-    private final List<SamplingRule.SpanSamplingRule> spanSamplingRules;
+    private final List<RateSamplingRule.SpanSamplingRule> spanSamplingRules;
 
     public RuleBasedSingleSpanSampler(SpanSamplingRules rules) {
       if (rules == null) {
@@ -66,8 +66,8 @@ public interface SingleSpanSampler {
             rule.getMaxPerSecond() == Integer.MAX_VALUE
                 ? null
                 : new SimpleRateLimiter(rule.getMaxPerSecond());
-        SamplingRule.SpanSamplingRule spanSamplingRule =
-            new SamplingRule.SpanSamplingRule(
+        RateSamplingRule.SpanSamplingRule spanSamplingRule =
+            new RateSamplingRule.SpanSamplingRule(
                 rule.getService(), rule.getName(), sampler, simpleRateLimiter);
         spanSamplingRules.add(spanSamplingRule);
       }
@@ -75,7 +75,7 @@ public interface SingleSpanSampler {
 
     @Override
     public <T extends CoreSpan<T>> boolean setSamplingPriority(T span) {
-      for (SamplingRule.SpanSamplingRule rule : spanSamplingRules) {
+      for (RateSamplingRule.SpanSamplingRule rule : spanSamplingRules) {
         if (rule.matches(span)) {
           if (rule.sample(span)) {
             double rate = rule.getSampler().getSampleRate();

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/SpanSamplingRules.java
@@ -88,7 +88,7 @@ public class SpanSamplingRules {
     private final Map<String, String> tags;
     private final double sampleRate;
     private final int maxPerSecond;
-    private final String provenance;
+    private final Provenance provenance;
 
     private Rule(
         String service,
@@ -97,7 +97,7 @@ public class SpanSamplingRules {
         Map<String, String> tags,
         double sampleRate,
         int maxPerSecond,
-        String provenance) {
+        Provenance provenance) {
       this.service = service;
       this.name = name;
       this.resource = resource;
@@ -148,7 +148,7 @@ public class SpanSamplingRules {
           return null;
         }
       }
-      return new Rule(service, name, resource, tags, sampleRate, maxPerSecond, CUSTOMER);
+      return new Rule(service, name, resource, tags, sampleRate, maxPerSecond, Provenance.LOCAL);
     }
 
     private static void logRuleError(JsonRule rule, String error) {
@@ -186,7 +186,7 @@ public class SpanSamplingRules {
     }
 
     @Override
-    public String getProvenance() {
+    public Provenance getProvenance() {
       return provenance;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/TraceSamplingRules.java
@@ -69,7 +69,7 @@ public class TraceSamplingRules {
     private final String resource;
     private final Map<String, String> tags;
     private final double sampleRate;
-    private final String provenance;
+    private final Provenance provenance;
 
     private Rule(
         String service,
@@ -77,7 +77,7 @@ public class TraceSamplingRules {
         String resource,
         Map<String, String> tags,
         double sampleRate,
-        String provenance) {
+        Provenance provenance) {
       this.service = service;
       this.name = name;
       this.resource = resource;
@@ -113,7 +113,7 @@ public class TraceSamplingRules {
           return null;
         }
       }
-      return new Rule(service, name, resource, tags, sampleRate, CUSTOMER);
+      return new Rule(service, name, resource, tags, sampleRate, Provenance.LOCAL);
     }
 
     private static void logRuleError(JsonRule rule, String error) {
@@ -146,7 +146,7 @@ public class TraceSamplingRules {
     }
 
     @Override
-    public String getProvenance() {
+    public Provenance getProvenance() {
       return provenance;
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1620,7 +1620,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
       if (null == oldSnapshot) {
         sampler = CoreTracer.this.initialSampler;
-      } else if (Objects.equals(getTraceSampleRate(), oldSnapshot.getTraceSampleRate())) {
+      } else if (Objects.equals(getTraceSampleRate(), oldSnapshot.getTraceSampleRate())
+          && Objects.equals(getTraceSamplingRules(), oldSnapshot.getTraceSamplingRules())) {
         sampler = oldSnapshot.sampler;
       } else {
         sampler = Sampler.Builder.forConfig(CoreTracer.this.initialConfig, this);

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -5,6 +5,7 @@ import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_LOGS_INJECTION;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_TRACING_DATA_STREAMS_ENABLED;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_TRACING_SAMPLE_RATE;
+import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_TRACING_SAMPLE_RULES;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_APM_TRACING_TRACING_ENABLED;
 import static datadog.trace.api.sampling.SamplingRule.normalizeGlob;
 
@@ -59,7 +60,8 @@ final class TracingConfigPoller {
               | CAPABILITY_APM_LOGS_INJECTION
               | CAPABILITY_APM_HTTP_HEADER_TAGS
               | CAPABILITY_APM_CUSTOM_TAGS
-              | CAPABILITY_APM_TRACING_DATA_STREAMS_ENABLED);
+              | CAPABILITY_APM_TRACING_DATA_STREAMS_ENABLED
+              | CAPABILITY_APM_TRACING_SAMPLE_RULES);
     }
     stopPolling = new Updater().register(config, configPoller);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -407,8 +407,12 @@ final class TracingConfigPoller {
     }
 
     @Override
-    public String getProvenance() {
-      return provenance;
+    public Provenance getProvenance() {
+      if ("dynamic".equals(provenance)) {
+        return Provenance.DYNAMIC;
+      } else {
+        return Provenance.CUSTOMER;
+      }
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -169,8 +169,10 @@ final class TracingConfigPoller {
         for (Iterator<TracingSamplingRule> itr = rules.iterator(); itr.hasNext(); ) {
           TracingSamplingRule rule = itr.next();
           // check for required fields
-          if (null == rule.service
-              || null == rule.resource
+          if ((null == rule.service
+                  && null == rule.name
+                  && null == rule.resource
+                  && null == rule.tags)
               || null == rule.sampleRate
               || null == rule.provenance) {
             log.debug(
@@ -182,7 +184,6 @@ final class TracingConfigPoller {
           rule.name = normalizeGlob(rule.name);
           rule.resource = normalizeGlob(rule.resource);
           rule.sampleRate = checkSampleRate(rule.sampleRate);
-          rule.provenance = normalizeGlob(rule.provenance);
         }
       }
       return rules;

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CPropagationTagsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/W3CPropagationTagsTest.groovy
@@ -304,7 +304,7 @@ class W3CPropagationTagsTest extends DDCoreSpecification {
     where:
     headerValue                       | priority                      | mechanism                           | origin  | expectedHeaderValue                | tags
     'dd=s:0;o:some;t.dm:934086a686-4' | PrioritySampling.SAMPLER_KEEP | SamplingMechanism.DEFAULT           | "other" | 'dd=s:0;o:other;t.dm:934086a686-4' | ['_dd.p.dm': '934086a686-4']
-    'dd=s:0;o:some;x:unknown'         | PrioritySampling.USER_KEEP    | SamplingMechanism.RULE              | "same"  | 'dd=s:2;o:same;t.dm:-3;x:unknown'  | ['_dd.p.dm': '-3']
+    'dd=s:0;o:some;x:unknown'         | PrioritySampling.USER_KEEP    | SamplingMechanism.LOCAL_USER_RULE   | "same"  | 'dd=s:2;o:same;t.dm:-3;x:unknown'  | ['_dd.p.dm': '-3']
     'dd=s:0;o:some;x:unknown'         | PrioritySampling.USER_DROP    | SamplingMechanism.MANUAL            | null    | 'dd=s:-1;x:unknown'                | [:]
     'dd=s:0;o:some;t.dm:934086a686-4' | PrioritySampling.SAMPLER_KEEP | SamplingMechanism.EXTERNAL_OVERRIDE | "other" | 'dd=s:1;o:other;t.dm:-0'           | ['_dd.p.dm': '-0']
     'dd=s:1;o:some;t.dm:934086a686-4' | PrioritySampling.SAMPLER_DROP | SamplingMechanism.EXTERNAL_OVERRIDE | "other" | 'dd=s:0;o:other'                   | [:]

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -39,6 +39,7 @@ excludedClassesCoverage += [
   // an enum
   "datadog.trace.api.sampling.AdaptiveSampler",
   "datadog.trace.api.sampling.ConstantSampler",
+  "datadog.trace.api.sampling.SamplingRule.Provenance",
   "datadog.trace.api.sampling.SamplingRule.TraceSamplingRule.TargetSpan",
   "datadog.trace.api.EndpointCheckpointerHolder",
   "datadog.trace.api.iast.IastAdvice.Kind",

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -105,7 +105,6 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     List<? extends SpanSamplingRule> spanSamplingRules;
     List<? extends TraceSamplingRule> traceSamplingRules;
-
     Double traceSampleRate;
 
     String preferredServiceName;
@@ -124,8 +123,12 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
       this.responseHeaderTags = snapshot.responseHeaderTags;
       this.baggageMapping = snapshot.baggageMapping;
 
+      this.spanSamplingRules = snapshot.spanSamplingRules;
+      this.traceSamplingRules = snapshot.traceSamplingRules;
       this.traceSampleRate = snapshot.traceSampleRate;
+
       this.tracingTags = snapshot.tracingTags;
+
       this.preferredServiceName = snapshot.preferredServiceName;
     }
 
@@ -326,16 +329,21 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
       this.responseHeaderTags = nullToEmpty(builder.responseHeaderTags);
       this.baggageMapping = nullToEmpty(builder.baggageMapping);
 
+      this.spanSamplingRules = nullToEmpty(builder.spanSamplingRules);
+      this.traceSamplingRules = nullToEmpty(builder.traceSamplingRules);
       this.traceSampleRate = builder.traceSampleRate;
 
-      this.spanSamplingRules = builder.spanSamplingRules;
-      this.traceSamplingRules = builder.traceSamplingRules;
-      this.tracingTags = builder.tracingTags;
+      this.tracingTags = nullToEmpty(builder.tracingTags);
+
       this.preferredServiceName = builder.preferredServiceName;
     }
 
     private static <K, V> Map<K, V> nullToEmpty(Map<K, V> mapping) {
       return null != mapping ? mapping : Collections.emptyMap();
+    }
+
+    private static <V> List<V> nullToEmpty(List<V> list) {
+      return null != list ? list : Collections.emptyList();
     }
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/SamplingMechanism.java
@@ -12,7 +12,7 @@ public class SamplingMechanism {
   /** Auto; reserved for future use */
   public static final byte REMOTE_AUTO_RATE = 2;
   /** Sampling rule or sampling rate based on tracer config */
-  public static final byte RULE = 3;
+  public static final byte LOCAL_USER_RULE = 3;
   /** User directly sets sampling priority via code using span.SetTag(ManualKeep) or similar API */
   public static final byte MANUAL = 4;
   /** AppSec */
@@ -23,6 +23,10 @@ public class SamplingMechanism {
   public static final byte SPAN_SAMPLING_RATE = 8;
   /** Data Jobs */
   public static final byte DATA_JOBS = 10;
+
+  public static final byte REMOTE_USER_RULE = 11;
+  public static final byte REMOTE_ADAPTIVE_RULE = 12;
+
   /** Force override sampling decision from external source, like W3C traceparent. */
   public static final byte EXTERNAL_OVERRIDE = Byte.MIN_VALUE;
 
@@ -36,7 +40,7 @@ public class SamplingMechanism {
       case REMOTE_AUTO_RATE:
         return priority == SAMPLER_DROP || priority == SAMPLER_KEEP;
 
-      case RULE:
+      case LOCAL_USER_RULE:
       case MANUAL:
       case REMOTE_USER_RATE:
         return priority == USER_DROP || priority == USER_KEEP;

--- a/internal-api/src/main/java/datadog/trace/api/sampling/SamplingRule.java
+++ b/internal-api/src/main/java/datadog/trace/api/sampling/SamplingRule.java
@@ -11,11 +11,16 @@ public interface SamplingRule {
   /** The "match all" glob pattern . */
   String MATCH_ALL = "*";
 
-  /** The provenance of rules generated from dynamic sampling. */
-  String DYNAMIC = "dynamic";
+  enum Provenance {
+    /** Rules generated from local static config. */
+    LOCAL,
 
-  /** The provenance of rules supplied by the customer. */
-  String CUSTOMER = "customer";
+    /** Rules generated from dynamic sampling via remote-config. */
+    DYNAMIC,
+
+    /** Rules supplied by the customer via remote-config. */
+    CUSTOMER
+  }
 
   /**
    * Gets the glob pattern the span service must match to validate the rule.
@@ -57,11 +62,11 @@ public interface SamplingRule {
   double getSampleRate();
 
   /**
-   * How this rule was generated; e.g. from {@link #DYNAMIC} sampling or the {@link #CUSTOMER}.
+   * How this rule was generated; e.g. from local config, dynamic sampling, or the customer.
    *
    * @return How this rule was generated.
    */
-  String getProvenance();
+  Provenance getProvenance();
 
   /** This interface describes the criteria of a sampling rule that can match against a trace. */
   interface TraceSamplingRule extends SamplingRule {}

--- a/internal-api/src/test/groovy/datadog/trace/api/sampling/SamplingMechanismTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/sampling/SamplingMechanismTest.groovy
@@ -47,13 +47,13 @@ class SamplingMechanismTest extends Specification {
     REMOTE_AUTO_RATE  | userDropX    | false
     REMOTE_AUTO_RATE  | userKeepX    | false
 
-    RULE              | UNSET        | false
-    RULE              | SAMPLER_DROP | false
-    RULE              | SAMPLER_KEEP | false
-    RULE              | USER_DROP    | true
-    RULE              | USER_KEEP    | true
-    RULE              | userDropX    | false
-    RULE              | userKeepX    | false
+    LOCAL_USER_RULE   | UNSET        | false
+    LOCAL_USER_RULE   | SAMPLER_DROP | false
+    LOCAL_USER_RULE   | SAMPLER_KEEP | false
+    LOCAL_USER_RULE   | USER_DROP    | true
+    LOCAL_USER_RULE   | USER_KEEP    | true
+    LOCAL_USER_RULE   | userDropX    | false
+    LOCAL_USER_RULE   | userKeepX    | false
 
     MANUAL            | UNSET        | false
     MANUAL            | SAMPLER_DROP | false


### PR DESCRIPTION
# What Does This Do

Merge of #6987 and #6989 for testing purposes

* #6987 adds capability to receive tracing sampling rules from remote-config.
* #6989 adds samplingMechanism information to TraceSamplingRule objects

# Motivation
Forthcoming changes will allow rules to be set via remote configuration.
Once rules can be either locally or remotely, we want the decision maker to reflect the source of the rule.

# Additional Notes
Change makes extensive changes to the sampling rule tests - previously these tests weren't checking the decision maker tag


Jira ticket: [AIT-9975]

[AIT-9975]: https://datadoghq.atlassian.net/browse/AIT-9975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ