### PR TITLE
Add option to limit number of frames captured

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -6,6 +6,7 @@ import com.datadog.debugger.sink.Snapshot;
 import com.datadog.debugger.util.ClassNameFiltering;
 import com.datadog.debugger.util.ExceptionHelper;
 import com.datadog.debugger.util.WeakIdentityHashMap;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import java.time.Clock;
 import java.time.Duration;
@@ -33,20 +34,33 @@ public class ExceptionProbeManager {
       Collections.synchronizedMap(new WeakIdentityHashMap<>());
   private final long captureIntervalS;
   private final Clock clock;
+  private final int maxCapturedFrames;
 
   public ExceptionProbeManager(ClassNameFiltering classNameFiltering, Duration captureInterval) {
-    this(classNameFiltering, captureInterval, Clock.systemUTC());
+    this(
+        classNameFiltering,
+        captureInterval,
+        Clock.systemUTC(),
+        Config.get().getDebuggerExceptionMaxCapturedFrames());
   }
 
   ExceptionProbeManager(ClassNameFiltering classNameFiltering) {
-    this(classNameFiltering, Duration.ofHours(1), Clock.systemUTC());
+    this(
+        classNameFiltering,
+        Duration.ofHours(1),
+        Clock.systemUTC(),
+        Config.get().getDebuggerExceptionMaxCapturedFrames());
   }
 
   ExceptionProbeManager(
-      ClassNameFiltering classNameFiltering, Duration captureInterval, Clock clock) {
+      ClassNameFiltering classNameFiltering,
+      Duration captureInterval,
+      Clock clock,
+      int maxCapturedFrames) {
     this.classNameFiltering = classNameFiltering;
     this.captureIntervalS = captureInterval.getSeconds();
     this.clock = clock;
+    this.maxCapturedFrames = maxCapturedFrames;
   }
 
   public ClassNameFiltering getClassNameFiltering() {
@@ -55,7 +69,11 @@ public class ExceptionProbeManager {
 
   public boolean createProbesForException(StackTraceElement[] stackTraceElements) {
     boolean created = false;
+    int maxFrames = maxCapturedFrames;
     for (StackTraceElement stackTraceElement : stackTraceElements) {
+      if (maxFrames <= 0) {
+        break;
+      }
       if (stackTraceElement.isNativeMethod() || stackTraceElement.getLineNumber() < 0) {
         // Skip native methods and lines without line numbers
         // TODO log?
@@ -73,6 +91,7 @@ public class ExceptionProbeManager {
       ExceptionProbe probe = createMethodProbe(this, where);
       created = true;
       probes.putIfAbsent(probe.getId(), probe);
+      maxFrames--;
     }
     return created;
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -190,7 +190,8 @@ public class ExceptionProbeInstrumentationTest {
       disabledReason = "Bug in J9: no LocalVariableTable for ClassFileTransformer")
   public void recursive() throws Exception {
     Config config = createConfig();
-    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
+    ExceptionProbeManager exceptionProbeManager =
+        new ExceptionProbeManager(classNameFiltering, Duration.ofHours(1), Clock.systemUTC(), 20);
     TestSnapshotListener listener =
         setupExceptionDebugging(config, exceptionProbeManager, classNameFiltering);
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
@@ -227,7 +228,7 @@ public class ExceptionProbeInstrumentationTest {
     Clock clockMock = mock(Clock.class);
     when(clockMock.instant()).thenReturn(Instant.now());
     ExceptionProbeManager exceptionProbeManager =
-        new ExceptionProbeManager(classNameFiltering, Duration.ofHours(1), clockMock);
+        new ExceptionProbeManager(classNameFiltering, Duration.ofHours(1), clockMock, 3);
     TestSnapshotListener listener =
         setupExceptionDebugging(config, exceptionProbeManager, classNameFiltering);
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -102,11 +102,10 @@ class ExceptionProbeManagerTest {
                     "worker.org.gradle.",
                     "org.junit.")
                 .collect(Collectors.toSet()));
-    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
+    ExceptionProbeManager exceptionProbeManager =
+        new ExceptionProbeManager(classNameFiltering, Duration.ofHours(1), Clock.systemUTC(), 3);
     exceptionProbeManager.createProbesForException(deepException.getStackTrace());
-    assertEquals(
-        Config.get().getDebuggerExceptionMaxCapturedFrames(),
-        exceptionProbeManager.getProbes().size());
+    assertEquals(3, exceptionProbeManager.getProbes().size());
   }
 
   RuntimeException level1() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -176,6 +176,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DEBUGGER_EXCEPTION_ENABLED = false;
   static final int DEFAULT_DEBUGGER_MAX_EXCEPTION_PER_SECOND = 100;
   static final boolean DEFAULT_DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT = true;
+  static final int DEFAULT_DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES = 3;
 
   static final boolean DEFAULT_TRACE_REPORT_HOSTNAME = false;
   static final String DEFAULT_TRACE_ANNOTATIONS = null;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -35,6 +35,8 @@ public final class DebuggerConfig {
       "exception.replay.max.exception.analysis.limit";
   public static final String DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT =
       "internal.exception.replay.only.local.root";
+  public static final String DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES =
+      "exception.replay.max.frames.to.capture";
   public static final String THIRD_PARTY_INCLUDES = "third.party.includes";
   public static final String THIRD_PARTY_EXCLUDES = "third.party.excludes";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -45,6 +45,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_CLASSFILE_DUMP_E
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_DIAGNOSTICS_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_ENABLED;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_DEBUGGER_MAX_EXCEPTION_PER_SECOND;
@@ -211,6 +212,7 @@ import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_CLASSFILE_DUMP_EN
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_DIAGNOSTICS_INTERVAL;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_ENABLED;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_ENABLED;
+import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_EXCLUDE_FILES;
 import static datadog.trace.api.config.DebuggerConfig.DEBUGGER_INSTRUMENT_THE_WORLD;
@@ -841,6 +843,7 @@ public class Config {
   private final boolean debuggerExceptionEnabled;
   private final int debuggerMaxExceptionPerSecond;
   private final boolean debuggerExceptionOnlyLocalRoot;
+  private final int debuggerExceptionMaxCapturedFrames;
 
   private final Set<String> debuggerThirdPartyIncludes;
   private final Set<String> debuggerThirdPartyExcludes;
@@ -1900,6 +1903,9 @@ public class Config {
     debuggerExceptionOnlyLocalRoot =
         configProvider.getBoolean(
             DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT, DEFAULT_DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT);
+    debuggerExceptionMaxCapturedFrames =
+        configProvider.getInteger(
+            DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES, DEFAULT_DEBUGGER_EXCEPTION_MAX_CAPTURED_FRAMES);
 
     debuggerThirdPartyIncludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_INCLUDES));
     debuggerThirdPartyExcludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_EXCLUDES));
@@ -3227,6 +3233,10 @@ public class Config {
 
   public boolean isDebuggerExceptionOnlyLocalRoot() {
     return debuggerExceptionOnlyLocalRoot;
+  }
+
+  public int getDebuggerExceptionMaxCapturedFrames() {
+    return debuggerExceptionMaxCapturedFrames;
   }
 
   public Set<String> getThirdPartyIncludes() {


### PR DESCRIPTION
# What Does This Do
Use `DD_EXCEPTION_REPLAY_MAX_FRAMES_TO_CAPTURE` to limit number of frame in user code (i.e. not third-party code) to instrument and capture per exception. Default value is 3

# Motivation
limit the amount of snapshots generated

# Additional Notes

Jira ticket: [DEBUG-2068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2068]: https://datadoghq.atlassian.net/browse/DEBUG-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ