### PR TITLE
Fix ArrayIndexOutOfBoundsException in adjustLocalVarsBasedOnArgs

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -222,8 +222,10 @@ public class ASMHelper {
   }
 
   public static LocalVariableNode[] createLocalVarNodes(List<LocalVariableNode> sortedLocalVars) {
-    int maxIndex = sortedLocalVars.get(sortedLocalVars.size() - 1).index;
-    LocalVariableNode[] localVars = new LocalVariableNode[maxIndex + 1];
+    LocalVariableNode maxVarNode = sortedLocalVars.get(sortedLocalVars.size() - 1);
+    int maxIndex = maxVarNode.index;
+    org.objectweb.asm.Type localType = org.objectweb.asm.Type.getType(maxVarNode.desc);
+    LocalVariableNode[] localVars = new LocalVariableNode[maxIndex + localType.getSize()];
     for (LocalVariableNode localVariableNode : sortedLocalVars) {
       localVars[localVariableNode.index] = localVariableNode;
     }
@@ -243,6 +245,9 @@ public class ASMHelper {
       int slot = isStatic ? 0 : 1;
       int localVarTableIdx = slot;
       for (org.objectweb.asm.Type t : argTypes) {
+        if (slot >= localVars.length) {
+          break;
+        }
         if (localVars[slot] == null && localVarTableIdx < sortedLocalVars.size()) {
           localVars[slot] = sortedLocalVars.get(localVarTableIdx);
         }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/ASMHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/ASMHelperTest.java
@@ -1,12 +1,22 @@
 package com.datadog.debugger.instrumentation;
 
+import static com.datadog.debugger.instrumentation.ASMHelper.createLocalVarNodes;
 import static com.datadog.debugger.instrumentation.ASMHelper.ensureSafeClassLoad;
+import static com.datadog.debugger.instrumentation.ASMHelper.sortLocalVariables;
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.LocalVariableNode;
 
 public class ASMHelperTest {
+
+  public static final LocalVariableNode THIS =
+      createLocalVar(null, Types.OBJECT_TYPE.getDescriptor(), 0);
 
   @Test
   public void ensureSafeLoadClass() {
@@ -28,5 +38,103 @@ public class ASMHelperTest {
         ensureSafeClassLoad(
             ASMHelperTest.class.getTypeName(), "", ASMHelperTest.class.getClassLoader());
     assertEquals(ASMHelperTest.class, clazz);
+  }
+
+  @Test
+  public void adjustLocalVarsBasedOnArgs_empty() {
+    LocalVariableNode[] emptyLocalVariables = new LocalVariableNode[0];
+    Type[] emptyArgs = new Type[0];
+    ASMHelper.adjustLocalVarsBasedOnArgs(
+        false, emptyLocalVariables, emptyArgs, Collections.emptyList());
+    ASMHelper.adjustLocalVarsBasedOnArgs(
+        true, emptyLocalVariables, emptyArgs, Collections.emptyList());
+  }
+
+  @Test
+  public void adjustLocalVarsBasedOnArgs() {
+    doAdjustLocalVarsBasedOnArgs(
+        true, asList(Type.INT_TYPE), asList(createLocalVar("a", "I", 0)), asList("a"));
+    doAdjustLocalVarsBasedOnArgs(
+        false, asList(Type.INT_TYPE), asList(THIS, createLocalVar("a", "I", 1)), asList("a"));
+    doAdjustLocalVarsBasedOnArgs(
+        true,
+        asList(Type.INT_TYPE, Type.INT_TYPE, Type.INT_TYPE),
+        asList(
+            createLocalVar("c", "I", 2), createLocalVar("b", "I", 1), createLocalVar("a", "I", 0)),
+        asList("a", "b", "c"));
+    doAdjustLocalVarsBasedOnArgs(
+        false,
+        asList(Type.INT_TYPE, Type.INT_TYPE, Type.INT_TYPE),
+        asList(
+            THIS,
+            createLocalVar("c", "I", 3),
+            createLocalVar("b", "I", 2),
+            createLocalVar("a", "I", 1)),
+        asList("a", "b", "c"));
+    doAdjustLocalVarsBasedOnArgs(
+        true,
+        asList(Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE),
+        asList(
+            createLocalVar("c", "J", 4), createLocalVar("b", "J", 2), createLocalVar("a", "J", 0)),
+        asList("a", "b", "c"));
+    doAdjustLocalVarsBasedOnArgs(
+        false,
+        asList(Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE),
+        asList(
+            THIS,
+            createLocalVar("c", "J", 5),
+            createLocalVar("b", "J", 3),
+            createLocalVar("a", "J", 1)),
+        asList("a", "b", "c"));
+    doAdjustLocalVarsBasedOnArgs(
+        true,
+        asList(Type.INT_TYPE, Type.INT_TYPE, Type.INT_TYPE),
+        asList(
+            createLocalVar("c", "I", 6), createLocalVar("b", "I", 5), createLocalVar("a", "I", 4)),
+        asList("a", "b", "c"));
+    doAdjustLocalVarsBasedOnArgs(
+        false,
+        asList(Type.INT_TYPE, Type.INT_TYPE, Type.INT_TYPE),
+        asList(
+            THIS,
+            createLocalVar("c", "I", 6),
+            createLocalVar("b", "I", 5),
+            createLocalVar("a", "I", 4)),
+        asList("a", "b", "c"));
+    doAdjustLocalVarsBasedOnArgs(
+        true,
+        asList(Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE),
+        asList(
+            createLocalVar("c", "J", 10), createLocalVar("b", "J", 8), createLocalVar("a", "J", 6)),
+        asList("a", "b", "c"));
+    doAdjustLocalVarsBasedOnArgs(
+        false,
+        asList(Type.LONG_TYPE, Type.LONG_TYPE, Type.LONG_TYPE),
+        asList(
+            THIS,
+            createLocalVar("c", "J", 10),
+            createLocalVar("b", "J", 8),
+            createLocalVar("a", "J", 6)),
+        asList("a", "b", "c"));
+  }
+
+  private void doAdjustLocalVarsBasedOnArgs(
+      boolean isStatic,
+      List<Type> argTypes,
+      List<LocalVariableNode> localVarNodes,
+      List<String> expectedLocalVarNames) {
+    Type[] args = argTypes.toArray(new Type[0]);
+    List<LocalVariableNode> sortedLocalVariables = sortLocalVariables(localVarNodes);
+    LocalVariableNode[] localVars = createLocalVarNodes(sortedLocalVariables);
+    ASMHelper.adjustLocalVarsBasedOnArgs(isStatic, localVars, args, sortedLocalVariables);
+    int idx = isStatic ? 0 : 1;
+    for (String name : expectedLocalVarNames) {
+      assertEquals(name, localVars[idx].name);
+      idx += Type.getType(localVars[idx].desc).getSize();
+    }
+  }
+
+  private static LocalVariableNode createLocalVar(String name, String desc, int index) {
+    return new LocalVariableNode(name, desc, null, null, null, index);
   }
 }


### PR DESCRIPTION
# What Does This Do
Add a protection against index out of bounds but also adjust local var array for long or double.

# Motivation
`ArrayIndexOutOfBoundsException` was thrown because size of the args and local vars were not correctly took into account. with Long/Double type it actually takes 2 slots into the local var tables.

```
java.lang.ArrayIndexOutOfBoundsException: Index 8 out of bounds for length 8
        at com.datadog.debugger.instrumentation.ASMHelper.adjustLocalVarsBasedOnArgs(ASMHelper.java:246)
        at com.datadog.debugger.symbol.SymbolExtractor.extractArgs(SymbolExtractor.java:314)
        at com.datadog.debugger.symbol.SymbolExtractor.extractMethods(SymbolExtractor.java:107)
        at com.datadog.debugger.symbol.SymbolExtractor.extractScopes(SymbolExtractor.java:41)
        at com.datadog.debugger.symbol.SymbolExtractor.extract(SymbolExtractor.java:35)
        at com.datadog.debugger.symbol.SymbolAggregator.parseClass(SymbolAggregator.java:70)
        at com.datadog.debugger.symbol.SymDBEnablement.parseJarEntry(SymDBEnablement.java:198)
        at com.datadog.debugger.symbol.SymDBEnablement.lambda$extractSymbolForLoadedClasses$4(SymDBEnablement.java:179)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:194)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:194)
        at java.base/java.util.zip.ZipFile$EntrySpliterator.tryAdvance(ZipFile.java:573)
        at java.base/java.util.Spliterator.forEachRemaining(Spliterator.java:332)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:556)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:611)
        at com.datadog.debugger.symbol.SymDBEnablement.extractSymbolForLoadedClasses(SymDBEnablement.java:179)
        at com.datadog.debugger.symbol.SymDBEnablement.startSymbolExtraction(SymDBEnablement.java:127)
        at datadog.trace.util.AgentTaskScheduler$RunnableTask.run(AgentTaskScheduler.java:41)
        at datadog.trace.util.AgentTaskScheduler$RunnableTask.run(AgentTaskScheduler.java:36)
        at datadog.trace.util.AgentTaskScheduler$PeriodicTask.run(AgentTaskScheduler.java:311)
        at datadog.trace.util.AgentTaskScheduler$Worker.run(AgentTaskScheduler.java:266)
        at java.base/java.lang.Thread.run(Thread.java:1570)
```

# Additional Notes

Jira ticket: [DEBUG-2373]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2373]: https://datadoghq.atlassian.net/browse/DEBUG-2373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ