### PR TITLE
Fix service version sanitize tags

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -45,8 +45,8 @@ public class SymbolSink {
 
   SymbolSink(Config config, BatchUploader symbolUploader) {
     this.serviceName = TagsHelper.sanitize(config.getServiceName());
-    this.env = config.getEnv();
-    this.version = config.getVersion();
+    this.env = TagsHelper.sanitize(config.getEnv());
+    this.version = TagsHelper.sanitize(config.getVersion());
     this.symbolUploader = symbolUploader;
     byte[] eventContent =
         String.format(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassNameFilteringTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ClassNameFilteringTest.java
@@ -79,10 +79,8 @@ class ClassNameFilteringTest {
       strings = {
         "java.FooBar",
         "org.junit.Test",
-        "org.junit.jupiter.api.Test",
         "akka.Actor",
         "cats.Functor",
-        "org.junit.jupiter.api.Test",
         "org.junit.jupiter.api.Test",
         "org.datadog.jmxfetch.FooBar"
       })


### PR DESCRIPTION
# What Does This Do

Sanitizes env and version in SymbolSink.

# Motivation

We're matching RC tags with these tags, so they have to be sanitized the same way.

https://github.com/DataDog/dd-trace-java/blob/65d7de13ac6a58d949af75fef4e9531bcaed5aab/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java#L54-L57

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
