### PR TITLE
Fix reliability env deploy / Gitlab scheduled pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -277,6 +277,12 @@ generate-lib-init-tag-values:
 
 deploy-lib-init-trigger:
   stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    # Do not tag release candidate versions
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: on_success
   # needs the version from the generate-tag-values job
   needs:
     - job: generate-lib-init-tag-values


### PR DESCRIPTION
# What Does This Do
The gitlab pipeline for scheduled jobs was broken. Gitlab is not smart enough to handle "If B needs A, and A's rule says not to run, don't run B either"

`generate-lib-init-tag-values` didn't run when `POPULATE_CACHE` was set. `deploy-lib-init-trigger` needs to have the same rules.

# Motivation
Gitlab pipeline broken overnight.
