### PR TITLE
Add a TracingFactory (since opentracing-tracerresolver 0.1.5) which resolves our tracer

### DIFF
--- a/dd-trace-ot/src/main/java/datadog/opentracing/resolver/DDTracerFactory.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/resolver/DDTracerFactory.java
@@ -1,0 +1,26 @@
+package datadog.opentracing.resolver;
+
+import com.google.auto.service.AutoService;
+import datadog.opentracing.DDTracer;
+import datadog.trace.api.Config;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@AutoService(TracerFactory.class)
+public class DDTracerFactory implements TracerFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(DDTracerFactory.class);
+
+  @Override
+  public Tracer getTracer() {
+    if (Config.get().isTraceResolverEnabled()) {
+      log.info("Creating DDTracer with DDTracerFactory");
+      return DDTracer.builder().build();
+    } else {
+      log.info("DDTracerFactory disabled");
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
# Motivation

This fixes CI failures involving `DDTracerResolverTest` that occurred since #7093 was merged.

# Additional Notes

`opentracing-tracerresolver` 0.1.5 added a new way to supply tracers, `TracerFactory` - this is checked before `TracerResolver` so we should provide our own `TracerFactory` to supply our tracer, like in `DDTracerResolver`.