### PR TITLE
Added support for SQLi exploit prevention

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -50,20 +50,11 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
   protected abstract String dbType();
 
-  protected String dbType(CONNECTION connection) {
-    return dbType();
-  }
-
   protected abstract String dbUser(CONNECTION connection);
 
   protected abstract String dbInstance(CONNECTION connection);
 
   protected abstract CharSequence dbHostname(CONNECTION connection);
-
-  // Extract this to allow for easier testing
-  protected AgentTracer.TracerAPI tracer() {
-    return AgentTracer.get();
-  }
 
   /**
    * This should be called when the connection is being used, not when it's created.
@@ -89,22 +80,6 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
 
         if (Config.get().isDbClientSplitByHost()) {
           span.setServiceName(hostName.toString());
-        }
-      }
-
-      if (Config.get().getAppSecRaspEnabled()) {
-        BiConsumer<RequestContext, String> connectDbCallback =
-            tracer()
-                .getCallbackProvider(RequestContextSlot.APPSEC)
-                .getCallback(EVENTS.databaseConnection());
-        if (connectDbCallback != null) {
-          RequestContext ctx = span.getRequestContext();
-          if (ctx != null) {
-            String dbType = dbType(connection);
-            if (dbType != null) {
-              connectDbCallback.accept(ctx, dbType);
-            }
-          }
         }
       }
     }
@@ -142,7 +117,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
   public AgentSpan onStatementRaw(AgentSpan span, String sql) {
     if (Config.get().getAppSecRaspEnabled()) {
       BiConsumer<RequestContext, String> sqlQueryCallback =
-          tracer()
+          AgentTracer.get()
               .getCallbackProvider(RequestContextSlot.APPSEC)
               .getCallback(EVENTS.databaseSqlQuery());
       if (sqlQueryCallback != null) {
@@ -161,6 +136,21 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     final NamingEntry namingEntry = CACHE.computeIfAbsent(dbType, NamingEntry::new);
     span.setTag(DB_TYPE, namingEntry.dbType);
     postProcessServiceAndOperationName(span, namingEntry);
+
+    if (Config.get().getAppSecRaspEnabled()) {
+      BiConsumer<RequestContext, String> connectDbCallback =
+          AgentTracer.get()
+              .getCallbackProvider(RequestContextSlot.APPSEC)
+              .getCallback(EVENTS.databaseConnection());
+      if (connectDbCallback != null) {
+        RequestContext ctx = span.getRequestContext();
+        if (ctx != null) {
+          if (dbType != null) {
+            connectDbCallback.accept(ctx, dbType);
+          }
+        }
+      }
+    }
   }
 
   protected void postProcessServiceAndOperationName(AgentSpan span, NamingEntry namingEntry) {}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -114,7 +114,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
    * The method used to provide raw sql to prevent SQL-injection attacks SQL query should never be
    * exposed because it may contain sensitive data.
    */
-  public AgentSpan onStatementRaw(AgentSpan span, String sql) {
+  public AgentSpan onRawStatement(AgentSpan span, String sql) {
     if (Config.get().getAppSecRaspEnabled() && sql != null && !sql.isEmpty()) {
       BiConsumer<RequestContext, String> sqlQueryCallback =
           AgentTracer.get()

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -115,7 +115,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
    * exposed because it may contain sensitive data.
    */
   public AgentSpan onStatementRaw(AgentSpan span, String sql) {
-    if (Config.get().getAppSecRaspEnabled()) {
+    if (Config.get().getAppSecRaspEnabled() && sql != null && !sql.isEmpty()) {
       BiConsumer<RequestContext, String> sqlQueryCallback =
           AgentTracer.get()
               .getCallbackProvider(RequestContextSlot.APPSEC)
@@ -123,9 +123,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       if (sqlQueryCallback != null) {
         RequestContext ctx = span.getRequestContext();
         if (ctx != null) {
-          if (sql != null && !sql.isEmpty()) {
-            sqlQueryCallback.accept(ctx, sql);
-          }
+          sqlQueryCallback.accept(ctx, sql);
         }
       }
     }
@@ -137,7 +135,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     span.setTag(DB_TYPE, namingEntry.dbType);
     postProcessServiceAndOperationName(span, namingEntry);
 
-    if (Config.get().getAppSecRaspEnabled()) {
+    if (Config.get().getAppSecRaspEnabled() && dbType != null) {
       BiConsumer<RequestContext, String> connectDbCallback =
           AgentTracer.get()
               .getCallbackProvider(RequestContextSlot.APPSEC)
@@ -145,9 +143,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       if (connectDbCallback != null) {
         RequestContext ctx = span.getRequestContext();
         if (ctx != null) {
-          if (dbType != null) {
-            connectDbCallback.accept(ctx, dbType);
-          }
+          connectDbCallback.accept(ctx, dbType);
         }
       }
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -114,7 +114,7 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
    * The method used to provide raw sql to prevent SQL-injection attacks SQL query should never be
    * exposed because it may contain sensitive data.
    */
-  public AgentSpan onRawStatement(AgentSpan span, String sql) {
+  public void onRawStatement(AgentSpan span, String sql) {
     if (Config.get().getAppSecRaspEnabled() && sql != null && !sql.isEmpty()) {
       BiConsumer<RequestContext, String> sqlQueryCallback =
           AgentTracer.get()
@@ -127,7 +127,6 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
         }
       }
     }
-    return span;
   }
 
   protected void processDatabaseType(AgentSpan span, String dbType) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -8,6 +8,7 @@ import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_DD_RULES;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_EXCLUSIONS;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_IP_BLOCKING;
+import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_RASP_SQLI;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_REQUEST_BLOCKING;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_TRUSTED_IPS;
 import static datadog.remoteconfig.tuf.RemoteConfigRequest.ClientInfo.CAPABILITY_ASM_USER_BLOCKING;
@@ -96,7 +97,8 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_USER_BLOCKING
             | CAPABILITY_ASM_CUSTOM_RULES
             | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
-            | CAPABILITY_ASM_TRUSTED_IPS);
+            | CAPABILITY_ASM_TRUSTED_IPS
+            | CAPABILITY_ASM_RASP_SQLI);
   }
 
   private void subscribeRulesAndData() {
@@ -334,7 +336,8 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_CUSTOM_RULES
             | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
             | CAPABILITY_ASM_TRUSTED_IPS
-            | CAPABILITY_ASM_API_SECURITY_SAMPLE_RATE);
+            | CAPABILITY_ASM_API_SECURITY_SAMPLE_RATE
+            | CAPABILITY_ASM_RASP_SQLI);
     this.configurationPoller.removeListeners(Product.ASM_DD);
     this.configurationPoller.removeListeners(Product.ASM_DATA);
     this.configurationPoller.removeListeners(Product.ASM);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -109,6 +109,10 @@ public interface KnownAddresses {
 
   Address<String> USER_ID = new Address<>("usr.id");
 
+  Address<String> DB_TYPE = new Address<>("server.db.system");
+
+  Address<String> DB_SQL_QUERY = new Address<>("server.db.statement");
+
   Address<Map<String, Object>> WAF_CONTEXT_PROCESSOR = new Address<>("waf.context.processor");
 
   static Address<?> forName(String name) {
@@ -165,6 +169,10 @@ public interface KnownAddresses {
         return SERVER_GRAPHQL_ALL_RESOLVERS;
       case "usr.id":
         return USER_ID;
+      case "server.db.system":
+        return DB_TYPE;
+      case "server.db.statement":
+        return DB_SQL_QUERY;
       case "waf.context.processor":
         return WAF_CONTEXT_PROCESSOR;
       default:

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -109,8 +109,10 @@ public interface KnownAddresses {
 
   Address<String> USER_ID = new Address<>("usr.id");
 
+  /** The database type (ex: mysql, postgresql, sqlite) */
   Address<String> DB_TYPE = new Address<>("server.db.system");
 
+  /** The SQL query being executed */
   Address<String> DB_SQL_QUERY = new Address<>("server.db.statement");
 
   Address<Map<String, Object>> WAF_CONTEXT_PROCESSOR = new Address<>("waf.context.processor");

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -434,7 +434,7 @@ public class GatewayBridge {
             }
             DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_TYPE, dbType);
             try {
-              producerService.publishDataEvent(subInfo, ctx, bundle, true);
+              producerService.publishDataEvent(subInfo, ctx, bundle, false);
               return;
             } catch (ExpiredSubscriberInfoException e) {
               dbConnectionSubInfo = null;
@@ -460,7 +460,7 @@ public class GatewayBridge {
             }
             DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_SQL_QUERY, sql);
             try {
-              producerService.publishDataEvent(subInfo, ctx, bundle, true);
+              producerService.publishDataEvent(subInfo, ctx, bundle, false);
               return;
             } catch (ExpiredSubscriberInfoException e) {
               dbSqlQuerySubInfo = null;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -368,6 +368,8 @@ public class PowerWAFModule implements AppSecModule {
     addressList.add(KnownAddresses.RESPONSE_HEADERS_NO_COOKIES);
     addressList.add(KnownAddresses.RESPONSE_BODY_OBJECT);
     addressList.add(KnownAddresses.GRAPHQL_SERVER_ALL_RESOLVERS);
+    addressList.add(KnownAddresses.DB_TYPE);
+    addressList.add(KnownAddresses.DB_SQL_QUERY);
 
     return addressList;
   }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -8,7 +8,6 @@ import datadog.remoteconfig.ConfigurationDeserializer
 import datadog.remoteconfig.ConfigurationEndListener
 import datadog.remoteconfig.ConfigurationPoller
 import datadog.remoteconfig.Product
-import datadog.trace.api.Config
 import datadog.trace.api.ProductActivation
 import datadog.trace.test.util.DDSpecification
 
@@ -18,7 +17,7 @@ import java.nio.file.Path
 class AppSecConfigServiceImplSpecification extends DDSpecification {
 
   ConfigurationPoller poller = Mock()
-  Config config = Mock(Class.forName('datadog.trace.api.Config')) as Config
+  def config = Mock(Class.forName('datadog.trace.api.Config'))
   AppSecModuleConfigurer.Reconfiguration reconf = Stub()
   AppSecConfigServiceImpl appSecConfigService = new AppSecConfigServiceImpl(config, poller, reconf)
 

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -8,6 +8,7 @@ import datadog.remoteconfig.ConfigurationDeserializer
 import datadog.remoteconfig.ConfigurationEndListener
 import datadog.remoteconfig.ConfigurationPoller
 import datadog.remoteconfig.Product
+import datadog.trace.api.Config
 import datadog.trace.api.ProductActivation
 import datadog.trace.test.util.DDSpecification
 
@@ -17,7 +18,7 @@ import java.nio.file.Path
 class AppSecConfigServiceImplSpecification extends DDSpecification {
 
   ConfigurationPoller poller = Mock()
-  def config = Mock(Class.forName('datadog.trace.api.Config'))
+  Config config = Mock(Class.forName('datadog.trace.api.Config')) as Config
   AppSecModuleConfigurer.Reconfiguration reconf = Stub()
   AppSecConfigServiceImpl appSecConfigService = new AppSecConfigServiceImpl(config, poller, reconf)
 
@@ -229,7 +230,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     }
     1 * poller.addConfigurationEndListener(_) >> { listeners.savedConfEndListener = it[0] }
     1 * poller.addCapabilities(2L)
-    1 * poller.addCapabilities(1980L)
+    1 * poller.addCapabilities(2099132L)
     0 * _._
     initialWafConfig.get() != null
 
@@ -366,7 +367,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     }
     1 * poller.addConfigurationEndListener(_) >> { listeners.savedConfEndListener = it[0] }
     1 * poller.addCapabilities(2L)
-    1 * poller.addCapabilities(1980L)
+    1 * poller.addCapabilities(2099132L)
     0 * _._
 
     when:
@@ -422,7 +423,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     poller = null
 
     then:
-    1 * poller.removeCapabilities(4030L)
+    1 * poller.removeCapabilities(2101182L)
     4 * poller.removeListeners(_)
     1 * poller.removeConfigurationEndListener(_)
     1 * poller.stop()

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -34,8 +34,6 @@ class KnownAddressesSpecification extends Specification {
       'graphql.server.resolver',
       'server.db.system',
       'server.db.statement',
-      'server.io.net.url',
-      'server.io.fs.file',
       'usr.id',
       'waf.context.processor',
     ]
@@ -43,7 +41,7 @@ class KnownAddressesSpecification extends Specification {
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 31
+    Address.instanceCount() == 29
     KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -32,6 +32,10 @@ class KnownAddressesSpecification extends Specification {
       'grpc.server.request.metadata',
       'graphql.server.all_resolvers',
       'graphql.server.resolver',
+      'server.db.system',
+      'server.db.statement',
+      'server.io.net.url',
+      'server.io.fs.file',
       'usr.id',
       'waf.context.processor',
     ]
@@ -39,7 +43,7 @@ class KnownAddressesSpecification extends Specification {
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 27
+    Address.instanceCount() == 31
     KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -24,6 +24,7 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase
 import datadog.trace.test.util.DDSpecification
 
+import java.util.function.BiConsumer
 import java.util.function.BiFunction
 import java.util.function.Function
 import java.util.function.Supplier
@@ -78,6 +79,8 @@ class GatewayBridgeSpecification extends DDSpecification {
   Function<RequestContext, Flow<Void>> respHeadersDoneCB
   BiFunction<RequestContext, Object, Flow<Void>> grpcServerRequestMessageCB
   BiFunction<RequestContext, Map<String, Object>, Flow<Void>> graphqlServerRequestMessageCB
+  BiConsumer<RequestContext, String> databaseConnectionCB
+  BiConsumer<RequestContext, String> databaseSqlQueryCB
 
   void setup() {
     callInitAndCaptureCBs()
@@ -412,6 +415,8 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * ig.registerCallback(EVENTS.responseHeaderDone(), _) >> { respHeadersDoneCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.grpcServerRequestMessage(), _) >> { grpcServerRequestMessageCB = it[1]; null }
     1 * ig.registerCallback(EVENTS.graphqlServerRequestMessage(), _) >> { graphqlServerRequestMessageCB = it[1]; null }
+    1 * ig.registerCallback(EVENTS.databaseConnection(), _) >> { databaseConnectionCB = it[1]; null }
+    1 * ig.registerCallback(EVENTS.databaseSqlQuery(), _) >> { databaseSqlQueryCB = it[1]; null }
     0 * ig.registerCallback(_, _)
 
     bridge.init()

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -205,7 +205,9 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     return dbInfo;
   }
 
-  public AgentSpan onStatement(AgentSpan span, DBQueryInfo dbQueryInfo) {
+  public AgentSpan onStatement(AgentSpan span, final String statement) {
+    span = onRawStatement(span, statement);
+    DBQueryInfo dbQueryInfo = DBQueryInfo.ofStatement(statement);
     return withQueryInfo(span, dbQueryInfo, JDBC_STATEMENT);
   }
 

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -230,15 +230,15 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   }
 
   /**
-   * The method used to provide raw sql to prevent SQL-injection attacks
-   * SQL query should never be exposed because it may contain sensitive data.
+   * The method used to provide raw sql to prevent SQL-injection attacks SQL query should never be
+   * exposed because it may contain sensitive data.
    */
   public AgentSpan onStatementRaw(AgentSpan span, String sql) {
     System.out.println("JDBCDecorator.onStatementRaw: " + sql);
     BiConsumer<RequestContext, String> sqlQueryCallback =
-            tracer()
-                    .getCallbackProvider(RequestContextSlot.APPSEC)
-                    .getCallback(EVENTS.databaseSqlQuery());
+        tracer()
+            .getCallbackProvider(RequestContextSlot.APPSEC)
+            .getCallback(EVENTS.databaseSqlQuery());
     if (sqlQueryCallback != null) {
       RequestContext ctx = span.getRequestContext();
       if (ctx != null) {

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -103,11 +103,6 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   }
 
   @Override
-  protected String dbType(final DBInfo info) {
-    return info.getType();
-  }
-
-  @Override
   protected String dbUser(final DBInfo info) {
     return info.getUser();
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -206,7 +206,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   }
 
   public AgentSpan onStatement(AgentSpan span, final String statement) {
-    span = onRawStatement(span, statement);
+    onRawStatement(span, statement);
     DBQueryInfo dbQueryInfo = DBQueryInfo.ofStatement(statement);
     return withQueryInfo(span, dbQueryInfo, JDBC_STATEMENT);
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -21,7 +21,6 @@ import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.jdbc.DBInfo;
-import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -112,8 +111,7 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
                   injectTraceContext,
                   appendComment);
         }
-        DECORATE.onStatement(span, DBQueryInfo.ofStatement(copy));
-        DECORATE.onStatementRaw(span, sql);
+        DECORATE.onStatement(span, copy);
         return activateSpan(span);
       } catch (SQLException e) {
         // if we can't get the connection for any reason

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -113,6 +113,7 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
                   appendComment);
         }
         DECORATE.onStatement(span, DBQueryInfo.ofStatement(copy));
+        DECORATE.onStatementRaw(span, sql);
         return activateSpan(span);
       } catch (SQLException e) {
         // if we can't get the connection for any reason

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -101,7 +101,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
   static final boolean DEFAULT_API_SECURITY_ENABLED = false;
   static final float DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE = 0.1f; // 10 %
-  static final boolean DEFAULT_APPSEC_RASP_ENABLED = true;
+  static final boolean DEFAULT_APPSEC_RASP_ENABLED = false;
   static final String DEFAULT_IAST_ENABLED = "false";
   static final boolean DEFAULT_IAST_DEBUG_ENABLED = false;
   public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 4;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -101,7 +101,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_APPSEC_WAF_TIMEOUT = 100000; // 0.1 s
   static final boolean DEFAULT_API_SECURITY_ENABLED = false;
   static final float DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE = 0.1f; // 10 %
-
+  static final boolean DEFAULT_APPSEC_RASP_ENABLED = true;
   static final String DEFAULT_IAST_ENABLED = "false";
   static final boolean DEFAULT_IAST_DEBUG_ENABLED = false;
   public static final int DEFAULT_IAST_MAX_CONCURRENT_REQUESTS = 4;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -27,6 +27,7 @@ public final class AppSecConfig {
   public static final String API_SECURITY_REQUEST_SAMPLE_RATE = "api-security.request.sample.rate";
 
   public static final String APPSEC_SCA_ENABLED = "appsec.sca.enabled";
+  public static final String APPSEC_RASP_ENABLED = "appsec.rasp.enabled";
 
   private AppSecConfig() {}
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_AGENT_WRITER_TYPE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ANALYTICS_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_RASP_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_REPORTING_INBAND;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_TRACE_RATE_LIMIT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_APPSEC_WAF_METRICS;
@@ -147,6 +148,7 @@ import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE
 import static datadog.trace.api.config.AppSecConfig.APPSEC_IP_ADDR_HEADER;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_RASP_ENABLED;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORTING_INBAND;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_REPORT_TIMEOUT_SEC;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_RULES_FILE;
@@ -736,6 +738,7 @@ public class Config {
   private final String appSecHttpBlockedTemplateJson;
   private final UserEventTrackingMode appSecUserEventsTracking;
   private final Boolean appSecScaEnabled;
+  private final Boolean appSecRaspEnabled;
   private final boolean apiSecurityEnabled;
   private final float apiSecurityRequestSampleRate;
 
@@ -1633,6 +1636,7 @@ public class Config {
             configProvider.getStringNotEmpty(
                 APPSEC_AUTOMATED_USER_EVENTS_TRACKING, SAFE.toString()));
     appSecScaEnabled = configProvider.getBoolean(APPSEC_SCA_ENABLED);
+    appSecRaspEnabled = configProvider.getBoolean(APPSEC_RASP_ENABLED, DEFAULT_APPSEC_RASP_ENABLED);
     apiSecurityEnabled =
         configProvider.getBoolean(
             API_SECURITY_ENABLED, DEFAULT_API_SECURITY_ENABLED, API_SECURITY_ENABLED_EXPERIMENTAL);
@@ -3976,6 +3980,10 @@ public class Config {
     return appSecScaEnabled;
   }
 
+  public Boolean getAppSecRaspEnabled() {
+    return appSecRaspEnabled;
+  }
+
   private <T> Set<T> getSettingsSetFromEnvironment(
       String name, Function<String, T> mapper, boolean splitOnWS) {
     final String value = configProvider.getString(name, "");
@@ -4612,6 +4620,8 @@ public class Config {
         + telemetryMetricsEnabled
         + ", appSecScaEnabled="
         + appSecScaEnabled
+        + ", appSecRaspEnabled="
+        + appSecRaspEnabled
         + ", dataJobsEnabled="
         + dataJobsEnabled
         + '}';

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -6,6 +6,7 @@ import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -200,6 +201,28 @@ public final class Events<D> {
       graphqlServerRequestMessage() {
     return (EventType<BiFunction<RequestContext, Map<String, ?>, Flow<Void>>>)
         GRAPHQL_SERVER_REQUEST_MESSAGE;
+  }
+
+  static final int DATABASE_CONNECTION_ID = 16;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType DATABASE_CONNECTION =
+      new ET<>("database.connection", DATABASE_CONNECTION_ID);
+  /** A database connection */
+  @SuppressWarnings("unchecked")
+  public EventType<BiConsumer<RequestContext, String>> databaseConnection() {
+    return (EventType<BiConsumer<RequestContext, String>>) DATABASE_CONNECTION;
+  }
+
+  static final int DATABASE_SQL_QUERY_ID = 17;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType DATABASE_SQL_QUERY =
+      new ET<>("database.query", DATABASE_SQL_QUERY_ID);
+  /** A database sql query */
+  @SuppressWarnings("unchecked")
+  public EventType<BiConsumer<RequestContext, String>> databaseSqlQuery() {
+    return (EventType<BiConsumer<RequestContext, String>>) DATABASE_SQL_QUERY;
   }
 
   static final int MAX_EVENTS = nextId.get();

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.gateway;
 
+import static datadog.trace.api.gateway.Events.DATABASE_CONNECTION_ID;
+import static datadog.trace.api.gateway.Events.DATABASE_SQL_QUERY_ID;
 import static datadog.trace.api.gateway.Events.GRAPHQL_SERVER_REQUEST_MESSAGE_ID;
 import static datadog.trace.api.gateway.Events.GRPC_SERVER_REQUEST_MESSAGE_ID;
 import static datadog.trace.api.gateway.Events.MAX_EVENTS;
@@ -24,6 +26,7 @@ import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -357,6 +360,19 @@ public class InstrumentationGateway {
                 } catch (Throwable t) {
                   log.warn("Callback for {} threw.", eventType, t);
                   return Flow.ResultFlow.empty();
+                }
+              }
+            };
+      case DATABASE_CONNECTION_ID:
+      case DATABASE_SQL_QUERY_ID:
+        return (C)
+            new BiConsumer<RequestContext, String>() {
+              @Override
+              public void accept(RequestContext ctx, String arg) {
+                try {
+                  ((BiConsumer<RequestContext, String>) callback).accept(ctx, arg);
+                } catch (Throwable t) {
+                  log.warn("Callback for {} threw.", eventType, t);
                 }
               }
             };

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -197,6 +197,10 @@ public class InstrumentationGatewayTest {
     ss.registerCallback(events.graphqlServerRequestMessage(), callback);
     assertThat(cbp.getCallback(events.graphqlServerRequestMessage()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
+    ss.registerCallback(events.databaseConnection(), callback);
+    cbp.getCallback(events.databaseConnection()).accept(null, null);
+    ss.registerCallback(events.databaseSqlQuery(), callback);
+    cbp.getCallback(events.databaseSqlQuery()).accept(null, null);
     assertThat(callback.count).isEqualTo(Events.MAX_EVENTS);
   }
 
@@ -246,6 +250,10 @@ public class InstrumentationGatewayTest {
     ss.registerCallback(events.graphqlServerRequestMessage(), throwback);
     assertThat(cbp.getCallback(events.graphqlServerRequestMessage()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
+    ss.registerCallback(events.databaseConnection(), throwback);
+    cbp.getCallback(events.databaseConnection()).accept(null, null);
+    ss.registerCallback(events.databaseSqlQuery(), throwback);
+    cbp.getCallback(events.databaseSqlQuery()).accept(null, null);
     assertThat(throwback.count).isEqualTo(Events.MAX_EVENTS);
   }
 


### PR DESCRIPTION
# What Does This Do
This PR introduces support for SQL capturing which can be used for detecting SQL injection attacks, e.i. added ability to collect data for `server.db.system` and `server.db.statement`  addresses via instrumentation gateway with subsequent forwarding to RASP (ex-WAF).
* `server.db.system` - sql dialect (mysql, postgresql, etc.)
* `server.db.statement` - raw sql-query to check for sql-injection attacks

# Motivation
This PR is part of ASM Exploit Prevention initiative (Runtime application self-protection).

# Additional Notes
The current set of dialects supported is:
* mysql
* sqlite
* pgsql

Jira ticket: [APPSEC-47228]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-47228]: https://datadoghq.atlassian.net/browse/APPSEC-47228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ