### PR TITLE
Add logs to tainted map 'garbage-collected entries are purged' flaky test

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObject.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObject.java
@@ -43,4 +43,18 @@ public class TaintedObject extends WeakReference<Object> {
   public void setRanges(@Nonnull final Range[] ranges) {
     this.ranges = ranges;
   }
+
+  @Override
+  public String toString() {
+    final Object referent = get();
+    return "[hash: "
+        + positiveHashCode
+        + ", gen: "
+        + generation
+        + "] "
+        + (referent == null ? "GCed" : referent)
+        + " ("
+        + (ranges == null ? 0 : ranges.length)
+        + " ranges)";
+  }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGen.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/ObjectGen.groovy
@@ -9,14 +9,16 @@ class ObjectGen {
 
   final int capacity
   final Map<Integer, List<Object>> pool
+  final Closure<Object> factory
 
-  ObjectGen(int capacity) {
+  ObjectGen(int capacity, Closure<Object> factory = { new Object() }) {
     assert (capacity & (capacity - 1)) == 0, 'capacity must be a power of 2'
     this.capacity = capacity
     this.pool = new HashMap<>(capacity)
     for (int i = 0; i < capacity; i++) {
       this.pool.put(i, new ArrayList<Object>())
     }
+    this.factory = factory
   }
 
   def genBuckets(int nBuckets, int nObjects) {
@@ -57,7 +59,7 @@ class ObjectGen {
   def genObjects(int nObjects, Closure<Boolean> isValid) {
     def res = new ArrayList(nObjects)
     while (res.size() < nObjects) {
-      def obj = new Object()
+      def obj = factory.call()
       int bucket = getIndex(obj)
       if (isValid.call(bucket)) {
         res.add(obj)
@@ -69,7 +71,7 @@ class ObjectGen {
   }
 
   def genObject() {
-    def obj = new Object()
+    def obj = factory.call()
     int bucket = getIndex(obj)
     pool.get(bucket).add(obj)
     return bucket

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedMapTest.groovy
@@ -15,6 +15,7 @@ import datadog.trace.util.AgentTaskScheduler
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class TaintedMapTest extends DDSpecification {
 
@@ -94,7 +95,8 @@ class TaintedMapTest extends DDSpecification {
 
     int iters = 16
     int nObjectsPerIter = flatModeThreshold - 1
-    def gen = new ObjectGen(capacity)
+    final atomic = new AtomicInteger()
+    def gen = new ObjectGen(capacity, { "object_${atomic.incrementAndGet()}"} )
     def objectBuffer = new CircularBuffer<Object>(iters)
 
     when:
@@ -119,7 +121,7 @@ class TaintedMapTest extends DDSpecification {
     }
 
     then:
-    map.size() == iters
+    assert map.size() == iters: map.toList()
     map.count() == iters
     final entries = map.toList()
     entries.findAll { it.get() != null }.size() == iters

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectTest.groovy
@@ -22,5 +22,6 @@ class TaintedObjectTest extends Specification {
     then:
     ranges.size() > max
     tainted.ranges.size() == max
+    tainted.toString().contains("${tainted.ranges.size()} ranges")
   }
 }


### PR DESCRIPTION
# What Does This Do
Add logs to the tainted map `garbage-collected entries are purged` test in order to understand why it might flake under JDK 21.

# Motivation
The test has been observed to fail with no reason in some builds: [example](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/37529/workflows/b88508d7-a0dc-4304-a38e-9e1d4f38f920/jobs/1362143/tests)

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
