### PR TITLE
Include propagationTags when resetting ContextInterpreter state

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -239,6 +239,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
             || this.clientIpResolutionEnabled && ActiveSubsystems.APPSEC_ACTIVE;
     headerTags = traceConfig.getRequestHeaderTags();
     baggageMapping = traceConfig.getBaggageMapping();
+    propagationTags = null;
     lastParentId = null;
     return this;
   }


### PR DESCRIPTION
# What Does This Do

clears `propagationTags` when resetting ContextInterpreter.

Jira ticket: [[AIT-9906](https://datadoghq.atlassian.net/browse/AIT-9906)]


[AIT-9906]: https://datadoghq.atlassian.net/browse/AIT-9906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ