### PR TITLE
Do not report code coverage for skipped tests

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -220,11 +220,15 @@ public class TestImpl implements DDTest {
     InstrumentationTestBridge.fireBeforeTestEnd(context);
 
     CoverageBridge.removeThreadLocalCoverageProbeStore();
-    boolean coveragesGathered =
-        context.getCoverageProbeStore().report(sessionId, suiteId, span.getSpanId());
-    if (!coveragesGathered && !TestStatus.skip.equals(span.getTag(Tags.TEST_STATUS))) {
-      // test is not skipped, but no coverages were gathered
-      metricCollector.add(CiVisibilityCountMetric.CODE_COVERAGE_IS_EMPTY, 1);
+
+    // do not process coverage reports for skipped tests
+    if (span.getTag(Tags.TEST_STATUS) != TestStatus.skip) {
+      CoverageProbeStore coverageStore = context.getCoverageProbeStore();
+      boolean coveragesGathered = coverageStore.report(sessionId, suiteId, span.getSpanId());
+      if (!coveragesGathered && !TestStatus.skip.equals(span.getTag(Tags.TEST_STATUS))) {
+        // test is not skipped, but no coverages were gathered
+        metricCollector.add(CiVisibilityCountMetric.CODE_COVERAGE_IS_EMPTY, 1);
+      }
     }
 
     scope.close();

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/TestImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/TestImplTest.groovy
@@ -5,9 +5,11 @@ import datadog.trace.agent.tooling.TracerInstaller
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.IdGenerationStrategy
+import datadog.trace.api.civisibility.coverage.CoverageProbeStore
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.civisibility.codeowners.NoCodeowners
+import datadog.trace.civisibility.coverage.CoverageProbeStoreFactory
 import datadog.trace.civisibility.coverage.NoopCoverageProbeStore
 import datadog.trace.civisibility.decorator.TestDecoratorImpl
 import datadog.trace.civisibility.domain.TestImpl
@@ -104,7 +106,24 @@ class TestImplTest extends DDSpecification {
     })
   }
 
-  private TestImpl givenATest() {
+  def "test coverage is not reported if test was skipped"() {
+    setup:
+    def coverageStore = Mock(CoverageProbeStore)
+    def coveageStoreFactory = Stub(CoverageProbeStoreFactory)
+    coveageStoreFactory.create(_, _) >> coverageStore
+
+    def test = givenATest(coveageStoreFactory)
+
+    when:
+    test.setSkipReason("skipped")
+    test.end(null)
+
+    then:
+    0 * coverageStore.report(_, _, _)
+  }
+
+  private TestImpl givenATest(
+    CoverageProbeStoreFactory coverageProbeStoreFactory = new NoopCoverageProbeStore.NoopCoverageProbeStoreFactory()) {
     def sessionId = 123
     def moduleId = 456
     def suiteId = 789
@@ -115,7 +134,6 @@ class TestImplTest extends DDSpecification {
     def testDecorator = new TestDecoratorImpl("component", [:])
     def methodLinesResolver = { it -> MethodLinesResolver.MethodLines.EMPTY }
     def codeowners = NoCodeowners.INSTANCE
-    def coverageProbeStoreFactory = new NoopCoverageProbeStore.NoopCoverageProbeStoreFactory()
     new TestImpl(
       sessionId,
       moduleId,


### PR DESCRIPTION
# What Does This Do

Updates code coverage processing logic so that code coverage is not processed/reported for skipped tests.

# Motivation
If a test is skipped, code coverage is likely to be empty or incomplete. The backend has no use for this coverage, at least as of now, so we can save some resources by not processing it and not reporting it.

Jira ticket: [SDTEST-493]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-493]: https://datadoghq.atlassian.net/browse/SDTEST-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ