### PR TITLE
Avoid duplicate debugger classes from ending up dd-java-agent

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -56,7 +56,7 @@ dependencies {
   implementation project(':utils:container-utils')
   implementation project(':utils:socket-utils')
   // for span exception debugging
-  implementation project(':dd-java-agent:agent-debugger:debugger-bootstrap')
+  compileOnly project(':dd-java-agent:agent-debugger:debugger-bootstrap')
 
   implementation deps.slf4j
   implementation deps.moshi

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -51,6 +51,8 @@ public class DDSpan
     implements AgentSpan, CoreSpan<DDSpan>, TransientProfilingContextHolder, AttachableWrapper {
   private static final Logger log = LoggerFactory.getLogger(DDSpan.class);
 
+  private static final boolean DEBUGGER_ENABLED = Config.get().isDebuggerEnabled();
+
   public static final String CHECKPOINTED_TAG = "checkpointed";
 
   static DDSpan create(
@@ -365,7 +367,7 @@ public class DDSpan
 
       setTag(DDTags.ERROR_MSG, message);
       setTag(DDTags.ERROR_TYPE, error.getClass().getName());
-      if (isLocalRootSpan()) {
+      if (DEBUGGER_ENABLED && isLocalRootSpan()) {
         DebuggerContext.handleException(error, this);
       }
     }


### PR DESCRIPTION
# What Does This Do

Change debugger-bootstrap to be an optional compileOnly dependency to dd-trace-core, otherwise it gets added multiple times in the final packaged dd-java-agent library.

Before:
```
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$Tracer.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$SkipCause.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$ExceptionDebugger.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$ProbeResolver.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$ClassFilter.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$1.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$MetricForwarder.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$MetricKind.classdata   OK
    testing: trace/datadog/trace/bootstrap/debugger/DebuggerContext$ValueSerializer.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$Tracer.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$SkipCause.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$ExceptionDebugger.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$ProbeResolver.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$ClassFilter.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$1.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$MetricForwarder.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$MetricKind.classdata   OK
    testing: inst/datadog/trace/bootstrap/debugger/DebuggerContext$ValueSerializer.classdata   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$ExceptionDebugger.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$ValueSerializer.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$ClassFilter.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$1.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$MetricKind.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$SkipCause.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$MetricForwarder.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$Tracer.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$ProbeResolver.class   OK
```

After:
```
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$ExceptionDebugger.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$ValueSerializer.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$ClassFilter.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$1.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$MetricKind.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$SkipCause.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$MetricForwarder.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$Tracer.class   OK
    testing: datadog/trace/bootstrap/debugger/DebuggerContext$ProbeResolver.class   OK
```

# Motivation

The build already arranges for debugger-bootstrap to be on the boot-class-path, so this is the simplest way to avoid the duplicate classes. The only additional change is to only call `DebuggerContext.handleException` when the live debugger product is enabled to make it a truly optional dependency, otherwise we get a NoClassDefFoundError in dd-trace-ot

(dd-trace-ot isn't meant to include the debugger, so this also helps remove the extra classes from that deliverable)
