### PR TITLE
netty client: don't finish parent span

### DIFF
--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
@@ -71,7 +71,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     parentAttr.setIfAbsent(noopSpan());
     final AgentSpan parent = parentAttr.get();
     final AgentSpan span = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).getAndSet(parent);
-    if (span != null) {
+    if (span != null && span != parent) {
       try (final AgentScope scope = activateSpan(span)) {
         DECORATE.beforeFinish(span);
         span.finish();

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -80,7 +80,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     parentAttr.setIfAbsent(noopSpan());
     final AgentSpan parent = parentAttr.get();
     final AgentSpan span = ctx.channel().attr(SPAN_ATTRIBUTE_KEY).getAndSet(parent);
-    if (span != null) {
+    if (span != null && span != parent) {
       try (final AgentScope scope = activateSpan(span)) {
         DECORATE.beforeFinish(span);
         span.finish();


### PR DESCRIPTION
# What Does This Do

Avoid finishing the parent span when `channelInactive` is called. 

# Motivation

# Additional Notes

Jira ticket: [APMS-12066]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-12066]: https://datadoghq.atlassian.net/browse/APMS-12066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ