### PR TITLE
Add Cloud Foundry release automation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,6 +12,14 @@ _Action:_ Get the last (by name) opened milestone and affect it to the closed pu
 
 _Recovery:_ Attach the milestone by hand to the PR.
 
+### add-release-to-cloudfoundry [🔗](add-release-to-cloudfoundry.yaml)
+
+_Trigger:_ When a release is published.
+
+_Action:_ Append the new release to the Cloud Foundry repository.
+
+_Recovery:_ Manually edit and push the `index.yml` file from [the cloudfoundry branch](https://github.com/DataDog/dd-trace-java/tree/cloudfoundry).
+
 ### create-next-milestone [🔗](create-next-milestone.yaml)
 
 _Trigger:_ When closing a milestone.

--- a/.github/workflows/add-release-to-cloudfoundry.yaml
+++ b/.github/workflows/add-release-to-cloudfoundry.yaml
@@ -1,0 +1,28 @@
+name: Add release to Cloud Foundry
+on: 
+  release:
+    types:
+      - released
+jobs:
+  update-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout "cloudfoundry" branch
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # 4.1.6
+        with:
+          ref: cloudfoundry
+      - name: Get release version
+        id: get-release-version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "VERSION=$(echo ${TAG_NAME/#v/})" >> $GITHUB_OUTPUT
+      - name: Append release to Cloud Foundry repository
+        env:
+            VERSION: ${{ steps.get-release-version.outputs.VERSION }}
+        run: |
+          git checkout -b ci/cloudfoundry
+          echo "${VERSION}: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar" >> index.yml
+          git add index.yml
+          git commit -m "chore: Add version ${VERSION} to Cloud Foundry"
+          git push -u origin ci/cloudfoundry
+          gh pr create --title "Add version ${VERSION} to Cloud Foundry" --body "This PR add the version ${VERSION} to Cloud Foundry.  Make sure [the JAR is online](https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar) before merging." --base cloudfoundry


### PR DESCRIPTION
# What Does This Do

This PR adds a GitHub workflow to automate the Cloud Foundry repository update when releasing.

# Motivation

We had too many typo error while doing it manually.

# Additional Notes

The workflow can only be tested during release.
If it fails, it should not impact production and can be easily recovered by doing the repository update manually.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
