### PR TITLE
upgrade(CI): Run installer system tests using the QA OCI registry

### DIFF
--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -10,6 +10,7 @@
     - export DD_APP_KEY_ONBOARDING=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.dd-app-key-onboarding --with-decryption --query "Parameter.Value" --out text)
     - export ONBOARDING_AWS_INFRA_SUBNET_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.aws-infra-subnet-id --with-decryption --query "Parameter.Value" --out text)
     - export ONBOARDING_AWS_INFRA_SECURITY_GROUPS_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.aws-infra-securiy-groups-id --with-decryption --query "Parameter.Value" --out text)
+    - export ONBOARDING_AWS_INFRA_IAM_INSTANCE_PROFILE=ec2InstanceRole
     - export PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.pulumi-config-passphrase --with-decryption --query "Parameter.Value" --out text) 
     #Install plugins for PULUMI you need connect to gh. Sometimes this problem arises: GitHub rate limit exceeded
     - export GITHUB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.gh-token --with-decryption --query "Parameter.Value" --out text) 
@@ -33,10 +34,34 @@
       paths:
         - system-tests/reports/
 
+oci-internal-publish:
+  extends: .oci-internal-publish
+  stage: package
+  needs: [ package-oci ]
+  rules:
+    - when: on_success
+  variables: 
+    FLAVOR: datadog-apm-library-java
+
+oci-internal-test-ecr-publish:
+  stage: package
+  needs: [ oci-internal-publish ]
+  rules:
+    - when: on_success
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: registry.ddbuild.io/ci/remote-updates/datadog-apm-library-java:pipeline-${CI_PIPELINE_ID}-1
+    IMG_DESTINATIONS: apm-library-java-package:pipeline-${CI_PIPELINE_ID}
+    IMG_REGISTRIES: agent-qa
+
+
 onboarding_tests:
   extends: .base_job_onboarding_tests
   stage: single-step-instrumentation-tests
-  needs: [ package, package-arm]
+  needs: [ package, package-arm, oci-internal-test-ecr-publish ]
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"
       when: on_success
@@ -50,10 +75,13 @@ onboarding_tests:
           SCENARIO: [SIMPLE_HOST_AUTO_INJECTION]
         - ONBOARDING_FILTER_WEBLOG: [test-app-java-container,test-app-java-buildpack,test-app-java-alpine]
           SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION]
+        - ONBOARDING_FILTER_WEBLOG: [test-app-java,test-app-java-container,test-app-java-buildpack,test-app-java-alpine]
+          SCENARIO: [INSTALLER_AUTO_INJECTION]
   script:
     - git clone https://git@github.com/DataDog/system-tests.git system-tests
     - cp packaging/*.rpm system-tests/binaries
     - cp packaging/*.deb system-tests/binaries
+    - export DD_INSTALLER_LIBRARY_VERSION="pipeline-${CI_PIPELINE_ID}"
     - ls system-tests/binaries
     - cd system-tests
     - ./build.sh -i runner


### PR DESCRIPTION
# What Does This Do
Adds installer-based tests to the single step instrumentation steps, using the OCI package that is now pushed to the QA registry on every commit

# Motivation
Single step instrumentation using the datadog installer

# Additional Notes
N/A
