### PR TITLE
Enable spring boot service name detection from spring.application.name

### DIFF
--- a/dd-java-agent/instrumentation/spring-boot/src/main/java/datadog/trace/instrumentation/springboot/SpringApplicationInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-boot/src/main/java/datadog/trace/instrumentation/springboot/SpringApplicationInstrumentation.java
@@ -28,11 +28,6 @@ public class SpringApplicationInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".DeploymentHelper",

--- a/dd-java-agent/instrumentation/spring-boot/src/test/groovy/SpringBootApplicationTest.groovy
+++ b/dd-java-agent/instrumentation/spring-boot/src/test/groovy/SpringBootApplicationTest.groovy
@@ -9,7 +9,6 @@ class SpringBootApplicationTest extends AgentTestRunner {
   @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
-    injectSysConfig("trace.integration.spring-boot.enabled", "true")
   }
   static class BeanWhoTraces implements InitializingBean {
 
@@ -50,7 +49,6 @@ class SpringBootApplicationNotAppliedForkedTest extends AgentTestRunner {
   protected void configurePreAgent() {
     super.configurePreAgent()
     injectSysConfig("service", "myservice")
-    injectSysConfig("trace.integration.spring-boot.enabled", "true")
   }
 
   def 'should not service name when user inferred dd_service'() {


### PR DESCRIPTION
# What Does This Do

Enable by default spring boot environment instrumentation that infer the service name to the value of `spring.application.name` if the user did not provide any `DD_SERVICE`

The instrumentation was in beta. I'm turning it on by default. It can be disabled by adding
* A sysprop `-Ddd.trace.integration.spring-boot.enabled=false`
* An env `DD_TRACE_INTEGRATION_SPRING_BOOT_ENABLED=false`

# Motivation

# Additional Notes

This change is a breaking change for applications that meets all following conditions:
* The application is a standalone spring boot jar
* The property `spring.application.name` is defined in the spring environment (properties, env, etc...)
* The service name is not provided using `DD_SERVICE` or `-Ddd.service`

In this specific use case, without this change, the service name would have been the default `unnamed-java-application`. Now it's improved with the name of the spring application

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
