### PR TITLE
Use same approach as agent-tooling to setup otel-tooling instrumentPluginClasspath

### DIFF
--- a/dd-java-agent/agent-otel/otel-bootstrap/build.gradle
+++ b/dd-java-agent/agent-otel/otel-bootstrap/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
   implementation project(':dd-java-agent:agent-otel:otel-shim')
 
-  instrumentPluginClasspath project(':dd-java-agent:agent-otel:otel-tooling')
+  instrumentPluginClasspath project(path: ':dd-java-agent:agent-otel:otel-tooling', configuration: 'instrumentPluginClasspath')
 }
 
 // unpack embeddedClasspath to same path as compiled classes so it can get instrumented

--- a/dd-java-agent/agent-otel/otel-tooling/build.gradle
+++ b/dd-java-agent/agent-otel/otel-tooling/build.gradle
@@ -3,6 +3,14 @@ apply from: "$rootDir/gradle/java.gradle"
 minimumInstructionCoverage = 0.0
 minimumBranchCoverage = 0.0
 
+configurations {
+  instrumentPluginClasspath {
+    canBeConsumed = true
+    canBeResolved = false
+    extendsFrom runtimeElements
+  }
+}
+
 dependencies {
   api deps.bytebuddy
   api deps.bytebuddyagent


### PR DESCRIPTION
This should hopefully address the intermittent failure to find `OtelShimGradlePlugin` seen recently in CI