### PR TITLE
Preserve original types before passing data to the WAF

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/ObjectIntrospection.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/ObjectIntrospection.java
@@ -1,7 +1,11 @@
 package com.datadog.appsec.event.data;
 
 import datadog.trace.api.Platform;
-import java.lang.reflect.*;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,38 +36,89 @@ public final class ObjectIntrospection {
   private ObjectIntrospection() {}
 
   /**
-   * Converts arbitrary objects to strings, maps and lists, by using reflection. This serves two
-   * main purposes: - the objects can be inspected by the appsec subsystem and passed to the WAF. -
-   * By creating new containers and not transforming only immutable objects like strings, the new
-   * object can be safely manipulated by the appsec subsystem without worrying about modifications
-   * in other threads.
+   * Converts arbitrary objects compatible with ddwaf_object. Possible types in the result are:
+   *
+   * <ul>
+   *   <li>Null
+   *   <li>Strings
+   *   <li>Boolean
+   *   <li>Byte, Short, Integer, Long (will be serialized as int64)
+   *   <li>Float, Double (will be serialized as float64)
+   *   <li>Maps with string keys
+   *   <li>Lists
+   * </ul>
+   *
+   * This serves two purposes:
+   *
+   * <ul>
+   *   <li>The objects can be inspected by the appsec subsystem and passed to the WAF.
+   *   <li>>By creating new containers and not transforming only immutable objects like strings, the
+   *       new object can be safely manipulated by the appsec subsystem without worrying about
+   *       modifications in other threads.
+   * </ul>
    *
    * <p>Certain instance fields are excluded. Right now, this includes metaClass fields in Groovy
    * objects and this$0 fields in inner classes.
+   *
+   * <p>Only string values are preserved. Numbers or booleans are removed, since we do not expect
+   * rules to detect malicious payloads in these types. An exception to this are map keys, which are
+   * always converted to strings.
    *
    * @param obj an arbitrary object
    * @return the converted object
    */
   public static Object convert(Object obj) {
-    return guardedConversion(obj, 0, new int[] {MAX_ELEMENTS});
+    return guardedConversion(obj, 0, new State());
   }
 
-  private static Object guardedConversion(Object obj, int depth, int[] elemsLeft) {
+  private static class State {
+    int elemsLeft = MAX_ELEMENTS;
+    int invalidKeyId;
+  }
+
+  private static Object guardedConversion(Object obj, int depth, State state) {
     try {
-      return doConversion(obj, depth, elemsLeft);
+      return doConversion(obj, depth, state);
     } catch (Throwable t) {
-      return "<error: " + t.getMessage() + ">";
+      // TODO: Use invalid object
+      return "error:" + t.getMessage();
     }
   }
 
-  private static Object doConversion(Object obj, int depth, int[] elemsLeft) {
-    elemsLeft[0]--;
-    if (elemsLeft[0] <= 0 || obj == null || depth > MAX_DEPTH) {
+  private static String keyConversion(Object key, State state) {
+    state.elemsLeft--;
+    if (state.elemsLeft <= 0) {
+      return null;
+    }
+    if (key == null) {
+      return "null";
+    }
+    if (key instanceof String) {
+      return (String) key;
+    }
+    if (key instanceof Number
+        || key instanceof Boolean
+        || key instanceof Character
+        || key instanceof CharSequence) {
+      return key.toString();
+    }
+    return "invalid_key:" + (++state.invalidKeyId);
+  }
+
+  private static Object doConversion(Object obj, int depth, State state) {
+    state.elemsLeft--;
+    if (state.elemsLeft <= 0 || obj == null || depth > MAX_DEPTH) {
       return null;
     }
 
-    // char sequences / numbers
-    if (obj instanceof CharSequence || obj instanceof Number) {
+    // strings, booleans and numbers are preserved
+    if (obj instanceof String || obj instanceof Boolean || obj instanceof Number) {
+      return obj;
+    }
+
+    // char sequences are transformed just in case they are not immutable,
+    // single char sequences are transformed to strings for ddwaf compatibility.
+    if (obj instanceof CharSequence || obj instanceof Character) {
       return obj.toString();
     }
 
@@ -72,12 +127,12 @@ public final class ObjectIntrospection {
       Map<Object, Object> newMap = new HashMap<>((int) Math.ceil(((Map) obj).size() / .75));
       for (Map.Entry<?, ?> e : ((Map<?, ?>) obj).entrySet()) {
         Object key = e.getKey();
-        Object newKey = guardedConversion(e.getKey(), depth + 1, elemsLeft);
+        Object newKey = keyConversion(e.getKey(), state);
         if (newKey == null && key != null) {
           // probably we're out of elements anyway
           continue;
         }
-        newMap.put(newKey, guardedConversion(e.getValue(), depth + 1, elemsLeft));
+        newMap.put(newKey, guardedConversion(e.getValue(), depth + 1, state));
       }
       return newMap;
     }
@@ -91,10 +146,10 @@ public final class ObjectIntrospection {
         newList = new ArrayList<>();
       }
       for (Object o : ((Iterable<?>) obj)) {
-        if (elemsLeft[0] <= 0) {
+        if (state.elemsLeft <= 0) {
           break;
         }
-        newList.add(guardedConversion(o, depth + 1, elemsLeft));
+        newList.add(guardedConversion(o, depth + 1, state));
       }
       return newList;
     }
@@ -104,8 +159,8 @@ public final class ObjectIntrospection {
     if (clazz.isArray()) {
       int length = Array.getLength(obj);
       List<Object> newList = new ArrayList<>(length);
-      for (int i = 0; i < length && elemsLeft[0] > 0; i++) {
-        newList.add(guardedConversion(Array.get(obj, i), depth + 1, elemsLeft));
+      for (int i = 0; i < length && state.elemsLeft > 0; i++) {
+        newList.add(guardedConversion(Array.get(obj, i), depth + 1, state));
       }
       return newList;
     }
@@ -122,7 +177,7 @@ public final class ObjectIntrospection {
     outer:
     for (Field[] fields : allFields) {
       for (Field f : fields) {
-        if (elemsLeft[0] <= 0) {
+        if (state.elemsLeft <= 0) {
           break outer;
         }
         if (Modifier.isStatic(f.getModifiers())) {
@@ -132,25 +187,38 @@ public final class ObjectIntrospection {
           continue;
         }
         String name = f.getName();
-        if (name.equals("this$0")) {
+        if (ignoredFieldName(name)) {
           continue;
         }
 
         if (setAccessible(f)) {
           try {
-            newMap.put(f.getName(), guardedConversion(f.get(obj), depth + 1, elemsLeft));
+            newMap.put(f.getName(), guardedConversion(f.get(obj), depth + 1, state));
           } catch (IllegalAccessException e) {
             log.error("Unable to get field value", e);
+            // TODO: Use invalid object
           }
         } else {
           // One of fields is inaccessible, might be it's Strongly Encapsulated Internal class
           // consider it as integral object without introspection
+          // TODO: Use invalid object
           return obj.toString();
         }
       }
     }
 
     return newMap;
+  }
+
+  private static boolean ignoredFieldName(final String name) {
+    switch (name) {
+      case "this$0":
+      case "memoizedHashCode":
+      case "memoizedSize":
+        return true;
+      default:
+        return false;
+    }
   }
 
   /**

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/ObjectIntrospectionSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/ObjectIntrospectionSpecification.groovy
@@ -8,61 +8,47 @@ import static com.datadog.appsec.event.data.ObjectIntrospection.convert
 
 class ObjectIntrospectionSpecification extends Specification {
 
-  void 'strings are preserved'() {
+  void 'null is preserved'() {
     expect:
-    convert('hello') === 'hello'
+    convert(null) == null
   }
 
-  void 'boolean are preserved'() {
-    expect:
-    convert(true) === true
+  void 'type #type is preserved'() {
+    when:
+    def result = convert(input)
+
+    then:
+    input.getClass() == type
+    result.getClass() == type
+    result == input
+
+    where:
+    input        | type
+    'hello'      | String
+    true         | Boolean
+    (byte) 1     | Byte
+    (short) 1    | Short
+    1            | Integer
+    1L           | Long
+    1.0F         | Float
+    (double) 1.0 | Double
+    1G           | BigInteger
+    1.0G         | BigDecimal
   }
 
-  void 'bytes are preserved'() {
-    expect:
-    convert(1 as byte) === 1 as byte
-  }
+  void 'type #type is converted to string'() {
+    when:
+    def result = convert(input)
 
-  void 'shorts are preserved'() {
-    expect:
-    convert(1 as short) === 1 as short
-  }
+    then:
+    type.isAssignableFrom(input.getClass())
+    result instanceof String
+    result == output
 
-  void 'ints are preserved'() {
-    expect:
-    convert(1) === 1
-  }
-
-  void 'longs are preserved'() {
-    expect:
-    convert(1L) === 1L
-  }
-
-  void 'floats are preserved'() {
-    expect:
-    convert(1.0F) instanceof Float
-    convert(1.0F) == Float.valueOf(1.0F)
-  }
-
-  void 'doubles are preserved'() {
-    expect:
-    convert(1.0) === 1.0
-  }
-
-  void 'big integers are preserved'() {
-    expect:
-    convert(1G) === 1G
-  }
-
-  void 'big decimals are preserved'() {
-    expect:
-    convert(1.0G) === 1.0G
-  }
-
-  void 'chars are converted to strings'() {
-    expect:
-    convert('a' as Character) instanceof String
-    convert('a' as Character) == 'a'
+    where:
+    input                     | type       || output
+    (char) 'a'                | Character  || 'a'
+    createCharBuffer('hello') | CharBuffer || 'hello'
   }
 
   static CharBuffer createCharBuffer(String s) {
@@ -70,11 +56,6 @@ class ObjectIntrospectionSpecification extends Specification {
     charBuffer.put(s)
     charBuffer.position(0)
     charBuffer
-  }
-
-  void 'char sequences are converted to strings'() {
-    expect:
-    convert(createCharBuffer('hello')) == 'hello'
   }
 
   void 'iterables are converted to lists'() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -878,6 +878,35 @@ class PowerWAFModuleSpecification extends DDSpecification {
     flow.blocking == false
   }
 
+  void 'non-string types work'() {
+    setupWithStubConfigService()
+    ChangeableFlow flow = new ChangeableFlow()
+    DataBundle db = MapDataBundle.of(KnownAddresses.REQUEST_BODY_OBJECT,
+      [
+        [key: [
+            true,
+            (byte)1,
+            (short)2,
+            (int)3,
+            (long)4,
+            (float)5.0,
+            (double)6.0,
+            (char)'7',
+            (BigDecimal)8.0G,
+            (BigInteger)9.0G
+          ]]
+      ])
+
+    when:
+    dataListener.onDataAvailable(flow, ctx, db, false)
+
+    then:
+    ctx.getOrCreateAdditive(_, true) >> {
+      pwafAdditive = it[0].openAdditive()
+    }
+    flow.blocking == false
+  }
+
   void 'powerwaf exceptions do not propagate'() {
     setupWithStubConfigService()
     ChangeableFlow flow = new ChangeableFlow()


### PR DESCRIPTION
# What Does This Do
* When converting parsed body or grpc messages, preserve types to the extent that they are supported by libddwaf. Rules that apply only to strings can be skipped for numbers, booleans, etc.
* For anything that is not supported by libddwaf, such as non-string keys in maps, just convert to strings.
* When a key cannot be converted, use `invalid_key:$i` string
* Skip fields that are known to be useless, such as `memoizedHashCode` and `memoizedSize` in protobuf.

# Motivation
Originally motivated by spurious matches of internal protobuf fields, then also realized there are several cases where we are doing unnecessary work. This turns out to be the first of a possible series of performance optimizations.

# Additional Notes

Jira ticket: [APPSEC-53469](https://datadoghq.atlassian.net/browse/APPSEC-53469)

Future work:
* When an object cannot be converted correctly, do not use anything that will be extraneous to the WAF (such as `MyClass@1234`). Fall back should to be an invalid object, which is a well defined type in the WAF. We'll need to change libddwaf-java a bit to expose the invalid object type.
* Emit further metrics or logs when we hit this sort of edge case.

[APPSEC-53469]: https://datadoghq.atlassian.net/browse/APPSEC-53469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ