### PR TITLE
Fix NPE when kafka consumer info is not available

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/ConsumerCoordinatorInstrumentation.java
@@ -65,7 +65,7 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
         @Advice.This ConsumerCoordinator coordinator,
         @Advice.Return RequestFuture<Void> requestFuture,
         @Advice.Argument(0) final Map<TopicPartition, OffsetAndMetadata> offsets) {
-      if (requestFuture.failed()) {
+      if (requestFuture == null || requestFuture.failed()) {
         return;
       }
       if (offsets == null) {
@@ -74,6 +74,10 @@ public final class ConsumerCoordinatorInstrumentation extends InstrumenterModule
       KafkaConsumerInfo kafkaConsumerInfo =
           InstrumentationContext.get(ConsumerCoordinator.class, KafkaConsumerInfo.class)
               .get(coordinator);
+
+      if (kafkaConsumerInfo == null) {
+        return;
+      }
 
       String consumerGroup = kafkaConsumerInfo.getConsumerGroup();
       Metadata consumerMetadata = kafkaConsumerInfo.getClientMetadata();


### PR DESCRIPTION
# What Does This Do

The `ConsumerCoordinatorInstrumentation` is accessing kafka consumer info through the context store but does not checks for nullity 

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
