### PR TITLE
Fix Gradle instrumentation: do not fail if Jacoco excluded CL list is immutable

### DIFF
--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityPluginExtension.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityPluginExtension.java
@@ -146,9 +146,15 @@ public abstract class CiVisibilityPluginExtension {
   private void applyJacocoSettings(Path jvmExecutable, JacocoTaskExtension jacocoTaskExtension) {
     CiVisibilityService ciVisibilityService = getCiVisibilityService().get();
 
-    List<String> taskExcludeClassLoader = jacocoTaskExtension.getExcludeClassLoaders();
-    if (taskExcludeClassLoader != null) {
-      taskExcludeClassLoader.addAll(ciVisibilityService.getExcludeClassLoaders());
+    List<String> taskExcludeClassLoaders = jacocoTaskExtension.getExcludeClassLoaders();
+    if (taskExcludeClassLoaders != null) {
+      // taskExcludeClassLoaders list may be immutable, so we need to construct a new one
+      List<String> ciVisExcludedClassLoaders = ciVisibilityService.getExcludeClassLoaders();
+      List<String> updatedTaskExcludeClassLoaders =
+          new ArrayList<>(taskExcludeClassLoaders.size() + ciVisExcludedClassLoaders.size());
+      updatedTaskExcludeClassLoaders.addAll(taskExcludeClassLoaders);
+      updatedTaskExcludeClassLoaders.addAll(ciVisExcludedClassLoaders);
+      jacocoTaskExtension.setExcludeClassLoaders(updatedTaskExcludeClassLoaders);
     } else {
       jacocoTaskExtension.setExcludeClassLoaders(
           new ArrayList<>(ciVisibilityService.getExcludeClassLoaders()));


### PR DESCRIPTION
# What Does This Do

Fixes CI Visibility's Gradle instrumentation: if the instrumentation determines that Gradle Jacoco plugin is used in the instrumented project, it modifies Jacoco's list of ignored classloaders (the main reason is to add the tracer's classloader to the list to avoid instrumenting tracer classes).
It is possible for the modified list to be immutable, in which case it needs to be replaced with a newly constructed list.

Jira ticket: [CIVIS-10049]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-10049]: https://datadoghq.atlassian.net/browse/CIVIS-10049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ