### PR TITLE
Set appsec.blocked in local root span

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1485,9 +1485,11 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     def trace = TEST_WRITER.get(0)
 
     then:
-    trace.size() == 1
-    trace[0].tags['http.status_code'] == 418
-    trace[0].tags['appsec.blocked'] == 'true'
+    !trace.isEmpty()
+    def rootSpan = trace.find { it.parentId == 0 }
+    assert rootSpan != null
+    rootSpan.tags['http.status_code'] == 418
+    rootSpan.tags['appsec.blocked'] == 'true'
 
     and:
     if (isDataStreamsEnabled()) {
@@ -1794,14 +1796,14 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     response.header(IG_RESPONSE_HEADER) == null // the header should've been cleared
     response.body().charStream().text.contains('"title":"You\'ve been blocked"')
     TEST_WRITER.waitForTraces(1)
+    def trace = TEST_WRITER.get(0)
 
     then:
-    TEST_WRITER.flatten().find { DDSpan it ->
-      it.tags['http.status_code'] == 413
-    } != null
-    TEST_WRITER.flatten().find { DDSpan it ->
-      it.tags['appsec.blocked'] == 'true'
-    } != null
+    !trace.isEmpty()
+    def rootSpan = trace.find { it.parentId == 0 }
+    assert rootSpan != null
+    rootSpan.tags['http.status_code'] == 413
+    rootSpan.tags['appsec.blocked'] == 'true'
   }
 
 
@@ -1823,14 +1825,14 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     response.code() == 301
     response.header("Location") == 'https://www.google.com/'
     TEST_WRITER.waitForTraces(1)
+    def trace = TEST_WRITER.get(0)
 
     then:
-    TEST_WRITER.flatten().find { DDSpan it ->
-      it.tags['http.status_code'] == 301
-    } != null
-    TEST_WRITER.flatten().find { DDSpan it ->
-      it.tags['appsec.blocked'] == 'true'
-    } != null
+    !trace.isEmpty()
+    def rootSpan = trace.find { it.parentId == 0 }
+    assert rootSpan != null
+    rootSpan.tags['http.status_code'] == 301
+    rootSpan.tags['appsec.blocked'] == 'true'
   }
 
   void controllerSpan(TraceAssert trace, ServerEndpoint endpoint = null) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1619,14 +1619,14 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     response.body().charStream().text.contains('"title":"You\'ve been blocked"')
     !handlerRan
     TEST_WRITER.waitForTraces(1)
+    def trace = TEST_WRITER.get(0)
 
     then:
-    TEST_WRITER.flatten().find { DDSpan it ->
-      it.tags['http.status_code'] == 413
-    } != null
-    TEST_WRITER.flatten().find { DDSpan it ->
-      it.tags['appsec.blocked'] == 'true'
-    } != null
+    !trace.isEmpty()
+    def rootSpan = trace.find { it.parentId == 0 }
+    assert rootSpan != null
+    rootSpan.tags['http.status_code'] == 413
+    rootSpan.tags['appsec.blocked'] == 'true'
 
     and:
     if (isDataStreamsEnabled()) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -995,7 +995,7 @@ public class DDSpanContext
 
   @Override
   public void effectivelyBlocked() {
-    setTag("appsec.blocked", "true");
+    setTagTop("appsec.blocked", "true");
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do
* Always set `appsec.blocked:true` in the local root span.

# Motivation
* In some cases, such as mid-request blocks (e.g. path params, RASP) or certain web frameworks, a block will happen while the active span is not the root span. We use `appsec.blocked` to mark local roots, so make sure we always set the tag there.

# Additional Notes

Jira ticket: [APPSEC-53857](https://datadoghq.atlassian.net/browse/APPSEC-53857)

[APPSEC-53857]: https://datadoghq.atlassian.net/browse/APPSEC-53857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ