### PR TITLE
Exclude non username and password authentication from user tracking

### DIFF
--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/SpringSecurityUserEventDecorator.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java17/datadog/trace/instrumentation/springsecurity5/SpringSecurityUserEventDecorator.java
@@ -118,7 +118,7 @@ public class SpringSecurityUserEventDecorator extends AppSecUserEventDecorator {
     }
     if (SKIPPED_AUTHS.add(authentication.getClass())) {
       final Class<?> authClass = authentication.getClass();
-      LOGGER.warn(
+      LOGGER.debug(
           SEND_TELEMETRY, "Skipped authentication, auth={}", findRootAuthentication(authClass));
     }
     return true;

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SpringBootBasedTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.instrumentation.springsecurity5
 
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.core.Appender
 import com.datadog.appsec.AppSecHttpServerTest
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.core.DDSpan
@@ -14,6 +16,7 @@ import spock.lang.Shared
 
 import static datadog.trace.instrumentation.springsecurity5.TestEndpoint.LOGIN
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.instrumentation.springsecurity5.TestEndpoint.CUSTOM
 import static datadog.trace.instrumentation.springsecurity5.TestEndpoint.REGISTER
 import static datadog.trace.instrumentation.springsecurity5.TestEndpoint.UNKNOWN
 import static datadog.trace.instrumentation.springsecurity5.TestEndpoint.NOT_FOUND
@@ -223,6 +226,33 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     then:
     response.code() == 500
     span.getTags().findAll { it.key.startsWith('appsec.events.users.signup') }.isEmpty()
+  }
+
+  void 'test skipped authentication'() {
+    setup:
+    final appender = Mock(Appender)
+    final logger = SpringSecurityUserEventDecorator.LOGGER as Logger
+    logger.addAppender(appender)
+
+    and:
+    final requestCount = 3
+    final request = request(CUSTOM, "GET", null).addHeader('X-Custom-User', 'batman').build()
+
+    when:
+    final response = (1..requestCount).collect { client.newCall(request).execute() }.first()
+    TEST_WRITER.waitForTraces(3)
+    final span = TEST_WRITER.flatten().first() as DDSpan
+    logger.detachAppender(appender) // cant add cleanup
+
+    then:
+    response.code() == CUSTOM.status
+    span.context().resourceName.contains(CUSTOM.path)
+    span.getTags().findAll { key, value -> key.startsWith('appsec.events.users.login')}.isEmpty()
+    // single call to the appender
+    1 * appender.doAppend(_) >> {
+      assert it[0].toString().contains('Skipped authentication, auth=org.springframework.security.authentication.AbstractAuthenticationToken')
+    }
+    0 * appender._
   }
 
   @SuppressWarnings('GroovyAssignabilityCheck')

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/TestEndpoint.groovy
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/TestEndpoint.groovy
@@ -5,6 +5,7 @@ enum TestEndpoint {
   REGISTER("register", 200, ""),
   NOT_FOUND("not-found", 404, "not found"),
   UNKNOWN("", 451, null), // This needs to have a valid status code
+  CUSTOM("custom", 302, ""),
 
   private final String path
   private final String rawPath

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/java/custom/CustomAuthenticationFilter.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/java/custom/CustomAuthenticationFilter.java
@@ -1,0 +1,33 @@
+package custom;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+
+public class CustomAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+  private static final String HEADER_NAME = "X-Custom-User";
+
+  private final AuthenticationManager authenticationManager;
+
+  public CustomAuthenticationFilter(final AuthenticationManager authenticationManager) {
+    super("/custom");
+    this.authenticationManager = authenticationManager;
+  }
+
+  @Override
+  public Authentication attemptAuthentication(
+      HttpServletRequest request, HttpServletResponse response)
+      throws AuthenticationException, IOException, ServletException {
+    final String user = request.getHeader(HEADER_NAME);
+    if (user == null) {
+      return null;
+    }
+    return authenticationManager.authenticate(new CustomAuthenticationToken(user));
+  }
+}

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/java/custom/CustomAuthenticationProvider.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/java/custom/CustomAuthenticationProvider.java
@@ -1,0 +1,18 @@
+package custom;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    return authentication;
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return CustomAuthenticationToken.class.isAssignableFrom(authentication);
+  }
+}

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/java/custom/CustomAuthenticationToken.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/java/custom/CustomAuthenticationToken.java
@@ -1,0 +1,24 @@
+package custom;
+
+import java.util.Collections;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class CustomAuthenticationToken extends AbstractAuthenticationToken {
+
+  private final String user;
+
+  public CustomAuthenticationToken(String user) {
+    super(Collections.emptyList());
+    this.user = user;
+  }
+
+  @Override
+  public Object getCredentials() {
+    return user;
+  }
+
+  @Override
+  public Object getPrincipal() {
+    return user;
+  }
+}


### PR DESCRIPTION
# What Does This Do
Skips auto user tracking events for authentication tokens other than username and password.

# Motivation
Detection of account take over campaigns are very sensitive to false positives in regards of events, having authentication events from systems like OAuth or Saml only introduces noise that might affect the detection.

# Additional Notes

Jira ticket: [APPSEC-53059]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-53059]: https://datadoghq.atlassian.net/browse/APPSEC-53059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ