### PR TITLE
Revert PR #6990 (Add product tags to each span if products are enabled)

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -1,5 +1,7 @@
 package datadog.trace.core
 
+import static datadog.trace.api.DDTags.DJM_ENABLED
+import static datadog.trace.api.DDTags.DSM_ENABLED
 import static datadog.trace.api.DDTags.PROFILING_ENABLED
 import static datadog.trace.api.DDTags.SCHEMA_VERSION_TAG_KEY
 
@@ -81,6 +83,8 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
       (PID_TAG)         : Config.get().getProcessId(),
       (SCHEMA_VERSION_TAG_KEY) : SpanNaming.instance().version(),
       (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0,
+      (DSM_ENABLED)           : Config.get().isDataStreamsEnabled() ? 1 : 0,
+      (DJM_ENABLED)           : Config.get().isDataJobsEnabled() ? 1 : 0
     ]
 
     when:
@@ -358,6 +362,8 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
         (THREAD_NAME)           : thread.name, (THREAD_ID): thread.id, (PID_TAG): Config.get().getProcessId(),
         (SCHEMA_VERSION_TAG_KEY): SpanNaming.instance().version(),
         (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0,
+        (DSM_ENABLED)           : Config.get().isDataStreamsEnabled() ? 1 : 0,
+        (DJM_ENABLED)           : Config.get().isDataJobsEnabled() ? 1 : 0
       ]
 
     where:
@@ -381,6 +387,8 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
       (PID_TAG)               : Config.get().getProcessId(),
       (SCHEMA_VERSION_TAG_KEY): SpanNaming.instance().version(),
       (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0,
+      (DSM_ENABLED)           : Config.get().isDataStreamsEnabled() ? 1 : 0,
+      (DJM_ENABLED)           : Config.get().isDataJobsEnabled() ? 1 : 0
     ]
 
     cleanup:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/DDSpanContextTest.groovy
@@ -299,6 +299,7 @@ class DDSpanContextTest extends DDCoreSpecification {
     sourceWithoutCommonTags.remove("_dd.trace_span_attribute_schema")
     sourceWithoutCommonTags.remove(DDTags.PROFILING_ENABLED)
     sourceWithoutCommonTags.remove(DDTags.PROFILING_CONTEXT_ENGINE)
+    sourceWithoutCommonTags.remove(DDTags.DSM_ENABLED)
     sourceWithoutCommonTags.remove(DDTags.DJM_ENABLED)
     if (removeThread) {
       sourceWithoutCommonTags.remove(DDTags.THREAD_ID)

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3473,6 +3473,8 @@ public class Config {
     result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
     result.put(SCHEMA_VERSION_TAG_KEY, SpanNaming.instance().version());
     result.put(PROFILING_ENABLED, isProfilingEnabled() ? 1 : 0);
+    result.put(DSM_ENABLED, isDataStreamsEnabled() ? 1 : 0);
+    result.put(DJM_ENABLED, isDataJobsEnabled() ? 1 : 0);
 
     if (reportHostName) {
       final String hostName = getHostName();
@@ -3541,14 +3543,8 @@ public class Config {
   }
 
   public Map<String, String> getSpanTags() {
-    final Map<String, String> result = newHashMap(spanTags.size() + 2);
+    final Map<String, String> result = newHashMap(spanTags.size());
     result.putAll(spanTags);
-    if (isDataStreamsEnabled()) {
-      result.put(DSM_ENABLED, "1");
-    }
-    if (isDataJobsEnabled()) {
-      result.put(DJM_ENABLED, "1");
-    }
     return Collections.unmodifiableMap(result);
   }
 


### PR DESCRIPTION
# What Does This Do

PR #6990 accidentally uses a `Config` method that is going away as part of the cleanup in #6996

# Additional Notes

The `getSpanTags` method was only recently added and isn't really the same thing as `getLocalRootSpanTags`

While `getLocalRootSpanTags` returns tracer-defined tags to be added to the local root span, `getSpanTags` was returning user-defined tags to be added to every span. User-defined tags are supposed be ignored if remote-config overrides them via `tracing_tags`. Mixing tracer-defined tags with user-defined tags in the same config method makes it difficult to remove one without removing the other, leading to subtle bugs.

Once this revert is applied, I'll merge #6996 and propose an alternative approach.