### PR TITLE
Print the specification name to help identify flaky tests

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -418,7 +418,7 @@ abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.L
     // even though the agent is already installed
     configurePreAgent()
 
-    println "Starting test: ${getSpecificationContext().getCurrentIteration().getName()}"
+    println "Starting test: ${getSpecificationContext().getCurrentIteration().getName()} from ${specificationContext.currentSpec.name}"
     TEST_TRACER.flush()
     TEST_SPANS.clear()
 


### PR DESCRIPTION
# What Does This Do

This PR dumps the specification name to help identify flaky tests.

# Motivation

There is something wrong with the tests reports where parametrized spock tests are no more attached to their class.
It might be due to using a deprecated JUnit 4 runner.
As we are losing the class name, we can't identify flaky tests using features from a parent specification.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
