### PR TITLE
Fix flakiness in Maven and Gradle smoke tests

### DIFF
--- a/dd-smoke-tests/backend-mock/src/main/groovy/datadog/smoketest/MockBackend.groovy
+++ b/dd-smoke-tests/backend-mock/src/main/groovy/datadog/smoketest/MockBackend.groovy
@@ -210,12 +210,16 @@ class MockBackend implements AutoCloseable {
 
   List<Map<String, Object>> waitForEvents(int expectedEventsSize) {
     def traceReceiveConditions = new PollingConditions(timeout: 15, initialDelay: 1, delay: 0.5, factor: 1)
-    traceReceiveConditions.eventually {
-      int eventsSize = 0
-      for (Map<String, Object> trace : receivedTraces) {
-        eventsSize += trace["events"].size()
+    try {
+      traceReceiveConditions.eventually {
+        int eventsSize = 0
+        for (Map<String, Object> trace : receivedTraces) {
+          eventsSize += trace["events"].size()
+        }
+        assert eventsSize >= expectedEventsSize
       }
-      assert eventsSize >= expectedEventsSize
+    } catch (AssertionError e) {
+      throw new AssertionError("Error while waiting for $expectedEventsSize trace events, received: $receivedTraces", e)
     }
 
     List<Map<String, Object>> events = new ArrayList<>()
@@ -226,10 +230,18 @@ class MockBackend implements AutoCloseable {
     return events
   }
 
-  List<Map<String, Object>> waitForCoverages(int traceSize) {
+  List<Map<String, Object>> waitForCoverages(int expectedCoveragesSize) {
     def traceReceiveConditions = new PollingConditions(timeout: 15, initialDelay: 1, delay: 0.5, factor: 1)
-    traceReceiveConditions.eventually {
-      assert receivedCoverages.size() == traceSize
+    try {
+      traceReceiveConditions.eventually {
+        int coveragesSize = 0
+        for (Map<String, Object> trace : receivedCoverages) {
+          coveragesSize += trace["coverages"].size()
+        }
+        assert coveragesSize >= expectedCoveragesSize
+      }
+    } catch (AssertionError e) {
+      throw new AssertionError("Error while waiting for $expectedCoveragesSize coverages, received: $receivedCoverages", e)
     }
 
     List<Map<String, Object>> coverages = new ArrayList<>()

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -7,7 +7,6 @@ import datadog.trace.api.Platform
 import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.civisibility.CiVisibilitySmokeTest
-import datadog.trace.test.util.Flaky
 import datadog.trace.util.Strings
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -73,7 +72,6 @@ class GradleDaemonSmokeTest extends CiVisibilitySmokeTest {
     mockBackend.reset()
   }
 
-  @Flaky("https://github.com/DataDog/dd-trace-java/issues/7024")
   def "test #projectName, v#gradleVersion, configCache: #configurationCache"() {
     givenGradleVersionIsCompatibleWithCurrentJvm(gradleVersion)
     givenConfigurationCacheIsCompatibleWithCurrentPlatform(configurationCache)
@@ -104,9 +102,6 @@ class GradleDaemonSmokeTest extends CiVisibilitySmokeTest {
     where:
     gradleVersion         | projectName                                        | configurationCache | successExpected | flakyRetries | expectedTraces | expectedCoverages
     "3.0"                 | "test-succeed-old-gradle"                          | false              | true            | false        | 5              | 1
-    "4.0"                 | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
-    "5.0"                 | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
-    "6.0"                 | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
     "7.6.4"               | "test-succeed-legacy-instrumentation"              | false              | true            | false        | 5              | 1
     "8.3"                 | "test-succeed-new-instrumentation"                 | false              | true            | false        | 5              | 1
     LATEST_GRADLE_VERSION | "test-succeed-new-instrumentation"                 | false              | true            | false        | 5              | 1
@@ -140,6 +135,7 @@ class GradleDaemonSmokeTest extends CiVisibilitySmokeTest {
       "-javaagent:${agentShadowJar}=" +
       // for convenience when debugging locally
       (System.getenv("DD_CIVISIBILITY_SMOKETEST_DEBUG_CHILD") != null ? "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_DEBUG_PORT)}=5055," : "") +
+      "dd.trace.debug=true," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.ENV)}=${TEST_ENVIRONMENT_NAME}," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.SERVICE_NAME)}=${TEST_SERVICE_NAME}," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.API_KEY_FILE)}=${ddApiKeyPath.toAbsolutePath().toString()}," +

--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleDaemonSmokeTest.groovy
@@ -150,7 +150,7 @@ class GradleDaemonSmokeTest extends CiVisibilitySmokeTest {
       "-javaagent:${agentShadowJar}=" +
       // for convenience when debugging locally
       (System.getenv("DD_CIVISIBILITY_SMOKETEST_DEBUG_CHILD") != null ? "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_DEBUG_PORT)}=5055," : "") +
-      "dd.trace.debug=true," +
+      "${Strings.propertyNameToSystemPropertyName(GeneralConfig.TRACE_DEBUG)}=true," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.ENV)}=${TEST_ENVIRONMENT_NAME}," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.SERVICE_NAME)}=${TEST_SERVICE_NAME}," +
       "${Strings.propertyNameToSystemPropertyName(GeneralConfig.API_KEY_FILE)}=${ddApiKeyPath.toAbsolutePath().toString()}," +

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -231,7 +231,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
       def agentArgument = "-javaagent:${agentShadowJar}=" +
         // for convenience when debugging locally
         (System.getenv("DD_CIVISIBILITY_SMOKETEST_DEBUG_CHILD") != null ? "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_DEBUG_PORT)}=5055," : "") +
-        "dd.trace.debug=true," +
+        "${Strings.propertyNameToSystemPropertyName(GeneralConfig.TRACE_DEBUG)}=true," +
         "${Strings.propertyNameToSystemPropertyName(GeneralConfig.ENV)}=${TEST_ENVIRONMENT_NAME}," +
         "${Strings.propertyNameToSystemPropertyName(GeneralConfig.SERVICE_NAME)}=${TEST_SERVICE_NAME}," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_ENABLED)}=true," +

--- a/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
+++ b/dd-smoke-tests/maven/src/test/groovy/datadog/smoketest/MavenSmokeTest.groovy
@@ -1,11 +1,9 @@
 package datadog.smoketest
 
-
 import datadog.trace.api.Config
 import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.civisibility.CiVisibilitySmokeTest
-import datadog.trace.test.util.Flaky
 import datadog.trace.util.Strings
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -58,7 +56,6 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
     mockBackend.reset()
   }
 
-  @Flaky("https://github.com/DataDog/dd-trace-java/issues/7025")
   def "test #projectName, v#mavenVersion"() {
     Assumptions.assumeTrue(Jvm.current.isJavaVersionCompatible(minSupportedJavaVersion),
       "Current JVM " + Jvm.current.javaVersion + " is not compatible with minimum required version " + minSupportedJavaVersion)
@@ -95,7 +92,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
     "test_successful_maven_run_with_jacoco_and_argline" | "3.9.7"              | 5              | 1                 | true          | false        | true           | 8
     // "expectedEvents" count for this test case does not include the spans that correspond to Cucumber steps
     "test_successful_maven_run_with_cucumber"           | "3.9.7"              | 4              | 1                 | true          | false        | true           | 8
-    "test_failed_maven_run_flaky_retries"               | "3.9.7"              | 8              | 1                 | false         | true         | true           | 8
+    "test_failed_maven_run_flaky_retries"               | "3.9.7"              | 8              | 5                 | false         | true         | true           | 8
     "test_successful_maven_run_junit_platform_runner"   | "3.9.7"              | 4              | 0                 | true          | false        | false          | 8
   }
 
@@ -234,6 +231,7 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
       def agentArgument = "-javaagent:${agentShadowJar}=" +
         // for convenience when debugging locally
         (System.getenv("DD_CIVISIBILITY_SMOKETEST_DEBUG_CHILD") != null ? "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_DEBUG_PORT)}=5055," : "") +
+        "dd.trace.debug=true," +
         "${Strings.propertyNameToSystemPropertyName(GeneralConfig.ENV)}=${TEST_ENVIRONMENT_NAME}," +
         "${Strings.propertyNameToSystemPropertyName(GeneralConfig.SERVICE_NAME)}=${TEST_SERVICE_NAME}," +
         "${Strings.propertyNameToSystemPropertyName(CiVisibilityConfig.CIVISIBILITY_ENABLED)}=true," +


### PR DESCRIPTION
# What Does This Do
Fixes logic that waits for coverage messages in Gradle and Maven smoke tests: now coverage records are counted instead of coverage requests, so asserts are not affected by batching in the tracer.

Disables smoke tests for older Gradle versions when testing with OpenJ9: Gradle Jacoco plugin does not work with this combination, and neither does the coverage solution built on top of Jacoco.

Gradle and Maven builds triggered by the smoke tests now run with tracer debug logging to simplify debugging any future failures.

"Flaky" annotation is removed from Gradle and Maven smoke tests.

# Motivation
Re-enabling Gradle and Maven instrumentations testing.

Jira ticket: [SDTEST-384]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-384]: https://datadoghq.atlassian.net/browse/SDTEST-384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ