### PR TITLE
Avoid publishing RC to Sonatype and upload the right assets to GitHub release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,7 +184,8 @@ deploy_to_sonatype:
   rules:
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+    # Do not deploy release candidate versions
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
     - when: manual
       allow_failure: true
@@ -221,7 +222,7 @@ generate-lib-init-tag-values:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    # We don't tag prerelease versions
+    # Do not tag release candidate versions
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
     - when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -206,6 +206,12 @@ deploy_artifacts_to_github:
       when: on_success
     - when: manual
       allow_failure: true
+  # Requires the deploy_to_sonatype job to have run first as build cache is broken
+  # This will deploy the artifacts built from the publishToSonatype task to the GitHub release
+  needs:
+    - job: deploy_to_sonatype
+      # The deploy_to_sonatype job is not run for release candidate versions
+      optional: true
   script:
     - aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.gh_release_token --with-decryption --query "Parameter.Value" --out text > github-token.txt
     - gh auth login --with-token < github-token.txt


### PR DESCRIPTION
# What Does This Do

This PR tries to fix two issues of the GitLab CI:
* Avoid publishing release candidates to Sonatype,
* Upload the same artifacts we send to Sonatype as GitHub release assets

# Motivation

Our release process is broken. We ship three different binaires for the same version.
If this works, Maven central and GitHub release should be the same. Only lib-injection will be wrong.

# Additional Notes

I could not test the pipeline, so it will be test as part of the next release.

Added @randomanderson for review as he might have a better understanding of the whole pipeline and [the GitLab workflow syntax](https://docs.gitlab.com/ee/ci/yaml/#needs).

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
