### PR TITLE
Fix expensive folding only in debug level

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -288,7 +288,7 @@ public class MoshiSnapshotHelper {
     }
 
     private static class JsonTokenWriter implements SerializerWithLimits.TokenWriter {
-      private static final Logger LOG = LoggerFactory.getLogger(JsonTokenWriter.class);
+      private static final Logger LOGGER = LoggerFactory.getLogger(JsonTokenWriter.class);
 
       private final JsonWriter jsonWriter;
 
@@ -424,10 +424,13 @@ public class MoshiSnapshotHelper {
 
       @Override
       public void handleFieldException(Exception ex, Field field) {
-        LOG.debug(
-            "Exception when extracting field={} exception={}",
-            field.getName(),
-            ExceptionHelper.foldExceptionStackTrace(ex));
+        if (LOGGER.isDebugEnabled()) {
+          // foldExceptionStackTrace can be expensive, only do it if debug is enabled
+          LOGGER.debug(
+              "Exception when extracting field={} exception={}",
+              field.getName(),
+              ExceptionHelper.foldExceptionStackTrace(ex));
+        }
         String fieldName = field.getName();
         try {
           jsonWriter.name(fieldName);
@@ -438,7 +441,7 @@ public class MoshiSnapshotHelper {
           jsonWriter.value(ex.toString());
           jsonWriter.endObject();
         } catch (IOException e) {
-          LOG.debug("Serialization error: failed to extract field", e);
+          LOGGER.debug("Serialization error: failed to extract field", e);
         }
       }
 


### PR DESCRIPTION
# What Does This Do
foldExceptionStackTrace can be expensive and must be called only in debug level log.
This happens when a field is not accessible (cross module since JDK16)

# Motivation
undesirable overhead

# Additional Notes

Jira ticket: [DEBUG-2388]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2388]: https://datadoghq.atlassian.net/browse/DEBUG-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ