### PR TITLE
Ignore exception when trying to remove Git data upload shutdown hook during JVM shutdown

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitDataUploaderImpl.java
@@ -167,7 +167,15 @@ public class GitDataUploaderImpl implements GitDataUploader {
       LOGGER.error("Failed to upload git tree data for remote {}", remoteName, e);
       callback.completeExceptionally(e);
     } finally {
+      removeShutdownHook();
+    }
+  }
+
+  private void removeShutdownHook() {
+    try {
       Runtime.getRuntime().removeShutdownHook(uploadFinishedShutdownHook);
+    } catch (IllegalStateException e) {
+      // JVM is being shutdown
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Suppresses `IllegalStateException` that can be thrown when removing Git data upload shutdown hook.

# Motivation

The Git data upload shutdown hook is needed to make JVM wait before shutting down if Git data upload hasn't had enough time to finish.
If Git data upload finishes while the JVM is running, no shutdown hook is needed.
Which is why the hook is removed when the upload completes.

However, if by the time the upload completes the JVM has already started shutdown, an attempt to remove the shutdown hook will result in exception.
This exception does not indicate any problem and can be annoying for the users, therefore it's best if it is suppressed.

# Additional Notes

Jira ticket: [CIVIS-10174]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-10174]: https://datadoghq.atlassian.net/browse/CIVIS-10174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ