### PR TITLE
Add /info and /telemetry endpoints to smoke tests agent

### DIFF
--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -45,6 +45,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
           "endpoints": [
             "/v0.4/traces",
             "/v0.5/traces",
+            "/telemetry/proxy/",
           ],
           "client_drop_p0s": true,
           "span_meta_structs": true,
@@ -103,6 +104,9 @@ abstract class AbstractSmokeTest extends ProcessManager {
       }
       prefix("/v0.7/config") {
         response.status(200).send(remoteConfigResponse)
+      }
+      prefix("/telemetry/proxy/api/v2/apmtelemetry") {
+        response.status(202).send()
       }
     }
   }

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -38,6 +38,27 @@ abstract class AbstractSmokeTest extends ProcessManager {
   @AutoCleanup
   protected TestHttpServer server = httpServer {
     handlers {
+      prefix("/info") {
+        response.status(200).send("""{
+          "version": "7.54.1",
+          "git_commit": "44d1992",
+          "endpoints": [
+            "/v0.4/traces",
+            "/v0.5/traces",
+          ],
+          "client_drop_p0s": true,
+          "span_meta_structs": true,
+          "long_running_spans": true,
+          "evp_proxy_allowed_headers": [
+            "Content-Type",
+            "Accept-Encoding",
+            "Content-Encoding",
+            "User-Agent",
+            "DD-CI-PROVIDER-NAME"
+          ],
+          "config": {}
+        }""")
+      }
       prefix("/v0.4/traces") {
         def countString = request.getHeader("X-Datadog-Trace-Count")
         int count = countString != null ? Integer.parseInt(countString) : 0


### PR DESCRIPTION
# What Does This Do
* Add `/info` and `/telemetry` endpoints to the test agent used in smoke tests.

# Motivation
* Make it closer to a real agent.
* Avoid logs noise from telemetry errors.
* Avoid unnecessary probing for feature discovery, stressing the most usual path with real agent, and reducing noise in logs and debugging.

# Additional Notes

Possible future work:
* Intercept telemetry messages, this would enable better smoke tests for telemetry.
* Make `/info` responses configurable to test different scenarios.
