### PR TITLE
Fix error handling on RabbitMQ channel cleanup

### DIFF
--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -1,11 +1,11 @@
 import com.rabbitmq.client.AMQP
-import com.rabbitmq.client.AlreadyClosedException
 import com.rabbitmq.client.Channel
 import com.rabbitmq.client.ConnectionFactory
 import com.rabbitmq.client.Consumer
 import com.rabbitmq.client.DefaultConsumer
 import com.rabbitmq.client.Envelope
 import com.rabbitmq.client.GetResponse
+import com.rabbitmq.client.ShutdownSignalException
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.PortUtils
@@ -89,7 +89,7 @@ abstract class RabbitMQTestBase extends VersionedNamingTestBase {
       channel?.close()
       conn?.close()
       TEST_DATA_STREAMS_WRITER?.clear()
-    } catch (AlreadyClosedException e) {
+    } catch (ShutdownSignalException e) {
       // Ignore
     }
   }


### PR DESCRIPTION
# What Does This Do

Closing channels may raise wider type of error.

# Motivation

Uncaught errors make the CI flaky.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
