### PR TITLE
Add support of Set in Expression Language

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
@@ -31,9 +31,11 @@ import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NullValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.ObjectValue;
+import com.datadog.debugger.el.values.SetValue;
 import com.datadog.debugger.el.values.StringValue;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A debugger DSL representation. A simple all-static class which can be used to build a complete
@@ -138,6 +140,10 @@ public class DSL {
 
   public static ListValue value(Collection<?> value) {
     return new ListValue(value);
+  }
+
+  public static SetValue value(Set<?> value) {
+    return new SetValue(value);
   }
 
   public static NullValue nullValue() {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/PrettyPrintVisitor.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/PrettyPrintVisitor.java
@@ -30,6 +30,7 @@ import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NullValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.ObjectValue;
+import com.datadog.debugger.el.values.SetValue;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.Values;
 import java.math.BigDecimal;
@@ -264,6 +265,14 @@ public class PrettyPrintVisitor implements Visitor<String> {
   public String visit(MapValue mapValue) {
     if (mapValue.getMapHolder() instanceof Map) {
       return "Map";
+    }
+    return "null";
+  }
+
+  @Override
+  public String visit(SetValue setValue) {
+    if (setValue.getSetHolder() instanceof Set) {
+      return "Set";
     }
     return "null";
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Value.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Value.java
@@ -6,12 +6,14 @@ import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NullValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.ObjectValue;
+import com.datadog.debugger.el.values.SetValue;
 import com.datadog.debugger.el.values.StringValue;
 import com.datadog.debugger.el.values.UndefinedValue;
 import datadog.trace.bootstrap.debugger.el.Values;
 import datadog.trace.bootstrap.debugger.util.WellKnownClasses;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /** Represents any value of the expression language */
@@ -76,6 +78,8 @@ public interface Value<T> {
       return new ListValue(value);
     } else if (value instanceof Map) {
       return new MapValue(value);
+    } else if (value instanceof Set) {
+      return new SetValue(value);
     } else if (value instanceof Value) {
       return (Value<?>) value;
     } else {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Visitor.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Visitor.java
@@ -29,6 +29,7 @@ import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NullValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.ObjectValue;
+import com.datadog.debugger.el.values.SetValue;
 import com.datadog.debugger.el.values.StringValue;
 
 public interface Visitor<R> {
@@ -91,4 +92,6 @@ public interface Visitor<R> {
   R visit(ListValue listValue);
 
   R visit(MapValue mapValue);
+
+  R visit(SetValue setValue);
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
@@ -1,0 +1,86 @@
+package com.datadog.debugger.el.values;
+
+import com.datadog.debugger.el.Value;
+import com.datadog.debugger.el.Visitor;
+import com.datadog.debugger.el.expressions.ValueExpression;
+import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
+import datadog.trace.bootstrap.debugger.el.Values;
+import datadog.trace.bootstrap.debugger.util.WellKnownClasses;
+import java.util.Set;
+
+public class SetValue implements CollectionValue<Object>, ValueExpression<SetValue> {
+
+  private final Object setHolder;
+
+  public SetValue(Object object) {
+    if (object instanceof Set) {
+      setHolder = object;
+    } else if (object == null || object == Values.NULL_OBJECT) {
+      setHolder = Value.nullValue();
+    } else {
+      setHolder = Value.undefinedValue();
+    }
+  }
+
+  @Override
+  public SetValue evaluate(ValueReferenceResolver valueRefResolver) {
+    return this;
+  }
+
+  @Override
+  public Object getValue() {
+    return setHolder;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    if (setHolder instanceof Set) {
+      return ((Set<?>) setHolder).isEmpty();
+    } else if (setHolder instanceof Value) {
+      Value<?> val = (Value<?>) setHolder;
+      return val.isNull() || val.isUndefined();
+    }
+    return true;
+  }
+
+  @Override
+  public int count() {
+    if (setHolder instanceof Set) {
+      if (WellKnownClasses.isSizeSafe((Set<?>) setHolder)) {
+        return ((Set<?>) setHolder).size();
+      }
+      throw new RuntimeException("Unsupported Set class: " + setHolder.getClass().getTypeName());
+    } else if (setHolder == Value.nullValue()) {
+      return 0;
+    }
+    return -1;
+  }
+
+  @Override
+  public Value<?> get(Object key) {
+    if (key == Value.undefinedValue() || key == Values.UNDEFINED_OBJECT) {
+      return Value.undefinedValue();
+    }
+    if (key == null || key == Value.nullValue() || key == Values.NULL_OBJECT) {
+      return Value.nullValue();
+    }
+
+    if (setHolder instanceof Set) {
+      Set<?> set = (Set<?>) setHolder;
+      key = key instanceof Value ? ((Value<?>) key).getValue() : key;
+      return Value.of(set.contains(key));
+    }
+    // the result will be either Value.nullValue() or Value.undefinedValue() depending on the holder
+    // value
+    return (Value<?>) setHolder;
+  }
+
+  @Override
+  public <R> R accept(Visitor<R> visitor) {
+    return visitor.visit(this);
+  }
+
+  public Object getSetHolder() {
+    return setHolder;
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -18,8 +18,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import okio.Okio;
 import org.junit.jupiter.api.Test;
@@ -236,6 +238,27 @@ public class ProbeConditionTest {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, fields);
     assertTrue(probeCondition.execute(ctx));
   }
+
+  @Test
+  void testLenCount() throws Exception {
+    ProbeCondition probeCondition = load("/test_conditional_13.json");
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("intArray", new int[] {1, 1, 1});
+    fields.put("strArray", new String[] {"foo", "bar"});
+    Map<String, String> strMap = new HashMap<>();
+    strMap.put("foo", "bar");
+    strMap.put("bar", "foobar");
+    fields.put("strMap", strMap);
+    Set<String> strSet = new HashSet<>();
+    strSet.add("foo");
+    fields.put("strSet", strSet);
+    List<String> strList = new ArrayList<>();
+    strList.add("foo");
+    fields.put("strList", strList);
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, fields);
+    assertTrue(probeCondition.execute(ctx));
+  }
+
 
   private static ProbeCondition load(String resourcePath) throws IOException {
     InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath);

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -242,7 +242,7 @@ public class ProbeConditionTest {
 
   @Test
   void testLenCount() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_13.json");
+    ProbeCondition probeCondition = load("/test_conditional_14.json");
     Map<String, Object> fields = new HashMap<>();
     fields.put("intArray", new int[] {1, 1, 1});
     fields.put("strArray", new String[] {"foo", "bar"});
@@ -259,7 +259,6 @@ public class ProbeConditionTest {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, fields);
     assertTrue(probeCondition.execute(ctx));
   }
-
 
   private static ProbeCondition load(String resourcePath) throws IOException {
     InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath);

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -219,6 +219,7 @@ public class ProbeConditionTest {
     fields.put("emptyStr", "");
     fields.put("emptyList", new ArrayList<>());
     fields.put("emptyMap", new HashMap<>());
+    fields.put("emptySet", new HashSet<>());
     fields.put("emptyArray", new Object[0]);
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, fields);
     assertTrue(probeCondition.execute(ctx));

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/SetValueEmptyTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/SetValueEmptyTest.java
@@ -1,0 +1,46 @@
+package com.datadog.debugger.el.values;
+
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadog.debugger.el.Value;
+import datadog.trace.bootstrap.debugger.el.Values;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SetValueEmptyTest {
+  private SetValue instance;
+
+  @BeforeEach
+  void setup() throws Exception {
+    instance = new SetValue(Collections.emptySet());
+  }
+
+  @Test
+  void prettyPrint() {
+    assertEquals("Set", print(instance));
+  }
+
+  @Test
+  void isEmpty() {
+    assertTrue(instance.isEmpty());
+  }
+
+  @Test
+  void count() {
+    assertEquals(0, instance.count());
+  }
+
+  @Test
+  void get() {
+    assertEquals(BooleanValue.FALSE, instance.get("a"));
+    assertEquals(BooleanValue.FALSE, instance.get("b"));
+    assertEquals(Value.undefinedValue(), instance.get(Values.UNDEFINED_OBJECT));
+    assertEquals(Value.undefinedValue(), instance.get(Value.undefinedValue()));
+    assertEquals(Value.nullValue(), instance.get(Values.NULL_OBJECT));
+    assertEquals(Value.nullValue(), instance.get(Value.nullValue()));
+    assertEquals(Value.nullValue(), instance.get(null));
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/SetValueNullTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/SetValueNullTest.java
@@ -1,0 +1,39 @@
+package com.datadog.debugger.el.values;
+
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadog.debugger.el.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SetValueNullTest {
+  private SetValue instance;
+
+  @BeforeEach
+  void setup() throws Exception {
+    instance = new SetValue(null);
+  }
+
+  @Test
+  void prettyPrint() {
+    assertEquals("null", print(instance));
+  }
+
+  @Test
+  void isEmpty() {
+    assertTrue(instance.isEmpty());
+  }
+
+  @Test
+  void count() {
+    assertEquals(0, instance.count());
+  }
+
+  @Test
+  void get() {
+    assertEquals(Value.nullValue(), instance.get(0));
+    assertEquals(Value.nullValue(), instance.get(10));
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/SetValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/SetValueTest.java
@@ -1,0 +1,50 @@
+package com.datadog.debugger.el.values;
+
+import static com.datadog.debugger.el.PrettyPrintVisitor.print;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadog.debugger.el.Value;
+import datadog.trace.bootstrap.debugger.el.Values;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SetValueTest {
+  private SetValue instance;
+
+  @BeforeEach
+  void setup() throws Exception {
+    Set<String> set = new HashSet<>();
+    set.add("foo");
+    set.add("bar");
+    instance = new SetValue(set);
+  }
+
+  @Test
+  void prettyPrint() {
+    assertEquals("Set", print(instance));
+  }
+
+  @Test
+  void isEmpty() {
+    assertFalse(instance.isEmpty());
+  }
+
+  @Test
+  void count() {
+    assertEquals(2, instance.count());
+  }
+
+  @Test
+  void get() {
+    assertEquals(Value.of(true), instance.get("foo"));
+    assertEquals(BooleanValue.TRUE, instance.get("foo"));
+    assertEquals(Value.of(true), instance.get(Value.of("foo")));
+    assertEquals(Value.of(false), instance.get("oof"));
+    assertEquals(BooleanValue.FALSE, instance.get("oof"));
+    assertEquals(Value.of(false), instance.get(Value.of("oof")));
+    assertEquals(Value.undefinedValue(), instance.get(Values.UNDEFINED_OBJECT));
+    assertEquals(Value.undefinedValue(), instance.get(Value.undefinedValue()));
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_11.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_11.json
@@ -5,6 +5,7 @@
       {"isEmpty": {"ref": "emptyStr"}},
       {"isEmpty": {"ref": "emptyList"}},
       {"isEmpty": {"ref": "emptyMap"}},
+      {"isEmpty": {"ref": "emptySet"}},
       {"isEmpty": {"ref": "emptyArray"}},
       {"not": {"isDefined":  {"ref": "@exception"}}}
     ]

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_13.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_13.json
@@ -13,4 +13,18 @@
   }
 }
 
+{
+  "dsl": "",
+  "json": {
+    "and": [
+      {"eq": [{"count": {"ref": "intArray"}}, 3]},
+      {"eq": [{"len": {"ref": "intArray"}}, 3]},
+      {"eq": [{"count": {"ref": "strArray"}}, 2]},
+      {"eq": [{"count": {"ref": "strMap"}}, 2]},
+      {"eq": [{"count": {"ref": "strSet"}}, 1]},
+      {"eq": [{"count": {"ref": "strList"}}, 1]}
+    ]
+  }
+}
+
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_13.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_13.json
@@ -13,18 +13,4 @@
   }
 }
 
-{
-  "dsl": "",
-  "json": {
-    "and": [
-      {"eq": [{"count": {"ref": "intArray"}}, 3]},
-      {"eq": [{"len": {"ref": "intArray"}}, 3]},
-      {"eq": [{"count": {"ref": "strArray"}}, 2]},
-      {"eq": [{"count": {"ref": "strMap"}}, 2]},
-      {"eq": [{"count": {"ref": "strSet"}}, 1]},
-      {"eq": [{"count": {"ref": "strList"}}, 1]}
-    ]
-  }
-}
-
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_14.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_14.json
@@ -1,0 +1,13 @@
+{
+  "dsl": "",
+  "json": {
+    "and": [
+      {"eq": [{"count": {"ref": "intArray"}}, 3]},
+      {"eq": [{"len": {"ref": "intArray"}}, 3]},
+      {"eq": [{"count": {"ref": "strArray"}}, 2]},
+      {"eq": [{"count": {"ref": "strMap"}}, 2]},
+      {"eq": [{"count": {"ref": "strSet"}}, 1]},
+      {"eq": [{"count": {"ref": "strList"}}, 1]}
+    ]
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -45,6 +45,7 @@ import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NullValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.ObjectValue;
+import com.datadog.debugger.el.values.SetValue;
 import com.datadog.debugger.el.values.StringValue;
 import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.Where;
@@ -655,6 +656,11 @@ public class MetricInstrumentor extends Instrumentor {
 
     @Override
     public VisitorResult visit(MapValue mapValue) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VisitorResult visit(SetValue setValue) {
       throw new UnsupportedOperationException();
     }
 

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MoshiConfigTestHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MoshiConfigTestHelper.java
@@ -32,6 +32,7 @@ import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NullValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.ObjectValue;
+import com.datadog.debugger.el.values.SetValue;
 import com.datadog.debugger.el.values.StringValue;
 import com.datadog.debugger.probe.LogProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
@@ -331,6 +332,11 @@ public class MoshiConfigTestHelper {
 
     @Override
     public Void visit(MapValue mapValue) {
+      throw new UnsupportedOperationException("mapValue");
+    }
+
+    @Override
+    public Void visit(SetValue setValue) {
       throw new UnsupportedOperationException("mapValue");
     }
   }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MoshiConfigTestHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MoshiConfigTestHelper.java
@@ -337,7 +337,7 @@ public class MoshiConfigTestHelper {
 
     @Override
     public Void visit(SetValue setValue) {
-      throw new UnsupportedOperationException("mapValue");
+      throw new UnsupportedOperationException("setValue");
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
When having a value with a Set interface creates a SetValue to hold that Set instance
Allow to call size() on it if it safe list for lists and maps

# Motivation
Support `count(set)`

# Additional Notes

Jira ticket: [DEBUG-2329]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2329]: https://datadoghq.atlassian.net/browse/DEBUG-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ