### PR TITLE
Collect and report RASP events (+Stack traces)

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -76,8 +76,8 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   }
 
   private final ConcurrentHashMap<Address<?>, Object> persistentData = new ConcurrentHashMap<>();
-  private volatile Queue<AppSecEvent> appSecEvents; // guarded by this
-  private volatile Queue<StackTraceEvent> stackTraceEvents; // guarded by this
+  private volatile Queue<AppSecEvent> appSecEvents;
+  private volatile Queue<StackTraceEvent> stackTraceEvents;
 
   // assume these will always be written and read by the same thread
   private String scheme;
@@ -438,15 +438,24 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   }
 
   Collection<AppSecEvent> transferCollectedEvents() {
+    if (this.appSecEvents == null) {
+      return Collections.emptyList();
+    }
+
     Collection<AppSecEvent> events = new ArrayList<>();
     AppSecEvent item;
     while ((item = this.appSecEvents.poll()) != null) {
       events.add(item);
     }
+
     return events;
   }
 
   StackTraceCollection transferStackTracesCollection() {
+    if (this.stackTraceEvents == null) {
+      return null;
+    }
+
     Collection<StackTraceEvent> stackTraces = new ArrayList<>();
     StackTraceEvent item;
     while ((item = this.stackTraceEvents.poll()) != null) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -19,6 +19,8 @@ import com.datadog.appsec.event.data.ObjectIntrospection;
 import com.datadog.appsec.event.data.SingletonDataBundle;
 import com.datadog.appsec.report.AppSecEvent;
 import com.datadog.appsec.report.AppSecEventWrapper;
+import com.datadog.appsec.stack_trace.StackTraceCollection;
+import com.datadog.appsec.util.ObjectFlattener;
 import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.api.function.TriConsumer;
@@ -163,6 +165,14 @@ public class GatewayBridge {
                 writeRequestHeaders(traceSeg, REQUEST_HEADERS_ALLOW_LIST, ctx.getRequestHeaders());
                 writeResponseHeaders(
                     traceSeg, RESPONSE_HEADERS_ALLOW_LIST, ctx.getResponseHeaders());
+
+                // Report collected stack traces
+                StackTraceCollection stackTraceCollection = ctx.transferStackTracesCollection();
+                if (stackTraceCollection != null) {
+                  Object flatStruct = ObjectFlattener.flatten(stackTraceCollection);
+                  traceSeg.setMetaStructTop("_dd.stack", flatStruct);
+                }
+
               } else if (hasUserTrackingEvent(traceSeg)) {
                 // Report all collected request headers on user tracking event
                 writeRequestHeaders(traceSeg, REQUEST_HEADERS_ALLOW_LIST, ctx.getRequestHeaders());

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -170,7 +170,9 @@ public class GatewayBridge {
                 StackTraceCollection stackTraceCollection = ctx.transferStackTracesCollection();
                 if (stackTraceCollection != null) {
                   Object flatStruct = ObjectFlattener.flatten(stackTraceCollection);
-                  traceSeg.setMetaStructTop("_dd.stack", flatStruct);
+                  if (flatStruct != null) {
+                    traceSeg.setMetaStructTop("_dd.stack", flatStruct);
+                  }
                 }
 
               } else if (hasUserTrackingEvent(traceSeg)) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -14,6 +14,8 @@ import com.datadog.appsec.event.data.DataBundle;
 import com.datadog.appsec.event.data.KnownAddresses;
 import com.datadog.appsec.gateway.AppSecRequestContext;
 import com.datadog.appsec.report.AppSecEvent;
+import com.datadog.appsec.stack_trace.StackTraceEvent;
+import com.datadog.appsec.stack_trace.StackTraceEvent.Frame;
 import com.datadog.appsec.util.StandardizedLogging;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -26,6 +28,7 @@ import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.api.telemetry.WafMetricCollector;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.util.stacktrace.StackWalkerFactory;
 import io.sqreen.powerwaf.Additive;
 import io.sqreen.powerwaf.Powerwaf;
 import io.sqreen.powerwaf.PowerwafConfig;
@@ -57,6 +60,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +79,8 @@ public class PowerWAFModule implements AppSecModule {
   private static final JsonAdapter<List<PowerWAFResultData>> RES_JSON_ADAPTER;
 
   private static final Map<String, ActionInfo> DEFAULT_ACTIONS;
+
+  private static final String EXPLOIT_DETECTED_MSG = "Exploit detected";
 
   private static class ActionInfo {
     final String type;
@@ -430,6 +436,11 @@ public class PowerWAFModule implements AppSecModule {
             Flow.Action.RequestBlockingAction rba = createRedirectRequestAction(actionInfo);
             flow.setAction(rba);
             break;
+          } else if ("generate_stack".equals(actionInfo.type)
+              && Config.get().isAppSecStackTraceEnabled()) {
+            String stackId = (String) actionInfo.parameters.get("stack_id");
+            StackTraceEvent stackTraceEvent = createExploitStackTraceEvent(stackId);
+            reqCtx.reportStackTrace(stackTraceEvent);
           } else {
             log.info("Ignoring action with type {}", actionInfo.type);
           }
@@ -495,6 +506,29 @@ public class PowerWAFModule implements AppSecModule {
         log.warn("Invalid blocking action data", cce);
         return null;
       }
+    }
+
+    private StackTraceEvent createExploitStackTraceEvent(String stackId) {
+      if (stackId == null || stackId.isEmpty()) {
+        return null;
+      }
+      List<Frame> result = generateUserCodeStackTrace();
+      return new StackTraceEvent(stackId, EXPLOIT_DETECTED_MSG, result);
+    }
+
+    /** Function generates stack trace of the user code (excluding datadog classes) */
+    private List<Frame> generateUserCodeStackTrace() {
+      int stackCapacity = Config.get().getAppSecMaxStackTraceDepth();
+      List<StackTraceElement> elements =
+          StackWalkerFactory.INSTANCE.walk(
+              stream ->
+                  stream
+                      .filter(elem -> !elem.getClassName().startsWith("com.datadog"))
+                      .limit(stackCapacity)
+                      .collect(Collectors.toList()));
+      return IntStream.range(0, elements.size())
+          .mapToObj(idx -> new Frame(elements.get(idx), idx))
+          .collect(Collectors.toList());
     }
 
     private Powerwaf.ResultWithData doRunPowerwaf(
@@ -563,6 +597,7 @@ public class PowerWAFModule implements AppSecModule {
         .withRule(wafResult.rule)
         .withRuleMatches(wafResult.rule_matches)
         .withSpanId(spanId)
+        .withStackId(wafResult.stack_id)
         .build();
   }
 

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -431,11 +431,9 @@ public class PowerWAFModule implements AppSecModule {
           if ("block_request".equals(actionInfo.type)) {
             Flow.Action.RequestBlockingAction rba = createBlockRequestAction(actionInfo);
             flow.setAction(rba);
-            break;
           } else if ("redirect_request".equals(actionInfo.type)) {
             Flow.Action.RequestBlockingAction rba = createRedirectRequestAction(actionInfo);
             flow.setAction(rba);
-            break;
           } else if ("generate_stack".equals(actionInfo.type)
               && Config.get().isAppSecStackTraceEnabled()) {
             String stackId = (String) actionInfo.parameters.get("stack_id");

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -521,7 +521,10 @@ public class PowerWAFModule implements AppSecModule {
           StackWalkerFactory.INSTANCE.walk(
               stream ->
                   stream
-                      .filter(elem -> !elem.getClassName().startsWith("com.datadog"))
+                      .filter(
+                          elem ->
+                              !elem.getClassName().startsWith("com.datadog")
+                                  && !elem.getClassName().startsWith("datadog.trace"))
                       .limit(stackCapacity)
                       .collect(Collectors.toList()));
       return IntStream.range(0, elements.size())

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFResultData.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFResultData.java
@@ -6,6 +6,7 @@ import java.util.Map;
 public class PowerWAFResultData {
   Rule rule;
   List<RuleMatch> rule_matches;
+  String stack_id;
 
   public static class RuleMatch {
     String operator;
@@ -19,10 +20,16 @@ public class PowerWAFResultData {
     Map<String, String> tags;
   }
 
-  public static class Parameter {
+  public static class Parameter extends MatchInfo {
+    MatchInfo resources;
+    MatchInfo params;
+    MatchInfo db_type;
+    List<String> highlight;
+  }
+
+  public static class MatchInfo {
     String address;
     List<Object> key_path;
     String value;
-    List<String> highlight;
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/AppSecEvent.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/report/AppSecEvent.java
@@ -18,6 +18,9 @@ public class AppSecEvent {
   @com.squareup.moshi.Json(name = "span_id")
   private Long spanId;
 
+  @com.squareup.moshi.Json(name = "stack_id")
+  private String stackId;
+
   public Rule getRule() {
     return rule;
   }
@@ -28,6 +31,10 @@ public class AppSecEvent {
 
   public Long getSpanId() {
     return spanId;
+  }
+
+  public String getStackId() {
+    return stackId;
   }
 
   @Override
@@ -48,6 +55,9 @@ public class AppSecEvent {
     sb.append("spanId");
     sb.append('=');
     sb.append(((this.spanId == null) ? "<null>" : this.spanId));
+    sb.append("stackId");
+    sb.append('=');
+    sb.append(((this.stackId == null) ? "<null>" : this.stackId));
     if (sb.charAt((sb.length() - 1)) == ',') {
       sb.setCharAt((sb.length() - 1), ']');
     } else {
@@ -62,6 +72,7 @@ public class AppSecEvent {
     result = ((result * 31) + ((this.rule == null) ? 0 : this.rule.hashCode()));
     result = ((result * 31) + ((this.ruleMatches == null) ? 0 : this.ruleMatches.hashCode()));
     result = ((result * 31) + ((this.spanId == null) ? 0 : this.spanId.hashCode()));
+    result = ((result * 31) + ((this.stackId == null) ? 0 : this.stackId.hashCode()));
     return result;
   }
 
@@ -76,7 +87,8 @@ public class AppSecEvent {
     AppSecEvent rhs = ((AppSecEvent) other);
     return ((Objects.equals(this.rule, rhs.rule))
         && (Objects.equals(this.ruleMatches, rhs.ruleMatches))
-        && (Objects.equals(this.spanId, rhs.spanId)));
+        && (Objects.equals(this.spanId, rhs.spanId))
+        && (Objects.equals(this.stackId, rhs.stackId)));
   }
 
   public static class Builder {
@@ -106,6 +118,11 @@ public class AppSecEvent {
 
     public Builder withSpanId(Long spanId) {
       this.instance.spanId = spanId;
+      return this;
+    }
+
+    public Builder withStackId(String stackId) {
+      this.instance.stackId = stackId;
       return this;
     }
   }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/stack_trace/StackTraceCollection.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/stack_trace/StackTraceCollection.java
@@ -1,0 +1,12 @@
+package com.datadog.appsec.stack_trace;
+
+import java.util.Collection;
+
+public class StackTraceCollection {
+  public final Collection<StackTraceEvent> exploit;
+  // TODO: Add vulnerability and exception collections for future use in IAST and APM
+
+  public StackTraceCollection(Collection<StackTraceEvent> exploit) {
+    this.exploit = exploit;
+  }
+}

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/stack_trace/StackTraceEvent.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/stack_trace/StackTraceEvent.java
@@ -1,0 +1,35 @@
+package com.datadog.appsec.stack_trace;
+
+import java.util.List;
+
+public class StackTraceEvent {
+
+  public final String id;
+  public final String language = "java";
+  public final String message;
+  public final List<Frame> frames;
+
+  public StackTraceEvent(String id, String message, List<Frame> frames) {
+    this.id = id;
+    this.message = message;
+    this.frames = frames;
+  }
+
+  public static class Frame {
+    public final int id;
+    public final String text;
+    public final String file;
+    public final int line;
+    public final String class_name;
+    public final String function;
+
+    public Frame(StackTraceElement element, int id) {
+      this.id = id;
+      this.text = element.toString();
+      this.file = element.getFileName();
+      this.line = element.getLineNumber();
+      this.class_name = element.getClassName();
+      this.function = element.getMethodName();
+    }
+  }
+}

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/util/ObjectFlattener.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/util/ObjectFlattener.java
@@ -1,6 +1,7 @@
 package com.datadog.appsec.util;
 
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonDataException;
 import com.squareup.moshi.Moshi;
 
 /**
@@ -18,9 +19,13 @@ public class ObjectFlattener {
    *
    * @param obj the object to flatten
    * @return the flattened object as a Map, or the original object if it's a primitive type or a
-   *     Collection or a Map. Returns null if the input object is null.
+   *     Collection or a Map. Returns null if the input object is null or if it cannot be flattened.
    */
   public static Object flatten(Object obj) {
-    return JSON_ADAPTER.toJsonValue(obj);
+    try {
+      return JSON_ADAPTER.toJsonValue(obj);
+    } catch (JsonDataException e) {
+      return null;
+    }
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/util/ObjectFlattener.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/util/ObjectFlattener.java
@@ -1,0 +1,26 @@
+package com.datadog.appsec.util;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+
+/**
+ * This class provides a utility method to flatten an object into a Map. The object's fields are
+ * used as keys in the Map, and the field values are used as values. The field values are
+ * recursively flattened if they are custom objects.
+ */
+public class ObjectFlattener {
+
+  private static final JsonAdapter<Object> JSON_ADAPTER =
+      new Moshi.Builder().build().adapter(Object.class);
+
+  /**
+   * Flattens an object into a Map.
+   *
+   * @param obj the object to flatten
+   * @return the flattened object as a Map, or the original object if it's a primitive type or a
+   *     Collection or a Map. Returns null if the input object is null.
+   */
+  public static Object flatten(Object obj) {
+    return JSON_ADAPTER.toJsonValue(obj);
+  }
+}

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -110,9 +110,11 @@ class AppSecRequestContextSpecification extends DDSpecification {
 
     when:
     ctx.reportEvents([new AppSecEvent()])
+    events = ctx.transferCollectedEvents()
 
     then:
-    thrown IllegalStateException
+    events.size() == 1
+    events[0] != null
   }
 
   void 'collect events when none reported'() {
@@ -142,6 +144,11 @@ class AppSecRequestContextSpecification extends DDSpecification {
     collection.exploit[0].frames[0].line == 1
     collection.exploit[0].frames[0].class_name == 'class'
     collection.exploit[0].frames[0].function == 'method'
+  }
+
+  void 'collect stack traces when none reported'() {
+    expect:
+    ctx.transferStackTracesCollection() == null
   }
 
   void 'headers allow list should contains only lowercase names'() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/util/ObjectFlattenerSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/util/ObjectFlattenerSpecification.groovy
@@ -1,0 +1,111 @@
+package com.datadog.appsec.util
+
+import datadog.trace.test.util.DDSpecification
+
+class ObjectFlattenerSpecification extends DDSpecification {
+
+  def "flatten should return null for null input"() {
+    expect:
+    ObjectFlattener.flatten(null) == null
+  }
+
+  def "flatten should return primitive types as is"() {
+    expect:
+    ObjectFlattener.flatten(42) == 42
+    ObjectFlattener.flatten("test") == "test"
+    ObjectFlattener.flatten(true) == true
+    //        ObjectFlattener.flatten(3.14) == 3.14
+  }
+
+  def "flatten should return collections with flattened elements"() {
+    given:
+    def list = [1, "test", [nested: "value"]] as List
+
+    when:
+    def result = ObjectFlattener.flatten(list)
+
+    then:
+    result instanceof List
+    result.size() == 3
+    result[0] == 1
+    result[1] == "test"
+    result[2] == [nested: "value"]
+  }
+
+  def "flatten should return maps with flattened values"() {
+    given:
+    def map = [key1: 1, key2: "test", key3: [nested: "value"]] as Map
+
+    when:
+    def result = ObjectFlattener.flatten(map)
+
+    then:
+    result instanceof Map
+    result.size() == 3
+    result.key1 == 1
+    result.key2 == "test"
+    result.key3 == [nested: "value"]
+  }
+
+  def "flatten should return custom objects as map"() {
+    given:
+    def nestedObject = new NestedObject("NestedName", 456)
+    def testObject = new TestObject(name: "TestName", value: 123, nestedObject: nestedObject)
+
+    when:
+    def result = ObjectFlattener.flatten(testObject)
+
+    then:
+    result instanceof Map
+    result.name == "TestName"
+    result.value == 123
+    result.nestedObject instanceof Map
+    result.nestedObject.nestedName == "NestedName"
+    result.nestedObject.nestedValue == 456
+  }
+
+  def "flatten should handle nested collections and maps"() {
+    given:
+    def nestedMap = [key1: [nestedKey: "nestedValue"]] as Map
+    def nestedList = [1, [2, 3], ["nested": "value"]] as List
+    def testObject = new TestObject(name: "TestName", value: 123, nestedObject: new NestedObject("NestedName", 456))
+    testObject.setList(nestedList)
+    testObject.setMap(nestedMap)
+
+    when:
+    def result = ObjectFlattener.flatten(testObject)
+
+    then:
+    result instanceof Map
+    result.name == "TestName"
+    result.value == 123
+    result.nestedObject instanceof Map
+    result.nestedObject.nestedName == "NestedName"
+    result.nestedObject.nestedValue == 456
+    result.list instanceof List
+    result.list.size() == 3
+    result.list[0] == 1
+    result.list[1] == [2, 3]
+    result.list[2] == ["nested": "value"]
+    result.map instanceof Map
+    result.map.key1 == [nestedKey: "nestedValue"]
+  }
+
+  private static class TestObject {
+    String name
+    int value
+    NestedObject nestedObject
+    List<Object> list
+    Map<String, Object> map
+  }
+
+  private static class NestedObject {
+    String nestedName
+    int nestedValue
+
+    NestedObject(String nestedName, int nestedValue) {
+      this.nestedName = nestedName
+      this.nestedValue = nestedValue
+    }
+  }
+}

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/util/ObjectFlattenerSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/util/ObjectFlattenerSpecification.groovy
@@ -91,6 +91,19 @@ class ObjectFlattenerSpecification extends DDSpecification {
     result.map.key1 == [nestedKey: "nestedValue"]
   }
 
+  def "flatten should handle circular references"() {
+    given:
+    def circular = new Circular()
+    circular.name = "circular"
+    circular.circular = circular
+
+    when:
+    def result = ObjectFlattener.flatten(circular)
+
+    then:
+    result == null
+  }
+
   private static class TestObject {
     String name
     int value
@@ -107,5 +120,10 @@ class ObjectFlattenerSpecification extends DDSpecification {
       this.nestedName = nestedName
       this.nestedValue = nestedValue
     }
+  }
+
+  private static class Circular {
+    String name
+    Circular circular
   }
 }

--- a/dd-java-agent/appsec/src/test/resources/test_multi_config.json
+++ b/dd-java-agent/appsec/src/test/resources/test_multi_config.json
@@ -3803,7 +3803,7 @@
         }
       ],
       "transformers": [],
-      "on_match": ["block"]
+      "on_match": ["block", "stack_trace"]
     },
     {
       "id": "ua0-600-13x",


### PR DESCRIPTION
# What Does This Do
Implemented reporting RASP events and Stack traces.
- Implemented Stack trace generation when WAF returns `generate_stack` action type
- Implemented Reporting Stack traces for exploits (for IAST vulnerabilities and APM exceptions will be implemented later)
- Extended `rule_match` structure to report detected exploits (added support for `resources`, `params` and `db_types`)
- Added `ObjectFlattener` for accurate serialisation of reported data

# Motivation
This is part of Exploit prevention initiative (RASP)

# Additional Notes

Jira ticket: [APPSEC-46818]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-46818]: https://datadoghq.atlassian.net/browse/APPSEC-46818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ