### PR TITLE
Update missing RFC parts for user event tacking

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecoratorTest.groovy
@@ -1,9 +1,13 @@
 package datadog.trace.bootstrap.instrumentation.decorator
 
+import datadog.trace.api.Config
 import datadog.trace.api.internal.TraceSegment
 import datadog.trace.bootstrap.ActiveSubsystems
 import datadog.trace.test.util.DDSpecification
 
+import static datadog.trace.api.UserEventTrackingMode.DISABLED
+import static datadog.trace.api.UserEventTrackingMode.EXTENDED
+import static datadog.trace.api.UserEventTrackingMode.SAFE
 import static datadog.trace.api.config.AppSecConfig.APPSEC_AUTOMATED_USER_EVENTS_TRACKING
 
 class AppSecUserEventDecoratorTest extends DDSpecification {
@@ -27,20 +31,26 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     def decorator = newDecorator()
 
     when:
-    decorator.onSignup('user', ['key1': 'value1', 'key2': 'value2'])
+    decorator.onSignup(user, ['key1': 'value1', 'key2': 'value2'])
 
     then:
-    1 * traceSegment.setTagTop('_dd.appsec.events.users.signup.auto.mode', modeTag)
+    1 * traceSegment.setTagTop('_dd.appsec.events.users.signup.auto.mode', mode)
     1 * traceSegment.setTagTop('appsec.events.users.signup.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
-    1 * traceSegment.setTagTop('usr.id', 'user')
-    1 * traceSegment.setTagTop('appsec.events.users.signup', ['key1':'value1', 'key2':'value2'])
+    if (setUser) {
+      1 * traceSegment.setTagTop('usr.id', user)
+    }
+    1 * traceSegment.setTagTop('appsec.events.users.signup', ['key1': 'value1', 'key2': 'value2'])
     0 * _
 
     where:
-    mode        | modeTag
-    'safe'      | 'SAFE'
-    'extended'  | 'EXTENDED'
+    mode       | user                                   | setUser
+    'safe'     | 'user'                                 | false
+    'safe'     | '1234'                                 | true
+    'safe'     | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
+    'extended' | 'user'                                 | true
+    'extended' | '1234'                                 | true
+    'extended' | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
   }
 
   def "test onLoginSuccess [#mode]"() {
@@ -49,44 +59,54 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     def decorator = newDecorator()
 
     when:
-    decorator.onLoginSuccess('user', ['key1': 'value1', 'key2': 'value2'])
+    decorator.onLoginSuccess(user, ['key1': 'value1', 'key2': 'value2'])
 
     then:
-    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.success.auto.mode', modeTag)
+    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.success.auto.mode', mode)
     1 * traceSegment.setTagTop('appsec.events.users.login.success.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
-    1 * traceSegment.setTagTop('usr.id', 'user')
-    1 * traceSegment.setTagTop('appsec.events.users.login.success', ['key1':'value1', 'key2':'value2'])
+    if (setUser) {
+      1 * traceSegment.setTagTop('usr.id', user)
+    }
+    1 * traceSegment.setTagTop('appsec.events.users.login.success', ['key1': 'value1', 'key2': 'value2'])
     0 * _
 
     where:
-    mode        | modeTag
-    'safe'      | 'SAFE'
-    'extended'  | 'EXTENDED'
+    mode       | user                                   | setUser
+    'safe'     | 'user'                                 | false
+    'safe'     | '1234'                                 | true
+    'safe'     | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
+    'extended' | 'user'                                 | true
+    'extended' | '1234'                                 | true
+    'extended' | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
   }
 
-  def "test onLoginFailed #description [#mode]"() {
+  def "test onLoginFailed [#mode]"() {
     setup:
     injectSysConfig(APPSEC_AUTOMATED_USER_EVENTS_TRACKING, mode)
     def decorator = newDecorator()
 
     when:
-    decorator.onLoginFailure('user', ['key1': 'value1', 'key2': 'value2'])
+    decorator.onLoginFailure(user, ['key1': 'value1', 'key2': 'value2'])
 
     then:
-    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.auto.mode', modeTag)
+    1 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.auto.mode', mode)
     1 * traceSegment.setTagTop('appsec.events.users.login.failure.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
-    1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.id', 'user')
-    1 * traceSegment.setTagTop('appsec.events.users.login.failure', ['key1':'value1', 'key2':'value2'])
+    if (setUser) {
+      1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.id', user)
+    }
+    1 * traceSegment.setTagTop('appsec.events.users.login.failure', ['key1': 'value1', 'key2': 'value2'])
     0 * _
 
     where:
-    mode       | modeTag    | description
-    'safe'     | 'SAFE'     | 'with existing user'
-    'safe'     | 'SAFE'     | 'user doesn\'t exist'
-    'extended' | 'EXTENDED' | 'with existing user'
-    'extended' | 'EXTENDED' | 'user doesn\'t exist'
+    mode       | user                                   | setUser
+    'safe'     | 'user'                                 | false
+    'safe'     | '1234'                                 | true
+    'safe'     | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
+    'extended' | 'user'                                 | true
+    'extended' | '1234'                                 | true
+    'extended' | '591dc126-8431-4d0f-9509-b23318d3dce4' | true
   }
 
   def "test onUserNotFound [#mode]"() {
@@ -102,9 +122,7 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     0 * _
 
     where:
-    mode       | modeTag
-    'safe'     | 'SAFE'
-    'extended' | 'EXTENDED'
+    mode << ['safe', 'extended']
   }
 
   def "test isEnabled (appsec = #appsec, mode = #mode)"() {
@@ -119,14 +137,21 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     then:
     enabled == result
 
+    and:
+    Config.get().getAppSecUserEventsTrackingMode() == expectedMode
+
     where:
-    appsec | mode       | result
-    false  | "disabled" | false
-    false  | "safe"     | false
-    false  | "extended" | false
-    true   | "disabled" | false
-    true   | "safe"     | true
-    true   | "extended" | true
+    appsec | mode       | result | expectedMode
+    false  | "disabled" | false  | DISABLED
+    false  | "safe"     | false  | SAFE
+    false  | "1"        | false  | SAFE
+    false  | "true"     | false  | SAFE
+    false  | "extended" | false  | EXTENDED
+    true   | "disabled" | false  | DISABLED
+    true   | "safe"     | true   | SAFE
+    true   | "1"        | true   | SAFE
+    true   | "true"     | true   | SAFE
+    true   | "extended" | true   | EXTENDED
   }
 
   def newDecorator() {

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SpringBootBasedTest.groovy
@@ -124,7 +124,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     response.body().string() == REGISTER.body
     !span.getTags().isEmpty()
     span.getTag("appsec.events.users.signup.track") == true
-    span.getTag("_dd.appsec.events.users.signup.auto.mode") == 'EXTENDED'
+    span.getTag("_dd.appsec.events.users.signup.auto.mode") == 'extended'
     span.getTag("usr.id") == 'admin'
     span.getTag("appsec.events.users.signup")['enabled'] == 'true'
     span.getTag("appsec.events.users.signup")['authorities'] == 'ROLE_USER'
@@ -150,7 +150,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     response.body().string() == LOGIN.body
     !span.getTags().isEmpty()
     span.getTag("appsec.events.users.login.failure.track") == true
-    span.getTag("_dd.appsec.events.users.login.failure.auto.mode") == 'EXTENDED'
+    span.getTag("_dd.appsec.events.users.login.failure.auto.mode") == 'extended'
     span.getTag("appsec.events.users.login.failure.usr.exists") == false
     span.getTag("appsec.events.users.login.failure.usr.id") == 'not_existing_user'
   }
@@ -174,7 +174,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     response.body().string() == LOGIN.body
     !span.getTags().isEmpty()
     span.getTag("appsec.events.users.login.failure.track") == true
-    span.getTag("_dd.appsec.events.users.login.failure.auto.mode") == 'EXTENDED'
+    span.getTag("_dd.appsec.events.users.login.failure.auto.mode") == 'extended'
     // TODO: Ideally should be `false` but we have no reliable method to detect it it is just absent. See APPSEC-12765.
     span.getTag("appsec.events.users.login.failure.usr.exists") == null
     span.getTag("appsec.events.users.login.failure.usr.id") == 'admin'
@@ -200,7 +200,7 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     response.body().string() == LOGIN.body
     !span.getTags().isEmpty()
     span.getTag("appsec.events.users.login.success.track") == true
-    span.getTag("_dd.appsec.events.users.login.success.auto.mode") == 'EXTENDED'
+    span.getTag("_dd.appsec.events.users.login.success.auto.mode") == 'extended'
     span.getTag("usr.id") == 'admin'
     span.getTag("appsec.events.users.login.success")['credentialsNonExpired'] == 'true'
     span.getTag("appsec.events.users.login.success")['accountNonExpired'] == 'true'

--- a/internal-api/src/main/java/datadog/trace/api/UserEventTrackingMode.java
+++ b/internal-api/src/main/java/datadog/trace/api/UserEventTrackingMode.java
@@ -1,17 +1,39 @@
 package datadog.trace.api;
 
 public enum UserEventTrackingMode {
-  DISABLED,
-  SAFE,
-  EXTENDED;
+  DISABLED("disabled"),
+  SAFE("safe", "true", "1"),
+  EXTENDED("extended");
+
+  private final String value;
+  private final String[] modes;
+
+  UserEventTrackingMode(final String... modes) {
+    value = modes[0];
+    this.modes = modes;
+  }
+
+  private boolean matches(final String mode) {
+    for (final String value : modes) {
+      if (value.equalsIgnoreCase(mode)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   public static UserEventTrackingMode fromString(String s) {
-    if ("true".equalsIgnoreCase(s) || "1".equals(s) || "safe".equalsIgnoreCase(s)) {
+    if (SAFE.matches(s)) {
       return SAFE;
     }
-    if ("extended".equalsIgnoreCase(s)) {
+    if (EXTENDED.matches(s)) {
       return EXTENDED;
     }
     return DISABLED;
+  }
+
+  @Override
+  public String toString() {
+    return value;
   }
 }


### PR DESCRIPTION
# What Does This Do
Updates support of user event tracking to support all functionality from the RFC, specially:

- Use lower case values for the modes included in the spans
- Allow to send user ids when alphanumeric/uuid in the safe mode.

# Motivation

# Additional Notes
[RFC](https://docs.google.com/document/d/1-trUpphvyZY7k5ldjhW-MgqWl0xOm7AMEQDJEAZ63_Q/edit)

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
