### PR TITLE
Bump byte-buddy to 1.14.16

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
   implementation(gradleApi())
   implementation(localGroovy())
 
-  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.13")
+  implementation("net.bytebuddy", "byte-buddy-gradle-plugin", "1.14.16")
 
   implementation("org.eclipse.aether", "aether-connector-basic", "1.1.0")
   implementation("org.eclipse.aether", "aether-transport-http", "1.1.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -43,8 +43,8 @@ dependencies {
   implementation("org.apache.maven", "maven-aether-provider", "3.3.9")
 
   implementation("com.google.guava", "guava", "20.0")
-  implementation("org.ow2.asm", "asm", "9.6")
-  implementation("org.ow2.asm", "asm-tree", "9.6")
+  implementation("org.ow2.asm", "asm", "9.7")
+  implementation("org.ow2.asm", "asm-tree", "9.7")
 
   testImplementation("org.spockframework", "spock-core", "2.2-groovy-3.0")
   testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
   implementation("org.ow2.asm", "asm-tree", "9.0")
   implementation("com.github.javaparser", "javaparser-symbol-solver-core", "3.24.4")
 
-  testImplementation("net.bytebuddy", "byte-buddy", "1.14.13")
+  testImplementation("net.bytebuddy", "byte-buddy", "1.14.16")
   testImplementation("org.spockframework", "spock-core", "2.0-groovy-3.0")
   testImplementation("org.objenesis", "objenesis", "3.0.1")
   testImplementation("org.codehaus.groovy", "groovy-all", "3.0.17")

--- a/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
+++ b/buildSrc/src/test/groovy/CallSiteInstrumentationPluginTest.groovy
@@ -27,7 +27,7 @@ class CallSiteInstrumentationPluginTest extends Specification {
     }
     
     dependencies {
-      implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.13'
+      implementation group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.16'
       implementation group: 'com.google.auto.service', name: 'auto-service-annotations', version: '1.0-rc7'
     }
   '''

--- a/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
+++ b/buildSrc/src/test/groovy/InstrumentPluginTest.groovy
@@ -23,7 +23,7 @@ class InstrumentPluginTest extends Specification {
     }
 
     dependencies {
-      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.13' // just to build TestPlugin
+      compileOnly group: 'net.bytebuddy', name: 'byte-buddy', version: '1.14.16' // just to build TestPlugin
     }
 
     apply plugin: 'instrument'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -14,7 +14,7 @@ final class CachedData {
     groovy        : groovyVer,
     junit5        : "5.9.2",
     logback       : "1.2.3",
-    bytebuddy     : "1.14.13",
+    bytebuddy     : "1.14.16",
     scala         : "2.11.12",  // Last version to support Java 7 (2.12+ require Java 8+)
     scala210      : "2.10.7",
     scala211      : "2.11.12",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -34,7 +34,7 @@ final class CachedData {
     jmc           : "8.1.0",
     autoservice   : "1.0-rc7",
     ddprof        : "1.7.0",
-    asm           : "9.6",
+    asm           : "9.7",
     cafe_crypto   : "0.1.0",
     lz4           : "1.7.1"
   ]


### PR DESCRIPTION
Supports transforming Java 23 bytecode

Changes since last update:
* Update ASM and introduce support for Java 23.
* Allow attaching from root on J9.
* Adjust type validation to accept additional names that are legal in the class file format.
* Fix dynamic attach on Windows when a service user is active.
* Avoid failure when using Android's strict mode.

Also updates the ASM dependencies in our build to 9.7 to match