### PR TITLE
PROF-10082: Add support for 'auto' value in DD_PROFILING_ENABLED

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -32,6 +32,7 @@ import datadog.trace.api.config.TracerConfig;
 import datadog.trace.api.config.UsmConfig;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.gateway.SubscriptionService;
+import datadog.trace.api.profiling.ProfilingEnablement;
 import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.benchmark.StaticEventLogger;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -1124,6 +1125,11 @@ public class Agent {
       // true unless it's explicitly set to "false"
       return !("false".equalsIgnoreCase(featureEnabled) || "0".equals(featureEnabled));
     } else {
+      if (feature == AgentFeature.PROFILING) {
+        // We need this hack because profiling in SSI can receive 'auto' value in
+        // the enablement config
+        return ProfilingEnablement.of(featureEnabled).isActive();
+      }
       // false unless it's explicitly set to "true"
       return Boolean.parseBoolean(featureEnabled) || "1".equals(featureEnabled);
     }

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -68,6 +68,7 @@ import static datadog.trace.api.config.UsmConfig.USM_ENABLED;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
 
+import datadog.trace.api.profiling.ProfilingEnablement;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.reflect.Method;
@@ -103,7 +104,7 @@ public class InstrumenterConfig {
   private final boolean traceEnabled;
   private final boolean traceOtelEnabled;
   private final boolean logs128bTraceIdEnabled;
-  private final boolean profilingEnabled;
+  private final ProfilingEnablement profilingEnabled;
   private final boolean ciVisibilityEnabled;
   private final ProductActivation appSecActivation;
   private final ProductActivation iastActivation;
@@ -178,7 +179,9 @@ public class InstrumenterConfig {
     logs128bTraceIdEnabled =
         configProvider.getBoolean(
             TRACE_128_BIT_TRACEID_LOGGING_ENABLED, DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED);
-    profilingEnabled = configProvider.getBoolean(PROFILING_ENABLED, PROFILING_ENABLED_DEFAULT);
+    profilingEnabled =
+        ProfilingEnablement.of(
+            configProvider.getString(PROFILING_ENABLED, String.valueOf(PROFILING_ENABLED_DEFAULT)));
 
     if (!Platform.isNativeImageBuilder()) {
       ciVisibilityEnabled =
@@ -301,7 +304,7 @@ public class InstrumenterConfig {
   }
 
   public boolean isProfilingEnabled() {
-    return profilingEnabled;
+    return profilingEnabled.isActive();
   }
 
   public boolean isCiVisibilityEnabled() {

--- a/internal-api/src/main/java/datadog/trace/api/profiling/ProfilingEnablement.java
+++ b/internal-api/src/main/java/datadog/trace/api/profiling/ProfilingEnablement.java
@@ -1,0 +1,32 @@
+package datadog.trace.api.profiling;
+
+public enum ProfilingEnablement {
+  ENABLED(true),
+  DISABLED(false),
+  AUTO(true);
+
+  private final boolean active;
+
+  ProfilingEnablement(boolean active) {
+    this.active = active;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public static ProfilingEnablement of(String value) {
+    if (value == null) {
+      return DISABLED;
+    }
+    switch (value.toLowerCase()) {
+      case "true":
+      case "1":
+        return ENABLED;
+      case "auto":
+        return AUTO;
+      default:
+        return DISABLED;
+    }
+  }
+}

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -75,7 +75,9 @@ import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PASSWORD
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_PORT
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_PROXY_USERNAME
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_DELAY_DEFAULT
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_FORCE_FIRST
+import static datadog.trace.api.config.ProfilingConfig.PROFILING_START_FORCE_FIRST_DEFAULT
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_TAGS
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_TEMPLATE_OVERRIDE_FILE
 import static datadog.trace.api.config.ProfilingConfig.PROFILING_UPLOAD_COMPRESSION
@@ -2439,5 +2441,28 @@ class ConfigTest extends DDSpecification {
     null                     | 47                        | 47
     true                     | 11                        | 11
     false                    | 17                        | 0
+  }
+
+  def "check profiling SSI auto-enablement"() {
+    when:
+    def prop = new Properties()
+    prop.setProperty(PROFILING_ENABLED, enablementMode)
+    prop.setProperty(PROFILING_START_DELAY, "1")
+    prop.setProperty(PROFILING_START_FORCE_FIRST, "true")
+
+    Config config = Config.get(prop)
+
+    then:
+    config.profilingEnabled == expectedEnabled
+    config.profilingStartDelay == expectedStartDelay
+    config.profilingStartForceFirst == expectedStartForceFirst
+
+    where:
+    // spotless:off
+    enablementMode | expectedEnabled | expectedStartDelay             | expectedStartForceFirst
+    "true"         | true            | 1                              | true
+    "false"        | false           | 1                              | true
+    "auto"         | true            | PROFILING_START_DELAY_DEFAULT  | PROFILING_START_FORCE_FIRST_DEFAULT
+    // spotless:on
   }
 }

--- a/internal-api/src/test/java/datadog/trace/api/profiling/ProfilingEnablementTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/profiling/ProfilingEnablementTest.java
@@ -1,0 +1,34 @@
+package datadog.trace.api.profiling;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ProfilingEnablementTest {
+
+  @ParameterizedTest
+  @MethodSource("provideValues")
+  void of(String value, ProfilingEnablement expected) {
+    assertEquals(expected, ProfilingEnablement.of(value));
+  }
+
+  private static Stream<Arguments> provideValues() {
+    return Stream.of(
+        Arguments.of("true", ProfilingEnablement.ENABLED),
+        Arguments.of("TRUE", ProfilingEnablement.ENABLED),
+        Arguments.of("tRuE", ProfilingEnablement.ENABLED),
+        Arguments.of("1", ProfilingEnablement.ENABLED),
+        Arguments.of("auto", ProfilingEnablement.AUTO),
+        Arguments.of("AUTO", ProfilingEnablement.AUTO),
+        Arguments.of("aUtO", ProfilingEnablement.AUTO),
+        Arguments.of("false", ProfilingEnablement.DISABLED),
+        Arguments.of("FALSE", ProfilingEnablement.DISABLED),
+        Arguments.of("fAlSe", ProfilingEnablement.DISABLED),
+        Arguments.of("0", ProfilingEnablement.DISABLED),
+        Arguments.of("anything", ProfilingEnablement.DISABLED),
+        Arguments.of(null, ProfilingEnablement.DISABLED));
+  }
+}


### PR DESCRIPTION
# What Does This Do
Adds a support for a new state `auto` for `profiling.enabled` config option.

# Motivation
For SSI (Single Step Instrumentation) a new state for the profiler enablement was added - 'auto'.
The enablement used to be a boolean flag, so the only supported values were `true` and `false` , regardless of the case.
Therefore, a specific support for `auto` must be added.

# Additional Notes
Since the 'auto' activation presumes a 'testing' period before enabling profiling (eg. an app must have been running for 10-20 seconds so we don't activate for something like command line utilities) a part of the 'auto' enablement is making sure that the user defined values for the initial delay and 'force-start-first' flag are ignored.

Jira ticket: [PROF-10082]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-10082]: https://datadoghq.atlassian.net/browse/PROF-10082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ