### PR TITLE
extend latest dep test for undertow

### DIFF
--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/build.gradle
@@ -6,12 +6,29 @@ muzzle {
     skipVersions = ["2.2.25.Final"] // half propagated
     assertInverse = false
   }
+  pass {
+    group = "io.undertow"
+    module = "undertow-servlet"
+    versions = "[2.3,]"
+    javaVersion = "11"
+    skipVersions = ["2.2.25.Final"] // half propagated
+    assertInverse = false
+  }
+
+  pass {
+    name = "javax.servlet"
+    group = "io.undertow"
+    module = "undertow-servlet"
+    versions = "[2.0.0.Final,2.3)"
+    skipVersions = ["2.2.25.Final"] // half propagated
+    assertInverse = false
+  }
 }
 
 apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
-addTestSuiteForDir('latestDepForkedTest', 'test')
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.undertow', name: 'undertow-servlet', version: '2.0.0.Final'
@@ -24,5 +41,5 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:servlet:request-3')
   testRuntimeOnly project(':dd-java-agent:instrumentation:servlet:request-5')
 
-  latestDepTestImplementation group: 'io.undertow', name: 'undertow-servlet', version: '2.2.24.Final' // 2.2.25 is half propagated
+  latestDepTestImplementation group: 'io.undertow', name: 'undertow-servlet', version: '2.2.+'
 }

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/ServletInstrumentation.java
@@ -54,6 +54,11 @@ public final class ServletInstrumentation extends InstrumenterModule.Tracing
     };
   }
 
+  @Override
+  public String muzzleDirective() {
+    return "javax.servlet";
+  }
+
   public static class DispatchAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void enter(

--- a/dd-java-agent/instrumentation/undertow/undertow-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.2/build.gradle
@@ -1,3 +1,7 @@
+ext {
+  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_11
+  latestDepForkedTestMinJavaVersionForTests = JavaVersion.VERSION_11
+}
 muzzle {
   pass {
     group = "io.undertow"
@@ -5,13 +9,21 @@ muzzle {
     versions = "[2.2.14.Final,]"
     assertInverse = false
   }
+  pass {
+    group = "io.undertow"
+    module = "undertow-servlet"
+    versions = "[2.3.0.Final,]"
+    javaVersion = "11"
+    assertInverse = true
+  }
 }
 
 apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest', 'test')
-addTestSuiteForDir('latestDepForkedTest', 'test')
-
+addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
+addTestSuiteForDir('latest22Test', 'test')
+addTestSuiteExtendingForDir('latest22ForkedTest', 'latest22Test', 'test')
 dependencies {
   compileOnly group: 'io.undertow', name: 'undertow-servlet-jakarta', version: '2.2.14.Final'
   implementation project(':dd-java-agent:instrumentation:undertow')
@@ -24,5 +36,8 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:servlet:request-3')
   testRuntimeOnly project(':dd-java-agent:instrumentation:servlet:request-5')
 
-  latestDepTestImplementation group: 'io.undertow', name: 'undertow-servlet-jakarta', version: '2.2.+'
+  latest22TestImplementation group: 'io.undertow', name: 'undertow-servlet-jakarta', version: '2.2.+'
+  latestDepTestImplementation group: 'io.undertow', name: 'undertow-servlet', version: '+', {
+    exclude group: 'io.undertow', module: 'undertow-servlet-jakarta'
+  }
 }


### PR DESCRIPTION
# What Does This Do

LatestDep (and some muzzle) where locked to 2.2 while the stable latest undertow branch is 2.3

More in the detail the undertow-jakarta-servlet artifact seems no to be maintained but moved to regular undertow-servlet since 2.3.0

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
