### PR TITLE
Ensure locals are in scope when generating metrics

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -16,6 +16,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
+import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.InsnList;
@@ -23,6 +24,7 @@ import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.LdcInsnNode;
 import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TypeInsnNode;
 
 /** Helper class for bytecode generation */
@@ -272,6 +274,23 @@ public class ASMHelper {
             org.objectweb.asm.Type.getMethodDescriptor(org.objectweb.asm.Type.VOID_TYPE, argTypes),
             false));
     // stack: []
+  }
+
+  /** Checks if the given variable is in scope at the given location */
+  public static boolean isInScope(
+      MethodNode methodNode, LocalVariableNode variableNode, AbstractInsnNode location) {
+    AbstractInsnNode startScope =
+        variableNode.start != null ? variableNode.start : methodNode.instructions.getFirst();
+    AbstractInsnNode endScope =
+        variableNode.end != null ? variableNode.end : methodNode.instructions.getLast();
+    AbstractInsnNode insn = startScope;
+    while (insn != null && insn != endScope) {
+      if (insn == location) {
+        return true;
+      }
+      insn = insn.getNext();
+    }
+    return false;
   }
 
   /** Wraps ASM's {@link org.objectweb.asm.Type} with associated generic types */


### PR DESCRIPTION
# What Does This Do
Verify that where the metric is inserted, the local variable that we
 try to access is in scope (from the LocalVariableTable)
We are doing this for CapturedContext now we add this for metrics to avoid having a VerifyError raised because the variable is not accessible or reused with another type than expected.

# Motivation
avoid VerifyError exception when loading the instrumented class

# Additional Notes

Jira ticket: [DEBUG-2400]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2400]: https://datadoghq.atlassian.net/browse/DEBUG-2400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ