### PR TITLE
Fix the cws tracer on systems using musl libc (like alpine)

### DIFF
--- a/dd-java-agent/cws-tls/src/main/java/datadog/cws/tls/ErpcTls.java
+++ b/dd-java-agent/cws-tls/src/main/java/datadog/cws/tls/ErpcTls.java
@@ -39,7 +39,7 @@ public class ErpcTls implements Tls {
   static int getGettidSyscallId() {
     String arch = System.getProperty("os.arch");
     if (arch.equals("amd64")) {
-        return 186; // 186 is the syscall ID for "gettid" on amd64
+      return 186; // 186 is the syscall ID for "gettid" on amd64
     } else if (arch.equals("arm64")) {
       return 178; // 78 is the syscall ID for "gettid" on arm64
     }
@@ -52,7 +52,7 @@ public class ErpcTls implements Tls {
       return false;
     }
     try {
-        CLibrary.Instance.syscall(new NativeLong(syscallID));
+      CLibrary.Instance.syscall(new NativeLong(syscallID));
     } catch (UnsatisfiedLinkError error) {
       return false;
     }


### PR DESCRIPTION
# What Does This Do

This fixes the CWS on systems using musl, which doesn't expose the `gettid()` syscall. We replace it instead by directly calling syscall with the related syscall ID.

# Motivation

Be able to retrieve trace spans on docker images build upon alpine.

# Additional Notes

Only AMD64 and ARM64 archs are handled.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
