### PR TITLE
Include lastParentId when resetting ContextInterpreter state

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -33,12 +33,12 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * When adding new context fields to the ContextInterpreter class remember to clear them
- * in the reset() method.
+ * When adding new context fields to the ContextInterpreter class remember to clear them in the
+ * reset() method.
  */
 public abstract class ContextInterpreter implements AgentPropagation.KeyClassifier {
   private TraceConfig traceConfig;
-  
+
   protected Map<String, String> headerTags;
   protected Map<String, String> baggageMapping;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -32,9 +32,13 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
 
+/**
+ * When adding new context fields to the ContextInterpreter class remember to clear them
+ * in the reset() method.
+ */
 public abstract class ContextInterpreter implements AgentPropagation.KeyClassifier {
   private TraceConfig traceConfig;
-
+  
   protected Map<String, String> headerTags;
   protected Map<String, String> baggageMapping;
 
@@ -235,6 +239,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
             || this.clientIpResolutionEnabled && ActiveSubsystems.APPSEC_ACTIVE;
     headerTags = traceConfig.getRequestHeaderTags();
     baggageMapping = traceConfig.getBaggageMapping();
+    lastParentId = null;
     return this;
   }
 


### PR DESCRIPTION
# What Does This Do

Also clears `lastParentId` when resetting ContextInterpreter

Jira ticket: [[AIT-9906](https://datadoghq.atlassian.net/browse/AIT-9906)]

[AIT-9906]: https://datadoghq.atlassian.net/browse/AIT-9906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ