### PR TITLE
Avoid creating unnecessary OtelSpanContext…

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelExtractedContext.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelExtractedContext.java
@@ -29,6 +29,10 @@ public class OtelExtractedContext implements AgentSpan.Context {
 
   public static AgentSpan.Context extract(Context context) {
     Span span = Span.fromContext(context);
+    if (span instanceof OtelSpan) {
+      // avoid creating unnecessary OtelSpanContext
+      return ((OtelSpan) span).getAgentSpanContext();
+    }
     SpanContext spanContext = span.getSpanContext();
     if (spanContext instanceof OtelSpanContext) {
       return ((OtelSpanContext) spanContext).delegate;


### PR DESCRIPTION
…when extracting context from OTel wrapper around Datadog span

# Motivation

`getSpanContext` ends up creating an intermediate `OtelSpanContext` when we really just need the agent span context.

( It also queries the local root span for the sampling priority and creates a default trace state, which is also never used here. )