### PR TITLE
Remove too generic redaction keywords

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/Redaction.java
@@ -20,7 +20,6 @@ public class Redaction {
       Arrays.asList(
           "2fa",
           "accesstoken",
-          "address",
           "aiohttpsession",
           "apikey",
           "appkey",
@@ -35,7 +34,6 @@ public class Redaction {
           "cipher",
           "clientid",
           "clientsecret",
-          "config",
           "connectionstring",
           "connectsid",
           "cookie",


### PR DESCRIPTION
# What Does This Do

# Motivation
config and address are too generic and can redact useful and not sensible variables

# Additional Notes


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
