### PR TITLE
Do not include system-properties in test session command tag

### DIFF
--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListener.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListener.java
@@ -151,15 +151,6 @@ public class CiVisibilityGradleListener extends BuildAdapter
       }
     }
 
-    for (Map.Entry<String, String> e : startParameter.getSystemPropertiesArgs().entrySet()) {
-      String propertyKey = e.getKey();
-      String propertyValue = e.getValue();
-      command.append(" -D").append(propertyKey);
-      if (propertyValue != null && !propertyValue.isEmpty()) {
-        command.append('=').append(propertyValue);
-      }
-    }
-
     return command.toString();
   }
 

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/legacy/GradleUtils.groovy
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/legacy/GradleUtils.groovy
@@ -49,15 +49,6 @@ abstract class GradleUtils {
       }
     }
 
-    for (Map.Entry<String, String> e : startParameter.getSystemPropertiesArgs().entrySet()) {
-      String propertyKey = e.getKey()
-      String propertyValue = e.getValue()
-      command.append(" -D").append(propertyKey)
-      if (propertyValue != null && !propertyValue.isEmpty()) {
-        command.append('=').append(propertyValue)
-      }
-    }
-
     return command.toString()
   }
 

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
@@ -104,7 +104,7 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
         // otherwise reference to "@{argLine}" that we add when configuring tracer
         // might cause failure
         // (test executions config is changed even if auto configuration is disabled:
-        // for passing module and sesion IDs to child JVM)
+        // for passing module and session IDs to child JVM)
         projectProperties.setProperty("argLine", "");
       }
     }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenUtils.java
@@ -4,7 +4,6 @@ import datadog.trace.util.MethodHandles;
 import java.lang.invoke.MethodHandle;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import org.apache.maven.BuildFailureException;
@@ -162,18 +161,6 @@ public abstract class MavenUtils {
     List<String> goals = request.getGoals();
     for (String goal : goals) {
       command.append(' ').append(goal);
-    }
-
-    Properties userProperties = request.getUserProperties();
-    if (userProperties != null) {
-      for (Map.Entry<Object, Object> e : userProperties.entrySet()) {
-        command
-            .append(" -")
-            .append(CLIManager.SET_SYSTEM_PROPERTY)
-            .append(e.getKey())
-            .append('=')
-            .append(e.getValue());
-      }
     }
 
     if (!request.getActiveProfiles().isEmpty()) {


### PR DESCRIPTION
# What Does This Do

Updates logic that puts together test session commands for Maven and Gradle builds: system properties are no longer a part of the command.

# Motivation

System properties have no effect on the subset of executed tests (this is usually controlled with specifying tasks and/or profiles).
The downside of including them in session commands is that test session fingerprint may become unstable (if a property value changes from run to run, e.g. contains a path that has branch name in it).
They might also contain sensitive info that we don't want to send to Datadog.

Jira ticket: [SDTEST-454]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-454]: https://datadoghq.atlassian.net/browse/SDTEST-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ