### PR TITLE
Update URI and URL call sites for precise taint tracking

### DIFF
--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URICallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URICallSite.java
@@ -1,9 +1,12 @@
 package datadog.trace.instrumentation.java.net;
 
+import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED;
+
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
+import datadog.trace.api.iast.propagation.CodecModule;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import java.net.URI;
 import javax.annotation.Nonnull;
@@ -17,10 +20,10 @@ public class URICallSite {
   public static URI afterCreate(
       @CallSite.Argument @Nullable final String value, @CallSite.Return @Nonnull final URI result) {
     if (value != null) {
-      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      final CodecModule module = InstrumentationBridge.CODEC;
       if (module != null) {
         try {
-          module.taintObjectIfTainted(result, value);
+          module.onUriCreate(result, value);
         } catch (final Throwable e) {
           module.onUnexpectedException("create threw", e);
         }
@@ -40,10 +43,10 @@ public class URICallSite {
   public static URI afterCtor(
       @CallSite.AllArguments final Object[] args, @CallSite.Return @Nonnull final URI result) {
     if (args != null && args.length > 0) {
-      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      final CodecModule module = InstrumentationBridge.CODEC;
       if (module != null) {
         try {
-          module.taintObjectIfAnyTainted(result, args);
+          module.onUriCreate(result, args);
         } catch (final Throwable e) {
           module.onUnexpectedException("ctor threw", e);
         }
@@ -52,14 +55,18 @@ public class URICallSite {
     return result;
   }
 
+  /**
+   * Internally the URI is tainted following the <code>toString</code> representation
+   *
+   * @see CodecModule#onUriCreate(URI, Object...)
+   */
   @CallSite.After("java.lang.String java.net.URI.toString()")
-  @CallSite.After("java.lang.String java.net.URI.toASCIIString()")
   public static String afterToString(
       @CallSite.This final URI url, @CallSite.Return final String result) {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
     if (module != null) {
       try {
-        module.taintStringIfTainted(result, url);
+        module.taintStringIfTainted(result, url, true, NOT_MARKED);
       } catch (final Throwable e) {
         module.onUnexpectedException("After toString threw", e);
       }
@@ -67,13 +74,31 @@ public class URICallSite {
     return result;
   }
 
+  /** @see #afterToString(URI, String) */
+  @CallSite.After("java.lang.String java.net.URI.toASCIIString()")
+  public static String afterToASCIIString(
+      @CallSite.This final URI url, @CallSite.Return final String result) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null && result != null) {
+      try {
+        boolean keepRanges = url.toString().equals(result);
+        module.taintStringIfTainted(result, url, keepRanges, NOT_MARKED);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After toASCIIString threw", e);
+      }
+    }
+    return result;
+  }
+
+  /** @see #afterToString(URI, String) */
   @CallSite.After("java.net.URI java.net.URI.normalize()")
   public static URI afterNormalize(
       @CallSite.This final URI url, @CallSite.Return final URI result) {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
-    if (module != null) {
+    if (module != null && result != null) {
       try {
-        module.taintObjectIfTainted(result, url);
+        boolean keepRanges = url.toString().equals(result.toString());
+        module.taintObjectIfTainted(result, url, keepRanges, NOT_MARKED);
       } catch (final Throwable e) {
         module.onUnexpectedException("After toString threw", e);
       }

--- a/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLCallSite.java
+++ b/dd-java-agent/instrumentation/java-net/src/main/java/datadog/trace/instrumentation/java/net/URLCallSite.java
@@ -1,11 +1,14 @@
 package datadog.trace.instrumentation.java.net;
 
+import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED;
+
 import datadog.trace.agent.tooling.csi.CallSite;
 import datadog.trace.api.iast.IastCallSites;
 import datadog.trace.api.iast.InstrumentationBridge;
 import datadog.trace.api.iast.Propagation;
 import datadog.trace.api.iast.Sink;
 import datadog.trace.api.iast.VulnerabilityTypes;
+import datadog.trace.api.iast.propagation.CodecModule;
 import datadog.trace.api.iast.propagation.PropagationModule;
 import datadog.trace.api.iast.sink.SsrfModule;
 import java.net.Proxy;
@@ -29,10 +32,10 @@ public class URLCallSite {
   public static URL afterCtor(
       @CallSite.AllArguments final Object[] args, @CallSite.Return @Nonnull final URL result) {
     if (args != null && args.length > 0) {
-      final PropagationModule module = InstrumentationBridge.PROPAGATION;
+      final CodecModule module = InstrumentationBridge.CODEC;
       if (module != null) {
         try {
-          module.taintObjectIfAnyTainted(result, args);
+          module.onUrlCreate(result, args);
         } catch (final Throwable e) {
           module.onUnexpectedException("ctor threw", e);
         }
@@ -41,15 +44,19 @@ public class URLCallSite {
     return result;
   }
 
+  /**
+   * Internally the URL is tainted following the <code>toString</code> representation
+   *
+   * @see CodecModule#onUrlCreate(URL, Object...)
+   */
   @Propagation
   @CallSite.After("java.lang.String java.net.URL.toString()")
-  @CallSite.After("java.lang.String java.net.URL.toExternalForm()")
   public static String afterToString(
       @CallSite.This final URL url, @CallSite.Return final String result) {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
-    if (module != null) {
+    if (module != null && result != null) {
       try {
-        module.taintStringIfTainted(result, url);
+        module.taintStringIfTainted(result, url, true, NOT_MARKED);
       } catch (final Throwable e) {
         module.onUnexpectedException("After toString threw", e);
       }
@@ -57,13 +64,32 @@ public class URLCallSite {
     return result;
   }
 
+  /** @see #afterToString(URL, String) */
+  @Propagation
+  @CallSite.After("java.lang.String java.net.URL.toExternalForm()")
+  public static String afterToExternalForm(
+      @CallSite.This final URL url, @CallSite.Return final String result) {
+    final PropagationModule module = InstrumentationBridge.PROPAGATION;
+    if (module != null && result != null) {
+      try {
+        boolean keepRanges = url.toString().equals(result);
+        module.taintStringIfTainted(result, url, keepRanges, NOT_MARKED);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("After toExternalForm threw", e);
+      }
+    }
+    return result;
+  }
+
+  /** @see #afterToString(URL, String) */
   @Propagation
   @CallSite.After("java.net.URI java.net.URL.toURI()")
   public static URI afterToURI(@CallSite.This final URL url, @CallSite.Return final URI result) {
     final PropagationModule module = InstrumentationBridge.PROPAGATION;
-    if (module != null) {
+    if (module != null && result != null) {
       try {
-        module.taintObjectIfTainted(result, url);
+        boolean keepRanges = url.toString().equals(result.toString());
+        module.taintObjectIfTainted(result, url, keepRanges, NOT_MARKED);
       } catch (final Throwable e) {
         module.onUnexpectedException("After toURI threw", e);
       }

--- a/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URLEncoderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-net/src/test/groovy/datadog/trace/instrumentation/java/net/URLEncoderCallSiteTest.groovy
@@ -2,7 +2,7 @@ package datadog.trace.instrumentation.java.net
 
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
-import datadog.trace.api.iast.VulnerabilityMarks
+import datadog.trace.api.iast.propagation.CodecModule
 import datadog.trace.api.iast.propagation.PropagationModule
 import foo.bar.TestURLEncoderCallSiteSuite
 
@@ -15,7 +15,7 @@ class URLEncoderCallSiteTest extends AgentTestRunner {
 
   def 'test encode with args: #args'() {
     setup:
-    final iastModule = Mock(PropagationModule)
+    final iastModule = Mock(CodecModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
@@ -23,7 +23,7 @@ class URLEncoderCallSiteTest extends AgentTestRunner {
 
     then:
     result == expected
-    1 * iastModule.taintStringIfTainted(_ as String, args[0], false, VulnerabilityMarks.XSS_MARK)
+    1 * iastModule.onUrlEncode(args[0], args.size() == 1 ? null : args[1], _ as String)
     0 * _
 
     where:

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/IastOkHttp2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/IastOkHttp2InstrumentationTest.groovy
@@ -2,6 +2,7 @@ import com.squareup.okhttp.OkHttpClient
 import com.squareup.okhttp.Request
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.iast.InstrumentationBridge
+import datadog.trace.api.iast.propagation.CodecModule
 import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.api.iast.sink.SsrfModule
 import datadog.trace.instrumentation.okhttp2.IastHttpUrlInstrumentation
@@ -61,18 +62,21 @@ class IastOkHttp2InstrumentationTest extends AgentTestRunner {
   }
 
   private void mockPropagation() {
-    final propagation = Mock(PropagationModule) {
-      taintObjectIfAnyTainted(_, _) >> {
-        if ((it[1] as List).any { input -> tainteds.containsKey(input) }) {
-          tainteds.put(it[0], null)
-        }
-      }
-      taintObjectIfTainted(_, _) >> {
-        if (tainteds.containsKey(it[1])) {
-          tainteds.put(it[0], null)
-        }
+    final Closure taint = { target, inputs ->
+      if (inputs.any { input -> tainteds.containsKey(input) }) {
+        tainteds.put(target, null)
       }
     }
+
+    final propagation = Mock(PropagationModule) {
+      taintStringIfTainted(_, _) >> { taint(it[0], [it[1]]) }
+      taintObjectIfTainted(_, _) >> { taint(it[0], [it[1]]) }
+    }
     InstrumentationBridge.registerIastModule(propagation)
+
+    final codec = Mock(CodecModule) {
+      onUrlCreate(_, _) >> { taint(it[0], it[1] as List) }
+    }
+    InstrumentationBridge.registerIastModule(codec)
   }
 }

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/IastOkHttp2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/IastOkHttp2InstrumentationTest.groovy
@@ -69,13 +69,13 @@ class IastOkHttp2InstrumentationTest extends AgentTestRunner {
     }
 
     final propagation = Mock(PropagationModule) {
-      taintStringIfTainted(_, _) >> { taint(it[0], [it[1]]) }
-      taintObjectIfTainted(_, _) >> { taint(it[0], [it[1]]) }
+      taintStringIfTainted(*_) >> { taint(it[0], [it[1]]) }
+      taintObjectIfTainted(*_) >> { taint(it[0], [it[1]]) }
     }
     InstrumentationBridge.registerIastModule(propagation)
 
     final codec = Mock(CodecModule) {
-      onUrlCreate(_, _) >> { taint(it[0], it[1] as List) }
+      onUrlCreate(*_) >> { taint(it[0], it[1] as List) }
     }
     InstrumentationBridge.registerIastModule(codec)
   }

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -248,14 +248,16 @@ public class IastWebController {
   }
 
   @PostMapping("/ssrf")
-  public String ssrf(@RequestParam("url") final String url) {
+  public String ssrf(
+      @RequestParam(value = "url", required = false) final String url,
+      @RequestParam(value = "host", required = false) final String host) {
     try {
-      final URL target = new URL(url);
+      final URL target = url != null ? new URL(url) : new URL("https", host, 443, "/test");
       final HttpURLConnection conn = (HttpURLConnection) target.openConnection();
       conn.disconnect();
     } catch (final Exception e) {
     }
-    return "Url is: " + url;
+    return "ok";
   }
 
   @GetMapping("/weak_randomness")

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -87,7 +87,7 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     !logHasErrors
   }
 
-  void 'Multipart Request parameters'(){
+  void 'Multipart Request parameters'() {
     given:
     String url = "http://localhost:${httpPort}/multipart"
 
@@ -114,7 +114,7 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
 
   }
 
-  void 'Multipart Request original file name'(){
+  void 'Multipart Request original file name'() {
     given:
     String url = "http://localhost:${httpPort}/multipart"
 
@@ -432,23 +432,23 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     hasVulnerability { vul -> vul.type == 'XSS' && vul.location.method == method }
 
     where:
-    method     | param
-    'write'    | 'test'
-    'write2'   | 'test'
-    'write3'   | 'test'
-    'write4'   | 'test'
-    'print'    | 'test'
-    'print2'   | 'test'
-    'println'  | 'test'
-    'println2' | 'test'
-    'printf'   | 'Formatted%20like%3A%20%251%24s%20and%20%252%24s.'
-    'printf2'  | 'test'
-    'printf3'  | 'Formatted%20like%3A%20%251%24s%20and%20%252%24s.'
-    'printf4'  | 'test'
-    'format'   | 'Formatted%20like%3A%20%251%24s%20and%20%252%24s.'
-    'format2'  | 'test'
-    'format3'  | 'Formatted%20like%3A%20%251%24s%20and%20%252%24s.'
-    'format4'  | 'test'
+    method         | param
+    'write'        | 'test'
+    'write2'       | 'test'
+    'write3'       | 'test'
+    'write4'       | 'test'
+    'print'        | 'test'
+    'print2'       | 'test'
+    'println'      | 'test'
+    'println2'     | 'test'
+    'printf'       | 'Formatted%20like%3A%20%251%24s%20and%20%252%24s.'
+    'printf2'      | 'test'
+    'printf3'      | 'Formatted%20like%3A%20%251%24s%20and%20%252%24s.'
+    'printf4'      | 'test'
+    'format'       | 'Formatted%20like%3A%20%251%24s%20and%20%252%24s.'
+    'format2'      | 'test'
+    'format3'      | 'Formatted%20like%3A%20%251%24s%20and%20%252%24s.'
+    'format4'      | 'test'
     'responseBody' | 'test'
   }
 
@@ -681,14 +681,35 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
   void 'ssrf is present'() {
     setup:
     final url = "http://localhost:${httpPort}/ssrf"
-    final body = new FormBody.Builder().add('url', 'https://dd.datad0g.com/').build()
+    final body = new FormBody.Builder().add(parameter, value).build()
     final request = new Request.Builder().url(url).post(body).build()
 
     when:
     client.newCall(request).execute()
 
     then:
-    hasVulnerability { vul -> vul.type == 'SSRF' }
+    hasVulnerability { vul ->
+      if (vul.type = !'SSRF') {
+        return false
+      }
+      final parts = vul.evidence.valueParts
+      if (parameter == 'url') {
+        return parts.size() == 1
+        && parts[0].value == value && parts[0].source.origin == 'http.request.parameter' && parts[0].source.name == parameter
+      } else if (parameter == 'host') {
+        return parts.size() == 3
+        && parts[0].value == 'https://' && parts[0].source == null
+        && parts[1].value == value && parts[1].source.origin == 'http.request.parameter' && parts[1].source.name == parameter
+        && parts[2].value == ':443/test' && parts[2].source == null
+      } else {
+        throw new IllegalArgumentException("Parameter $parameter not supported")
+      }
+    }
+
+    where:
+    parameter | value
+    'url'     | 'https://dd.datad0g.com/'
+    'host'    | 'dd.datad0g.com'
   }
 
   void 'test iast metrics stored in spans'() {
@@ -855,7 +876,7 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     }
   }
 
-  void 'header injection'(){
+  void 'header injection'() {
     setup:
     final url = "http://localhost:${httpPort}/header_injection?param=test"
     final request = new Request.Builder().url(url).get().build()
@@ -867,7 +888,7 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     hasVulnerability { vul -> vul.type == 'HEADER_INJECTION' }
   }
 
-  void 'header injection exclusion'(){
+  void 'header injection exclusion'() {
     setup:
     final url = "http://localhost:${httpPort}/header_injection_exclusion?param=testExclusion"
     final request = new Request.Builder().url(url).get().build()
@@ -876,10 +897,10 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    noVulnerability { vul -> vul.type == 'HEADER_INJECTION'}
+    noVulnerability { vul -> vul.type == 'HEADER_INJECTION' }
   }
 
-  void 'header injection redaction'(){
+  void 'header injection redaction'() {
     setup:
     String bearer = URLEncoder.encode("Authorization: bearer 12345644", "UTF-8")
     final url = "http://localhost:${httpPort}/header_injection_redaction?param=" + bearer
@@ -914,7 +935,8 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    hasVulnerability { vul -> vul.type == 'REFLECTION_INJECTION'
+    hasVulnerability { vul ->
+      vul.type == 'REFLECTION_INJECTION'
       && vul.location.method == 'reflectionInjectionClass'
       && vul.evidence.valueParts[0].value == "java.lang.String"
     }
@@ -929,7 +951,8 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    hasVulnerability { vul -> vul.type == 'REFLECTION_INJECTION'
+    hasVulnerability { vul ->
+      vul.type == 'REFLECTION_INJECTION'
       && vul.location.method == 'reflectionInjectionMethod'
       && vul.evidence.valueParts[0].value == "java.lang.String#"
       && vul.evidence.valueParts[1].value == "isEmpty"
@@ -946,7 +969,8 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    hasVulnerability { vul -> vul.type == 'REFLECTION_INJECTION'
+    hasVulnerability { vul ->
+      vul.type == 'REFLECTION_INJECTION'
       && vul.location.method == 'reflectionInjectionField'
       && vul.evidence.valueParts[0].value == "java.lang.String#"
       && vul.evidence.valueParts[1].value == "hash"
@@ -962,7 +986,8 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     client.newCall(request).execute()
 
     then:
-    hasVulnerability { vul -> vul.type == 'REFLECTION_INJECTION'
+    hasVulnerability { vul ->
+      vul.type == 'REFLECTION_INJECTION'
       && vul.location.method == 'reflectionInjectionLookup'
       && vul.evidence.valueParts[0].value == "java.lang.String#"
       && vul.evidence.valueParts[1].value == "hash"
@@ -982,7 +1007,6 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
       vul.type == 'SESSION_REWRITING'
     }
   }
-
 
 
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/CodecModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/CodecModule.java
@@ -1,12 +1,20 @@
 package datadog.trace.api.iast.propagation;
 
 import datadog.trace.api.iast.IastModule;
+import java.net.URI;
+import java.net.URL;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface CodecModule extends IastModule {
 
   void onUrlDecode(@Nonnull String value, @Nullable String encoding, @Nonnull String result);
+
+  void onUrlEncode(@Nonnull String value, @Nullable String encoding, @Nonnull String result);
+
+  void onUriCreate(@Nonnull URI result, Object... args);
+
+  void onUrlCreate(@Nonnull URL result, Object... args);
 
   void onStringFromBytes(
       @Nonnull byte[] value,


### PR DESCRIPTION
# What Does This Do
Updates the URL and URI call sites to ensure that we keep tracking of the different ranges on a best effort basis.

# Motivation
SSRF vulnerability has different scores depending on the part of the url that is coming from an external source (e.g. the host is the most important part to track as it gives big room for attacks).

# Additional Notes

Jira ticket: [APPSEC-53838]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-53838]: https://datadoghq.atlassian.net/browse/APPSEC-53838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ