### PR TITLE
Cleanup OTSpanTest…

### DIFF
--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OTSpanTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OTSpanTest.groovy
@@ -5,15 +5,14 @@ import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
 import datadog.trace.test.util.DDSpecification
 import io.opentracing.Scope
 import io.opentracing.Span
-import io.opentracing.util.GlobalTracer
 import spock.lang.Shared
 
 class OTSpanTest extends DDSpecification {
   @Shared
   DDTracer tracer = DDTracer.builder().build()
 
-  def setup() {
-    GlobalTracer.register(tracer)
+  def cleanup() {
+    tracer?.close()
   }
 
   def "test resource name assignment through MutableSpan casting"() {
@@ -22,9 +21,9 @@ class OTSpanTest extends DDSpecification {
     OTScopeManager.OTScope testScope = tracer.activateSpan(testSpan) as OTScopeManager.OTScope
 
     when:
-    Span active = GlobalTracer.get().activeSpan()
-    Span child = GlobalTracer.get().buildSpan("child").asChildOf(active).start()
-    Scope scope = GlobalTracer.get().activateSpan(child)
+    Span active = tracer.activeSpan()
+    Span child = tracer.buildSpan("child").asChildOf(active).start()
+    Scope scope = tracer.activateSpan(child)
 
     MutableSpan localRootSpan = ((MutableSpan) child).getLocalRootSpan()
     localRootSpan.setResourceName("correct-resource")

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/resolver/DDTracerResolverTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/resolver/DDTracerResolverTest.groovy
@@ -6,7 +6,7 @@ import io.opentracing.contrib.tracerresolver.TracerResolver
 
 import static datadog.trace.api.config.TracerConfig.TRACE_RESOLVER_ENABLED
 
-class DDTracerResolverForkedTest extends DDSpecification {
+class DDTracerResolverTest extends DDSpecification {
 
   def resolver = new DDTracerResolver()
 


### PR DESCRIPTION
…so it doesn't call GlobalTracer.register and leak state to other tests, especially DDTracerResolverTest.

It didn't need to register the tracer with GlobalTracer in order to test the behaviour of OTSpan - it was also failing to close the tracer, leaking threads.

With these changes we can move DDTracerResolverTest back to being a non-forked test.
