### PR TITLE
Add detailed debug logging for tracing/profiler context integration

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -24,6 +24,8 @@ import static com.datadog.profiling.utils.ProfilingMode.ALLOCATION;
 import static com.datadog.profiling.utils.ProfilingMode.CPU;
 import static com.datadog.profiling.utils.ProfilingMode.MEMLEAK;
 import static com.datadog.profiling.utils.ProfilingMode.WALL;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DETAILED_DEBUG_LOGGING;
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_DETAILED_DEBUG_LOGGING_DEFAULT;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS;
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_QUEUEING_TIME_THRESHOLD_MILLIS_DEFAULT;
 
@@ -61,6 +63,8 @@ public final class DatadogProfiler {
   private static final String RESOURCE = "_dd.trace.resource";
 
   private static final int MAX_NUM_ENDPOINTS = 8192;
+
+  private final boolean detailedDebugLogging;
 
   /**
    * Creates a profiler API with default configuration, may result in loading the profiler native
@@ -106,6 +110,9 @@ public final class DatadogProfiler {
   DatadogProfiler(ConfigProvider configProvider, Set<String> contextAttributes) {
     this.configProvider = configProvider;
     this.profiler = JavaProfilerLoader.PROFILER;
+    this.detailedDebugLogging =
+        configProvider.getBoolean(
+            PROFILING_DETAILED_DEBUG_LOGGING, PROFILING_DETAILED_DEBUG_LOGGING_DEFAULT);
     if (JavaProfilerLoader.REASON_NOT_LOADED != null) {
       throw new UnsupportedOperationException(
           "Unable to instantiate datadog profiler", JavaProfilerLoader.REASON_NOT_LOADED);
@@ -301,6 +308,7 @@ public final class DatadogProfiler {
   }
 
   public void setSpanContext(long spanId, long rootSpanId) {
+    debugLogging(rootSpanId);
     try {
       profiler.setContext(spanId, rootSpanId);
     } catch (IllegalStateException e) {
@@ -309,6 +317,7 @@ public final class DatadogProfiler {
   }
 
   public void clearSpanContext() {
+    debugLogging(0L);
     try {
       profiler.setContext(0L, 0L);
     } catch (IllegalStateException e) {
@@ -350,6 +359,12 @@ public final class DatadogProfiler {
       return contextSetter.clearContextValue(offset);
     }
     return false;
+  }
+
+  private void debugLogging(long localRootSpanId) {
+    if (detailedDebugLogging && log.isDebugEnabled()) {
+      log.debug("localRootSpanId={}", localRootSpanId, new Throwable());
+    }
   }
 
   int encode(CharSequence constant) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -208,5 +208,8 @@ public final class ProfilingConfig {
       "profiling.timeline.events.enabled";
   public static final boolean PROFILING_TIMELINE_EVENTS_ENABLED_DEFAULT = false;
 
+  public static final String PROFILING_DETAILED_DEBUG_LOGGING = "profiling.detailed.debug.logging";
+  public static final boolean PROFILING_DETAILED_DEBUG_LOGGING_DEFAULT = false;
+
   private ProfilingConfig() {}
 }


### PR DESCRIPTION
# What Does This Do

Adds a detailed debugging mode for the profiler to diagnose when the tracer sets zero span context unexpectedly.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
