### PR TITLE
Serialize restricted collections as regular object

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -744,10 +744,11 @@ public class SnapshotSerializationTest {
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
     Map<String, Object> locals = getLocalsFromJson(buffer);
-    Map<String, Object> mapFieldObj = (Map<String, Object>) locals.get("listLocal");
-    Assertions.assertEquals(
-        "java.lang.RuntimeException: Unsupported Collection type: com.datadog.debugger.agent.SnapshotSerializationTest$1",
-        mapFieldObj.get(NOT_CAPTURED_REASON));
+    Map<String, Object> listLocalField = (Map<String, Object>) locals.get("listLocal");
+    Map<String, Object> listLocalFieldFields = (Map<String, Object>) listLocalField.get(FIELDS);
+    assertTrue(listLocalFieldFields.containsKey("elementData"));
+    assertTrue(listLocalFieldFields.containsKey("size"));
+    assertTrue(listLocalFieldFields.containsKey("modCount"));
   }
 
   @Test
@@ -763,10 +764,12 @@ public class SnapshotSerializationTest {
     String buffer = adapter.toJson(snapshot);
     System.out.println(buffer);
     Map<String, Object> locals = getLocalsFromJson(buffer);
-    Map<String, Object> mapFieldObj = (Map<String, Object>) locals.get("mapLocal");
-    Assertions.assertEquals(
-        "java.lang.RuntimeException: Unsupported Map type: com.datadog.debugger.agent.SnapshotSerializationTest$2",
-        mapFieldObj.get(NOT_CAPTURED_REASON));
+    Map<String, Object> mapLocalField = (Map<String, Object>) locals.get("mapLocal");
+    Map<String, Object> mapLocalFieldFields = (Map<String, Object>) mapLocalField.get(FIELDS);
+    assertTrue(mapLocalFieldFields.containsKey("table"));
+    assertTrue(mapLocalFieldFields.containsKey("size"));
+    assertTrue(mapLocalFieldFields.containsKey("threshold"));
+    assertTrue(mapLocalFieldFields.containsKey("loadFactor"));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
We specially serialize collections/maps into snapshot using interfaces and calling methods like `size()` but we restrict this for JDK collections that are guarantee to be only in-memory. For all others we are raising an exception. Instead we should just serialize then as regular object with fields.

# Motivation

https://github.com/DataDog/dd-trace-java/issues/7254

# Additional Notes

Jira ticket: [DEBUG-2502]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2502]: https://datadoghq.atlassian.net/browse/DEBUG-2502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ