### PR TITLE
Add support for meta_struct field in API v4

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -547,6 +547,18 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     }
 
     @Override
+    void setMetaStructTop(String key, Object value) {
+      check()
+      delegate.setMetaStructTop(key, value)
+    }
+
+    @Override
+    void setMetaStructCurrent(String key, Object value) {
+      check()
+      delegate.setMetaStructCurrent(key, value)
+    }
+
+    @Override
     void effectivelyBlocked() {
       check()
       delegate.effectivelyBlocked()

--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.internal;
 
+import java.util.Map;
+
 /**
  * A {@code TraceSegment} represents the local, i.e. in the scope of this {@code Tracer}, part of a
  * a {@code Trace}. It can consist of multiple spans, and the {@code TraceSegment} instance can only
@@ -118,6 +120,28 @@ public interface TraceSegment {
    */
   Object getDataCurrent(String key);
 
+  /**
+   * Add a field to the metaStruct of the top of this {@code TraceSegment}.
+   *
+   * @param field field name
+   * @param value value of the data
+   * @see #setMetaStructCurrent(String, Object) (String, Object)
+   */
+  void setMetaStructTop(String field, Object value);
+
+  /**
+   * Add a field to the current span metaStruct in this {@code TraceSegment}.
+   *
+   * <p>For non JDK classes (primitives, wrappers, collections, ...) a custom {@link
+   * datadog.communication.serialization.ValueWriter} has to be registered with {@link
+   * datadog.communication.serialization.Codec#Codec(Map)} or the {@code toString} representation
+   * will be used instead
+   *
+   * @param field field name
+   * @param value value of the data
+   */
+  void setMetaStructCurrent(String field, Object value);
+
   class NoOp implements TraceSegment {
     public static final TraceSegment INSTANCE = new NoOp();
 
@@ -157,5 +181,11 @@ public interface TraceSegment {
     public Object getDataCurrent(String key) {
       return null;
     }
+
+    @Override
+    public void setMetaStructTop(String key, Object value) {}
+
+    @Override
+    public void setMetaStructCurrent(String key, Object value) {}
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/internal/TraceSegment.java
@@ -1,7 +1,5 @@
 package datadog.trace.api.internal;
 
-import java.util.Map;
-
 /**
  * A {@code TraceSegment} represents the local, i.e. in the scope of this {@code Tracer}, part of a
  * a {@code Trace}. It can consist of multiple spans, and the {@code TraceSegment} instance can only
@@ -121,7 +119,7 @@ public interface TraceSegment {
   Object getDataCurrent(String key);
 
   /**
-   * Add a field to the metaStruct of the top of this {@code TraceSegment}.
+   * Add a field to the meta_struct of the top of this {@code TraceSegment}.
    *
    * @param field field name
    * @param value value of the data
@@ -130,15 +128,12 @@ public interface TraceSegment {
   void setMetaStructTop(String field, Object value);
 
   /**
-   * Add a field to the current span metaStruct in this {@code TraceSegment}.
-   *
-   * <p>For non JDK classes (primitives, wrappers, collections, ...) a custom {@link
-   * datadog.communication.serialization.ValueWriter} has to be registered with {@link
-   * datadog.communication.serialization.Codec#Codec(Map)} or the {@code toString} representation
-   * will be used instead
+   * Add a field to the current span meta_struct in this {@code TraceSegment}.
    *
    * @param field field name
    * @param value value of the data
+   * @see datadog.trace.common.writer.ddagent.TraceMapperV0_4.MetaStructWriter
+   * @see datadog.trace.core.CoreSpan#setMetaStruct(String, Object)
    */
   void setMetaStructCurrent(String field, Object value);
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/ddagent/TraceMapperV0_4.java
@@ -185,9 +185,10 @@ public final class TraceMapperV0_4 implements TraceMapper {
    * The MetaStruct field can safely be used with v4 agents and will be discarded for other
    * versions.
    *
-   * <p>Any type that needs to be serialized as part of the metaStruct field has to either be a JDK
+   * <p>Any type that needs to be serialized as part of the meta_struct field has to either be a JDK
    * known type (primitives, wrappers, collections ...) or registered with {@link
-   * datadog.communication.serialization.Codec#Codec(Map)}.
+   * datadog.communication.serialization.Codec#Codec(Map)}, in the rest of the cases the {@code
+   * toString} representation of the object will be used instead
    */
   public static class MetaStructWriter {
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -1,6 +1,7 @@
 package datadog.trace.core;
 
 import datadog.trace.api.DDTraceId;
+import java.util.Map;
 
 public interface CoreSpan<T extends CoreSpan<T>> {
 
@@ -87,4 +88,8 @@ public interface CoreSpan<T extends CoreSpan<T>> {
   T setFlag(CharSequence name, boolean value);
 
   int samplingPriority();
+
+  Map<String, Object> getMetaStruct();
+
+  T setMetaStruct(final String field, final Object value);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -89,7 +89,22 @@ public interface CoreSpan<T extends CoreSpan<T>> {
 
   int samplingPriority();
 
+  /**
+   * Returns a readonly view of the current meta_struct data stored in the span
+   *
+   * @return readonly map with all the fields
+   */
   Map<String, Object> getMetaStruct();
 
+  /**
+   * Adds a new field to the meta_struct stored in the span
+   *
+   * <p>Existing field value with the same value will be replaced. Setting a field with a {@code
+   * null} value will remove the field from the metaStruct.
+   *
+   * @param field name of the field
+   * @param value value of the field
+   * @return this
+   */
   T setMetaStruct(final String field, final Object value);
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -835,4 +835,15 @@ public class DDSpan
   public long getStartTimeNano() {
     return startTimeNano;
   }
+
+  @Override
+  public Map<String, Object> getMetaStruct() {
+    return context.getMetaStruct();
+  }
+
+  @Override
+  public DDSpan setMetaStruct(final String field, final Object value) {
+    context.setMetaStruct(field, value);
+    return this;
+  }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -789,20 +789,12 @@ public class DDSpanContext
     }
   }
 
-  /** Builds a readonly view of the metaStruct */
+  /** @see CoreSpan#getMetaStruct() */
   public Map<String, Object> getMetaStruct() {
     return Collections.unmodifiableMap(metaStruct);
   }
 
-  /**
-   * Adds a new field to the metaStruct.
-   *
-   * <p>Existing field value with the same value will be replaced. Setting a field with a {@code
-   * null} value will remove the field from the metaStruct.
-   *
-   * @param field The field name.
-   * @param value The nullable field value.
-   */
+  /** @see CoreSpan#setMetaStruct(String, Object) */
   public <T> void setMetaStruct(final String field, final T value) {
     if (null == field) {
       return;

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SimpleSpan.groovy
@@ -244,4 +244,14 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   int samplingPriority() {
     return 0
   }
+
+  @Override
+  Map<String, Object> getMetaStruct() {
+    return [:]
+  }
+
+  @Override
+  SimpleSpan setMetaStruct(String field, Object value) {
+    return this
+  }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceGenerator.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/TraceGenerator.groovy
@@ -144,6 +144,7 @@ class TraceGenerator {
     private final Metadata metadata
     private short httpStatusCode
     private final int samplingPriority
+    private final Map<String, Object> metaStruct = [:]
 
     PojoSpan(
     String serviceName,
@@ -407,6 +408,21 @@ class TraceGenerator {
     @Override
     boolean hasSamplingPriority() {
       return samplingPriority != UNSET
+    }
+
+    @Override
+    Map<String, Object> getMetaStruct() {
+      return metaStruct
+    }
+
+    @Override
+    PojoSpan setMetaStruct(String field, Object value) {
+      if (value == null) {
+        metaStruct.remove(field)
+      } else {
+        metaStruct[field] = value
+      }
+      return this
     }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/ddagent/TraceMapperV04PayloadTest.groovy
@@ -5,6 +5,7 @@ import datadog.communication.serialization.FlushingBuffer
 import datadog.communication.serialization.msgpack.MsgPackWriter
 import datadog.trace.api.DD64bTraceId
 import datadog.trace.api.DDTags
+import datadog.trace.api.DDTraceId
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.common.writer.Payload
 import datadog.trace.common.writer.TraceGenerator
@@ -83,22 +84,22 @@ class TraceMapperV04PayloadTest extends DDSpecification {
   def "test full 64-bit trace and span identifiers"() {
     setup:
     def span = new TraceGenerator.PojoSpan(
-      "service",
-      "operation",
-      "resource",
-      traceId,
-      spanId,
-      parentId,
-      123L,
-      456L,
-      0,
-      [:],
-      [:],
-      "type",
-      false,
-      0,
-      0,
-      "origin")
+    "service",
+    "operation",
+    "resource",
+    traceId,
+    spanId,
+    parentId,
+    123L,
+    456L,
+    0,
+    [:],
+    [:],
+    "type",
+    false,
+    0,
+    0,
+    "origin")
     def traces = [[span]]
     TraceMapperV0_4 traceMapper = new TraceMapperV0_4()
     PayloadVerifier verifier = new PayloadVerifier(traces, traceMapper)
@@ -118,17 +119,68 @@ class TraceMapperV04PayloadTest extends DDSpecification {
     DD64bTraceId.from(-10) | -11L   | -12L
   }
 
+  void 'test metaStruct support'() {
+    def span = new TraceGenerator.PojoSpan(
+    'service',
+    'operation',
+    'resource',
+    DDTraceId.ONE,
+    1L,
+    -1L,
+    123L,
+    456L,
+    0,
+    [:],
+    [:],
+    'type',
+    false,
+    0,
+    0,
+    'origin')
+    span.setMetaStruct('stack', Thread.currentThread().stackTrace.take(3).toList().collect {
+      [
+        file: it.fileName,
+        class_name: it.className,
+        function: it.methodName
+      ]
+    })
+    def traces = [[span]]
+    TraceMapperV0_4 traceMapper = new TraceMapperV0_4()
+    PayloadVerifier verifier = new PayloadVerifier(traces, traceMapper, (List<?> expected, received) -> {
+      int size = received.unpackArrayHeader()
+      assertEquals(expected.size(), size)
+      expected.eachWithIndex {
+        def stackEntry, int i ->
+        int fields = received.unpackMapHeader()
+        (0..<fields).each {
+          String field = received.unpackString()
+          assertEquals(stackEntry[field], received.unpackString())
+        }
+      }
+    })
+    MsgPackWriter packer = new MsgPackWriter(new FlushingBuffer(20 << 10, verifier))
+
+    when:
+    packer.format([span], traceMapper)
+    packer.flush()
+
+    then:
+    verifier.verifyTracesConsumed()
+  }
+
   private static final class PayloadVerifier implements ByteBufferConsumer, WritableByteChannel {
 
     private final List<List<TraceGenerator.PojoSpan>> expectedTraces
     private final TraceMapperV0_4 mapper
     private ByteBuffer captured = ByteBuffer.allocate(200 << 10)
+    private MetaStructVerifier<?> metaStructVerifier
 
     private int position = 0
 
-    private PayloadVerifier(List<List<TraceGenerator.PojoSpan>> traces, TraceMapperV0_4 mapper) {
+    private PayloadVerifier(List<List<TraceGenerator.PojoSpan>> traces, TraceMapperV0_4 mapper, MetaStructVerifier<?> metaStructVerifier = null) {
       this.expectedTraces = traces
       this.mapper = mapper
+      this.metaStructVerifier = metaStructVerifier
     }
 
     void skipLargeTrace() {
@@ -153,7 +205,8 @@ class TraceMapperV04PayloadTest extends DDSpecification {
           for (int k = 0; k < spanCount; ++k) {
             TraceGenerator.PojoSpan expectedSpan = expectedTrace.get(k)
             int elementCount = unpacker.unpackMapHeader()
-            assertEquals(12, elementCount)
+            boolean hasMetaStruct = !expectedSpan.getMetaStruct().isEmpty()
+            assertEquals(hasMetaStruct ? 13 : 12, elementCount)
             assertEquals("service", unpacker.unpackString())
             String serviceName = unpacker.unpackString()
             assertEqualsWithNullAsEmpty(expectedSpan.getServiceName(), serviceName)
@@ -200,20 +253,20 @@ class TraceMapperV04PayloadTest extends DDSpecification {
                 case UINT16:
                 case INT32:
                 case UINT32:
-                  n = unpacker.unpackInt()
-                  break
+                n = unpacker.unpackInt()
+                break
                 case INT64:
                 case UINT64:
-                  n = unpacker.unpackLong()
-                  break
+                n = unpacker.unpackLong()
+                break
                 case FLOAT32:
-                  n = unpacker.unpackFloat()
-                  break
+                n = unpacker.unpackFloat()
+                break
                 case FLOAT64:
-                  n = unpacker.unpackDouble()
-                  break
+                n = unpacker.unpackDouble()
+                break
                 default:
-                  Assertions.fail("Unexpected type in metrics values: " + format)
+                Assertions.fail("Unexpected type in metrics values: " + format)
               }
               if (DD_MEASURED.toString() == key) {
                 assert ((n == 1) && expectedSpan.isMeasured()) || !expectedSpan.isMeasured()
@@ -252,6 +305,17 @@ class TraceMapperV04PayloadTest extends DDSpecification {
                   assertEquals(String.valueOf(tag), entry.getValue())
                 } else {
                   assertEquals(expectedSpan.getBaggage().get(entry.getKey()), entry.getValue())
+                }
+              }
+            }
+            if (hasMetaStruct) {
+              Map<String, Object> metaStruct = expectedSpan.getMetaStruct()
+              assertEquals("meta_struct", unpacker.unpackString())
+              int metaStructSize = unpacker.unpackMapHeader()
+              for (int j = 0; j < metaStructSize; ++j) {
+                String field = unpacker.unpackString()
+                if (metaStructVerifier != null) {
+                  metaStructVerifier.verify(metaStruct.get(field), unpacker)
                 }
               }
             }
@@ -299,5 +363,9 @@ class TraceMapperV04PayloadTest extends DDSpecification {
     } else {
       assertEquals(expected.toString(), actual.toString())
     }
+  }
+
+  private static interface MetaStructVerifier<E> {
+    void verify(final E expected, final MessageUnpacker received)
   }
 }

--- a/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
+++ b/dd-trace-core/src/traceAgentTest/groovy/TraceGenerator.groovy
@@ -385,5 +385,15 @@ class TraceGenerator {
     boolean hasSamplingPriority() {
       return false
     }
+
+    @Override
+    Map<String, Object> getMetaStruct() {
+      return [:]
+    }
+
+    @Override
+    PojoSpan setMetaStruct(String field, Object value) {
+      return this
+    }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -146,6 +146,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo, ImplicitContextKeyed
     return context.with(ScopedContextKey.SPAN_KEY, this);
   }
 
+  AgentSpan setMetaStruct(final String field, final Object value);
+
   interface Context {
     /**
      * Gets the TraceId of the span's trace.

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -848,6 +848,11 @@ public class AgentTracer {
 
     @Override
     public void addLink(AgentSpanLink link) {}
+
+    @Override
+    public AgentSpan setMetaStruct(String field, Object value) {
+      return this;
+    }
   }
 
   public static final class NoopAgentScope implements AgentScope {


### PR DESCRIPTION
# What Does This Do
This PR allows adding `meta_struct` data to spans, the `meta_struct` is lazy initialized to reduce memory consumption and uses a double locking mechanism to be initialized (same as baggage).

# Motivation
The new RASP module requires this new data structure in order to be able to send binary data efficiently to the backend.

# Additional Notes

The agent fully supports `meta_struct` from version v7.35.0 (April 2022).

Jira ticket: [APPSEC-52826]
Agent: https://github.com/DataDog/datadog-agent/pull/10366
.NET: https://github.com/DataDog/dd-trace-dotnet/pull/5287
JS: https://github.com/DataDog/dd-trace-js/pull/4287

Sample result of adding a stack to the `metra_struct`:
![image](https://github.com/DataDog/dd-trace-java/assets/4885539/c8259bc3-b11d-43ae-8bae-9c75a4e72174)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-52826]: https://datadoghq.atlassian.net/browse/APPSEC-52826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ