### PR TITLE
Fix line probe in method with inline lambdas

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -655,10 +655,15 @@ public class DebuggerTransformer implements ClassFileTransformer {
     }
     Where.SourceLine sourceLine = lines[0]; // assume only 1 range
     int matchingLine = sourceLine.getFrom();
-    MethodNode matchingMethod = classFileLines.getMethodByLine(matchingLine);
-    if (matchingMethod != null) {
-      log.debug("Found lineNode {} method: {}", matchingLine, matchingMethod.name);
-      return matchingMethod;
+    List<MethodNode> matchingMethods = classFileLines.getMethodsByLine(matchingLine);
+    if (matchingMethods != null) {
+      matchingMethods.forEach(
+          methodNode -> {
+            log.debug("Found lineNode {} method: {}", matchingLine, methodNode.name);
+          });
+      // pick the first matching method.
+      // TODO need a way to disambiguate if multiple methods match the same line
+      return matchingMethods.isEmpty() ? null : matchingMethods.get(0);
     }
     log.debug("Cannot find line: {} in class {}", matchingLine, classNode.name);
     return null;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileLines.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileLines.java
@@ -1,6 +1,8 @@
 package com.datadog.debugger.util;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -10,7 +12,7 @@ import org.objectweb.asm.tree.LineNumberNode;
 import org.objectweb.asm.tree.MethodNode;
 
 public class ClassFileLines {
-  private final Map<Integer, MethodNode> methodByLine = new HashMap<>();
+  private final Map<Integer, List<MethodNode>> methodByLine = new HashMap<>();
   private final TreeMap<Integer, LabelNode> lineLabels = new TreeMap<>();
 
   public ClassFileLines(ClassNode classNode) {
@@ -19,7 +21,14 @@ public class ClassFileLines {
       while (currentNode != null) {
         if (currentNode.getType() == AbstractInsnNode.LINE) {
           LineNumberNode lineNode = (LineNumberNode) currentNode;
-          methodByLine.put(lineNode.line, methodNode);
+          // on the same line, we can have multiple methods (lambdas, inner classes, etc)
+          List<MethodNode> methodNodes =
+              methodByLine.computeIfAbsent(lineNode.line, k -> new ArrayList<>());
+          // We are not using a Set here to keep the order of the methods
+          // We assume also that the number of methods per line is small
+          if (!methodNodes.contains(methodNode)) {
+            methodNodes.add(methodNode);
+          }
           // we are putting the line only the first time in the map.
           // for-loops can generate 2 line nodes for the same line, 1 before the loop, 1 for the
           // incrementation part.
@@ -31,7 +40,7 @@ public class ClassFileLines {
     }
   }
 
-  public MethodNode getMethodByLine(int line) {
+  public List<MethodNode> getMethodsByLine(int line) {
     return methodByLine.get(line);
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1443,12 +1443,12 @@ public class CapturedSnapshotTest {
     setCorrelationSingleton(spyCorrelationAccess);
     doReturn(true).when(spyCorrelationAccess).isAvailable();
     TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "33"));
+        installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "37"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.onClass(testClass).call("main", "static", "email@address").get();
     assertEquals(8, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    CapturedContext context = snapshot.getCaptures().getLines().get(33);
+    CapturedContext context = snapshot.getCaptures().getLines().get(37);
     assertNotNull(context);
     assertCaptureLocals(context, "idx", "int", "5");
   }
@@ -1460,15 +1460,32 @@ public class CapturedSnapshotTest {
     setCorrelationSingleton(spyCorrelationAccess);
     doReturn(true).when(spyCorrelationAccess).isAvailable();
     TestSnapshotListener listener =
-        installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "44"));
+        installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "48"));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.onClass(testClass).call("main", "capturing", "email@address").get();
     assertEquals(8, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    CapturedContext context = snapshot.getCaptures().getLines().get(44);
+    CapturedContext context = snapshot.getCaptures().getLines().get(48);
     assertNotNull(context);
     assertCaptureLocals(context, "idx", "int", "5");
     assertCaptureFields(context, "strValue", "java.lang.String", "email@address");
+  }
+
+  @Test
+  public void multiLambdas() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot07";
+    CorrelationAccess spyCorrelationAccess = spy(CorrelationAccess.instance());
+    setCorrelationSingleton(spyCorrelationAccess);
+    doReturn(true).when(spyCorrelationAccess).isAvailable();
+    TestSnapshotListener listener =
+        installProbes(CLASS_NAME, createProbe(PROBE_ID, CLASS_NAME, null, null, "58"));
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.onClass(testClass).call("main", "multi", "FOO1,FOO2,FOO3").get();
+    assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    CapturedContext context = snapshot.getCaptures().getLines().get(58);
+    assertNotNull(context);
+    assertCaptureArgs(context, "arg", String.class.getTypeName(), "FOO1,FOO2,FOO3");
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
@@ -8,6 +8,7 @@ import com.datadog.debugger.util.ClassFileLines;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
 import java.io.IOException;
+import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.tree.MethodNode;
@@ -119,7 +120,7 @@ public class WhereTest {
     where = new Where("MyClass", "myMethod", null, new String[] {"42"}, null);
     ClassFileLines classFileLines = mock(ClassFileLines.class);
     MethodNode myMethodNode = createMethodNode("myMethod", "()V");
-    when(classFileLines.getMethodByLine(42)).thenReturn(myMethodNode);
+    when(classFileLines.getMethodsByLine(42)).thenReturn(Arrays.asList(myMethodNode));
     assertTrue(where.isMethodMatching(myMethodNode, classFileLines));
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassFileLinesTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassFileLinesTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static utils.InstrumentationTestHelper.compile;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.tree.ClassNode;
@@ -21,7 +22,7 @@ class ClassFileLinesTest {
 
   @Test
   void ValidateLineMapReturnLinesInRangeOrNull() throws Exception {
-    ClassFileLines classFileLines = createClassFileLines();
+    ClassFileLines classFileLines = createClassFileLines("CapturedSnapshot02");
     LabelNode line13 = classFileLines.getLineLabel(13);
     LabelNode line17 = classFileLines.getLineLabel(17);
 
@@ -31,34 +32,54 @@ class ClassFileLinesTest {
   }
 
   @Test
-  void getMethodByLine() throws Exception {
-    ClassFileLines classFileLines = createClassFileLines();
-    MethodNode method13 = classFileLines.getMethodByLine(13);
+  void getMethodsByLine() throws Exception {
+    ClassFileLines classFileLines = createClassFileLines("CapturedSnapshot02");
+    MethodNode method13 = classFileLines.getMethodsByLine(13).get(0);
     assertEquals("<init>", method13.name);
     assertEquals("()V", method13.desc);
-    MethodNode method17 = classFileLines.getMethodByLine(17);
+    MethodNode method17 = classFileLines.getMethodsByLine(17).get(0);
     assertEquals("<init>", method17.name);
     assertEquals("(Ljava/lang/Throwable;)V", method17.desc);
-    MethodNode method26 = classFileLines.getMethodByLine(26);
+    MethodNode method26 = classFileLines.getMethodsByLine(26).get(0);
     assertEquals("<init>", method26.name);
     assertEquals("(Ljava/lang/String;Ljava/lang/Object;)V", method26.desc);
-    MethodNode method32 = classFileLines.getMethodByLine(32);
+    MethodNode method32 = classFileLines.getMethodsByLine(32).get(0);
     assertEquals("createObject", method32.name);
     assertEquals("()Ljava/lang/Object;", method32.desc);
-    MethodNode method37 = classFileLines.getMethodByLine(37);
+    MethodNode method37 = classFileLines.getMethodsByLine(37).get(0);
     assertEquals("f", method37.name);
     assertEquals("()V", method37.desc);
-    MethodNode method44 = classFileLines.getMethodByLine(44);
+    MethodNode method44 = classFileLines.getMethodsByLine(44).get(0);
     assertEquals("synchronizedBlock", method44.name);
     assertEquals("(I)I", method44.desc);
-    MethodNode method54 = classFileLines.getMethodByLine(54);
+    MethodNode method54 = classFileLines.getMethodsByLine(54).get(0);
     assertEquals("main", method54.name);
     assertEquals("(Ljava/lang/String;)I", method54.desc);
   }
 
-  private ClassFileLines createClassFileLines() throws Exception {
-    final String CLASS_NAME = "CapturedSnapshot02";
-    byte[] byteBuffer = compile(CLASS_NAME).get(CLASS_NAME);
+  @Test
+  void getMethodsByLineWithLambdas() throws Exception {
+    ClassFileLines classFileLines = createClassFileLines("CapturedSnapshot07");
+    List<MethodNode> methods57 = classFileLines.getMethodsByLine(57);
+    // despite having the return on multi line which yield multiple BCI for same line
+    // this is still the same method
+    assertEquals(1, methods57.size());
+    assertEquals("multiLambda", methods57.get(0).name);
+    assertEquals("(Ljava/lang/String;)I", methods57.get(0).desc);
+    List<MethodNode> methods58 = classFileLines.getMethodsByLine(58);
+    assertEquals(3, methods58.size());
+    assertEquals("multiLambda", methods58.get(0).name);
+    assertEquals("(Ljava/lang/String;)I", methods58.get(0).desc);
+    // filter
+    assertEquals("lambda$multiLambda$3", methods58.get(1).name);
+    assertEquals("(Ljava/lang/String;)Z", methods58.get(1).desc);
+    // map
+    assertEquals("lambda$multiLambda$2", methods58.get(2).name);
+    assertEquals("(Ljava/lang/String;)Ljava/lang/String;", methods58.get(2).desc);
+  }
+
+  private ClassFileLines createClassFileLines(String className) throws Exception {
+    byte[] byteBuffer = compile(className).get(className);
     ClassReader reader = new ClassReader(byteBuffer);
     ClassNode classNode = new ClassNode();
     reader.accept(classNode, ClassReader.SKIP_FRAMES);

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot07.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot07.java
@@ -24,6 +24,10 @@ public class CapturedSnapshot07 {
       cs7.strValue = arg;
       return cs7.capturingLambda(arg);
     }
+    if (mode.equals("multi")) {
+      CapturedSnapshot07 cs7 = new CapturedSnapshot07();
+      return cs7.multiLambda(arg);
+    }
     return 0;
   }
 
@@ -47,5 +51,11 @@ public class CapturedSnapshot07 {
       return strValue.substring(0);
     };
     return func.apply(arg).length();
+  }
+
+  private int multiLambda(String arg) {
+    return (int)Arrays.stream(arg.split(","))
+        .map(s -> s.toUpperCase()).filter(s -> s.startsWith("FOO"))
+        .count();
   }
 }


### PR DESCRIPTION
# What Does This Do
Multiple methods can match a line if inline lambdas are defined on the same line.
we need to collect all methods associated to a line and pick one. Here the first which will be the enclosing method
ClassFileLines now collect all methods for a same line

# Motivation
line probe on line 3
```
1  private int multiLambda(String arg) {
2    return (int)Arrays.stream(arg.split(","))
3        .map(s -> s.toUpperCase()).filter(s -> s.startsWith("FOO"))
4        .count();
5  }
```
throws:
```
Cannot transform:  [exception:java.lang.ArrayIndexOutOfBoundsException: Index 62 out of bounds for length 21. 
at org.objectweb.asm.ClassReader.readLabel(ClassReader.java:2695) 
at org.objectweb.asm.ClassReader.createLabel(ClassReader.java:2711) 
at org.objectweb.asm.ClassReader.readCode(ClassReader.java:1853)
at org.objectweb.asm.ClassReader.readMethod(ClassReader.java:1515)
at org.objectweb.asm.ClassReader.accept(ClassReader.java:745)
at org.objectweb.asm.ClassReader.accept(ClassReader.java:425)
at com.datadog.debugger.agent.DebuggerTransformer.verifyByteCode(DebuggerTransformer.java:383)
```


# Additional Notes

Jira ticket: [DEBUG-2168]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2168]: https://datadoghq.atlassian.net/browse/DEBUG-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ