### PR TITLE
Add missing git configuration to cloudfoundry automation

### DIFF
--- a/.github/workflows/add-release-to-cloudfoundry.yaml
+++ b/.github/workflows/add-release-to-cloudfoundry.yaml
@@ -19,10 +19,16 @@ jobs:
       - name: Append release to Cloud Foundry repository
         env:
             VERSION: ${{ steps.get-release-version.outputs.VERSION }}
+            GH_TOKEN: ${{ github.token }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b ci/cloudfoundry
           echo "${VERSION}: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar" >> index.yml
           git add index.yml
           git commit -m "chore: Add version ${VERSION} to Cloud Foundry"
           git push -u origin ci/cloudfoundry
-          gh pr create --title "Add version ${VERSION} to Cloud Foundry" --body "This PR add the version ${VERSION} to Cloud Foundry.  Make sure [the JAR is online](https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar) before merging." --base cloudfoundry
+          gh pr create \
+            --title "Add version ${VERSION} to Cloud Foundry" \
+            --body "This PR add the version ${VERSION} to Cloud Foundry.  Make sure [the JAR is online](https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar) before merging." \
+            --base cloudfoundry


### PR DESCRIPTION
# What Does This Do

This PR add the missing git configuration to Cloud Foundry release process automation.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

I won't backport this fix to 1.35.x branch as it is too late.
It will be tested for 1.36 now.

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
