### PR TITLE
Report updated `trace.sampling.rules` to telemetry

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
+++ b/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
@@ -48,6 +48,12 @@
     ]
   },
   {
+    "name" : "datadog.trace.agent.core.TracingConfigPoller$TracingSamplingRulesAdapter",
+    "methods": [
+      {"name": "fromJson"}
+    ]
+  },
+  {
     "name" : "datadog.trace.agent.core.DDSpanLink$SpanLinkAdapter",
     "methods": [
       {"name": "toSpanLinkJson"}

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -40,6 +40,7 @@ excludedClassesCoverage += [
   'datadog.trace.core.TracingConfigPoller.SamplingRuleTagEntry',
   'datadog.trace.core.TracingConfigPoller.TracingSamplingRule',
   'datadog.trace.core.TracingConfigPoller.TracingSamplingRules',
+  'datadog.trace.core.TracingConfigPoller.TracingSamplingRulesAdapter',
   'datadog.trace.core.TracingConfigPoller.Updater',
 ]
 

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -39,6 +39,7 @@ excludedClassesCoverage += [
   'datadog.trace.common.sampling.SpanSamplingRules.RuleAdapter',
   'datadog.trace.core.TracingConfigPoller.SamplingRuleTagEntry',
   'datadog.trace.core.TracingConfigPoller.TracingSamplingRule',
+  'datadog.trace.core.TracingConfigPoller.TracingSamplingRules',
   'datadog.trace.core.TracingConfigPoller.Updater',
 ]
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -559,10 +559,13 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     this.initialSampler = sampler;
 
     // Get initial Trace Sampling Rules from config
-    TraceSamplingRules traceSamplingRules =
-        config.getTraceSamplingRules() == null
-            ? TraceSamplingRules.EMPTY
-            : TraceSamplingRules.deserialize(config.getTraceSamplingRules());
+    String traceSamplingRulesJson = config.getTraceSamplingRules();
+    TraceSamplingRules traceSamplingRules = TraceSamplingRules.EMPTY;
+    if (traceSamplingRulesJson != null) {
+      traceSamplingRules = TraceSamplingRules.deserialize(traceSamplingRulesJson);
+    } else {
+      traceSamplingRulesJson = "[]";
+    }
     // Get initial Span Sampling Rules from config
     String spanSamplingRulesJson = config.getSpanSamplingRules();
     String spanSamplingRulesFile = config.getSpanSamplingRulesFile();
@@ -586,7 +589,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
             .setBaggageMapping(baggageMapping)
             .setTraceSampleRate(config.getTraceSampleRate())
             .setSpanSamplingRules(spanSamplingRules.getRules())
-            .setTraceSamplingRules(traceSamplingRules.getRules())
+            .setTraceSamplingRules(traceSamplingRules.getRules(), traceSamplingRulesJson)
             .setTracingTags(config.getMergedSpanTags())
             .apply();
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -560,11 +560,12 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     // Get initial Trace Sampling Rules from config
     String traceSamplingRulesJson = config.getTraceSamplingRules();
-    TraceSamplingRules traceSamplingRules = TraceSamplingRules.EMPTY;
-    if (traceSamplingRulesJson != null) {
-      traceSamplingRules = TraceSamplingRules.deserialize(traceSamplingRulesJson);
-    } else {
+    TraceSamplingRules traceSamplingRules;
+    if (traceSamplingRulesJson == null) {
       traceSamplingRulesJson = "[]";
+      traceSamplingRules = TraceSamplingRules.EMPTY;
+    } else {
+      traceSamplingRules = TraceSamplingRules.deserialize(traceSamplingRulesJson);
     }
     // Get initial Span Sampling Rules from config
     String spanSamplingRulesJson = config.getSpanSamplingRules();

--- a/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/TracingConfigPoller.java
@@ -179,8 +179,7 @@ final class TracingConfigPoller {
                 && null == rule.name
                 && null == rule.resource
                 && null == rule.tags)
-            || null == rule.sampleRate
-            || null == rule.provenance) {
+            || null == rule.sampleRate) {
           log.debug(
               "Invalid sampling rule from remote-config, rule will be removed: {}",
               TRACE_SAMPLING_RULE.toJson(rule));

--- a/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/DynamicConfig.java
@@ -9,6 +9,7 @@ import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.RESPONSE_HEADER_TAGS;
 import static datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE;
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_RULES;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
 
 import datadog.trace.api.sampling.SamplingRule.SpanSamplingRule;
@@ -105,6 +106,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     List<? extends SpanSamplingRule> spanSamplingRules;
     List<? extends TraceSamplingRule> traceSamplingRules;
+    String traceSamplingRulesJson;
     Double traceSampleRate;
 
     String preferredServiceName;
@@ -125,6 +127,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
       this.spanSamplingRules = snapshot.spanSamplingRules;
       this.traceSamplingRules = snapshot.traceSamplingRules;
+      this.traceSamplingRulesJson = snapshot.traceSamplingRulesJson;
       this.traceSampleRate = snapshot.traceSampleRate;
 
       this.tracingTags = snapshot.tracingTags;
@@ -196,8 +199,10 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
       return this;
     }
 
-    public Builder setTraceSamplingRules(List<? extends TraceSamplingRule> traceSamplingRules) {
+    public Builder setTraceSamplingRules(
+        List<? extends TraceSamplingRule> traceSamplingRules, String traceSamplingRulesJson) {
       this.traceSamplingRules = traceSamplingRules;
+      this.traceSamplingRulesJson = traceSamplingRulesJson;
       return this;
     }
 
@@ -285,6 +290,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
     update.put(RESPONSE_HEADER_TAGS, newSnapshot.responseHeaderTags);
     update.put(BAGGAGE_MAPPING, newSnapshot.baggageMapping);
 
+    update.put(TRACE_SAMPLING_RULES, newSnapshot.traceSamplingRulesJson);
     maybePut(update, TRACE_SAMPLE_RATE, newSnapshot.traceSampleRate);
 
     ConfigCollector.get().putAll(update, ConfigOrigin.REMOTE);
@@ -311,6 +317,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
     final List<? extends SpanSamplingRule> spanSamplingRules;
     final List<? extends TraceSamplingRule> traceSamplingRules;
+    final String traceSamplingRulesJson;
 
     final Double traceSampleRate;
     final Map<String, String> tracingTags;
@@ -331,6 +338,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
 
       this.spanSamplingRules = nullToEmpty(builder.spanSamplingRules);
       this.traceSamplingRules = nullToEmpty(builder.traceSamplingRules);
+      this.traceSamplingRulesJson = builder.traceSamplingRulesJson;
       this.traceSampleRate = builder.traceSampleRate;
 
       this.tracingTags = nullToEmpty(builder.tracingTags);
@@ -433,7 +441,7 @@ public final class DynamicConfig<S extends DynamicConfig.Snapshot> {
           + ", spanSamplingRules="
           + spanSamplingRules
           + ", traceSamplingRules="
-          + traceSamplingRules
+          + traceSamplingRulesJson
           + ", traceSampleRate="
           + traceSampleRate
           + ", tracingTags="


### PR DESCRIPTION
# Additional Notes

The approach take here is to cache the original JSON that was parsed into the rules, for both the original static config and any updates to the dynamic config. This required a custom Moshi adapter to capture the raw JSON before it was parsed, but it was simpler than trying to reconstruct the JSON from the rule objects and more consistent with what we were sent.

Jira ticket: [APMAPI-78]

[APMAPI-78]: https://datadoghq.atlassian.net/browse/APMAPI-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ