### PR TITLE
Only rebuild tracer tags when the remote-config 'tracing_tags' change

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -24,6 +24,7 @@ import datadog.trace.api.EndpointTracker;
 import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.StatsDClient;
+import datadog.trace.api.TraceConfig;
 import datadog.trace.api.TracePropagationStyle;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.experimental.DataStreamsCheckpointer;
@@ -443,7 +444,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
               invertMap(config.getBaggageMapping())));
       // Explicitly skip setting scope manager because it depends on statsDClient
       localRootSpanTags(config.getLocalRootSpanTags());
-      defaultSpanTags(config.getMergedSpanTags());
+      defaultSpanTags(withTracerTags(config.getMergedSpanTags(), config, null));
       serviceNameMappings(config.getServiceMapping());
       taggedHeaders(config.getRequestHeaderTags());
       baggageMapping(config.getBaggageMapping());
@@ -548,6 +549,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       spanSamplingRules = SpanSamplingRules.deserializeFile(spanSamplingRulesFile);
     }
 
+    this.defaultSpanTags = defaultSpanTags;
+
     this.dynamicConfig =
         DynamicConfig.create(ConfigSnapshot::new)
             .setTracingEnabled(true) // implied by installation of CoreTracer
@@ -560,11 +563,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
             .setTraceSampleRate(config.getTraceSampleRate())
             .setSpanSamplingRules(spanSamplingRules.getRules())
             .setTraceSamplingRules(traceSamplingRules.getRules())
-            .setTracingTags(config.getGlobalTags())
+            .setTracingTags(config.getMergedSpanTags())
             .apply();
 
     this.logs128bTraceIdEnabled = InstrumenterConfig.get().isLogs128bTraceIdEnabled();
-    this.defaultSpanTags = defaultSpanTags;
     this.partialFlushMinSpans = partialFlushMinSpans;
     this.idGenerationStrategy =
         null == idGenerationStrategy
@@ -1529,6 +1531,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         }
       }
 
+      ConfigSnapshot traceConfig = parentTrace.getTraceConfig();
+
       // Use parent pathwayContext if present and started
       pathwayContext =
           parentContext != null
@@ -1544,7 +1548,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         serviceName = rootSpan != null ? rootSpan.getServiceName() : null;
       }
       if (serviceName == null) {
-        serviceName = captureTraceConfig().getPreferredServiceName();
+        serviceName = traceConfig.getPreferredServiceName();
         if (serviceName == null) {
           // it could be on the initial snapshot but may be overridden to null and service name
           // cannot be null
@@ -1555,9 +1559,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       final CharSequence operationName =
           this.operationName != null ? this.operationName : resourceName;
 
+      final Map<String, ?> mergedTracerTags = traceConfig.mergedTracerTags;
+
       final int tagsSize =
-          (null == tags ? 0 : tags.size())
-              + defaultSpanTags.size()
+          mergedTracerTags.size()
+              + (null == tags ? 0 : tags.size())
               + (null == coreTags ? 0 : coreTags.size())
               + (null == rootSpanTags ? 0 : rootSpanTags.size());
 
@@ -1600,7 +1606,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       // By setting the tags on the context we apply decorators to any tags that have been set via
       // the builder. This is the order that the tags were added previously, but maybe the `tags`
       // set in the builder should come last, so that they override other tags.
-      context.setAllTags(captureTraceConfig().getMergedSpanTags());
+      context.setAllTags(mergedTracerTags);
       context.setAllTags(tags);
       context.setAllTags(coreTags);
       context.setAllTags(rootSpanTags);
@@ -1628,6 +1634,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   protected class ConfigSnapshot extends DynamicConfig.Snapshot {
     final Sampler sampler;
 
+    final Map<String, ?> mergedTracerTags;
+
     protected ConfigSnapshot(
         DynamicConfig<ConfigSnapshot>.Builder builder, ConfigSnapshot oldSnapshot) {
       super(builder, oldSnapshot);
@@ -1640,18 +1648,32 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       } else {
         sampler = Sampler.Builder.forConfig(CoreTracer.this.initialConfig, this);
       }
-    }
 
-    public Map<String, String> getMergedSpanTags() {
-      // Do not include runtimeId into span tags: we only want that added to the root span
-      if (getTracingTags().isEmpty()) {
-        return CoreTracer.this.initialConfig.getMergedSpanTags();
+      if (null == oldSnapshot) {
+        mergedTracerTags = CoreTracer.this.defaultSpanTags;
+      } else if (getTracingTags().equals(oldSnapshot.getTracingTags())) {
+        mergedTracerTags = oldSnapshot.mergedTracerTags;
+      } else {
+        mergedTracerTags = withTracerTags(getTracingTags(), CoreTracer.this.initialConfig, this);
       }
-      int size = getTracingTags().size() + CoreTracer.this.initialConfig.getSpanTags().size();
-      final Map<String, String> result = new HashMap<>(size + 1, 1f);
-      result.putAll(getTracingTags());
-      result.putAll(CoreTracer.this.initialConfig.getSpanTags());
-      return Collections.unmodifiableMap(result);
     }
+  }
+
+  /**
+   * Tags added by the tracer to all spans; combines user-supplied tags with tracer-defined tags.
+   */
+  static Map<String, ?> withTracerTags(
+      Map<String, ?> userSpanTags, Config config, TraceConfig traceConfig) {
+    final Map<String, Object> result = new HashMap<>(userSpanTags.size() + 3, 1f);
+    result.putAll(userSpanTags);
+    if (null != config) {
+      if (!config.getEnv().isEmpty()) {
+        result.put("env", config.getEnv());
+      }
+      if (!config.getVersion().isEmpty()) {
+        result.put("version", config.getVersion());
+      }
+    }
+    return Collections.unmodifiableMap(result);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -2,7 +2,6 @@ package datadog.trace.core;
 
 import datadog.communication.monitor.Recording;
 import datadog.trace.api.DDTraceId;
-import datadog.trace.api.TraceConfig;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.time.TimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -166,7 +165,7 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     return tracer;
   }
 
-  TraceConfig getTraceConfig() {
+  ConfigSnapshot getTraceConfig() {
     return traceConfig;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -238,11 +238,11 @@ final class TracingConfigPoller {
   }
 
   private Map<String, String> parseTagListToMap(List<String> input) {
-    Map<String, String> resultMap = Collections.emptyMap();
-    if (null == input || input.isEmpty()) {
-      return resultMap;
+    if (null == input) {
+      return null;
     }
-    resultMap = new HashMap<>(input.size());
+
+    Map<String, String> resultMap = new HashMap<>(input.size());
     for (String s : input) {
       int colonIndex = s.indexOf(":");
       if (colonIndex > -1

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreTracerTest.groovy
@@ -457,7 +457,7 @@ class CoreTracerTest extends DDCoreSpecification {
 
     then:
     tracer.captureTraceConfig().tracingTags == expectedValue
-    tracer.captureTraceConfig().getMergedSpanTags() == expectedValue
+    tracer.captureTraceConfig().mergedTracerTags == expectedValue
     when:
     updater.remove(key, null)
     updater.commit()

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3542,12 +3542,6 @@ public class Config {
     return Collections.unmodifiableMap(result);
   }
 
-  public Map<String, String> getSpanTags() {
-    final Map<String, String> result = newHashMap(spanTags.size());
-    result.putAll(spanTags);
-    return Collections.unmodifiableMap(result);
-  }
-
   public Map<String, String> getMergedJmxTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
     final Map<String, String> result =


### PR DESCRIPTION
# Motivation

Avoids continually repeating the same merge for every span context built.

# Additional Notes

Other fixes:

* Remote 'tracing_tags' now replace all static tracer tags except `env` and `version`

  Previously remote 'tracing_tags' would completely replace any static configuration
  such as `DD_TAGS`,` DD_TRACE_TAGS`, or `DD_TRACE_GLOBAL_TAGS` - but would not replace
 `DD_TRACE_SPAN_TAGS` - the old merge code also accidentally omitted `env` and `version`
  tags which are stored under global tags, but should be merged with remote-config.

* If 'tracing_tags' is not overridden in remote-config we revert to the static config

  Previously a null 'tracing_tags' override was mapped to the empty list, which is
  not the same (empty list means replace the static config with nothing, whereas a
  missing/null override means revert to the static config)