### PR TITLE
Add log file if size is not too big

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -289,23 +289,24 @@ final class TracerFlareService {
     }
     Path path = Paths.get(logFile);
     if (Files.exists(path)) {
-      long size = Files.size(path);
-      if (size > MAX_LOGFILE_SIZE_BYTES) {
-        TracerFlare.addText(
-            zip,
-            "tracer.log",
-            "Can't add tracer log file to the flare due to its size: "
-                + size
-                + "."
-                + "Max Size is "
-                + MAX_LOGFILE_SIZE_MB
-                + " MB.");
-      } else {
-        try {
+      try {
+        long size = Files.size(path);
+        if (size > MAX_LOGFILE_SIZE_BYTES) {
+          TracerFlare.addText(
+              zip,
+              "tracer.log",
+              "Can't add tracer log file to the flare due to its size: "
+                  + size
+                  + "."
+                  + "Max Size is "
+                  + MAX_LOGFILE_SIZE_MB
+                  + " MB.");
+        } else {
+
           TracerFlare.addBinary(zip, "tracer.log", readAllBytes(path));
-        } catch (Throwable e) {
-          TracerFlare.addText(zip, "tracer.log", "Problem collecting tracer log: " + e);
         }
+      } catch (Throwable e) {
+        TracerFlare.addText(zip, "tracer.log", "Problem collecting tracer log: " + e);
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -1,6 +1,7 @@
 package datadog.trace.core.flare;
 
 import static datadog.trace.util.AgentThreadFactory.AgentThread.TRACER_FLARE;
+import static java.nio.file.Files.readAllBytes;
 
 import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
@@ -47,6 +48,10 @@ final class TracerFlareService {
   private static final String REPORT_PREFIX = "dd-java-flare-";
 
   private static final MediaType OCTET_STREAM = MediaType.get("application/octet-stream");
+
+  private static final int MAX_LOGFILE_SIZE_MB = 15;
+
+  private static final int MAX_LOGFILE_SIZE_BYTES = MAX_LOGFILE_SIZE_MB << 20;
 
   private final AgentTaskScheduler scheduler = new AgentTaskScheduler(TRACER_FLARE);
 
@@ -204,7 +209,7 @@ final class TracerFlareService {
   private byte[] buildFlareZip(long startMillis, long endMillis, boolean dumpThreads)
       throws IOException {
     try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        ZipOutputStream zip = new ZipOutputStream(bytes)) {
+         ZipOutputStream zip = new ZipOutputStream(bytes)) {
 
       addPrelude(zip, startMillis, endMillis);
       addConfig(zip);
@@ -214,6 +219,7 @@ final class TracerFlareService {
       if (dumpThreads) {
         addThreadDump(zip);
       }
+      addLogs(zip);
       zip.finish();
 
       return bytes.toByteArray();
@@ -272,6 +278,28 @@ final class TracerFlareService {
       buf.append("Problem collecting thread dump: ").append(e);
     }
     TracerFlare.addText(zip, "threads.txt", buf.toString());
+  }
+
+  private void addLogs(ZipOutputStream zip) throws IOException {
+
+    String logFile = System.getProperty("org.slf4j.simpleLogger.logFile");
+    if (logFile == null || logFile.isEmpty()) {
+      log.info("No tracer log file specified");
+      return;
+    }
+    Path path = Paths.get(logFile);
+    if (Files.exists(path)) {
+      long size = Files.size(path);
+      log.debug("Size of the log file: " + size);
+      if (size > MAX_LOGFILE_SIZE_BYTES) {
+        log.info(
+            "Can't add tracer log file to the flare due to its size: {}. Max Size is {} MB.",
+            size,
+            MAX_LOGFILE_SIZE_MB);
+      } else {
+        TracerFlare.addBinary(zip, "tracer.log", readAllBytes(path));
+      }
+    }
   }
 
   final class CleanupTask implements Runnable {

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -209,7 +209,7 @@ final class TracerFlareService {
   private byte[] buildFlareZip(long startMillis, long endMillis, boolean dumpThreads)
       throws IOException {
     try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-         ZipOutputStream zip = new ZipOutputStream(bytes)) {
+        ZipOutputStream zip = new ZipOutputStream(bytes)) {
 
       addPrelude(zip, startMillis, endMillis);
       addConfig(zip);

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -284,20 +284,28 @@ final class TracerFlareService {
 
     String logFile = System.getProperty("org.slf4j.simpleLogger.logFile");
     if (logFile == null || logFile.isEmpty()) {
-      log.info("No tracer log file specified");
+      TracerFlare.addText(zip, "tracer.log", "No tracer log file specified");
       return;
     }
     Path path = Paths.get(logFile);
     if (Files.exists(path)) {
       long size = Files.size(path);
-      log.debug("Size of the log file: " + size);
       if (size > MAX_LOGFILE_SIZE_BYTES) {
-        log.info(
-            "Can't add tracer log file to the flare due to its size: {}. Max Size is {} MB.",
-            size,
-            MAX_LOGFILE_SIZE_MB);
+        TracerFlare.addText(
+            zip,
+            "tracer.log",
+            "Can't add tracer log file to the flare due to its size: "
+                + size
+                + "."
+                + "Max Size is "
+                + MAX_LOGFILE_SIZE_MB
+                + " MB.");
       } else {
-        TracerFlare.addBinary(zip, "tracer.log", readAllBytes(path));
+        try {
+          TracerFlare.addBinary(zip, "tracer.log", readAllBytes(path));
+        } catch (Throwable e) {
+          TracerFlare.addText(zip, "tracer.log", "Problem collecting tracer log: " + e);
+        }
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -281,7 +281,8 @@ final class TracerFlareService {
   }
 
   private void addLogs(ZipOutputStream zip) throws IOException {
-
+    // org.slf4j.simpleLogger.logFile transformed as datadog.slf4j.simpleLogger.logFile in the final
+    // dd-java-agent jar
     String logFile = System.getProperty("org.slf4j.simpleLogger.logFile");
     if (logFile == null || logFile.isEmpty()) {
       TracerFlare.addText(zip, "tracer.log", "No tracer log file specified");


### PR DESCRIPTION
# What Does This Do

Add tracer log file to tracer flare, requested by the UI or by Triage mode:
- if a tracer log file has been defined with datadog.slf4j.simpleLogger.logFile
- and if the size of the tracer log file is < 15MB

# Motivation
Getting tracer logs in tracer flare to get as much information as possible to better troubleshoot issues

# Additional Notes
This is only a Draft

Jira ticket: [APMAPI-32]



[APMAPI-32]: https://datadoghq.atlassian.net/browse/APMAPI-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ