### PR TITLE
SpanId in reported AppSec events

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -27,6 +27,8 @@ import datadog.trace.api.ProductActivation;
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.api.telemetry.WafMetricCollector;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.sqreen.powerwaf.Additive;
 import io.sqreen.powerwaf.Powerwaf;
 import io.sqreen.powerwaf.PowerwafConfig;
@@ -580,6 +582,12 @@ public class PowerWAFModule implements AppSecModule {
       ruleMatchList.add(ruleMatch);
     }
 
+    Long spanId = null;
+    AgentSpan agentSpan = AgentTracer.get().activeSpan();
+    if (agentSpan != null) {
+      spanId = agentSpan.getSpanId();
+    }
+
     return new AppSecEvent.Builder()
         .withRule(
             new Rule.Builder()
@@ -588,6 +596,7 @@ public class PowerWAFModule implements AppSecModule {
                 .withTags(wafResult.rule.tags)
                 .build())
         .withRuleMatches(ruleMatchList)
+        .withSpanId(spanId)
         .build();
   }
 

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/AppSecEvent.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/AppSecEvent.java
@@ -2,6 +2,7 @@ package com.datadog.appsec.report;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class AppSecEvent {
 
@@ -11,16 +12,19 @@ public class AppSecEvent {
   @com.squareup.moshi.Json(name = "rule_matches")
   private List<RuleMatch> ruleMatches = new ArrayList<>();
 
+  @com.squareup.moshi.Json(name = "span_id")
+  private Long spanId;
+
   public Rule getRule() {
     return rule;
   }
 
-  public void setRule(Rule rule) {
-    this.rule = rule;
-  }
-
   public List<RuleMatch> getRuleMatches() {
     return ruleMatches;
+  }
+
+  public Long getSpanId() {
+    return spanId;
   }
 
   @Override
@@ -38,6 +42,9 @@ public class AppSecEvent {
     sb.append('=');
     sb.append(((this.ruleMatches == null) ? "<null>" : this.ruleMatches));
     sb.append(',');
+    sb.append("spanId");
+    sb.append('=');
+    sb.append(((this.spanId == null) ? "<null>" : this.spanId));
     if (sb.charAt((sb.length() - 1)) == ',') {
       sb.setCharAt((sb.length() - 1), ']');
     } else {
@@ -51,6 +58,7 @@ public class AppSecEvent {
     int result = 1;
     result = ((result * 31) + ((this.rule == null) ? 0 : this.rule.hashCode()));
     result = ((result * 31) + ((this.ruleMatches == null) ? 0 : this.ruleMatches.hashCode()));
+    result = ((result * 31) + ((this.spanId == null) ? 0 : this.spanId.hashCode()));
     return result;
   }
 
@@ -63,9 +71,9 @@ public class AppSecEvent {
       return false;
     }
     AppSecEvent rhs = ((AppSecEvent) other);
-    return (((this.rule == rhs.rule) || ((this.rule != null) && this.rule.equals(rhs.rule)))
-        && ((this.ruleMatches == rhs.ruleMatches)
-            || ((this.ruleMatches != null) && this.ruleMatches.equals(rhs.ruleMatches))));
+    return ((Objects.equals(this.rule, rhs.rule))
+        && (Objects.equals(this.ruleMatches, rhs.ruleMatches))
+        && (Objects.equals(this.spanId, rhs.spanId)));
   }
 
   public static class Builder {
@@ -90,6 +98,11 @@ public class AppSecEvent {
 
     public Builder withRuleMatches(List<RuleMatch> ruleMatches) {
       this.instance.ruleMatches = ruleMatches;
+      return this;
+    }
+
+    public Builder withSpanId(Long spanId) {
+      this.instance.spanId = spanId;
       return this;
     }
   }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -203,6 +203,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
       pwafAdditive = it[0].openAdditive()
     }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
@@ -234,6 +235,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
       pwafAdditive = it[0].openAdditive()
     }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     2 * ctx.closeAdditive()
@@ -273,6 +275,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
       pwafAdditive = it[0].openAdditive()
     }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
@@ -295,6 +298,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
       pwafAdditive = it[0].openAdditive()
     }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
@@ -349,6 +353,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
       pwafAdditive = it[0].openAdditive()
     }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
@@ -423,6 +428,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true) >> {
       pwafAdditive = it[0].openAdditive()
     }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> { pwafAdditive.close() }
@@ -501,6 +507,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true) >> {
       pwafAdditive = it[0].openAdditive()
     }
+    2 * tracer.activeSpan()
     // we get two events: one for origin rule, and one for the custom one
     1 * ctx.reportEvents(hasSize(2))
     1 * ctx.getWafMetrics()
@@ -576,6 +583,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
         rba.blockingContentType == BlockingContentType.AUTO
     })
     1 * ctx.getOrCreateAdditive(_, true) >> { it[0].openAdditive() }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
@@ -976,6 +984,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     1 * reconf.reloadSubscriptions()
     1 * ctx.getOrCreateAdditive(_, true) >> { pwafAdditive = it[0].openAdditive() }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * flow.setAction({ it.blocking })
@@ -1074,6 +1083,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * reconf.reloadSubscriptions()
     1 * ctx.getOrCreateAdditive(_, true) >> {
       pwafAdditive = it[0].openAdditive() }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * flow.setAction({ it.blocking })
@@ -1176,6 +1186,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getWafMetrics()
     1 * flow.isBlocking()
     1 * flow.setAction({ it.blocking })
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     _ * ctx.increaseTimeouts()
@@ -1306,6 +1317,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     1 * ctx.getOrCreateAdditive(_, true) >> {
       pwafAdditive = it[0].openAdditive() }
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>) >> {
       it[0].iterator().next().ruleMatches[0].parameters[0].value == '/cybercop'
     }
@@ -1321,6 +1333,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true) >> {
       pwafAdditive }
     1 * flow.setAction({ it.blocking })
+    1 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>) >> {
       it[0].iterator().next().ruleMatches[0].parameters[0].value == 'user-to-block-1'
     }


### PR DESCRIPTION
# What Does This Do
Added `spanId` in AppSec events. It points to the span where the AppSec detected malicious data.

# Motivation
This is preparation work for stack trace reporting in Exploit prevention initiative (RASP)

# Additional Notes
<img width="698" alt="image" src="https://github.com/DataDog/dd-trace-java/assets/7569471/14a7e1c5-382f-48d6-a51f-0923e90e3d54">

Jira ticket: [APPSEC-46818]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-46818]: https://datadoghq.atlassian.net/browse/APPSEC-46818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ