### PR TITLE
Add tracer log file to tracer flare when datadog.slf4j.simpleLogger.logFile is NOT defined 

### DIFF
--- a/dd-java-agent/agent-logging/build.gradle
+++ b/dd-java-agent/agent-logging/build.gradle
@@ -15,6 +15,8 @@ excludedClassesCoverage += [
   'datadog.trace.logging.ddlogger.DDLoggerFactory',
   'datadog.trace.logging.simplelogger.SLCompatFactory',
   'datadog.trace.logging.simplelogger.SLCompatSettings',
+  'datadog.trace.logging.PrintStreamWrapper',
+  'datadog.trace.logging.LogReporter',
 ]
 
 dependencies {

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LogReporter.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LogReporter.java
@@ -1,0 +1,128 @@
+package datadog.trace.logging;
+
+import static java.nio.file.Files.readAllBytes;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.flare.TracerFlare;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.ZipOutputStream;
+
+public class LogReporter implements TracerFlare.Reporter {
+  private static final LogReporter INSTANCE = new LogReporter();
+  private static final int MAX_LOGFILE_SIZE_MB = 15;
+  public static final int MAX_LOGFILE_SIZE_BYTES = MAX_LOGFILE_SIZE_MB << 20;
+  private static String tmpLogFile;
+  private final String configuredLogFile;
+  private boolean isFlarePrepared;
+
+  public LogReporter() {
+    // org.slf4j.simpleLogger.logFile transformed as datadog.slf4j.simpleLogger.logFile in the final
+    // dd-java-agent jar
+    this.configuredLogFile = System.getProperty("org.slf4j.simpleLogger.logFile");
+  }
+
+  public static void register() {
+    TracerFlare.addReporter(INSTANCE);
+  }
+
+  @Override
+  public void prepareForFlare() {
+    isFlarePrepared = true;
+    if (configuredLogFile == null
+        || configuredLogFile.isEmpty()
+        || !(new File(configuredLogFile).exists())) {
+      long endMillis = System.currentTimeMillis();
+      String file =
+          System.getProperty("java.io.tmpdir")
+              + File.separator
+              + "tracer"
+              + "-"
+              + Config.get().getRuntimeId()
+              + "-"
+              + endMillis
+              + ".log";
+      File outputFile = new File(file);
+      File parentFile = outputFile.getParentFile();
+      boolean a = parentFile.exists();
+      boolean b = parentFile.mkdirs();
+      tmpLogFile = null;
+      try {
+        boolean c = outputFile.createNewFile();
+        if ((a || b) && c) {
+          tmpLogFile = file;
+          PrintStreamWrapper.start(tmpLogFile);
+        }
+      } catch (IOException e) {
+        // Nothing to do, file creation failed, we don't have access to log yet
+      }
+    }
+  }
+
+  @Override
+  public void addReportToFlare(ZipOutputStream zip) throws IOException {
+    if (configuredLogFile == null
+        || configuredLogFile.isEmpty()
+        || !(new File(configuredLogFile).exists())) {
+      if (isFlarePrepared) {
+        try {
+          if (tmpLogFile != null) {
+            TracerFlare.addBinary(zip, "tracer.log", readAllBytes(Paths.get(tmpLogFile)));
+          }
+        } catch (Exception e) {
+          TracerFlare.addText(
+              zip, "tracer.log", "Problem reading temporary tracer log file: " + e.getMessage());
+        }
+      } else {
+        TracerFlare.addText(
+            zip, "tracer.log", "No tracer log file specified and no prepare flare event received");
+      }
+
+    } else {
+      Path path = Paths.get(configuredLogFile);
+      if (Files.exists(path)) {
+        try {
+          long size = Files.size(path);
+          if (size > MAX_LOGFILE_SIZE_BYTES) {
+            int maxSizeOfSplit = MAX_LOGFILE_SIZE_BYTES / 2;
+            File originalFile = new File(path.toString());
+            try (RandomAccessFile ras = new RandomAccessFile(originalFile, "r")) {
+              final byte[] buffer = new byte[maxSizeOfSplit];
+              ras.readFully(buffer);
+              TracerFlare.addBinary(zip, "tracer_begin.log", buffer);
+              ras.seek(size - maxSizeOfSplit);
+              ras.readFully(buffer);
+              TracerFlare.addBinary(zip, "tracer_end.log", buffer);
+            }
+          } else {
+            TracerFlare.addBinary(zip, "tracer.log", readAllBytes(path));
+          }
+        } catch (Throwable e) {
+          TracerFlare.addText(zip, "tracer.log", "Problem collecting tracer log: " + e);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void cleanupAfterFlare() {
+    isFlarePrepared = false;
+    try {
+      PrintStreamWrapper.clean();
+      File outputFile = new File(tmpLogFile);
+      if (outputFile.exists()) {
+        if (!outputFile.delete()) {
+          throw new RuntimeException("Failed to delete file: " + tmpLogFile);
+        }
+      }
+
+    } catch (Exception e) {
+      // not sure what to do here
+
+    }
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LogReporter.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/LogReporter.java
@@ -21,7 +21,7 @@ public class LogReporter implements TracerFlare.Reporter {
   private static File configuredLogFile;
   private static PrintStreamWrapper wrappedPrintStream;
 
-  public LogReporter() {}
+  private LogReporter() {}
 
   public static void register(PrintStreamWrapper printStreamWrapper) {
     wrappedPrintStream = printStreamWrapper;

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/PrintStreamWrapper.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/PrintStreamWrapper.java
@@ -28,13 +28,13 @@ public class PrintStreamWrapper extends PrintStream {
   public void println(String x) {
     super.println(x); // log as usual
     if (activate) {
-      synchronized (this) {
-        currentSize += x.getBytes().length + lineSeparatorLength;
-        if (currentSize < LogReporter.MAX_LOGFILE_SIZE_BYTES) {
+      currentSize += x.getBytes().length + lineSeparatorLength;
+      if (currentSize < LogReporter.MAX_LOGFILE_SIZE_BYTES) {
+        synchronized (this) {
           printStream.println(x);
-        } else {
-          activate = false;
         }
+      } else {
+        activate = false;
       }
     }
   }

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/PrintStreamWrapper.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/PrintStreamWrapper.java
@@ -1,0 +1,74 @@
+package datadog.trace.logging;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class PrintStreamWrapper extends PrintStream {
+  private static final String lineSeparator = System.getProperty("line.separator");
+  private static final byte[] lineSeparatorBytes = lineSeparator.getBytes();
+  private static final int lineSeparatorLength = lineSeparatorBytes.length;
+
+  private static boolean activate = false;
+  private static int currentSize = 0;
+  private static PrintStream printStream = null;
+  private static FileOutputStream fileOutputStream = null;
+  private static String logFile = null;
+
+  public PrintStreamWrapper(PrintStream ps) {
+    super(ps);
+  }
+  // use for tests only
+  public OutputStream getMainPrintStream() {
+    return super.out;
+  }
+
+  @Override
+  public void println(String x) {
+    super.println(x); // log as usual
+    if (activate) {
+      synchronized (this) {
+        currentSize += x.getBytes().length + lineSeparatorLength;
+        if (currentSize < LogReporter.MAX_LOGFILE_SIZE_BYTES) {
+          printStream.println(x);
+        } else {
+          activate = false;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void println(Object x) {
+    String s = String.valueOf(x);
+    println(s);
+  }
+
+  public static void start(String filepath) {
+    clean();
+    logFile = filepath;
+    try {
+      if (logFile != null) {
+
+        fileOutputStream = new FileOutputStream(logFile);
+        printStream = new PrintStream(fileOutputStream, true);
+        activate = true;
+      }
+    } catch (FileNotFoundException e) {
+      // TODO maybe have support for delayed logging of early failures?
+    }
+  }
+
+  public static void clean() {
+
+    if (printStream != null) {
+      printStream.close();
+      printStream = null;
+    }
+    fileOutputStream = null;
+    logFile = null;
+    activate = false;
+    currentSize = 0;
+  }
+}

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
@@ -1,6 +1,8 @@
 package datadog.trace.logging.simplelogger;
 
 import datadog.trace.logging.LogLevel;
+import datadog.trace.logging.LogReporter;
+import datadog.trace.logging.PrintStreamWrapper;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -165,11 +167,17 @@ public class SLCompatSettings {
   }
 
   static PrintStream getPrintStream(String logFile) {
+    LogReporter.register();
     switch (logFile.toLowerCase(Locale.ROOT)) {
       case "system.err":
-        return System.err;
+        {
+          return new PrintStreamWrapper(System.err);
+        }
       case "system.out":
-        return System.out;
+        {
+          return new PrintStreamWrapper(System.out);
+        }
+
       default:
         FileOutputStream outputStream = null;
         try {
@@ -190,7 +198,7 @@ public class SLCompatSettings {
             }
           }
           // TODO maybe have support for delayed logging of early failures?
-          return System.err;
+          return new PrintStreamWrapper(System.err);
         }
     }
   }

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
@@ -170,14 +170,9 @@ public class SLCompatSettings {
     LogReporter.register();
     switch (logFile.toLowerCase(Locale.ROOT)) {
       case "system.err":
-        {
-          return new PrintStreamWrapper(System.err);
-        }
+        return new PrintStreamWrapper(System.err);
       case "system.out":
-        {
-          return new PrintStreamWrapper(System.out);
-        }
-
+        return new PrintStreamWrapper(System.out);
       default:
         FileOutputStream outputStream = null;
         try {

--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/simplelogger/SLCompatSettings.java
@@ -167,12 +167,14 @@ public class SLCompatSettings {
   }
 
   static PrintStream getPrintStream(String logFile) {
-    LogReporter.register();
+    PrintStreamWrapper printStreamWrapper;
     switch (logFile.toLowerCase(Locale.ROOT)) {
       case "system.err":
-        return new PrintStreamWrapper(System.err);
+        printStreamWrapper = new PrintStreamWrapper(System.err);
+        break;
       case "system.out":
-        return new PrintStreamWrapper(System.out);
+        printStreamWrapper = new PrintStreamWrapper(System.out);
+        break;
       default:
         FileOutputStream outputStream = null;
         try {
@@ -183,6 +185,7 @@ public class SLCompatSettings {
           }
           outputStream = new FileOutputStream(outputFile);
           PrintStream printStream = new PrintStream(outputStream, true);
+          LogReporter.register(outputFile);
           return printStream;
         } catch (IOException | SecurityException e) {
           if (outputStream != null) {
@@ -193,9 +196,11 @@ public class SLCompatSettings {
             }
           }
           // TODO maybe have support for delayed logging of early failures?
-          return new PrintStreamWrapper(System.err);
+          printStreamWrapper = new PrintStreamWrapper(System.err);
         }
     }
+    LogReporter.register(printStreamWrapper);
+    return printStreamWrapper;
   }
 
   private static final class ResourceStreamPrivilegedAction

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
@@ -103,6 +103,8 @@ class SLCompatSettingsTest extends Specification {
 
     expect:
     file.exists()
+    settings.printStream != System.err
+    settings.printStream != System.out
 
     cleanup:
     settings.printStream.close()
@@ -144,8 +146,6 @@ class SLCompatSettingsTest extends Specification {
     expect:
     !file.exists()
     ((PrintStreamWrapper) settings.printStream).getMainPrintStream() == System.err
-
-
 
     cleanup:
     dir.setWritable(true, true)

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.logging.simplelogger
 
 import datadog.trace.logging.LogLevel
+import datadog.trace.logging.PrintStreamWrapper
 import spock.lang.Specification
 
 import java.text.SimpleDateFormat
@@ -63,7 +64,7 @@ class SLCompatSettingsTest extends Specification {
     then:
     settings.warnLevelString == null
     settings.levelInBrackets == false
-    settings.printStream == System.err
+    ((PrintStreamWrapper) settings.printStream).getMainPrintStream()  == System.err
     settings.showShortLogName == false
     settings.showLogName == true
     settings.showThreadName == true
@@ -83,7 +84,7 @@ class SLCompatSettingsTest extends Specification {
     then:
     settings.warnLevelString == "WRN"
     settings.levelInBrackets == true
-    settings.printStream == System.out
+    ((PrintStreamWrapper) settings.printStream).sgetMainPrintStream()  == System.out
     settings.showShortLogName == true
     settings.showLogName == false
     settings.showThreadName == false
@@ -102,8 +103,6 @@ class SLCompatSettingsTest extends Specification {
 
     expect:
     file.exists()
-    settings.printStream != System.err
-    settings.printStream != System.out
 
     cleanup:
     settings.printStream.close()
@@ -124,8 +123,6 @@ class SLCompatSettingsTest extends Specification {
 
     expect:
     file.exists()
-    settings.printStream != System.err
-    settings.printStream != System.out
 
     cleanup:
     settings.printStream.close()
@@ -146,7 +143,9 @@ class SLCompatSettingsTest extends Specification {
 
     expect:
     !file.exists()
-    settings.printStream == System.err
+    ((PrintStreamWrapper) settings.printStream).getMainPrintStream() == System.err
+
+
 
     cleanup:
     dir.setWritable(true, true)

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
@@ -84,7 +84,7 @@ class SLCompatSettingsTest extends Specification {
     then:
     settings.warnLevelString == "WRN"
     settings.levelInBrackets == true
-    ((PrintStreamWrapper) settings.printStream).sgetMainPrintStream()  == System.out
+    ((PrintStreamWrapper) settings.printStream).getMainPrintStream()  == System.out
     settings.showShortLogName == true
     settings.showLogName == false
     settings.showThreadName == false

--- a/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
+++ b/dd-java-agent/agent-logging/src/test/groovy/datadog/trace/logging/simplelogger/SLCompatSettingsTest.groovy
@@ -64,7 +64,7 @@ class SLCompatSettingsTest extends Specification {
     then:
     settings.warnLevelString == null
     settings.levelInBrackets == false
-    ((PrintStreamWrapper) settings.printStream).getMainPrintStream()  == System.err
+    ((PrintStreamWrapper) settings.printStream).getOriginalPrintStream()  == System.err
     settings.showShortLogName == false
     settings.showLogName == true
     settings.showThreadName == true
@@ -84,7 +84,7 @@ class SLCompatSettingsTest extends Specification {
     then:
     settings.warnLevelString == "WRN"
     settings.levelInBrackets == true
-    ((PrintStreamWrapper) settings.printStream).getMainPrintStream()  == System.out
+    ((PrintStreamWrapper) settings.printStream).getOriginalPrintStream()  == System.out
     settings.showShortLogName == true
     settings.showLogName == false
     settings.showThreadName == false
@@ -145,7 +145,7 @@ class SLCompatSettingsTest extends Specification {
 
     expect:
     !file.exists()
-    ((PrintStreamWrapper) settings.printStream).getMainPrintStream() == System.err
+    ((PrintStreamWrapper) settings.printStream).getOriginalPrintStream() == System.err
 
     cleanup:
     dir.setWritable(true, true)

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -103,6 +103,8 @@ public final class NativeImageGeneratorRunnerInstrumentation
               + "datadog.trace.bootstrap.instrumentation.jfr.directallocation.DirectAllocationTotalEvent:build_time,"
               + "datadog.trace.logging.LoggingSettingsDescription:build_time,"
               + "datadog.trace.logging.simplelogger.SLCompatFactory:build_time,"
+              + "datadog.trace.logging.LogReporter:build_time,"
+              + "datadog.trace.logging.PrintStreamWrapper:build_time,"
               + "datadog.trace.util.CollectionUtils:build_time,"
               + "datadog.slf4j.impl.StaticLoggerBinder:build_time,"
               + "datadog.slf4j.LoggerFactory:build_time,"


### PR DESCRIPTION
# What Does This Do
Collect tracer logs in a tracer log file in the tracer flare:
Changes:
- handle the case when no tracer log file is configured in the tracer configuration and we're able to create a temporary log file to collect the logs
- move the logic when a tracer log file is configured from TracerFlareService.java to LogReporter.java to avoid having multiple locations for handling the tracer log in tracer flare depending on the use cases

Note that:
- Use case when no tracer log file is configured in the tracer configuration and we're not able to create a temporary log file to collect the logs is not supported right now ( tracer.log file generated but no tracer logs inside)
- Use case when no tracer log file is configured  and the tracer flare is requested by Remote Config without DEBUG log level will lead to tracer flare with no tracer logs ( a tracer.log file is created but with the following content: "No tracer log file specified and no prepare flare event received") 

Notes on tests:
- I'll add system test tests to check the presence of the tracer file(s) and their size in tracer flare 

# Motivation

# Additional Notes

Jira ticket: [[APMAPI-85](https://datadoghq.atlassian.net/browse/APMAPI-85)]


[APMAPI-85]: https://datadoghq.atlassian.net/browse/APMAPI-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ