### PR TITLE
Improve agentServiceCheck to handle scenarios where the tracer is configured to use UDS

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -12,6 +12,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.ProductActivation;
 import datadog.trace.logging.LoggingSettingsDescription;
 import datadog.trace.util.AgentTaskScheduler;
+import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -153,11 +154,15 @@ public final class StatusLogger extends JsonAdapter<Config>
   }
 
   private static boolean agentServiceCheck(Config config) {
-    try (Socket s = new Socket()) {
-      s.connect(new InetSocketAddress(config.getAgentHost(), config.getAgentPort()), 500);
-      return true;
-    } catch (IOException ex) {
-      return false;
+    if (config.getAgentUrl().startsWith("unix:")) {
+      return new File(config.getAgentUnixDomainSocket()).exists();
+    } else {
+      try (Socket s = new Socket()) {
+        s.connect(new InetSocketAddress(config.getAgentHost(), config.getAgentPort()), 500);
+        return true;
+      } catch (IOException ex) {
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
# Motivation

Avoids misleading `agent_error` statuses when the simple `host:port` check fails, but UDS would have succeeded. 

Jira ticket: [APMJAVA-1147]

[APMJAVA-1147]: https://datadoghq.atlassian.net/browse/APMJAVA-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ