### PR TITLE
Fix instrumentation for legacy JUnit 3.8 tests

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit38SuiteEventsInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit38SuiteEventsInstrumentation.java
@@ -40,6 +40,13 @@ public class JUnit38SuiteEventsInstrumentation extends InstrumenterModule.CiVisi
   }
 
   @Override
+  public int order() {
+    // Should be applied after datadog.trace.instrumentation.junit4.JUnit4Instrumentation,
+    // because it relies on JUnit4TracingListener to be registered
+    return JUnit4Instrumentation.ORDER + 1;
+  }
+
+  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("run").and(takesArgument(0, named("org.junit.runner.notification.RunNotifier"))),

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -26,6 +26,8 @@ import org.junit.runner.notification.RunNotifier;
 public class JUnit4Instrumentation extends InstrumenterModule.CiVisibility
     implements Instrumenter.ForTypeHierarchy {
 
+  static final int ORDER = 0;
+
   public JUnit4Instrumentation() {
     super("ci-visibility", "junit-4");
   }
@@ -33,6 +35,11 @@ public class JUnit4Instrumentation extends InstrumenterModule.CiVisibility
   @Override
   public String hierarchyMarkerType() {
     return "org.junit.runner.Runner";
+  }
+
+  @Override
+  public int order() {
+    return ORDER;
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
Fixes instrumentation of JUnit 3.8 tests.
There are two instrumentation modules that play a part:
- `JUnit4Instrumentation` that registers the test tracing listener
- `JUnit38SuiteEventsInstrumentation` that adds missing tracing events to legacy JUnit 3.8 runner adapter.

The code added by the second implementation relies on the code in the first one: it expects the tracing listener to be already initialised by the time it fires.
Thus, instrumentation order should be set explicitly in this case.

# Motivation
Some CI Visibility users still use legacy JUnit 3.8-based tests, even though they are executed with the newer JUnit 4 runner.

Jira ticket: [CIVIS-10040]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-10040]: https://datadoghq.atlassian.net/browse/CIVIS-10040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ