### PR TITLE
Move backend communication logic to common module

### DIFF
--- a/communication/build.gradle
+++ b/communication/build.gradle
@@ -41,6 +41,12 @@ ext {
     'datadog.communication.monitor.DDAgentStatsDConnection',
     'datadog.communication.monitor.DDAgentStatsDConnection.*',
     'datadog.communication.monitor.LoggingStatsDClient',
+    'datadog.communication.BackendApiFactory',
+    'datadog.communication.BackendApiFactory.Intake',
+    'datadog.communication.EvpProxyApi',
+    'datadog.communication.IntakeApi',
+    'datadog.communication.util.IOUtils',
+    'datadog.communication.util.IOUtils.1',
   ]
   excludedClassesBranchCoverage = ['datadog.communication.ddagent.TracerVersion',]
   excludedClassesInstructionCoverage = [

--- a/communication/build.gradle
+++ b/communication/build.gradle
@@ -48,11 +48,22 @@ ext {
     'datadog.communication.util.IOUtils',
     'datadog.communication.util.IOUtils.1',
   ]
-  excludedClassesBranchCoverage = ['datadog.communication.ddagent.TracerVersion',]
+  excludedClassesBranchCoverage = [
+    'datadog.communication.ddagent.TracerVersion',
+    'datadog.communication.BackendApiFactory',
+    'datadog.communication.EvpProxyApi',
+    'datadog.communication.IntakeApi',
+  ]
   excludedClassesInstructionCoverage = [
     // can't reach the error condition now
     'datadog.communication.fleet.FleetServiceImpl',
     'datadog.communication.ddagent.SharedCommunicationObjects',
     'datadog.communication.ddagent.TracerVersion',
+    'datadog.communication.BackendApiFactory',
+    'datadog.communication.BackendApiFactory.Intake',
+    'datadog.communication.EvpProxyApi',
+    'datadog.communication.IntakeApi',
+    'datadog.communication.util.IOUtils',
+    'datadog.communication.util.IOUtils.1',
   ]
 }

--- a/communication/src/main/java/datadog/communication/BackendApi.java
+++ b/communication/src/main/java/datadog/communication/BackendApi.java
@@ -1,7 +1,7 @@
-package datadog.trace.civisibility.communication;
+package datadog.communication;
 
 import datadog.communication.http.OkHttpUtils;
-import datadog.trace.civisibility.utils.IOThrowingFunction;
+import datadog.communication.util.IOThrowingFunction;
 import java.io.IOException;
 import java.io.InputStream;
 import javax.annotation.Nullable;
@@ -14,6 +14,7 @@ public interface BackendApi {
       String uri,
       RequestBody requestBody,
       IOThrowingFunction<InputStream, T> responseParser,
-      @Nullable OkHttpUtils.CustomListener requestListener)
+      @Nullable OkHttpUtils.CustomListener requestListener,
+      boolean requestCompression)
       throws IOException;
 }

--- a/communication/src/main/java/datadog/communication/EvpProxyApi.java
+++ b/communication/src/main/java/datadog/communication/EvpProxyApi.java
@@ -1,8 +1,8 @@
-package datadog.trace.civisibility.communication;
+package datadog.communication;
 
 import datadog.communication.http.HttpRetryPolicy;
 import datadog.communication.http.OkHttpUtils;
-import datadog.trace.civisibility.utils.IOThrowingFunction;
+import datadog.communication.util.IOThrowingFunction;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
@@ -14,50 +14,37 @@ import okhttp3.RequestBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** API for posting HTTP requests directly to backend, without the need for DD Agent */
-public class IntakeApi implements BackendApi {
+/** API that uses DD Agent as a proxy to post request to backend. */
+public class EvpProxyApi implements BackendApi {
 
-  private static final Logger log = LoggerFactory.getLogger(IntakeApi.class);
+  private static final Logger log = LoggerFactory.getLogger(EvpProxyApi.class);
 
-  public static final String API_VERSION = "v2";
-
-  private static final String DD_API_KEY_HEADER = "dd-api-key";
+  private static final String API_VERSION = "v2";
+  private static final String X_DATADOG_EVP_SUBDOMAIN_HEADER = "X-Datadog-EVP-Subdomain";
   private static final String X_DATADOG_TRACE_ID_HEADER = "x-datadog-trace-id";
   private static final String X_DATADOG_PARENT_ID_HEADER = "x-datadog-parent-id";
   private static final String ACCEPT_ENCODING_HEADER = "Accept-Encoding";
   private static final String CONTENT_ENCODING_HEADER = "Content-Encoding";
+  private static final String API_SUBDOMAIN = "api";
   private static final String GZIP_ENCODING = "gzip";
 
-  private final String apiKey;
   private final String traceId;
   private final HttpRetryPolicy.Factory retryPolicyFactory;
-  private final boolean gzipEnabled;
-  private final HttpUrl hostUrl;
+  private final HttpUrl evpProxyUrl;
   private final OkHttpClient httpClient;
+  private final boolean responseCompression;
 
-  public IntakeApi(
-      HttpUrl hostUrl,
-      String apiKey,
+  public EvpProxyApi(
       String traceId,
-      long timeoutMillis,
-      HttpRetryPolicy.Factory retryPolicyFactory) {
-    this(hostUrl, apiKey, traceId, timeoutMillis, retryPolicyFactory, true);
-  }
-
-  public IntakeApi(
-      HttpUrl hostUrl,
-      String apiKey,
-      String traceId,
-      long timeoutMillis,
+      HttpUrl evpProxyUrl,
       HttpRetryPolicy.Factory retryPolicyFactory,
-      boolean gzipEnabled) {
-    this.hostUrl = hostUrl;
-    this.apiKey = apiKey;
+      OkHttpClient httpClient,
+      boolean responseCompression) {
     this.traceId = traceId;
+    this.evpProxyUrl = evpProxyUrl.resolve(String.format("api/%s/", API_VERSION));
     this.retryPolicyFactory = retryPolicyFactory;
-    this.gzipEnabled = gzipEnabled;
-
-    httpClient = OkHttpUtils.buildHttpClient(hostUrl, timeoutMillis);
+    this.httpClient = httpClient;
+    this.responseCompression = responseCompression;
   }
 
   @Override
@@ -65,14 +52,15 @@ public class IntakeApi implements BackendApi {
       String uri,
       RequestBody requestBody,
       IOThrowingFunction<InputStream, T> responseParser,
-      @Nullable OkHttpUtils.CustomListener requestListener)
+      @Nullable OkHttpUtils.CustomListener requestListener,
+      boolean requestCompression)
       throws IOException {
-    HttpUrl url = hostUrl.resolve(uri);
+    final HttpUrl url = evpProxyUrl.resolve(uri);
+
     Request.Builder requestBuilder =
         new Request.Builder()
             .url(url)
-            .post(requestBody)
-            .addHeader(DD_API_KEY_HEADER, apiKey)
+            .addHeader(X_DATADOG_EVP_SUBDOMAIN_HEADER, API_SUBDOMAIN)
             .addHeader(X_DATADOG_TRACE_ID_HEADER, traceId)
             .addHeader(X_DATADOG_PARENT_ID_HEADER, traceId);
 
@@ -80,15 +68,21 @@ public class IntakeApi implements BackendApi {
       requestBuilder.tag(OkHttpUtils.CustomListener.class, requestListener);
     }
 
-    if (gzipEnabled) {
+    if (requestCompression) {
+      requestBuilder.addHeader(CONTENT_ENCODING_HEADER, GZIP_ENCODING);
+    }
+
+    if (responseCompression) {
       requestBuilder.addHeader(ACCEPT_ENCODING_HEADER, GZIP_ENCODING);
     }
 
-    Request request = requestBuilder.build();
+    final Request request = requestBuilder.post(requestBody).build();
+
     try (okhttp3.Response response =
         OkHttpUtils.sendWithRetries(httpClient, retryPolicyFactory, request)) {
       if (response.isSuccessful()) {
         log.debug("Request to {} returned successful response: {}", uri, response.code());
+
         InputStream responseBodyStream = response.body().byteStream();
 
         String contentEncoding = response.header(CONTENT_ENCODING_HEADER);

--- a/communication/src/main/java/datadog/communication/util/IOThrowingFunction.java
+++ b/communication/src/main/java/datadog/communication/util/IOThrowingFunction.java
@@ -1,4 +1,4 @@
-package datadog.trace.civisibility.utils;
+package datadog.communication.util;
 
 import java.io.IOException;
 

--- a/communication/src/main/java/datadog/communication/util/IOUtils.java
+++ b/communication/src/main/java/datadog/communication/util/IOUtils.java
@@ -1,4 +1,4 @@
-package datadog.trace.civisibility.utils;
+package datadog.communication.util;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedReader;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility;
 
+import datadog.communication.BackendApi;
 import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.config.ModuleExecutionSettings;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
@@ -10,7 +11,6 @@ import datadog.trace.civisibility.ci.CITagsProvider;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.codeowners.CodeownersProvider;
 import datadog.trace.civisibility.codeowners.NoCodeowners;
-import datadog.trace.civisibility.communication.BackendApi;
 import datadog.trace.civisibility.config.CachingModuleExecutionSettingsFactory;
 import datadog.trace.civisibility.config.ConfigurationApi;
 import datadog.trace.civisibility.config.ConfigurationApiImpl;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityServices.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityServices.java
@@ -1,12 +1,12 @@
 package datadog.trace.civisibility;
 
+import datadog.communication.BackendApi;
+import datadog.communication.BackendApiFactory;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.civisibility.ci.CIProviderInfoFactory;
-import datadog.trace.civisibility.communication.BackendApi;
-import datadog.trace.civisibility.communication.BackendApiFactory;
 import datadog.trace.civisibility.config.CachingJvmInfoFactory;
 import datadog.trace.civisibility.config.JvmInfoFactory;
 import datadog.trace.civisibility.config.JvmInfoFactoryImpl;
@@ -61,7 +61,8 @@ public class CiVisibilityServices {
       GitInfoProvider gitInfoProvider) {
     this.config = config;
     this.metricCollector = metricCollector;
-    this.backendApi = new BackendApiFactory(config, sco).createBackendApi();
+    this.backendApi =
+        new BackendApiFactory(config, sco).createBackendApi(BackendApiFactory.Intake.API);
     this.jvmInfoFactory = new CachingJvmInfoFactory(config, new JvmInfoFactoryImpl());
     this.gitClientFactory = new GitClient.Factory(config, metricCollector);
     this.ciProviderInfoFactory = new CIProviderInfoFactory(config);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -3,6 +3,7 @@ package datadog.trace.civisibility.config;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import datadog.communication.BackendApi;
 import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
@@ -13,7 +14,6 @@ import datadog.trace.api.civisibility.telemetry.tag.EarlyFlakeDetectionEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.ItrEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.ItrSkipEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.RequireGit;
-import datadog.trace.civisibility.communication.BackendApi;
 import datadog.trace.civisibility.communication.TelemetryListener;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
@@ -109,7 +109,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
             SETTINGS_URI,
             requestBody,
             is -> settingsResponseAdapter.fromJson(Okio.buffer(Okio.source(is))).data.attributes,
-            telemetryListener);
+            telemetryListener,
+            false);
 
     metricCollector.add(
         CiVisibilityCountMetric.GIT_REQUESTS_SETTINGS_RESPONSE,
@@ -145,7 +146,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
             SKIPPABLE_TESTS_URI,
             requestBody,
             is -> testIdentifiersResponseAdapter.fromJson(Okio.buffer(Okio.source(is))),
-            telemetryListener);
+            telemetryListener,
+            false);
 
     List<TestIdentifier> testIdentifiers =
         response.data.stream().map(DataDto::getAttributes).collect(Collectors.toList());
@@ -170,7 +172,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
             FLAKY_TESTS_URI,
             requestBody,
             is -> testIdentifiersResponseAdapter.fromJson(Okio.buffer(Okio.source(is))).data,
-            null);
+            null,
+            false);
     return response.stream().map(DataDto::getAttributes).collect(Collectors.toList());
   }
 
@@ -196,7 +199,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
             requestBody,
             is ->
                 testFullNamesResponseAdapter.fromJson(Okio.buffer(Okio.source(is))).data.attributes,
-            telemetryListener);
+            telemetryListener,
+            false);
     return parseTestIdentifiers(knownTests);
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
@@ -1,12 +1,12 @@
 package datadog.trace.civisibility.git.tree;
 
+import datadog.communication.util.IOUtils;
 import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityDistributionMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.tag.Command;
 import datadog.trace.api.civisibility.telemetry.tag.ExitCode;
-import datadog.trace.civisibility.utils.IOUtils;
 import datadog.trace.civisibility.utils.ShellCommandExecutor;
 import datadog.trace.util.Strings;
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataApi.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataApi.java
@@ -3,13 +3,13 @@ package datadog.trace.civisibility.git.tree;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import datadog.communication.BackendApi;
 import datadog.communication.http.OkHttpUtils;
+import datadog.communication.util.IOUtils;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityDistributionMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
-import datadog.trace.civisibility.communication.BackendApi;
 import datadog.trace.civisibility.communication.TelemetryListener;
-import datadog.trace.civisibility.utils.IOUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -78,7 +78,8 @@ public class GitDataApi {
             SEARCH_COMMITS_URI,
             requestBody,
             is -> searchCommitsResponseAdapter.fromJson(Okio.buffer(Okio.source(is))),
-            telemetryListener);
+            telemetryListener,
+            false);
 
     return response.data.stream().map(Commit::getId).collect(Collectors.toSet());
   }
@@ -119,7 +120,8 @@ public class GitDataApi {
             .build();
 
     String response =
-        backendApi.post(UPLOAD_PACKFILES_URI, requestBody, IOUtils::readFully, telemetryListener);
+        backendApi.post(
+            UPLOAD_PACKFILES_URI, requestBody, IOUtils::readFully, telemetryListener, false);
     LOGGER.debug("Uploading pack file {} returned response {}", packFile, response);
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/ShellCommandExecutor.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/ShellCommandExecutor.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.utils;
 
+import datadog.communication.util.IOUtils;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.context.TraceScope;
 import datadog.trace.util.AgentThreadFactory;

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/GitClientGitInfoBuilderTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/GitClientGitInfoBuilderTest.groovy
@@ -3,7 +3,7 @@ package datadog.trace.civisibility.git
 import datadog.trace.api.Config
 import datadog.trace.civisibility.telemetry.CiVisibilityMetricCollectorImpl
 import datadog.trace.civisibility.git.tree.GitClient
-import datadog.trace.civisibility.utils.IOUtils
+import datadog.communication.util.IOUtils
 import spock.lang.Specification
 import spock.lang.TempDir
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitClientTest.groovy
@@ -3,7 +3,7 @@ package datadog.trace.civisibility.git.tree
 import datadog.trace.civisibility.telemetry.CiVisibilityMetricCollectorImpl
 import datadog.trace.civisibility.git.GitObject
 import datadog.trace.civisibility.git.pack.V2PackGitInfoExtractor
-import datadog.trace.civisibility.utils.IOUtils
+import datadog.communication.util.IOUtils
 import spock.lang.Specification
 import spock.lang.TempDir
 

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataApiTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataApiTest.groovy
@@ -5,8 +5,8 @@ import datadog.communication.http.HttpRetryPolicy
 import datadog.communication.http.OkHttpUtils
 import datadog.trace.agent.test.server.http.TestHttpServer
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector
-import datadog.trace.civisibility.communication.BackendApi
-import datadog.trace.civisibility.communication.EvpProxyApi
+import datadog.communication.BackendApi
+import datadog.communication.EvpProxyApi
 import datadog.trace.test.util.MultipartRequestParser
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -121,7 +121,7 @@ class GitDataApiTest extends Specification {
     HttpUrl proxyUrl = HttpUrl.get(intakeServer.address)
     HttpRetryPolicy.Factory retryPolicyFactory = new HttpRetryPolicy.Factory(5, 100, 2.0)
     OkHttpClient client = OkHttpUtils.buildHttpClient(proxyUrl, REQUEST_TIMEOUT_MILLIS)
-    return new EvpProxyApi(traceId, proxyUrl, retryPolicyFactory, client)
+    return new EvpProxyApi(traceId, proxyUrl, retryPolicyFactory, client, true)
   }
 
   private Path givenPackFile() {

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataUploaderImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/git/tree/GitDataUploaderImplTest.groovy
@@ -4,7 +4,7 @@ import datadog.trace.api.Config
 import datadog.trace.civisibility.telemetry.CiVisibilityMetricCollectorImpl
 import datadog.trace.api.git.GitInfo
 import datadog.trace.api.git.GitInfoProvider
-import datadog.trace.civisibility.utils.IOUtils
+import datadog.communication.util.IOUtils
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.TypeSafeMatcher

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/utils/ShellCommandExecutorTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/utils/ShellCommandExecutorTest.groovy
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.utils
 
+import datadog.communication.util.IOUtils
 import spock.lang.Specification
 import spock.lang.TempDir
 

--- a/dd-java-agent/instrumentation/selenium/src/testFixtures/groovy/datadog/trace/instrumentation/selenium/AbstractSeleniumTest.groovy
+++ b/dd-java-agent/instrumentation/selenium/src/testFixtures/groovy/datadog/trace/instrumentation/selenium/AbstractSeleniumTest.groovy
@@ -3,7 +3,7 @@ package datadog.trace.instrumentation.selenium
 import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.trace.agent.test.server.http.TestHttpServer
 import datadog.trace.civisibility.CiVisibilityInstrumentationTest
-import datadog.trace.civisibility.utils.IOUtils
+import datadog.communication.util.IOUtils
 import datadog.trace.instrumentation.junit5.TestEventsHandlerHolder
 import org.junit.jupiter.engine.JupiterTestEngine
 import org.junit.platform.engine.DiscoverySelector


### PR DESCRIPTION
# What Does This Do
Moves logic for direct ("agentless") communication with the Datadog backend to the common module.

# Motivation
With the implementation of agentless log submission, there will be other modules besides CI Visibility that will reuse this logic.

Jira ticket: [CIVIS-10104]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-10104]: https://datadoghq.atlassian.net/browse/CIVIS-10104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ