### PR TITLE
Move 'recordEvent' method to StatsDClient interface

### DIFF
--- a/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClient.java
+++ b/communication/src/main/java/datadog/communication/monitor/DDAgentStatsDClient.java
@@ -88,20 +88,10 @@ public final class DDAgentStatsDClient implements StatsDClient {
     connection.statsd.recordServiceCheckRun(serviceCheck);
   }
 
-  /**
-   * Record a statsd event
-   *
-   * @param type the type of event (error, warning, info, success - @see Event.AlertType)
-   * @param source the source of the event (e.g. java, myapp, CrashTracking, Telemetry, etc)
-   * @param eventName the name of the event (or title)
-   * @param message the message of the event
-   * @param tags the tags to attach to the event
-   */
+  @Override
   public void recordEvent(
       String type, String source, String eventName, String message, String... tags) {
     Event.AlertType alertType = Event.AlertType.valueOf(type.toUpperCase());
-    log.debug(
-        "Recording event: {} - {} - {} - {} [{}]", alertType, source, eventName, message, tags);
     Event.Builder eventBuilder =
         Event.builder()
             .withTitle(eventName)

--- a/communication/src/main/java/datadog/communication/monitor/LoggingStatsDClient.java
+++ b/communication/src/main/java/datadog/communication/monitor/LoggingStatsDClient.java
@@ -19,6 +19,7 @@ public final class LoggingStatsDClient implements StatsDClient {
   private static final String HISTOGRAM_FORMAT = "{}:{}|h{}";
   private static final String DISTRIBUTION_FORMAT = "{}:{}|d{}";
   private static final String SERVICE_CHECK_FORMAT = "_sc|{}|{}{}{}";
+  private static final String EVENT_FORMAT = "_e|{}|{}|{}|{}|{}";
 
   private static final DecimalFormat DECIMAL_FORMAT;
 
@@ -109,6 +110,12 @@ public final class LoggingStatsDClient implements StatsDClient {
   @Override
   public int getErrorCount() {
     return 0;
+  }
+
+  @Override
+  public void recordEvent(
+      String type, String source, String eventName, String message, String... tags) {
+    log.info(EVENT_FORMAT, type, source, eventName, message, join(tagMapping.apply(tags)));
   }
 
   @Override

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -91,7 +91,6 @@ public final class CrashUploader {
 
     ConfigProvider configProvider = config.configProvider();
 
-    System.out.println("===> telemetryUrl: " + telemetryUrl);
     telemetryClient =
         OkHttpUtils.buildHttpClient(
             config,

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/OOMENotifier.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/OOMENotifier.java
@@ -2,7 +2,7 @@ package com.datadog.crashtracking;
 
 import static datadog.communication.monitor.DDAgentStatsDClientManager.statsDClientManager;
 
-import datadog.communication.monitor.DDAgentStatsDClient;
+import datadog.trace.api.StatsDClient;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.concurrent.locks.LockSupport;
 import org.slf4j.Logger;
@@ -14,9 +14,8 @@ public final class OOMENotifier {
   // This method is called via CLI so we don't need to be paranoid about the forbiddend APIs
   @SuppressForbidden
   public static void sendOomeEvent(String taglist) {
-    try (DDAgentStatsDClient client =
-        (DDAgentStatsDClient)
-            statsDClientManager().statsDClient(null, null, null, null, null, false)) {
+    try (StatsDClient client =
+        statsDClientManager().statsDClient(null, null, null, null, null, false)) {
       String[] tags = taglist.split(",");
       client.recordEvent(
           "error",

--- a/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
+++ b/internal-api/src/main/java/datadog/trace/api/StatsDClient.java
@@ -27,6 +27,18 @@ public interface StatsDClient extends Closeable {
 
   int getErrorCount();
 
+  /**
+   * Record a statsd event
+   *
+   * @param type the type of event (error, warning, info, success - @see Event.AlertType)
+   * @param source the source of the event (e.g. java, myapp, CrashTracking, Telemetry, etc)
+   * @param eventName the name of the event (or title)
+   * @param message the message of the event
+   * @param tags the tags to attach to the event
+   */
+  default void recordEvent(
+      String type, String source, String eventName, String message, String... tags) {};
+
   @Override
   void close();
 }


### PR DESCRIPTION
# What Does This Do
Follow-up to #10025 to move the `recordEvent` to `StatsDClient` interface

Jira ticket: [PROF-10025]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-10025]: https://datadoghq.atlassian.net/browse/PROF-10025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ