### PR TITLE
Fix debugger batch upload URL when using UDS

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -3326,18 +3326,21 @@ public class Config {
     return debuggerThirdPartyExcludes;
   }
 
-  public String getFinalDebuggerProbeUrl() {
-    // by default poll from datadog agent
-    return "http://" + agentHost + ":" + agentPort;
+  private String getFinalDebuggerBaseUrl() {
+    if (agentUrl.startsWith("unix:")) {
+      // provide placeholder agent URL, in practice we'll be tunnelling over UDS
+      return "http://" + agentHost + ":" + agentPort;
+    } else {
+      return agentUrl;
+    }
   }
 
   public String getFinalDebuggerSnapshotUrl() {
-    // by default send to datadog agent
-    return agentUrl + "/debugger/v1/input";
+    return getFinalDebuggerBaseUrl() + "/debugger/v1/input";
   }
 
   public String getFinalDebuggerSymDBUrl() {
-    return agentUrl + "/symdb/v1/input";
+    return getFinalDebuggerBaseUrl() + "/symdb/v1/input";
   }
 
   public String getDebuggerProbeFileLocation() {


### PR DESCRIPTION
These direct uses of `Config.agentUrl` were missed in #7094

This PR fixes them the same way we fixed uses of `Config.getAgentUrl()` in the original PR; i.e. when using UDS any endpoint using `Config.agentUrl` directly rather than `SharedCommunicationObjects` should use a placeholder of `http://${agentHost}:${agentPort}` instead of `unix:...` to satisfy OkHttp's `HttpUrl.get`. 

This is necessary because the `agentUrl` captured in `Config` will now preserve the original connection string, which when using UDS will start with `unix:`. This protocol will be rejected by OkHttp's `HttpUrl.get`, so to satisfy that call we use the above `http:` placeholder - note the actual connection will be tunnelled over UDS, which is why the URL is a placeholder.

Ideally all remote connections to the agent will eventually migrate to use `SharedCommunicationObjects` to avoid having to repeat this.