### PR TITLE
Add more metrics and tags to CI Visibility telemetry

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
@@ -4,6 +4,7 @@ import datadog.communication.BackendApi;
 import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.config.ModuleExecutionSettings;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.civisibility.ci.CIInfo;
 import datadog.trace.civisibility.ci.CIProviderInfo;
@@ -45,8 +46,8 @@ public class CiVisibilityRepoServices {
 
   final String repoRoot;
   final String moduleName;
+  final Provider ciProvider;
   final Map<String, String> ciTags;
-  final boolean supportedCiProvider;
 
   final GitDataUploader gitDataUploader;
   final RepoIndexProvider repoIndexProvider;
@@ -56,11 +57,12 @@ public class CiVisibilityRepoServices {
 
   CiVisibilityRepoServices(CiVisibilityServices services, Path path) {
     CIProviderInfo ciProviderInfo = services.ciProviderInfoFactory.createCIProviderInfo(path);
+    ciProvider = ciProviderInfo.getProvider();
+
     CIInfo ciInfo = ciProviderInfo.buildCIInfo();
     repoRoot = ciInfo.getCiWorkspace();
     moduleName = getModuleName(services.config, path, ciInfo);
     ciTags = new CITagsProvider().getCiTags(ciInfo);
-    supportedCiProvider = ciProviderInfo.isSupportedCiProvider();
 
     gitDataUploader =
         buildGitDataUploader(

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilitySystem.java
@@ -210,7 +210,7 @@ public class CiVisibilitySystem {
           repoServices.repoRoot,
           startCommand,
           startTime,
-          repoServices.supportedCiProvider,
+          repoServices.ciProvider,
           services.config,
           services.metricCollector,
           testModuleRegistry,
@@ -262,7 +262,7 @@ public class CiVisibilitySystem {
       return new HeadlessTestSession(
           projectName,
           startTime,
-          repoServices.supportedCiProvider,
+          repoServices.ciProvider,
           services.config,
           services.metricCollector,
           testDecorator,
@@ -282,7 +282,7 @@ public class CiVisibilitySystem {
       return new ManualApiTestSession(
           projectName,
           startTime,
-          repoServices.supportedCiProvider,
+          repoServices.ciProvider,
           services.config,
           services.metricCollector,
           testDecorator,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AppVeyorInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AppVeyorInfo.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.PersonInfo;
@@ -111,5 +112,10 @@ class AppVeyorInfo implements CIProviderInfo {
     return new PersonInfo(
         System.getenv(APPVEYOR_REPO_COMMIT_AUTHOR_NAME),
         System.getenv(APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL));
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.APPVEYOR;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AwsCodePipelineInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AwsCodePipelineInfo.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.ci;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.GitInfo;
 
 class AwsCodePipelineInfo implements CIProviderInfo {
@@ -25,5 +26,10 @@ class AwsCodePipelineInfo implements CIProviderInfo {
             AWS_CODEPIPELINE_ACTION_EXECUTION_ID,
             AWS_CODEPIPELINE_ARN)
         .build();
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.AWS;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AzurePipelinesInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/AzurePipelinesInfo.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.PersonInfo;
@@ -133,5 +134,10 @@ class AzurePipelinesInfo implements CIProviderInfo {
     return new PersonInfo(
         System.getenv(AZURE_BUILD_REQUESTED_FOR_ID),
         System.getenv(AZURE_BUILD_REQUESTED_FOR_EMAIL));
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.AZP;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BitBucketInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BitBucketInfo.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.util.Strings;
@@ -74,5 +75,10 @@ class BitBucketInfo implements CIProviderInfo {
       id = Strings.replace(id, "}", "");
     }
     return id;
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.BITBUCKET;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BitriseInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BitriseInfo.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.PersonInfo;
@@ -64,5 +65,10 @@ class BitriseInfo implements CIProviderInfo {
     } else {
       return System.getenv(BITRISE_GIT_COMMIT);
     }
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.BITRISE;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuddyInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuddyInfo.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.git.GitUtils.filterSensitiveInfo;
 import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.PersonInfo;
@@ -64,5 +65,10 @@ class BuddyInfo implements CIProviderInfo {
   private PersonInfo buildGitCommiter() {
     return new PersonInfo(
         System.getenv(BUDDY_GIT_COMMIT_AUTHOR), System.getenv(BUDDY_GIT_COMMIT_EMAIL));
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.BUDDYCI;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuildkiteInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/BuildkiteInfo.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 import static datadog.trace.util.Strings.toJson;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.PersonInfo;
@@ -83,5 +84,10 @@ class BuildkiteInfo implements CIProviderInfo {
   private PersonInfo buildGitCommitAuthor() {
     return new PersonInfo(
         System.getenv(BUILDKITE_GIT_AUTHOR_NAME), System.getenv(BUILDKITE_GIT_AUTHOR_EMAIL));
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.BUILDKITE;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CIProviderInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CIProviderInfo.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.ci;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.GitInfo;
 
 public interface CIProviderInfo {
@@ -8,7 +9,5 @@ public interface CIProviderInfo {
 
   CIInfo buildCIInfo();
 
-  default boolean isSupportedCiProvider() {
-    return true;
-  }
+  Provider getProvider();
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CircleCIInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CircleCIInfo.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 
@@ -54,5 +55,10 @@ class CircleCIInfo implements CIProviderInfo {
     }
 
     return String.format("https://app.circleci.com/pipelines/workflows/%s", pipelineId);
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.CIRCLECI;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CodefreshInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/CodefreshInfo.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.git.GitUtils.isTagReference;
 import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.PersonInfo;
@@ -64,5 +65,10 @@ public class CodefreshInfo implements CIProviderInfo {
         .ciJobName(System.getenv(CF_STEP_NAME))
         .ciEnvVars(CODEFRESH)
         .build();
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.CODEFRESH;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GitLabInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GitLabInfo.java
@@ -5,6 +5,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitUtils;
@@ -77,5 +78,10 @@ class GitLabInfo implements CIProviderInfo {
     final PersonInfo personInfo = GitUtils.splitAuthorAndEmail(gitAuthor);
     return new PersonInfo(
         personInfo.getName(), personInfo.getEmail(), System.getenv(GITLAB_GIT_COMMIT_TIMESTAMP));
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.GITLAB;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GithubActionsInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/GithubActionsInfo.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 
@@ -109,5 +110,10 @@ class GithubActionsInfo implements CIProviderInfo {
 
   private String buildJobUrl(final String host, final String repo, final String commit) {
     return String.format("%s/%s/commit/%s/checks", host, repo, commit);
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.GITHUBACTIONS;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/JenkinsInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/JenkinsInfo.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.util.Strings;
@@ -136,5 +137,10 @@ class JenkinsInfo implements CIProviderInfo {
       // the jobName is the first part of the splited raw jobName.
       return jobNameParts[0];
     }
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.JENKINS;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/TeamcityInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/TeamcityInfo.java
@@ -1,5 +1,6 @@
 package datadog.trace.civisibility.ci;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 
@@ -21,5 +22,10 @@ public class TeamcityInfo implements CIProviderInfo {
         .ciJobName(System.getenv(TEAMCITY_BUILDCONF_NAME))
         .ciJobUrl(System.getenv(BUILD_URL))
         .build();
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.TEAMCITY;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/TravisInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/TravisInfo.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.git.GitUtils.normalizeBranch;
 import static datadog.trace.api.git.GitUtils.normalizeTag;
 import static datadog.trace.civisibility.utils.FileUtils.expandTilde;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.CommitInfo;
 import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.PersonInfo;
@@ -80,5 +81,10 @@ class TravisInfo implements CIProviderInfo {
       repoSlug = System.getenv(TRAVIS_REPOSITORY_SLUG);
     }
     return repoSlug;
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.TRAVISCI;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/UnknownCIInfo.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/ci/UnknownCIInfo.java
@@ -2,6 +2,7 @@ package datadog.trace.civisibility.ci;
 
 import static datadog.trace.civisibility.utils.FileUtils.findParentPathBackwards;
 
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.api.git.GitInfo;
 import java.nio.file.Path;
 import org.slf4j.Logger;
@@ -69,7 +70,7 @@ class UnknownCIInfo implements CIProviderInfo {
   }
 
   @Override
-  public boolean isSupportedCiProvider() {
-    return false;
+  public Provider getProvider() {
+    return Provider.UNSUPPORTED;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
@@ -8,6 +8,7 @@ import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.TagValue;
 import datadog.trace.api.civisibility.telemetry.tag.EarlyFlakeDetectionAbortReason;
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.InstrumentationType;
 import datadog.trace.civisibility.codeowners.Codeowners;
@@ -68,7 +69,7 @@ public class BuildSystemSessionImpl extends AbstractTestSession implements Build
       String repoRoot,
       String startCommand,
       @Nullable Long startTime,
-      boolean supportedCiProvider,
+      Provider ciProvider,
       Config config,
       CiVisibilityMetricCollector metricCollector,
       TestModuleRegistry testModuleRegistry,
@@ -84,7 +85,7 @@ public class BuildSystemSessionImpl extends AbstractTestSession implements Build
         projectName,
         startTime,
         InstrumentationType.BUILD,
-        supportedCiProvider,
+        ciProvider,
         config,
         metricCollector,
         testDecorator,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestSession.java
@@ -7,6 +7,7 @@ import datadog.trace.api.civisibility.config.ModuleExecutionSettings;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.TagValue;
 import datadog.trace.api.civisibility.telemetry.tag.EarlyFlakeDetectionAbortReason;
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.civisibility.InstrumentationType;
@@ -36,7 +37,7 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
   public HeadlessTestSession(
       String projectName,
       @Nullable Long startTime,
-      boolean supportedCiProvider,
+      Provider ciProvider,
       Config config,
       CiVisibilityMetricCollector metricCollector,
       TestDecorator testDecorator,
@@ -49,7 +50,7 @@ public class HeadlessTestSession extends AbstractTestSession implements TestFram
         projectName,
         startTime,
         InstrumentationType.HEADLESS,
-        supportedCiProvider,
+        ciProvider,
         config,
         metricCollector,
         testDecorator,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestSession.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestSession.java
@@ -3,6 +3,7 @@ package datadog.trace.civisibility.domain.manualapi;
 import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.DDTestSession;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
 import datadog.trace.civisibility.InstrumentationType;
 import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.coverage.CoverageProbeStoreFactory;
@@ -21,7 +22,7 @@ public class ManualApiTestSession extends AbstractTestSession implements DDTestS
   public ManualApiTestSession(
       String projectName,
       @Nullable Long startTime,
-      boolean supportedCiProvider,
+      Provider ciProvider,
       Config config,
       CiVisibilityMetricCollector metricCollector,
       TestDecorator testDecorator,
@@ -33,7 +34,7 @@ public class ManualApiTestSession extends AbstractTestSession implements DDTestS
         projectName,
         startTime,
         InstrumentationType.MANUAL_API,
-        supportedCiProvider,
+        ciProvider,
         config,
         metricCollector,
         testDecorator,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
@@ -556,7 +556,12 @@ public class GitClient {
       return ExitCode.from(scfe.getExitCode());
 
     } else {
-      return ExitCode.CODE_UNKNOWN;
+      String m = e.getMessage();
+      if (m != null && m.toLowerCase().contains("no such file or directory")) {
+        return ExitCode.EXECUTABLE_MISSING;
+      } else {
+        return ExitCode.CODE_UNKNOWN;
+      }
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityInstrumentationTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityInstrumentationTest.groovy
@@ -14,6 +14,7 @@ import datadog.trace.api.civisibility.config.TestIdentifier
 import datadog.trace.api.civisibility.coverage.CoverageBridge
 import datadog.trace.api.civisibility.events.TestEventsHandler
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector
+import datadog.trace.api.civisibility.telemetry.tag.Provider
 import datadog.trace.api.config.CiVisibilityConfig
 import datadog.trace.api.config.GeneralConfig
 import datadog.trace.bootstrap.ContextStore
@@ -76,7 +77,7 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
     def rootPath = currentPath.parent
     dummyModule = rootPath.relativize(currentPath)
 
-    def supportedCiProvider = true
+    def ciProvider = Provider.GITHUBACTIONS
 
     def metricCollector = Stub(CiVisibilityMetricCollectorImpl)
 
@@ -127,7 +128,7 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
       return new HeadlessTestSession(
       projectName,
       startTime,
-      supportedCiProvider,
+      ciProvider,
       Config.get(),
       metricCollector,
       testDecorator,
@@ -152,7 +153,7 @@ abstract class CiVisibilityInstrumentationTest extends AgentTestRunner {
       rootPath.toString(),
       startCommand,
       startTime,
-      supportedCiProvider,
+      ciProvider,
       Config.get(),
       metricCollector,
       testModuleRegistry,

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -66,6 +66,8 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_TELEMETRY_ENABLED = "civisibility.telemetry.enabled";
   public static final String CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS =
       "civisibility.rum.flush.wait.millis";
+  public static final String CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER =
+      "civisibility.auto.instrumentation.provider";
 
   /* COVERAGE SETTINGS */
   public static final String CIVISIBILITY_CODE_COVERAGE_ENABLED =

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -101,6 +101,8 @@ excludedClassesCoverage += [
   "datadog.trace.api.civisibility.events.TestSuiteDescriptor",
   "datadog.trace.api.civisibility.telemetry.tag.ErrorType",
   "datadog.trace.api.civisibility.telemetry.tag.ExitCode",
+  "datadog.trace.api.civisibility.telemetry.tag.ResponseCompressed",
+  "datadog.trace.api.civisibility.telemetry.tag.StatusCode",
   "datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric.IndexHolder",
   "datadog.trace.api.civisibility.telemetry.CiVisibilityDistributionMetric",
   "datadog.trace.api.civisibility.telemetry.CiVisibilityMetricData",

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -167,6 +167,7 @@ import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENTLESS_URL;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AGENT_JAR_URI;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AUTO_CONFIGURATION_ENABLED;
+import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_BACKEND_API_TIMEOUT_MILLIS;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_BUILD_INSTRUMENTATION_ENABLED;
 import static datadog.trace.api.config.CiVisibilityConfig.CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED;
@@ -827,6 +828,7 @@ public class Config {
   private final String ciVisibilityModuleName;
   private final boolean ciVisibilityTelemetryEnabled;
   private final long ciVisibilityRumFlushWaitMillis;
+  private final boolean ciVisibilityAutoInjected;
 
   private final boolean remoteConfigEnabled;
   private final boolean remoteConfigIntegrityCheckEnabled;
@@ -1867,6 +1869,8 @@ public class Config {
     ciVisibilityTelemetryEnabled = configProvider.getBoolean(CIVISIBILITY_TELEMETRY_ENABLED, true);
     ciVisibilityRumFlushWaitMillis =
         configProvider.getLong(CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS, 500);
+    ciVisibilityAutoInjected =
+        Strings.isNotBlank(configProvider.getString(CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER));
 
     remoteConfigEnabled =
         configProvider.getBoolean(
@@ -3196,6 +3200,10 @@ public class Config {
 
   public long getCiVisibilityRumFlushWaitMillis() {
     return ciVisibilityRumFlushWaitMillis;
+  }
+
+  public boolean isCiVisibilityAutoInjected() {
+    return ciVisibilityAutoInjected;
   }
 
   public String getAppSecRulesFile() {

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityCountMetric.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.civisibility.telemetry;
 
+import datadog.trace.api.civisibility.telemetry.tag.AutoInjected;
 import datadog.trace.api.civisibility.telemetry.tag.BrowserDriver;
 import datadog.trace.api.civisibility.telemetry.tag.Command;
 import datadog.trace.api.civisibility.telemetry.tag.CoverageEnabled;
@@ -19,12 +20,20 @@ import datadog.trace.api.civisibility.telemetry.tag.IsUnsupportedCI;
 import datadog.trace.api.civisibility.telemetry.tag.ItrEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.ItrSkipEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.Library;
+import datadog.trace.api.civisibility.telemetry.tag.Provider;
+import datadog.trace.api.civisibility.telemetry.tag.RequestCompressed;
 import datadog.trace.api.civisibility.telemetry.tag.RequireGit;
+import datadog.trace.api.civisibility.telemetry.tag.StatusCode;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import java.util.Arrays;
 
 public enum CiVisibilityCountMetric {
 
+  /**
+   * The number of test sessions started. This metric is separate from event_created to avoid
+   * increasing the cardinality too much
+   */
+  TEST_SESSION("test_session", Provider.class, AutoInjected.class),
   /** The number of events created */
   EVENT_CREATED(
       "event_created",
@@ -67,10 +76,10 @@ public enum CiVisibilityCountMetric {
   /** The number of events enqueued for serialization */
   EVENTS_ENQUEUED_FOR_SERIALIZATION("events_enqueued_for_serialization"),
   /** The number of requests sent to the endpoint, regardless of success */
-  ENDPOINT_PAYLOAD_REQUESTS("endpoint_payload.requests", Endpoint.class),
+  ENDPOINT_PAYLOAD_REQUESTS("endpoint_payload.requests", Endpoint.class, RequestCompressed.class),
   /** The number of requests sent to the endpoint that errored */
   ENDPOINT_PAYLOAD_REQUESTS_ERRORS(
-      "endpoint_payload.requests_errors", Endpoint.class, ErrorType.class),
+      "endpoint_payload.requests_errors", Endpoint.class, ErrorType.class, StatusCode.class),
   /** The number of payloads dropped after all retries */
   ENDPOINT_PAYLOAD_DROPPED("endpoint_payload.dropped", Endpoint.class),
   /** The number of git commands executed */
@@ -78,17 +87,19 @@ public enum CiVisibilityCountMetric {
   /** The number of git commands that errored */
   GIT_COMMAND_ERRORS("git.command_errors", Command.class, ExitCode.class),
   /** The number of requests sent to the search commit endpoint */
-  GIT_REQUESTS_SEARCH_COMMITS("git_requests.search_commits"),
+  GIT_REQUESTS_SEARCH_COMMITS("git_requests.search_commits", RequestCompressed.class),
   /** The number of search commit requests sent to the endpoint that errored */
-  GIT_REQUESTS_SEARCH_COMMITS_ERRORS("git_requests.search_commits_errors", ErrorType.class),
+  GIT_REQUESTS_SEARCH_COMMITS_ERRORS(
+      "git_requests.search_commits_errors", ErrorType.class, StatusCode.class),
   /** The number of requests sent to the git object pack endpoint */
-  GIT_REQUESTS_OBJECTS_PACK("git_requests.objects_pack"),
+  GIT_REQUESTS_OBJECTS_PACK("git_requests.objects_pack", RequestCompressed.class),
   /** The number of git object pack requests sent to the endpoint that errored */
-  GIT_REQUESTS_OBJECTS_PACK_ERRORS("git_requests.objects_pack_errors", ErrorType.class),
+  GIT_REQUESTS_OBJECTS_PACK_ERRORS(
+      "git_requests.objects_pack_errors", ErrorType.class, StatusCode.class),
   /** The number of requests sent to the settings endpoint, regardless of success */
-  GIT_REQUESTS_SETTINGS("git_requests.settings"),
+  GIT_REQUESTS_SETTINGS("git_requests.settings", RequestCompressed.class),
   /** The number of settings requests sent to the endpoint that errored */
-  GIT_REQUESTS_SETTINGS_ERRORS("git_requests.settings_errors", ErrorType.class),
+  GIT_REQUESTS_SETTINGS_ERRORS("git_requests.settings_errors", ErrorType.class, StatusCode.class),
   /** The number of settings responses from the endpoint */
   GIT_REQUESTS_SETTINGS_RESPONSE(
       "git_requests.settings_response",
@@ -98,9 +109,10 @@ public enum CiVisibilityCountMetric {
       EarlyFlakeDetectionEnabled.class,
       RequireGit.class),
   /** The number of requests sent to the itr skippable tests endpoint */
-  ITR_SKIPPABLE_TESTS_REQUEST("itr_skippable_tests.request"),
+  ITR_SKIPPABLE_TESTS_REQUEST("itr_skippable_tests.request", RequestCompressed.class),
   /** The number of itr skippable tests requests sent to the endpoint that errored */
-  ITR_SKIPPABLE_TESTS_REQUEST_ERRORS("itr_skippable_tests.request_errors", ErrorType.class),
+  ITR_SKIPPABLE_TESTS_REQUEST_ERRORS(
+      "itr_skippable_tests.request_errors", ErrorType.class, StatusCode.class),
   /** The number of tests to skip returned by the endpoint */
   ITR_SKIPPABLE_TESTS_RESPONSE_TESTS("itr_skippable_tests.response_tests"),
   /** The number of tests or test suites skipped */
@@ -113,9 +125,9 @@ public enum CiVisibilityCountMetric {
    */
   ITR_FORCED_RUN("itr_forced_run", EventType.class),
   /** The number of requests sent to the known tests endpoint */
-  EFD_REQUEST("early_flake_detection.request"),
+  EFD_REQUEST("early_flake_detection.request", RequestCompressed.class),
   /** The number of known tests requests sent to the endpoint that errored */
-  EFD_REQUEST_ERRORS("early_flake_detection.request_errors", ErrorType.class);
+  EFD_REQUEST_ERRORS("early_flake_detection.request_errors", ErrorType.class, StatusCode.class);
 
   // need a "holder" class, as accessing static fields from enum constructors is illegal
   static class IndexHolder {

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/CiVisibilityDistributionMetric.java
@@ -2,6 +2,7 @@ package datadog.trace.api.civisibility.telemetry;
 
 import datadog.trace.api.civisibility.telemetry.tag.Command;
 import datadog.trace.api.civisibility.telemetry.tag.Endpoint;
+import datadog.trace.api.civisibility.telemetry.tag.ResponseCompressed;
 import datadog.trace.api.telemetry.MetricCollector;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,13 +35,14 @@ public enum CiVisibilityDistributionMetric {
   /** The time it takes to get the response of the itr skippable tests endpoint request in ms */
   ITR_SKIPPABLE_TESTS_REQUEST_MS("itr_skippable_tests.request_ms"),
   /** The number of bytes received by the skippable tests endpoint */
-  ITR_SKIPPABLE_TESTS_RESPONSE_BYTES("itr_skippable_tests.response_bytes"),
+  ITR_SKIPPABLE_TESTS_RESPONSE_BYTES(
+      "itr_skippable_tests.response_bytes", ResponseCompressed.class),
   /** The number of files covered inside a coverage payload */
   CODE_COVERAGE_FILES("code_coverage.files"),
   /* The time it takes to get the response of the known tests endpoint request in ms */
   EFD_REQUEST_MS("early_flake_detection.request_ms"),
   /** The number of bytes received by the known tests endpoint */
-  EFD_RESPONSE_BYTES("early_flake_detection.response_bytes"),
+  EFD_RESPONSE_BYTES("early_flake_detection.response_bytes", ResponseCompressed.class),
   /** The number of tests received by the known tests endpoint */
   EFD_RESPONSE_TESTS("early_flake_detection.response_tests");
 

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/AutoInjected.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/AutoInjected.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether the tracer was injected using CI-provider-specific auto-instrumentation. */
+public enum AutoInjected implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "auto_injected:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ExitCode.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ExitCode.java
@@ -11,6 +11,7 @@ public enum ExitCode implements TagValue {
   CODE_127("127"),
   CODE_128("128"),
   CODE_129("129"),
+  EXECUTABLE_MISSING("missing"),
   CODE_UNKNOWN("unknown");
 
   private final String s;

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/Provider.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/Provider.java
@@ -1,0 +1,33 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** What kind of CI provider is running the test session. */
+public enum Provider implements TagValue {
+  APPVEYOR,
+  AWS,
+  AZP,
+  BITBUCKET,
+  BITRISE,
+  BUILDKITE,
+  CIRCLECI,
+  CODEFRESH,
+  GITHUBACTIONS,
+  GITLAB,
+  JENKINS,
+  TEAMCITY,
+  TRAVISCI,
+  BUDDYCI,
+  UNSUPPORTED;
+
+  private final String s;
+
+  Provider() {
+    s = "provider:" + name().toLowerCase();
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/RequestCompressed.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/RequestCompressed.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether request body is compressed. */
+public enum RequestCompressed implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "rq_compressed:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ResponseCompressed.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/ResponseCompressed.java
@@ -1,0 +1,13 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+/** Whether response body is compressed. */
+public enum ResponseCompressed implements TagValue {
+  TRUE;
+
+  @Override
+  public String asString() {
+    return "rs_compressed:true";
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/StatusCode.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/StatusCode.java
@@ -1,0 +1,45 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+import javax.annotation.Nullable;
+
+/** The type of HTTP request error */
+public enum StatusCode implements TagValue {
+  BAD_REQUEST(400),
+  UNAUTHORIZED(401),
+  FORBIDDEN(403),
+  NOT_FOUND(404),
+  REQUEST_TIMEOUT(408),
+  TOO_MANY_REQUESTS(429);
+
+  private final String s;
+
+  StatusCode(int code) {
+    s = "status_code:" + code;
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+
+  @Nullable
+  public static StatusCode from(int responseCode) {
+    switch (responseCode) {
+      case 400:
+        return BAD_REQUEST;
+      case 401:
+        return UNAUTHORIZED;
+      case 403:
+        return FORBIDDEN;
+      case 404:
+        return NOT_FOUND;
+      case 408:
+        return REQUEST_TIMEOUT;
+      case 429:
+        return TOO_MANY_REQUESTS;
+      default:
+        return null;
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

Adds more metrics and tags to CI Visibility telemetry.

# Motivation
[Improve libraries telemetry RFC](https://docs.google.com/document/d/1zbo9NC7S6X5JgNnIs1N4loBfl95oDUnhYpwAk12I9hE/edit#heading=h.tkj80rdujdri)

Jira ticket: [SDTEST-412]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-412]: https://datadoghq.atlassian.net/browse/SDTEST-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ