### PR TITLE
Fix `ExtractedContext`'s  `toString`

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ExtractedContext.java
@@ -81,10 +81,10 @@ public class ExtractedContext extends TagContext {
       builder.append("traceId=").append(traceId).append(", ");
     }
     if (spanId != 0) {
-      builder.append("endToEndStartTime=").append(spanId).append(", ");
+      builder.append("spanId=").append(spanId).append(", ");
     }
     if (endToEndStartTime != 0) {
-      builder.append("spanId=").append(spanId).append(", ");
+      builder.append("endToEndStartTime=").append(endToEndStartTime).append(", ");
     }
     if (getOrigin() != null) {
       builder.append("origin=").append(getOrigin()).append(", ");


### PR DESCRIPTION
# What Does This Do

fix copy/paste errors in the toString
(span ID and endToEndStartTime were mix-mashed)
