### PR TITLE
Fix Gradle version locking

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -303,6 +303,9 @@ jobs:
       - run:
           name: Build Project
           command: >-
+{% if is_nightly %}
+            ./gradlew resolveAndLockAll --write-locks
+{% endif %}
             MAVEN_OPTS="-Xms64M -Xmx256M"
             GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2560M -Xms2560M -XX:ErrorFile=/tmp/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'"
             ./gradlew clean

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ buildscript {
 }
 
 plugins {
+  id "datadog.dependency-locking"
+
   id "com.diffplug.spotless" version "6.13.0"
   id 'com.github.spotbugs' version '5.0.14'
   id "de.thetaphi.forbiddenapis" version "3.5.1"
@@ -190,32 +192,6 @@ def testAggregate(String baseTaskName, includePrefixes, excludePrefixes, boolean
   createRootTask "${baseTaskName}Test", 'allTests'
   createRootTask "${baseTaskName}LatestDepTest", 'allLatestDepTests'
   createRootTask "${baseTaskName}Check", 'check'
-}
-
-// To lock dependency versions, run `./gradlew resolveAndLockAll --write-locks`
-tasks.register('resolveAndLockAll') {
-  notCompatibleWithConfigurationCache("Filters configurations at execution time")
-  doFirst {
-    assert gradle.startParameter.writeDependencyLocks
-  }
-  doLast {
-    allprojects { project ->
-      project.configurations.findAll {
-        it.canBeResolved && !it.name.startsWith('incrementalScalaAnalysis')
-      }.each { it.resolve() }
-    }
-  }
-}
-
-allprojects { project ->
-  project.dependencyLocking {
-    lockAllConfigurations()
-    //lockmode set to LENIENT because there are resolution
-    //errors in the build with an apiguardian dependency.
-    //See: https://docs.gradle.org/current/userguide/dependency_locking.html for more info
-    lockMode = LockMode.LENIENT
-
-  }
 }
 
 testAggregate("smoke", [":dd-smoke-tests"], [])

--- a/buildSrc/src/main/kotlin/datadog.dependency-locking.gradle.kts
+++ b/buildSrc/src/main/kotlin/datadog.dependency-locking.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ * This plugin enables dependency locking.
+ *
+ * The goal is to be able to later rebuild any version, by pinning floating versions.
+ * It will also help IDEs not having to re-index any latest library release.
+ * Pinned versions will be updated by the CI on a weekly basis.
+ *
+ * Pinned version can be updated using: ./gradlew resolveAndLockAll --write-locks
+ *
+ * See https://docs.gradle.org/current/userguide/dependency_locking.html
+ */
+
+project.dependencyLocking {
+  lockAllConfigurations()
+  //lockmode set to LENIENT because there are resolution
+  //errors in the build with an apiguardian dependency.
+  //See: https://docs.gradle.org/current/userguide/dependency_locking.html for more info
+  lockMode = LockMode.LENIENT
+}
+
+tasks.register("resolveAndLockAll") {
+  notCompatibleWithConfigurationCache("Filters configurations at execution time")
+  doFirst {
+    require(gradle.startParameter.isWriteDependencyLocks)
+  }
+  doLast {
+    configurations.filter {
+      // Add any custom filtering on the configurations to be resolved
+      it.isCanBeResolved
+    }.forEach { it.resolve() }
+  }
+}

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,2 +1,4 @@
+apply plugin: 'datadog.dependency-locking'
+
 apply from: "$rootDir/gradle/java_deps.gradle"
 apply from: "$rootDir/gradle/java_no_deps.gradle"


### PR DESCRIPTION
# What Does This Do

This PR moves the version locking into a Gradle convention plugin as `subprojects` and `allprojects` [must be avoid for shared project configuration](https://docs.gradle.org/current/userguide/sharing_build_logic_between_subprojects.html#sec:convention_plugins_vs_cross_configuration).
It also updates the pinned version before building nightly versions.

# Motivation

Version locking was broken. Nightly build does no more test latest library versions.

# Additional Notes

Not sure about the CI script update... Can it mess with the cache?

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
