### PR TITLE
Use three modes for auto user id collection: identification (default), anonymization and disabled

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecorator.java
@@ -1,32 +1,35 @@
 package datadog.trace.bootstrap.instrumentation.decorator;
 
-import static datadog.trace.api.UserEventTrackingMode.DISABLED;
-import static datadog.trace.api.UserEventTrackingMode.SAFE;
+import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
+import static datadog.trace.util.Strings.toHexString;
 
 import datadog.trace.api.Config;
-import datadog.trace.api.UserEventTrackingMode;
+import datadog.trace.api.UserIdCollectionMode;
 import datadog.trace.api.internal.TraceSegment;
+import datadog.trace.api.telemetry.WafMetricCollector;
 import datadog.trace.bootstrap.ActiveSubsystems;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Map;
-import java.util.regex.Pattern;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AppSecUserEventDecorator {
 
-  private static final String NUMBER_PATTERN = "[0-9]+";
-  private static final String UUID_PATTERN =
-      "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
-  private static final Pattern SAFE_USER_ID_PATTERN =
-      Pattern.compile(NUMBER_PATTERN + "|" + UUID_PATTERN, Pattern.CASE_INSENSITIVE);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AppSecUserEventDecorator.class);
+  private static final int HASH_SIZE_BYTES = 16; // 128 bits
+  private static final String ANONYM_PREFIX = "anon_";
+  private static AtomicBoolean SHA_MISSING_REPORTED = new AtomicBoolean(false);
 
   public boolean isEnabled() {
     if (!ActiveSubsystems.APPSEC_ACTIVE) {
       return false;
     }
-    UserEventTrackingMode mode = Config.get().getAppSecUserEventsTrackingMode();
-    if (mode == DISABLED) {
+    if (getUserIdCollectionMode() == UserIdCollectionMode.DISABLED) {
       return false;
     }
     return true;
@@ -44,6 +47,11 @@ public class AppSecUserEventDecorator {
   }
 
   public void onLoginSuccess(String userId, Map<String, String> metadata) {
+    if (userId == null) {
+      onMissingUserId();
+      return;
+    }
+
     TraceSegment segment = getSegment();
     if (segment == null) {
       return;
@@ -54,6 +62,11 @@ public class AppSecUserEventDecorator {
   }
 
   public void onLoginFailure(String userId, Map<String, String> metadata) {
+    if (userId == null) {
+      onMissingUserId();
+      return;
+    }
+
     TraceSegment segment = getSegment();
     if (segment == null) {
       return;
@@ -64,6 +77,11 @@ public class AppSecUserEventDecorator {
   }
 
   public void onSignup(String userId, Map<String, String> metadata) {
+    if (userId == null) {
+      onMissingUserId();
+      return;
+    }
+
     TraceSegment segment = getSegment();
     if (segment == null) {
       return;
@@ -78,9 +96,9 @@ public class AppSecUserEventDecorator {
     segment.setTagTop(Tags.ASM_KEEP, true);
     segment.setTagTop(Tags.PROPAGATED_APPSEC, true);
 
-    // Report user event tracking mode ("safe" or "extended")
-    UserEventTrackingMode mode = Config.get().getAppSecUserEventsTrackingMode();
-    if (mode != DISABLED) {
+    // Report user event tracking mode ("identification" or "anonymization")
+    UserIdCollectionMode mode = getUserIdCollectionMode();
+    if (mode != UserIdCollectionMode.DISABLED) {
       segment.setTagTop("_dd.appsec.events." + eventName + ".auto.mode", mode.toString());
     }
 
@@ -89,19 +107,56 @@ public class AppSecUserEventDecorator {
     }
   }
 
-  private void onUserId(final TraceSegment segment, final String tag, final String userId) {
+  /** Takes care of user anonymization if required. */
+  protected void onUserId(final TraceSegment segment, final String tagName, final String userId) {
+    if (segment.getTagTop(tagName) != null) {
+      // do not override user ids set by the SDK
+      return;
+    }
+    String finalUserId =
+        getUserIdCollectionMode() == UserIdCollectionMode.ANONYMIZATION
+            ? anonymize(userId)
+            : userId;
+    segment.setTagTop(tagName, finalUserId);
+  }
+
+  protected static String anonymize(String userId) {
     if (userId == null) {
-      return;
+      return null;
     }
-    UserEventTrackingMode mode = Config.get().getAppSecUserEventsTrackingMode();
-    if (mode == SAFE && !SAFE_USER_ID_PATTERN.matcher(userId).matches()) {
-      // do not set the user id if not numeric or UUID
-      return;
+    MessageDigest digest;
+    try {
+      // TODO avoid lookup a new instance every time
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      if (!SHA_MISSING_REPORTED.getAndSet(true)) {
+        LOGGER.error(
+            SEND_TELEMETRY,
+            "Missing SHA-256 digest, user collection in 'anon' mode cannot continue",
+            e);
+      }
+      return null;
     }
-    segment.setTagTop(tag, userId);
+    digest.update(userId.getBytes());
+    byte[] hash = digest.digest();
+    if (hash.length > HASH_SIZE_BYTES) {
+      byte[] temp = new byte[HASH_SIZE_BYTES];
+      System.arraycopy(hash, 0, temp, 0, temp.length);
+      hash = temp;
+    }
+    return ANONYM_PREFIX + toHexString(hash);
   }
 
   protected TraceSegment getSegment() {
     return AgentTracer.get().getTraceSegment();
+  }
+
+  protected void onMissingUserId() {
+    WafMetricCollector.get().missingUserId();
+  }
+
+  /** TODO link with remote config when ready */
+  protected UserIdCollectionMode getUserIdCollectionMode() {
+    return Config.get().getAppSecUserIdCollectionMode();
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecoratorTest.groovy
@@ -1,16 +1,17 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
-import datadog.trace.api.Config
 import datadog.trace.api.internal.TraceSegment
+import datadog.trace.api.telemetry.WafMetricCollector
 import datadog.trace.bootstrap.ActiveSubsystems
 import datadog.trace.test.util.DDSpecification
 
-import static datadog.trace.api.UserEventTrackingMode.DISABLED
-import static datadog.trace.api.UserEventTrackingMode.EXTENDED
-import static datadog.trace.api.UserEventTrackingMode.SAFE
 import static datadog.trace.api.config.AppSecConfig.APPSEC_AUTOMATED_USER_EVENTS_TRACKING
+import static datadog.trace.api.config.AppSecConfig.APPSEC_AUTO_USER_INSTRUMENTATION_MODE
 
 class AppSecUserEventDecoratorTest extends DDSpecification {
+
+  private static final String USER_ID = 'user'
+  private static final String ANONYMIZED_USER_ID = 'anon_04f8996da763b7a969b1028ee3007569'
 
   def traceSegment = Mock(TraceSegment)
 
@@ -27,94 +28,81 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
 
   def "test onSignup [#mode]"() {
     setup:
-    injectSysConfig(APPSEC_AUTOMATED_USER_EVENTS_TRACKING, mode)
+    injectSysConfig(APPSEC_AUTO_USER_INSTRUMENTATION_MODE, mode)
     def decorator = newDecorator()
 
     when:
-    decorator.onSignup(user, ['key1': 'value1', 'key2': 'value2'])
+    decorator.onSignup(USER_ID, ['key1': 'value1', 'key2': 'value2'])
 
     then:
-    1 * traceSegment.setTagTop('_dd.appsec.events.users.signup.auto.mode', mode)
+    1 * traceSegment.setTagTop('_dd.appsec.events.users.signup.auto.mode', modeTag)
     1 * traceSegment.setTagTop('appsec.events.users.signup.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
     1 * traceSegment.setTagTop('_dd.p.appsec', true)
-    if (setUser) {
-      1 * traceSegment.setTagTop('usr.id', user)
-    }
+    1 * traceSegment.getTagTop('usr.id') >> null
+    1 * traceSegment.setTagTop('usr.id', expectedUserId)
     1 * traceSegment.setTagTop('appsec.events.users.signup', ['key1': 'value1', 'key2': 'value2'])
     0 * _
 
     where:
-    mode       | user                                   | setUser
-    'safe'     | 'user'                                 | false
-    'safe'     | '1234'                                 | true
-    'safe'     | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
-    'extended' | 'user'                                 | true
-    'extended' | '1234'                                 | true
-    'extended' | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
+    mode    | modeTag          | expectedUserId
+    'anon'  | 'anonymization'  | ANONYMIZED_USER_ID
+    'ident' | 'identification' | USER_ID
   }
 
   def "test onLoginSuccess [#mode]"() {
     setup:
-    injectSysConfig(APPSEC_AUTOMATED_USER_EVENTS_TRACKING, mode)
+    injectSysConfig(APPSEC_AUTO_USER_INSTRUMENTATION_MODE, mode)
     def decorator = newDecorator()
 
     when:
-    decorator.onLoginSuccess(user, ['key1': 'value1', 'key2': 'value2'])
+    decorator.onLoginSuccess(USER_ID, ['key1': 'value1', 'key2': 'value2'])
 
     then:
-    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.success.auto.mode', mode)
+    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.success.auto.mode', modeTag)
     1 * traceSegment.setTagTop('appsec.events.users.login.success.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
     1 * traceSegment.setTagTop('_dd.p.appsec', true)
-    if (setUser) {
-      1 * traceSegment.setTagTop('usr.id', user)
-    }
+    1 * traceSegment.getTagTop('usr.id') >> null
+    1 * traceSegment.setTagTop('usr.id', expectedUserId)
     1 * traceSegment.setTagTop('appsec.events.users.login.success', ['key1': 'value1', 'key2': 'value2'])
     0 * _
 
     where:
-    mode       | user                                   | setUser
-    'safe'     | 'user'                                 | false
-    'safe'     | '1234'                                 | true
-    'safe'     | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
-    'extended' | 'user'                                 | true
-    'extended' | '1234'                                 | true
-    'extended' | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
+    mode    | modeTag          | expectedUserId
+    'anon'  | 'anonymization'  | ANONYMIZED_USER_ID
+    'ident' | 'identification' | USER_ID
   }
 
-  def "test onLoginFailed [#mode]"() {
+  def "test onLoginFailed #description [#mode]"() {
     setup:
-    injectSysConfig(APPSEC_AUTOMATED_USER_EVENTS_TRACKING, mode)
+    injectSysConfig(APPSEC_AUTO_USER_INSTRUMENTATION_MODE, mode)
     def decorator = newDecorator()
 
     when:
-    decorator.onLoginFailure(user, ['key1': 'value1', 'key2': 'value2'])
+    decorator.onLoginFailure(USER_ID, ['key1': 'value1', 'key2': 'value2'])
 
     then:
-    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.auto.mode', mode)
+    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.auto.mode', modeTag)
     1 * traceSegment.setTagTop('appsec.events.users.login.failure.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
     1 * traceSegment.setTagTop('_dd.p.appsec', true)
-    if (setUser) {
-      1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.id', user)
-    }
+    1 * traceSegment.getTagTop('appsec.events.users.login.failure.usr.id') >> null
+    1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.id', expectedUserId)
     1 * traceSegment.setTagTop('appsec.events.users.login.failure', ['key1': 'value1', 'key2': 'value2'])
     0 * _
 
     where:
-    mode       | user                                   | setUser
-    'safe'     | 'user'                                 | false
-    'safe'     | '1234'                                 | true
-    'safe'     | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
-    'extended' | 'user'                                 | true
-    'extended' | '1234'                                 | true
-    'extended' | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
+    mode    | modeTag          | description           | expectedUserId
+    'anon'  | 'anonymization'  | 'with existing user'  | ANONYMIZED_USER_ID
+    'anon'  | 'anonymization'  | 'user doesn\'t exist' | ANONYMIZED_USER_ID
+    'ident' | 'identification' | 'with existing user'  | USER_ID
+    'ident' | 'identification' | 'user doesn\'t exist' | USER_ID
   }
 
   def "test onUserNotFound [#mode]"() {
     setup:
-    injectSysConfig(APPSEC_AUTOMATED_USER_EVENTS_TRACKING, mode)
+    injectSysConfig(APPSEC_AUTO_USER_INSTRUMENTATION_MODE, mode)
     def decorator = newDecorator()
 
     when:
@@ -125,13 +113,23 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     0 * _
 
     where:
-    mode << ['safe', 'extended']
+    mode    | modeTag
+    'anon'  | 'ANONYMIZATION'
+    'ident' | 'IDENTIFIED'
   }
 
-  def "test isEnabled (appsec = #appsec, mode = #mode)"() {
+  def "test isEnabled (appsec = #appsec, tracking = #trackingMode, collection = #collectionMode)"() {
     setup:
     ActiveSubsystems.APPSEC_ACTIVE = appsec
-    injectSysConfig(APPSEC_AUTOMATED_USER_EVENTS_TRACKING, mode)
+    final addConfig = (String name, String value) -> {
+      if (value) {
+        injectSysConfig(name, value)
+      } else {
+        removeSysConfig(name)
+      }
+    }
+    addConfig(APPSEC_AUTOMATED_USER_EVENTS_TRACKING, trackingMode)
+    addConfig(APPSEC_AUTO_USER_INSTRUMENTATION_MODE, collectionMode)
     def decorator = newDecorator()
 
     when:
@@ -140,29 +138,87 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     then:
     enabled == result
 
-    and:
-    Config.get().getAppSecUserEventsTrackingMode() == expectedMode
+    where:
+    appsec | collectionMode | trackingMode | result
+    // disabled states
+    false  | null           | null         | false
+    false  | null           | 'safe'       | false
+    false  | null           | 'extended'   | false
+    false  | null           | 'disabled'   | false
+    false  | 'ident'        | null         | false
+    false  | 'ident'        | 'safe'       | false
+    false  | 'ident'        | 'extended'   | false
+    false  | 'ident'        | 'disabled'   | false
+    false  | 'anon'         | null         | false
+    false  | 'anon'         | 'safe'       | false
+    false  | 'anon'         | 'extended'   | false
+    false  | 'anon'         | 'disabled'   | false
+    false  | 'disabled'     | null         | false
+    false  | 'disabled'     | 'safe'       | false
+    false  | 'disabled'     | 'extended'   | false
+    false  | 'disabled'     | 'disabled'   | false
+    true   | null           | 'disabled'   | false
+    true   | 'disabled'     | null         | false
+    true   | 'disabled'     | 'safe'       | false
+    true   | 'disabled'     | 'extended'   | false
+    true   | 'disabled'     | 'disabled'   | false
+
+    // enabled states
+    true   | null           | null         | true
+    true   | null           | 'safe'       | true
+    true   | null           | 'extended'   | true
+    true   | 'ident'        | null         | true
+    true   | 'ident'        | 'safe'       | true
+    true   | 'ident'        | 'extended'   | true
+    true   | 'ident'        | 'disabled'   | true
+    true   | 'anon'         | null         | true
+    true   | 'anon'         | 'safe'       | true
+    true   | 'anon'         | 'extended'   | true
+    true   | 'anon'         | 'disabled'   | true
+  }
+
+  void 'test missing user id callback'() {
+    setup:
+    final collector = WafMetricCollector.get()
+    collector.prepareMetrics()
+    collector.drain()
+    injectSysConfig(APPSEC_AUTO_USER_INSTRUMENTATION_MODE, 'ident')
+    def decorator = newDecorator()
+
+    when:
+    decorator.onLoginSuccess(null, [:])
+
+    then:
+    collector.prepareMetrics()
+    final metrics = collector.drain()
+    metrics.size() == 1
+    final metric = metrics.first()
+    metric.namespace == 'appsec'
+    metric.type == 'count'
+    metric.metricName == 'instrum.user_auth.missing_user_id'
+    metric.value == 1
+    0 * _
+  }
+
+  void 'test user id anonymization of #userId'() {
+    when:
+    final anonymized = AppSecUserEventDecorator.anonymize(userId)
+
+    then:
+    anonymized == expected
 
     where:
-    appsec | mode       | result | expectedMode
-    false  | "disabled" | false  | DISABLED
-    false  | "safe"     | false  | SAFE
-    false  | "1"        | false  | SAFE
-    false  | "true"     | false  | SAFE
-    false  | "extended" | false  | EXTENDED
-    true   | "disabled" | false  | DISABLED
-    true   | "safe"     | true   | SAFE
-    true   | "1"        | true   | SAFE
-    true   | "true"     | true   | SAFE
-    true   | "extended" | true   | EXTENDED
+    userId                  | expected
+    null                    | null
+    'zouzou@sansgluten.com' | 'anon_0c76692372ebf01a7da6e9570fb7d0a1'
   }
 
   def newDecorator() {
     return new AppSecUserEventDecorator() {
-        @Override
-        protected TraceSegment getSegment() {
-          return traceSegment
-        }
+      @Override
+      protected TraceSegment getSegment() {
+        return traceSegment
       }
+    }
   }
 }

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SpringBootBasedTest.groovy
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Logger
 import ch.qos.logback.core.Appender
 import com.datadog.appsec.AppSecHttpServerTest
 import datadog.trace.agent.test.base.HttpServer
+import datadog.trace.api.config.AppSecConfig
 import datadog.trace.core.DDSpan
 import okhttp3.FormBody
 import okhttp3.HttpUrl
@@ -83,7 +84,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
   @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
-    injectSysConfig('dd.appsec.automated-user-events-tracking', 'extended')
+    injectSysConfig(AppSecConfig.APPSEC_AUTO_USER_INSTRUMENTATION_MODE, 'identification')
   }
 
   Request.Builder request(TestEndpoint uri, String method, RequestBody body) {
@@ -124,7 +125,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     response.body().string() == REGISTER.body
     !span.getTags().isEmpty()
     span.getTag("appsec.events.users.signup.track") == true
-    span.getTag("_dd.appsec.events.users.signup.auto.mode") == 'extended'
+    span.getTag("_dd.appsec.events.users.signup.auto.mode") == 'identification'
     span.getTag("usr.id") == 'admin'
     span.getTag("appsec.events.users.signup")['enabled'] == 'true'
     span.getTag("appsec.events.users.signup")['authorities'] == 'ROLE_USER'
@@ -150,7 +151,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     response.body().string() == LOGIN.body
     !span.getTags().isEmpty()
     span.getTag("appsec.events.users.login.failure.track") == true
-    span.getTag("_dd.appsec.events.users.login.failure.auto.mode") == 'extended'
+    span.getTag("_dd.appsec.events.users.login.failure.auto.mode") == 'identification'
     span.getTag("appsec.events.users.login.failure.usr.exists") == false
     span.getTag("appsec.events.users.login.failure.usr.id") == 'not_existing_user'
   }
@@ -174,7 +175,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     response.body().string() == LOGIN.body
     !span.getTags().isEmpty()
     span.getTag("appsec.events.users.login.failure.track") == true
-    span.getTag("_dd.appsec.events.users.login.failure.auto.mode") == 'extended'
+    span.getTag("_dd.appsec.events.users.login.failure.auto.mode") == 'identification'
     // TODO: Ideally should be `false` but we have no reliable method to detect it it is just absent. See APPSEC-12765.
     span.getTag("appsec.events.users.login.failure.usr.exists") == null
     span.getTag("appsec.events.users.login.failure.usr.id") == 'admin'
@@ -200,7 +201,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     response.body().string() == LOGIN.body
     !span.getTags().isEmpty()
     span.getTag("appsec.events.users.login.success.track") == true
-    span.getTag("_dd.appsec.events.users.login.success.auto.mode") == 'extended'
+    span.getTag("_dd.appsec.events.users.login.success.auto.mode") == 'identification'
     span.getTag("usr.id") == 'admin'
     span.getTag("appsec.events.users.login.success")['credentialsNonExpired'] == 'true'
     span.getTag("appsec.events.users.login.success")['accountNonExpired'] == 'true'

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/AppSecConfig.java
@@ -21,6 +21,8 @@ public final class AppSecConfig {
       "appsec.http.blocked.template.json";
   public static final String APPSEC_AUTOMATED_USER_EVENTS_TRACKING =
       "appsec.automated-user-events-tracking";
+  public static final String APPSEC_AUTO_USER_INSTRUMENTATION_MODE =
+      "appsec.auto-user-instrumentation-mode";
   public static final String API_SECURITY_ENABLED = "api-security.enabled";
   public static final String API_SECURITY_ENABLED_EXPERIMENTAL =
       "experimental.api-security.enabled";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -141,11 +141,11 @@ import static datadog.trace.api.DDTags.RUNTIME_VERSION_TAG;
 import static datadog.trace.api.DDTags.SCHEMA_VERSION_TAG_KEY;
 import static datadog.trace.api.DDTags.SERVICE;
 import static datadog.trace.api.DDTags.SERVICE_TAG;
-import static datadog.trace.api.UserEventTrackingMode.SAFE;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENABLED;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_ENABLED_EXPERIMENTAL;
 import static datadog.trace.api.config.AppSecConfig.API_SECURITY_REQUEST_SAMPLE_RATE;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_AUTOMATED_USER_EVENTS_TRACKING;
+import static datadog.trace.api.config.AppSecConfig.APPSEC_AUTO_USER_INSTRUMENTATION_MODE;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_HTML;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_HTTP_BLOCKED_TEMPLATE_JSON;
 import static datadog.trace.api.config.AppSecConfig.APPSEC_IP_ADDR_HEADER;
@@ -751,7 +751,7 @@ public class Config {
   private final String appSecObfuscationParameterValueRegexp;
   private final String appSecHttpBlockedTemplateHtml;
   private final String appSecHttpBlockedTemplateJson;
-  private final UserEventTrackingMode appSecUserEventsTracking;
+  private final UserIdCollectionMode appSecUserIdCollectionMode;
   private final Boolean appSecScaEnabled;
   private final boolean appSecRaspEnabled;
   private final boolean appSecStackTraceEnabled;
@@ -1685,10 +1685,10 @@ public class Config {
         configProvider.getString(APPSEC_HTTP_BLOCKED_TEMPLATE_HTML, null);
     appSecHttpBlockedTemplateJson =
         configProvider.getString(APPSEC_HTTP_BLOCKED_TEMPLATE_JSON, null);
-    appSecUserEventsTracking =
-        UserEventTrackingMode.fromString(
-            configProvider.getStringNotEmpty(
-                APPSEC_AUTOMATED_USER_EVENTS_TRACKING, SAFE.toString()));
+    appSecUserIdCollectionMode =
+        UserIdCollectionMode.fromString(
+            configProvider.getStringNotEmpty(APPSEC_AUTO_USER_INSTRUMENTATION_MODE, null),
+            configProvider.getStringNotEmpty(APPSEC_AUTOMATED_USER_EVENTS_TRACKING, null));
     appSecScaEnabled = configProvider.getBoolean(APPSEC_SCA_ENABLED);
     appSecStandaloneEnabled = configProvider.getBoolean(APPSEC_STANDALONE_ENABLED, false);
     appSecRaspEnabled = configProvider.getBoolean(APPSEC_RASP_ENABLED, DEFAULT_APPSEC_RASP_ENABLED);
@@ -2911,8 +2911,8 @@ public class Config {
     return appSecHttpBlockedTemplateJson;
   }
 
-  public UserEventTrackingMode getAppSecUserEventsTrackingMode() {
-    return appSecUserEventsTracking;
+  public UserIdCollectionMode getAppSecUserIdCollectionMode() {
+    return appSecUserIdCollectionMode;
   }
 
   public boolean isApiSecurityEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/UserIdCollectionMode.java
+++ b/internal-api/src/main/java/datadog/trace/api/UserIdCollectionMode.java
@@ -1,0 +1,55 @@
+package datadog.trace.api;
+
+public enum UserIdCollectionMode {
+  IDENTIFICATION("identification", "ident"),
+  ANONYMIZATION("anonymization", "anon"),
+  DISABLED("disabled");
+
+  private final String[] values;
+
+  UserIdCollectionMode(final String... values) {
+    this.values = values;
+  }
+
+  public static UserIdCollectionMode fromString(String collectionMode, String trackingMode) {
+    if (collectionMode == null && trackingMode != null) {
+      return fromTracking(trackingMode);
+    } else {
+      return fromMode(collectionMode);
+    }
+  }
+
+  private static UserIdCollectionMode fromMode(String mode) {
+    if (mode == null || IDENTIFICATION.matches(mode)) {
+      return IDENTIFICATION;
+    } else if (ANONYMIZATION.matches(mode)) {
+      return ANONYMIZATION;
+    }
+    return DISABLED;
+  }
+
+  private static UserIdCollectionMode fromTracking(String tracking) {
+    switch (UserEventTrackingMode.fromString(tracking)) {
+      case SAFE:
+        return ANONYMIZATION;
+      case EXTENDED:
+        return IDENTIFICATION;
+      default:
+        return DISABLED;
+    }
+  }
+
+  private boolean matches(final String mode) {
+    for (String value : values) {
+      if (value.equalsIgnoreCase(mode)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return values[0];
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -181,8 +181,11 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
     }
 
     // Missing user id
-    if (missingUserIdCounter.get() > 0) {
-      rawMetricsQueue.offer(new MissingUserIdMetric(missingUserIdCounter.getAndReset()));
+    long missingUserId = missingUserIdCounter.getAndReset();
+    if (missingUserId > 0) {
+      if (!rawMetricsQueue.offer(new MissingUserIdMetric(missingUserId))) {
+        return;
+      }
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -1,5 +1,7 @@
 package datadog.trace.util;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -11,6 +13,10 @@ import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nonnull;
 
 public final class Strings {
+
+  private static final byte[] HEX_DIGITS = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+  };
 
   public static String escapeToJson(String string) {
     if (string == null || string.isEmpty()) {
@@ -354,5 +360,18 @@ public final class Strings {
       c[i] = (char) ('a' + ThreadLocalRandom.current().nextInt(26));
     }
     return new String(c);
+  }
+
+  public static String toHexString(byte[] value) {
+    if (value == null) {
+      return null;
+    }
+    byte[] bytes = new byte[value.length * 2];
+    for (int i = 0; i < value.length; i++) {
+      byte v = value[i];
+      bytes[i * 2] = HEX_DIGITS[(v & 0xF0) >>> 4];
+      bytes[i * 2 + 1] = HEX_DIGITS[v & 0x0F];
+    }
+    return new String(bytes, US_ASCII);
   }
 }

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigCollectorTest.groovy
@@ -14,7 +14,6 @@ import datadog.trace.util.Strings
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_IAST_WEAK_HASH_ALGORITHMS
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL
-import static datadog.trace.api.UserEventTrackingMode.SAFE
 
 class ConfigCollectorTest extends DDSpecification {
 
@@ -93,7 +92,6 @@ class ConfigCollectorTest extends DDSpecification {
     configKey                                                  | defaultValue
     IastConfig.IAST_TELEMETRY_VERBOSITY                        | Verbosity.INFORMATION.toString()
     TracerConfig.TRACE_SPAN_ATTRIBUTE_SCHEMA                   | "v" + SpanNaming.SCHEMA_MIN_VERSION
-    AppSecConfig.APPSEC_AUTOMATED_USER_EVENTS_TRACKING         | SAFE.toString()
     GeneralConfig.TELEMETRY_HEARTBEAT_INTERVAL                 | new Float(DEFAULT_TELEMETRY_HEARTBEAT_INTERVAL).toString()
     CiVisibilityConfig.CIVISIBILITY_JACOCO_GRADLE_SOURCE_SETS  | "main"
     IastConfig.IAST_WEAK_HASH_ALGORITHMS                       | DEFAULT_IAST_WEAK_HASH_ALGORITHMS.join(",")

--- a/internal-api/src/test/groovy/datadog/trace/api/UserIdCollectionModeTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/UserIdCollectionModeTest.groovy
@@ -1,0 +1,59 @@
+package datadog.trace.api
+
+import spock.lang.Specification
+
+import static datadog.trace.api.UserIdCollectionMode.ANONYMIZATION
+import static datadog.trace.api.UserIdCollectionMode.DISABLED
+import static datadog.trace.api.UserIdCollectionMode.IDENTIFICATION
+
+class UserIdCollectionModeTest extends Specification {
+
+  void 'test user id collection mode "#mode"'() {
+    when:
+    def result = UserIdCollectionMode.fromString(mode, null)
+
+    then:
+    result == expected
+
+    where:
+    mode                          | expected
+    null                          | IDENTIFICATION
+    'identification'              | IDENTIFICATION
+    'iDeNTiFiCaTioN'              | IDENTIFICATION
+    'ident'                       | IDENTIFICATION
+    'anonymization'               | ANONYMIZATION
+    'aNoNyMiZaTioN'               | ANONYMIZATION
+    'anon'                        | ANONYMIZATION
+    'disabled'                    | DISABLED
+    'dIsAblEd'                    | DISABLED
+    ''                            | DISABLED
+    'go loves node but java wins' | DISABLED
+  }
+
+  void 'test user id collection mode "#mode" with tracking "#tracking"'() {
+    when:
+    def result = UserIdCollectionMode.fromString(mode, tracking)
+
+    then:
+    result == expected
+
+    where:
+    mode    | tracking   | expected
+    // when value is not defined
+    null    | 'extended' | IDENTIFICATION
+    null    | 'safe'     | ANONYMIZATION
+    null    | 'disabled' | DISABLED
+    // actual value takes priority
+    'ident' | null       | IDENTIFICATION
+    'ident' | 'extended' | IDENTIFICATION
+    'ident' | 'safe'     | IDENTIFICATION
+    'ident' | 'disabled' | IDENTIFICATION
+    'anon'  | null       | ANONYMIZATION
+    'anon'  | 'extended' | ANONYMIZATION
+    'anon'  | 'safe'     | ANONYMIZATION
+    'anon'  | 'disabled' | ANONYMIZATION
+    // by default
+    null    | null       | IDENTIFICATION
+
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -164,4 +164,22 @@ class WafMetricCollectorTest extends DDSpecification {
     noExceptionThrown()
     collector.drain().size() == limit
   }
+
+  void 'test missing user id event metric'() {
+    given:
+    def collector = WafMetricCollector.get()
+
+    when:
+    collector.missingUserId()
+    collector.prepareMetrics()
+
+    then:
+    noExceptionThrown()
+    def metrics = collector.drain()
+    def metric = metrics.find { it.metricName == 'instrum.user_auth.missing_user_id'}
+    metric.namespace == 'appsec'
+    metric.type == 'count'
+    metric.value == 1
+    metric.tags == []
+  }
 }

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -211,4 +211,22 @@ class StringsTest extends DDSpecification {
     " 測 試    " | true
     "   𐢀𐢀𐢀𐢀"    | true
   }
+
+  void 'test hexadecimal encoding of #value'() {
+    when:
+    def encoded = Strings.toHexString(value?.bytes)
+
+    then:
+    if (value == null) {
+      encoded == expected
+    } else {
+      encoded.equalsIgnoreCase(expected)
+    }
+
+    where:
+    value                   | expected
+    null                    | null
+    ''                      | ''
+    'zouzou@sansgluten.com' | '7A6F757A6F754073616E73676C7574656E2E636F6D'
+  }
 }


### PR DESCRIPTION
# What Does This Do
Applies the new erratum/addendum of automated user events trancking. The new RFC defines three different modes based on the env `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE`

- `identification` (by default) user ids are sent the backend without any modification
- `anonymization` user ids are hashed with SHA256
- `disabled` auto user event tracking is disabled

This new option deprecates `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING`, the deprecated option will be automatically converted to the new schema following the next table:

| DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING |  DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE |
|---|---|
|`extended`|`identification`|
|`safe`|`anonymization`|
|`disabled`|`disabled`|


# Motivation
Tracking of real user ids is very important for the detection of account take over campaigns, this PR ensures that the backend has all required information in order to provide adequate protection.

# Additional Notes

Jira ticket: [APPSEC-53547]

RFC: [link](https://docs.google.com/document/d/19VHLdJLVFwRb_JrE87fmlIM5CL5LdOBv4AmLxgdo9qI/edit?pli=1#heading=h.hidcz5iyug2k)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-53547]: https://datadoghq.atlassian.net/browse/APPSEC-53547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ