### PR TITLE
Bumps opentracing-tracerresolver to 0.1.6

### DIFF
--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -45,7 +45,7 @@ dependencies {
   api group: 'io.opentracing', name: 'opentracing-api', version: '0.32.0'
   api group: 'io.opentracing', name: 'opentracing-noop', version: '0.32.0'
   api group: 'io.opentracing', name: 'opentracing-util', version: '0.32.0'
-  api group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.0'
+  api group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.6'
 
   api deps.slf4j
   implementation project(':dd-trace-ot:correlation-id-injection')


### PR DESCRIPTION
# What Does This Do

Bumps io.opentracing.contrib:opentracing-tracerresolver version to 0.1.6

# Motivation

Current version ([0.1.0](https://mvnrepository.com/artifact/io.opentracing.contrib/opentracing-tracerresolver/0.1.0)) depends on [opentracing-api 0.21.0](https://mvnrepository.com/artifact/io.opentracing/opentracing-api/0.21.0) while the project depends on [opentracing-api 0.32.0](https://mvnrepository.com/artifact/io.opentracing/opentracing-api/0.32.0).

Setting dependency version to [0.1.6](https://mvnrepository.com/artifact/io.opentracing.contrib/opentracing-tracerresolver/0.1.6) aligns the opentracing-api version.

# Additional Notes

* [opentracing-tracerresolver-0.1.6.pom](https://repo1.maven.org/maven2/io/opentracing/contrib/opentracing-tracerresolver/0.1.6/opentracing-tracerresolver-0.1.6.pom)
* [opentracing-tracerresolver-parent-0.1.6.pom](https://repo1.maven.org/maven2/io/opentracing/contrib/opentracing-tracerresolver-parent/0.1.6/opentracing-tracerresolver-parent-0.1.6.pom)

```xml
<opentracing-api.version>0.32.0</opentracing-api.version>
```
