### PR TITLE
Do not modify readonly message attributes map on SNS integration

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sns-1.0/src/test/groovy/SnsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sns-1.0/src/test/groovy/SnsClientTest.groovy
@@ -87,7 +87,7 @@ abstract class SnsClientTest extends VersionedNamingTestBase {
     TEST_WRITER.clear()
 
     def headers = new HashMap<String, MessageAttributeValue>()
-    headers.put("mykey", new MessageAttributeValue().withStringValue("myvalue"))
+    headers.put("mykey", new MessageAttributeValue().withStringValue("myvalue").withDataType("String"))
     def readonlyHeaders = Collections.unmodifiableMap(headers)
     snsClient.publish(new PublishRequest().withMessage("sometext").withTopicArn(testTopicARN).withMessageAttributes(readonlyHeaders))
 


### PR DESCRIPTION
# What Does This Do

Fix a bug where the integration would crash in the sdk v1 integration if the message attributes were a readonly map
Also fix a minor bug in the sdk v2 batch requests where we'd write more than 10 message attributes, which is not supported in SQS.

# Motivation

#7147 