### PR TITLE
[DSM] - Tag every span with the product tag if it is enabled

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -2,6 +2,8 @@ package datadog.trace.core;
 
 import static datadog.communication.monitor.DDAgentStatsDClientManager.statsDClientManager;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
+import static datadog.trace.api.DDTags.DJM_ENABLED;
+import static datadog.trace.api.DDTags.DSM_ENABLED;
 import static datadog.trace.api.DDTags.PROFILING_CONTEXT_ENGINE;
 import static datadog.trace.common.metrics.MetricsAggregatorFactory.createMetricsAggregator;
 import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
@@ -1664,14 +1666,27 @@ public class CoreTracer implements AgentTracer.TracerAPI {
    */
   static Map<String, ?> withTracerTags(
       Map<String, ?> userSpanTags, Config config, TraceConfig traceConfig) {
-    final Map<String, Object> result = new HashMap<>(userSpanTags.size() + 3, 1f);
+    final Map<String, Object> result = new HashMap<>(userSpanTags.size() + 5, 1f);
     result.putAll(userSpanTags);
-    if (null != config) {
+    if (null != config) { // static
       if (!config.getEnv().isEmpty()) {
         result.put("env", config.getEnv());
       }
       if (!config.getVersion().isEmpty()) {
         result.put("version", config.getVersion());
+      }
+      if (config.isDataJobsEnabled()) {
+        result.put(DJM_ENABLED, 1);
+      }
+      if (config.isDataStreamsEnabled()) {
+        result.put(DSM_ENABLED, 1);
+      }
+    }
+    if (null != traceConfig) { // dynamic
+      if (traceConfig.isDataStreamsEnabled()) {
+        result.put(DSM_ENABLED, 1);
+      } else {
+        result.remove(DSM_ENABLED);
       }
     }
     return Collections.unmodifiableMap(result);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/CoreSpanBuilderTest.groovy
@@ -76,16 +76,13 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
 
     then:
     span.getTags() == [
-      (THREAD_NAME)     : Thread.currentThread().getName(),
-      (THREAD_ID)       : Thread.currentThread().getId(),
-      (RUNTIME_ID_TAG)  : Config.get().getRuntimeId(),
-      (LANGUAGE_TAG_KEY): LANGUAGE_TAG_VALUE,
-      (PID_TAG)         : Config.get().getProcessId(),
-      (SCHEMA_VERSION_TAG_KEY) : SpanNaming.instance().version(),
-      (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0,
-      (DSM_ENABLED)           : Config.get().isDataStreamsEnabled() ? 1 : 0,
-      (DJM_ENABLED)           : Config.get().isDataJobsEnabled() ? 1 : 0
-    ]
+      (THREAD_NAME)            : Thread.currentThread().getName(),
+      (THREAD_ID)              : Thread.currentThread().getId(),
+      (RUNTIME_ID_TAG)         : Config.get().getRuntimeId(),
+      (LANGUAGE_TAG_KEY)       : LANGUAGE_TAG_VALUE,
+      (PID_TAG)                : Config.get().getProcessId(),
+      (SCHEMA_VERSION_TAG_KEY) : SpanNaming.instance().version()
+    ] + productTags()
 
     when:
     // with all custom fields provided
@@ -356,15 +353,12 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     span.samplingPriority == null
     span.context().origin == tagContext.origin
     span.context().baggageItems == [:]
-    span.context().tags == tagContext.tags +
-      [(RUNTIME_ID_TAG)        : Config.get().getRuntimeId(),
-        (LANGUAGE_TAG_KEY)      : LANGUAGE_TAG_VALUE,
-        (THREAD_NAME)           : thread.name, (THREAD_ID): thread.id, (PID_TAG): Config.get().getProcessId(),
-        (SCHEMA_VERSION_TAG_KEY): SpanNaming.instance().version(),
-        (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0,
-        (DSM_ENABLED)           : Config.get().isDataStreamsEnabled() ? 1 : 0,
-        (DJM_ENABLED)           : Config.get().isDataJobsEnabled() ? 1 : 0
-      ]
+    span.context().tags == tagContext.tags + [
+      (RUNTIME_ID_TAG)         : Config.get().getRuntimeId(),
+      (LANGUAGE_TAG_KEY)       : LANGUAGE_TAG_VALUE,
+      (THREAD_NAME)            : thread.name, (THREAD_ID): thread.id, (PID_TAG): Config.get().getProcessId(),
+      (SCHEMA_VERSION_TAG_KEY) : SpanNaming.instance().version()
+    ] + productTags()
 
     where:
     tagContext                                      | _
@@ -380,16 +374,13 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
 
     expect:
     span.tags == tags + [
-      (THREAD_NAME)           : Thread.currentThread().getName(),
-      (THREAD_ID)             : Thread.currentThread().getId(),
-      (RUNTIME_ID_TAG)        : Config.get().getRuntimeId(),
-      (LANGUAGE_TAG_KEY)      : LANGUAGE_TAG_VALUE,
-      (PID_TAG)               : Config.get().getProcessId(),
-      (SCHEMA_VERSION_TAG_KEY): SpanNaming.instance().version(),
-      (PROFILING_ENABLED)     : Config.get().isProfilingEnabled() ? 1 : 0,
-      (DSM_ENABLED)           : Config.get().isDataStreamsEnabled() ? 1 : 0,
-      (DJM_ENABLED)           : Config.get().isDataJobsEnabled() ? 1 : 0
-    ]
+      (THREAD_NAME)            : Thread.currentThread().getName(),
+      (THREAD_ID)              : Thread.currentThread().getId(),
+      (RUNTIME_ID_TAG)         : Config.get().getRuntimeId(),
+      (LANGUAGE_TAG_KEY)       : LANGUAGE_TAG_VALUE,
+      (PID_TAG)                : Config.get().getProcessId(),
+      (SCHEMA_VERSION_TAG_KEY) : SpanNaming.instance().version()
+    ] + productTags()
 
     cleanup:
     customTracer.close()
@@ -463,5 +454,18 @@ class CoreSpanBuilderTest extends DDCoreSpecification {
     span3.finish()
     span2.finish()
     span1.finish()
+  }
+
+  def productTags() {
+    def productTags = [
+      (PROFILING_ENABLED) : Config.get().isProfilingEnabled() ? 1 : 0
+    ]
+    if (Config.get().isDataStreamsEnabled()) {
+      productTags[DSM_ENABLED] = 1
+    }
+    if (Config.get().isDataJobsEnabled()) {
+      productTags[DJM_ENABLED] = 1
+    }
+    return productTags
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -123,8 +123,6 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_REPORT_HOSTNAME;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_RESOLVER_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_WRITER_BAGGAGE_INJECT;
-import static datadog.trace.api.DDTags.DJM_ENABLED;
-import static datadog.trace.api.DDTags.DSM_ENABLED;
 import static datadog.trace.api.DDTags.HOST_TAG;
 import static datadog.trace.api.DDTags.INTERNAL_HOST_NAME;
 import static datadog.trace.api.DDTags.LANGUAGE_TAG_KEY;
@@ -3473,8 +3471,6 @@ public class Config {
     result.put(LANGUAGE_TAG_KEY, LANGUAGE_TAG_VALUE);
     result.put(SCHEMA_VERSION_TAG_KEY, SpanNaming.instance().version());
     result.put(PROFILING_ENABLED, isProfilingEnabled() ? 1 : 0);
-    result.put(DSM_ENABLED, isDataStreamsEnabled() ? 1 : 0);
-    result.put(DJM_ENABLED, isDataJobsEnabled() ? 1 : 0);
 
     if (reportHostName) {
       final String hostName = getHostName();


### PR DESCRIPTION
# What Does This Do
This is a re-worked version of https://github.com/DataDog/dd-trace-java/pull/6990 and a followup to https://github.com/DataDog/dd-trace-java/pull/6967.

# Motivation
Adding product tags only to local root is not enough, as there's no guarantee that every trace segment received by the backend will have this tag (due to partial flushing, trace segment splitting etc). We need a simple and robust way of marking all data coming from DSM / DJM products. Adding the tag only when the product is enabled will add the overhead only for customers of this product.

# Additional Notes

[Jira](https://datadoghq.atlassian.net/browse/DSMON-356)