### PR TITLE
Always collect accept, content-type and user-agent when appsec is enabled

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -49,6 +49,10 @@ public class AppSecRequestContext implements DataBundle, Closeable {
               "accept-encoding",
               "accept-language"));
 
+  // request headers that will always be set when appsec is enabled
+  public static final Set<String> DEFAULT_REQUEST_HEADERS_ALLOW_LIST =
+      new TreeSet<>(Arrays.asList("accept", "content-type", "user-agent"));
+
   private final ConcurrentHashMap<Address<?>, Object> persistentData = new ConcurrentHashMap<>();
   private Collection<AppSecEvent> collectedEvents; // guarded by this
 


### PR DESCRIPTION
# What Does This Do
Always collects `Accept`, `Content-Type` and `User-Agent` when appsec is enabled

# Motivation

# Additional Notes

Jira ticket: [APPSEC-52885]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-52885]: https://datadoghq.atlassian.net/browse/APPSEC-52885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ