### PR TITLE
Fix case where past automation branch where not deleted

### DIFF
--- a/.github/workflows/add-release-to-cloudfoundry.yaml
+++ b/.github/workflows/add-release-to-cloudfoundry.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "${VERSION}: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar" >> index.yml
           git add index.yml
           git commit -m "chore: Add version ${VERSION} to Cloud Foundry"
-          git push -u origin ci/cloudfoundry
+          git push -u origin ci/cloudfoundry --force
           gh pr create \
             --title "Add version ${VERSION} to Cloud Foundry" \
             --body "This PR add the version ${VERSION} to Cloud Foundry.  Make sure [the JAR is online](https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar) before merging." \


### PR DESCRIPTION
# What Does This Do

Fix CloudFoundry repository update automation.

# Motivation

This happens when the generated PR is not merged.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
