### PR TITLE
Capture all spark conf parameter

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkConfAllowList.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/SparkConfAllowList.java
@@ -1,8 +1,15 @@
 package datadog.trace.instrumentation.spark;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.spark.SparkConf;
+import scala.Tuple2;
 
 /**
  * Helper class to only capture a selected subset of the spark configuration
@@ -10,43 +17,6 @@ import java.util.Set;
  * @see <a href="https://spark.apache.org/docs/latest/configuration.html">Spark Configuration</a>
  */
 class SparkConfAllowList {
-
-  /**
-   * Application parameters defined at the start of the application, with the spark-submit command
-   */
-  private static final Set<String> allowedApplicationParams =
-      new HashSet<>(
-          Arrays.asList(
-              "spark.default.parallelism",
-              "spark.dynamicAllocation.enabled",
-              "spark.dynamicAllocation.executorIdleTimeout",
-              "spark.dynamicAllocation.initialExecutors",
-              "spark.dynamicAllocation.maxExecutors",
-              "spark.dynamicAllocation.minExecutors",
-              "spark.dynamicAllocation.executorAllocationRatio",
-              "spark.dynamicAllocation.schedulerBacklogTimeout",
-              "spark.driver.cores",
-              "spark.driver.maxResultSize",
-              "spark.driver.memory",
-              "spark.driver.memoryOverhead",
-              "spark.driver.memoryOverheadFactor",
-              "spark.executor.cores",
-              "spark.executor.instances",
-              "spark.executor.memory",
-              "spark.executor.pyspark.memory",
-              "spark.executor.memoryOverhead",
-              "spark.executor.memoryOverheadFactor",
-              "spark.files.maxPartitionBytes",
-              "spark.master",
-              "spark.memory.fraction",
-              "spark.memory.storageFraction",
-              "spark.memory.offHeap.enabled",
-              "spark.memory.offHeap.size",
-              "spark.submit.deployMode",
-              "spark.sql.autoBroadcastJoinThreshold",
-              "spark.sql.files.maxPartitionBytes",
-              "spark.sql.shuffle.partitions"));
-
   /**
    * Job-specific parameters that can be used to control job execution or provide metadata about the
    * job being executed
@@ -70,19 +40,65 @@ class SparkConfAllowList {
               "spark.databricks.job.type",
               "spark.databricks.sparkContextId",
               "spark.databricks.workload.name",
+              "spark.default.parallelism",
+              "spark.dynamicAllocation.enabled",
+              "spark.dynamicAllocation.executorIdleTimeout",
+              "spark.dynamicAllocation.initialExecutors",
+              "spark.dynamicAllocation.maxExecutors",
+              "spark.dynamicAllocation.minExecutors",
+              "spark.dynamicAllocation.executorAllocationRatio",
+              "spark.dynamicAllocation.schedulerBacklogTimeout",
+              "spark.driver.cores",
+              "spark.driver.maxResultSize",
+              "spark.driver.memory",
+              "spark.driver.memoryOverhead",
+              "spark.driver.memoryOverheadFactor",
+              "spark.executor.cores",
+              "spark.executor.instances",
+              "spark.executor.memory",
+              "spark.executor.pyspark.memory",
+              "spark.executor.memoryOverhead",
+              "spark.executor.memoryOverheadFactor",
+              "spark.files.maxPartitionBytes",
               "spark.job.description",
               "spark.jobGroup.id",
+              "spark.master",
+              "spark.memory.fraction",
+              "spark.memory.storageFraction",
+              "spark.memory.offHeap.enabled",
+              "spark.memory.offHeap.size",
+              "spark.submit.deployMode",
+              "spark.sql.autoBroadcastJoinThreshold",
+              "spark.sql.files.maxPartitionBytes",
+              "spark.sql.shuffle.partitions",
               "spark.sql.execution.id",
               "sql.streaming.queryId",
               "streaming.sql.batchId",
               "user"));
 
-  public static boolean canCaptureApplicationParameter(String parameterName) {
-    return allowedApplicationParams.contains(parameterName)
-        || allowedJobParams.contains(parameterName);
-  }
-
   public static boolean canCaptureJobParameter(String parameterName) {
     return allowedJobParams.contains(parameterName);
+  }
+
+  public static List<Map.Entry<String, String>> getRedactedSparkConf(SparkConf conf) {
+    // Using values from
+    // https://github.com/apache/spark/blob/v3.5.1/core/src/main/scala/org/apache/spark/internal/config/package.scala#L1150-L1158
+    String redactionPattern =
+        conf.get("spark.redaction.regex", "(?i)secret|password|token|access.key|api.key");
+    List<Map.Entry<String, String>> redacted = new ArrayList<>();
+    Pattern pattern = Pattern.compile(redactionPattern);
+
+    for (Tuple2<String, String> entry : conf.getAll()) {
+      String key = entry._1;
+      String value = entry._2;
+
+      if (pattern.matcher(key).find() || pattern.matcher(value).find()) {
+        redacted.add(new AbstractMap.SimpleEntry<>(key, "[redacted]"));
+      } else {
+        redacted.add(new AbstractMap.SimpleEntry<>(key, value));
+      }
+    }
+
+    return redacted;
   }
 }

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkTest.groovy
@@ -742,4 +742,30 @@ abstract class AbstractSparkTest extends AgentTestRunner {
       }
     }
   }
+
+  def "redact application parameters"() {
+    def sparkSession = SparkSession.builder()
+      .config("spark.master", "local")
+      .config("spark.database.password", "value")
+      .config("database.secret", "value")
+      .config("spark.DD-API-KEY", "value")
+      .config("spark.shuffle.compress", "false")
+      .getOrCreate()
+
+    sparkSession.stop()
+
+    expect:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spark.application"
+          spanType "spark"
+          assert span.tags["config.spark_database_password"] == "[redacted]"
+          assert span.tags["config.database_secret"] == "[redacted]"
+          assert span.tags["config.spark_DD-API-KEY"] == "[redacted]"
+          assert span.tags["config.spark_shuffle_compress"] == "false"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
# What Does This Do

Capture all spark conf properties. Use the `spark.redaction.regex` pattern to redact secret in the same way spark is doing

Also changed capturing the job parameters to only capture those for local root spans

# Motivation

Only capturing a subset meant that important properties for users could be missed

# Additional Notes

https://datadoghq.atlassian.net/browse/DJM-150

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
