### PR TITLE
Add grpc.server.method to WAF addresses with FQN of the grpc method

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -93,6 +93,8 @@ public interface KnownAddresses {
   Address<CaseInsensitiveMap<List<String>>> HEADERS_NO_COOKIES =
       new Address<>("server.request.headers.no_cookies");
 
+  Address<Object> GRPC_SERVER_METHOD = new Address<>("grpc.server.method");
+
   Address<Object> GRPC_SERVER_REQUEST_MESSAGE = new Address<>("grpc.server.request.message");
 
   // XXX: Not really used yet, but it's a known address and we should not treat it as unknown.
@@ -159,6 +161,8 @@ public interface KnownAddresses {
         return REQUEST_QUERY;
       case "server.request.headers.no_cookies":
         return HEADERS_NO_COOKIES;
+      case "grpc.server.method":
+        return GRPC_SERVER_METHOD;
       case "grpc.server.request.message":
         return GRPC_SERVER_REQUEST_MESSAGE;
       case "grpc.server.request.metadata":

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -61,7 +61,7 @@ public class GatewayBridge {
   private static final Pattern QUERY_PARAM_VALUE_SPLITTER = Pattern.compile("=");
   private static final Pattern QUERY_PARAM_SPLITTER = Pattern.compile("&");
   private static final Map<String, List<String>> EMPTY_QUERY_PARAMS = Collections.emptyMap();
-  private static final char GRPC_METHOD_START = '/';
+  private static final String GRPC_FULL_METHOD_NAME_TAG = "rpc.grpc.full_method";
 
   /** User tracking tags that will force the collection of request headers */
   private static final String[] USER_TRACKING_TAGS = {
@@ -370,6 +370,9 @@ public class GatewayBridge {
           if (ctx == null || method == null || method.isEmpty()) {
             return NoopFlow.INSTANCE;
           }
+          // set the tag used by the backend to generate the grpc pass-lists
+          TraceSegment segment = ctx_.getTraceSegment();
+          segment.setTagCurrent(GRPC_FULL_METHOD_NAME_TAG, method);
           while (true) {
             DataSubscriberInfo subInfo = grpcServerMethodSubInfo;
             if (subInfo == null) {
@@ -378,9 +381,6 @@ public class GatewayBridge {
             }
             if (subInfo == null || subInfo.isEmpty()) {
               return NoopFlow.INSTANCE;
-            }
-            if (method.charAt(0) != GRPC_METHOD_START) {
-              method = GRPC_METHOD_START + method;
             }
             DataBundle bundle =
                 new SingletonDataBundle<>(KnownAddresses.GRPC_SERVER_METHOD, method);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -61,6 +61,7 @@ public class GatewayBridge {
   private static final Pattern QUERY_PARAM_VALUE_SPLITTER = Pattern.compile("=");
   private static final Pattern QUERY_PARAM_SPLITTER = Pattern.compile("&");
   private static final Map<String, List<String>> EMPTY_QUERY_PARAMS = Collections.emptyMap();
+  private static final char GRPC_METHOD_START = '/';
 
   /** User tracking tags that will force the collection of request headers */
   private static final String[] USER_TRACKING_TAGS = {
@@ -366,7 +367,7 @@ public class GatewayBridge {
         EVENTS.grpcServerMethod(),
         (ctx_, method) -> {
           AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
-          if (ctx == null) {
+          if (ctx == null || method == null || method.isEmpty()) {
             return NoopFlow.INSTANCE;
           }
           while (true) {
@@ -377,6 +378,9 @@ public class GatewayBridge {
             }
             if (subInfo == null || subInfo.isEmpty()) {
               return NoopFlow.INSTANCE;
+            }
+            if (method.charAt(0) != GRPC_METHOD_START) {
+              method = GRPC_METHOD_START + method;
             }
             DataBundle bundle =
                 new SingletonDataBundle<>(KnownAddresses.GRPC_SERVER_METHOD, method);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -61,7 +61,6 @@ public class GatewayBridge {
   private static final Pattern QUERY_PARAM_VALUE_SPLITTER = Pattern.compile("=");
   private static final Pattern QUERY_PARAM_SPLITTER = Pattern.compile("&");
   private static final Map<String, List<String>> EMPTY_QUERY_PARAMS = Collections.emptyMap();
-  private static final String GRPC_FULL_METHOD_NAME_TAG = "rpc.grpc.full_method";
 
   /** User tracking tags that will force the collection of request headers */
   private static final String[] USER_TRACKING_TAGS = {
@@ -370,9 +369,6 @@ public class GatewayBridge {
           if (ctx == null || method == null || method.isEmpty()) {
             return NoopFlow.INSTANCE;
           }
-          // set the tag used by the backend to generate the grpc pass-lists
-          TraceSegment segment = ctx_.getTraceSegment();
-          segment.setTagCurrent(GRPC_FULL_METHOD_NAME_TAG, method);
           while (true) {
             DataSubscriberInfo subInfo = grpcServerMethodSubInfo;
             if (subInfo == null) {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -28,6 +28,7 @@ class KnownAddressesSpecification extends Specification {
       'server.request.body.combined_file_size',
       'server.request.query',
       'server.request.headers.no_cookies',
+      'grpc.server.method',
       'grpc.server.request.message',
       'grpc.server.request.metadata',
       'graphql.server.all_resolvers',
@@ -41,7 +42,7 @@ class KnownAddressesSpecification extends Specification {
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 29
+    Address.instanceCount() == 30
     KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }

--- a/dd-java-agent/instrumentation/armeria-grpc/src/test/groovy/ArmeriaGrpcTest.groovy
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/test/groovy/ArmeriaGrpcTest.groovy
@@ -45,6 +45,7 @@ abstract class ArmeriaGrpcTest extends VersionedNamingTestBase {
 
   def collectedAppSecHeaders = [:]
   boolean appSecHeaderDone = false
+  def collectedAppSecServerMethods = []
   def collectedAppSecReqMsgs = []
 
   final Duration timeoutDuration() {
@@ -97,6 +98,10 @@ abstract class ArmeriaGrpcTest extends VersionedNamingTestBase {
       collectedAppSecReqMsgs << obj
       Flow.ResultFlow.empty()
     } as BiFunction<RequestContext, Object, Flow<Void>>)
+    ig.registerCallback(EVENTS.grpcServerMethod(), { reqCtx, method ->
+      collectedAppSecServerMethods << method
+      Flow.ResultFlow.empty()
+    } as BiFunction<RequestContext, String, Flow<Void>>)
   }
 
   def cleanup() {
@@ -230,6 +235,8 @@ abstract class ArmeriaGrpcTest extends VersionedNamingTestBase {
     traceId.toLong() as String == collectedAppSecHeaders['x-datadog-trace-id']
     collectedAppSecReqMsgs.size() == 1
     collectedAppSecReqMsgs.first().name == name
+    collectedAppSecServerMethods.size() == 1
+    collectedAppSecServerMethods.first() == 'example.Greeter/SayHello'
 
     and:
     if (isDataStreamsEnabled()) {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -27,6 +27,7 @@ import io.grpc.ForwardingServerCall;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Grpc;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
@@ -75,6 +76,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
     if (reqContext != null) {
       callIGCallbackClientAddress(cbp, reqContext, call);
       callIGCallbackHeaders(cbp, reqContext, headers);
+      callIGCallbackGrpcServerMethod(cbp, reqContext, call.getMethodDescriptor());
     }
 
     DECORATE.afterStart(span);
@@ -312,6 +314,16 @@ public class TracingServerInterceptor implements ServerInterceptor {
         callback.apply(requestContext, span);
       }
     }
+  }
+
+  private static <ReqT, RespT> void callIGCallbackGrpcServerMethod(
+      CallbackProvider cbp, RequestContext ctx, MethodDescriptor<ReqT, RespT> methodDescriptor) {
+    String method = methodDescriptor.getFullMethodName();
+    BiFunction<RequestContext, String, Flow<Void>> cb = cbp.getCallback(EVENTS.grpcServerMethod());
+    if (method == null || cb == null) {
+      return;
+    }
+    cb.apply(ctx, method);
   }
 
   private static void callIGCallbackGrpcMessage(@Nonnull final AgentSpan span, Object obj) {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -47,6 +47,7 @@ abstract class GrpcTest extends VersionedNamingTestBase {
   def collectedAppSecHeaders = [:]
   boolean appSecHeaderDone = false
   def collectedAppSecReqMsgs = []
+  def collectedAppSecServerMethods = []
 
   @Override
   final String service() {
@@ -89,6 +90,10 @@ abstract class GrpcTest extends VersionedNamingTestBase {
       collectedAppSecReqMsgs << obj
       Flow.ResultFlow.empty()
     } as BiFunction<RequestContext, Object, Flow<Void>>)
+    ig.registerCallback(EVENTS.grpcServerMethod(), { reqCtx, method ->
+      collectedAppSecServerMethods << method
+      Flow.ResultFlow.empty()
+    } as BiFunction<RequestContext, String, Flow<Void>>)
   }
 
   def cleanup() {
@@ -217,6 +222,8 @@ abstract class GrpcTest extends VersionedNamingTestBase {
     traceId.toLong() as String == collectedAppSecHeaders['x-datadog-trace-id']
     collectedAppSecReqMsgs.size() == 1
     collectedAppSecReqMsgs.first().name == name
+    collectedAppSecServerMethods.size() == 1
+    collectedAppSecServerMethods.first() == 'example.Greeter/SayHello'
 
     and:
     if (isDataStreamsEnabled()) {

--- a/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/AbstractSpringBootWithGRPCAppSecTest.groovy
+++ b/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/AbstractSpringBootWithGRPCAppSecTest.groovy
@@ -1,0 +1,24 @@
+package datadog.smoketest.appsec
+
+abstract class AbstractSpringBootWithGRPCAppSecTest extends AbstractAppSecServerSmokeTest {
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    String springBootShadowJar = System.getProperty("datadog.smoketest.appsec.springboot-grpc.shadowJar.path")
+    assert springBootShadowJar != null
+
+    List<String> command = [
+      javaPath(),
+      *defaultJavaProperties,
+      *defaultAppSecProperties,
+      "-jar",
+      springBootShadowJar,
+      "--server.port=${httpPort}"
+    ].collect { it as String }
+
+    ProcessBuilder processBuilder = new ProcessBuilder(command)
+    processBuilder.directory(new File(buildDirectory))
+  }
+
+  static final String ROUTE = 'async_annotation_greeting'
+}

--- a/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerMethodTest.groovy
+++ b/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerMethodTest.groovy
@@ -28,9 +28,9 @@ class ServerMethodTest extends AbstractSpringBootWithGRPCAppSecTest {
           [
             parameters: [
               inputs: [[address: 'grpc.server.method']],
-              list : ['/smoketest.Greeter/Hello'],
+              regex : 'Greeter',
             ],
-            operator  : 'phrase_match',
+            operator  : 'match_regex',
           ]
         ],
         transformers: [],
@@ -66,6 +66,5 @@ class ServerMethodTest extends AbstractSpringBootWithGRPCAppSecTest {
     match != null
     match['parameters'][0]['address'] == 'grpc.server.method'
     match['parameters'][0]['value'] == 'smoketest.Greeter/Hello'
-    grpcRootSpan.meta['rpc.grpc.full_method'] == 'smoketest.Greeter/Hello'
   }
 }

--- a/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerMethodTest.groovy
+++ b/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerMethodTest.groovy
@@ -1,0 +1,67 @@
+package datadog.smoketest.appsec
+
+
+import okhttp3.Request
+import spock.lang.Shared
+
+class ServerMethodTest extends AbstractSpringBootWithGRPCAppSecTest {
+
+  @Shared
+  String buildDir = new File(System.getProperty("datadog.smoketest.builddir")).absolutePath
+  @Shared
+  String customRulesPath = "${buildDir}/appsec_custom_rules.json"
+
+  @Override
+  ProcessBuilder createProcessBuilder() {
+    // We run this here to ensure it runs before starting the process. Child setupSpec runs after parent setupSpec,
+    // so it is not a valid location.
+    appendRules(customRulesPath, [
+      [
+        id          : '__test_server_method_bock',
+        name        : 'test rule to block on server method',
+        tags        : [
+          type      : 'test',
+          category  : 'test',
+          confidence: '1',
+        ],
+        conditions  : [
+          [
+            parameters: [
+              inputs: [[address: 'grpc.server.method']],
+              regex : '^smoketest',
+            ],
+            operator  : 'match_regex',
+          ]
+        ],
+        transformers: [],
+        on_match    : ['block']
+      ]
+    ])
+    return super.createProcessBuilder()
+  }
+
+  void 'test grpc.server.method address'() {
+    setup:
+    String url = "http://localhost:${httpPort}/${ROUTE}"
+    def request = new Request.Builder()
+      .url("${url}?message=${'Hello!'.bytes.encodeBase64()}")
+      .get().build()
+
+    when:
+    def response = client.newCall(request).execute()
+
+    then:
+    def responseBodyStr = response.body().string()
+    responseBodyStr != null
+    responseBodyStr.contains("bye")
+    response.body().contentType().toString().contains("text/plain")
+    response.code() == 200
+
+    and:
+    waitForTraceCount(2) == 2
+    rootSpans.size() == 2
+    def grpcRootSpan = rootSpans.find { it.triggers }
+    grpcRootSpan != null
+    grpcRootSpan.triggers[0]['rule_matches'][0]['parameters']['address'][0] == 'grpc.server.method'
+  }
+}

--- a/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerMethodTest.groovy
+++ b/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerMethodTest.groovy
@@ -65,6 +65,7 @@ class ServerMethodTest extends AbstractSpringBootWithGRPCAppSecTest {
     def match = grpcRootSpan.triggers[0]['rule_matches'][0]
     match != null
     match['parameters'][0]['address'] == 'grpc.server.method'
-    match['parameters'][0]['value'] == '/smoketest.Greeter/Hello'
+    match['parameters'][0]['value'] == 'smoketest.Greeter/Hello'
+    grpcRootSpan.meta['rpc.grpc.full_method'] == 'smoketest.Greeter/Hello'
   }
 }

--- a/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerMethodTest.groovy
+++ b/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerMethodTest.groovy
@@ -28,9 +28,9 @@ class ServerMethodTest extends AbstractSpringBootWithGRPCAppSecTest {
           [
             parameters: [
               inputs: [[address: 'grpc.server.method']],
-              regex : '^smoketest',
+              list : ['/smoketest.Greeter/Hello'],
             ],
-            operator  : 'match_regex',
+            operator  : 'phrase_match',
           ]
         ],
         transformers: [],
@@ -62,6 +62,9 @@ class ServerMethodTest extends AbstractSpringBootWithGRPCAppSecTest {
     rootSpans.size() == 2
     def grpcRootSpan = rootSpans.find { it.triggers }
     grpcRootSpan != null
-    grpcRootSpan.triggers[0]['rule_matches'][0]['parameters']['address'][0] == 'grpc.server.method'
+    def match = grpcRootSpan.triggers[0]['rule_matches'][0]
+    match != null
+    match['parameters'][0]['address'] == 'grpc.server.method'
+    match['parameters'][0]['value'] == '/smoketest.Greeter/Hello'
   }
 }

--- a/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerRequestMessageTest.groovy
+++ b/dd-smoke-tests/appsec/springboot-grpc/src/test/groovy/datadog/smoketest/appsec/ServerRequestMessageTest.groovy
@@ -3,29 +3,9 @@ package datadog.smoketest.appsec
 
 import okhttp3.Request
 
-class SpringBootWithGRPCAppSecTest extends AbstractAppSecServerSmokeTest {
+class ServerRequestMessageTest extends AbstractSpringBootWithGRPCAppSecTest {
 
-  @Override
-  ProcessBuilder createProcessBuilder() {
-    String springBootShadowJar = System.getProperty("datadog.smoketest.appsec.springboot-grpc.shadowJar.path")
-    assert springBootShadowJar != null
-
-    List<String> command = [
-      javaPath(),
-      *defaultJavaProperties,
-      *defaultAppSecProperties,
-      "-jar",
-      springBootShadowJar,
-      "--server.port=${httpPort}"
-    ].collect { it as String }
-
-    ProcessBuilder processBuilder = new ProcessBuilder(command)
-    processBuilder.directory(new File(buildDirectory))
-  }
-
-  static final String ROUTE = 'async_annotation_greeting'
-
-  def greeter() {
+  void 'test grpc.server.request.message address'() {
     setup:
     String url = "http://localhost:${httpPort}/${ROUTE}"
     def request = new Request.Builder()

--- a/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
@@ -4,11 +4,15 @@ import datadog.smoketest.AbstractServerSmokeTest
 import datadog.trace.test.agent.decoder.DecodedSpan
 import datadog.trace.test.agent.decoder.DecodedTrace
 import datadog.trace.test.agent.decoder.Decoder
+import groovy.json.JsonGenerator
 import groovy.json.JsonSlurper
+import org.apache.commons.io.IOUtils
 import spock.lang.Shared
 
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.jar.JarFile
 
 abstract class AbstractAppSecServerSmokeTest extends AbstractServerSmokeTest {
 
@@ -77,5 +81,24 @@ abstract class AbstractAppSecServerSmokeTest extends AbstractServerSmokeTest {
       assert it.meta.get('_dd.appsec.json') != null, 'No attack detected'
     }
     rootSpans.collectMany {it.triggers }.forEach closure
+  }
+
+  /**
+   * This method fetches default ruleset included in the agent and appends the selected rules, then it points
+   * the {@code dd.appsec.rules} variable to the new file
+   */
+  void appendRules(final String path, final List<Map<String, Object>> customRules) {
+    // Prepare a file with the new rules
+    final jarFile = new JarFile(shadowJarPath)
+    final zipEntry = jarFile.getEntry("appsec/default_config.json")
+    final content = IOUtils.toString(jarFile.getInputStream(zipEntry), StandardCharsets.UTF_8)
+    final json = new JsonSlurper().parseText(content) as Map<String, Object>
+    final rules = json.rules as List<Map<String, Object>>
+    rules.addAll(customRules)
+    final gen = new JsonGenerator.Options().build()
+    IOUtils.write(gen.toJson(json), new FileOutputStream(path, false), StandardCharsets.UTF_8)
+
+    // Add a new property pointing to the new ruleset
+    defaultAppSecProperties += "-Ddd.appsec.rules=${path}" as String
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -225,6 +225,17 @@ public final class Events<D> {
     return (EventType<BiConsumer<RequestContext, String>>) DATABASE_SQL_QUERY;
   }
 
+  static final int GRPC_SERVER_METHOD_ID = 18;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType GRPC_SERVER_METHOD =
+      new ET<>("grpc.server.method", GRPC_SERVER_METHOD_ID);
+
+  @SuppressWarnings("unchecked")
+  public EventType<BiFunction<RequestContext, String, Flow<Void>>> grpcServerMethod() {
+    return (EventType<BiFunction<RequestContext, String, Flow<Void>>>) GRPC_SERVER_METHOD;
+  }
+
   static final int MAX_EVENTS = nextId.get();
 
   private static final class ET<T> extends EventType<T> {

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -3,6 +3,7 @@ package datadog.trace.api.gateway;
 import static datadog.trace.api.gateway.Events.DATABASE_CONNECTION_ID;
 import static datadog.trace.api.gateway.Events.DATABASE_SQL_QUERY_ID;
 import static datadog.trace.api.gateway.Events.GRAPHQL_SERVER_REQUEST_MESSAGE_ID;
+import static datadog.trace.api.gateway.Events.GRPC_SERVER_METHOD_ID;
 import static datadog.trace.api.gateway.Events.GRPC_SERVER_REQUEST_MESSAGE_ID;
 import static datadog.trace.api.gateway.Events.MAX_EVENTS;
 import static datadog.trace.api.gateway.Events.REQUEST_BODY_CONVERTED_ID;
@@ -287,6 +288,7 @@ public class InstrumentationGateway {
                 return callback.equals(obj);
               }
             };
+      case GRPC_SERVER_METHOD_ID:
       case REQUEST_INFERRED_CLIENT_ADDRESS_ID:
         return (C)
             new BiFunction<RequestContext, String, Flow<Void>>() {

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -185,6 +185,9 @@ public class InstrumentationGatewayTest {
     ss.registerCallback(events.requestBodyProcessed(), callback);
     assertThat(cbp.getCallback(events.requestBodyProcessed()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
+    ss.registerCallback(events.grpcServerMethod(), callback);
+    assertThat(cbp.getCallback(events.grpcServerMethod()).apply(null, null).getAction())
+        .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.grpcServerRequestMessage(), callback);
     assertThat(cbp.getCallback(events.grpcServerRequestMessage()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
@@ -237,6 +240,9 @@ public class InstrumentationGatewayTest {
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.requestBodyProcessed(), throwback);
     assertThat(cbp.getCallback(events.requestBodyProcessed()).apply(null, null).getAction())
+        .isEqualTo(Flow.Action.Noop.INSTANCE);
+    ss.registerCallback(events.grpcServerMethod(), throwback);
+    assertThat(cbp.getCallback(events.grpcServerMethod()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.grpcServerRequestMessage(), throwback);
     assertThat(cbp.getCallback(events.grpcServerRequestMessage()).apply(null, null).getAction())


### PR DESCRIPTION
# What Does This Do
Adds a new WAF address named `grpc.server.method` with the FQN of the grpc method

# Motivation

# Additional Notes

Jira ticket: [APPSEC-51748]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-51748]: https://datadoghq.atlassian.net/browse/APPSEC-51748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ