### PR TITLE
Update benchmarks gitlab workflow with circle ci token

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -10,6 +10,7 @@ variables:
   image: $BASE_CI_IMAGE
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && mkdir -p "${ARTIFACTS_DIR}"
+    - export CIRCLE_CI_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.circleci_token --with-decryption --query "Parameter.Value" --out text)
     - git config --global url."https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/".insteadOf "https://github.com/DataDog/"
     - git clone --branch dd-trace-java/tracer-benchmarks https://github.com/DataDog/benchmarking-platform.git /platform && cd /platform
   artifacts:


### PR DESCRIPTION
# What Does This Do
Adds a Circle CI token to the benchmarks workflow so they can use the Circle CI API to query for artifacts and download them. 

# Motivation
The benchmarks runs started to fail without the token intermitently.

# Additional Notes
Depends on: https://github.com/DataDog/benchmarking-platform/pull/65
