### PR TITLE
Add fingerprint info into Tracer flare

### DIFF
--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -15,6 +15,7 @@ excludedClassesCoverage += [
   'com.datadog.debugger.agent.DebuggerProbe.When.Threshold',
   'com.datadog.debugger.agent.DebuggerAgent.ShutdownHook',
   'com.datadog.debugger.agent.DebuggerAgent',
+  'com.datadog.debugger.agent.DebuggerAgent.DebuggerReporter',
   // too old for this coverage (JDK 1.2)
   'antlr.*',
   // only static classes

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -145,7 +145,7 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
     return true;
   }
 
-  ExceptionProbeManager getExceptionProbeManager() {
+  public ExceptionProbeManager getExceptionProbeManager() {
     return exceptionProbeManager;
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -96,6 +96,10 @@ public class ExceptionProbeManager {
     return probes.values();
   }
 
+  public Map<String, Instant> getFingerprints() {
+    return fingerprints;
+  }
+
   public boolean shouldCaptureException(String fingerprint) {
     return shouldCaptureException(fingerprint, clock);
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -715,7 +715,8 @@ public class LogProbe extends ProbeDefinition {
   @Generated
   @Override
   public String toString() {
-    return "LogProbe{"
+    return getClass().getSimpleName()
+        + "{"
         + "language='"
         + language
         + '\''


### PR DESCRIPTION
# What Does This Do
Having fingerprint maps into the DI flare helps to know how many exceptions are tracked and when are the last time the snapshots were reported.
Exception probes are reported in Probe definitions section.

Example:
```
Snapshot url: 
http://localhost:8126/debugger/v1/input
Diagnostic url: 
http://localhost:8126/debugger/v1/diagnostics
SymbolDB url: 
http://localhost:8126/symdb/v1/input
Probe definitions:
{893f0968-5f64-4eb8-b86f-02339c801aba:0=ExceptionProbe{language='java', id='893f0968-5f64-4eb8-b86f-02339c801aba', version=0, tags=null, tagMap={}, where=Where{typeName='org.springframework.samples.petclinic.vet.VetController', methodName='processUUId', sourceFile='null', signature='null', lines=[240]}, evaluateAt=EXIT, template='null', segments=null, captureSnapshot=true, when=null, capture=null, sampling=null} , 966709d5-76e3-4a95-b536-e1e4675b7a7f:0=ExceptionProbe{language='java', id='966709d5-76e3-4a95-b536-e1e4675b7a7f', version=0, tags=null, tagMap={}, where=Where{typeName='org.springframework.samples.petclinic.vet.VetController', methodName='showVetList', sourceFile='null', signature='null', lines=[190]}, evaluateAt=EXIT, template='null', segments=null, captureSnapshot=true, when=null, capture=null, sampling=null} , d4659b32-ae68-44ab-a8cd-68a18415f659:1=LogProbe{language='java', id='d4659b32-ae68-44ab-a8cd-68a18415f659', version=1, tags=[], tagMap={}, where=Where{typeName='null', methodName='null', sourceFile='VetController.java', signature='null', lines=[224]}, evaluateAt=EXIT, template='In VetController.java, line 201', segments=[Segment{str='In VetController.java, line 201', parsedExr=null}], captureSnapshot=true, when=ProbeCondition{dslExpression='serviceDefinitionHasChanged1 < 0'}, capture=Capture{maxReferenceDepth=3, maxCollectionSize=100, maxLength=255, maxFieldCount=20}, sampling=Sampling{snapshotsPerSecond=1.0}} , d31c5021-2fa8-454a-a278-1ffdbff9782c:0=ExceptionProbe{language='java', id='d31c5021-2fa8-454a-a278-1ffdbff9782c', version=0, tags=null, tagMap={}, where=Where{typeName='org.springframework.samples.petclinic.vet.VetController', methodName='processArguments', sourceFile='null', signature='null', lines=[230]}, evaluateAt=EXIT, template='null', segments=null, captureSnapshot=true, when=null, capture=null, sampling=null} , f8e0c43d-2bc5-4f09-8bb1-046ef3529592:2=LogProbe{language='java', id='f8e0c43d-2bc5-4f09-8bb1-046ef3529592', version=2, tags=[], tagMap={}, where=Where{typeName='VetController', methodName='showVetList', sourceFile='null', signature='null', lines=null}, evaluateAt=EXIT, template='Executed VetController.showVetList, it took {@duration}ms', segments=[Segment{str='Executed VetController.showVetList, it took ', parsedExr=null}, Segment{str='null', parsedExr=ValueScript{dsl='@duration'}}, Segment{str='ms', parsedExr=null}], captureSnapshot=true, when=ProbeCondition{dslExpression='@return == 'true''}, capture=Capture{maxReferenceDepth=3, maxCollectionSize=100, maxLength=255, maxFieldCount=20}, sampling=Sampling{snapshotsPerSecond=1.0}} }
Instrumented probes:
{893f0968-5f64-4eb8-b86f-02339c801aba:0=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='893f0968-5f64-4eb8-b86f-02339c801aba', version=0}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='processUUId'}, 966709d5-76e3-4a95-b536-e1e4675b7a7f:0=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='966709d5-76e3-4a95-b536-e1e4675b7a7f', version=0}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='showVetList'}, d4659b32-ae68-44ab-a8cd-68a18415f659:1=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='d4659b32-ae68-44ab-a8cd-68a18415f659', version=1}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='addOverhead'}, d31c5021-2fa8-454a-a278-1ffdbff9782c:0=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='d31c5021-2fa8-454a-a278-1ffdbff9782c', version=0}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='processArguments'}, f8e0c43d-2bc5-4f09-8bb1-046ef3529592:2=InstrumentationResult{status=INSTALLED, diagnostics={ProbeId{id='f8e0c43d-2bc5-4f09-8bb1-046ef3529592', version=2}=[]}, typeName='org.springframework.samples.petclinic.vet.VetController', methodName='showVetList'}}
Probe statuses:
{893f0968-5f64-4eb8-b86f-02339c801aba:0=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-05-15T13:56:35.762Z', message='Probe 893f0968-5f64-4eb8-b86f-02339c801aba:0 is emitting.', debugger=Diagnostics{probeId='893f0968-5f64-4eb8-b86f-02339c801aba', probeVersion=0, runtimeId='c095fad0-bc8c-4561-b299-2a47343c6088', status=EMITTING, exception=null}}, 966709d5-76e3-4a95-b536-e1e4675b7a7f:0=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-05-15T13:56:35.762Z', message='Probe 966709d5-76e3-4a95-b536-e1e4675b7a7f:0 is emitting.', debugger=Diagnostics{probeId='966709d5-76e3-4a95-b536-e1e4675b7a7f', probeVersion=0, runtimeId='c095fad0-bc8c-4561-b299-2a47343c6088', status=EMITTING, exception=null}}, d4659b32-ae68-44ab-a8cd-68a18415f659:1=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-05-15T13:56:07.776Z', message='Installed probe ProbeId{id='d4659b32-ae68-44ab-a8cd-68a18415f659', version=1}.', debugger=Diagnostics{probeId='d4659b32-ae68-44ab-a8cd-68a18415f659', probeVersion=1, runtimeId='c095fad0-bc8c-4561-b299-2a47343c6088', status=INSTALLED, exception=null}}, d31c5021-2fa8-454a-a278-1ffdbff9782c:0=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-05-15T13:56:35.762Z', message='Probe d31c5021-2fa8-454a-a278-1ffdbff9782c:0 is emitting.', debugger=Diagnostics{probeId='d31c5021-2fa8-454a-a278-1ffdbff9782c', probeVersion=0, runtimeId='c095fad0-bc8c-4561-b299-2a47343c6088', status=EMITTING, exception=null}}, f8e0c43d-2bc5-4f09-8bb1-046ef3529592:2=ProbeDiagnosticMessage{ddSource='dd_debugger', service='petclinic-benchmark', timestamp='2024-05-15T13:56:35.762Z', message='Probe f8e0c43d-2bc5-4f09-8bb1-046ef3529592:2 is emitting.', debugger=Diagnostics{probeId='f8e0c43d-2bc5-4f09-8bb1-046ef3529592', probeVersion=2, runtimeId='c095fad0-bc8c-4561-b299-2a47343c6088', status=EMITTING, exception=null}}}
SymbolDB stats:
Stats{totalClassScopes=34, totalSize=149104}
Exception Fingerprints:
{96e1a213c523a5a87ca5ff2e9ce4a31c94622184e8780e51bdd1fff2cbf5=2024-05-15T13:56:35.793Z}
```


# Motivation
Improve troubleshooting for Exception debugging feature

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ