### PR TITLE
Fix test names to be unique

### DIFF
--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastVertxSmokeTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastVertxSmokeTest.groovy
@@ -94,7 +94,7 @@ abstract class AbstractIastVertxSmokeTest extends AbstractIastServerSmokeTest {
     }
   }
 
-  void 'test parameter names list source'() {
+  void 'test #type parameter names list source'() {
     setup:
     final request = builder.call("http://localhost:${httpPort}/paramnames")
     final name = params.split('=')[0]
@@ -111,9 +111,9 @@ abstract class AbstractIastVertxSmokeTest extends AbstractIastServerSmokeTest {
     }
 
     where:
-    params            | builder
-    'postparam=value' | { String url -> new Request.Builder().url(url).post(RequestBody.create(FORM, params)).build() }
-    'getparam=value'  | { String url -> new Request.Builder().url("$url?$params").get().build() }
+    type   | params            | builder
+    'post' | 'postparam=value' | { String url -> new Request.Builder().url(url).post(RequestBody.create(FORM, params)).build() }
+    'get'  | 'getparam=value'  | { String url -> new Request.Builder().url("$url?$params").get().build() }
   }
 
   void 'test form source'() {


### PR DESCRIPTION
# What Does This Do

This PR fix few test names to not rely on toString() for generated names, making them unique across runs.

# Motivation

This will help identify tests in CI visibility.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
