### PR TITLE
Add Throwable capturing fields support for JDK16+

### DIFF
--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -74,16 +74,10 @@ jar {
 
 tasks.withType(Test).configureEach {
   onlyIf { !project.rootProject.hasProperty("skipDebuggerTests") }
-  // DebuggerTransformerTest made some Reflective calls on java.lang package
-  // needs to open it since jdk16
-  def matcher = it.name =~ /testJava(\d+)Generated/
-  if (matcher) {
-    def javaVersion = matcher.group(1) as int
-    if (javaVersion >= 16) {
-      jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
-    }
-  }
 }
+
+// we want to test with no special reflective access (no --add-opens)
+ext.allowReflectiveAccessToJdk = false
 
 subprojects { Project subProj ->
   subProj.tasks.withType(Test).configureEach { subTask ->

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -136,10 +136,20 @@ public class CapturedContext implements ValueReferenceResolver {
         CapturedValue specialField = specialFieldAccess.apply(target);
         if (specialField != null && specialField.getName().equals(memberName)) {
           return specialField.getValue();
-        } else {
-          target = Values.UNDEFINED_OBJECT;
         }
+        target = Values.UNDEFINED_OBJECT;
       } else {
+        Map<String, Function<Object, CapturedValue>> specialTypeAccess =
+            WellKnownClasses.getSpecialTypeAccess(target);
+        if (specialTypeAccess != null) {
+          specialFieldAccess = specialTypeAccess.get(memberName);
+          if (specialFieldAccess != null) {
+            CapturedValue specialField = specialFieldAccess.apply(target);
+            if (specialField != null && specialField.getName().equals(memberName)) {
+              return specialField.getValue();
+            }
+          }
+        }
         target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), memberName);
       }
     }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -130,28 +130,18 @@ public class CapturedContext implements ValueReferenceResolver {
         }
       }
     } else {
-      Function<Object, CapturedValue> specialFieldAccess =
-          WellKnownClasses.getSpecialFieldAccess(target.getClass().getTypeName());
-      if (specialFieldAccess != null) {
-        CapturedValue specialField = specialFieldAccess.apply(target);
-        if (specialField != null && specialField.getName().equals(memberName)) {
-          return specialField.getValue();
-        }
-        target = Values.UNDEFINED_OBJECT;
-      } else {
-        Map<String, Function<Object, CapturedValue>> specialTypeAccess =
-            WellKnownClasses.getSpecialTypeAccess(target);
-        if (specialTypeAccess != null) {
-          specialFieldAccess = specialTypeAccess.get(memberName);
-          if (specialFieldAccess != null) {
-            CapturedValue specialField = specialFieldAccess.apply(target);
-            if (specialField != null && specialField.getName().equals(memberName)) {
-              return specialField.getValue();
-            }
+      Map<String, Function<Object, CapturedValue>> specialTypeAccess =
+          WellKnownClasses.getSpecialTypeAccess(target);
+      if (specialTypeAccess != null) {
+        Function<Object, CapturedValue> specialFieldAccess = specialTypeAccess.get(memberName);
+        if (specialFieldAccess != null) {
+          CapturedValue specialField = specialFieldAccess.apply(target);
+          if (specialField != null && specialField.getName().equals(memberName)) {
+            return specialField.getValue();
           }
         }
-        target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), memberName);
       }
+      target = ReflectiveFieldValueResolver.resolve(target, target.getClass(), memberName);
     }
     checkUndefined(target, memberName, "Cannot dereference to field: ");
     return target;

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -1,6 +1,8 @@
 package datadog.trace.bootstrap.debugger.util;
 
 import datadog.trace.bootstrap.debugger.CapturedContext;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -9,47 +11,52 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WellKnownClasses {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WellKnownClasses.class);
 
   /** Set of class names which have a toString side effect free and class final */
-  private static Map<String, Function<Object, String>> toStringFinalSafeClasses = new HashMap<>();
+  private static final Map<String, Function<Object, String>> TO_STRING_FINAL_SAFE_CLASSES =
+      new HashMap<>();
 
   static {
-    toStringFinalSafeClasses.put("java.lang.Class", WellKnownClasses::classToString);
-    toStringFinalSafeClasses.put("java.lang.String", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.lang.Boolean", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.lang.Integer", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.lang.Long", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.lang.Double", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.lang.Character", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.lang.Byte", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.lang.Float", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.lang.Short", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.math.BigDecimal", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.math.BigInteger", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.time.Duration", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.time.Instant", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.time.LocalTime", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.time.LocalDate", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.time.LocalDateTime", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.util.UUID", WellKnownClasses::genericToString);
-    toStringFinalSafeClasses.put("java.net.URI", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Class", WellKnownClasses::classToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.String", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Boolean", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Integer", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Long", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Double", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Character", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Byte", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Float", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Short", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.math.BigDecimal", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.math.BigInteger", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.Duration", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.Instant", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalTime", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalDate", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalDateTime", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.util.UUID", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.net.URI", WellKnownClasses::genericToString);
   }
 
-  private static Map<String, Function<Object, String>> safeToStringFunctions = new HashMap<>();
+  private static final Map<String, Function<Object, String>> SAFE_TO_STRING_FUNCTIONS =
+      new HashMap<>();
 
   static {
-    safeToStringFunctions.putAll(toStringFinalSafeClasses);
-    safeToStringFunctions.put(
+    SAFE_TO_STRING_FUNCTIONS.putAll(TO_STRING_FINAL_SAFE_CLASSES);
+    SAFE_TO_STRING_FUNCTIONS.put(
         "java.util.concurrent.atomic.AtomicBoolean", WellKnownClasses::genericToString);
-    safeToStringFunctions.put(
+    SAFE_TO_STRING_FUNCTIONS.put(
         "java.util.concurrent.atomic.AtomicInteger", WellKnownClasses::genericToString);
-    safeToStringFunctions.put(
+    SAFE_TO_STRING_FUNCTIONS.put(
         "java.util.concurrent.atomic.AtomicLong", WellKnownClasses::genericToString);
   }
 
-  private static Set<String> stringPrimitives =
+  private static final Set<String> STRING_PRIMITIVES =
       new HashSet<>(
           Arrays.asList(
               "java.lang.Class",
@@ -61,11 +68,47 @@ public class WellKnownClasses {
               "java.time.LocalDateTime",
               "java.util.UUID"));
 
-  private static Map<String, Function<Object, CapturedContext.CapturedValue>> specialFields =
+  private static final Map<String, Function<Object, CapturedContext.CapturedValue>> SPECIAL_FIELDS =
       new HashMap<>();
 
   static {
-    specialFields.put("java.util.Optional", WellKnownClasses::optionalSpecialField);
+    SPECIAL_FIELDS.put("java.util.Optional", WellKnownClasses::optionalSpecialField);
+  }
+
+  private static final Map<Class<?>, Map<String, Function<Object, CapturedContext.CapturedValue>>>
+      SPECIAL_TYPE_ACCESS = new HashMap<>();
+
+  private static final Map<String, Function<Object, CapturedContext.CapturedValue>>
+      STACKTRACEELEMENT_SPECIAL_FIELDS = new HashMap<>();
+
+  private static Method getModuleNameMethod;
+
+  static {
+    STACKTRACEELEMENT_SPECIAL_FIELDS.put("declaringClass", StackTraceElementFields::declaringClass);
+    STACKTRACEELEMENT_SPECIAL_FIELDS.put("methodName", StackTraceElementFields::methodName);
+    STACKTRACEELEMENT_SPECIAL_FIELDS.put("fileName", StackTraceElementFields::fileName);
+    STACKTRACEELEMENT_SPECIAL_FIELDS.put("lineNumber", StackTraceElementFields::lineNumber);
+    STACKTRACEELEMENT_SPECIAL_FIELDS.put("moduleName", StackTraceElementFields::moduleName);
+    try {
+      getModuleNameMethod = StackTraceElement.class.getMethod("getModuleName");
+    } catch (NoSuchMethodException e) {
+      getModuleNameMethod = null;
+    }
+    ;
+  }
+
+  static {
+    SPECIAL_TYPE_ACCESS.put(StackTraceElement.class, STACKTRACEELEMENT_SPECIAL_FIELDS);
+  }
+
+  private static final Map<String, Function<Object, CapturedContext.CapturedValue>>
+      THROWABLE_SPECIAL_FIELDS = new HashMap<>();
+
+  static {
+    THROWABLE_SPECIAL_FIELDS.put("detailMessage", ThrowableFields::detailMessage);
+    THROWABLE_SPECIAL_FIELDS.put("suppressedExceptions", ThrowableFields::suppressedExceptions);
+    THROWABLE_SPECIAL_FIELDS.put("stackTrace", ThrowableFields::stackTrace);
+    THROWABLE_SPECIAL_FIELDS.put("cause", ThrowableFields::cause);
   }
 
   /**
@@ -73,7 +116,7 @@ public class WellKnownClasses {
    *     free
    */
   public static boolean isToStringFinalSafe(String type) {
-    return toStringFinalSafeClasses.containsKey(type);
+    return TO_STRING_FINAL_SAFE_CLASSES.containsKey(type);
   }
 
   /**
@@ -82,7 +125,7 @@ public class WellKnownClasses {
    *     classes are not final and could be overridden toString
    */
   public static boolean isToStringSafe(String concreteType) {
-    return safeToStringFunctions.containsKey(concreteType);
+    return SAFE_TO_STRING_FUNCTIONS.containsKey(concreteType);
   }
 
   /** @return true if collection implementation is safe to call (only in-memory) */
@@ -110,7 +153,7 @@ public class WellKnownClasses {
    * with Expression Language
    */
   public static boolean isStringPrimitive(String type) {
-    return stringPrimitives.contains(type);
+    return STRING_PRIMITIVES.contains(type);
   }
 
   /**
@@ -118,7 +161,27 @@ public class WellKnownClasses {
    *     used to avoid using reflection to access fields on well known types
    */
   public static Function<Object, CapturedContext.CapturedValue> getSpecialFieldAccess(String type) {
-    return specialFields.get(type);
+    return SPECIAL_FIELDS.get(type);
+  }
+
+  /**
+   * @return a map of fields with function to access special field of a type, or null if type is not
+   *     supported. This is used to avoid using reflection to access fields on well known types
+   */
+  public static Map<String, Function<Object, CapturedContext.CapturedValue>> getSpecialTypeAccess(
+      Object value) {
+    if (value == null) {
+      return null;
+    }
+    Map<String, Function<Object, CapturedContext.CapturedValue>> specialTypeAccess =
+        SPECIAL_TYPE_ACCESS.get(value.getClass());
+    if (specialTypeAccess != null) {
+      return specialTypeAccess;
+    }
+    if (value instanceof Throwable) {
+      return THROWABLE_SPECIAL_FIELDS;
+    }
+    return null;
   }
 
   /**
@@ -126,7 +189,7 @@ public class WellKnownClasses {
    *     method is not suitable
    */
   public static Function<Object, String> getSafeToString(String type) {
-    return safeToStringFunctions.get(type);
+    return SAFE_TO_STRING_FUNCTIONS.get(type);
   }
 
   private static CapturedContext.CapturedValue optionalSpecialField(Object o) {
@@ -140,5 +203,88 @@ public class WellKnownClasses {
 
   private static String genericToString(Object o) {
     return String.valueOf(o);
+  }
+
+  private static boolean isOverridden(
+      Object value, String methodName, Class<?> originalDeclaringClass) {
+    Class<?> declaringClass = null;
+    try {
+      declaringClass = value.getClass().getMethod(methodName).getDeclaringClass();
+    } catch (NoSuchMethodException e) {
+      LOGGER.debug("Failed to get declaring class for Throwable::getMessage", e);
+    }
+    return declaringClass != originalDeclaringClass;
+  }
+
+  private static class ThrowableFields {
+    public static final String BECAUSE_OVERRIDDEN =
+        "Special access method not safe to be called because overridden";
+
+    public static CapturedContext.CapturedValue detailMessage(Object o) {
+      if (isOverridden(o, "getMessage", Throwable.class)) {
+        return CapturedContext.CapturedValue.notCapturedReason(
+            "detailMessage", String.class.getTypeName(), BECAUSE_OVERRIDDEN);
+      }
+      return CapturedContext.CapturedValue.of(
+          "detailMessage", String.class.getTypeName(), ((Throwable) o).getMessage());
+    }
+
+    public static CapturedContext.CapturedValue suppressedExceptions(Object o) {
+      return CapturedContext.CapturedValue.of(
+          "suppressedExceptions", String.class.getTypeName(), ((Throwable) o).getSuppressed());
+    }
+
+    public static CapturedContext.CapturedValue stackTrace(Object o) {
+      if (isOverridden(o, "getStackTrace", Throwable.class)) {
+        return CapturedContext.CapturedValue.notCapturedReason(
+            "stackTrace", StackTraceElement[].class.getTypeName(), BECAUSE_OVERRIDDEN);
+      }
+      return CapturedContext.CapturedValue.of(
+          "stackTrace", String.class.getTypeName(), ((Throwable) o).getStackTrace());
+    }
+
+    public static CapturedContext.CapturedValue cause(Object o) {
+      if (isOverridden(o, "getCause", Throwable.class)) {
+        return CapturedContext.CapturedValue.notCapturedReason(
+            "cause", Throwable.class.getTypeName(), BECAUSE_OVERRIDDEN);
+      }
+      return CapturedContext.CapturedValue.of(
+          "cause", String.class.getTypeName(), ((Throwable) o).getCause());
+    }
+  }
+
+  private static class StackTraceElementFields {
+    public static CapturedContext.CapturedValue declaringClass(Object o) {
+      return CapturedContext.CapturedValue.of(
+          "declaringClass", String.class.getTypeName(), ((StackTraceElement) o).getClassName());
+    }
+
+    public static CapturedContext.CapturedValue methodName(Object o) {
+      return CapturedContext.CapturedValue.of(
+          "methodName", String.class.getTypeName(), ((StackTraceElement) o).getMethodName());
+    }
+
+    public static CapturedContext.CapturedValue fileName(Object o) {
+      return CapturedContext.CapturedValue.of(
+          "fileName", String.class.getTypeName(), ((StackTraceElement) o).getFileName());
+    }
+
+    public static CapturedContext.CapturedValue lineNumber(Object o) {
+      return CapturedContext.CapturedValue.of(
+          "lineNumber", String.class.getTypeName(), ((StackTraceElement) o).getLineNumber());
+    }
+
+    public static CapturedContext.CapturedValue moduleName(Object o) {
+      StackTraceElement stackTraceElement = (StackTraceElement) o;
+      Object value = null;
+      if (getModuleNameMethod != null) {
+        try {
+          value = getModuleNameMethod.invoke(stackTraceElement);
+        } catch (InvocationTargetException | IllegalAccessException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return CapturedContext.CapturedValue.of("moduleName", String.class.getTypeName(), value);
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SerializerWithLimits.java
@@ -257,13 +257,6 @@ public class SerializerWithLimits {
 
   private void serializeObjectValue(Object value, Limits limits) throws Exception {
     tokenWriter.objectPrologue(value);
-    Function<Object, CapturedContext.CapturedValue> specialFieldAccess =
-        WellKnownClasses.getSpecialFieldAccess(value.getClass().getTypeName());
-    if (specialFieldAccess != null) {
-      onSpecialField(specialFieldAccess, value, limits);
-      tokenWriter.objectEpilogue(value);
-      return;
-    }
     Map<String, Function<Object, CapturedContext.CapturedValue>> specialTypeAccess =
         WellKnownClasses.getSpecialTypeAccess(value);
     Class<?> currentClass = value.getClass();
@@ -283,7 +276,8 @@ public class SerializerWithLimits {
           }
           processedFieldCount++;
           if (specialTypeAccess != null) {
-            specialFieldAccess = specialTypeAccess.get(field.getName());
+            Function<Object, CapturedContext.CapturedValue> specialFieldAccess =
+                specialTypeAccess.get(field.getName());
             if (specialFieldAccess != null) {
               onSpecialField(specialFieldAccess, value, limits);
             } else {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -299,6 +299,8 @@ public class SnapshotSerializationTest {
     URI uri = URI.create("https://www.datadoghq.com");
     Optional<Date> maybeDate = Optional.of(new Date());
     Optional<Object> empty = Optional.empty();
+    Exception ex = new IllegalArgumentException("invalid arg");
+    StackTraceElement element = new StackTraceElement("Foo", "bar", "foo.java", 42);
   }
 
   @Test
@@ -344,6 +346,19 @@ public class SnapshotSerializationTest {
     value = (Map<String, Object>) emptyFields.get("value");
     assertEquals(Object.class.getTypeName(), value.get(TYPE));
     assertTrue((Boolean) value.get(IS_NULL));
+    Map<String, Object> ex = (Map<String, Object>) objLocalFields.get("ex");
+    assertComplexClass(ex, IllegalArgumentException.class.getTypeName());
+    Map<String, Object> exFields = (Map<String, Object>) ex.get(FIELDS);
+    assertPrimitiveValue(exFields, "detailMessage", String.class.getTypeName(), "invalid arg");
+    Map<String, Object> stackTrace = (Map<String, Object>) exFields.get("stackTrace");
+    Assertions.assertEquals(StackTraceElement[].class.getTypeName(), stackTrace.get(TYPE));
+    Map<String, Object> element = (Map<String, Object>) objLocalFields.get("element");
+    assertComplexClass(element, StackTraceElement.class.getTypeName());
+    Map<String, Object> elementFields = (Map<String, Object>) element.get(FIELDS);
+    assertPrimitiveValue(elementFields, "declaringClass", String.class.getTypeName(), "Foo");
+    assertPrimitiveValue(elementFields, "methodName", String.class.getTypeName(), "bar");
+    assertPrimitiveValue(elementFields, "fileName", String.class.getTypeName(), "foo.java");
+    assertPrimitiveValue(elementFields, "lineNumber", Integer.class.getTypeName(), "42");
   }
 
   @Test

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -172,6 +172,10 @@ project.afterEvaluate {
   }
 
   tasks.withType(Test).configureEach {
+    def allowReflectiveAccessToJdk = true
+    if (project.hasProperty('allowReflectiveAccessToJdk')) {
+      allowReflectiveAccessToJdk = project.getProperty('allowReflectiveAccessToJdk')
+    }
     if (javaTestLauncher) {
       def metadata = javaTestLauncher.get().metadata
       def allowedOrForced = !isJdkExcluded(testJvm) &&
@@ -184,14 +188,14 @@ project.afterEvaluate {
           enabled = false
         }
       }
-      if (metadata.languageVersion.asInt() >= 16) {
+      if (metadata.languageVersion.asInt() >= 16 && allowReflectiveAccessToJdk) {
         // temporary workaround when using Java16+: some tests require reflective access to java.lang/java.util
         jvmArgs += ['--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED']
       }
     } else {
       def name = it.name
       onlyIf { isJavaVersionAllowed(JavaVersion.current(), name) }
-      if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+      if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16) && allowReflectiveAccessToJdk) {
         jvmArgs += ['--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED']
       }
     }


### PR DESCRIPTION
# What Does This Do
We introduce in `WellKnownClasses` the mechanism to fetch fields through dedicated call to getter for registered classes.
In the special case of `Throwable` we are allowing any inherited classes to capture the `Throwable` fields as well as custom fields. Though, to capture `Throwable` fields (like `detailMessage`) we need to call getter that could be overridden. Hence ,we are checking before calling them that they are not overridden by checking the declaring class of the getter.
Add option in build to not allow reflection access for debugger tests to assess that we can access correctly even for recent JDKs

# Motivation
Since JDK16 it's not possible to extract values by reflection for JDK modules without adding `--add-opens=java.base/java.lang=ALL-UNNAMED` so when capturing an exception (like in `@exception`) we are not allowed to capture fields like `detailMessage`, `cause`, `stacktrace` which can be valuable to troubleshoot.

# Additional Notes
Results:
<img width="742" alt="Screenshot 2024-05-17 at 14 00 48" src="https://github.com/DataDog/dd-trace-java/assets/4610701/e7df5bbe-83fd-4615-a92c-c45aaea4a7ad">

<img width="732" alt="Screenshot 2024-05-17 at 14 01 23" src="https://github.com/DataDog/dd-trace-java/assets/4610701/11f69063-de29-41b6-9090-2ec51f1e5f4d">


Jira ticket: [DEBUG-2389]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2389]: https://datadoghq.atlassian.net/browse/DEBUG-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ