### PR TITLE
Rework the bytecode cache for extensions so it works across connections

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExtensionHandler.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/ExtensionHandler.java
@@ -79,7 +79,7 @@ public class ExtensionHandler {
 
   /** Provides access to bytecode mapped from the extension. */
   protected static class ClassMappingConnection extends JarFileConnection {
-    private static final DDCache<String, byte[]> bytecodeCache = DDCaches.newFixedSizeCache(32);
+    private static final DDCache<String, byte[]> BYTECODE_CACHE = DDCaches.newFixedSizeCache(32);
 
     private final Function<ClassVisitor, ClassVisitor> mapping;
 
@@ -108,7 +108,7 @@ public class ExtensionHandler {
     }
 
     private byte[] mapBytecode() {
-      return bytecodeCache.computeIfAbsent(url.getFile(), this::doMapBytecode);
+      return BYTECODE_CACHE.computeIfAbsent(url.getFile(), this::doMapBytecode);
     }
 
     private byte[] doMapBytecode(String unused) {


### PR DESCRIPTION
# Motivation

This is a performance improvement to avoid re-mapping OpenTelemetry class files even when the surrounding `URLConnection` request is different (for example byte-buddy may repeatedly access the advice class while applying it to different types.)

# Additional Notes

The shared cache can be small because extension requests are typically localized - in other words we are more likely to get a repeated sequence of requests involving the same advice class, than random requests over all classes in the extension.

Jira ticket: [APMAPI-6]


[APMAPI-6]: https://datadoghq.atlassian.net/browse/APMAPI-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ