### PR TITLE
Fix perf issue when accessing fields by reflection

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
@@ -165,13 +165,15 @@ public class ReflectiveFieldValueResolver {
 
   private static Field getField(Class<?> container, String name) {
     while (container != null) {
-      try {
-        Field fld = container.getDeclaredField(name);
-        fld.setAccessible(true);
-        return fld;
-      } catch (NoSuchFieldException ignored) {
-        container = container.getSuperclass();
+      Field[] declaredFields = container.getDeclaredFields();
+      for (int i = 0; i < declaredFields.length; i++) {
+        Field declaredField = declaredFields[i];
+        if (declaredField.getName().equals(name)) {
+          declaredField.setAccessible(true);
+          return declaredField;
+        }
       }
+      container = container.getSuperclass();
     }
     return null;
   }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolverTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolverTest.java
@@ -1,0 +1,29 @@
+package datadog.trace.bootstrap.debugger.el;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ReflectiveFieldValueResolverTest {
+
+  @Test
+  void getFieldAsCapturedValue() {
+    assertNull(ReflectiveFieldValueResolver.getFieldAsCapturedValue(null, "fieldName").getValue());
+    C c = new C();
+    assertEquals(3, ReflectiveFieldValueResolver.getFieldAsCapturedValue(c, "c1").getValue());
+    assertEquals(1, ReflectiveFieldValueResolver.getFieldAsCapturedValue(c, "a1").getValue());
+    assertEquals("2", ReflectiveFieldValueResolver.getFieldAsCapturedValue(c, "a2").getValue());
+    assertNull(ReflectiveFieldValueResolver.getFieldAsCapturedValue(c, "notExist").getValue());
+  }
+
+  static class A {
+    private int a1 = 1;
+    private String a2 = "2";
+  }
+
+  static class B extends A {}
+
+  static class C extends A {
+    private int c1 = 3;
+  }
+}


### PR DESCRIPTION
# What Does This Do
Instead of relying on exception using `getDeclaredField(String)` we are using `getDeclaredFields()` and scanning the field by name.

# Motivation
Overhead because of too many exceptions

# Additional Notes
Benchmarks Before/After:

```
---
Benchmark                                    Mode  Cnt     Score    Error  Units
GetFieldBenchmark.getFieldGetAllDeclared     avgt    5    24.734 ±  0.437  ns/op
GetFieldBenchmark.getFieldGetDeclaredByName  avgt    5  1756.905 ± 47.458  ns/op
---

@State(Scope.Benchmark)
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(1)
public class GetFieldBenchmark {

    @Benchmark
    public void getFieldGetDeclaredByName(Blackhole bh) {
        bh.consume(getField(GrokProcessor.class, "id"));
    }

    @Benchmark
    public void getFieldGetAllDeclared(Blackhole bh) {
        bh.consume(getFieldGetAllDeclared(GrokProcessor.class, "id"));
    }

    public static class GrokProcessor extends SynchronousProcessor {

    }

    public static class SynchronousProcessor extends Processor {

    }

    public static class Processor {
        protected String id;
    }

    private static Field getField(Class<?> container, String name) {
        while (container != null) {
            try {
                Field fld = container.getDeclaredField(name);
                fld.setAccessible(true);
                return fld;
            } catch (NoSuchFieldException ignored) {
                container = container.getSuperclass();
            }
        }
        return null;
    }

    private static Field getFieldGetAllDeclared(Class<?> container, String name) {
        while (container != null) {
            Field[] declaredFields = container.getDeclaredFields();
            for (int i = 0; i < declaredFields.length; i++) {
                Field declaredField = declaredFields[i];
                if (declaredField.getName().equals(name)) {
                    declaredField.setAccessible(true);
                    return declaredField;
                }
            }
            container = container.getSuperclass();
        }
        return null;
    }
}
```


Jira ticket: [DEBUG-2393]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2393]: https://datadoghq.atlassian.net/browse/DEBUG-2393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ