### PR TITLE
Fix spring-messaging tests

### DIFF
--- a/dd-java-agent/instrumentation/spring-messaging-4/src/test/groovy/listener/Config.groovy
+++ b/dd-java-agent/instrumentation/spring-messaging-4/src/test/groovy/listener/Config.groovy
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 
 import jakarta.annotation.PreDestroy
@@ -34,6 +35,7 @@ class Config {
     def sqsAddress = sqsRestServer().waitUntilStarted().localAddress()
     return SqsAsyncClient.builder()
       .credentialsProvider(AnonymousCredentialsProvider.create())
+      .region(Region.AWS_GLOBAL)
       .endpointOverride(new URI("http://localhost:${sqsAddress.port}"))
       .build()
   }


### PR DESCRIPTION
# What Does This Do

Statically forces the AWS region that's mandatory. On dev laptops can work because of `.aws` directory on the home

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
