### PR TITLE
Update shim fields to have the types expected by OtelShimInjector

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/OtelContext.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/OtelContext.java
@@ -18,7 +18,7 @@ public class OtelContext implements Context {
   private static final Object[] NO_ENTRIES = {};
 
   /** Overridden root context. */
-  public static final OtelContext ROOT = new OtelContext(OtelSpan.invalid(), OtelSpan.invalid());
+  public static final Context ROOT = new OtelContext(OtelSpan.invalid(), OtelSpan.invalid());
 
   private static final String OTEL_CONTEXT_SPAN_KEY = "opentelemetry-trace-span-key";
   private static final String OTEL_CONTEXT_ROOT_SPAN_KEY = "opentelemetry-traces-local-root-span";

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelTracerProvider.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelTracerProvider.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 public class OtelTracerProvider implements TracerProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(OtelTracerProvider.class);
   private static final String DEFAULT_TRACER_NAME = "";
-  public static final OtelTracerProvider INSTANCE = new OtelTracerProvider();
+  public static final TracerProvider INSTANCE = new OtelTracerProvider();
 
   /** Tracer instances, indexed by instrumentation scope name. */
   private final Map<String, Tracer> tracers;


### PR DESCRIPTION
Fix for an issue I found while doing manual testing - the [shim injector](https://github.com/DataDog/dd-trace-java/blob/v1.35.0-RC1/dd-java-agent/agent-otel/otel-tooling/src/main/java/datadog/opentelemetry/tooling/shim/OtelShimInjector.java) used for drop-in support expects the `ROOT` and `INSTANCE` fields to have the OTel type, not our implementation type (all the other reflected fields in the shim have the expected types)

Jira ticket: [APMAPI-6]


[APMAPI-6]: https://datadoghq.atlassian.net/browse/APMAPI-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ