### PR TITLE
Disable URL instrumentation by default

### DIFF
--- a/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
+++ b/dd-java-agent/instrumentation/http-url-connection/src/main/java/datadog/trace/instrumentation/http_url_connection/UrlInstrumentation.java
@@ -26,6 +26,11 @@ public class UrlInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
+  protected boolean defaultEnabled() {
+    return false;
+  }
+
+  @Override
   public String instrumentedType() {
     return "java.net.URL";
   }


### PR DESCRIPTION
# What Does This Do

Exceptions during HTTP connections are already captured by `HttpUrlConnectionInstrumentation` so we don't need to also instrument the generic `URL` connection code.

The alternative would be to have an allow (or deny) list of protocols to decide when to report URL connection exceptions as spans.

# Motivation

Avoids creating unnecessary spans when exceptions occur during custom non-HTTP connections, like the custom Jar connection recently added in #7049.

# Additional Notes

* The URL instrumentation can be re-enabled with `DD_INTEGRATION_URLCONNECTION_ENABLED=true`
* The respective instrumentation in OpenTelemetry was also removed for the same reason.
