### PR TITLE
Reduce scope listener API

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/log/LogContextScopeListener.java
@@ -1,35 +1,22 @@
 package datadog.trace.agent.tooling.log;
 
 import datadog.trace.api.CorrelationIdentifier;
-import datadog.trace.api.DDSpanId;
-import datadog.trace.api.DDTraceId;
-import datadog.trace.api.InstrumenterConfig;
-import datadog.trace.api.TraceConfig;
 import datadog.trace.api.WithGlobalTracer;
-import datadog.trace.api.scopemanager.ExtendedScopeListener;
+import datadog.trace.api.scopemanager.ScopeListener;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
 
 /**
  * A scope listener that receives the MDC/ThreadContext put and receive methods and update the trace
  * and span reference anytime a new scope is activated or closed.
  */
-public abstract class LogContextScopeListener
-    implements ExtendedScopeListener, WithGlobalTracer.Callback {
+public abstract class LogContextScopeListener implements ScopeListener, WithGlobalTracer.Callback {
 
   @Override
-  public void afterScopeActivated() {}
-
-  @Override
-  public void afterScopeActivated(
-      DDTraceId traceId, long localRootSpanId, long spanId, TraceConfig traceConfig) {
-    if (traceConfig != null && traceConfig.isLogsInjectionEnabled()) {
-      if (InstrumenterConfig.get().isLogs128bTraceIdEnabled() && traceId.toHighOrderLong() != 0) {
-        add(CorrelationIdentifier.getTraceIdKey(), traceId.toHexString());
-      } else {
-        add(CorrelationIdentifier.getTraceIdKey(), traceId.toString());
-      }
-
-      add(CorrelationIdentifier.getSpanIdKey(), DDSpanId.toString(spanId));
+  public void afterScopeActivated() {
+    if (AgentTracer.traceConfig().isLogsInjectionEnabled()) {
+      add(CorrelationIdentifier.getTraceIdKey(), CorrelationIdentifier.getTraceId());
+      add(CorrelationIdentifier.getSpanIdKey(), CorrelationIdentifier.getSpanId());
     }
   }
 

--- a/dd-java-agent/cws-tls/src/main/java/datadog/cws/tls/TlsScopeListener.java
+++ b/dd-java-agent/cws-tls/src/main/java/datadog/cws/tls/TlsScopeListener.java
@@ -2,7 +2,6 @@ package datadog.cws.tls;
 
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
-import datadog.trace.api.TraceConfig;
 import datadog.trace.api.scopemanager.ExtendedScopeListener;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -50,12 +49,11 @@ public class TlsScopeListener implements ExtendedScopeListener {
 
   @Override
   public void afterScopeActivated() {
-    afterScopeActivated(DDTraceId.ZERO, DDSpanId.ZERO, DDSpanId.ZERO, null);
+    afterScopeActivated(DDTraceId.ZERO, DDSpanId.ZERO);
   }
 
   @Override
-  public void afterScopeActivated(
-      DDTraceId traceId, long localRootSpanId, long spanId, TraceConfig traceConfig) {
+  public void afterScopeActivated(DDTraceId traceId, long spanId) {
     push(traceId, spanId);
   }
 

--- a/dd-java-agent/cws-tls/src/test/groovy/datadog/cws/tls/TlsTest.groovy
+++ b/dd-java-agent/cws-tls/src/test/groovy/datadog/cws/tls/TlsTest.groovy
@@ -1,6 +1,6 @@
 package datadog.cws.tls
 
-import datadog.trace.api.DDSpanId
+
 import datadog.trace.api.DDTraceId
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.test.util.DDSpecification
@@ -20,8 +20,8 @@ class TlsTest extends DDSpecification {
     span.getSpanId() >> 22L
 
     when:
-    listener.afterScopeActivated(DDTraceId.from(11L), DDSpanId.ZERO, 12L, null)
-    listener.afterScopeActivated(DDTraceId.from(21L), DDSpanId.ZERO, 22L, null)
+    listener.afterScopeActivated(DDTraceId.from(11L), 12L)
+    listener.afterScopeActivated(DDTraceId.from(21L), 22L)
     then:
     tls.getTraceId() == DDTraceId.from(21L)
     tls.getSpanId() == 22L

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -178,11 +178,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
 
     for (final ExtendedScopeListener listener : scopeManager.extendedScopeListeners) {
       try {
-        listener.afterScopeActivated(
-            span.getTraceId(),
-            span.getLocalRootSpan().getSpanId(),
-            span.context().getSpanId(),
-            span.traceConfig());
+        listener.afterScopeActivated(span.getTraceId(), span.getSpanId());
       } catch (Throwable e) {
         ContinuableScopeManager.log.debug(
             "ExtendedScopeListener threw exception in afterActivated()", e);

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -270,11 +270,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     AgentSpan activeSpan = activeSpan();
     if (activeSpan != null && activeSpan != NoopAgentSpan.INSTANCE) {
       // Notify the listener about the currently active scope
-      listener.afterScopeActivated(
-          activeSpan.getTraceId(),
-          activeSpan.getLocalRootSpan().getSpanId(),
-          activeSpan.context().getSpanId(),
-          activeSpan.traceConfig());
+      listener.afterScopeActivated(activeSpan.getTraceId(), activeSpan.getSpanId());
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -3,7 +3,6 @@ package datadog.trace.core.scopemanager
 import datadog.trace.agent.test.utils.ThreadUtils
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.Stateful
-import datadog.trace.api.TraceConfig
 import datadog.trace.api.interceptor.MutableSpan
 import datadog.trace.api.interceptor.TraceInterceptor
 import datadog.trace.api.scopemanager.ExtendedScopeListener
@@ -1114,7 +1113,7 @@ class EventCountingExtendedListener implements ExtendedScopeListener {
   }
 
   @Override
-  void afterScopeActivated(DDTraceId traceId, long localRootSpanId, long spanId, TraceConfig traceConfig) {
+  void afterScopeActivated(DDTraceId traceId, long spanId) {
     synchronized (events) {
       events.add(ACTIVATE)
     }

--- a/internal-api/src/main/java/datadog/trace/api/scopemanager/ExtendedScopeListener.java
+++ b/internal-api/src/main/java/datadog/trace/api/scopemanager/ExtendedScopeListener.java
@@ -1,11 +1,9 @@
 package datadog.trace.api.scopemanager;
 
 import datadog.trace.api.DDTraceId;
-import datadog.trace.api.TraceConfig;
 
 public interface ExtendedScopeListener extends ScopeListener {
-  void afterScopeActivated(
-      DDTraceId traceId, long localRootSpanId, long spanId, TraceConfig traceConfig);
+  void afterScopeActivated(DDTraceId traceId, long spanId);
 
   /** Called just after a scope is closed. */
   @Override


### PR DESCRIPTION
# What Does This Do

This PR reduces the API of the `ExtendedScopeListener`.

It also replaces the implementation of the `LogContextScopeListener` to use the common `CorrelationIdentifier` that already support 128-bit TID correlation.


# Motivation

Limit the internal API to what’s needed.

# Additional Notes

Now, only CWS-TLS needs the `ExtendedScopeListener`.
I kept it for performance reason as it needs ID using the `long` form.

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
