### PR TITLE
Remove sampling_rules from StatusLogger

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -101,11 +101,6 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(config.isTraceAnalyticsEnabled());
     writer.name("sample_rate");
     writer.value(config.getTraceSampleRate());
-    writer.name("sampling_rules");
-    writer.beginArray();
-    writeMap(writer, config.getTraceSamplingServiceRules());
-    writeMap(writer, config.getTraceSamplingOperationRules());
-    writer.endArray();
     writer.name("priority_sampling_enabled");
     writer.value(config.isPrioritySamplingEnabled());
     writer.name("logs_correlation_enabled");


### PR DESCRIPTION
# What Does This Do
Removes `sampling_rules` from StatusLogger

# Motivation
The `sampling_rules` field in StatusLogger does not currently work with our new sampling mechanism. This has caused confusion for users as they're setting up sampling. This PR removes that log to alleviate confusion

We intend to re-add a sampling log statement back in the future as part of [APMAPI-61](https://datadoghq.atlassian.net/browse/APMAPI-61)

# Additional Notes

Jira ticket: [APMS-12002](https://datadoghq.atlassian.net/browse/APMS-12002)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-61]: https://datadoghq.atlassian.net/browse/APMAPI-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APMS-12002]: https://datadoghq.atlassian.net/browse/APMS-12002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ