### PR TITLE
Fix 'polynomial regular expression used on uncontrolled data' vulnerability in Git config parsing logic

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/GitConfig.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/GitConfig.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.git;
 
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
@@ -18,6 +19,7 @@ public class GitConfig {
     load(path);
   }
 
+  @SuppressForbidden // split with one-char String use a fast-path without regex usage
   private void load(final String path) {
     if (path == null || path.isEmpty()) {
       return;


### PR DESCRIPTION
# What Does This Do
Fixes the logic that parses Git config files.
The fix is to replace a regular expression with a more ad-hoc logic.

# Motivation
The logic contains a regular expression that can require polynomial time to match (the one that splits a config line into key and value, polynomial since greedy quantifiers are used).
Since the contents of Git config files comes from outside the tracer, this regular expression can be leveraged for a DDoS attack.

# Additional Notes

Jira ticket: [VULN-6863]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[VULN-6863]: https://datadoghq.atlassian.net/browse/VULN-6863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ