### PR TITLE
Add more tests about OpenTelemetry attributes conventions

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ConventionsTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14ConventionsTest.groovy
@@ -11,6 +11,7 @@ import static datadog.opentelemetry.shim.trace.OtelConventions.OPERATION_NAME_SP
 import static datadog.opentelemetry.shim.trace.OtelConventions.SPAN_KIND_INTERNAL
 import static datadog.opentelemetry.shim.trace.OtelConventions.toSpanKindTagValue
 import static io.opentelemetry.api.common.AttributeKey.longKey
+import static io.opentelemetry.api.common.AttributeKey.stringKey
 import static io.opentelemetry.api.trace.SpanKind.CLIENT
 import static io.opentelemetry.api.trace.SpanKind.CONSUMER
 import static io.opentelemetry.api.trace.SpanKind.INTERNAL
@@ -100,20 +101,21 @@ class OpenTelemetry14ConventionsTest extends AgentTestRunner {
   def "test span specific tags"() {
     setup:
     def builder = tracer.spanBuilder("some-name")
+    def keyFor = (String key) -> useAttributeKey ? stringKey(key) : key
 
     when:
     if (setInBuilder) {
-      builder.setAttribute("operation.name", "my-operation")
-        .setAttribute("service.name", "my-service")
-        .setAttribute("resource.name", "/my-resource")
-        .setAttribute("span.type", "http")
+      builder.setAttribute(keyFor("operation.name"), "my-operation")
+      .setAttribute(keyFor("service.name"), "my-service")
+      .setAttribute(keyFor("resource.name"), "/my-resource")
+      .setAttribute(keyFor("span.type"), "http")
     }
     def result = builder.startSpan()
     if (!setInBuilder) {
-      result.setAttribute("operation.name", "my-operation")
-        .setAttribute("service.name", "my-service")
-        .setAttribute("resource.name", "/my-resource")
-        .setAttribute("span.type", "http")
+      result.setAttribute(keyFor("operation.name"), "my-operation")
+      .setAttribute(keyFor("service.name"), "my-service")
+      .setAttribute(keyFor("resource.name"), "/my-resource")
+      .setAttribute(keyFor("span.type"), "http")
     }
     result.end()
 
@@ -135,7 +137,11 @@ class OpenTelemetry14ConventionsTest extends AgentTestRunner {
     }
 
     where:
-    setInBuilder << [true, false]
+    setInBuilder | useAttributeKey
+    true         | true
+    true         | false
+    false        | true
+    false        | false
   }
 
   def "test span analytics.event specific tag"() {


### PR DESCRIPTION
# What Does This Do

This PR adds more tests about the OpenTelemetry attributes conventions.

# Motivation

This is a follow up from the discussion on #7138

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
