### PR TITLE
Skip tests for Spark 4.x

### DIFF
--- a/dd-java-agent/instrumentation/spark-executor/build.gradle
+++ b/dd-java-agent/instrumentation/spark-executor/build.gradle
@@ -27,10 +27,7 @@ ext {
   excludeJdk = ['SEMERU8', 'SEMERU11']
 
   // Spark does not support Java > 11 until 3.3.0 https://issues.apache.org/jira/browse/SPARK-33772
-  baseTestMaxJavaVersionForTests = JavaVersion.VERSION_11
-  latest212DepTestMaxJavaVersionForTests = JavaVersion.VERSION_11
-  latest213DepTestMinJavaVersionForTests = JavaVersion.VERSION_17
-  latest213DepTestMaxJavaVersionForTests = JavaVersion.VERSION_17
+  maxJavaVersionForTests = JavaVersion.VERSION_11
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/spark-executor/build.gradle
+++ b/dd-java-agent/instrumentation/spark-executor/build.gradle
@@ -40,9 +40,9 @@ dependencies {
   baseTestImplementation group: 'org.apache.spark', name: "spark-core_2.12", version: "2.4.0"
   baseTestImplementation group: 'org.apache.spark', name: "spark-sql_2.12", version: "2.4.0"
 
-  latest212DepTestImplementation group: 'org.apache.spark', name: "spark-core_2.12", version: '+'
-  latest212DepTestImplementation group: 'org.apache.spark', name: "spark-sql_2.12", version: '+'
+  latest212DepTestImplementation group: 'org.apache.spark', name: "spark-core_2.12", version: '3.+'
+  latest212DepTestImplementation group: 'org.apache.spark', name: "spark-sql_2.12", version: '3.+'
 
-  latest213DepTestImplementation group: 'org.apache.spark', name: "spark-core_2.13", version: '+'
-  latest213DepTestImplementation group: 'org.apache.spark', name: "spark-sql_2.13", version: '+'
+  latest213DepTestImplementation group: 'org.apache.spark', name: "spark-core_2.13", version: '3.+'
+  latest213DepTestImplementation group: 'org.apache.spark', name: "spark-sql_2.13", version: '3.+'
 }

--- a/dd-java-agent/instrumentation/spark-executor/build.gradle
+++ b/dd-java-agent/instrumentation/spark-executor/build.gradle
@@ -27,7 +27,10 @@ ext {
   excludeJdk = ['SEMERU8', 'SEMERU11']
 
   // Spark does not support Java > 11 until 3.3.0 https://issues.apache.org/jira/browse/SPARK-33772
-  maxJavaVersionForTests = JavaVersion.VERSION_11
+  baseTestMaxJavaVersionForTests = JavaVersion.VERSION_11
+  latest212DepTestMaxJavaVersionForTests = JavaVersion.VERSION_11
+  latest213DepTestMinJavaVersionForTests = JavaVersion.VERSION_17
+  latest213DepTestMaxJavaVersionForTests = JavaVersion.VERSION_17
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -26,10 +26,7 @@ ext {
   excludeJdk = ['SEMERU8', 'SEMERU11', 'IBM8']
 
   // Spark does not support Java > 11 until 3.3.0 https://issues.apache.org/jira/browse/SPARK-33772
-  testMaxJavaVersionForTests = JavaVersion.VERSION_11
-  test_spark32MaxJavaVersionForTests = JavaVersion.VERSION_11
-  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_17
-  latestDepTestMaxJavaVersionForTests = JavaVersion.VERSION_17
+  maxJavaVersionForTests = JavaVersion.VERSION_11
 }
 configurations.all {
   resolutionStrategy.deactivateDependencyLocking()
@@ -49,9 +46,10 @@ dependencies {
   test_spark32Implementation group: 'org.apache.spark', name: "spark-sql_$scalaVersion", version: "3.2.4"
   test_spark32Implementation group: 'org.apache.spark', name: "spark-yarn_$scalaVersion", version: "3.2.4"
 
-  latestDepTestImplementation group: 'org.apache.spark', name: "spark-core_$scalaVersion", version: '+'
-  latestDepTestImplementation group: 'org.apache.spark', name: "spark-sql_$scalaVersion", version: '+'
-  latestDepTestImplementation group: 'org.apache.spark', name: "spark-yarn_$scalaVersion", version: '+'
+  // FIXME: Currently not working on Spark 4.0.0 preview releases.
+  latestDepTestImplementation group: 'org.apache.spark', name: "spark-core_$scalaVersion", version: '3.+'
+  latestDepTestImplementation group: 'org.apache.spark', name: "spark-sql_$scalaVersion", version: '3.+'
+  latestDepTestImplementation group: 'org.apache.spark', name: "spark-yarn_$scalaVersion", version: '3.+'
 }
 
 tasks.named("test").configure {

--- a/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
+++ b/dd-java-agent/instrumentation/spark/spark_2.13/build.gradle
@@ -26,7 +26,10 @@ ext {
   excludeJdk = ['SEMERU8', 'SEMERU11', 'IBM8']
 
   // Spark does not support Java > 11 until 3.3.0 https://issues.apache.org/jira/browse/SPARK-33772
-  maxJavaVersionForTests = JavaVersion.VERSION_11
+  testMaxJavaVersionForTests = JavaVersion.VERSION_11
+  test_spark32MaxJavaVersionForTests = JavaVersion.VERSION_11
+  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_17
+  latestDepTestMaxJavaVersionForTests = JavaVersion.VERSION_17
 }
 configurations.all {
   resolutionStrategy.deactivateDependencyLocking()


### PR DESCRIPTION
# What Does This Do

* Limit Spark tests to 3.x.

# Motivation

```
org.junit.platform.commons.JUnitException: TestEngine with ID 'junit-jupiter' failed to discover tests
[...]
Caused by: java.lang.UnsupportedClassVersionError: org/apache/spark/sql/SparkSession has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
[...]
```
