### PR TITLE
Fix support of literals in Expression Language

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -401,6 +401,11 @@ public class JsonToExpressionConverter {
           reader.nextNull();
           return DSL.nullValue();
         }
+      case BOOLEAN:
+        {
+          boolean boolValue = reader.nextBoolean();
+          return DSL.value(boolValue);
+        }
       default:
         throw new UnsupportedOperationException(
             "Invalid value definition, not supported token: " + currentToken);

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Value.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/Value.java
@@ -64,6 +64,8 @@ public interface Value<T> {
     }
     if (value instanceof Boolean) {
       return new BooleanValue((Boolean) value);
+    } else if (value instanceof Character) {
+      return new StringValue(value.toString());
     } else if (value instanceof Number) {
       return new NumericValue((Number) value);
     } else if (value instanceof String) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -222,6 +222,21 @@ public class ProbeConditionTest {
     assertTrue(probeCondition.execute(ctx));
   }
 
+  @Test
+  void testLiterals() throws Exception {
+    ProbeCondition probeCondition = load("/test_conditional_13.json");
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("boolVal", true);
+    fields.put("intVal", 1);
+    fields.put("longVal", 1L);
+    fields.put("doubleVal", 1.0);
+    fields.put("strVal", "foo");
+    fields.put("objVal", null);
+    fields.put("charVal", 'a');
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null, fields);
+    assertTrue(probeCondition.execute(ctx));
+  }
+
   private static ProbeCondition load(String resourcePath) throws IOException {
     InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath);
     Moshi moshi =

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_13.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_13.json
@@ -1,0 +1,16 @@
+{
+  "dsl": "isEmpty(emptyStr) && isEmpty(emptyList) && isEmpty(emptyMap) && isEmpty(emptyArray) && isUndefined(@exception)",
+  "json": {
+    "and": [
+      {"eq": [{"ref": "boolVal"}, true]},
+      {"eq": [{"ref": "intVal"}, 1]},
+      {"eq": [{"ref": "longVal"}, 1]},
+      {"eq": [{"ref": "doubleVal"}, 1.0]},
+      {"eq": [{"ref": "strVal"}, "foo"]},
+      {"eq": [{"ref": "objVal"}, null]},
+      {"eq": [{"ref": "charVal"}, "a"]}
+    ]
+  }
+}
+
+


### PR DESCRIPTION
# What Does This Do
Add support of boolean
support characters as strings

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2371]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2371]: https://datadoghq.atlassian.net/browse/DEBUG-2371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ