### PR TITLE
Mark test profiling smoke test as flaky

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
@@ -159,6 +159,7 @@ public final class CodeHotspotsTest {
 
   @Test
   @DisplayName("Test batch app")
+  @Flaky
   void testBatch() throws Exception {
     System.out.println("Test batch app");
     int meanServiceTimeSecs = 1; // seconds
@@ -256,7 +257,7 @@ public final class CodeHotspotsTest {
     runTestGenerativeStackTraces("MethodHandles", depth);
   }
 
-  @Flaky("hasCpuEvents assertions failes sometimes")
+  @Flaky("hasCpuEvents assertions fails sometimes")
   @ParameterizedTest
   @ValueSource(ints = {128})
   void testGenerativeStackTracesWithCapturingLambdas(int depth) throws Exception {
@@ -311,7 +312,7 @@ public final class CodeHotspotsTest {
       IItemCollection events = JfrLoaderToolkit.loadEvents(f);
       IItemCollection wallclock = events.apply(ItemFilters.type("datadog.MethodSample"));
       //      IItemCollection cpu = events.apply(ItemFilters.type("datadog.ExecutionSample"));
-      assertTrue(wallclock.hasItems());
+      assertTrue(wallclock.hasItems(), "No datadog.MethodSample events found from " + f.getName());
       //      assertTrue(cpu.hasItems());
 
       validateStats(wallclock, idleness, minCoverage);


### PR DESCRIPTION
# What Does This Do

This PR marks the last profiling integration smoke tests as flaky.

# Motivation

All the tests from `CodeHotspotsTest` are either disabled or flaky except this one.
It was the most frequent flaky test to break the CI.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
