### PR TITLE
Remove system test results upload

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -838,26 +838,6 @@ jobs:
             DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
 
       - run:
-          name: Upload data to CI Visibility
-          command: |
-            cd system-tests
-            export DD_API_KEY=$SYSTEM_TESTS_CI_API_KEY
-            export DD_APP_KEY=$SYSTEM_TESTS_CI_APP_KEY
-
-            # Causes conflicts with DD_API_KEY and datadog-ci tool
-            unset DATADOG_API_KEY
-            
-            echo "Uploading tests results to CI Visibility"  
-            utils/scripts/upload_results_CI_visibility.sh dev java-tracer << pipeline.id >>-<< pipeline.number >>
-
-            if [[ $CIRCLE_BRANCH == "master" ]]; then
-              echo "Updating dashboard from dd-trace-java main branch"
-              utils/scripts/update_dashboard_CI_visibility.sh java-tracer << pipeline.id >>-<< pipeline.number >>
-            else
-              echo "Skipping CI Visibility dashboard update due to it is not a main branch"
-            fi
-
-      - run:
           name: Collect artifacts
           command: tar -cvzf logs_java_<< parameters.weblog-variant >>_dev.tar.gz -C system-tests logs logs_apm_tracing_e2e logs_apm_tracing_e2e_single_span
 


### PR DESCRIPTION

# What Does This Do

This PR removes system tests results upload.

# Motivation

The API key expired.
According to the system tests team, this step is not expected in our workflow. Removing it accordingly.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
