### PR TITLE
Protect Map and Set accesses to be only in-memory

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -85,11 +85,8 @@ public class WellKnownClasses {
     return safeToStringFunctions.containsKey(concreteType);
   }
 
-  /**
-   * @return true if collection is the implementation of size method is side effect free and O(1)
-   *     complexity
-   */
-  public static boolean isSizeSafe(Collection<?> collection) {
+  /** @return true if collection implementation is safe to call (only in-memory) */
+  public static boolean isSafe(Collection<?> collection) {
     String className = collection.getClass().getTypeName();
     if (className.startsWith("java.")) {
       // All Collection implementations from JDK base module are considered as safe
@@ -98,11 +95,8 @@ public class WellKnownClasses {
     return false;
   }
 
-  /**
-   * @return true if map is the implementation of size method is side effect free and O(1)
-   *     complexity
-   */
-  public static boolean isSizeSafe(Map<?, ?> map) {
+  /** @return true if map implementation is safe to call (only in-memory) */
+  public static boolean isSafe(Map<?, ?> map) {
     String className = map.getClass().getTypeName();
     if (className.startsWith("java.")) {
       // All Map implementations from JDK base module are considered as safe

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -69,7 +69,7 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
 
   public int count() {
     if (listHolder instanceof Collection) {
-      if (WellKnownClasses.isSizeSafe((Collection<?>) listHolder)) {
+      if (WellKnownClasses.isSafe((Collection<?>) listHolder)) {
         return ((Collection<?>) listHolder).size();
       } else {
         throw new RuntimeException(

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueEmptyTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueEmptyTest.java
@@ -34,8 +34,8 @@ class MapValueEmptyTest {
 
   @Test
   void get() {
-    assertEquals(Value.undefinedValue(), instance.get("a"));
-    assertEquals(Value.undefinedValue(), instance.get("b"));
+    assertEquals(Value.nullValue(), instance.get("a"));
+    assertEquals(Value.nullValue(), instance.get("b"));
     assertEquals(Value.undefinedValue(), instance.get(Values.UNDEFINED_OBJECT));
     assertEquals(Value.undefinedValue(), instance.get(Value.undefinedValue()));
     assertEquals(Value.nullValue(), instance.get(Values.NULL_OBJECT));

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/values/MapValueTest.java
@@ -42,8 +42,8 @@ class MapValueTest {
     assertEquals(Value.of("a"), instance.get(Value.of("a")));
     assertEquals(Value.nullValue(), instance.get("b"));
     assertEquals(Value.nullValue(), instance.get(Value.of("b")));
-    assertEquals(Value.undefinedValue(), instance.get("c"));
-    assertEquals(Value.undefinedValue(), instance.get(Value.of("c")));
+    assertEquals(Value.nullValue(), instance.get("c"));
+    assertEquals(Value.nullValue(), instance.get(Value.of("c")));
     assertEquals(Value.undefinedValue(), instance.get(Values.UNDEFINED_OBJECT));
     assertEquals(Value.undefinedValue(), instance.get(Value.undefinedValue()));
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_07.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_conditional_07.json
@@ -1,5 +1,5 @@
 {
-  "dsl": "intArray[2] > 0 && intArray[idx] > 0 && intArray[count(strArray)] > 0 && intArray[intArray[1]] > 0 && strMap[\"foo\"] != null && strMap[strMap[\"foo\"]] == \"foobar\"",
+  "dsl": "intArray[2] > 0 && intArray[idx] > 0 && intArray[count(strArray)] > 0 && intArray[intArray[1]] > 0 && strMap[\"foo\"] != null && strMap[\"foobar\"] == null && strMap[strMap[\"foo\"]] == \"foobar\"",
   "json": {
     "and": [
       {"gt": [{"index": [{"ref": "intArray"}, 2]}, 0]},
@@ -7,6 +7,7 @@
       {"gt": [{"index": [{"ref": "intArray"}, {"count": {"ref": "strArray"}} ]}, 0]},
       {"gt": [{"index": [{"ref": "intArray"}, {"index": [{"ref": "intArray"}, 1]} ]}, 0]},
       {"ne": [{"index": [{"ref": "strMap"}, "foo" ]}, null]},
+      {"eq": [{"index": [{"ref": "strMap"}, "foobar" ]}, null]},
       {"eq": [{"index": [{"ref": "strMap"}, {"index": [{"ref": "strMap"}, "foo"]}]}, "foobar"]}
     ]
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -170,7 +170,7 @@ public class SerializerWithLimits {
     int size = 0;
     try {
       map = (Map<?, ?>) value;
-      if (WellKnownClasses.isSizeSafe(map)) {
+      if (WellKnownClasses.isSafe(map)) {
         size = map.size(); // /!\ alien call /!\
         Set<? extends Map.Entry<?, ?>> entries = map.entrySet(); // /!\ alien call /!\
         isComplete = serializeMapEntries(entries, limits); // /!\ contains alien calls /!\
@@ -191,7 +191,7 @@ public class SerializerWithLimits {
     int size = 0;
     try {
       col = (Collection<?>) value;
-      if (WellKnownClasses.isSizeSafe(col)) {
+      if (WellKnownClasses.isSafe(col)) {
         size = col.size(); // /!\ alien call /!\
         isComplete = serializeCollection(col, limits); // /!\ contains alien calls /!\
       } else {


### PR DESCRIPTION
# What Does This Do
Accessing Map and set is only safe for JDK classes so all accesses are not protected to be a JDK implementation
Fix also when a key is not in the map it returns null so we can test against null in EL

# Motivation

# Additional Notes



<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
