### PR TITLE
Added addresses for SSRF and LFI exploits

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -111,6 +111,12 @@ public interface KnownAddresses {
 
   Address<String> USER_ID = new Address<>("usr.id");
 
+  /** The URL of a network resource being requested (outgoing request) */
+  Address<String> IO_NET_URL = new Address<>("server.io.net.url");
+
+  /** The representation of opened file on the filesystem */
+  Address<String> IO_FS_FILE = new Address<>("server.io.fs.file");
+
   /** The database type (ex: mysql, postgresql, sqlite) */
   Address<String> DB_TYPE = new Address<>("server.db.system");
 
@@ -175,6 +181,10 @@ public interface KnownAddresses {
         return SERVER_GRAPHQL_ALL_RESOLVERS;
       case "usr.id":
         return USER_ID;
+      case "server.io.net.url":
+        return IO_NET_URL;
+      case "server.io.fs.file":
+        return IO_FS_FILE;
       case "server.db.system":
         return DB_TYPE;
       case "server.db.statement":

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -42,7 +42,7 @@ class KnownAddressesSpecification extends Specification {
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 30
+    Address.instanceCount() == 32
     KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }


### PR DESCRIPTION
# What Does This Do
Added addresses for Server-side request forgery (SSRF) and Local File Inclusion (LFI) exploits

# Motivation
This is part of AM Exploit Prevention initiative

# Additional Notes


<!--Jira ticket: [PROJ-IDENT]

# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
