### PR TITLE
java-dogstatsd-client 4.4.0 (fix potential file-descriptor leak)

### DIFF
--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDConnection.java
@@ -5,7 +5,7 @@ import static datadog.trace.util.AgentThreadFactory.AgentThread.STATSD_CLIENT;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.timgroup.statsd.NoOpStatsDClient;
+import com.timgroup.statsd.NoOpDirectStatsDClient;
 import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClientErrorHandler;
 import datadog.trace.api.Config;
@@ -23,7 +23,7 @@ final class DDAgentStatsDConnection implements StatsDClientErrorHandler {
   private static final Logger log = LoggerFactory.getLogger(DDAgentStatsDConnection.class);
   private static final IOLogger ioLogger = new IOLogger(log);
 
-  private static final com.timgroup.statsd.StatsDClient NO_OP = new NoOpStatsDClient();
+  private static final com.timgroup.statsd.StatsDClient NO_OP = new NoOpDirectStatsDClient();
 
   private static final String UNIX_DOMAIN_SOCKET_PREFIX = "unix://";
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ final class CachedData {
     truth         : "1.1.3",
     kotlin        : "1.6.21",
     coroutines    : "1.3.0",
-    dogstatsd     : "4.3.0",
+    dogstatsd     : "4.4.0",
     jnr_unixsocket: "0.38.22",
     jnr_posix     : '3.1.19',
     commons       : "3.2",


### PR DESCRIPTION
# Motivation

https://github.com/DataDog/java-dogstatsd-client/pull/243