### PR TITLE
Preserve `unix:` agent URLs

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -29,7 +29,7 @@ public class SharedCommunicationObjects {
       monitoring = Monitoring.DISABLED;
     }
     if (agentUrl == null) {
-      agentUrl = HttpUrl.parse(config.getAgentUrl());
+      agentUrl = parseAgentUrl(config);
       if (agentUrl == null) {
         throw new IllegalArgumentException("Bad agent URL: " + config.getAgentUrl());
       }
@@ -41,6 +41,15 @@ public class SharedCommunicationObjects {
           OkHttpUtils.buildHttpClient(
               agentUrl, unixDomainSocket, namedPipe, getHttpClientTimeout(config));
     }
+  }
+
+  private static HttpUrl parseAgentUrl(Config config) {
+    String agentUrl = config.getAgentUrl();
+    if (agentUrl.startsWith("unix:")) {
+      // provide placeholder agent URL, in practice we'll be tunnelling over UDS
+      agentUrl = "http://" + config.getAgentHost() + ":" + config.getAgentPort();
+    }
+    return HttpUrl.parse(agentUrl);
   }
 
   private static long getHttpClientTimeout(Config config) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -142,7 +142,9 @@ public class DebuggerAgent {
   private static String getDiagnosticEndpoint(
       Config config, DDAgentFeaturesDiscovery ddAgentFeaturesDiscovery) {
     if (ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics()) {
-      return config.getAgentUrl() + "/" + DDAgentFeaturesDiscovery.DEBUGGER_DIAGNOSTICS_ENDPOINT;
+      return ddAgentFeaturesDiscovery
+          .buildUrl(DDAgentFeaturesDiscovery.DEBUGGER_DIAGNOSTICS_ENDPOINT)
+          .toString();
     }
     return config.getFinalDebuggerSnapshotUrl();
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ConflatingMetricsAggregator.java
@@ -71,7 +71,7 @@ public final class ConflatingMetricsAggregator implements MetricsAggregator, Eve
         sharedCommunicationObjects.featuresDiscovery(config),
         new OkHttpSink(
             sharedCommunicationObjects.okHttpClient,
-            config.getAgentUrl(),
+            sharedCommunicationObjects.agentUrl.toString(),
             V6_METRICS_ENDPOINT,
             config.isTracerMetricsBufferingEnabled(),
             false,

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/MetricsAggregatorFactoryTest.groovy
@@ -3,6 +3,7 @@ package datadog.trace.common.metrics
 import datadog.communication.ddagent.SharedCommunicationObjects
 import datadog.trace.api.Config
 import datadog.trace.test.util.DDSpecification
+import okhttp3.HttpUrl
 
 class MetricsAggregatorFactoryTest extends DDSpecification {
 
@@ -10,8 +11,10 @@ class MetricsAggregatorFactoryTest extends DDSpecification {
     setup:
     Config config = Mock(Config)
     config.isTracerMetricsEnabled() >> false
+    def sco = Mock(SharedCommunicationObjects)
+    sco.agentUrl = HttpUrl.parse("http://localhost:8126")
     expect:
-    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, Mock(SharedCommunicationObjects))
+    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, sco)
     assert aggregator instanceof NoOpMetricsAggregator
   }
 
@@ -19,8 +22,10 @@ class MetricsAggregatorFactoryTest extends DDSpecification {
     setup:
     Config config = Spy(Config.get())
     config.isTracerMetricsEnabled() >> true
+    def sco = Mock(SharedCommunicationObjects)
+    sco.agentUrl = HttpUrl.parse("http://localhost:8126")
     expect:
-    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, Mock(SharedCommunicationObjects))
+    def aggregator = MetricsAggregatorFactory.createMetricsAggregator(config, sco)
     assert aggregator instanceof ConflatingMetricsAggregator
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1090,14 +1090,17 @@ public class Config {
       }
     }
 
-    if (agentHostFromEnvironment == null) {
-      agentHostFromEnvironment = configProvider.getString(AGENT_HOST);
-      rebuildAgentUrl = true;
-    }
-
-    if (agentPortFromEnvironment < 0) {
-      agentPortFromEnvironment = configProvider.getInteger(TRACE_AGENT_PORT, -1, AGENT_PORT_LEGACY);
-      rebuildAgentUrl = true;
+    // avoid merging in supplementary host/port settings when dealing with unix: URLs
+    if (unixSocketFromEnvironment == null) {
+      if (agentHostFromEnvironment == null) {
+        agentHostFromEnvironment = configProvider.getString(AGENT_HOST);
+        rebuildAgentUrl = true;
+      }
+      if (agentPortFromEnvironment < 0) {
+        agentPortFromEnvironment =
+            configProvider.getInteger(TRACE_AGENT_PORT, -1, AGENT_PORT_LEGACY);
+        rebuildAgentUrl = true;
+      }
     }
 
     if (agentHostFromEnvironment == null) {


### PR DESCRIPTION
# What Does This Do

Avoids merging in any additional host/port settings when dealing with `unix:` URLs.

If the user has configured a `unix:` agent URL that means they want the tracer to communicate over the given UDS file, in which case we shouldn't then check for any additional agent host or agent port settings, because they won't be applicable. Instead it should just use the default host/port and not rebuild the agent URL.

This does mean that consumers of the agent URL should handle that it might now start with `unix:` - in practice this only affects one place, `SharedCommunicationObjects` which now uses a placeholder `http://{agent.host}:{agent.port}` for `unix:` URLs. Note this is just to satisfy the OkHttp API, the actual communication will be tunnelled over UDS.

The other updates were to a couple of products still using the raw agent URL - they now use `SharedCommunicationObjects` /  `DDAgentFeaturesDiscovery` to get the parsed agent URL for use with OkHttp.

# Motivation

Merging in additional host/port settings triggers a rebuild of the agent URL in `Config`, which is misleading because the actual agent URL is the original one that starts with `unix:`.

