### PR TITLE
Update docker builder image

### DIFF
--- a/.circleci/render_config.py
+++ b/.circleci/render_config.py
@@ -28,7 +28,7 @@ MASTER_ONLY_JDKS = {
 }
 # Version to use for all the base Docker images, see
 # https://github.com/DataDog/dd-trace-java-docker-build/pkgs/container/dd-trace-java-docker-build
-DOCKER_IMAGE_VERSION="v24.01"
+DOCKER_IMAGE_VERSION="v24.04"
 
 # Get labels from pull requests to override some defaults for jobs to run.
 # `run-tests: all` will run all tests.


### PR DESCRIPTION
# What Does This Do

This PR update the docker builder image to `v24-04` which includes the latest JDKs upgrades.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
