### PR TITLE
Add builder for vulnerability types and fix insecure auth protocol

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Vulnerability.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Vulnerability.java
@@ -50,9 +50,7 @@ public final class Vulnerability {
   public void updateSpan(final AgentSpan newSpan) {
     if (newSpan != null) {
       location.updateSpan(newSpan);
-      if (type instanceof VulnerabilityType.HeaderVulnerabilityType) {
-        hash = type.calculateHash(this);
-      }
+      hash = type.calculateHash(this);
     }
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -1,96 +1,107 @@
 package com.datadog.iast.model;
 
+import static com.datadog.iast.util.CRCUtils.update;
+import static datadog.trace.api.iast.VulnerabilityMarks.COMMAND_INJECTION_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.HEADER_INJECTION_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.LDAP_INJECTION_MARK;
 import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED;
+import static datadog.trace.api.iast.VulnerabilityMarks.PATH_TRAVERSAL_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.REFLECTION_INJECTION_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.SQL_INJECTION_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.SSRF_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.TRUST_BOUNDARY_VIOLATION_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.UNVALIDATED_REDIRECT_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.XPATH_INJECTION_MARK;
+import static datadog.trace.api.iast.VulnerabilityMarks.XSS_MARK;
 
-import datadog.trace.api.iast.VulnerabilityMarks;
 import datadog.trace.api.iast.VulnerabilityTypes;
 import java.io.File;
-import java.nio.charset.StandardCharsets;
+import java.util.function.BiFunction;
 import java.util.zip.CRC32;
 import javax.annotation.Nonnull;
 
 public interface VulnerabilityType {
-  VulnerabilityType WEAK_CIPHER = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_CIPHER);
-  VulnerabilityType WEAK_HASH = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_HASH);
+
+  VulnerabilityType WEAK_CIPHER = type(VulnerabilityTypes.WEAK_CIPHER).build();
+  VulnerabilityType WEAK_HASH = type(VulnerabilityTypes.WEAK_HASH).build();
   VulnerabilityType INSECURE_COOKIE =
-      new CookieVulnerabilityType(VulnerabilityTypes.INSECURE_COOKIE);
+      type(VulnerabilityTypes.INSECURE_COOKIE).hash(VulnerabilityType::evidenceHash).build();
   VulnerabilityType NO_HTTPONLY_COOKIE =
-      new CookieVulnerabilityType(VulnerabilityTypes.NO_HTTPONLY_COOKIE);
+      type(VulnerabilityTypes.NO_HTTPONLY_COOKIE).hash(VulnerabilityType::evidenceHash).build();
   VulnerabilityType HSTS_HEADER_MISSING =
-      new HeaderVulnerabilityType(VulnerabilityTypes.HSTS_HEADER_MISSING);
+      type(VulnerabilityTypes.HSTS_HEADER_MISSING).hash(VulnerabilityType::serviceHash).build();
   VulnerabilityType XCONTENTTYPE_HEADER_MISSING =
-      new HeaderVulnerabilityType(VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING);
+      type(VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING)
+          .hash(VulnerabilityType::serviceHash)
+          .build();
   VulnerabilityType NO_SAMESITE_COOKIE =
-      new CookieVulnerabilityType(VulnerabilityTypes.NO_SAMESITE_COOKIE);
+      type(VulnerabilityTypes.NO_SAMESITE_COOKIE).hash(VulnerabilityType::evidenceHash).build();
 
   VulnerabilityType SQL_INJECTION =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.SQL_INJECTION, VulnerabilityMarks.SQL_INJECTION_MARK);
+      type(VulnerabilityTypes.SQL_INJECTION).mark(SQL_INJECTION_MARK).build();
   VulnerabilityType COMMAND_INJECTION =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.COMMAND_INJECTION, VulnerabilityMarks.COMMAND_INJECTION_MARK);
+      type(VulnerabilityTypes.COMMAND_INJECTION).mark(COMMAND_INJECTION_MARK).build();
   VulnerabilityType PATH_TRAVERSAL =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.PATH_TRAVERSAL,
-          File.separatorChar,
-          VulnerabilityMarks.PATH_TRAVERSAL_MARK);
+      type(VulnerabilityTypes.PATH_TRAVERSAL)
+          .separator(File.separatorChar)
+          .mark(PATH_TRAVERSAL_MARK)
+          .build();
   VulnerabilityType LDAP_INJECTION =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.LDAP_INJECTION, VulnerabilityMarks.LDAP_INJECTION_MARK);
-  VulnerabilityType SSRF =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.SSRF, VulnerabilityMarks.SSRF_MARK);
+      type(VulnerabilityTypes.LDAP_INJECTION).mark(LDAP_INJECTION_MARK).build();
+  VulnerabilityType SSRF = type(VulnerabilityTypes.SSRF).mark(SSRF_MARK).build();
   VulnerabilityType UNVALIDATED_REDIRECT =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.UNVALIDATED_REDIRECT, VulnerabilityMarks.UNVALIDATED_REDIRECT_MARK);
-  VulnerabilityType WEAK_RANDOMNESS = new VulnerabilityTypeImpl(VulnerabilityTypes.WEAK_RANDOMNESS);
+      type(VulnerabilityTypes.UNVALIDATED_REDIRECT).mark(UNVALIDATED_REDIRECT_MARK).build();
+  VulnerabilityType WEAK_RANDOMNESS = type(VulnerabilityTypes.WEAK_RANDOMNESS).build();
 
   VulnerabilityType XPATH_INJECTION =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.XPATH_INJECTION, VulnerabilityMarks.XPATH_INJECTION_MARK);
+      type(VulnerabilityTypes.XPATH_INJECTION).mark(XPATH_INJECTION_MARK).build();
 
   VulnerabilityType TRUST_BOUNDARY_VIOLATION =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION, VulnerabilityMarks.TRUST_BOUNDARY_VIOLATION);
+      type(VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION).mark(TRUST_BOUNDARY_VIOLATION_MARK).build();
 
-  VulnerabilityType XSS =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.XSS, VulnerabilityMarks.XSS_MARK);
+  VulnerabilityType XSS = type(VulnerabilityTypes.XSS).mark(XSS_MARK).build();
 
   VulnerabilityType HEADER_INJECTION =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.HEADER_INJECTION, VulnerabilityMarks.HEADER_INJECTION_MARK);
+      type(VulnerabilityTypes.HEADER_INJECTION).mark(HEADER_INJECTION_MARK).build();
 
-  VulnerabilityType STACKTRACE_LEAK = new VulnerabilityTypeImpl(VulnerabilityTypes.STACKTRACE_LEAK);
+  VulnerabilityType STACKTRACE_LEAK = type(VulnerabilityTypes.STACKTRACE_LEAK).build();
 
-  VulnerabilityType VERB_TAMPERING = new VulnerabilityTypeImpl(VulnerabilityTypes.VERB_TAMPERING);
+  VulnerabilityType VERB_TAMPERING = type(VulnerabilityTypes.VERB_TAMPERING).build();
 
   VulnerabilityType ADMIN_CONSOLE_ACTIVE =
-      new ServiceVulnerabilityType(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE, false);
+      type(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE)
+          .deduplicable(false)
+          .hash(VulnerabilityType::serviceHash)
+          .build();
 
   VulnerabilityType DEFAULT_HTML_ESCAPE_INVALID =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID);
+      type(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID).build();
 
-  VulnerabilityType SESSION_TIMEOUT = new VulnerabilityTypeImpl(VulnerabilityTypes.SESSION_TIMEOUT);
+  VulnerabilityType SESSION_TIMEOUT = type(VulnerabilityTypes.SESSION_TIMEOUT).build();
 
   VulnerabilityType DIRECTORY_LISTING_LEAK =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.DIRECTORY_LISTING_LEAK);
-  VulnerabilityType INSECURE_JSP_LAYOUT =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_JSP_LAYOUT);
+      type(VulnerabilityTypes.DIRECTORY_LISTING_LEAK).build();
+  VulnerabilityType INSECURE_JSP_LAYOUT = type(VulnerabilityTypes.INSECURE_JSP_LAYOUT).build();
 
-  VulnerabilityType HARDCODED_SECRET =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.HARDCODED_SECRET);
+  VulnerabilityType HARDCODED_SECRET = type(VulnerabilityTypes.HARDCODED_SECRET).build();
 
   VulnerabilityType INSECURE_AUTH_PROTOCOL =
-      new VulnerabilityTypeImpl(VulnerabilityTypes.INSECURE_AUTH_PROTOCOL);
+      type(VulnerabilityTypes.INSECURE_AUTH_PROTOCOL).hash(VulnerabilityType::evidenceHash).build();
 
   VulnerabilityType REFLECTION_INJECTION =
-      new VulnerabilityTypeImpl(
-          VulnerabilityTypes.REFLECTION_INJECTION, VulnerabilityMarks.REFLECTION_INJECTION_MARK);
+      type(VulnerabilityTypes.REFLECTION_INJECTION).mark(REFLECTION_INJECTION_MARK).build();
 
   VulnerabilityType SESSION_REWRITING =
-      new ServiceVulnerabilityType(VulnerabilityTypes.SESSION_REWRITING, false);
+      type(VulnerabilityTypes.SESSION_REWRITING)
+          .deduplicable(false)
+          .hash(VulnerabilityType::serviceHash)
+          .build();
 
   VulnerabilityType DEFAULT_APP_DEPLOYED =
-      new ServiceVulnerabilityType(VulnerabilityTypes.DEFAULT_APP_DEPLOYED, false);
+      type(VulnerabilityTypes.DEFAULT_APP_DEPLOYED)
+          .deduplicable(false)
+          .hash(VulnerabilityType::serviceHash)
+          .build();
 
   String name();
 
@@ -104,6 +115,10 @@ public interface VulnerabilityType {
   /** A flag to indicate if the vulnerability is deduplicable. */
   boolean isDeduplicable();
 
+  static Builder type(final byte type) {
+    return new Builder(type);
+  }
+
   class VulnerabilityTypeImpl implements VulnerabilityType {
 
     private final byte type;
@@ -114,24 +129,19 @@ public interface VulnerabilityType {
 
     private final boolean deduplicable;
 
-    public VulnerabilityTypeImpl(final byte type, final int... marks) {
-      this(type, ' ', marks);
-    }
-
-    public VulnerabilityTypeImpl(final byte type, boolean deduplicable, final int... marks) {
-      this(type, ' ', deduplicable, marks);
-    }
-
-    public VulnerabilityTypeImpl(final byte type, final char separator, final int... marks) {
-      this(type, separator, true, marks);
-    }
+    private final BiFunction<VulnerabilityType, Vulnerability, Long> hash;
 
     public VulnerabilityTypeImpl(
-        final byte type, final char separator, final boolean deduplicable, final int... marks) {
+        final byte type,
+        final char separator,
+        final int mark,
+        final boolean deduplicable,
+        final BiFunction<VulnerabilityType, Vulnerability, Long> hash) {
       this.type = type;
       this.separator = separator;
-      mark = computeMarks(marks);
+      this.mark = mark;
       this.deduplicable = deduplicable;
+      this.hash = hash;
     }
 
     @Override
@@ -150,89 +160,86 @@ public interface VulnerabilityType {
     }
 
     @Override
-    public long calculateHash(@Nonnull final Vulnerability vulnerability) {
-      CRC32 crc = new CRC32();
-      update(crc, name());
-      final Location location = vulnerability.getLocation();
-      if (location != null) {
-        crc.update(location.getLine());
-        if (location.getPath() != null) {
-          update(crc, location.getPath());
-        }
-        if (location.getLine() <= -1 && location.getMethod() != null) {
-          update(crc, location.getMethod());
-        }
-      }
-      return crc.getValue();
+    public long calculateHash(@Nonnull Vulnerability vulnerability) {
+      return hash.apply(this, vulnerability);
     }
 
     @Override
     public boolean isDeduplicable() {
       return deduplicable;
     }
+  }
 
-    protected void update(final CRC32 crc, final String value) {
-      final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-      crc.update(bytes, 0, bytes.length);
+  class Builder {
+    private final byte type;
+    private char separator = ' ';
+    private int mark = NOT_MARKED;
+    private boolean deduplicable = true;
+    private BiFunction<VulnerabilityType, Vulnerability, Long> hash =
+        VulnerabilityType::fileAndLineHash;
+
+    public Builder(byte type) {
+      this.type = type;
     }
 
-    private static int computeMarks(final int... marks) {
-      int result = NOT_MARKED;
-      for (final int mark : marks) {
-        result |= mark;
-      }
-      return result;
+    public Builder separator(final char separator) {
+      this.separator = separator;
+      return this;
+    }
+
+    public Builder mark(final int mark) {
+      this.mark = mark;
+      return this;
+    }
+
+    public Builder deduplicable(final boolean deduplicable) {
+      this.deduplicable = deduplicable;
+      return this;
+    }
+
+    public Builder hash(final BiFunction<VulnerabilityType, Vulnerability, Long> hash) {
+      this.hash = hash;
+      return this;
+    }
+
+    public VulnerabilityType build() {
+      return new VulnerabilityTypeImpl(type, separator, mark, deduplicable, hash);
     }
   }
 
-  class HeaderVulnerabilityType extends VulnerabilityTypeImpl {
-    public HeaderVulnerabilityType(byte type, int... marks) {
-      super(type, marks);
-    }
-
-    @Override
-    public long calculateHash(@Nonnull final Vulnerability vulnerability) {
-      CRC32 crc = new CRC32();
-      update(crc, name());
-      String serviceName = vulnerability.getLocation().getServiceName();
-      if (serviceName != null) {
-        update(crc, serviceName);
+  static long fileAndLineHash(final VulnerabilityType type, final Vulnerability vulnerability) {
+    CRC32 crc = new CRC32();
+    update(crc, type.name());
+    final Location location = vulnerability.getLocation();
+    if (location != null) {
+      crc.update(location.getLine());
+      if (location.getPath() != null) {
+        update(crc, location.getPath());
       }
-      return crc.getValue();
+      if (location.getLine() <= -1 && location.getMethod() != null) {
+        update(crc, location.getMethod());
+      }
     }
+    return crc.getValue();
   }
 
-  class CookieVulnerabilityType extends VulnerabilityTypeImpl {
-    public CookieVulnerabilityType(byte type, int... marks) {
-      super(type, marks);
+  static long evidenceHash(final VulnerabilityType type, final Vulnerability vulnerability) {
+    CRC32 crc = new CRC32();
+    update(crc, type.name());
+    final Evidence evidence = vulnerability.getEvidence();
+    if (evidence != null) {
+      update(crc, evidence.getValue());
     }
-
-    @Override
-    public long calculateHash(@Nonnull final Vulnerability vulnerability) {
-      CRC32 crc = new CRC32();
-      update(crc, name());
-      final Evidence evidence = vulnerability.getEvidence();
-      if (evidence != null) {
-        update(crc, evidence.getValue());
-      }
-      return crc.getValue();
-    }
+    return crc.getValue();
   }
 
-  class ServiceVulnerabilityType extends VulnerabilityTypeImpl {
-    public ServiceVulnerabilityType(byte type, boolean deduplicable, int... marks) {
-      super(type, deduplicable, marks);
+  static long serviceHash(final VulnerabilityType type, final Vulnerability vulnerability) {
+    CRC32 crc = new CRC32();
+    update(crc, type.name());
+    final String serviceName = vulnerability.getLocation().getServiceName();
+    if (serviceName != null) {
+      update(crc, serviceName);
     }
-
-    @Override
-    public long calculateHash(@Nonnull final Vulnerability vulnerability) {
-      CRC32 crc = new CRC32();
-      update(crc, name());
-      String serviceName = vulnerability.getLocation().getServiceName();
-      if (serviceName != null) {
-        update(crc, serviceName);
-      }
-      return crc.getValue();
-    }
+    return crc.getValue();
   }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/CRCUtils.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/CRCUtils.java
@@ -1,0 +1,25 @@
+package com.datadog.iast.util;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
+
+public abstract class CRCUtils {
+
+  private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+  private CRCUtils() {}
+
+  public static void update(final CRC32 crc, final String value) {
+    update(crc, value, DEFAULT_CHARSET);
+  }
+
+  public static void update(final CRC32 crc, final String value, final Charset charset) {
+    final byte[] bytes = value.getBytes(charset);
+    update(crc, bytes);
+  }
+
+  public static void update(final CRC32 crc, final byte[] bytes) {
+    crc.update(bytes, 0, bytes.length);
+  }
+}

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/ReporterTest.groovy
@@ -149,7 +149,7 @@ class ReporterTest extends DDSpecification {
     0 * _
   }
 
-  void 'null span creates a new one before reporting'() {
+  void 'null span creates a new one before reporting #v.type.name()'() {
     given:
     final tracerAPI = Mock(TracerAPI)
     AgentTracer.forceRegister(tracerAPI)
@@ -180,29 +180,24 @@ class ReporterTest extends DDSpecification {
     0 * _
 
     when:
-    def newSpanId = null
-    def newServiceName = null
-    if(v.getType() instanceof VulnerabilityType.HeaderVulnerabilityType){
-      newServiceName = v.getLocation().getServiceName()
-    }else{
-      newSpanId =  v.getLocation().getSpanId()
-    }
+    def newSpanId = v.getLocation().getSpanId()
+    def newServiceName = v.getLocation().getServiceName()
     def newHash = v.getHash()
 
     then:
-    if(v.getType() instanceof VulnerabilityType.HeaderVulnerabilityType){
-      assert newServiceName == serviceName
+    assert newServiceName == serviceName
+    assert newSpanId == spanId
+    if (hashServiceName) {
       assert newHash != hash
-    }else{
-      assert newSpanId == spanId
+    } else {
       assert newHash == hash
     }
 
     where:
-    v | _
-    defaultVulnerability() | _
-    cookieVulnerability() | _
-    headerVulnerability() | _
+    v                      | hashServiceName
+    defaultVulnerability() | false
+    cookieVulnerability()  | false
+    headerVulnerability()  | true
   }
 
   void 'no spans are create if duplicates are reported'() {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/VulnerabilityTypeTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/VulnerabilityTypeTest.groovy
@@ -3,6 +3,7 @@ package com.datadog.iast.model
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
 
+import static com.datadog.iast.model.VulnerabilityType.INSECURE_AUTH_PROTOCOL
 import static com.datadog.iast.model.VulnerabilityType.INSECURE_COOKIE
 import static com.datadog.iast.model.VulnerabilityType.NO_HTTPONLY_COOKIE
 import static com.datadog.iast.model.VulnerabilityType.NO_SAMESITE_COOKIE
@@ -21,31 +22,34 @@ class VulnerabilityTypeTest extends DDSpecification {
     vulnerability.hash == expected
 
     where:
-    type                        | location                              | evidence                    | expected
-    WEAK_CIPHER                 | getSpanAndStackLocation(123)          | new Evidence("MD5")         | 1045110372
-    WEAK_CIPHER                 | getSpanAndStackLocation(456)          | new Evidence("MD4")         | 1045110372
-    WEAK_CIPHER                 | getSpanAndStackLocation(789)          | null                        | 1045110372
-    WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(123) | new Evidence("MD5")         | 3265519776
-    WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(456) | new Evidence("MD4")         | 3265519776
-    WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(789) | null                        | 3265519776
-    INSECURE_COOKIE             | getSpanAndStackLocation(123)          | null                        | 3471934557
-    INSECURE_COOKIE             | getSpanAndStackLocation(123)          | new Evidence("cookieName1") | 360083726
-    INSECURE_COOKIE             | getSpanAndStackLocation(123)          | new Evidence("cookieName2") | 2357141684
-    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)          | null                        | 2115643285
-    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)          | new Evidence("cookieName1") | 585548920
-    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)          | new Evidence("cookieName2") | 3153040834
-    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)          | null                        | 3683185539
-    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)          | new Evidence("cookieName1") | 881944211
-    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)          | new Evidence("cookieName2") | 2912433961
-    XCONTENTTYPE_HEADER_MISSING | getSpanLocation(123, null)            | null                        | 3429203725
-    XCONTENTTYPE_HEADER_MISSING | getSpanLocation(123, 'serviceName1')  | null                        | 2718833340
-    XCONTENTTYPE_HEADER_MISSING | getSpanLocation(123, 'serviceName2')  | null                        | 990333702
-    HSTS_HEADER_MISSING         | getSpanLocation(123, null)            | null                        | 121310697
-    HSTS_HEADER_MISSING         | getSpanLocation(123, 'serviceName1')  | null                        | 3533496951
-    HSTS_HEADER_MISSING         | getSpanLocation(123, 'serviceName2')  | null                        | 1268102093
-    SESSION_REWRITING         | getSpanLocation(123, null)            | null                        | 2255304761
-    SESSION_REWRITING         | getSpanLocation(123, 'serviceName1')  | null                        | 305779398
-    SESSION_REWRITING         | getSpanLocation(123, 'serviceName2')  | null                        | 2335212412
+    type                        | location                               | evidence                               | expected
+    WEAK_CIPHER                 | getSpanAndStackLocation(123)           | new Evidence("MD5")                    | 1045110372
+    WEAK_CIPHER                 | getSpanAndStackLocation(456)           | new Evidence("MD4")                    | 1045110372
+    WEAK_CIPHER                 | getSpanAndStackLocation(789)           | null                                   | 1045110372
+    WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(123)  | new Evidence("MD5")                    | 3265519776
+    WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(456)  | new Evidence("MD4")                    | 3265519776
+    WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(789)  | null                                   | 3265519776
+    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | null                                   | 3471934557
+    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 360083726
+    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 2357141684
+    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | null                                   | 2115643285
+    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 585548920
+    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 3153040834
+    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | null                                   | 3683185539
+    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 881944211
+    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 2912433961
+    XCONTENTTYPE_HEADER_MISSING | getSpanAndService(123, null)           | null                                   | 3429203725
+    XCONTENTTYPE_HEADER_MISSING | getSpanAndService(123, 'serviceName1') | null                                   | 2718833340
+    XCONTENTTYPE_HEADER_MISSING | getSpanAndService(123, 'serviceName2') | null                                   | 990333702
+    HSTS_HEADER_MISSING         | getSpanAndService(123, null)           | null                                   | 121310697
+    HSTS_HEADER_MISSING         | getSpanAndService(123, 'serviceName1') | null                                   | 3533496951
+    HSTS_HEADER_MISSING         | getSpanAndService(123, 'serviceName2') | null                                   | 1268102093
+    SESSION_REWRITING           | getSpanAndService(123, null)           | null                                   | 2255304761
+    SESSION_REWRITING           | getSpanAndService(123, 'serviceName1') | null                                   | 305779398
+    SESSION_REWRITING           | getSpanAndService(123, 'serviceName2') | null                                   | 2335212412
+    INSECURE_AUTH_PROTOCOL      | getSpanAndStackLocation(123)           | null                                   | 2355929438
+    INSECURE_AUTH_PROTOCOL      | getSpanAndStackLocation(123)           | new Evidence("Authorization : Basic")  | 19385012
+    INSECURE_AUTH_PROTOCOL      | getSpanAndStackLocation(123)           | new Evidence("Authorization : Digest") | 871205334
   }
 
   private Location getSpanAndStackLocation(final long spanId) {
@@ -60,7 +64,7 @@ class VulnerabilityTypeTest extends DDSpecification {
     return Location.forSpanAndClassAndMethod(span, "foo", "foo")
   }
 
-  private Location getSpanLocation(final long spanId, final String serviceName) {
+  private Location getSpanAndService(final long spanId, final String serviceName) {
     final span = Stub(AgentSpan)
     span.getSpanId() >> spanId
     span.getServiceName() >> serviceName

--- a/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityMarks.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/VulnerabilityMarks.java
@@ -16,7 +16,7 @@ public class VulnerabilityMarks {
 
   public static final int XSS_MARK = 1 << 7;
 
-  public static final int TRUST_BOUNDARY_VIOLATION = 1 << 8;
+  public static final int TRUST_BOUNDARY_VIOLATION_MARK = 1 << 8;
   public static final int HEADER_INJECTION_MARK = 1 << 9;
   public static final int REFLECTION_INJECTION_MARK = 1 << 10;
 }


### PR DESCRIPTION
# What Does This Do
Refactor `VulnerabilityType` constructor and fix `INSECURE_AUTH_PROTOCOL` hash.

# Motivation
The hashing of the `INSECURE_AUTH_PROTOCOL` was using file and line which makes no sense.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
