### PR TITLE
Mark Gradle and Maven smoke tests as flaky

### DIFF
--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -7,6 +7,7 @@ import datadog.trace.api.Platform
 import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.civisibility.CiVisibilitySmokeTest
+import datadog.trace.test.util.Flaky
 import datadog.trace.util.Strings
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -63,6 +64,7 @@ class GradleDaemonSmokeTest extends CiVisibilitySmokeTest {
     givenGradleProperties()
   }
 
+  @Flaky("https://github.com/DataDog/dd-trace-java/issues/7024")
   def "test #projectName, v#gradleVersion, configCache: #configurationCache"() {
     givenGradleVersionIsCompatibleWithCurrentJvm(gradleVersion)
     givenConfigurationCacheIsCompatibleWithCurrentPlatform(configurationCache)

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.api.Config
 import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.civisibility.CiVisibilitySmokeTest
+import datadog.trace.test.util.Flaky
 import datadog.trace.util.Strings
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -45,6 +46,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
   @TempDir
   Path projectHome
 
+  @Flaky("https://github.com/DataDog/dd-trace-java/issues/7025")
   def "test #projectName, v#mavenVersion"() {
     givenWrapperPropertiesFile(mavenVersion)
     givenMavenProjectFiles(projectName)


### PR DESCRIPTION
# What Does This Do

This PR marks the Gradle and Maven smoke tests as flaky.

# Motivation

See #7024 and #7025 

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
