### PR TITLE
Create commmon backend-mock module to use in smoke tests

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilitySmokeTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilitySmokeTest.groovy
@@ -1,181 +1,11 @@
 package datadog.trace.civisibility
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import datadog.trace.agent.test.server.http.TestHttpServer
-import datadog.trace.test.util.MultipartRequestParser
-import org.apache.commons.io.IOUtils
-import org.msgpack.jackson.dataformat.MessagePackFactory
-import spock.lang.AutoCleanup
-import spock.lang.Shared
+
 import spock.lang.Specification
-import spock.util.concurrent.PollingConditions
-
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.zip.GZIPInputStream
-import java.util.zip.GZIPOutputStream
-
-import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
 
 abstract class CiVisibilitySmokeTest extends Specification {
 
-  @Shared
-  ObjectMapper msgPackMapper = new ObjectMapper(new MessagePackFactory())
-
-  @Shared
-  Queue<Map<String, Object>> receivedTraces = new ConcurrentLinkedQueue<>()
-
-  @Shared
-  Queue<Map<String, Object>> receivedCoverages = new ConcurrentLinkedQueue<>()
-
-  @Shared
-  Queue<Map<String, Object>> receivedTelemetryMetrics = new ConcurrentLinkedQueue<>()
-
-  @Shared
-  Queue<Map<String, Object>> receivedTelemetryDistributions = new ConcurrentLinkedQueue<>()
-
-  @Shared
-  boolean codeCoverageEnabled = true
-
-  @Shared
-  boolean testsSkippingEnabled = true
-
-  @Shared
-  boolean flakyRetriesEnabled = false
-
-  def setup() {
-    receivedTraces.clear()
-    receivedCoverages.clear()
-    receivedTelemetryMetrics.clear()
-    receivedTelemetryDistributions.clear()
-  }
-
-  @Shared
-  @AutoCleanup
-  protected TestHttpServer intakeServer = httpServer {
-    handlers {
-      prefix("/api/v2/citestcycle") {
-        def contentEncodingHeader = request.getHeader("Content-Encoding")
-        def gzipEnabled = contentEncodingHeader != null && contentEncodingHeader.contains("gzip")
-        def requestBody = gzipEnabled ? CiVisibilitySmokeTest.decompress(request.body) : request.body
-        def decodedEvent = msgPackMapper.readValue(requestBody, Map)
-        receivedTraces.add(decodedEvent)
-
-        response.status(200).send()
-      }
-
-      prefix("/api/v2/citestcov") {
-        def contentEncodingHeader = request.getHeader("Content-Encoding")
-        def gzipEnabled = contentEncodingHeader != null && contentEncodingHeader.contains("gzip")
-        def requestBody = gzipEnabled ? CiVisibilitySmokeTest.decompress(request.body) : request.body
-        def parsed = MultipartRequestParser.parseRequest(requestBody, request.headers.get("Content-Type"))
-        def coverages = parsed.get("coverage1")
-        for (def coverage : coverages) {
-          def decodedCoverage = msgPackMapper.readValue(coverage.get(), Map)
-          receivedCoverages.add(decodedCoverage)
-        }
-
-        response.status(202).send()
-      }
-
-      prefix("/api/v2/libraries/tests/services/setting") {
-        // not compressing settings response on purpose, to better mimic real backend behavior:
-        // it may choose to compress the response or not based on its size,
-        // so smaller responses (like those of /setting endpoint) are uncompressed,
-        // while the larger ones (skippable and flaky test lists) are compressed
-        response.status(200).send(('{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { '
-          + '"code_coverage": ' + codeCoverageEnabled
-          + ', "tests_skipping": ' + testsSkippingEnabled
-          + ', "flaky_test_retries_enabled": ' + flakyRetriesEnabled +  '} } }').bytes)
-      }
-
-      prefix("/api/v2/ci/tests/skippable") {
-        response.status(200).addHeader("Content-Encoding", "gzip").send(CiVisibilitySmokeTest.compress(('{ "data": [{' +
-          '  "id": "d230520a0561ee2f",' +
-          '  "type": "test",' +
-          '  "attributes": {' +
-          '    "configurations": {' +
-          '        "test.bundle": "Maven Smoke Tests Project maven-surefire-plugin default-test"' +
-          '    },' +
-          '    "name": "test_to_skip_with_itr",' +
-          '    "suite": "datadog.smoke.TestSucceed"' +
-          '  }' +
-          '}, {' +
-          '  "id": "d230520a0561ee2g",' +
-          '  "type": "test",' +
-          '  "attributes": {' +
-          '    "configurations": {' +
-          '        "test.bundle": ":test"' +
-          '    },' +
-          '    "name": "test_to_skip_with_itr",' +
-          '    "suite": "datadog.smoke.TestSucceed"' +
-          '  }' +
-          '}] ' +
-          '}').bytes))
-      }
-
-      prefix("/api/v2/ci/libraries/tests/flaky") {
-        response.status(200).addHeader("Content-Encoding", "gzip").send(CiVisibilitySmokeTest.compress(('{ "data": [{' +
-          '  "id": "d230520a0561ee2f",' +
-          '  "type": "test",' +
-          '  "attributes": {' +
-          '    "configurations": {' +
-          '        "test.bundle": "Maven Smoke Tests Project maven-surefire-plugin default-test"' +
-          '    },' +
-          '    "name": "test_failed",' +
-          '    "suite": "datadog.smoke.TestFailed"' +
-          '  }' +
-          '}, {' +
-          '  "id": "d230520a0561ee2g",' +
-          '  "type": "test",' +
-          '  "attributes": {' +
-          '    "configurations": {' +
-          '        "test.bundle": ":test"' +
-          '    },' +
-          '    "name": "test_failed",' +
-          '    "suite": "datadog.smoke.TestFailed"' +
-          '  }' +
-          '}] ' +
-          '}').bytes))
-      }
-
-      prefix("/api/v2/apmtelemetry") {
-        def telemetryRequest = CiVisibilityTestUtils.JSON_MAPPER.readerFor(Map.class).readValue(request.body)
-        def requestType = telemetryRequest["request_type"]
-        if (requestType == "message-batch") {
-          for (def message : telemetryRequest["payload"]) {
-            def payload = message["payload"]
-            if (message["request_type"] == 'generate-metrics') {
-              receivedTelemetryMetrics.addAll((List) payload["series"])
-            } else if (message["request_type"] == 'distributions') {
-              receivedTelemetryDistributions.addAll((List) payload["series"])
-            }
-          }
-        }
-        response.status(202).send()
-      }
-    }
-  }
-
-  private static byte[] compress(byte[] bytes) {
-    def baos = new ByteArrayOutputStream()
-    try (GZIPOutputStream zip = new GZIPOutputStream(baos)) {
-      IOUtils.copy(new ByteArrayInputStream(bytes), zip)
-    }
-    return baos.toByteArray()
-  }
-
-  private static byte[] decompress(byte[] bytes) {
-    def baos = new ByteArrayOutputStream()
-    try (GZIPInputStream zip = new GZIPInputStream(new ByteArrayInputStream(bytes))) {
-      IOUtils.copy(zip, baos)
-    }
-    return baos.toByteArray()
-  }
-
-  protected verifyEventsAndCoverages(String projectName, String toolchain, String toolchainVersion, int expectedEventsCount, int expectedCoveragesCount) {
-    def events = waitForEvents(expectedEventsCount)
-    def coverages = waitForCoverages(expectedCoveragesCount)
-
+  protected verifyEventsAndCoverages(String projectName, String toolchain, String toolchainVersion, List<Map<String, Object>> events, List<Map<String, Object>> coverages) {
     def additionalReplacements = ["content.meta.['test.toolchain']": "$toolchain:$toolchainVersion"]
 
     // uncomment to generate expected data templates
@@ -192,7 +22,7 @@ abstract class CiVisibilitySmokeTest extends Specification {
    * Currently the check is not performed for Gradle builds:
    * Gradle daemon started with Gradle TestKit outlives the test, so the final telemetry flush happens after the assertions.
    */
-  protected verifyTelemetryMetrics( int expectedEventsCount) {
+  protected verifyTelemetryMetrics(List<Map<String, Object>> receivedTelemetryMetrics, List<Map<String, Object>> receivedTelemetryDistributions, int expectedEventsCount) {
     int eventsCreated = 0, eventsFinished = 0
     for (Map<String, Object> metric : receivedTelemetryMetrics) {
       if (metric["metric"] == "event_created") {
@@ -211,37 +41,5 @@ abstract class CiVisibilitySmokeTest extends Specification {
 
     // an even more basic smoke check for distributions: assert that we received some
     assert !receivedTelemetryDistributions.isEmpty()
-  }
-
-  protected List<Map<String, Object>> waitForEvents(int expectedEventsSize) {
-    def traceReceiveConditions = new PollingConditions(timeout: 15, initialDelay: 1, delay: 0.5, factor: 1)
-    traceReceiveConditions.eventually {
-      int eventsSize = 0
-      for (Map<String, Object> trace : receivedTraces) {
-        eventsSize += trace["events"].size()
-      }
-      assert eventsSize >= expectedEventsSize
-    }
-
-    List<Map<String, Object>> events = new ArrayList<>()
-    while (!receivedTraces.isEmpty()) {
-      def trace = receivedTraces.poll()
-      events.addAll((List<Map<String, Object>>) trace["events"])
-    }
-    return events
-  }
-
-  protected List<Map<String, Object>> waitForCoverages(int traceSize) {
-    def traceReceiveConditions = new PollingConditions(timeout: 15, initialDelay: 1, delay: 0.5, factor: 1)
-    traceReceiveConditions.eventually {
-      assert receivedCoverages.size() == traceSize
-    }
-
-    List<Map<String, Object>> coverages = new ArrayList<>()
-    while (!receivedCoverages.isEmpty()) {
-      def trace = receivedCoverages.poll()
-      coverages.addAll((List<Map<String, Object>>) trace["coverages"])
-    }
-    return coverages
   }
 }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
@@ -290,6 +290,8 @@ public abstract class MavenUtils {
   private static final MethodHandle SESSION_FIELD =
       METHOD_HANDLES.privateFieldGetter(MavenSession.class, "session");
   private static final MethodHandle LOOKUP_FIELD =
+      METHOD_HANDLES.privateFieldGetter("org.apache.maven.internal.impl.AbstractSession", "lookup");
+  private static final MethodHandle ALTERNATIVE_LOOKUP_FIELD =
       METHOD_HANDLES.privateFieldGetter("org.apache.maven.internal.impl.DefaultSession", "lookup");
   private static final MethodHandle LOOKUP_METHOD =
       METHOD_HANDLES.method("org.apache.maven.api.services.Lookup", "lookup", Class.class);
@@ -301,8 +303,12 @@ public abstract class MavenUtils {
     }
     Object /* org.apache.maven.internal.impl.DefaultSession */ session =
         METHOD_HANDLES.invoke(SESSION_FIELD, mavenSession);
-    Object /* org.apache.maven.api.services.Lookup */ lookup =
-        METHOD_HANDLES.invoke(LOOKUP_FIELD, session);
+    Object /* org.apache.maven.api.services.Lookup */ lookup;
+    if (LOOKUP_FIELD != null) {
+      lookup = METHOD_HANDLES.invoke(LOOKUP_FIELD, session);
+    } else {
+      lookup = METHOD_HANDLES.invoke(ALTERNATIVE_LOOKUP_FIELD, session);
+    }
     return METHOD_HANDLES.invoke(LOOKUP_METHOD, lookup, PlexusContainer.class);
   }
 }

--- a/dd-smoke-tests/backend-mock/build.gradle
+++ b/dd-smoke-tests/backend-mock/build.gradle
@@ -1,0 +1,7 @@
+apply from: "$rootDir/gradle/java.gradle"
+description = 'Mock Datadog backend used by smoke tests.'
+
+dependencies {
+  api project(':dd-smoke-tests')
+  api testFixtures(project(':dd-java-agent:agent-ci-visibility'))
+}

--- a/dd-smoke-tests/backend-mock/src/main/groovy/datadog/smoketest/MockBackend.groovy
+++ b/dd-smoke-tests/backend-mock/src/main/groovy/datadog/smoketest/MockBackend.groovy
@@ -1,0 +1,263 @@
+package datadog.smoketest
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import datadog.trace.agent.test.server.http.TestHttpServer
+import datadog.trace.test.util.MultipartRequestParser
+import org.apache.commons.io.IOUtils
+import org.msgpack.jackson.dataformat.MessagePackFactory
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+import static datadog.trace.agent.test.server.http.TestHttpServer.httpServer
+
+class MockBackend implements AutoCloseable {
+
+  private static final ObjectMapper MSG_PACK_MAPPER = new ObjectMapper(new MessagePackFactory())
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper()
+
+  private final Queue<Map<String, Object>> receivedTraces = new ConcurrentLinkedQueue<>()
+
+  private final Queue<Map<String, Object>> receivedCoverages = new ConcurrentLinkedQueue<>()
+
+  private final Queue<Map<String, Object>> receivedTelemetryMetrics = new ConcurrentLinkedQueue<>()
+
+  private final Queue<Map<String, Object>> receivedTelemetryDistributions = new ConcurrentLinkedQueue<>()
+  private final Queue<Map<String, Object>> receivedLogs = new ConcurrentLinkedQueue<>()
+
+  private final Collection<Map<String, Object>> skippableTests = new CopyOnWriteArrayList<>()
+  private final Collection<Map<String, Object>> flakyTests = new CopyOnWriteArrayList<>()
+
+  private boolean codeCoverageEnabled = true
+
+  private boolean testsSkippingEnabled = true
+
+  private boolean flakyRetriesEnabled = false
+
+  void reset() {
+    receivedTraces.clear()
+    receivedCoverages.clear()
+    receivedTelemetryMetrics.clear()
+    receivedTelemetryDistributions.clear()
+    receivedLogs.clear()
+
+    skippableTests.clear()
+    flakyTests.clear()
+  }
+
+  @Override
+  void close() throws Exception {
+    intakeServer.close()
+  }
+
+  void givenFlakyRetries(boolean flakyRetries) {
+    this.flakyRetriesEnabled = flakyRetries
+  }
+
+  void givenFlakyTest(String module, String suite, String name) {
+    flakyTests.add(["module": module, "suite": suite, "name": name])
+  }
+
+  void givenSkippableTest(String module, String suite, String name) {
+    skippableTests.add(["module": module, "suite": suite, "name": name])
+  }
+
+  String getIntakeUrl() {
+    return intakeServer.address.toString()
+  }
+
+  private final TestHttpServer intakeServer = httpServer {
+    handlers {
+      prefix("/api/v2/citestcycle") {
+        def contentEncodingHeader = request.getHeader("Content-Encoding")
+        def gzipEnabled = contentEncodingHeader != null && contentEncodingHeader.contains("gzip")
+        def requestBody = gzipEnabled ? MockBackend.decompress(request.body) : request.body
+        def decodedEvent = MSG_PACK_MAPPER.readValue(requestBody, Map)
+        receivedTraces.add(decodedEvent)
+
+        response.status(200).send()
+      }
+
+      prefix("/api/v2/citestcov") {
+        def contentEncodingHeader = request.getHeader("Content-Encoding")
+        def gzipEnabled = contentEncodingHeader != null && contentEncodingHeader.contains("gzip")
+        def requestBody = gzipEnabled ? MockBackend.decompress(request.body) : request.body
+        def parsed = MultipartRequestParser.parseRequest(requestBody, request.headers.get("Content-Type"))
+        def coverages = parsed.get("coverage1")
+        for (def coverage : coverages) {
+          def decodedCoverage = MSG_PACK_MAPPER.readValue(coverage.get(), Map)
+          receivedCoverages.add(decodedCoverage)
+        }
+
+        response.status(202).send()
+      }
+
+      prefix("/api/v2/libraries/tests/services/setting") {
+        // not compressing settings response on purpose, to better mimic real backend behavior:
+        // it may choose to compress the response or not based on its size,
+        // so smaller responses (like those of /setting endpoint) are uncompressed,
+        // while the larger ones (skippable and flaky test lists) are compressed
+        response.status(200).send(('{ "data": { "type": "ci_app_tracers_test_service_settings", "id": "uuid", "attributes": { '
+          + '"code_coverage": ' + codeCoverageEnabled
+          + ', "tests_skipping": ' + testsSkippingEnabled
+          + ', "flaky_test_retries_enabled": ' + flakyRetriesEnabled +  '} } }').bytes)
+      }
+
+      prefix("/api/v2/ci/tests/skippable") {
+        StringBuilder skippableTestsResponse = new StringBuilder("[")
+        def i = skippableTests.iterator()
+        while (i.hasNext()) {
+          def test = i.next()
+          skippableTestsResponse.append("""
+          {
+            "id": "${UUID.randomUUID().toString()}",
+            "type": "test",
+            "attributes": {
+              "configurations": {
+                  "test.bundle": "$test.module"
+              },
+              "name": "$test.name",
+              "suite": "$test.suite"
+            }
+          }
+          """)
+          if (i.hasNext()) {
+            skippableTestsResponse.append(',')
+          }
+        }
+        skippableTestsResponse.append("]")
+
+        response.status(200)
+          .addHeader("Content-Encoding", "gzip")
+          .send(MockBackend.compress((""" { "data": $skippableTestsResponse } """).bytes))
+      }
+
+      prefix("/api/v2/ci/libraries/tests/flaky") {
+        StringBuilder flakyTestsResponse = new StringBuilder("[")
+        def i = flakyTests.iterator()
+        while (i.hasNext()) {
+          def test = i.next()
+          flakyTestsResponse.append("""
+          {
+            "id": "${UUID.randomUUID().toString()}",
+            "type": "test",
+            "attributes": {
+              "configurations": {
+                  "test.bundle": "$test.module"
+              },
+              "name": "$test.name",
+              "suite": "$test.suite"
+            }
+          }
+          """)
+          if (i.hasNext()) {
+            flakyTestsResponse.append(',')
+          }
+        }
+        flakyTestsResponse.append("]")
+
+        response.status(200)
+          .addHeader("Content-Encoding", "gzip")
+          .send(MockBackend.compress((""" { "data": $flakyTestsResponse } """).bytes))
+      }
+
+      prefix("/api/v2/apmtelemetry") {
+        def telemetryRequest = JSON_MAPPER.readerFor(Map.class).readValue(request.body)
+        def requestType = telemetryRequest["request_type"]
+        if (requestType == "message-batch") {
+          for (def message : telemetryRequest["payload"]) {
+            def payload = message["payload"]
+            if (message["request_type"] == 'generate-metrics') {
+              receivedTelemetryMetrics.addAll((List) payload["series"])
+            } else if (message["request_type"] == 'distributions') {
+              receivedTelemetryDistributions.addAll((List) payload["series"])
+            }
+          }
+        }
+        response.status(202).send()
+      }
+
+      prefix("/api/v2/logs") {
+        def contentEncodingHeader = request.getHeader("Content-Encoding")
+        def gzipEnabled = contentEncodingHeader != null && contentEncodingHeader.contains("gzip")
+        def requestBody = gzipEnabled ? MockBackend.decompress(request.body) : request.body
+        def decodedEvent = JSON_MAPPER.readValue(requestBody, List)
+        receivedLogs.addAll(decodedEvent)
+
+        response.status(200).send()
+      }
+    }
+  }
+
+  private static byte[] compress(byte[] bytes) {
+    def baos = new ByteArrayOutputStream()
+    try (GZIPOutputStream zip = new GZIPOutputStream(baos)) {
+      IOUtils.copy(new ByteArrayInputStream(bytes), zip)
+    }
+    return baos.toByteArray()
+  }
+
+  private static byte[] decompress(byte[] bytes) {
+    def baos = new ByteArrayOutputStream()
+    try (GZIPInputStream zip = new GZIPInputStream(new ByteArrayInputStream(bytes))) {
+      IOUtils.copy(zip, baos)
+    }
+    return baos.toByteArray()
+  }
+
+  List<Map<String, Object>> waitForEvents(int expectedEventsSize) {
+    def traceReceiveConditions = new PollingConditions(timeout: 15, initialDelay: 1, delay: 0.5, factor: 1)
+    traceReceiveConditions.eventually {
+      int eventsSize = 0
+      for (Map<String, Object> trace : receivedTraces) {
+        eventsSize += trace["events"].size()
+      }
+      assert eventsSize >= expectedEventsSize
+    }
+
+    List<Map<String, Object>> events = new ArrayList<>()
+    while (!receivedTraces.isEmpty()) {
+      def trace = receivedTraces.poll()
+      events.addAll((List<Map<String, Object>>) trace["events"])
+    }
+    return events
+  }
+
+  List<Map<String, Object>> waitForCoverages(int traceSize) {
+    def traceReceiveConditions = new PollingConditions(timeout: 15, initialDelay: 1, delay: 0.5, factor: 1)
+    traceReceiveConditions.eventually {
+      assert receivedCoverages.size() == traceSize
+    }
+
+    List<Map<String, Object>> coverages = new ArrayList<>()
+    while (!receivedCoverages.isEmpty()) {
+      def trace = receivedCoverages.poll()
+      coverages.addAll((List<Map<String, Object>>) trace["coverages"])
+    }
+    return coverages
+  }
+
+  List<Map<String, Object>> waitForLogs(int expectedCount) {
+    def traceReceiveConditions = new PollingConditions(timeout: 15, initialDelay: 1, delay: 0.5, factor: 1)
+    traceReceiveConditions.eventually {
+      assert receivedLogs.size() == expectedCount
+    }
+
+    List<Map<String, Object>> logs = new ArrayList<>()
+    while (!receivedLogs.isEmpty()) {
+      logs.add(receivedLogs.poll())
+    }
+    return logs
+  }
+
+  List<Map<String, Object>> getAllReceivedTelemetryMetrics() {
+    return new ArrayList(receivedTelemetryMetrics)
+  }
+
+  List<Map<String, Object>> getAllReceivedTelemetryDistributions() {
+    return new ArrayList(receivedTelemetryDistributions)
+  }
+}

--- a/dd-smoke-tests/gradle/build.gradle
+++ b/dd-smoke-tests/gradle/build.gradle
@@ -6,9 +6,8 @@ apply from: "$rootDir/gradle/java.gradle"
 description = 'Gradle Daemon Instrumentation Smoke Tests.'
 
 dependencies {
-  testImplementation project(':dd-smoke-tests')
   testImplementation gradleTestKit()
-  testImplementation testFixtures(project(':dd-java-agent:agent-ci-visibility'))
+  testImplementation project(':dd-smoke-tests:backend-mock')
 }
 
 test {

--- a/dd-smoke-tests/maven/build.gradle
+++ b/dd-smoke-tests/maven/build.gradle
@@ -8,8 +8,7 @@ description = 'Maven Instrumentation Smoke Tests.'
 dependencies {
   implementation group: 'org.apache.maven.wrapper', name: 'maven-wrapper', version: '3.2.0'
 
-  testImplementation project(':dd-smoke-tests')
-  testImplementation testFixtures(project(':dd-java-agent:agent-ci-visibility'))
+  testImplementation project(':dd-smoke-tests:backend-mock')
 }
 
 jar {

--- a/settings.gradle
+++ b/settings.gradle
@@ -86,6 +86,7 @@ include ':utils:version-utils'
 
 // smoke tests
 include ':dd-smoke-tests:armeria-grpc'
+include ':dd-smoke-tests:backend-mock'
 include ':dd-smoke-tests:cli'
 include ':dd-smoke-tests:custom-systemloader'
 include ':dd-smoke-tests:dynamic-config'


### PR DESCRIPTION
# What Does This Do
Moves test fixtures that mock Datadog backend to a separate module.

# Motivation
With the implementation of agentless log submission, there will be more smoke test modules that will benefit from using the mock backend. 

# Additional Notes
The CI Visibility subprojects contains some text fixtures that are used by Maven and Gradle instrumentations smoke tests.
These test fixtures contain logic that allows to start a mock Datadog backend.

Jira ticket: [CIVIS-10104]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-10104]: https://datadoghq.atlassian.net/browse/CIVIS-10104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ