### PR TITLE
enable timeline events by default when ddprof disabled

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -216,7 +216,7 @@ public final class ProfilingConfig {
 
   public static final String PROFILING_TIMELINE_EVENTS_ENABLED =
       "profiling.timeline.events.enabled";
-  public static final boolean PROFILING_TIMELINE_EVENTS_ENABLED_DEFAULT = false;
+  public static final boolean PROFILING_TIMELINE_EVENTS_ENABLED_DEFAULT = true;
 
   public static final String PROFILING_DETAILED_DEBUG_LOGGING = "profiling.detailed.debug.logging";
   public static final boolean PROFILING_DETAILED_DEBUG_LOGGING_DEFAULT = false;


### PR DESCRIPTION
# What Does This Do

Enables timeline events by default when JFR profiler is used, which allows for better integration into the timeline.

# Motivation

# Additional Notes

Jira ticket: [PROF-10003]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-10003]: https://datadoghq.atlassian.net/browse/PROF-10003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ