### PR TITLE
Report span metrics for Exploit Prevention

### DIFF
--- a/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/EventDispatcherBenchmark.java
+++ b/dd-java-agent/appsec/src/jmh/java/datadog/appsec/benchmark/EventDispatcherBenchmark.java
@@ -87,7 +87,8 @@ public class EventDispatcherBenchmark {
                 ChangeableFlow flow,
                 AppSecRequestContext context,
                 DataBundle dataBundle,
-                boolean isTransient) {}
+                boolean isTransient,
+                boolean isRasp) {}
 
             @Override
             public Priority getPriority() {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/blocking/BlockingServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/blocking/BlockingServiceImpl.java
@@ -45,7 +45,7 @@ public class BlockingServiceImpl implements BlockingService {
       }
       SingletonDataBundle<String> db = new SingletonDataBundle<>(KnownAddresses.USER_ID, userId);
       try {
-        flow = eventProducer.publishDataEvent(subInfo, reqCtx, db, true);
+        flow = eventProducer.publishDataEvent(subInfo, reqCtx, db, true, false);
         break;
       } catch (ExpiredSubscriberInfoException e) {
         subInfo = null;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/DataListener.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/DataListener.java
@@ -8,5 +8,6 @@ public interface DataListener extends OrderedCallback {
       ChangeableFlow flow,
       AppSecRequestContext context,
       DataBundle dataBundle,
-      boolean isTransient);
+      boolean isTransient,
+      boolean isRasp);
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/EventDispatcher.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/EventDispatcher.java
@@ -132,7 +132,8 @@ public class EventDispatcher implements EventProducerService {
       DataSubscriberInfo subscribers,
       AppSecRequestContext ctx,
       DataBundle newData,
-      boolean isTransient)
+      boolean isTransient,
+      boolean isRasp)
       throws ExpiredSubscriberInfoException {
     if (!((DataSubscriberInfoImpl) subscribers).isEventDispatcher(this)) {
       throw new ExpiredSubscriberInfoException();
@@ -144,7 +145,7 @@ public class EventDispatcher implements EventProducerService {
     ChangeableFlow flow = new ChangeableFlow();
     for (int idx : ((DataSubscriberInfoImpl) subscribers).listenerIndices) {
       try {
-        dataListenersIdx.get(idx).onDataAvailable(flow, ctx, newData, isTransient);
+        dataListenersIdx.get(idx).onDataAvailable(flow, ctx, newData, isTransient, isRasp);
       } catch (RuntimeException rte) {
         log.warn("AppSec callback exception", rte);
       }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/EventProducerService.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/EventProducerService.java
@@ -14,7 +14,7 @@ public interface EventProducerService {
    * set of addresses is identical.
    *
    * <p>The return value is to be passed to {@link #publishDataEvent(DataSubscriberInfo,
-   * AppSecRequestContext, DataBundle, boolean)}.
+   * AppSecRequestContext, DataBundle, boolean, boolean)}.
    *
    * @param newAddresses the addresses contained in the {@link DataBundle} that is to be passed to
    *     <code>publishDataEvent()</code>.
@@ -35,7 +35,8 @@ public interface EventProducerService {
       DataSubscriberInfo subscribers,
       AppSecRequestContext ctx,
       DataBundle newData,
-      boolean isTransient)
+      boolean isTransient,
+      boolean isRasp)
       throws ExpiredSubscriberInfoException;
 
   interface DataSubscriberInfo {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/ReplaceableEventProducerService.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/ReplaceableEventProducerService.java
@@ -23,9 +23,10 @@ public class ReplaceableEventProducerService implements EventProducerService {
       DataSubscriberInfo subscribers,
       AppSecRequestContext ctx,
       DataBundle newData,
-      boolean isTransient)
+      boolean isTransient,
+      boolean isRasp)
       throws ExpiredSubscriberInfoException {
-    return cur.publishDataEvent(subscribers, ctx, newData, isTransient);
+    return cur.publishDataEvent(subscribers, ctx, newData, isTransient, isRasp);
   }
 
   @Override

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -170,7 +170,18 @@ public class AppSecRequestContext implements DataBundle, Closeable {
     return timeouts;
   }
 
-  public Additive getOrCreateAdditive(PowerwafContext ctx, boolean createMetrics) {
+  public Additive getOrCreateAdditive(PowerwafContext ctx, boolean createMetrics, boolean isRasp) {
+
+    if (createMetrics) {
+      if (wafMetrics == null) {
+        this.wafMetrics = ctx.createMetrics();
+      }
+      if (isRasp && raspMetrics == null) {
+        this.raspMetrics = ctx.createMetrics();
+        this.raspMetricsCounter = new AtomicInteger(0);
+      }
+    }
+
     Additive curAdditive;
     synchronized (this) {
       curAdditive = this.additive;
@@ -179,13 +190,6 @@ public class AppSecRequestContext implements DataBundle, Closeable {
       }
       curAdditive = ctx.openAdditive();
       this.additive = curAdditive;
-    }
-
-    // new additive was created
-    if (createMetrics) {
-      this.wafMetrics = ctx.createMetrics();
-      this.raspMetrics = ctx.createMetrics();
-      this.raspMetricsCounter = new AtomicInteger(0);
     }
     return curAdditive;
   }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -17,6 +17,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,6 +113,8 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private Additive additive;
   // set after additive is set
   private volatile PowerwafMetrics wafMetrics;
+  private volatile PowerwafMetrics raspMetrics;
+  private AtomicInteger raspMetricsCounter;
   private volatile boolean blocked;
   private volatile int timeouts;
 
@@ -141,6 +144,14 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   public PowerwafMetrics getWafMetrics() {
     return wafMetrics;
+  }
+
+  public PowerwafMetrics getRaspMetrics() {
+    return raspMetrics;
+  }
+
+  public AtomicInteger getRaspMetricsCounter() {
+    return raspMetricsCounter;
   }
 
   public void setBlocked() {
@@ -173,6 +184,8 @@ public class AppSecRequestContext implements DataBundle, Closeable {
     // new additive was created
     if (createMetrics) {
       this.wafMetrics = ctx.createMetrics();
+      this.raspMetrics = ctx.createMetrics();
+      this.raspMetricsCounter = new AtomicInteger(0);
     }
     return curAdditive;
   }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -235,7 +235,7 @@ public class GatewayBridge {
               DataBundle bundle =
                   new SingletonDataBundle<>(KnownAddresses.REQUEST_PATH_PARAMS, data);
               try {
-                return producerService.publishDataEvent(subInfo, ctx, bundle, false);
+                return producerService.publishDataEvent(subInfo, ctx, bundle, false, false);
               } catch (ExpiredSubscriberInfoException e) {
                 pathParamsSubInfo = null;
               }
@@ -269,7 +269,7 @@ public class GatewayBridge {
             DataBundle bundle =
                 new SingletonDataBundle<>(KnownAddresses.REQUEST_BODY_RAW, bodyContent);
             try {
-              return producerService.publishDataEvent(subInfo, ctx, bundle, false);
+              return producerService.publishDataEvent(subInfo, ctx, bundle, false, false);
             } catch (ExpiredSubscriberInfoException e) {
               rawRequestBodySubInfo = null;
             }
@@ -306,7 +306,7 @@ public class GatewayBridge {
                   new SingletonDataBundle<>(
                       KnownAddresses.REQUEST_BODY_OBJECT, ObjectIntrospection.convert(obj));
               try {
-                return producerService.publishDataEvent(subInfo, ctx, bundle, false);
+                return producerService.publishDataEvent(subInfo, ctx, bundle, false, false);
               } catch (ExpiredSubscriberInfoException e) {
                 requestBodySubInfo = null;
               }
@@ -385,7 +385,7 @@ public class GatewayBridge {
             DataBundle bundle =
                 new SingletonDataBundle<>(KnownAddresses.GRPC_SERVER_METHOD, method);
             try {
-              return producerService.publishDataEvent(subInfo, ctx, bundle, true);
+              return producerService.publishDataEvent(subInfo, ctx, bundle, true, false);
             } catch (ExpiredSubscriberInfoException e) {
               grpcServerMethodSubInfo = null;
             }
@@ -413,7 +413,7 @@ public class GatewayBridge {
             DataBundle bundle =
                 new SingletonDataBundle<>(KnownAddresses.GRPC_SERVER_REQUEST_MESSAGE, convObj);
             try {
-              return producerService.publishDataEvent(subInfo, ctx, bundle, true);
+              return producerService.publishDataEvent(subInfo, ctx, bundle, true, false);
             } catch (ExpiredSubscriberInfoException e) {
               grpcServerRequestMsgSubInfo = null;
             }
@@ -440,7 +440,7 @@ public class GatewayBridge {
             DataBundle bundle =
                 new SingletonDataBundle<>(KnownAddresses.GRAPHQL_SERVER_ALL_RESOLVERS, data);
             try {
-              return producerService.publishDataEvent(subInfo, ctx, bundle, true);
+              return producerService.publishDataEvent(subInfo, ctx, bundle, true, false);
             } catch (ExpiredSubscriberInfoException e) {
               graphqlServerRequestMsgSubInfo = null;
             }
@@ -481,7 +481,7 @@ public class GatewayBridge {
                     .add(KnownAddresses.DB_SQL_QUERY, sql)
                     .build();
             try {
-              return producerService.publishDataEvent(subInfo, ctx, bundle, false);
+              return producerService.publishDataEvent(subInfo, ctx, bundle, false, true);
             } catch (ExpiredSubscriberInfoException e) {
               dbSqlQuerySubInfo = null;
             }
@@ -678,7 +678,7 @@ public class GatewayBridge {
       }
 
       try {
-        return producerService.publishDataEvent(subInfo, ctx, bundle, false);
+        return producerService.publishDataEvent(subInfo, ctx, bundle, false, false);
       } catch (ExpiredSubscriberInfoException e) {
         this.initialReqDataSubInfo = null;
       }
@@ -710,7 +710,7 @@ public class GatewayBridge {
       }
 
       try {
-        return producerService.publishDataEvent(subInfo, ctx, bundle, false);
+        return producerService.publishDataEvent(subInfo, ctx, bundle, false, false);
       } catch (ExpiredSubscriberInfoException e) {
         respDataSubInfo = null;
       }
@@ -742,7 +742,7 @@ public class GatewayBridge {
               KnownAddresses.WAF_CONTEXT_PROCESSOR,
               Collections.singletonMap("extract-schema", true));
       try {
-        producerService.publishDataEvent(subInfo, ctx, bundle, false);
+        producerService.publishDataEvent(subInfo, ctx, bundle, false, false);
         return;
       } catch (ExpiredSubscriberInfoException e) {
         requestEndSubInfo = null;

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -591,7 +591,7 @@ public class PowerWAFModule implements AppSecModule {
         boolean isRasp)
         throws AbstractPowerwafException {
 
-      Additive additive = reqCtx.getOrCreateAdditive(ctxAndAddr.ctx, wafMetricsEnabled);
+      Additive additive = reqCtx.getOrCreateAdditive(ctxAndAddr.ctx, wafMetricsEnabled, isRasp);
       PowerwafMetrics metrics;
       if (isRasp) {
         metrics = reqCtx.getRaspMetrics();

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFStatsReporter.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFStatsReporter.java
@@ -8,8 +8,11 @@ import io.sqreen.powerwaf.PowerwafMetrics;
 import java.util.Collection;
 
 public class PowerWAFStatsReporter implements TraceSegmentPostProcessor {
-  private static final String TOTAL_DURATION_US_TAG = "_dd.appsec.waf.duration_ext";
-  private static final String TOTAL_DDWAF_RUN_DURATION_US_TAG = "_dd.appsec.waf.duration";
+  private static final String WAF_TOTAL_DURATION_US_TAG = "_dd.appsec.waf.duration_ext";
+  private static final String WAF_TOTAL_DDWAF_RUN_DURATION_US_TAG = "_dd.appsec.waf.duration";
+  private static final String RASP_TOTAL_DURATION_US_TAG = "_dd.appsec.rasp.duration_ext";
+  private static final String RASP_TOTAL_DDWAF_RUN_DURATION_US_TAG = "_dd.appsec.rasp.duration";
+  private static final String RASP_RULE_EVAL = "_dd.appsec.rasp.rule.eval";
   private static final String RULE_FILE_VERSION = "_dd.appsec.event_rules.version";
   public static final String TIMEOUTS_TAG = "_dd.appsec.waf.timeouts";
 
@@ -20,14 +23,27 @@ public class PowerWAFStatsReporter implements TraceSegmentPostProcessor {
   @Override
   public void processTraceSegment(
       TraceSegment segment, AppSecRequestContext ctx, Collection<AppSecEvent> collectedEvents) {
-    PowerwafMetrics metrics = ctx.getWafMetrics();
-    if (metrics != null) {
-      segment.setTagTop(TOTAL_DURATION_US_TAG, metrics.getTotalRunTimeNs() / 1000L);
-      segment.setTagTop(TOTAL_DDWAF_RUN_DURATION_US_TAG, metrics.getTotalDdwafRunTimeNs() / 1000L);
+    PowerwafMetrics wafMetrics = ctx.getWafMetrics();
+    if (wafMetrics != null) {
+      segment.setTagTop(WAF_TOTAL_DURATION_US_TAG, wafMetrics.getTotalRunTimeNs() / 1000L);
+      segment.setTagTop(
+          WAF_TOTAL_DDWAF_RUN_DURATION_US_TAG, wafMetrics.getTotalDdwafRunTimeNs() / 1000L);
 
       String rulesVersion = this.rulesVersion;
       if (rulesVersion != null) {
         segment.setTagTop(RULE_FILE_VERSION, rulesVersion);
+      }
+    }
+
+    PowerwafMetrics raspMetrics = ctx.getRaspMetrics();
+    if (raspMetrics != null) {
+      int raspCounter = ctx.getRaspMetricsCounter().get();
+
+      if (raspCounter > 0) {
+        segment.setTagTop(RASP_TOTAL_DURATION_US_TAG, raspMetrics.getTotalRunTimeNs() / 1000L);
+        segment.setTagTop(
+            RASP_TOTAL_DDWAF_RUN_DURATION_US_TAG, raspMetrics.getTotalDdwafRunTimeNs() / 1000L);
+        segment.setTagTop(RASP_RULE_EVAL, raspCounter);
       }
     }
     if (ctx.getTimeouts() > 0) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFStatsReporter.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFStatsReporter.java
@@ -28,24 +28,21 @@ public class PowerWAFStatsReporter implements TraceSegmentPostProcessor {
       segment.setTagTop(WAF_TOTAL_DURATION_US_TAG, wafMetrics.getTotalRunTimeNs() / 1000L);
       segment.setTagTop(
           WAF_TOTAL_DDWAF_RUN_DURATION_US_TAG, wafMetrics.getTotalDdwafRunTimeNs() / 1000L);
-
-      String rulesVersion = this.rulesVersion;
-      if (rulesVersion != null) {
-        segment.setTagTop(RULE_FILE_VERSION, rulesVersion);
-      }
     }
 
     PowerwafMetrics raspMetrics = ctx.getRaspMetrics();
     if (raspMetrics != null) {
-      int raspCounter = ctx.getRaspMetricsCounter().get();
-
-      if (raspCounter > 0) {
-        segment.setTagTop(RASP_TOTAL_DURATION_US_TAG, raspMetrics.getTotalRunTimeNs() / 1000L);
-        segment.setTagTop(
-            RASP_TOTAL_DDWAF_RUN_DURATION_US_TAG, raspMetrics.getTotalDdwafRunTimeNs() / 1000L);
-        segment.setTagTop(RASP_RULE_EVAL, raspCounter);
-      }
+      segment.setTagTop(RASP_TOTAL_DURATION_US_TAG, raspMetrics.getTotalRunTimeNs() / 1000L);
+      segment.setTagTop(
+          RASP_TOTAL_DDWAF_RUN_DURATION_US_TAG, raspMetrics.getTotalDdwafRunTimeNs() / 1000L);
+      segment.setTagTop(RASP_RULE_EVAL, ctx.getRaspMetricsCounter().get());
     }
+
+    String rulesVersion = this.rulesVersion;
+    if (rulesVersion != null) {
+      segment.setTagTop(RULE_FILE_VERSION, rulesVersion);
+    }
+
     if (ctx.getTimeouts() > 0) {
       segment.setTagTop(TIMEOUTS_TAG, ctx.getTimeouts());
     }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/AppSecModuleSpecification.groovy
@@ -33,7 +33,7 @@ class AppSecModuleSpecification extends DDSpecification {
     }
 
     @Override
-    void onDataAvailable(ChangeableFlow flow, AppSecRequestContext context, DataBundle dataBundle, boolean isTransient) {
+    void onDataAvailable(ChangeableFlow flow, AppSecRequestContext context, DataBundle dataBundle, boolean isTransient, boolean isRasp) {
     }
 
     @Override

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/blocking/BlockingServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/blocking/BlockingServiceImplSpecification.groovy
@@ -41,7 +41,7 @@ class BlockingServiceImplSpecification extends DDSpecification {
       final OrderedCallback.Priority priority = OrderedCallback.Priority.DEFAULT
 
       @Override
-      void onDataAvailable(ChangeableFlow flow, AppSecRequestContext context, DataBundle dataBundle, boolean isTransient) {
+      void onDataAvailable(ChangeableFlow flow, AppSecRequestContext context, DataBundle dataBundle, boolean isTransient, boolean isRasp) {
         if (dataBundle.get(KnownAddresses.USER_ID) == 'blocked.user') {
           flow.action = new Flow.Action.RequestBlockingAction(405, BlockingContentType.HTML)
         }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -4,6 +4,7 @@ import com.datadog.appsec.AppSecSystem
 import com.datadog.appsec.config.TraceSegmentPostProcessor
 import com.datadog.appsec.event.EventDispatcher
 import com.datadog.appsec.event.EventProducerService
+import com.datadog.appsec.event.data.Address
 import com.datadog.appsec.event.data.DataBundle
 import com.datadog.appsec.event.data.KnownAddresses
 import com.datadog.appsec.report.AppSecEvent
@@ -214,7 +215,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     ctx.data.rawURI = '/'
     ctx.data.peerAddress = '0.0.0.0'
     eventDispatcher.getDataSubscribers(_) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     and:
@@ -232,7 +233,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     when:
     eventDispatcher.getDataSubscribers(_) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     and:
@@ -250,7 +251,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     when:
     eventDispatcher.getDataSubscribers(_) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     and:
@@ -268,7 +269,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     when:
     eventDispatcher.getDataSubscribers(_) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     and:
@@ -286,7 +287,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     when:
     eventDispatcher.getDataSubscribers({ KnownAddresses.REQUEST_URI_RAW in it }) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     and:
@@ -317,7 +318,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     when:
     eventDispatcher.getDataSubscribers({ KnownAddresses.REQUEST_URI_RAW in it }) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     and:
@@ -347,7 +348,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     when:
     eventDispatcher.getDataSubscribers({ KnownAddresses.REQUEST_PATH_PARAMS in it }) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     and:
@@ -525,7 +526,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     setup:
     supplier.get() >> 'foobar'
     eventDispatcher.getDataSubscribers({ KnownAddresses.REQUEST_BODY_RAW in it }) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     when:
@@ -557,7 +558,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     setup:
     eventDispatcher.getDataSubscribers({KnownAddresses.REQUEST_BODY_OBJECT in it}) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >> { bundle = it[2]; NoopFlow.INSTANCE }
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >> { bundle = it[2]; NoopFlow.INSTANCE }
 
     when:
     requestBodyProcessedCB.apply(ctx, obj)
@@ -591,8 +592,8 @@ class GatewayBridgeSpecification extends DDSpecification {
       })
 
     then:
-    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
-    { a, b, db, c -> bundle = db; NoopFlow.INSTANCE }
+    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
+    { a, b, db, c, e -> bundle = db; NoopFlow.INSTANCE }
     bundle.get(KnownAddresses.REQUEST_BODY_OBJECT) == [foo: 'bar']
     flow.result == null
     flow.action == Flow.Action.Noop.INSTANCE
@@ -604,7 +605,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     setup:
     eventDispatcher.getDataSubscribers({ KnownAddresses.REQUEST_METHOD in it }) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     when:
@@ -622,7 +623,7 @@ class GatewayBridgeSpecification extends DDSpecification {
 
     when:
     eventDispatcher.getDataSubscribers({ KnownAddresses.REQUEST_SCHEME in it }) >> nonEmptyDsInfo
-    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { bundle = it[2]; NoopFlow.INSTANCE }
 
     and:
@@ -661,7 +662,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     Flow<AppSecRequestContext> flow2 = respHeadersDoneCB.apply(ctx)
 
     then:
-    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false) >>
+    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, false, false) >>
     { NoopFlow.INSTANCE }
     flow1.result == null
     flow1.action == Flow.Action.Noop.INSTANCE
@@ -681,8 +682,8 @@ class GatewayBridgeSpecification extends DDSpecification {
       })
 
     then:
-    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, true) >>
-    { a, b, db, c -> bundle = db; NoopFlow.INSTANCE }
+    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, true, false) >>
+    { a, b, db, c, e -> bundle = db; NoopFlow.INSTANCE }
     bundle.get(KnownAddresses.GRPC_SERVER_REQUEST_MESSAGE) == [foo: 'bar']
     flow.result == null
     flow.action == Flow.Action.Noop.INSTANCE
@@ -697,7 +698,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     Flow<?> flow = grpcServerMethodCB.apply(ctx, '/my.package.Greeter/SayHello')
 
     then:
-    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, true) >>
+    1 * eventDispatcher.publishDataEvent(nonEmptyDsInfo, ctx.data, _ as DataBundle, true, false) >>
     { args -> bundle = args[2]; NoopFlow.INSTANCE }
     bundle.get(KnownAddresses.GRPC_SERVER_METHOD) == '/my.package.Greeter/SayHello'
     flow.result == null

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -4,7 +4,6 @@ import com.datadog.appsec.AppSecSystem
 import com.datadog.appsec.config.TraceSegmentPostProcessor
 import com.datadog.appsec.event.EventDispatcher
 import com.datadog.appsec.event.EventProducerService
-import com.datadog.appsec.event.data.Address
 import com.datadog.appsec.event.data.DataBundle
 import com.datadog.appsec.event.data.KnownAddresses
 import com.datadog.appsec.report.AppSecEvent

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -193,7 +193,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       KnownAddresses.REQUEST_INFERRED_CLIENT_IP,
       '1.2.3.4'
       )
-    dataListener.onDataAvailable(flow, ctx, newBundle, false)
+    dataListener.onDataAvailable(flow, ctx, newBundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -227,7 +227,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       KnownAddresses.USER_ID,
       'user-to-block-1'
       )
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -267,7 +267,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       it.dirtyStatus.clearDirty()
     }
 
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -292,7 +292,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       KnownAddresses.USER_ID,
       'user-to-block-2'
       )
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -347,7 +347,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       KnownAddresses.USER_ID,
       'user-to-block-2'
       )
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -372,7 +372,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       KnownAddresses.USER_ID,
       'user-to-block-1'
       )
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -428,7 +428,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * reconf.reloadSubscriptions()
 
     when:
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -450,7 +450,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       KnownAddresses.REQUEST_INFERRED_CLIENT_IP,
       '192.168.0.1'
       )
-    dataListener.onDataAvailable(flow, ctx, newBundle, false)
+    dataListener.onDataAvailable(flow, ctx, newBundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -508,7 +508,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * reconf.reloadSubscriptions()
 
     when:
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -582,7 +582,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     2 * reconf.reloadSubscriptions()
 
     when:
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -607,7 +607,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     DataBundle bundle = MapDataBundle.of(KnownAddresses.HEADERS_NO_COOKIES,
       new CaseInsensitiveMap<List<String>>(['user-agent': 'redirect' + variant]))
     def flow = new ChangeableFlow()
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -672,7 +672,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ChangeableFlow flow = new ChangeableFlow()
 
     when:
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -701,7 +701,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ChangeableFlow flow = new ChangeableFlow()
 
     when:
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -726,7 +726,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     when:
     setupWithStubConfigService()
     pp = service.traceSegmentPostProcessors[1]
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
     pp.processTraceSegment(segment, ctx, [])
 
@@ -752,7 +752,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ChangeableFlow flow = new ChangeableFlow()
 
     when:
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
 
     then:
     1 * ctx.getOrCreateAdditive(_, true) >> {
@@ -778,7 +778,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     pwafModule = new PowerWAFModule() // replace the one created too soon
 
     when:
-    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -816,7 +816,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     when:
     def bundle = MapDataBundle.of(KnownAddresses.HEADERS_NO_COOKIES,
       new CaseInsensitiveMap<List<String>>(['user-agent': [password: 'Arachni/v0']]))
-    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, bundle, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -839,7 +839,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     when:
     def bundle = MapDataBundle.of(KnownAddresses.HEADERS_NO_COOKIES,
       new CaseInsensitiveMap<List<String>>(['user-agent': [password: 'Arachni/v0']]))
-    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, bundle, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -861,7 +861,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     AppSecEvent event
 
     when:
-    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -883,7 +883,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       new CaseInsensitiveMap<List<String>>(['user-agent': 'Harmless']))
 
     when:
-    dataListener.onDataAvailable(flow, ctx, db, false)
+    dataListener.onDataAvailable(flow, ctx, db, false, false)
 
     then:
     ctx.getOrCreateAdditive(_, true) >> {
@@ -912,7 +912,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       ])
 
     when:
-    dataListener.onDataAvailable(flow, ctx, db, false)
+    dataListener.onDataAvailable(flow, ctx, db, false, false)
 
     then:
     ctx.getOrCreateAdditive(_, true) >> {
@@ -927,7 +927,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     DataBundle db = MapDataBundle.of(KnownAddresses.HEADERS_NO_COOKIES, [get: { null }] as List)
 
     when:
-    dataListener.onDataAvailable(flow, ctx, db, false)
+    dataListener.onDataAvailable(flow, ctx, db, false, false)
 
     then:
     ctx.getOrCreateAdditive(_, true) >> {
@@ -949,7 +949,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     TraceSegmentPostProcessor pp = service.traceSegmentPostProcessors.last()
 
     when:
-    dataListener.onDataAvailable(flow, ctx, db, false)
+    dataListener.onDataAvailable(flow, ctx, db, false, false)
 
     then:
     ctx.getOrCreateAdditive(_, true) >> {
@@ -983,7 +983,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     when:
     cfgService.listeners['waf'].onNewSubconfig(defaultConfig['waf'], reconf)
     dataListener = pwafModule.dataSubscriptions.first()
-    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(Stub(ChangeableFlow), ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -1018,7 +1018,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
 
     dataListener = pwafModule.dataSubscriptions.first()
     def bundle = MapDataBundle.of(KnownAddresses.REQUEST_INFERRED_CLIENT_IP, '1.2.3.4')
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then:
@@ -1074,7 +1074,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
 
     dataListener = pwafModule.dataSubscriptions.first()
     def bundle = MapDataBundle.of(KnownAddresses.REQUEST_INFERRED_CLIENT_IP, '1.2.3.4')
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then: 'no match; rule is disabled'
@@ -1097,7 +1097,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       it.dirtyStatus.clearDirty()
     }
 
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then: 'no match; data was cleared (though rule is no longer disabled)'
@@ -1117,7 +1117,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       it.dirtyStatus.clearDirty()
     }
 
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then: 'now we have match'
@@ -1144,7 +1144,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       it.dirtyStatus.clearDirty()
     }
 
-    dataListener.onDataAvailable(flow, ctx, bundle, false)
+    dataListener.onDataAvailable(flow, ctx, bundle, false, false)
     ctx.closeAdditive()
 
     then: 'nothing again; we disabled the rule'
@@ -1172,7 +1172,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       it.dirtyStatus.clearDirty()
     }
     dataListener = pwafModule.dataSubscriptions.first()
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -1194,7 +1194,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       service.listeners['waf'].onNewSubconfig(it, reconf)
       it.dirtyStatus.clearDirty()
     }
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -1217,7 +1217,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       service.listeners['waf'].onNewSubconfig(it, reconf)
       it.dirtyStatus.clearDirty()
     }
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -1243,7 +1243,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       service.listeners['waf'].onNewSubconfig(it, reconf)
       it.dirtyStatus.clearDirty()
     }
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -1355,7 +1355,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       KnownAddresses.REQUEST_BODY_OBJECT,
       '/cybercop'
       )
-    dataListener.onDataAvailable(flow, ctx, transientBundle, false)
+    dataListener.onDataAvailable(flow, ctx, transientBundle, false, false)
 
     then:
     1 * ctx.getOrCreateAdditive(_, true) >> {
@@ -1370,7 +1370,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     0 * _
 
     when:
-    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+    dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
     ctx.closeAdditive()
 
     then:
@@ -1401,7 +1401,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     when:
     for (int t = 0; t < 20; t++) {
       CountDownLatch latch = new CountDownLatch(1)
-      dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false)
+      dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
       Thread thread = new Thread({ p ->
         latch.countDown()
         ctx.closeAdditive()

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -202,7 +202,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       rba.statusCode == 501 &&
         rba.blockingContentType == BlockingContentType.JSON
     })
-    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
+    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     2 * tracer.activeSpan()
@@ -235,7 +235,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       rba.statusCode == 403 &&
         rba.blockingContentType == BlockingContentType.AUTO
     })
-    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
+    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     2 * tracer.activeSpan()
@@ -276,7 +276,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       rba.statusCode == 403 &&
         rba.blockingContentType == BlockingContentType.AUTO
     })
-    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
+    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     2 * tracer.activeSpan()
@@ -300,7 +300,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       rba.statusCode == 403 &&
         rba.blockingContentType == BlockingContentType.AUTO
     })
-    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
+    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     2 * tracer.activeSpan()
@@ -356,7 +356,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       rba.statusCode == 403 &&
         rba.blockingContentType == BlockingContentType.AUTO
     })
-    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
+    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     2 * tracer.activeSpan()
@@ -376,7 +376,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true) >> {
+    1 * ctx.getOrCreateAdditive(_ as PowerwafContext, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     1 * ctx.getWafMetrics()
@@ -432,7 +432,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     2 * tracer.activeSpan()
@@ -454,7 +454,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     1 * ctx.getWafMetrics()
@@ -512,7 +512,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     3 * tracer.activeSpan()
@@ -591,7 +591,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       rba.statusCode == 401 &&
         rba.blockingContentType == BlockingContentType.AUTO
     })
-    1 * ctx.getOrCreateAdditive(_, true) >> { it[0].openAdditive() }
+    1 * ctx.getOrCreateAdditive(_, true, false) >> { it[0].openAdditive() }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
@@ -611,7 +611,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       PowerwafContext pwCtx = it[0] as PowerwafContext
       pwafAdditive = pwCtx.openAdditive()
       metrics = pwCtx.createMetrics()
@@ -676,7 +676,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       PowerwafContext pwCtx = it[0] as PowerwafContext
       pwafAdditive = pwCtx.openAdditive()
       metrics = pwCtx.createMetrics()
@@ -705,7 +705,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_, false) >> {
+    1 * ctx.getOrCreateAdditive(_, false, false) >> {
       pwafAdditive = it[0].openAdditive()
     }
     1 * ctx.getWafMetrics() >> null
@@ -731,7 +731,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     pp.processTraceSegment(segment, ctx, [])
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       PowerwafContext pwCtx = it[0] as PowerwafContext
       pwafAdditive = pwCtx.openAdditive()
       metrics = pwCtx.createMetrics()
@@ -755,7 +755,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     dataListener.onDataAvailable(flow, ctx, ATTACK_BUNDLE, false, false)
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       PowerwafContext pwCtx = it[0] as PowerwafContext
       pwafAdditive = pwCtx.openAdditive()
       metrics = pwCtx.createMetrics()
@@ -987,7 +987,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * reconf.reloadSubscriptions()
@@ -1023,7 +1023,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
 
     then:
     1 * reconf.reloadSubscriptions()
-    1 * ctx.getOrCreateAdditive(_, true) >> { pwafAdditive = it[0].openAdditive() }
+    1 * ctx.getOrCreateAdditive(_, true, false) >> { pwafAdditive = it[0].openAdditive() }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
@@ -1079,7 +1079,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
 
     then: 'no match; rule is disabled'
     1 * reconf.reloadSubscriptions()
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> { pwafAdditive.close() }
@@ -1101,7 +1101,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then: 'no match; data was cleared (though rule is no longer disabled)'
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
@@ -1122,7 +1122,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
 
     then: 'now we have match'
     1 * reconf.reloadSubscriptions()
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
@@ -1149,7 +1149,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
 
     then: 'nothing again; we disabled the rule'
     1 * reconf.reloadSubscriptions()
-    1 * ctx.getOrCreateAdditive(_, true) >> { pwafAdditive = it[0].openAdditive() }
+    1 * ctx.getOrCreateAdditive(_, true, false) >> { pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
     _ * ctx.increaseTimeouts()
@@ -1178,7 +1178,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     1 * reconf.reloadSubscriptions()
     // no attack
-    1 * ctx.getOrCreateAdditive(_, true) >> { pwafAdditive = it[0].openAdditive() }
+    1 * ctx.getOrCreateAdditive(_, true, false) >> { pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     _ * ctx.increaseTimeouts()
@@ -1200,7 +1200,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     1 * reconf.reloadSubscriptions()
     // no attack
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
@@ -1223,7 +1223,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     1 * reconf.reloadSubscriptions()
     // attack found
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * flow.isBlocking()
@@ -1249,7 +1249,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     1 * reconf.reloadSubscriptions()
     // no attack
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
     1 * ctx.closeAdditive()
@@ -1358,7 +1358,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     dataListener.onDataAvailable(flow, ctx, transientBundle, false, false)
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>) >> {
@@ -1374,7 +1374,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     ctx.closeAdditive()
 
     then:
-    1 * ctx.getOrCreateAdditive(_, true) >> {
+    1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive }
     1 * flow.setAction({ it.blocking })
     2 * tracer.activeSpan()

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFStatsReporterSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFStatsReporterSpecification.groovy
@@ -5,11 +5,13 @@ import datadog.trace.api.internal.TraceSegment
 import datadog.trace.test.util.DDSpecification
 import io.sqreen.powerwaf.PowerwafMetrics
 
+import java.util.concurrent.atomic.AtomicInteger
+
 class PowerWAFStatsReporterSpecification extends DDSpecification {
   PowerWAFStatsReporter reporter = new PowerWAFStatsReporter()
   AppSecRequestContext ctx = Mock()
 
-  void 'reporter reports timings and version'() {
+  void 'reporter reports waf timings and version'() {
     setup:
     PowerwafMetrics metrics = new PowerwafMetrics()
     metrics.totalRunTimeNs = 2_000
@@ -24,6 +26,31 @@ class PowerWAFStatsReporterSpecification extends DDSpecification {
     1 * ctx.getWafMetrics() >> metrics
     1 * segment.setTagTop('_dd.appsec.waf.duration', 1)
     1 * segment.setTagTop('_dd.appsec.waf.duration_ext', 2)
+    1 * segment.setTagTop('_dd.appsec.event_rules.version', '1.2.3')
+  }
+
+  void 'reporter reports rasp timings and version'() {
+    setup:
+    PowerwafMetrics metrics = new PowerwafMetrics()
+    metrics.totalRunTimeNs = 2_000
+    metrics.totalDdwafRunTimeNs = 1_000
+
+    PowerwafMetrics raspMetrics = new PowerwafMetrics()
+    raspMetrics.totalRunTimeNs = 4_000
+    raspMetrics.totalDdwafRunTimeNs = 3_000
+    TraceSegment segment = Mock()
+    reporter.rulesVersion = '1.2.3'
+
+    when:
+    reporter.processTraceSegment(segment, ctx, [])
+
+    then:
+    1 * ctx.getWafMetrics() >> null
+    1 * ctx.getRaspMetrics() >> raspMetrics
+    1 * ctx.getRaspMetricsCounter() >> new AtomicInteger(5)
+    1 * segment.setTagTop('_dd.appsec.rasp.duration', 3)
+    1 * segment.setTagTop('_dd.appsec.rasp.duration_ext', 4)
+    1 * segment.setTagTop('_dd.appsec.rasp.rule.eval', 5)
     1 * segment.setTagTop('_dd.appsec.event_rules.version', '1.2.3')
   }
 


### PR DESCRIPTION
# What Does This Do
Added new span metrics for Exploit prevention:

- `_dd.appsec.rasp.duration` - cumulative runtime in nanoseconds of every call to libddwaf thought a RASP instrumentation with a request
- `_dd.appsec.rasp.duration_ext` - cumulative runtime in nanoseconds of libddwaf call + binginds cost through RASP instrumentation with a request
- `_dd.appsec.rasp.rule.eval` - counts the number of times libddwaf calls per request

# Motivation
This is part of Exploit prevention to let collect useful metrics for future analysis of effectiveness.

# Additional Notes

Jira ticket: [APPSEC-47228]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-47228]: https://datadoghq.atlassian.net/browse/APPSEC-47228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ