### PR TITLE
Add circuit breaker for Exception Debugging

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -86,7 +86,10 @@ public class DebuggerAgent {
     if (config.isDebuggerExceptionEnabled()) {
       defaultExceptionDebugger =
           new DefaultExceptionDebugger(
-              configurationUpdater, classNameFiltering, EXCEPTION_CAPTURE_INTERVAL);
+              configurationUpdater,
+              classNameFiltering,
+              EXCEPTION_CAPTURE_INTERVAL,
+              config.getDebuggerMaxExceptionPerSecond());
       DebuggerContext.initExceptionDebugger(defaultExceptionDebugger);
     }
     if (config.isDebuggerInstrumentTheWorld()) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/CircuitBreaker.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/CircuitBreaker.java
@@ -1,0 +1,41 @@
+package com.datadog.debugger.util;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// CircuitBreaker is a simple circuit breaker implementation that allows a certain number of trips
+// within a time window. If the number of trips exceeds the limit, the circuit breaker will trip and
+// return false until the time window has passed.
+public class CircuitBreaker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CircuitBreaker.class);
+
+  private final int maxTrips;
+  private final Duration timeWindow;
+  private AtomicInteger count = new AtomicInteger(0);
+  private volatile long lastResetTime = System.currentTimeMillis();
+  private volatile long lastLoggingTime = System.currentTimeMillis();
+
+  public CircuitBreaker(int maxTrips, Duration timeWindow) {
+    this.maxTrips = maxTrips;
+    this.timeWindow = timeWindow;
+  }
+
+  public boolean trip() {
+    int localCount = count.incrementAndGet();
+    if (localCount > maxTrips) {
+      long currentTime = System.currentTimeMillis();
+      if (currentTime - lastLoggingTime > Duration.ofMinutes(1).toMillis()) {
+        lastLoggingTime = currentTime;
+        LOGGER.debug("Circuit breaker opened");
+      }
+      if (currentTime - lastResetTime > timeWindow.toMillis()) {
+        lastResetTime = currentTime;
+        localCount = 1;
+        count.set(localCount);
+      }
+    }
+    return localCount <= maxTrips;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -60,7 +60,8 @@ class DefaultExceptionDebuggerTest {
     configurationUpdater = mock(ConfigurationUpdater.class);
     classNameFiltering = new ClassNameFiltering(emptySet());
     exceptionDebugger =
-        new DefaultExceptionDebugger(configurationUpdater, classNameFiltering, Duration.ofHours(1));
+        new DefaultExceptionDebugger(
+            configurationUpdater, classNameFiltering, Duration.ofHours(1), 100);
     listener = new TestSnapshotListener(createConfig(), mock(ProbeStatusSink.class));
     DebuggerAgentHelper.injectSink(listener);
   }
@@ -203,7 +204,7 @@ class DefaultExceptionDebuggerTest {
   public void filteringOutErrors() {
     ExceptionProbeManager manager = mock(ExceptionProbeManager.class);
     exceptionDebugger =
-        new DefaultExceptionDebugger(manager, configurationUpdater, classNameFiltering);
+        new DefaultExceptionDebugger(manager, configurationUpdater, classNameFiltering, 100);
     exceptionDebugger.handleException(new AssertionError("test"), mock(AgentSpan.class));
     verify(manager, times(0)).isAlreadyInstrumented(any());
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -326,7 +326,7 @@ public class ExceptionProbeInstrumentationTest {
     DebuggerContext.initValueSerializer(new JsonSnapshotSerializer());
     DefaultExceptionDebugger exceptionDebugger =
         new DefaultExceptionDebugger(
-            exceptionProbeManager, configurationUpdater, classNameFiltering);
+            exceptionProbeManager, configurationUpdater, classNameFiltering, 100);
     DebuggerContext.initExceptionDebugger(exceptionDebugger);
     configurationUpdater.accept(REMOTE_CONFIG, null);
     return listener;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/CircuitBreakerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/CircuitBreakerTest.java
@@ -1,0 +1,37 @@
+package com.datadog.debugger.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.concurrent.locks.LockSupport;
+import org.junit.jupiter.api.Test;
+
+class CircuitBreakerTest {
+
+  @Test
+  void noBreaker() {
+    CircuitBreaker cb = new CircuitBreaker(3, Duration.ofMillis(10));
+    for (int i = 0; i < 10; i++) {
+      assertTrue(cb.trip());
+      LockSupport.parkNanos(Duration.ofMillis(50).toNanos());
+    }
+  }
+
+  @Test
+  void breaker() {
+    CircuitBreaker cb = new CircuitBreaker(3, Duration.ofMillis(200));
+    for (int i = 0; i < 3; i++) {
+      assertTrue(cb.trip());
+    }
+    for (int i = 0; i < 100; i++) {
+      assertFalse(cb.trip());
+    }
+    LockSupport.parkNanos(Duration.ofMillis(250).toNanos());
+    for (int i = 0; i < 3; i++) {
+      assertTrue(cb.trip());
+    }
+    for (int i = 0; i < 100; i++) {
+      assertFalse(cb.trip());
+    }
+  }
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -174,6 +174,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DEBUGGER_SYMBOL_FORCE_UPLOAD = false;
   static final int DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD = 100; // nb of classes
   static final boolean DEFAULT_DEBUGGER_EXCEPTION_ENABLED = false;
+  static final int DEFAULT_DEBUGGER_MAX_EXCEPTION_PER_SECOND = 100;
   static final boolean DEFAULT_DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT = true;
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -31,6 +31,8 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_SYMBOL_FLUSH_THRESHOLD = "symbol.database.flush.threshold";
   public static final String DEBUGGER_EXCEPTION_ENABLED = "exception.debugging.enabled";
   public static final String EXCEPTION_REPLAY_ENABLED = "exception.replay.enabled";
+  public static final String DEBUGGER_MAX_EXCEPTION_PER_SECOND =
+      "exception.replay.max.exception.analysis.limit";
   public static final String DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT =
       "internal.exception.replay.only.local.root";
   public static final String THIRD_PARTY_INCLUDES = "third.party.includes";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -47,6 +47,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_MAX_EXCEPTION_PER_SECOND;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_MAX_PAYLOAD_SIZE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_METRICS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_POLL_INTERVAL;
@@ -213,6 +214,7 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_ENABLED
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_INSTRUMENT_THE_WORLD;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_EXCEPTION_PER_SECOND;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_MAX_PAYLOAD_SIZE;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_METRICS_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_POLL_INTERVAL;
@@ -837,6 +839,7 @@ public class Config {
   private final String debuggerSymbolIncludes;
   private final int debuggerSymbolFlushThreshold;
   private final boolean debuggerExceptionEnabled;
+  private final int debuggerMaxExceptionPerSecond;
   private final boolean debuggerExceptionOnlyLocalRoot;
 
   private final Set<String> debuggerThirdPartyIncludes;
@@ -1891,6 +1894,9 @@ public class Config {
             DEBUGGER_EXCEPTION_ENABLED,
             DEFAULT_DEBUGGER_EXCEPTION_ENABLED,
             EXCEPTION_REPLAY_ENABLED);
+    debuggerMaxExceptionPerSecond =
+        configProvider.getInteger(
+            DEBUGGER_MAX_EXCEPTION_PER_SECOND, DEFAULT_DEBUGGER_MAX_EXCEPTION_PER_SECOND);
     debuggerExceptionOnlyLocalRoot =
         configProvider.getBoolean(
             DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT, DEFAULT_DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT);
@@ -3213,6 +3219,10 @@ public class Config {
 
   public boolean isDebuggerExceptionEnabled() {
     return debuggerExceptionEnabled;
+  }
+
+  public int getDebuggerMaxExceptionPerSecond() {
+    return debuggerMaxExceptionPerSecond;
   }
 
   public boolean isDebuggerExceptionOnlyLocalRoot() {


### PR DESCRIPTION
# What Does This Do
To avoid having a spike of exceptions to analyze
(fingerprint/instrument) we put in front of handling the exception a circuit breaker which open when we reach more than 100 (configurable via `DD_EXCEPTION_REPLAY_MAX_EXCEPTION_ANALYSIS_LIMIT`) per second

# Motivation
Avoid spike of exception to be analyzed which can add overhead

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ