### PR TITLE
Fix IP denylist parsing when expiration date does not fit an integer

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfig.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfig.java
@@ -1,19 +1,16 @@
 package com.datadog.appsec.config;
 
 import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.JsonReader;
-import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 public interface AppSecConfig {
 
-  Moshi MOSHI = new Moshi.Builder().add(Double.class, new NumberJsonAdapter()).build();
+  Moshi MOSHI = new Moshi.Builder().build();
   JsonAdapter<AppSecConfigV1> ADAPTER_V1 = MOSHI.adapter(AppSecConfigV1.class);
   JsonAdapter<AppSecConfigV2> ADAPTER_V2 = MOSHI.adapter(AppSecConfigV2.class);
 
@@ -122,20 +119,6 @@ public interface AppSecConfig {
       hash = 31 * hash + (version == null ? 0 : version.hashCode());
       hash = 31 * hash + (rawConfig == null ? 0 : rawConfig.hashCode());
       return hash;
-    }
-  }
-
-  class NumberJsonAdapter extends JsonAdapter<Number> {
-
-    @Nullable
-    @Override
-    public Number fromJson(JsonReader reader) throws IOException {
-      return reader.nextInt();
-    }
-
-    @Override
-    public void toJson(JsonWriter writer, @Nullable Number value) throws IOException {
-      writer.value(value);
     }
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecDataDeserializerSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecDataDeserializerSpecification.groovy
@@ -1,0 +1,63 @@
+package com.datadog.appsec.config
+
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class AppSecDataDeserializerSpecification extends Specification {
+
+  void "deserialize IP denylist"() {
+    given:
+    final deser = AppSecDataDeserializer.INSTANCE
+    final input = """
+{
+  "rules_data": [
+    {
+      "data": [
+        {
+          "expiration": 0,
+          "value": "1.1.1.1"
+        },
+        {
+          "expiration": 1717083300,
+          "value": "2.2.2.2"
+        },
+        {
+          "expiration": 9223372036854775807,
+          "value": "3.3.3.3"
+        }
+      ],
+      "id": "blocked_ips",
+      "type": "ip_with_expiration"
+    }
+  ]
+}
+    """
+
+    when:
+    def result = deser.deserialize(input.getBytes(StandardCharsets.UTF_8))
+
+    then:
+    result != null
+    result == [
+      [
+        data: [
+          [
+            expiration: 0.0,
+            value     : "1.1.1.1"
+          ],
+          [
+            expiration: 1717083300.0,
+            value     : "2.2.2.2"
+          ],
+          [
+            expiration: 9223372036854775807.0,
+            value     : "3.3.3.3"
+          ]
+        ],
+        id: "blocked_ips",
+        type: "ip_with_expiration"
+      ]
+    ]
+  }
+}

--- a/dd-java-agent/appsec/src/test/resources/rules_with_data_config.json
+++ b/dd-java-agent/appsec/src/test/resources/rules_with_data_config.json
@@ -40,6 +40,16 @@
           "expiration": 0
         }
       ]
+    },
+    {
+      "id": "ip_data",
+      "type": "ip_with_expiration",
+      "data": [
+        {
+          "value": "1.1.1.1",
+          "expiration": 9223372036854775807
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# What Does This Do
Fix parsing of IP denylist in remote configuration when an expiration date does not fit an integer.

# Motivation
https://github.com/DataDog/dd-trace-java/pull/5888 changed JSON deserialization, breaking parsing denylists with expiration dates not fitting an integer. This leads to remote configuration updates failing with the following error in that case:

```
[dd.trace 2024-05-30 14:02:26:998 +0000] [dd-remote-config] WARN datadog.remoteconfig.state.ProductState - Error processing config key datadog/152608/ASM_DATA/blocked_ips/9fac00de04816f5c402a0bc5d4e649758e0d3a5246c9ae3b9b7a5a8f6af99721: Expected an int but was 3676668445 at path $.rules_data[0].data[1].expiration (Will not log warnings for 5 minutes)
com.squareup.moshi.JsonDataException: Expected an int but was 3676668445 at path $.rules_data[0].data[1].expiration
 	at com.squareup.moshi.JsonUtf8Reader.nextInt(JsonUtf8Reader.java:926)
 	at com.datadog.appsec.config.AppSecConfig$NumberJsonAdapter.fromJson(AppSecConfig.java:133)
 	at com.datadog.appsec.config.AppSecConfig$NumberJsonAdapter.fromJson(AppSecConfig.java:128)
...
```

# Additional Notes

* Jira ticket: [APPSEC-53445](https://datadoghq.atlassian.net/browse/APPSEC-53445)

[APPSEC-53445]: https://datadoghq.atlassian.net/browse/APPSEC-53445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ