### PR TITLE
Use default trace protocol version in smoke tests

### DIFF
--- a/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/src/main/groovy/datadog/smoketest/appsec/AbstractAppSecServerSmokeTest.groovy
@@ -44,8 +44,6 @@ abstract class AbstractAppSecServerSmokeTest extends AbstractServerSmokeTest {
   protected String[] defaultAppSecProperties = [
     "-Ddd.appsec.enabled=${System.getProperty('smoke_test.appsec.enabled') ?: 'true'}",
     "-Ddd.profiling.enabled=false",
-    // decoding received traces is only available for v0.5 right now
-    "-Ddd.trace.agent.v0.5.enabled=true",
     // disable AppSec rate limit
     "-Ddd.appsec.trace.rate.limit=-1"
   ] + (System.getProperty('smoke_test.appsec.enabled') == 'inactive' ?

--- a/dd-smoke-tests/spring-boot-2.4-webflux/src/test/groovy/datadog/smoketest/SpringBootWebfluxIntegrationTest.groovy
+++ b/dd-smoke-tests/spring-boot-2.4-webflux/src/test/groovy/datadog/smoketest/SpringBootWebfluxIntegrationTest.groovy
@@ -14,8 +14,6 @@ class SpringBootWebfluxIntegrationTest extends AbstractServerSmokeTest {
     command.addAll(defaultJavaProperties)
     command.addAll((String[]) [
       "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter",
-      // decoding received traces is only available for v05 right now
-      "-Ddd.trace.agent.v0.5.enabled=true",
       "-jar",
       springBootShadowJar,
       "--server.port=${httpPort}"


### PR DESCRIPTION
# What Does This Do
Use the default trace protocol version (v0.4 at the moment) in smoke tests.

# Motivation
Support for decoding v0.4 in smoke tests agent was added in 2022, we can now just test the default behavior.

# Additional Notes
