### PR TITLE
Align classLoaderMatcher signature with OpenTelemetry

### DIFF
--- a/dd-java-agent/agent-otel/otel-tooling/src/main/java/datadog/opentelemetry/tooling/OtelElementMatchers.java
+++ b/dd-java-agent/agent-otel/otel-tooling/src/main/java/datadog/opentelemetry/tooling/OtelElementMatchers.java
@@ -1,0 +1,43 @@
+package datadog.opentelemetry.tooling;
+
+import datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers;
+import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+/** Replaces OpenTelemetry's {@code AgentElementMatchers} when mapping extensions. */
+public final class OtelElementMatchers {
+
+  public static ElementMatcher.Junction<TypeDescription> extendsClass(
+      ElementMatcher<TypeDescription> matcher) {
+    return HierarchyMatchers.extendsClass(matcher);
+  }
+
+  public static ElementMatcher.Junction<TypeDescription> implementsInterface(
+      ElementMatcher<TypeDescription> matcher) {
+    return HierarchyMatchers.implementsInterface(matcher);
+  }
+
+  public static ElementMatcher.Junction<TypeDescription> hasSuperType(
+      ElementMatcher<TypeDescription> matcher) {
+    return HierarchyMatchers.hasSuperType(matcher);
+  }
+
+  public static ElementMatcher.Junction<MethodDescription> methodIsDeclaredByType(
+      ElementMatcher<? super TypeDescription> matcher) {
+    return ElementMatchers.isDeclaredBy(matcher);
+  }
+
+  public static ElementMatcher.Junction<MethodDescription> hasSuperMethod(
+      ElementMatcher<? super MethodDescription> matcher) {
+    return HierarchyMatchers.hasSuperMethod(matcher);
+  }
+
+  public static ElementMatcher.Junction<ClassLoader> hasClassesNamed(String... classNames) {
+    return ClassLoaderMatchers.hasClassNamedOneOf(classNames);
+  }
+
+  private OtelElementMatchers() {}
+}

--- a/dd-java-agent/agent-otel/otel-tooling/src/main/java/datadog/opentelemetry/tooling/OtelInstrumentationMapper.java
+++ b/dd-java-agent/agent-otel/otel-tooling/src/main/java/datadog/opentelemetry/tooling/OtelInstrumentationMapper.java
@@ -45,11 +45,10 @@ public final class OtelInstrumentationMapper extends ClassRemapper {
   @Override
   public MethodVisitor visitMethod(
       int access, String name, String descriptor, String signature, String[] exceptions) {
-    if (!UNSUPPORTED_METHODS.contains(name)) {
-      return super.visitMethod(access, name, descriptor, signature, exceptions);
-    } else {
+    if (UNSUPPORTED_METHODS.contains(name)) {
       return null; // remove unsupported method
     }
+    return super.visitMethod(access, name, descriptor, signature, exceptions);
   }
 
   private String[] removeUnsupportedTypes(String[] interfaces) {
@@ -85,11 +84,11 @@ public final class OtelInstrumentationMapper extends ClassRemapper {
           "io/opentelemetry/javaagent/extension/instrumentation/TypeTransformer",
           "datadog/opentelemetry/tooling/OtelTransformer");
       RENAMED_TYPES.put(
+          "io/opentelemetry/javaagent/extension/matcher/AgentElementMatchers",
+          "datadog/opentelemetry/tooling/OtelElementMatchers");
+      RENAMED_TYPES.put(
           "io/opentelemetry/javaagent/bootstrap/Java8BytecodeBridge",
           "datadog/trace/bootstrap/otel/Java8BytecodeBridge");
-      RENAMED_TYPES.put(
-          "io/opentelemetry/javaagent/extension/matcher/AgentElementMatchers",
-          "datadog/trace/agent/tooling/bytebuddy/matcher/HierarchyMatchers");
     }
 
     @Override

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -142,7 +142,7 @@ public abstract class InstrumenterModule implements Instrumenter {
   }
 
   /** Override this to supply additional class-loader requirements. */
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return ANY_CLASS_LOADER;
   }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/matcher/ClassLoaderMatchers.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 public final class ClassLoaderMatchers {
   private static final Logger log = LoggerFactory.getLogger(ClassLoaderMatchers.class);
 
-  public static final ElementMatcher<ClassLoader> ANY_CLASS_LOADER = any();
+  public static final ElementMatcher.Junction<ClassLoader> ANY_CLASS_LOADER = any();
 
   private static final ClassLoader BOOTSTRAP_CLASSLOADER = null;
 

--- a/dd-java-agent/instrumentation/armeria-jetty/src/main/java/datadog/trace/instrumentation/armeria/jetty/ArmeriaHttpConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/armeria-jetty/src/main/java/datadog/trace/instrumentation/armeria/jetty/ArmeriaHttpConnectionInstrumentation.java
@@ -24,7 +24,7 @@ public class ArmeriaHttpConnectionInstrumentation extends InstrumenterModule.Tra
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("com.linecorp.armeria.server.ServiceRequestContext");
   }
 

--- a/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/InvokerInstrumentation.java
+++ b/dd-java-agent/instrumentation/cxf-2.1/src/main/java/datadog/trace/instrumentation/cxf/InvokerInstrumentation.java
@@ -24,7 +24,7 @@ public class InvokerInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return ClassLoaderMatchers.hasClassNamed("javax.servlet.ServletRequest")
         .or(ClassLoaderMatchers.hasClassNamed("jakarta.servlet.ServletRequest"));
   }

--- a/dd-java-agent/instrumentation/datastax-cassandra-3.8/src/main/java/datadog/trace/instrumentation/datastax/cassandra38/CassandraClusterInstrumentation.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3.8/src/main/java/datadog/trace/instrumentation/datastax/cassandra38/CassandraClusterInstrumentation.java
@@ -36,7 +36,7 @@ public class CassandraClusterInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("com.datastax.driver.core.EndPoint");
   }
 

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClusterInstrumentation.java
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/main/java/datadog/trace/instrumentation/datastax/cassandra/CassandraClusterInstrumentation.java
@@ -37,7 +37,7 @@ public class CassandraClusterInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return not(hasClassNamed("com.datastax.driver.core.EndPoint"));
   }
 

--- a/dd-java-agent/instrumentation/elasticsearch/rest-7/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/rest-7/src/main/java/datadog/trace/instrumentation/elasticsearch7/Elasticsearch7RestClientInstrumentation.java
@@ -31,7 +31,7 @@ public class Elasticsearch7RestClientInstrumentation extends InstrumenterModule.
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching pre-ES7 releases which have their own instrumentations.
     return hasClassNamed("org.elasticsearch.client.RestClient$InternalRequest");
   }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/Elasticsearch73TransportClientInstrumentation.java
@@ -32,7 +32,7 @@ public class Elasticsearch73TransportClientInstrumentation extends InstrumenterM
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching pre-ES7 releases which have their own instrumentations.
     return hasClassNamed("org.elasticsearch.action.ActionType");
   }

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildScopeServicesInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildScopeServicesInstrumentation.java
@@ -23,7 +23,7 @@ public class GradleBuildScopeServicesInstrumentation extends InstrumenterModule.
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only instrument Gradle 8.3+
     return hasClassNamed("org.gradle.api.file.ConfigurableFilePermissions");
   }

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradlePluginInjectorInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradlePluginInjectorInstrumentation.java
@@ -18,7 +18,7 @@ public class GradlePluginInjectorInstrumentation extends InstrumenterModule.CiVi
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only instrument Gradle 8.3+
     return hasClassNamed("org.gradle.api.file.ConfigurableFilePermissions");
   }

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/legacy/GradleBuildListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/legacy/GradleBuildListenerInstrumentation.java
@@ -22,7 +22,7 @@ public class GradleBuildListenerInstrumentation extends InstrumenterModule.CiVis
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only instrument Gradle older than 8.3
     return not(hasClassNamed("org.gradle.api.file.ConfigurableFilePermissions"));
   }

--- a/dd-java-agent/instrumentation/gson-1.6/src/main/java/datadog/trace/instrumentation/gson/JsonReaderInstrumentation.java
+++ b/dd-java-agent/instrumentation/gson-1.6/src/main/java/datadog/trace/instrumentation/gson/JsonReaderInstrumentation.java
@@ -34,7 +34,7 @@ public class JsonReaderInstrumentation extends InstrumenterModule.Iast
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("com.google.gson.stream.JsonReader");
   }
 

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java/datadog/trace/instrumentation/httpclient/HttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java/datadog/trace/instrumentation/httpclient/HttpClientInstrumentation.java
@@ -26,7 +26,7 @@ public class HttpClientInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("java.net.http.HttpClient");
   }
 

--- a/dd-java-agent/instrumentation/java-http-client/src/main/java/datadog/trace/instrumentation/httpclient/HttpHeadersInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-http-client/src/main/java/datadog/trace/instrumentation/httpclient/HttpHeadersInstrumentation.java
@@ -22,7 +22,7 @@ public class HttpHeadersInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("java.net.http.HttpRequest");
   }
 

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -54,7 +54,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching JAX-RS 2 which has its own instrumentation.
     return not(hasClassNamed("javax.ws.rs.container.AsyncResponse"));
   }

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -64,7 +64,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching JAX-RS 1 which has its own instrumentation.
     return hasClassNamed("javax.ws.rs.container.AsyncResponse");
   }

--- a/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
+++ b/dd-java-agent/instrumentation/jedis-1.4/src/main/java/datadog/trace/instrumentation/jedis/JedisInstrumentation.java
@@ -29,7 +29,7 @@ public final class JedisInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching Jedis 3+ which has its own instrumentation.
     return not(hasClassNamed("redis.clients.jedis.commands.ProtocolCommand"));
   }

--- a/dd-java-agent/instrumentation/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
@@ -75,17 +75,17 @@ public class RequestGetPartsInstrumentation extends InstrumenterModule.AppSec
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return RequestImplementationClassLoaderMatcher.INSTANCE;
   }
 
   public static class RequestImplementationClassLoaderMatcher
-      implements ElementMatcher<ClassLoader> {
-    public static final ElementMatcher<ClassLoader> INSTANCE =
+      extends ElementMatcher.Junction.ForNonNullValues<ClassLoader> {
+    public static final ElementMatcher.Junction<ClassLoader> INSTANCE =
         new RequestImplementationClassLoaderMatcher();
 
     @Override
-    public boolean matches(ClassLoader cl) {
+    protected boolean doMatch(ClassLoader cl) {
       InputStream is = cl.getResourceAsStream("org/eclipse/jetty/server/Request.class");
       if (is == null) {
         return false;

--- a/dd-java-agent/instrumentation/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-appsec-8.1.3/src/main/java/datadog/trace/instrumentation/jetty8/RequestGetPartsInstrumentation.java
@@ -86,17 +86,15 @@ public class RequestGetPartsInstrumentation extends InstrumenterModule.AppSec
 
     @Override
     protected boolean doMatch(ClassLoader cl) {
-      InputStream is = cl.getResourceAsStream("org/eclipse/jetty/server/Request.class");
-      if (is == null) {
-        return false;
-      }
-      try {
+      try (InputStream is = cl.getResourceAsStream("org/eclipse/jetty/server/Request.class")) {
+        if (is == null) {
+          return false;
+        }
         ClassReader classReader = new ClassReader(is);
         final boolean[] foundField = new boolean[1];
         final boolean[] foundGetParameters = new boolean[1];
         classReader.accept(new ClassLoaderMatcherClassVisitor(foundField, foundGetParameters), 0);
         return !foundField[0] && foundGetParameters[0];
-
       } catch (IOException e) {
         return false;
       }

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5CucumberInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5CucumberInstrumentation.java
@@ -30,7 +30,7 @@ public class JUnit5CucumberInstrumentation extends InstrumenterModule.CiVisibili
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("io.cucumber.junit.platform.engine.CucumberTestEngine");
   }
 

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5CucumberItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5CucumberItrInstrumentation.java
@@ -31,7 +31,7 @@ public class JUnit5CucumberItrInstrumentation extends InstrumenterModule.CiVisib
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("io.cucumber.junit.platform.engine.CucumberTestEngine");
   }
 

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockInstrumentation.java
@@ -30,7 +30,7 @@ public class JUnit5SpockInstrumentation extends InstrumenterModule.CiVisibility
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("org.spockframework.runtime.SpockEngine");
   }
 

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockItrInstrumentation.java
@@ -32,7 +32,7 @@ public class JUnit5SpockItrInstrumentation extends InstrumenterModule.CiVisibili
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("org.spockframework.runtime.SpockEngine");
   }
 

--- a/dd-java-agent/instrumentation/opensearch/transport/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/opensearch/transport/src/main/java/datadog/trace/instrumentation/opensearch/OpensearchTransportClientInstrumentation.java
@@ -31,7 +31,7 @@ public class OpensearchTransportClientInstrumentation extends InstrumenterModule
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("org.opensearch.action.ActionType");
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/GlobalTracerInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/GlobalTracerInstrumentation.java
@@ -26,7 +26,7 @@ public class GlobalTracerInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching OT 0.32+ which has its own instrumentation.
     return not(hasClassNamed("io.opentracing.tag.Tag"));
   }

--- a/dd-java-agent/instrumentation/osgi-4.3/src/main/java/datadog/trace/instrumentation/osgi43/BundleReferenceInstrumentation.java
+++ b/dd-java-agent/instrumentation/osgi-4.3/src/main/java/datadog/trace/instrumentation/osgi43/BundleReferenceInstrumentation.java
@@ -29,7 +29,7 @@ public final class BundleReferenceInstrumentation extends InstrumenterModule.Tra
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching older versions of OSGi that don't have the wiring API.
     return hasClassNamed("org.osgi.framework.wiring.BundleWiring");
   }

--- a/dd-java-agent/instrumentation/reactor-netty-1/src/main/java/datadog/trace/instrumentation/reactor/netty/HttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactor-netty-1/src/main/java/datadog/trace/instrumentation/reactor/netty/HttpClientInstrumentation.java
@@ -26,7 +26,7 @@ public class HttpClientInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching pre-1.0 releases which are not compatible.
     return hasClassNamed("reactor.netty.transport.AddressUtils");
   }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/IastServlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/IastServlet2Instrumentation.java
@@ -31,11 +31,11 @@ public final class IastServlet2Instrumentation extends InstrumenterModule.Iast
   }
 
   // Avoid matching servlet 3 which has its own instrumentation
-  static final ElementMatcher<ClassLoader> NOT_SERVLET_3 =
+  static final ElementMatcher.Junction<ClassLoader> NOT_SERVLET_3 =
       not(hasClassNamed("javax.servlet.AsyncEvent"));
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return NOT_SERVLET_3;
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Instrumentation.java
@@ -31,11 +31,11 @@ public final class Servlet2Instrumentation extends InstrumenterModule.Tracing
   }
 
   // Avoid matching servlet 3 which has its own instrumentation
-  static final ElementMatcher<ClassLoader> NOT_SERVLET_3 =
+  static final ElementMatcher.Junction<ClassLoader> NOT_SERVLET_3 =
       not(hasClassNamed("javax.servlet.AsyncEvent"));
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return NOT_SERVLET_3;
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2ResponseStatusInstrumentation.java
@@ -26,7 +26,7 @@ public final class Servlet2ResponseStatusInstrumentation extends InstrumenterMod
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return Servlet2Instrumentation.NOT_SERVLET_3;
   }
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletRequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/ServletRequestBodyInstrumentation.java
@@ -53,7 +53,7 @@ public class ServletRequestBodyInstrumentation extends InstrumenterModule.AppSec
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching request bodies after 3.0.x which have their own instrumentation
     return not(hasClassNamed("javax.servlet.ReadListener"));
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/IastServlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/IastServlet3Instrumentation.java
@@ -29,7 +29,7 @@ public final class IastServlet3Instrumentation extends InstrumenterModule.Iast
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching servlet 2 which has its own instrumentation
     return hasClassNamed("javax.servlet.AsyncEvent");
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet31RequestBodyInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet31RequestBodyInstrumentation.java
@@ -33,7 +33,7 @@ public class Servlet31RequestBodyInstrumentation extends InstrumenterModule.AppS
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching request bodies before 3.1.x which have their own instrumentation
     return hasClassNamed("javax.servlet.ReadListener");
   }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Instrumentation.java
@@ -27,7 +27,7 @@ public final class Servlet3Instrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching servlet 2 which has its own instrumentation
     return hasClassNamed("javax.servlet.AsyncEvent");
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HttpMessageConverterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HttpMessageConverterInstrumentation.java
@@ -36,7 +36,7 @@ public class HttpMessageConverterInstrumentation extends InstrumenterModule.AppS
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only apply this spring-framework instrumentation when spring-webmvc is also deployed.
     return hasClassNamed(
         "org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping");

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateAndMatrixVariablesInstrumentation.java
@@ -56,7 +56,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends InstrumenterModul
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only apply to versions of spring-webmvc that include request mapping information
     return hasClassNamed("org.springframework.web.servlet.mvc.method.RequestMappingInfo");
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/TemplateVariablesUrlHandlerInstrumentation.java
@@ -55,7 +55,7 @@ public class TemplateVariablesUrlHandlerInstrumentation extends InstrumenterModu
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only apply to versions of spring-webmvc that include request mapping information
     return hasClassNamed("org.springframework.web.servlet.mvc.method.RequestMappingInfo");
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/ServletPathRequestFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-5.3/src/main/java/datadog/trace/instrumentation/springweb/ServletPathRequestFilterInstrumentation.java
@@ -28,7 +28,7 @@ public class ServletPathRequestFilterInstrumentation extends InstrumenterModule.
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("org.springframework.web.filter.ServletRequestPathFilter")
         .and(hasClassNamed("javax.servlet.Filter"));
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/ServletPathRequestFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/ServletPathRequestFilterInstrumentation.java
@@ -25,7 +25,7 @@ public class ServletPathRequestFilterInstrumentation extends InstrumenterModule.
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     return hasClassNamed("org.springframework.web.filter.ServletRequestPathFilter")
         .and(hasClassNamed("jakarta.servlet.Filter"));
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/TemplateAndMatrixVariablesInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/TemplateAndMatrixVariablesInstrumentation.java
@@ -38,7 +38,7 @@ public class TemplateAndMatrixVariablesInstrumentation extends InstrumenterModul
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only apply to versions of spring-webmvc that include request mapping information
     return hasClassNamed("org.springframework.web.servlet.mvc.method.RequestMappingInfo");
   }

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/TemplateVariablesUrlHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java/datadog/trace/instrumentation/springweb6/TemplateVariablesUrlHandlerInstrumentation.java
@@ -38,7 +38,7 @@ public class TemplateVariablesUrlHandlerInstrumentation extends InstrumenterModu
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only apply to versions of spring-webmvc that include request mapping information
     return hasClassNamed("org.springframework.web.servlet.mvc.method.RequestMappingInfo");
   }

--- a/dd-java-agent/instrumentation/testng/testng-6/src/main/java/datadog/trace/instrumentation/testng6/TestNGClassListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/testng-6/src/main/java/datadog/trace/instrumentation/testng6/TestNGClassListenerInstrumentation.java
@@ -29,7 +29,7 @@ public class TestNGClassListenerInstrumentation extends InstrumenterModule.CiVis
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // do not apply to TestNG 7.x and above
     // since those versions are handled by a different instrumentation
     return not(hasClassNamed("org.testng.annotations.CustomAttribute"));

--- a/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/ParsedBodyParametersInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-5.5/src/main/java/datadog/trace/instrumentation/tomcat55/ParsedBodyParametersInstrumentation.java
@@ -40,7 +40,7 @@ public class ParsedBodyParametersInstrumentation extends InstrumenterModule.AppS
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Avoid matching Tomcat 5.0.x which is not supported by this instrumentation.
     return hasClassNamed("org.apache.tomcat.util.buf.StringCache");
   }

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -35,7 +35,7 @@ public class TwilioAsyncInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  public ElementMatcher<ClassLoader> classLoaderMatcher() {
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
     // Only apply instrumentation when guava's ListenableFuture is also deployed.
     return hasClassNamed("com.google.common.util.concurrent.ListenableFuture");
   }


### PR DESCRIPTION
# Motivation

This avoids the need to generate a bridge method when mapping OpenTelemetry extensions.

# Additional Notes

This PR also fixes a resource leak in `RequestImplementationClassLoaderMatcher` which I spotted while refactoring.

Jira ticket: [APMAPI-6]

[APMAPI-6]: https://datadoghq.atlassian.net/browse/APMAPI-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ