### PR TITLE
Support DD_LOG_LEVEL

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -1047,10 +1047,19 @@ public class Agent {
     setSystemPropertyDefault(
         SIMPLE_LOGGER_DATE_TIME_FORMAT_PROPERTY, SIMPLE_LOGGER_DATE_TIME_FORMAT_DEFAULT);
 
+    String logLevel;
     if (isDebugMode()) {
-      setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "DEBUG");
-    } else if (!isFeatureEnabled(AgentFeature.STARTUP_LOGS)) {
-      setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, "WARN");
+      logLevel = "DEBUG";
+    } else {
+      logLevel = ddGetProperty("dd.log.level");
+    }
+
+    if (null == logLevel && !isFeatureEnabled(AgentFeature.STARTUP_LOGS)) {
+      logLevel = "WARN";
+    }
+
+    if (null != logLevel) {
+      setSystemPropertyDefault(SIMPLE_LOGGER_DEFAULT_LOG_LEVEL_PROPERTY, logLevel);
     }
   }
 

--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/VMRuntimeInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/VMRuntimeInstrumentation.java
@@ -63,6 +63,11 @@ public final class VMRuntimeInstrumentation extends AbstractNativeImageInstrumen
           GlobalLogLevelSwitcher.get().switchLevel(LogLevel.DEBUG);
           configLogger.debug("New instance: {}", Config.get());
         }
+      } else {
+        String logLevel = Config.get().getLogLevel();
+        if (null != logLevel) {
+          GlobalLogLevelSwitcher.get().switchLevel(LogLevel.fromString(logLevel));
+        }
       }
 
       datadog.trace.agent.tooling.nativeimage.TracerActivation.activate();

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -29,6 +29,7 @@ public final class GeneralConfig {
   @Deprecated // Use dd.tags instead
   public static final String GLOBAL_TAGS = "trace.global.tags";
 
+  public static final String LOG_LEVEL = "log.level";
   public static final String TRACE_DEBUG = "trace.debug";
   public static final String TRACE_TRIAGE = "trace.triage";
   public static final String TRIAGE_REPORT_TRIGGER = "triage.report.trigger";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -262,6 +262,7 @@ import static datadog.trace.api.config.GeneralConfig.GLOBAL_TAGS;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_HOST;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_PORT;
+import static datadog.trace.api.config.GeneralConfig.LOG_LEVEL;
 import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG;
 import static datadog.trace.api.config.GeneralConfig.RUNTIME_ID_ENABLED;
@@ -906,6 +907,7 @@ public class Config {
 
   private final boolean traceAgentV05Enabled;
 
+  private final String logLevel;
   private final boolean debugEnabled;
   private final boolean triageEnabled;
   private final String triageReportTrigger;
@@ -2038,6 +2040,7 @@ public class Config {
 
     servletAsyncTimeoutError = configProvider.getBoolean(SERVLET_ASYNC_TIMEOUT_ERROR, true);
 
+    logLevel = configProvider.getString(LOG_LEVEL);
     debugEnabled = configProvider.getBoolean(TRACE_DEBUG, false);
     triageEnabled = configProvider.getBoolean(TRACE_TRIAGE, instrumenterConfig.isTriageEnabled());
     triageReportTrigger = configProvider.getString(TRIAGE_REPORT_TRIGGER);
@@ -3441,6 +3444,10 @@ public class Config {
     return traceAgentV05Enabled;
   }
 
+  public String getLogLevel() {
+    return logLevel;
+  }
+
   public boolean isDebugEnabled() {
     return debugEnabled;
   }
@@ -4626,6 +4633,8 @@ public class Config {
         + xDatadogTagsMaxLength
         + ", traceAgentV05Enabled="
         + traceAgentV05Enabled
+        + ", logLevel="
+        + logLevel
         + ", debugEnabled="
         + debugEnabled
         + ", triageEnabled="


### PR DESCRIPTION
# What Does This Do

Users can now configure the tracer's log level by setting `DD_LOG_LEVEL` in their environment:
```
DD_LOG_LEVEL=WARN
```
They can also use the `-Ddd.log.level` JVM option

# Motivation

Make it easier to apply a tracer log level for all Java tracers running in the same environment.

# Additional Notes
 
`DD_TRACE_DEBUG=true` implies a log level of `DEBUG`, but `DD_LOG_LEVEL=DEBUG` does not imply `DD_TRACE_DEBUG` is enabled.

Jira ticket: [AIT-9801]


[AIT-9801]: https://datadoghq.atlassian.net/browse/AIT-9801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ