### PR TITLE
Add missing appsec propagation tag on appsec events

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecorator.java
@@ -76,6 +76,7 @@ public class AppSecUserEventDecorator {
   private void onEvent(@Nonnull TraceSegment segment, String eventName, Map<String, String> tags) {
     segment.setTagTop("appsec.events." + eventName + ".track", true, true);
     segment.setTagTop(Tags.ASM_KEEP, true);
+    segment.setTagTop(Tags.PROPAGATED_APPSEC, true);
 
     // Report user event tracking mode ("safe" or "extended")
     UserEventTrackingMode mode = Config.get().getAppSecUserEventsTrackingMode();

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/AppSecUserEventDecoratorTest.groovy
@@ -37,6 +37,7 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     1 * traceSegment.setTagTop('_dd.appsec.events.users.signup.auto.mode', mode)
     1 * traceSegment.setTagTop('appsec.events.users.signup.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
+    1 * traceSegment.setTagTop('_dd.p.appsec', true)
     if (setUser) {
       1 * traceSegment.setTagTop('usr.id', user)
     }
@@ -65,6 +66,7 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     1 * traceSegment.setTagTop('_dd.appsec.events.users.login.success.auto.mode', mode)
     1 * traceSegment.setTagTop('appsec.events.users.login.success.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
+    1 * traceSegment.setTagTop('_dd.p.appsec', true)
     if (setUser) {
       1 * traceSegment.setTagTop('usr.id', user)
     }
@@ -93,6 +95,7 @@ class AppSecUserEventDecoratorTest extends DDSpecification {
     1 * traceSegment.setTagTop('_dd.appsec.events.users.login.failure.auto.mode', mode)
     1 * traceSegment.setTagTop('appsec.events.users.login.failure.track', true, true)
     1 * traceSegment.setTagTop('asm.keep', true)
+    1 * traceSegment.setTagTop('_dd.p.appsec', true)
     if (setUser) {
       1 * traceSegment.setTagTop('appsec.events.users.login.failure.usr.id', user)
     }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -142,6 +142,7 @@ public class GatewayBridge {
             if (!collectedEvents.isEmpty()) {
               // Set asm keep in case that root span was not available when events are detected
               traceSeg.setTagTop(Tags.ASM_KEEP, true);
+              traceSeg.setTagTop(Tags.PROPAGATED_APPSEC, true);
               traceSeg.setTagTop("appsec.event", true);
               traceSeg.setTagTop("network.client.ip", ctx.getPeerAddress());
 


### PR DESCRIPTION
# What Does This Do

Add appsec propagation tag:

- On appsec user event tracking
- On appsec request end  (this is necessary as we can't guarantee right now that the span is available when the event is detected)

# Additional notes

JIRA: [APPSEC-10459](https://datadoghq.atlassian.net/browse/APPSEC-10459)

[APPSEC-10459]: https://datadoghq.atlassian.net/browse/APPSEC-10459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ