### PR TITLE
Use spark application name when service is set to spark

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -1125,7 +1125,7 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
 
     // Keep service set by user, except if it is only "spark" that can be set by USM
     String serviceName = Config.get().getServiceName();
-    if ((Config.get().isServiceNameSetByUser() && !"spark".equals(serviceName))) {
+    if (Config.get().isServiceNameSetByUser() && !"spark".equals(serviceName)) {
       log.debug("Service '{}' explicitly set by user, not using the application name", serviceName);
       return null;
     }

--- a/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkTest.groovy
+++ b/dd-java-agent/instrumentation/spark/src/testFixtures/groovy/datadog/trace/instrumentation/spark/AbstractSparkTest.groovy
@@ -684,7 +684,8 @@ abstract class AbstractSparkTest extends AgentTestRunner {
 
     where:
     ddService | sparkAppNameAsService | appName    | isRunningOnDatabricks | expectedService
-    "foobar"  | true                  | "some_app" | true                  | "(?!.*some_app).*"
+    "foobar"  | true                  | "some_app" | false                 | "(?!.*some_app).*"
+    "spark"   | true                  | "some_app" | false                 | "some_app"
     null      | true                  | "some_app" | true                  | "(?!.*some_app).*"
     null      | true                  | "some_app" | false                 | "some_app"
     null      | false                 | "some_app" | false                 | "(?!.*some_app).*"


### PR DESCRIPTION
# What Does This Do

`DD_SPARK_APP_NAME_AS_SERVICE` also use `spark.app.name` as the default service if service is set to `spark`

# Motivation

USM can auto-infer the service to spark, in this case we still want to use the spark app name as the service

# Additional Notes

https://datadoghq.atlassian.net/browse/DJM-30

`DD_SPARK_APP_NAME_AS_SERVICE` was introduced in this PR: https://github.com/DataDog/dd-trace-java/pull/6460

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
