### PR TITLE
Fix dependency lock update task

### DIFF
--- a/buildSrc/src/main/kotlin/datadog.dependency-locking.gradle.kts
+++ b/buildSrc/src/main/kotlin/datadog.dependency-locking.gradle.kts
@@ -25,8 +25,10 @@ tasks.register("resolveAndLockAll") {
   }
   doLast {
     configurations.filter {
-      // Add any custom filtering on the configurations to be resolved
-      it.isCanBeResolved
+      // Add any custom filtering on the configurations to be resolved:
+      // - Should be resolvable
+      // - Should skip Scala related task (https://github.com/ben-manes/gradle-versions-plugin/issues/816#issuecomment-1872264880)
+      it.isCanBeResolved && !it.name.startsWith("incrementalScalaAnalysis")
     }.forEach { it.resolve() }
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR fixes the dependency lock update by not running it on unresolvable Scala Gradle configuration.

# Motivation

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
