### PR TITLE
Bump ddprof to 1.6.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ final class CachedData {
     testcontainers: '1.19.3',
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
-    ddprof        : "1.5.0",
+    ddprof        : "1.6.0",
     asm           : "9.6",
     cafe_crypto   : "0.1.0",
     lz4           : "1.7.1"


### PR DESCRIPTION
# What Does This Do
The 1.6.0 version of the profiler library contains changes preventing intermittent crashes and lockups in the profiler itself.

Details [here](https://github.com/DataDog/java-profiler/releases/tag/v_1.6.0)

# Motivation
Bring rather important fixes in.

# Additional Notes

Jira ticket: [PROF-9733]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-9733]: https://datadoghq.atlassian.net/browse/PROF-9733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ