### PR TITLE
Move snapshot UUID generation at serialization

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -8,6 +8,7 @@ variables:
   timeout: 1h
   tags: ["runner:apm-k8s-tweaked-metal"]
   image: $BASE_CI_IMAGE
+  needs: [ "build" ]
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && mkdir -p "${ARTIFACTS_DIR}"
     - export CIRCLE_CI_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.circleci_token --with-decryption --query "Parameter.Value" --out text)
@@ -80,6 +81,7 @@ benchmarks-post-results:
   interruptible: true
   timeout: 1h
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:java-dsm-kafka
+  needs: [ "build" ]
   script:
     - git clone --branch java/kafka-dsm-overhead https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform.git platform && cd platform
     - ./steps/run-benchmarks.sh
@@ -117,6 +119,7 @@ debugger-benchmarks:
   interruptible: true
   timeout: 1h
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:java-debugger
+  needs: ["build"]
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && mkdir -p "${ARTIFACTS_DIR}"
     - git clone --branch java/debugger-benchmarks https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform.git /platform && cd /platform

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Snapshot.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Snapshot.java
@@ -34,7 +34,6 @@ public class Snapshot {
   private String exceptionId;
 
   public Snapshot(java.lang.Thread thread, ProbeImplementation probeImplementation, int maxDepth) {
-    this.id = UUID.randomUUID().toString();
     this.version = VERSION;
     this.timestamp = System.currentTimeMillis();
     this.captures = new Captures();
@@ -105,6 +104,10 @@ public class Snapshot {
   }
 
   public String getId() {
+    // lazily generates snapshot id
+    if (id == null) {
+      id = UUID.randomUUID().toString();
+    }
     return id;
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
@@ -63,6 +63,7 @@ public class SnapshotSink {
   }
 
   String serializeSnapshot(String serviceName, Snapshot snapshot) {
+    snapshot.getId(); // Ensure id is generated
     String str = DebuggerAgent.getSnapshotSerializer().serializeSnapshot(serviceName, snapshot);
     String prunedStr = SnapshotPruner.prune(str, MAX_SNAPSHOT_SIZE, 4);
     if (prunedStr.length() != str.length()) {


### PR DESCRIPTION

# What Does This Do
UUID generation is not cheap, and therefore should be performed only when the snapshot is about to be sent.
Moving UUID generation at seriazliation time makes it out of the critical path.

# Motivation
Performance

# Additional Notes

Jira ticket: [DEBUG-2346]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2346]: https://datadoghq.atlassian.net/browse/DEBUG-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ