### PR TITLE
Exploit prevention for SQL injection (blocking support)

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -3,9 +3,12 @@ package datadog.trace.bootstrap.instrumentation.decorator;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
 
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.Config;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.naming.NamingSchema;
@@ -14,7 +17,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
-import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorator {
   protected static class NamingEntry {
@@ -116,14 +119,27 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
    */
   public void onRawStatement(AgentSpan span, String sql) {
     if (Config.get().isAppSecRaspEnabled() && sql != null && !sql.isEmpty()) {
-      BiConsumer<RequestContext, String> sqlQueryCallback =
+      BiFunction<RequestContext, String, Flow<Void>> sqlQueryCallback =
           AgentTracer.get()
               .getCallbackProvider(RequestContextSlot.APPSEC)
               .getCallback(EVENTS.databaseSqlQuery());
       if (sqlQueryCallback != null) {
         RequestContext ctx = span.getRequestContext();
         if (ctx != null) {
-          sqlQueryCallback.accept(ctx, sql);
+          Flow<Void> flow = sqlQueryCallback.apply(ctx, sql);
+          Flow.Action action = flow.getAction();
+          if (action instanceof Flow.Action.RequestBlockingAction) {
+            BlockResponseFunction brf = ctx.getBlockResponseFunction();
+            if (brf != null) {
+              Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+              brf.tryCommitBlockingResponse(
+                  ctx.getTraceSegment(),
+                  rba.getStatusCode(),
+                  rba.getBlockingContentType(),
+                  rba.getExtraHeaders());
+            }
+            throw new BlockingException("Blocked request (for SQL query)");
+          }
         }
       }
     }
@@ -135,14 +151,27 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
     postProcessServiceAndOperationName(span, namingEntry);
 
     if (Config.get().isAppSecRaspEnabled() && dbType != null) {
-      BiConsumer<RequestContext, String> connectDbCallback =
+      BiFunction<RequestContext, String, Flow<Void>> connectDbCallback =
           AgentTracer.get()
               .getCallbackProvider(RequestContextSlot.APPSEC)
               .getCallback(EVENTS.databaseConnection());
       if (connectDbCallback != null) {
         RequestContext ctx = span.getRequestContext();
         if (ctx != null) {
-          connectDbCallback.accept(ctx, dbType);
+          Flow<Void> flow = connectDbCallback.apply(ctx, dbType);
+            Flow.Action action = flow.getAction();
+            if (action instanceof Flow.Action.RequestBlockingAction) {
+              BlockResponseFunction brf = ctx.getBlockResponseFunction();
+              if (brf != null) {
+                Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+                brf.tryCommitBlockingResponse(
+                    ctx.getTraceSegment(),
+                    rba.getStatusCode(),
+                    rba.getBlockingContentType(),
+                    rba.getExtraHeaders());
+              }
+              throw new BlockingException("Blocked request (for DB connection)");
+            }
         }
       }
     }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -159,19 +159,19 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
         RequestContext ctx = span.getRequestContext();
         if (ctx != null) {
           Flow<Void> flow = connectDbCallback.apply(ctx, dbType);
-            Flow.Action action = flow.getAction();
-            if (action instanceof Flow.Action.RequestBlockingAction) {
-              BlockResponseFunction brf = ctx.getBlockResponseFunction();
-              if (brf != null) {
-                Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
-                brf.tryCommitBlockingResponse(
-                    ctx.getTraceSegment(),
-                    rba.getStatusCode(),
-                    rba.getBlockingContentType(),
-                    rba.getExtraHeaders());
-              }
-              throw new BlockingException("Blocked request (for DB connection)");
+          Flow.Action action = flow.getAction();
+          if (action instanceof Flow.Action.RequestBlockingAction) {
+            BlockResponseFunction brf = ctx.getBlockResponseFunction();
+            if (brf != null) {
+              Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+              brf.tryCommitBlockingResponse(
+                  ctx.getTraceSegment(),
+                  rba.getStatusCode(),
+                  rba.getBlockingContentType(),
+                  rba.getExtraHeaders());
             }
+            throw new BlockingException("Blocked request (for DB connection)");
+          }
         }
       }
     }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -94,6 +94,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private String inferredClientIp;
 
   private volatile StoredBodySupplier storedRequestBodySupplier;
+  private String dbType;
 
   private int responseStatus;
 
@@ -104,7 +105,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private boolean pathParamsPublished;
   private Map<String, String> apiSchemas;
 
-  private AtomicBoolean rateLimited = new AtomicBoolean(false);
+  private final AtomicBoolean rateLimited = new AtomicBoolean(false);
   private volatile boolean throttled;
 
   // should be guarded by this
@@ -339,6 +340,14 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   void setStoredRequestBodySupplier(StoredBodySupplier storedRequestBodySupplier) {
     this.storedRequestBodySupplier = storedRequestBodySupplier;
+  }
+
+  public String getDbType() {
+    return dbType;
+  }
+
+  public void setDbType(String dbType) {
+    this.dbType = dbType;
   }
 
   public int getResponseStatus() {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -452,7 +452,7 @@ public class GatewayBridge {
         (ctx_, dbType) -> {
           AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
           if (ctx == null) {
-            return;
+            return NoopFlow.INSTANCE;
           }
           while (true) {
             DataSubscriberInfo subInfo = dbConnectionSubInfo;
@@ -461,12 +461,11 @@ public class GatewayBridge {
               dbConnectionSubInfo = subInfo;
             }
             if (subInfo == null || subInfo.isEmpty()) {
-              return;
+              return NoopFlow.INSTANCE;
             }
             DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_TYPE, dbType);
             try {
-              producerService.publishDataEvent(subInfo, ctx, bundle, false);
-              return;
+              return producerService.publishDataEvent(subInfo, ctx, bundle, false);
             } catch (ExpiredSubscriberInfoException e) {
               dbConnectionSubInfo = null;
             }
@@ -478,7 +477,7 @@ public class GatewayBridge {
         (ctx_, sql) -> {
           AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
           if (ctx == null) {
-            return;
+            return NoopFlow.INSTANCE;
           }
           while (true) {
             DataSubscriberInfo subInfo = dbSqlQuerySubInfo;
@@ -487,12 +486,11 @@ public class GatewayBridge {
               dbSqlQuerySubInfo = subInfo;
             }
             if (subInfo == null || subInfo.isEmpty()) {
-              return;
+              return NoopFlow.INSTANCE;
             }
             DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_SQL_QUERY, sql);
             try {
-              producerService.publishDataEvent(subInfo, ctx, bundle, false);
-              return;
+              return producerService.publishDataEvent(subInfo, ctx, bundle, false);
             } catch (ExpiredSubscriberInfoException e) {
               dbSqlQuerySubInfo = null;
             }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -1,5 +1,6 @@
 package com.datadog.appsec.gateway;
 
+import static com.datadog.appsec.event.data.MapDataBundle.Builder.CAPACITY_0_2;
 import static com.datadog.appsec.event.data.MapDataBundle.Builder.CAPACITY_6_10;
 import static com.datadog.appsec.gateway.AppSecRequestContext.DEFAULT_REQUEST_HEADERS_ALLOW_LIST;
 import static com.datadog.appsec.gateway.AppSecRequestContext.REQUEST_HEADERS_ALLOW_LIST;
@@ -83,7 +84,6 @@ public class GatewayBridge {
   private volatile DataSubscriberInfo grpcServerRequestMsgSubInfo;
   private volatile DataSubscriberInfo graphqlServerRequestMsgSubInfo;
   private volatile DataSubscriberInfo requestEndSubInfo;
-  private volatile DataSubscriberInfo dbConnectionSubInfo;
   private volatile DataSubscriberInfo dbSqlQuerySubInfo;
 
   public GatewayBridge(
@@ -454,23 +454,7 @@ public class GatewayBridge {
           if (ctx == null) {
             return;
           }
-          while (true) {
-            DataSubscriberInfo subInfo = dbConnectionSubInfo;
-            if (subInfo == null) {
-              subInfo = producerService.getDataSubscribers(KnownAddresses.DB_TYPE);
-              dbConnectionSubInfo = subInfo;
-            }
-            if (subInfo == null || subInfo.isEmpty()) {
-              return;
-            }
-            DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_TYPE, dbType);
-            try {
-              producerService.publishDataEvent(subInfo, ctx, bundle, false);
-              return;
-            } catch (ExpiredSubscriberInfoException e) {
-              dbConnectionSubInfo = null;
-            }
-          }
+          ctx.setDbType(dbType);
         });
 
     subscriptionService.registerCallback(
@@ -483,13 +467,19 @@ public class GatewayBridge {
           while (true) {
             DataSubscriberInfo subInfo = dbSqlQuerySubInfo;
             if (subInfo == null) {
-              subInfo = producerService.getDataSubscribers(KnownAddresses.DB_SQL_QUERY);
+              subInfo =
+                  producerService.getDataSubscribers(
+                      KnownAddresses.DB_TYPE, KnownAddresses.DB_SQL_QUERY);
               dbSqlQuerySubInfo = subInfo;
             }
             if (subInfo == null || subInfo.isEmpty()) {
               return NoopFlow.INSTANCE;
             }
-            DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_SQL_QUERY, sql);
+            DataBundle bundle =
+                new MapDataBundle.Builder(CAPACITY_0_2)
+                    .add(KnownAddresses.DB_TYPE, ctx.getDbType())
+                    .add(KnownAddresses.DB_SQL_QUERY, sql)
+                    .build();
             try {
               return producerService.publishDataEvent(subInfo, ctx, bundle, false);
             } catch (ExpiredSubscriberInfoException e) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -463,10 +463,10 @@ public class GatewayBridge {
             if (subInfo == null || subInfo.isEmpty()) {
               return;
             }
-            DataBundle bundle =
-                new SingletonDataBundle<>(KnownAddresses.DB_TYPE, dbType);
+            DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_TYPE, dbType);
             try {
               producerService.publishDataEvent(subInfo, ctx, bundle, false);
+              return;
             } catch (ExpiredSubscriberInfoException e) {
               dbConnectionSubInfo = null;
             }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -452,7 +452,7 @@ public class GatewayBridge {
         (ctx_, dbType) -> {
           AppSecRequestContext ctx = ctx_.getData(RequestContextSlot.APPSEC);
           if (ctx == null) {
-            return NoopFlow.INSTANCE;
+            return;
           }
           while (true) {
             DataSubscriberInfo subInfo = dbConnectionSubInfo;
@@ -461,11 +461,11 @@ public class GatewayBridge {
               dbConnectionSubInfo = subInfo;
             }
             if (subInfo == null || subInfo.isEmpty()) {
-              return NoopFlow.INSTANCE;
+              return;
             }
             DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_TYPE, dbType);
             try {
-              return producerService.publishDataEvent(subInfo, ctx, bundle, false);
+              producerService.publishDataEvent(subInfo, ctx, bundle, false);
             } catch (ExpiredSubscriberInfoException e) {
               dbConnectionSubInfo = null;
             }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -463,7 +463,8 @@ public class GatewayBridge {
             if (subInfo == null || subInfo.isEmpty()) {
               return;
             }
-            DataBundle bundle = new SingletonDataBundle<>(KnownAddresses.DB_TYPE, dbType);
+            DataBundle bundle =
+                new SingletonDataBundle<>(KnownAddresses.DB_TYPE, dbType);
             try {
               producerService.publishDataEvent(subInfo, ctx, bundle, false);
             } catch (ExpiredSubscriberInfoException e) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFResultData.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFResultData.java
@@ -21,7 +21,7 @@ public class PowerWAFResultData {
   }
 
   public static class Parameter extends MatchInfo {
-    MatchInfo resources;
+    MatchInfo resource;
     MatchInfo params;
     MatchInfo db_type;
     List<String> highlight;

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -23,6 +23,7 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase
 import datadog.trace.test.util.DDSpecification
 
+import java.util.function.BiConsumer
 import java.util.function.BiFunction
 import java.util.function.Function
 import java.util.function.Supplier
@@ -77,7 +78,7 @@ class GatewayBridgeSpecification extends DDSpecification {
   BiFunction<RequestContext, String, Flow<Void>> grpcServerMethodCB
   BiFunction<RequestContext, Object, Flow<Void>> grpcServerRequestMessageCB
   BiFunction<RequestContext, Map<String, Object>, Flow<Void>> graphqlServerRequestMessageCB
-  BiFunction<RequestContext, String, Flow<Void>> databaseConnectionCB
+  BiConsumer<RequestContext, String> databaseConnectionCB
   BiFunction<RequestContext, String, Flow<Void>> databaseSqlQueryCB
 
   void setup() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -23,7 +23,6 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase
 import datadog.trace.test.util.DDSpecification
 
-import java.util.function.BiConsumer
 import java.util.function.BiFunction
 import java.util.function.Function
 import java.util.function.Supplier
@@ -78,8 +77,8 @@ class GatewayBridgeSpecification extends DDSpecification {
   BiFunction<RequestContext, String, Flow<Void>> grpcServerMethodCB
   BiFunction<RequestContext, Object, Flow<Void>> grpcServerRequestMessageCB
   BiFunction<RequestContext, Map<String, Object>, Flow<Void>> graphqlServerRequestMessageCB
-  BiConsumer<RequestContext, String> databaseConnectionCB
-  BiConsumer<RequestContext, String> databaseSqlQueryCB
+  BiFunction<RequestContext, String, Flow<Void>> databaseConnectionCB
+  BiFunction<RequestContext, String, Flow<Void>> databaseSqlQueryCB
 
   void setup() {
     callInitAndCaptureCBs()

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/InstrumentationLogger.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/InstrumentationLogger.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 public class InstrumentationLogger {
   public static void debug(
       String instrumentation, final Class<?> target, final Throwable throwable) {
-    // log exception
     LoggerFactory.getLogger(instrumentation)
         .debug("Failed to handle exception in instrumentation for " + target, throwable);
   }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/InstrumentationLogger.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/InstrumentationLogger.java
@@ -1,0 +1,12 @@
+package datadog.trace.instrumentation.jdbc;
+
+import org.slf4j.LoggerFactory;
+
+public class InstrumentationLogger {
+  public static void debug(
+      String instrumentation, final Class<?> target, final Throwable throwable) {
+    // log exception
+    LoggerFactory.getLogger(instrumentation)
+        .debug("Failed to handle exception in instrumentation for " + target, throwable);
+  }
+}

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.slf4j.LoggerFactory;
 
 @AutoService(InstrumenterModule.class)
 public final class StatementInstrumentation extends InstrumenterModule.Tracing
@@ -59,8 +58,7 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
     return new String[] {
       packageName + ".JDBCDecorator",
       packageName + ".SQLCommenter",
-      "org.slf4j.LoggerFactory",
-      "org.slf4j.Logger",
+      packageName + ".InstrumentationLogger",
     };
   }
 
@@ -126,8 +124,8 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
         throw e;
       } catch (Throwable e) {
         // suppress anything else
-        LoggerFactory.getLogger("datadog.trace.instrumentation.jdbc.StatementInstrumentation")
-            .debug("Failed to handle exception in instrumentation for " + statement.getClass(), e);
+        InstrumentationLogger.debug(
+            "datadog.trace.instrumentation.jdbc.StatementInstrumentation", statement.getClass(), e);
       }
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -82,10 +82,9 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
       if (callDepth > 0) {
         return null;
       }
-
-      final AgentSpan span = startSpan(DATABASE_QUERY);
       try {
         final Connection connection = statement.getConnection();
+        final AgentSpan span = startSpan(DATABASE_QUERY);
         DECORATE.afterStart(span);
         final DBInfo dbInfo =
             JDBCDecorator.parseDBInfo(
@@ -116,6 +115,7 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
                   appendComment);
         }
         DECORATE.onStatement(span, copy);
+        return activateSpan(span);
       } catch (SQLException e) {
         // if we can't get the connection for any reason
         return null;
@@ -126,8 +126,8 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
         // suppress anything else
         InstrumentationLogger.debug(
             "datadog.trace.instrumentation.jdbc.StatementInstrumentation", statement.getClass(), e);
+        return null;
       }
-      return activateSpan(span);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
+import org.slf4j.LoggerFactory;
 
 @AutoService(InstrumenterModule.class)
 public final class StatementInstrumentation extends InstrumenterModule.Tracing
@@ -56,7 +57,10 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".JDBCDecorator", packageName + ".SQLCommenter",
+      packageName + ".JDBCDecorator",
+      packageName + ".SQLCommenter",
+      "org.slf4j.LoggerFactory",
+      "org.slf4j.Logger",
     };
   }
 
@@ -122,6 +126,8 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
         throw e;
       } catch (Throwable e) {
         // suppress anything else
+        LoggerFactory.getLogger("datadog.trace.instrumentation.jdbc.StatementInstrumentation")
+            .debug("Failed to handle exception in instrumentation for " + statement.getClass(), e);
       }
       return activateSpan(span);
     }

--- a/dd-smoke-tests/appsec/springboot/build.gradle
+++ b/dd-smoke-tests/appsec/springboot/build.gradle
@@ -16,6 +16,7 @@ jar {
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.6.0'
   implementation(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.0')
+  implementation group: 'com.h2database', name: 'h2', version: '2.1.212'
 
   testImplementation project(':dd-smoke-tests:appsec')
 }

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,8 +32,16 @@ public class WebController {
     return obj.v;
   }
 
-  @GetMapping("/sqli")
-  public String sqli(@RequestParam("id") String id) throws Exception {
+  @GetMapping("/sqli/query")
+  public String sqliQuery(@RequestParam("id") String id) throws Exception {
+    Class.forName("org.h2.Driver");
+    Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
+    conn.createStatement().execute("SELECT 1 FROM DUAL WHERE '1' = '" + id + "'");
+    return "EXECUTED";
+  }
+
+  @GetMapping("/sqli/header")
+  public String sqliHeader(@RequestHeader("x-custom-header") String id) throws Exception {
     Class.forName("org.h2.Driver");
     Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
     conn.createStatement().execute("SELECT 1 FROM DUAL WHERE '1' = '" + id + "'");

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -1,10 +1,13 @@
 package datadog.smoketest.appsec.springboot.controller;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,5 +29,13 @@ public class WebController {
   @PostMapping("/request-body")
   public String requestBody(@RequestBody BodyMappedClass obj) {
     return obj.v;
+  }
+
+  @GetMapping("/sqli")
+  public String sqli(@RequestParam("id") String id) throws Exception {
+    Class.forName("org.h2.Driver");
+    Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
+    conn.createStatement().execute("SELECT 1 FROM DUAL WHERE '1' = '" + id + "'");
+    return "EXECUTED";
   }
 }

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -34,7 +34,6 @@ public class WebController {
 
   @GetMapping("/sqli/query")
   public String sqliQuery(@RequestParam("id") String id) throws Exception {
-    Class.forName("org.h2.Driver");
     Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
     conn.createStatement().execute("SELECT 1 FROM DUAL WHERE '1' = '" + id + "'");
     return "EXECUTED";
@@ -42,7 +41,6 @@ public class WebController {
 
   @GetMapping("/sqli/header")
   public String sqliHeader(@RequestHeader("x-custom-header") String id) throws Exception {
-    Class.forName("org.h2.Driver");
     Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
     conn.createStatement().execute("SELECT 1 FROM DUAL WHERE '1' = '" + id + "'");
     return "EXECUTED";

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -258,15 +258,16 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     waitForTraceCount(1)
 
     then:
+    def rootSpans = this.rootSpans.toList()
     rootSpans.size() == 1
-    rootSpans.each {
-      assert it.meta.get('appsec.blocked') == null, 'appsec.blocked is set'
-      assert it.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
-    }
+    def rootSpan = rootSpans[0]
+    assert rootSpan.meta.get('appsec.blocked') == null, 'appsec.blocked is set'
+    assert rootSpan.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
     def trigger
-    rootSpans[0].triggers.each {
-      if (it['rule']['id'] == '__test_sqli_stacktrace_on_query') {
-        trigger = it
+    for (t in rootSpan.triggers) {
+      if (t['rule']['id'] == '__test_sqli_stacktrace_on_query') {
+        trigger = t
+        break
       }
     }
     assert trigger != null, 'test trigger not found'
@@ -291,15 +292,16 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     waitForTraceCount(1)
 
     then:
+    def rootSpans = this.rootSpans.toList()
     rootSpans.size() == 1
-    rootSpans.each {
-      assert it.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
-      assert it.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
-    }
+    def rootSpan = rootSpans[0]
+    assert rootSpan.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
+    assert rootSpan.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
     def trigger = null
-    rootSpans[0].triggers.each {
-      if (it['rule']['id'] == '__test_sqli_block_on_header') {
-        trigger = it
+    for (t in rootSpan.triggers) {
+      if (t['rule']['id'] == '__test_sqli_block_on_header') {
+        trigger = t
+        break
       }
     }
     assert trigger != null, 'test trigger not found'

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -267,7 +267,12 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       assert it.meta.get('appsec.blocked') == null, 'appsec.blocked is set'
       assert it.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
     }
-    def trigger = rootSpans[0].triggers.find { it['rule']['id'] == '__test_sqli_stacktrace_on_query' }
+    def trigger
+    rootSpans[0].triggers.each {
+      if (it['rule']['id'] == '__test_sqli_stacktrace_on_query') {
+        trigger = it
+      }
+    }
     assert trigger != null, 'test trigger not found'
   }
 
@@ -295,7 +300,12 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       // assert it.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
       assert it.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
     }
-    def trigger = rootSpans[0].triggers.find { it['rule']['id'] == '__test_sqli_block_on_header' }
+    def trigger = null
+    rootSpans[0].triggers.each {
+      if (it['rule']['id'] == '__test_sqli_block_on_header') {
+        trigger = it
+      }
+    }
     assert trigger != null, 'test trigger not found'
   }
 }

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -258,6 +258,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     waitForTraceCount(1)
 
     then:
+    rootSpans.size() == 1
     rootSpans.each {
       assert it.meta.get('appsec.blocked') == null, 'appsec.blocked is set'
       assert it.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
@@ -290,6 +291,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     waitForTraceCount(1)
 
     then:
+    rootSpans.size() == 1
     rootSpans.each {
       assert it.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
       assert it.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -296,8 +296,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
 
     then:
     rootSpans.each {
-      // FIXME: appsec.blocked not set correctly for mid-request block
-      // assert it.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
+      assert it.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
       assert it.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
     }
     def trigger = null

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -283,15 +283,16 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
     def responseBodyStr = response.body().string()
 
     then:
-    response.code() == 200
-    responseBodyStr == 'EXECUTED'
+    response.code() == 403
+    responseBodyStr == '{"errors":[{"title":"You\'ve been blocked","detail":"Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog."}]}\n'
 
     when:
     waitForTraceCount(1)
 
     then:
     rootSpans.each {
-      assert it.meta.get('appsec.blocked') == null, 'appsec.blocked is set'
+      // FIXME: appsec.blocked not set correctly for mid-request block
+      // assert it.meta.get('appsec.blocked') == 'true', 'appsec.blocked is not set'
       assert it.meta.get('_dd.appsec.json') != null, '_dd.appsec.json is not set'
     }
     def trigger = rootSpans[0].triggers.find { it['rule']['id'] == '__test_sqli_block_on_header' }

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -13,11 +13,6 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
   @Shared
   String customRulesPath = "${buildDir}/appsec_custom_rules.json"
 
-  @Override
-  def logLevel() {
-    'DEBUG'
-  }
-
   def prepareCustomRules() {
     // Prepare ruleset with additional test rules
     appendRules(

--- a/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
@@ -43,6 +43,8 @@ abstract class AbstractAppSecServerSmokeTest extends AbstractServerSmokeTest {
   @Shared
   protected String[] defaultAppSecProperties = [
     "-Ddd.appsec.enabled=${System.getProperty('smoke_test.appsec.enabled') ?: 'true'}",
+    // TODO: rely on default once its true
+    "-Ddd.appsec.rasp.enabled=true",
     "-Ddd.profiling.enabled=false",
     // disable AppSec rate limit
     "-Ddd.appsec.trace.rate.limit=-1"

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -118,6 +118,8 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(config.getAppSecActivation().toString());
     writer.name("appsec_rules_file_path");
     writer.value(config.getAppSecRulesFile());
+    writer.name("rasp_enabled");
+    writer.value(config.isAppSecRaspEnabled());
     writer.name("telemetry_enabled");
     writer.value(config.isTelemetryEnabled());
     writer.name("telemetry_dependency_collection_enabled");

--- a/gradle/spotbugFilters/exclude.xml
+++ b/gradle/spotbugFilters/exclude.xml
@@ -5,6 +5,7 @@
       <Class name="~com.datadog.debugger.util.WeakIdentityHashMap.*" />
       <Package name="io.sqreen.testapp.sampleapp" />
       <Package name="datadog.trace.bootstrap.instrumentation.decorator.http.utils" />
+      <Package name="datadog.smoketest.appsec.springboot.controller" />
       <!-- these are auto-generated -->
       <Package name="com.datadog.appsec.report.raw.contexts._definitions" />
       <Package name="com.datadog.appsec.report.raw.contexts.actor" />

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -6,6 +6,7 @@ import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -209,8 +210,8 @@ public final class Events<D> {
       new ET<>("database.connection", DATABASE_CONNECTION_ID);
   /** A database connection */
   @SuppressWarnings("unchecked")
-  public EventType<BiFunction<RequestContext, String, Flow<Void>>> databaseConnection() {
-    return (EventType<BiFunction<RequestContext, String, Flow<Void>>>) DATABASE_CONNECTION;
+  public EventType<BiConsumer<RequestContext, String>> databaseConnection() {
+    return (EventType<BiConsumer<RequestContext, String>>) DATABASE_CONNECTION;
   }
 
   static final int DATABASE_SQL_QUERY_ID = 17;

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -6,7 +6,6 @@ import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -210,8 +209,8 @@ public final class Events<D> {
       new ET<>("database.connection", DATABASE_CONNECTION_ID);
   /** A database connection */
   @SuppressWarnings("unchecked")
-  public EventType<BiConsumer<RequestContext, String>> databaseConnection() {
-    return (EventType<BiConsumer<RequestContext, String>>) DATABASE_CONNECTION;
+  public EventType<BiFunction<RequestContext, String, Flow<Void>>> databaseConnection() {
+    return (EventType<BiFunction<RequestContext, String, Flow<Void>>>) DATABASE_CONNECTION;
   }
 
   static final int DATABASE_SQL_QUERY_ID = 17;
@@ -221,8 +220,8 @@ public final class Events<D> {
       new ET<>("database.query", DATABASE_SQL_QUERY_ID);
   /** A database sql query */
   @SuppressWarnings("unchecked")
-  public EventType<BiConsumer<RequestContext, String>> databaseSqlQuery() {
-    return (EventType<BiConsumer<RequestContext, String>>) DATABASE_SQL_QUERY;
+  public EventType<BiFunction<RequestContext, String, Flow<Void>>> databaseSqlQuery() {
+    return (EventType<BiFunction<RequestContext, String, Flow<Void>>>) DATABASE_SQL_QUERY;
   }
 
   static final int GRPC_SERVER_METHOD_ID = 18;

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -371,7 +371,8 @@ public class InstrumentationGateway {
               @Override
               public Flow<Void> apply(RequestContext ctx, String arg) {
                 try {
-                  return ((BiFunction<RequestContext, String, Flow<Void>>) callback).apply(ctx, arg);
+                  return ((BiFunction<RequestContext, String, Flow<Void>>) callback)
+                      .apply(ctx, arg);
                 } catch (Throwable t) {
                   log.warn("Callback for {} threw.", eventType, t);
                   return Flow.ResultFlow.empty();

--- a/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -27,6 +27,7 @@ import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -365,6 +366,17 @@ public class InstrumentationGateway {
               }
             };
       case DATABASE_CONNECTION_ID:
+        return (C)
+            new BiConsumer<RequestContext, String>() {
+              @Override
+              public void accept(RequestContext ctx, String arg) {
+                try {
+                  ((BiConsumer<RequestContext, String>) callback).accept(ctx, arg);
+                } catch (Throwable t) {
+                  log.warn("Callback for {} threw.", eventType, t);
+                }
+              }
+            };
       case DATABASE_SQL_QUERY_ID:
         return (C)
             new BiFunction<RequestContext, String, Flow<Void>>() {

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -201,9 +201,9 @@ public class InstrumentationGatewayTest {
     assertThat(cbp.getCallback(events.graphqlServerRequestMessage()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.databaseConnection(), callback);
-    cbp.getCallback(events.databaseConnection()).accept(null, null);
+    cbp.getCallback(events.databaseConnection()).apply(null, null);
     ss.registerCallback(events.databaseSqlQuery(), callback);
-    cbp.getCallback(events.databaseSqlQuery()).accept(null, null);
+    cbp.getCallback(events.databaseSqlQuery()).apply(null, null);
     assertThat(callback.count).isEqualTo(Events.MAX_EVENTS);
   }
 
@@ -257,9 +257,9 @@ public class InstrumentationGatewayTest {
     assertThat(cbp.getCallback(events.graphqlServerRequestMessage()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.databaseConnection(), throwback);
-    cbp.getCallback(events.databaseConnection()).accept(null, null);
+    cbp.getCallback(events.databaseConnection()).apply(null, null);
     ss.registerCallback(events.databaseSqlQuery(), throwback);
-    cbp.getCallback(events.databaseSqlQuery()).accept(null, null);
+    cbp.getCallback(events.databaseSqlQuery()).apply(null, null);
     assertThat(throwback.count).isEqualTo(Events.MAX_EVENTS);
   }
 

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -201,7 +201,7 @@ public class InstrumentationGatewayTest {
     assertThat(cbp.getCallback(events.graphqlServerRequestMessage()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.databaseConnection(), callback);
-    cbp.getCallback(events.databaseConnection()).apply(null, null);
+    cbp.getCallback(events.databaseConnection()).accept(null, null);
     ss.registerCallback(events.databaseSqlQuery(), callback);
     cbp.getCallback(events.databaseSqlQuery()).apply(null, null);
     assertThat(callback.count).isEqualTo(Events.MAX_EVENTS);
@@ -257,7 +257,7 @@ public class InstrumentationGatewayTest {
     assertThat(cbp.getCallback(events.graphqlServerRequestMessage()).apply(null, null).getAction())
         .isEqualTo(Flow.Action.Noop.INSTANCE);
     ss.registerCallback(events.databaseConnection(), throwback);
-    cbp.getCallback(events.databaseConnection()).apply(null, null);
+    cbp.getCallback(events.databaseConnection()).accept(null, null);
     ss.registerCallback(events.databaseSqlQuery(), throwback);
     cbp.getCallback(events.databaseSqlQuery()).apply(null, null);
     assertThat(throwback.count).isEqualTo(Events.MAX_EVENTS);


### PR DESCRIPTION
# What Does This Do
Implemented blocking functionality for the SQL-injection Exploit Prevention.

# Motivation

# Additional Notes
This is part of Exploit prevention initiative (RASP)

Jira ticket: [APPSEC-46818]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-46818]: https://datadoghq.atlassian.net/browse/APPSEC-46818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ