### PR TITLE
Tune static analysis rules

### DIFF
--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,9 +1,25 @@
 rulesets:
-  - java-best-practices
-  - java-code-style
+  - java-best-practices:
+    rules:
+      array-is-stored-directly:
+        ignore:
+          - "**"
+      avoid-reassigning-parameters:
+        ignore:
+          - "**"
+  - java-code-style:
+    rules:
+      boolean-get-method-name:
+        ignore:
+          - "**"
+      generics-naming:
+        ignore:
+          - "**"
   - java-security
 ignore-paths:
   - ".mvn/**"
   - "dd-java-agent/appsec/weblog/**"
   - "dd-java-agent/benchmark-integration/**"
   - "dd-smoke-tests/**"
+  - "**/src/test/**"
+  - "**/src/jmh/**"


### PR DESCRIPTION
# What Does This Do
* Disable some rules that are considered fine in our codebase.
* Disable all rules for `src/test` and `src/jmh`, since the results are generally irrelevant there.

# Motivation
Reduce noise in Static Analysis results.

# Additional Notes
