### PR TITLE
Fix short circuiting of boolean expressions

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BinaryExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BinaryExpression.java
@@ -21,7 +21,7 @@ public final class BinaryExpression implements BooleanExpression {
 
   @Override
   public Boolean evaluate(ValueReferenceResolver valueRefResolver) {
-    return operator.apply(left.evaluate(valueRefResolver), right.evaluate(valueRefResolver));
+    return operator.apply(left, right, valueRefResolver);
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BinaryOperator.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/BinaryOperator.java
@@ -1,18 +1,21 @@
 package com.datadog.debugger.el.expressions;
 
 import com.datadog.debugger.el.Visitor;
+import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
 public enum BinaryOperator {
   AND("&&") {
     @Override
-    public Boolean apply(Boolean left, Boolean right) {
-      return left && right;
+    public Boolean apply(
+        BooleanExpression left, BooleanExpression right, ValueReferenceResolver resolver) {
+      return left.evaluate(resolver) && right.evaluate(resolver);
     }
   },
   OR("||") {
     @Override
-    public Boolean apply(Boolean left, Boolean right) {
-      return left || right;
+    public Boolean apply(
+        BooleanExpression left, BooleanExpression right, ValueReferenceResolver resolver) {
+      return left.evaluate(resolver) || right.evaluate(resolver);
     }
   };
 
@@ -22,7 +25,8 @@ public enum BinaryOperator {
     this.symbol = symbol;
   }
 
-  public abstract Boolean apply(Boolean left, Boolean right);
+  public abstract Boolean apply(
+      BooleanExpression left, BooleanExpression right, ValueReferenceResolver resolver);
 
   public <R> R accept(Visitor<R> visitor) {
     return visitor.visit(this);

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/BinaryExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/BinaryExpressionTest.java
@@ -3,8 +3,10 @@ package com.datadog.debugger.el.expressions;
 import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.el.RefResolverHelper;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class BinaryExpressionTest {
@@ -22,5 +24,27 @@ class BinaryExpressionTest {
         new BinaryExpression(BooleanExpression.TRUE, null, BinaryOperator.AND);
     assertFalse(expression.evaluate(RefResolverHelper.createResolver(this)));
     assertEquals("true && false", print(expression));
+  }
+
+  @Test
+  void testShortCircuitAnd() {
+    BinaryExpression expression =
+        new BinaryExpression(
+            BooleanExpression.FALSE,
+            valueRefResolver -> Assertions.fail("should not reach"),
+            BinaryOperator.AND);
+    assertFalse(expression.evaluate(RefResolverHelper.createResolver(this)));
+    assertEquals("false && null", print(expression));
+  }
+
+  @Test
+  void testShortCircuitOr() {
+    BinaryExpression expression =
+        new BinaryExpression(
+            BooleanExpression.TRUE,
+            valueRefResolver -> Assertions.fail("should not reach"),
+            BinaryOperator.OR);
+    assertTrue(expression.evaluate(RefResolverHelper.createResolver(this)));
+    assertEquals("true || null", print(expression));
   }
 }


### PR DESCRIPTION
# What Does This Do
We are just delegating to the operator evaluation the evaluation of the left and right instead of evaluating operands before the operator.

# Motivation
Boolean expressions with AND (&&) or OR (||) should short circuit as expected for any languages. It helps to support correctly expressions like
`isDefined(@exception) && contains(@exception.detailMessage, 'closed')` 

# Additional Notes

Jira ticket: [DEBUG-2232]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2232]: https://datadoghq.atlassian.net/browse/DEBUG-2232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ