### PR TITLE
Do not transform Mockito-generated classes

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -97,6 +97,7 @@
 # USM needs it
 0 sun.security.ssl.*
 0 javax.net.ssl.SSLSocket
+1 org.mockito.codegen.*
 
 # Prevent IllegalAccessError in OpenJDK 17.0.4
 1 javax.management.*
@@ -355,7 +356,6 @@
 2 org.yaml.snakeyaml.*
 # saves ~0.5s skipping instrumentation of almost ~470 classes
 2 scala.collection.*
-1 org.mockito.codegen.*
 
 # -------- SPECIAL CASES --------
 

--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -355,6 +355,7 @@
 2 org.yaml.snakeyaml.*
 # saves ~0.5s skipping instrumentation of almost ~470 classes
 2 scala.collection.*
+1 org.mockito.codegen.*
 
 # -------- SPECIAL CASES --------
 


### PR DESCRIPTION
# What Does This Do
Adds the common package for Mockito-generated classes to the list of global ignores.

# Motivation
Whenever a class is mocked with Mockito, a new class is generated that replaces the original class' methods with the mocked ones.

If the tracer contains instrumentations that transform the original class, the same instrumentations will most likely be applied to the mocked class as it extends the original one.

Transforming the mocked class' code leads to errors: some instrumentations, when executed a transformed method, call another method of the same instance. Mockito does not handle this well: if a mocked method is called from inside another mocked method, Mockito's internal state gets corrupted.

The solution is to avoid transforming Mockito-generated classes, both because it fixes the errors and because tracing mock methods makes little sense.

Jira ticket: [CIVIS-10060]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-10060]: https://datadoghq.atlassian.net/browse/CIVIS-10060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ