### PR TITLE
Prevent AppSec context from being closed more than once on partial flush

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/PendingTrace.java
@@ -253,7 +253,11 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     // write method.
     healthMetrics.onFinishSpan();
     COMPLETED_SPAN_COUNT.incrementAndGet(this);
-    return decrementRefAndMaybeWrite(span == getRootSpan());
+    final DDSpan rootSpan = getRootSpan();
+    if (span == rootSpan) {
+      tracer.onRootSpanPublished(rootSpan);
+    }
+    return decrementRefAndMaybeWrite(span == rootSpan);
   }
 
   @Override

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -91,6 +91,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.getTimeWithNanoTicks(_)
+    1 * tracer.onRootSpanPublished(span)
     0 * _
 
     when:
@@ -123,6 +124,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * bufferSpy.longRunningSpansEnabled()
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.getTimeWithNanoTicks(_)
+    1 * tracer.onRootSpanPublished(parent)
     0 * _
 
     when:
@@ -180,6 +182,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * traceConfig.getServiceMapping() >> [:]
     _ * tracer.getTimeWithNanoTicks(_)
+    buffer.queue.capacity() * tracer.onRootSpanPublished(_)
     0 * _
 
     when:
@@ -195,6 +198,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * traceConfig.getServiceMapping() >> [:]
     2 * tracer.getTimeWithNanoTicks(_)
+    1 * tracer.onRootSpanPublished(_)
     0 * _
     pendingTrace.isEnqueued == 0
   }
@@ -216,6 +220,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * traceConfig.getServiceMapping() >> [:]
     _ * tracer.getTimeWithNanoTicks(_)
+    buffer.queue.capacity() * tracer.onRootSpanPublished(_)
     0 * _
 
     when:
@@ -223,7 +228,6 @@ class PendingTraceBufferTest extends DDSpecification {
     pendingTrace.longRunningTrackedState = LongRunningTracesTracker.TO_TRACK
     addContinuation(newSpanOf(pendingTrace)).finish()
 
-    then:
     then:
     1 * tracer.captureTraceConfig() >> traceConfig
     1 * bufferSpy.enqueue(_)
@@ -234,6 +238,7 @@ class PendingTraceBufferTest extends DDSpecification {
     _ * tracer.getPartialFlushMinSpans() >> 10
     _ * traceConfig.getServiceMapping() >> [:]
     _ * tracer.getTimeWithNanoTicks(_)
+    1 * tracer.onRootSpanPublished(_)
     0 * _
 
     pendingTrace.isEnqueued == 0
@@ -261,6 +266,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * bufferSpy.enqueue(trace)
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.getTimeWithNanoTicks(_)
+    1 * tracer.onRootSpanPublished(parent)
     0 * _
 
     when:
@@ -314,6 +320,7 @@ class PendingTraceBufferTest extends DDSpecification {
     }
     _ * tracer.getPartialFlushMinSpans() >> 10
     1 * tracer.getTimeWithNanoTicks(_)
+    1 * tracer.onRootSpanPublished(parent)
     0 * _
 
     when:
@@ -409,6 +416,7 @@ class PendingTraceBufferTest extends DDSpecification {
     1 * tracer.getPartialFlushMinSpans() >> 10000
     1 * traceConfig.getServiceMapping() >> [:]
     2 * tracer.getTimeWithNanoTicks(_)
+    1 * tracer.onRootSpanPublished(_)
     0 * _
 
     when: "fail to fill the buffer"

--- a/internal-api/src/main/java/datadog/trace/api/EndpointCheckpointer.java
+++ b/internal-api/src/main/java/datadog/trace/api/EndpointCheckpointer.java
@@ -4,7 +4,9 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 public interface EndpointCheckpointer {
   /**
-   * Callback to be called when a root span is written (together with the trace)
+   * Callback to be called when a root span is finished (together with the trace). With partial
+   * flushes, this may be called multiple times when any of the root span's children are finished
+   * even if the root span is not.
    *
    * @param rootSpan the local root span of the trace
    * @param tracker the endpoint tracker


### PR DESCRIPTION
# What Does This Do

Ensure that AppSec hooks for root span finished run only once.


# Motivation

We had some hooks in `CoreTracer.write` meant to be run whenever a root span is finished. However, they were effectively called not just when the root span finished, but also whenever a partial flush on a child span was performed. This ended up calling the hooks multiple teams, and earlier than expected.

When `DD_APPSEC_ENABLED=true`, this led to `WAF object had not been closed` warnings whenever a partial flush was triggered and the root span was not finished yet.

Reproducing the issue is easier when setting `-Ddd.trace.partial.flush.min.spans=1`.

# Additional Notes

Jira ticket: [APPSEC-53203](https://datadoghq.atlassian.net/browse/APPSEC-53203)

[APPSEC-53203]: https://datadoghq.atlassian.net/browse/APPSEC-53203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ