### PR TITLE
Fix HandleVisitor instrumentation for jetty >= 11.16.0 (avoids logged error)

### DIFF
--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/HttpChannelAppSecTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/HttpChannelAppSecTest.groovy
@@ -1,0 +1,82 @@
+import datadog.trace.agent.test.AgentTestRunner
+import net.bytebuddy.jar.asm.ClassReader
+import net.bytebuddy.jar.asm.ClassVisitor
+import net.bytebuddy.jar.asm.MethodVisitor
+import net.bytebuddy.utility.OpenedClassReader
+import org.eclipse.jetty.server.HttpChannel
+
+import java.lang.instrument.ClassFileTransformer
+import java.lang.instrument.IllegalClassFormatException
+import java.security.ProtectionDomain
+
+class HttpChannelAppSecTest extends AgentTestRunner {
+
+  void 'test blocking capabilities in HttpChannel'() {
+    given:
+    def target = HttpChannel
+    def name = target.name.replaceAll('\\.', '/')
+    def visitor = new BlockingClassVisitor()
+    def transformer = new ClassFileTransformer() {
+        @Override
+        byte[] transform(ClassLoader loader,
+          String className,
+          Class<?> classBeingRedefined,
+          ProtectionDomain protectionDomain,
+          byte[] classfileBuffer) throws IllegalClassFormatException {
+          if (name == className) {
+            final reader = new ClassReader(classfileBuffer)
+            reader.accept(visitor, 0)
+          }
+          return classfileBuffer
+        }
+      }
+
+    when:
+    INSTRUMENTATION.addTransformer(transformer, true)
+    INSTRUMENTATION.retransformClasses(target)
+
+    then:
+    visitor.blockApplied
+
+    cleanup:
+    INSTRUMENTATION.removeTransformer(transformer)
+  }
+
+  private static class BlockingClassVisitor extends ClassVisitor {
+
+    private BlockingMethodVisitor methodVisitor
+
+    protected BlockingClassVisitor() {
+      super(OpenedClassReader.ASM_API)
+    }
+
+    @Override
+    MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+      if ('handle' == name && '()Z' == descriptor) {
+        return methodVisitor = new BlockingMethodVisitor()
+      }
+      return super.visitMethod(access, name, descriptor, signature, exceptions)
+    }
+
+    boolean getBlockApplied() {
+      return methodVisitor?.blockApplied
+    }
+  }
+
+  private static class BlockingMethodVisitor extends MethodVisitor {
+
+    boolean blockApplied = false
+
+    protected BlockingMethodVisitor() {
+      super(OpenedClassReader.ASM_API)
+    }
+
+    @Override
+    void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+      if ('datadog/trace/bootstrap/instrumentation/api/AgentSpan' == owner && 'getRequestBlockingAction' == name) {
+        blockApplied = true
+      }
+      super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty9/DelayCertainInsMethodVisitor.java
+++ b/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty9/DelayCertainInsMethodVisitor.java
@@ -73,6 +73,8 @@ public class DelayCertainInsMethodVisitor extends MethodVisitor {
       final int opcode, final String owner, final String name, final String descriptor) {
     if (opcode == Opcodes.GETSTATIC) {
       heldVisitations.add(new GetStaticFieldInsn(opcode, owner, name, descriptor));
+    } else if (opcode == Opcodes.GETFIELD) {
+      heldVisitations.add(new GetFieldInsn(opcode, owner, name, descriptor));
     } else {
       commitVisitations();
       super.visitFieldInsn(opcode, owner, name, descriptor);
@@ -259,6 +261,26 @@ public class DelayCertainInsMethodVisitor extends MethodVisitor {
     public final String descriptor;
 
     public GetStaticFieldInsn(int opcode, String owner, String name, String descriptor) {
+      this.opcode = opcode;
+      this.owner = owner;
+      this.name = name;
+      this.descriptor = descriptor;
+    }
+
+    @Override
+    public Object apply(Object input) {
+      mv.visitFieldInsn(opcode, owner, name, descriptor);
+      return null;
+    }
+  }
+
+  public class GetFieldInsn implements Function {
+    public final int opcode;
+    public final String owner;
+    public final String name;
+    public final String descriptor;
+
+    public GetFieldInsn(int opcode, String owner, String name, String descriptor) {
       this.opcode = opcode;
       this.owner = owner;
       this.name = name;


### PR DESCRIPTION
# What Does This Do
Updates `HandleVisitor` used to instrument `HttpChannel` for blocking purposes in jetty, after version 11.16.0 the original code slightly changed causing a failure in the visitor and a warning message. Blocking was still working thanks of the instrumentation done in `DispatchableInstrumentation`, this just effectively removes the logger error and allows to block the request earlier.

# Motivation
The instrumentation done by `HandleVisitor` is required to provide blocking capabilities in jetty.

# Additional Notes

https://github.com/jetty/jetty.project/commit/9e16d81cf8922c75e3d2d96c66442b896a9c69e1
Jira ticket: [APPSEC-52394]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-52394]: https://datadoghq.atlassian.net/browse/APPSEC-52394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ