### PR TITLE
Use kotlin plugin 1.9.24 in iast-propagation

### DIFF
--- a/dd-smoke-tests/iast-propagation/build.gradle
+++ b/dd-smoke-tests/iast-propagation/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.github.johnrengelman.shadow'
   id 'java'
-  id 'org.jetbrains.kotlin.jvm' version '2.0.0'
+  id 'org.jetbrains.kotlin.jvm' version '1.9.24'
   id 'scala'
   id 'groovy'
 }


### PR DESCRIPTION
# What Does This Do
If using version 2.0.0 gradle will fail to lock versions with a messages like:

```
 No matching variant of org.spockframework:spock-core:2.2-groovy-3.0 was found. 
The consumer was configured to find sources for use during runtime, packaged as a jar, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm' ...

```

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
