### PR TITLE
Create new ranges for vulns to prevent GC issues

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Evidence.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Evidence.java
@@ -29,7 +29,7 @@ public final class Evidence {
 
   public Evidence(@Nonnull final String value, @Nullable final Range[] ranges) {
     this.value = value;
-    this.ranges = ranges;
+    this.ranges = consolidate(ranges);
   }
 
   @Nonnull
@@ -59,6 +59,23 @@ public final class Evidence {
   public int hashCode() {
     int result = Objects.hash(value);
     result = 31 * result + Arrays.hashCode(ranges);
+    return result;
+  }
+
+  /**
+   * This method ensures that once a vulnerability has been found, all of it range names and values
+   * are strongly reachable preventing the GC from freeing them before the vul is reported. The
+   * newly created ranges have a lifespan equal to the target vulnerability.
+   */
+  @Nullable
+  private static Range[] consolidate(@Nullable final Range[] ranges) {
+    if (ranges == null || ranges.length == 0) {
+      return ranges;
+    }
+    final Range[] result = new Range[ranges.length];
+    for (int i = 0; i < ranges.length; i++) {
+      result[i] = ranges[i].consolidate();
+    }
     return result;
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Range.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Range.java
@@ -82,4 +82,13 @@ public final class Range implements Ranged {
   public boolean isMarked(final int mark) {
     return (marks & mark) != NOT_MARKED;
   }
+
+  /** Creates a version of the range without weak references to be used in vulnerabilities */
+  public Range consolidate() {
+    if (!source.isReference()) {
+      return this;
+    }
+    return new Range(
+        start, length, new Source(source.getOrigin(), source.getName(), source.getValue()), marks);
+  }
 }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/PropagationModuleImpl.java
@@ -780,7 +780,7 @@ public class PropagationModuleImpl implements PropagationModule {
       ((Taintable) value).$$DD$setSource(source);
     } else {
       if (value instanceof CharSequence) {
-        source = source.attachValue((CharSequence) value);
+        source = attachSourceValue(source, (CharSequence) value);
         to.taint(value, Ranges.forCharSequence((CharSequence) value, source, mark));
       } else {
         to.taint(value, Ranges.forObject(source, mark));
@@ -796,7 +796,7 @@ public class PropagationModuleImpl implements PropagationModule {
     if (source == null) {
       return;
     }
-    source = source.attachValue(value);
+    source = attachSourceValue(source, value);
     to.taint(value, Ranges.forCharSequence(value, source, mark));
   }
 
@@ -865,6 +865,11 @@ public class PropagationModuleImpl implements PropagationModule {
     return result;
   }
 
+  private static Source attachSourceValue(final Source source, final CharSequence value) {
+    final Object newValue = sourceReference(value, value, true);
+    return newValue == null ? source : source.attachValue(newValue);
+  }
+
   private static Range[] attachSourceValue(
       @Nonnull final Range[] ranges, @Nonnull final CharSequence value) {
     // unbound sources can only occur when there's a single range in the array
@@ -873,7 +878,7 @@ public class PropagationModuleImpl implements PropagationModule {
     }
     final Range range = ranges[0];
     final Source source = range.getSource();
-    final Source newSource = range.getSource().attachValue(value);
+    final Source newSource = attachSourceValue(source, value);
     return newSource == source
         ? ranges
         : Ranges.forCharSequence(value, newSource, range.getMarks());

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/EvidenceTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/EvidenceTest.groovy
@@ -1,6 +1,14 @@
 package com.datadog.iast.model
 
+import com.datadog.iast.model.json.VulnerabilityEncoding
+import datadog.trace.api.iast.SourceTypes
 import datadog.trace.test.util.DDSpecification
+import groovy.json.JsonSlurper
+
+import java.lang.ref.Reference
+import java.lang.ref.WeakReference
+
+import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED
 
 class EvidenceTest extends DDSpecification {
 
@@ -26,5 +34,37 @@ class EvidenceTest extends DDSpecification {
 
     then:
     override
+  }
+
+  void 'test that evidences are consolidated preventing the GC from clearing data'() {
+    given:
+    final String name = "Hello world!"
+    final Reference<?> ref = new WeakReference<>(name)
+
+    when:
+    final source = new Source(SourceTypes.REQUEST_PARAMETER_NAME, ref, "a random value")
+    final batch = vulnBatchForSource(source)
+
+    then:
+    source.getName() == name
+    final parsedBefore = new JsonSlurper().parseText(VulnerabilityEncoding.toJson(batch))
+    parsedBefore["sources"][0]["name"] == name
+
+    when:
+    ref.clear()
+
+    then:
+    source.getName() == Source.GARBAGE_COLLECTED_REF
+    final parsedAfter = new JsonSlurper().parseText(VulnerabilityEncoding.toJson(batch))
+    parsedAfter["sources"][0]["name"] == name
+  }
+
+  private static VulnerabilityBatch vulnBatchForSource(final Source source) {
+    final location = Location.forClassAndMethodAndLine(EvidenceTest.name, 'vulnBatchForSource', 69)
+    final evidence = new Evidence("test", [new Range(0, 4, source, NOT_MARKED)] as Range[])
+    final vuln = new Vulnerability(VulnerabilityType.INSECURE_COOKIE, location, evidence)
+    final batch = new VulnerabilityBatch()
+    batch.add(vuln)
+    return batch
   }
 }


### PR DESCRIPTION
# What Does This Do

Creates new ranges without weak references for evidences in vulnerabilities

# Motivation

Before the vulnerability is written to the span in the end of the request, there's still the chance that the original value is GCed causing flaky tests in our pipelines.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
