### PR TITLE
Relocate JCTools

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
+++ b/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
@@ -98,32 +98,32 @@
     ]
   },
   {
-    "name" : "org.jctools.queues.MpscBlockingConsumerArrayQueueColdProducerFields",
+    "name" : "datadog.jctools.queues.MpscBlockingConsumerArrayQueueColdProducerFields",
     "fields": [
       {"name": "producerLimit", "allowUnsafeAccess": true}
     ]
   },
   {
-    "name" : "org.jctools.queues.MpscBlockingConsumerArrayQueueProducerFields",
+    "name" : "datadog.jctools.queues.MpscBlockingConsumerArrayQueueProducerFields",
     "fields": [
       {"name": "producerIndex", "allowUnsafeAccess": true}
     ]
   },
   {
-    "name" : "org.jctools.queues.MpscBlockingConsumerArrayQueueConsumerFields",
+    "name" : "datadog.jctools.queues.MpscBlockingConsumerArrayQueueConsumerFields",
     "fields": [
       {"name": "consumerIndex", "allowUnsafeAccess": true},
       {"name": "blocked", "allowUnsafeAccess": true}
     ]
   },
   {
-    "name" : "org.jctools.queues.SpscArrayQueueProducerIndexFields",
+    "name" : "datadog.jctools.queues.SpscArrayQueueProducerIndexFields",
     "fields": [
       {"name": "producerIndex", "allowUnsafeAccess": true}
     ]
   },
   {
-    "name" : "org.jctools.queues.SpscArrayQueueConsumerIndexField",
+    "name" : "datadog.jctools.queues.SpscArrayQueueConsumerIndexField",
     "fields": [
       {"name": "consumerIndex", "allowUnsafeAccess": true}
     ]

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -48,6 +48,8 @@ ext.generalShadowJarConfig = {
 
   // Prevents conflict with other SLF4J instances. Important for premain.
   relocate 'org.slf4j', 'datadog.slf4j'
+  // Prevents conflict with other JCTools instances
+  relocate 'org.jctools', 'datadog.jctools'
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'datadog.trace.bootstrap.PatchLogger'
 

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/AnnotationSubstitutionProcessorInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/AnnotationSubstitutionProcessorInstrumentation.java
@@ -35,8 +35,8 @@ public final class AnnotationSubstitutionProcessorInstrumentation
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".Target_org_jctools_counters_FixedSizeStripedLongCounterFields",
-      packageName + ".Target_org_jctools_util_UnsafeRefArrayAccess"
+      packageName + ".Target_datadog_jctools_counters_FixedSizeStripedLongCounterFields",
+      packageName + ".Target_datadog_jctools_util_UnsafeRefArrayAccess"
     };
   }
 
@@ -47,16 +47,16 @@ public final class AnnotationSubstitutionProcessorInstrumentation
       "jdk.vm.ci.meta.ResolvedJavaType",
       "jdk.vm.ci.meta.ResolvedJavaField",
       // ignore helper class names as usual
-      packageName + ".Target_org_jctools_counters_FixedSizeStripedLongCounterFields",
-      packageName + ".Target_org_jctools_util_UnsafeRefArrayAccess"
+      packageName + ".Target_datadog_jctools_counters_FixedSizeStripedLongCounterFields",
+      packageName + ".Target_datadog_jctools_util_UnsafeRefArrayAccess"
     };
   }
 
   public static class FindTargetClassesAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(@Advice.Return(readOnly = false) List<Class<?>> result) {
-      result.add(Target_org_jctools_counters_FixedSizeStripedLongCounterFields.class);
-      result.add(Target_org_jctools_util_UnsafeRefArrayAccess.class);
+      result.add(Target_datadog_jctools_counters_FixedSizeStripedLongCounterFields.class);
+      result.add(Target_datadog_jctools_util_UnsafeRefArrayAccess.class);
     }
   }
 }

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_datadog_jctools_counters_FixedSizeStripedLongCounterFields.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_datadog_jctools_counters_FixedSizeStripedLongCounterFields.java
@@ -4,8 +4,8 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "org.jctools.counters.FixedSizeStripedLongCounterFields")
-public final class Target_org_jctools_counters_FixedSizeStripedLongCounterFields {
+@TargetClass(className = "datadog.jctools.counters.FixedSizeStripedLongCounterFields")
+public final class Target_datadog_jctools_counters_FixedSizeStripedLongCounterFields {
   @Alias
   @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayBaseOffset, declClass = long[].class)
   public static long COUNTER_ARRAY_BASE;

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_datadog_jctools_util_UnsafeRefArrayAccess.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/Target_datadog_jctools_util_UnsafeRefArrayAccess.java
@@ -4,8 +4,8 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "org.jctools.util.UnsafeRefArrayAccess")
-public final class Target_org_jctools_util_UnsafeRefArrayAccess {
+@TargetClass(className = "datadog.jctools.util.UnsafeRefArrayAccess")
+public final class Target_datadog_jctools_util_UnsafeRefArrayAccess {
   @Alias
   @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.ArrayIndexShift, declClass = Object[].class)
   public static int REF_ELEMENT_SHIFT;


### PR DESCRIPTION
# What Does This Do
Relocates JCTools
# Motivation
DD JCTools usage is clashing with Quarkus 3.10, since they both use JCTools and it requires GraalVM substitutions. Quarkus has the GraalVM config to do substitutions, and DD does as well, so this yields the following error `Error: Substition: org.jctools.util.UnsafeRefArrayAccess.REF_ELEMENT_SHIFT conflicts with previously registered: org.jctools.util.UnsafeRefArrayAccess.REF_ELEMENT_SHIFT`... which means that there are two substitutions being registered for the same target.
Relocating JCTools fixes not only that but prevents it from happening with other Java frameworks, as GraalVM (https://github.com/oracle/graal/blob/481625b5da2b293cc672fd4b9348612483b6e76c/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java#L904) throws an error if there is more than one substitution for the same key.

fixes https://github.com/DataDog/dd-trace-java/issues/7002