### PR TITLE
JMS: trace Queue and Topic producers when destination is explicit

### DIFF
--- a/dd-java-agent/instrumentation/jakarta-jms/src/main/java/datadog/trace/instrumentation/jakarta/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-jms/src/main/java/datadog/trace/instrumentation/jakarta/jms/JMSMessageProducerInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jakarta.jms;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
@@ -65,7 +66,7 @@ public final class JMSMessageProducerInstrumentation extends InstrumenterModule.
         JMSMessageProducerInstrumentation.class.getName() + "$ProducerAdvice");
     transformer.applyAdvice(
         named("send")
-            .and(takesArgument(0, named("jakarta.jms.Destination")))
+            .and(takesArgument(0, hasInterface(named("jakarta.jms.Destination"))))
             .and(takesArgument(1, named("jakarta.jms.Message")))
             .and(isPublic()),
         JMSMessageProducerInstrumentation.class.getName() + "$ProducerWithDestinationAdvice");

--- a/dd-java-agent/instrumentation/jakarta-jms/src/test/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jakarta-jms/src/test/groovy/JMS2Test.groovy
@@ -83,7 +83,7 @@ class JMS2Test extends AgentTestRunner {
     def producer = session.createProducer(destination)
     def consumer = session.createConsumer(destination)
 
-    producer.send(message)
+    producer.send(destination, message)
 
     Message receivedMessage = consumer.receive()
     // required to finish auto-acknowledged spans

--- a/dd-java-agent/instrumentation/jakarta-jms/src/test/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jakarta-jms/src/test/groovy/JMS2Test.groovy
@@ -80,7 +80,7 @@ class JMS2Test extends AgentTestRunner {
 
   def "sending a message to #jmsResourceName generates spans"() {
     setup:
-    def producer = session.createProducer(destination)
+    def producer = session.createProducer(null)
     def consumer = session.createConsumer(destination)
 
     producer.send(destination, message)

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.jms;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
@@ -65,7 +66,7 @@ public final class JMSMessageProducerInstrumentation extends InstrumenterModule.
         JMSMessageProducerInstrumentation.class.getName() + "$ProducerAdvice");
     transformer.applyAdvice(
         named("send")
-            .and(takesArgument(0, named("javax.jms.Destination")))
+            .and(takesArgument(0, hasInterface(named("javax.jms.Destination"))))
             .and(takesArgument(1, named("javax.jms.Message")))
             .and(isPublic()),
         JMSMessageProducerInstrumentation.class.getName() + "$ProducerWithDestinationAdvice");

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -737,7 +737,7 @@ abstract class JMS1Test extends VersionedNamingTestBase {
 
     when:
     sender.send(message1)
-    sender.send(message2)
+    sender.send(destination, message2)
     sender.send(message3)
 
     TextMessage receivedMessage1 = receiver.receive()


### PR DESCRIPTION
# What Does This Do

The java agent today is not instrumenting jms send for signatures `QueueProducer.send(Queue, Message, ..)` or `TopicPublisher.send(Topic, Message)`.
Instead, we trace `MessageProducer.send(Destination, Message, ..)` only. 

This is generally OK when specialized classes are delegating to superclasses. In fact for ActiveMQ we have

```
public class ActiveMQQueueSender extends ActiveMQMessageProducer implements QueueSender {
   ....

    public void send(Queue queue, Message message) throws JMSException {
        super.send(queue, message);
    }
```

But it's not OK when the specialized class does not delegate to super. Hence we lost the tracing on the producer.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
