### PR TITLE
Enable telemetry logs for IAST, CI Visibility and Dynamic Instrumentation users

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1595,10 +1595,6 @@ public class Config {
         configProvider.getBoolean(
             TELEMETRY_DEPENDENCY_COLLECTION_ENABLED,
             DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED);
-
-    isTelemetryLogCollectionEnabled =
-        configProvider.getBoolean(
-            TELEMETRY_LOG_COLLECTION_ENABLED, DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED);
     telemetryDependencyResolutionQueueSize =
         configProvider.getInteger(
             TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE,
@@ -1909,6 +1905,19 @@ public class Config {
 
     debuggerThirdPartyIncludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_INCLUDES));
     debuggerThirdPartyExcludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_EXCLUDES));
+
+    // FIXME: For the initial rollout, we default log collection to true for IAST and CI Visibility
+    // users. This should be removed once we default to true, and then it can also be moved up
+    // together with the rest of telemetry ocnfig.
+    final boolean telemetryLogCollectionEnabledDefault =
+        instrumenterConfig.isTelemetryEnabled()
+                && (instrumenterConfig.getIastActivation() == ProductActivation.FULLY_ENABLED
+                    || instrumenterConfig.isCiVisibilityEnabled()
+                    || debuggerEnabled)
+            || DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED;
+    isTelemetryLogCollectionEnabled =
+        configProvider.getBoolean(
+            TELEMETRY_LOG_COLLECTION_ENABLED, telemetryLogCollectionEnabledDefault);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");


### PR DESCRIPTION
# What Does This Do

* Enable telemetry logs by default if IAST or CI Visibility are activated.

# Motivation

* This is part of a gradual rollout of telemetry logs, prioritizing first products that need it the most.

# Additional Notes

* This code will be removed once telemetry logs are fully enabled by default. If everything goes well, that should be in about 2 releases after this PR.
* Jira ticket: [APPSEC-53106](https://datadoghq.atlassian.net/browse/APPSEC-53106)

[APPSEC-53106]: https://datadoghq.atlassian.net/browse/APPSEC-53106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ