### PR TITLE
Fix milestone assignment automation

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yaml
+++ b/.github/workflows/add-milestone-to-pull-requests.yaml
@@ -27,7 +27,7 @@ jobs:
               return
             }
             // Get the base branch
-            const base = '${{ github.event.pull_request.base.label }}'
+            const base = '${{ github.event.pull_request.base.ref }}'
             // Look for the matching milestone
             let milestoneNumber = null
             if (base == 'master') {


### PR DESCRIPTION
# What Does This Do

This PR tries to fix a regression from https://github.com/DataDog/dd-trace-java/pull/7217

# Motivation

The workflow is failing to identify `master` branch.
See: https://dd.slack.com/archives/C047YAMGZ7T/p1719847370062669

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
