### PR TITLE
Exclude method handles exceptions from telemetry logs

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/MethodHandles.java
+++ b/internal-api/src/main/java/datadog/trace/util/MethodHandles.java
@@ -1,5 +1,6 @@
 package datadog.trace.util;
 
+import datadog.trace.api.telemetry.LogCollector;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -49,6 +50,7 @@ public class MethodHandles {
 
               } catch (Throwable t) {
                 log.debug(
+                    LogCollector.EXCLUDE_TELEMETRY,
                     "Could not get private field {} getter from class {}",
                     fieldName,
                     clazz.getName(),
@@ -84,6 +86,7 @@ public class MethodHandles {
 
               } catch (Throwable t) {
                 log.debug(
+                    LogCollector.EXCLUDE_TELEMETRY,
                     "Could not get private field {} setter from class {}",
                     fieldName,
                     clazz.getName(),
@@ -119,6 +122,7 @@ public class MethodHandles {
 
               } catch (Throwable t) {
                 log.debug(
+                    LogCollector.EXCLUDE_TELEMETRY,
                     "Could not get constructor accepting {} from class {}",
                     Arrays.toString(parameterTypes),
                     clazz.getName(),
@@ -154,6 +158,7 @@ public class MethodHandles {
 
               } catch (Throwable t) {
                 log.debug(
+                    LogCollector.EXCLUDE_TELEMETRY,
                     "Could not get method {} accepting {} from class {}",
                     methodName,
                     Arrays.toString(parameterTypes),
@@ -191,7 +196,11 @@ public class MethodHandles {
                 return null;
 
               } catch (Throwable t) {
-                log.debug("Could not find desired method in class {}", clazz, t);
+                log.debug(
+                    LogCollector.EXCLUDE_TELEMETRY,
+                    "Could not find desired method in class {}",
+                    clazz,
+                    t);
                 return null;
               }
             });
@@ -201,7 +210,7 @@ public class MethodHandles {
     try {
       return classLoader.loadClass(className);
     } catch (Throwable t) {
-      log.debug("Could not load class {}", className, t);
+      log.debug(LogCollector.EXCLUDE_TELEMETRY, "Could not load class {}", className, t);
       return null;
     }
   }


### PR DESCRIPTION
# What Does This Do

Adds `LogCollector.EXCLUDE_TELEMETRY` marker to logs in `MethodHandles` class.
As the result, these logs will not be reported to telemetry.

# Motivation

By default every log that contains a throwable is reported to telemetry regardless of its log level.

The `MethodHandles` class contains some debug logs that log errors that are expected to occur in some envs, depending on dependency versions that the traced app is using (example: in one version of a testing framework there is a field named "a", while in a later version of the same framework the same field is named "b" - attempting to get one of these will always fail and it will not be an error, which is why it is logged with debug level).
These logs are there only in case a specific issue needs to be investigated, they are not needed in telemetry.

Jira ticket: [SDTEST-461]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
