### PR TITLE
Support loading trace extensions from a comma-separated list of jars, or directories containing jars

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/ExtensionsLoader.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/ExtensionsLoader.java
@@ -1,0 +1,110 @@
+package datadog.trace.agent.tooling;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import de.thetaphi.forbiddenapis.SuppressForbidden;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Loads trace extensions from a comma-separated list of jars, or directories containing jars. */
+public final class ExtensionsLoader {
+  private static final Logger log = LoggerFactory.getLogger(ExtensionsLoader.class);
+
+  private static final String DATADOG_MODULE_EXTENSION_ID =
+      "datadog.trace.agent.tooling.InstrumenterModule";
+
+  private static final String[] NO_EXTENSIONS = {};
+
+  private final ClassLoader extensionLoader;
+
+  public ExtensionsLoader(String extensionsPath) {
+    extensionLoader =
+        new URLClassLoader(toURLs(extensionsPath), Instrumenter.class.getClassLoader());
+  }
+
+  public List<InstrumenterModule> loadModules() {
+    List<InstrumenterModule> modules = new ArrayList<>();
+    for (String className : discoverExtensions(extensionLoader, DATADOG_MODULE_EXTENSION_ID)) {
+      try {
+        modules.add(loadDatadogModule(className));
+      } catch (Throwable e) {
+        log.warn("Failed to load extension module {}", className, e);
+      }
+    }
+    return modules;
+  }
+
+  private InstrumenterModule loadDatadogModule(String className)
+      throws ReflectiveOperationException {
+    Class<?> moduleClass = extensionLoader.loadClass(className);
+    return (InstrumenterModule) moduleClass.getConstructor().newInstance();
+  }
+
+  /** Similar to {@link java.util.ServiceLoader} but doesn't load the discovered extensions. */
+  private static String[] discoverExtensions(ClassLoader loader, String extensionId) {
+    try {
+      Set<String> lines = new LinkedHashSet<>();
+      Enumeration<URL> urls = loader.getResources("META-INF/services/" + extensionId);
+      while (urls.hasMoreElements()) {
+        try (BufferedReader reader =
+            new BufferedReader(new InputStreamReader(urls.nextElement().openStream(), UTF_8))) {
+          String line = reader.readLine();
+          while (line != null) {
+            lines.add(line);
+            line = reader.readLine();
+          }
+        }
+      }
+      return lines.toArray(new String[0]);
+    } catch (Throwable e) {
+      log.warn("Problem reading extensions descriptor", e);
+      return NO_EXTENSIONS;
+    }
+  }
+
+  @SuppressForbidden // split on single-character uses fast path
+  private static URL[] toURLs(String path) {
+    List<URL> urls = new ArrayList<>();
+    for (String entry : path.split(",")) {
+      File file = new File(entry);
+      if (file.isDirectory()) {
+        visitDirectory(file, urls);
+      } else if (isJar(file)) {
+        addExtensionJar(file, urls);
+      }
+    }
+    return urls.toArray(new URL[0]);
+  }
+
+  private static void visitDirectory(File dir, List<URL> urls) {
+    File[] files = dir.listFiles(ExtensionsLoader::isJar);
+    if (null != files) {
+      for (File file : files) {
+        addExtensionJar(file, urls);
+      }
+    }
+  }
+
+  private static void addExtensionJar(File file, List<URL> urls) {
+    try {
+      urls.add(file.toURI().toURL());
+    } catch (MalformedURLException e) {
+      log.debug("Ignoring extension jar {}", file, e);
+    }
+  }
+
+  private static boolean isJar(File file) {
+    return file.getName().endsWith(".jar") && file.isFile();
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -13,6 +13,8 @@ public final class TraceInstrumentationConfig {
   public static final String TRACE_OTEL_ENABLED = "trace.otel.enabled";
   public static final String INTEGRATIONS_ENABLED = "integrations.enabled";
 
+  public static final String TRACE_EXTENSIONS_PATH = "trace.extensions.path";
+
   public static final String INTEGRATION_SYNAPSE_LEGACY_OPERATION_NAME =
       "integration.synapse.legacy-operation-name";
   public static final String TRACE_ANNOTATIONS = "trace.annotations";

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -58,6 +58,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_CODESOUR
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXECUTORS_ALL;
+import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_EXTENSIONS_PATH;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_METHODS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_OTEL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_THREAD_POOL_EXECUTORS_EXCLUDE;
@@ -105,6 +106,8 @@ public class InstrumenterConfig {
   private final ProductActivation iastActivation;
   private final boolean usmEnabled;
   private final boolean telemetryEnabled;
+
+  private final String traceExtensionsPath;
 
   private final boolean traceExecutorsAll;
   private final List<String> traceExecutors;
@@ -192,6 +195,8 @@ public class InstrumenterConfig {
       telemetryEnabled = false;
       usmEnabled = false;
     }
+
+    traceExtensionsPath = configProvider.getString(TRACE_EXTENSIONS_PATH);
 
     traceExecutorsAll = configProvider.getBoolean(TRACE_EXECUTORS_ALL, DEFAULT_TRACE_EXECUTORS_ALL);
     traceExecutors = tryMakeImmutableList(configProvider.getList(TRACE_EXECUTORS));
@@ -309,6 +314,10 @@ public class InstrumenterConfig {
 
   public boolean isTelemetryEnabled() {
     return telemetryEnabled;
+  }
+
+  public String getTraceExtensionsPath() {
+    return traceExtensionsPath;
   }
 
   public boolean isTraceExecutorsAll() {
@@ -506,6 +515,8 @@ public class InstrumenterConfig {
         + usmEnabled
         + ", telemetryEnabled="
         + telemetryEnabled
+        + ", traceExtensionsPath="
+        + traceExtensionsPath
         + ", traceExecutorsAll="
         + traceExecutorsAll
         + ", traceExecutors="


### PR DESCRIPTION
# What Does This Do

Users can add trace extensions to the `dd-java-agent` jar at runtime by setting this environment variable:
```
DD_TRACE_EXTENSIONS_PATH=my_extension.jar,my_other_extensions_dir
```
or adding this JVM option:
```
-Ddd.trace.extensions.path=my_extension.jar,my_other_extensions_dir
```

This PR supports extensions based on `InstrumenterModule`; future PRs will add support for other modules.

# Motivation

Provide a mechanism to add custom integrations to an existing installation of the Java tracer.

Jira ticket: [APMAPI-66]


[APMAPI-66]: https://datadoghq.atlassian.net/browse/APMAPI-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ