### PR TITLE
Track OpenTelemetry propagated context

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
@@ -58,6 +58,7 @@ public class OpenTelemetryInstrumentation extends InstrumenterModule.Tracing
   public String[] helperClassNames() {
     return new String[] {
       "datadog.opentelemetry.shim.context.OtelContext",
+      "datadog.opentelemetry.shim.context.OtelContext$1",
       "datadog.opentelemetry.shim.context.OtelScope",
       "datadog.opentelemetry.shim.context.propagation.AgentTextMapPropagator",
       "datadog.opentelemetry.shim.context.propagation.OtelContextPropagators",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextInstrumentation.java
@@ -55,6 +55,7 @@ public class OpenTelemetryContextInstrumentation extends InstrumenterModule.Trac
   public String[] helperClassNames() {
     return new String[] {
       "datadog.opentelemetry.shim.context.OtelContext",
+      "datadog.opentelemetry.shim.context.OtelContext$1",
       "datadog.opentelemetry.shim.context.OtelScope",
       "datadog.opentelemetry.shim.trace.OtelExtractedContext",
       "datadog.opentelemetry.shim.trace.OtelConventions",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextStorageInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextStorageInstrumentation.java
@@ -56,6 +56,7 @@ public class OpenTelemetryContextStorageInstrumentation extends InstrumenterModu
   public String[] helperClassNames() {
     return new String[] {
       "datadog.opentelemetry.shim.context.OtelContext",
+      "datadog.opentelemetry.shim.context.OtelContext$1",
       "datadog.opentelemetry.shim.context.OtelScope",
       "datadog.opentelemetry.shim.trace.OtelExtractedContext",
       "datadog.opentelemetry.shim.trace.OtelConventions",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -12,7 +12,6 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.context.ThreadLocalContextStorage
 import opentelemetry14.context.propagation.TextMap
 import org.skyscreamer.jsonassert.JSONAssert
-import spock.lang.Ignore
 import spock.lang.Subject
 
 import java.security.InvalidParameterException
@@ -100,7 +99,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
     }
   }
 
-  @Ignore("Core tracer is not picking incomplete span context from context")
   def "test parent span using propagation data"() {
     setup:
     def traceId = '00000000000000001111111111111111'


### PR DESCRIPTION
# What Does This Do

Uses a thread-local to track the last propagated context from OpenTelemetry that isn't already captured on the scope stack.

# Additional Notes

This is a short-term solution while we rework how we track context in the Java tracer.

It assumes that the propagated context will be used to build a span before any other span is activated on that thread.

Jira ticket: [APMAPI-104]

[APMAPI-104]: https://datadoghq.atlassian.net/browse/APMAPI-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ