### PR TITLE
Spring scheduling: do not wrap runnables on each schedule

### DIFF
--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
@@ -1,30 +1,24 @@
 package datadog.trace.instrumentation.springscheduling;
 
-import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
-import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.matcher.ElementMatcher;
-import org.springframework.scheduling.TaskScheduler;
 
 @AutoService(InstrumenterModule.class)
 public final class SpringSchedulingInstrumentation extends InstrumenterModule.Tracing
-    implements Instrumenter.ForTypeHierarchy {
+    implements Instrumenter.ForSingleType {
 
   public SpringSchedulingInstrumentation() {
     super("spring-scheduling");
   }
 
-  public String hierarchyMarkerType() {
-    return "org.springframework.scheduling.TaskScheduler";
+  @Override
+  public String instrumentedType() {
+    return "org.springframework.scheduling.config.Task";
   }
 
   @Override
@@ -35,35 +29,17 @@ public final class SpringSchedulingInstrumentation extends InstrumenterModule.Tr
   }
 
   @Override
-  public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return implementsInterface(named(hierarchyMarkerType()));
-  }
-
-  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
-        isMethod().and(nameStartsWith("schedule")).and(takesArgument(0, Runnable.class)),
+        isConstructor().and(takesArgument(0, Runnable.class)),
         getClass().getName() + "$SpringSchedulingAdvice");
   }
 
   public static class SpringSchedulingAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static boolean beforeSchedule(
+    public static void onConstruction(
         @Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
-      if (CallDepthThreadLocalMap.incrementCallDepth(TaskScheduler.class) > 0) {
-        return false;
-      }
       runnable = SpringSchedulingRunnableWrapper.wrapIfNeeded(runnable);
-      return true;
-    }
-
-    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    public static void afterSchedule(
-        @Advice.Enter boolean reset,
-        @Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
-      if (reset) {
-        CallDepthThreadLocalMap.reset(TaskScheduler.class);
-      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
@@ -44,4 +44,9 @@ public class SpringSchedulingRunnableWrapper implements Runnable {
     }
     return new SpringSchedulingRunnableWrapper(task);
   }
+
+  @Override
+  public String toString() {
+    return runnable.toString();
+  }
 }


### PR DESCRIPTION
# What Does This Do

This PR rollbacks instrumenting spring scheduling `TaskScheduler` which was wrapping the `Runnable` in each schedule.
This was done as part of #6249  in order to have the right Runnable names displayed on actuator's endpoints. 

Wrapping the runnable on each schedule can cause side effects if a custom task scheduler is used and if inside the `schedule` method `instanceof` is used to check whenever the Runnable is of a certain type since we're wrapping it with `SpringSchedulingRunnableWrapper`. 

In order to be less invasive and, at same time, preserve the right labelling on actuator, I've restored the old approach instrumenting `Task` instead of `TaskScheduler` which was causing that bad behaviour. I've also overridden the `toString` method of `SpringSchedulingRunnableWrapper` in order to target the wrapped runnable instead. This will work for spring boot actuator since the displayed name is obtained calling `toString` (https://github.com/spring-projects/spring-boot/blob/69630bba37caa3a092b19392949705a41234d703/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/scheduling/ScheduledTasksEndpoint.java#L285)
# Motivation

# Additional Notes

Jira ticket: [APMS-12578]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-12578]: https://datadoghq.atlassian.net/browse/APMS-12578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ