### PR TITLE
Add high rate queue for log template snapshots

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -7,10 +7,13 @@ import com.datadog.debugger.exception.DefaultExceptionDebugger;
 import com.datadog.debugger.exception.ExceptionProbeManager;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
+import com.datadog.debugger.sink.SnapshotSink;
+import com.datadog.debugger.sink.SymbolSink;
 import com.datadog.debugger.symbol.SymDBEnablement;
 import com.datadog.debugger.symbol.SymbolAggregator;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.ClassNameFiltering;
+import com.datadog.debugger.util.DebuggerMetrics;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.remoteconfig.ConfigurationPoller;
@@ -19,7 +22,9 @@ import datadog.trace.api.Config;
 import datadog.trace.api.flare.TracerFlare;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.util.Redaction;
+import datadog.trace.core.DDTraceCoreInfo;
 import datadog.trace.util.SizeCheckedInputStream;
+import datadog.trace.util.TagsHelper;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -30,6 +35,7 @@ import java.lang.ref.WeakReference;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.stream.Collectors;
 import java.util.zip.ZipOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +69,7 @@ public class DebuggerAgent {
     ProbeStatusSink probeStatusSink =
         new ProbeStatusSink(
             config, diagnosticEndpoint, ddAgentFeaturesDiscovery.supportsDebuggerDiagnostics());
-    DebuggerSink debuggerSink = new DebuggerSink(config, probeStatusSink);
+    DebuggerSink debuggerSink = createDebuggerSink(config, probeStatusSink);
     debuggerSink.start();
     ClassNameFiltering classNameFiltering = new ClassNameFiltering(config);
     ConfigurationUpdater configurationUpdater =
@@ -122,9 +128,7 @@ public class DebuggerAgent {
         Note: shutdown hooks are tricky because JVM holds reference for them forever preventing
         GC for anything that is reachable from it.
          */
-        Runtime.getRuntime()
-            .addShutdownHook(
-                new ShutdownHook(configurationPoller, debuggerSink.getSnapshotUploader()));
+        Runtime.getRuntime().addShutdownHook(new ShutdownHook(configurationPoller, debuggerSink));
       } catch (final IllegalStateException ex) {
         // The JVM is already shutting down.
       }
@@ -137,6 +141,39 @@ public class DebuggerAgent {
             : null;
     TracerFlare.addReporter(
         new DebuggerReporter(configurationUpdater, sink, exceptionProbeManager));
+  }
+
+  private static DebuggerSink createDebuggerSink(Config config, ProbeStatusSink probeStatusSink) {
+    String tags = getDefaultTagsMergedWithGlobalTags(config);
+    SnapshotSink snapshotSink =
+        new SnapshotSink(
+            config, tags, new BatchUploader(config, config.getFinalDebuggerSnapshotUrl()));
+    SymbolSink symbolSink = new SymbolSink(config);
+    return new DebuggerSink(
+        config,
+        tags,
+        DebuggerMetrics.getInstance(config),
+        probeStatusSink,
+        snapshotSink,
+        symbolSink);
+  }
+
+  public static String getDefaultTagsMergedWithGlobalTags(Config config) {
+    String debuggerTags =
+        TagsHelper.concatTags(
+            "env:" + config.getEnv(),
+            "version:" + config.getVersion(),
+            "debugger_version:" + DDTraceCoreInfo.VERSION,
+            "agent_version:" + DebuggerAgent.getAgentVersion(),
+            "host_name:" + config.getHostName());
+    if (config.getGlobalTags().isEmpty()) {
+      return debuggerTags;
+    }
+    String globalTags =
+        config.getGlobalTags().entrySet().stream()
+            .map(e -> e.getKey() + ":" + e.getValue())
+            .collect(Collectors.joining(","));
+    return debuggerTags + "," + globalTags;
   }
 
   private static String getDiagnosticEndpoint(
@@ -245,12 +282,12 @@ public class DebuggerAgent {
   private static class ShutdownHook extends Thread {
 
     private final WeakReference<ConfigurationPoller> pollerRef;
-    private final WeakReference<BatchUploader> uploaderRef;
+    private final WeakReference<DebuggerSink> sinkRef;
 
-    private ShutdownHook(ConfigurationPoller poller, BatchUploader uploader) {
+    private ShutdownHook(ConfigurationPoller poller, DebuggerSink debuggerSink) {
       super(AGENT_THREAD_GROUP, "dd-debugger-shutdown-hook");
       pollerRef = new WeakReference<>(poller);
-      uploaderRef = new WeakReference<>(uploader);
+      sinkRef = new WeakReference<>(debuggerSink);
     }
 
     @Override
@@ -264,10 +301,10 @@ public class DebuggerAgent {
         }
       }
 
-      final BatchUploader uploader = uploaderRef.get();
-      if (uploader != null) {
+      final DebuggerSink sink = sinkRef.get();
+      if (sink != null) {
         try {
-          uploader.shutdown();
+          sink.stop();
         } catch (Exception ex) {
           LOGGER.warn("Failed to shutdown SnapshotUploader", ex);
         }
@@ -296,7 +333,7 @@ public class DebuggerAgent {
           String.join(
               System.lineSeparator(),
               "Snapshot url: ",
-              sink.getSnapshotUploader().getUrl().toString(),
+              sink.getSnapshotSink().getUrl().toString(),
               "Diagnostic url: ",
               sink.getProbeStatusSink().getUrl().toString(),
               "SymbolDB url: ",

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -15,7 +15,11 @@ import com.datadog.debugger.probe.SpanProbe;
 import com.datadog.debugger.probe.Where;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
+import com.datadog.debugger.sink.SnapshotSink;
+import com.datadog.debugger.sink.SymbolSink;
+import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.ClassFileLines;
+import com.datadog.debugger.util.DebuggerMetrics;
 import com.datadog.debugger.util.ExceptionHelper;
 import datadog.trace.agent.tooling.AgentStrategies;
 import datadog.trace.api.Config;
@@ -117,7 +121,13 @@ public class DebuggerTransformer implements ClassFileTransformer {
         configuration,
         null,
         new DebuggerSink(
-            config, new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false)));
+            config,
+            "",
+            DebuggerMetrics.getInstance(config),
+            new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false),
+            new SnapshotSink(
+                config, "", new BatchUploader(config, config.getFinalDebuggerSnapshotUrl())),
+            new SymbolSink(config)));
   }
 
   private void readExcludeFiles(String commaSeparatedFileNames) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -535,8 +535,10 @@ public class LogProbe extends ProbeDefinition {
      */
     if (isCaptureSnapshot()) {
       snapshot.recordStackTrace(5);
+      sink.addSnapshot(snapshot);
+    } else {
+      sink.addHighRateSnapshot(snapshot);
     }
-    sink.addSnapshot(snapshot);
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -1,85 +1,60 @@
 package com.datadog.debugger.sink;
 
-import com.datadog.debugger.agent.DebuggerAgent;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.DebuggerMetrics;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.ProbeId;
-import datadog.trace.core.DDTraceCoreInfo;
 import datadog.trace.util.AgentTaskScheduler;
-import datadog.trace.util.TagsHelper;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Collects data that needs to be sent to the backend: Snapshots, metrics and statuses */
 public class DebuggerSink {
-  private static final Logger log = LoggerFactory.getLogger(DebuggerSink.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DebuggerSink.class);
   private static final double FREE_CAPACITY_LOWER_THRESHOLD = 0.25;
   private static final double FREE_CAPACITY_UPPER_THRESHOLD = 0.75;
-  private static final int MIN_FLUSH_INTERVAL = 100;
-  private static final int MAX_FLUSH_INTERVAL = 2000;
-  private static final long INITIAL_FLUSH_INTERVAL = 1000;
+  private static final int LOW_RATE_MIN_FLUSH_INTERVAL = 100;
+  private static final int LOW_RATE_MAX_FLUSH_INTERVAL = 2000;
+  private static final long LOW_RATE_INITIAL_FLUSH_INTERVAL = 1000;
+  static final long LOW_RATE_STEP_SIZE = 200;
   private static final String PREFIX = "debugger.sink.";
-  private static final int CAPACITY = 1000;
-  static final long STEP_SIZE = 200;
 
   private final ProbeStatusSink probeStatusSink;
   private final SnapshotSink snapshotSink;
   private final SymbolSink symbolSink;
   private final DebuggerMetrics debuggerMetrics;
-  private final BatchUploader snapshotUploader;
   private final String tags;
+  private final AtomicLong highRateDropped = new AtomicLong();
   private final int uploadFlushInterval;
-
-  private volatile AgentTaskScheduler.Scheduled<DebuggerSink> scheduled;
+  private final AgentTaskScheduler lowRateScheduler = AgentTaskScheduler.INSTANCE;
+  private volatile AgentTaskScheduler.Scheduled<DebuggerSink> lowRateScheduled;
   private volatile AgentTaskScheduler.Scheduled<DebuggerSink> flushIntervalScheduled;
-  private volatile long currentFlushInterval = INITIAL_FLUSH_INTERVAL;
+  private volatile long currentLowRateFlushInterval = LOW_RATE_INITIAL_FLUSH_INTERVAL;
 
   public DebuggerSink(Config config, ProbeStatusSink probeStatusSink) {
     this(
         config,
-        new BatchUploader(config, config.getFinalDebuggerSnapshotUrl()),
+        null,
         DebuggerMetrics.getInstance(config),
         probeStatusSink,
-        new SnapshotSink(config),
-        new SymbolSink(config));
-  }
-
-  // Used only for tests
-  DebuggerSink(Config config, ProbeStatusSink probeStatusSink, BatchUploader snapshotUploader) {
-    this(
-        config,
-        snapshotUploader,
-        DebuggerMetrics.getInstance(config),
-        probeStatusSink,
-        new SnapshotSink(config),
-        new SymbolSink(config));
-  }
-
-  DebuggerSink(Config config, BatchUploader snapshotUploader, DebuggerMetrics debuggerMetrics) {
-    this(
-        config,
-        snapshotUploader,
-        debuggerMetrics,
-        new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false),
-        new SnapshotSink(config),
+        new SnapshotSink(
+            config, null, new BatchUploader(config, config.getFinalDebuggerSnapshotUrl())),
         new SymbolSink(config));
   }
 
   public DebuggerSink(
       Config config,
-      BatchUploader snapshotUploader,
+      String tags,
       DebuggerMetrics debuggerMetrics,
       ProbeStatusSink probeStatusSink,
       SnapshotSink snapshotSink,
       SymbolSink symbolSink) {
-    this.snapshotUploader = snapshotUploader;
-    tags = getDefaultTagsMergedWithGlobalTags(config);
+    this.tags = tags;
     this.debuggerMetrics = debuggerMetrics;
     this.probeStatusSink = probeStatusSink;
     this.snapshotSink = snapshotSink;
@@ -87,51 +62,36 @@ public class DebuggerSink {
     this.uploadFlushInterval = config.getDebuggerUploadFlushInterval();
   }
 
-  private static String getDefaultTagsMergedWithGlobalTags(Config config) {
-    String debuggerTags =
-        TagsHelper.concatTags(
-            "env:" + config.getEnv(),
-            "version:" + config.getVersion(),
-            "debugger_version:" + DDTraceCoreInfo.VERSION,
-            "agent_version:" + DebuggerAgent.getAgentVersion(),
-            "host_name:" + config.getHostName());
-    if (config.getGlobalTags().isEmpty()) {
-      return debuggerTags;
-    }
-    String globalTags =
-        config.getGlobalTags().entrySet().stream()
-            .map(e -> e.getKey() + ":" + e.getValue())
-            .collect(Collectors.joining(","));
-    return debuggerTags + "," + globalTags;
-  }
-
   public void start() {
     if (uploadFlushInterval == 0) {
       flushIntervalScheduled =
-          AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
-              this::reconsiderFlushInterval, this, 0, 200, TimeUnit.MILLISECONDS);
+          lowRateScheduler.scheduleAtFixedRate(
+              this::reconsiderLowRateFlushInterval, this, 0, 200, TimeUnit.MILLISECONDS);
     } else {
-      currentFlushInterval = uploadFlushInterval;
+      currentLowRateFlushInterval = uploadFlushInterval;
     }
-    scheduled =
-        AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
-            this::flush, this, 0, currentFlushInterval, TimeUnit.MILLISECONDS);
+    lowRateScheduled =
+        lowRateScheduler.scheduleAtFixedRate(
+            this::lowRateFlush, this, 0, currentLowRateFlushInterval, TimeUnit.MILLISECONDS);
+    snapshotSink.start();
   }
 
   public void stop() {
-    AgentTaskScheduler.Scheduled<DebuggerSink> localScheduled = this.scheduled;
-    if (localScheduled != null) {
-      localScheduled.cancel();
-    }
-    AgentTaskScheduler.Scheduled<DebuggerSink> localFlushIntervalScheduled =
-        this.flushIntervalScheduled;
-    if (localFlushIntervalScheduled != null) {
-      localFlushIntervalScheduled.cancel();
+    cancelSchedule(this.flushIntervalScheduled);
+    cancelSchedule(this.lowRateScheduled);
+    probeStatusSink.stop();
+    symbolSink.stop();
+    snapshotSink.stop();
+  }
+
+  private void cancelSchedule(AgentTaskScheduler.Scheduled<DebuggerSink> scheduled) {
+    if (scheduled != null) {
+      scheduled.cancel();
     }
   }
 
-  public BatchUploader getSnapshotUploader() {
-    return snapshotUploader;
+  public SnapshotSink getSnapshotSink() {
+    return snapshotSink;
   }
 
   public ProbeStatusSink getProbeStatusSink() {
@@ -143,9 +103,21 @@ public class DebuggerSink {
   }
 
   public void addSnapshot(Snapshot snapshot) {
-    boolean added = snapshotSink.offer(snapshot);
+    boolean added = snapshotSink.addLowRate(snapshot);
     if (!added) {
       debuggerMetrics.count(PREFIX + "dropped.requests", 1);
+    } else {
+      probeStatusSink.addEmitting(snapshot.getProbe().getProbeId());
+    }
+  }
+
+  public void addHighRateSnapshot(Snapshot snapshot) {
+    boolean added = snapshotSink.addHighRate(snapshot);
+    if (!added) {
+      long dropped = highRateDropped.incrementAndGet();
+      if (dropped % 100 == 0) {
+        debuggerMetrics.count(PREFIX + "dropped.requests", 100);
+      }
     } else {
       probeStatusSink.addEmitting(snapshot.getProbe().getProbeId());
     }
@@ -155,58 +127,48 @@ public class DebuggerSink {
     return probeStatusSink;
   }
 
-  private void reschedule() {
-    AgentTaskScheduler.Scheduled<DebuggerSink> localScheduled = this.scheduled;
-    if (localScheduled != null) {
-      localScheduled.cancel();
-    }
-    this.scheduled =
-        AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
-            this::flush, this, currentFlushInterval, currentFlushInterval, TimeUnit.MILLISECONDS);
+  private void lowRateReschedule() {
+    cancelSchedule(this.lowRateScheduled);
+    LOGGER.debug("Rescheduling low rate debugger sink flush to {}ms", currentLowRateFlushInterval);
+    this.lowRateScheduled =
+        lowRateScheduler.scheduleAtFixedRate(
+            this::lowRateFlush,
+            this,
+            currentLowRateFlushInterval,
+            currentLowRateFlushInterval,
+            TimeUnit.MILLISECONDS);
   }
 
   // visible for testing
-  void flush(DebuggerSink ignored) {
+  void lowRateFlush(DebuggerSink ignored) {
     symbolSink.flush();
     probeStatusSink.flush(tags);
-    List<String> snapshots = snapshotSink.getSerializedSnapshots();
-    if (snapshots.isEmpty()) {
-      return;
-    }
-    if (snapshots.size() > 0) {
-      uploadPayloads(snapshots);
-    }
+    snapshotSink.lowRateFlush(tags);
   }
 
-  private void uploadPayloads(List<String> payloads) {
-    List<byte[]> batches = IntakeBatchHelper.createBatches(payloads);
-    for (byte[] batch : batches) {
-      snapshotUploader.upload(batch, tags);
-    }
-  }
-
-  private void reconsiderFlushInterval(DebuggerSink debuggerSink) {
+  private void reconsiderLowRateFlushInterval(DebuggerSink debuggerSink) {
     debuggerMetrics.histogram(
         PREFIX + "upload.queue.remaining.capacity", snapshotSink.remainingCapacity());
-    debuggerMetrics.histogram(PREFIX + "current.flush.interval", currentFlushInterval);
-    doReconsiderFlushInterval();
+    debuggerMetrics.histogram(PREFIX + "current.flush.interval", currentLowRateFlushInterval);
+    doReconsiderLowRateFlushInterval();
   }
 
-  void doReconsiderFlushInterval() {
-    double remainingCapacityPercent = snapshotSink.remainingCapacity() * 1D / CAPACITY;
-    long currentInterval = currentFlushInterval;
+  void doReconsiderLowRateFlushInterval() {
+    double remainingCapacityPercent =
+        snapshotSink.remainingCapacity() * 1D / SnapshotSink.LOW_RATE_CAPACITY;
+    long currentInterval = currentLowRateFlushInterval;
     long newInterval = currentInterval;
     if (remainingCapacityPercent <= FREE_CAPACITY_LOWER_THRESHOLD) {
-      newInterval = Math.max(currentInterval - STEP_SIZE, MIN_FLUSH_INTERVAL);
+      newInterval = Math.max(currentInterval - LOW_RATE_STEP_SIZE, LOW_RATE_MIN_FLUSH_INTERVAL);
     } else if (remainingCapacityPercent >= FREE_CAPACITY_UPPER_THRESHOLD) {
-      newInterval = Math.min(currentInterval + STEP_SIZE, MAX_FLUSH_INTERVAL);
+      newInterval = Math.min(currentInterval + LOW_RATE_STEP_SIZE, LOW_RATE_MAX_FLUSH_INTERVAL);
     }
     if (newInterval != currentInterval) {
-      currentFlushInterval = newInterval;
-      log.debug(
+      currentLowRateFlushInterval = newInterval;
+      LOGGER.debug(
           "Changing flush interval. Remaining available capacity in upload queue {}%, new flush interval {}ms",
-          remainingCapacityPercent * 100, currentInterval);
-      reschedule();
+          remainingCapacityPercent * 100, newInterval);
+      lowRateReschedule();
     }
   }
 
@@ -230,13 +192,13 @@ public class DebuggerSink {
     for (DiagnosticMessage msg : messages) {
       switch (msg.getKind()) {
         case INFO:
-          log.info(msg.getMessage());
+          LOGGER.info(msg.getMessage());
           break;
         case WARN:
-          log.warn(msg.getMessage());
+          LOGGER.warn(msg.getMessage());
           break;
         case ERROR:
-          log.error(msg.getMessage());
+          LOGGER.error(msg.getMessage());
           reportError(probeId, msg);
           break;
       }
@@ -269,7 +231,7 @@ public class DebuggerSink {
     debuggerMetrics.incrementCounter(PREFIX + "skip", causeTag, probeIdTag);
   }
 
-  long getCurrentFlushInterval() {
-    return currentFlushInterval;
+  long getCurrentLowRateFlushInterval() {
+    return currentLowRateFlushInterval;
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -153,6 +153,11 @@ public class DebuggerSink {
     doReconsiderLowRateFlushInterval();
   }
 
+  // Depending on the remaining capacity in the upload queue, we adjust the flush interval
+  // to avoid filling the queue if we are waiting too long between flushes.
+  // We are using 2 thresholds to adjust the flush interval:
+  // - if the remaining capacity is below the lower threshold, we decrease the flush interval
+  // - if the remaining capacity is above the upper threshold, we increase the flush interval
   void doReconsiderLowRateFlushInterval() {
     double remainingCapacityPercent =
         snapshotSink.remainingCapacity() * 1D / SnapshotSink.LOW_RATE_CAPACITY;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -52,6 +52,10 @@ public class ProbeStatusSink {
     this.isInstrumentTheWorld = config.isDebuggerInstrumentTheWorld();
   }
 
+  public void stop() {
+    diagnosticUploader.shutdown();
+  }
+
   public void addReceived(ProbeId probeId) {
     addDiagnostics(messageBuilder.receivedMessage(probeId));
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
@@ -1,46 +1,175 @@
 package com.datadog.debugger.sink;
 
 import com.datadog.debugger.agent.DebuggerAgent;
+import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.ExceptionHelper;
 import com.datadog.debugger.util.SnapshotPruner;
 import datadog.trace.api.Config;
-import datadog.trace.relocate.api.RatelimitedLogger;
+import datadog.trace.util.AgentTaskScheduler;
+import datadog.trace.util.AgentThreadFactory;
 import datadog.trace.util.TagsHelper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import okhttp3.HttpUrl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Collects snapshots that needs to be sent to the backend */
 public class SnapshotSink {
   private static final Logger LOGGER = LoggerFactory.getLogger(SnapshotSink.class);
-  private static final int CAPACITY = 1000;
   public static final int MAX_SNAPSHOT_SIZE = 1024 * 1024;
-  private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
+  public static final int LOW_RATE_CAPACITY = 1024;
+  static final int HIGH_RATE_MIN_FLUSH_INTERVAL = 1;
+  static final int HIGH_RATE_MAX_FLUSH_INTERVAL = 100;
+  private static final int HIGH_RATE_CAPACITY = 1024;
+  static final long HIGH_RATE_STEP_SIZE = 10;
 
-  private final BlockingQueue<Snapshot> snapshots = new ArrayBlockingQueue<>(CAPACITY);
+  private final BlockingQueue<Snapshot> lowRateSnapshots =
+      new ArrayBlockingQueue<>(LOW_RATE_CAPACITY);
+  private final BlockingQueue<Snapshot> highRateSnapshots =
+      new ArrayBlockingQueue<>(HIGH_RATE_CAPACITY);
   private final String serviceName;
   private final int batchSize;
-  private final RatelimitedLogger ratelimitedLogger =
-      new RatelimitedLogger(LOGGER, MINUTES_BETWEEN_ERROR_LOG, TimeUnit.MINUTES);
+  private final String tags;
+  private final BatchUploader snapshotUploader;
+  private final AgentTaskScheduler highRateScheduler =
+      new AgentTaskScheduler(AgentThreadFactory.AgentThread.DEBUGGER_SNAPSHOT_SERIALIZER);
+  private final AtomicBoolean started = new AtomicBoolean();
+  private volatile AgentTaskScheduler.Scheduled<SnapshotSink> highRateScheduled;
+  private volatile long currentHighRateFlushInterval = HIGH_RATE_MAX_FLUSH_INTERVAL;
 
-  public SnapshotSink(Config config) {
+  public SnapshotSink(Config config, String tags, BatchUploader snapshotUploader) {
     this.serviceName = TagsHelper.sanitize(config.getServiceName());
     this.batchSize = config.getDebuggerUploadBatchSize();
+    this.tags = tags;
+    this.snapshotUploader = snapshotUploader;
   }
 
-  public List<String> getSerializedSnapshots() {
+  public void start() {
+    if (started.compareAndSet(false, true)) {
+      highRateScheduled =
+          highRateScheduler.scheduleAtFixedRate(
+              this::highRateFlush, this, 0, currentHighRateFlushInterval, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  public void stop() {
+    AgentTaskScheduler.Scheduled<SnapshotSink> localScheduled = this.highRateScheduled;
+    if (localScheduled != null) {
+      localScheduled.cancel();
+    }
+    snapshotUploader.shutdown();
+    started.set(false);
+  }
+
+  public void lowRateFlush(String tags) {
+    List<String> snapshots = getSerializedSnapshots(lowRateSnapshots, batchSize);
+    if (snapshots.isEmpty()) {
+      return;
+    }
+    uploadPayloads(snapshots, tags);
+  }
+
+  public void highRateFlush(SnapshotSink ignored) {
+    do {
+      List<String> snapshots = getSerializedSnapshots(highRateSnapshots, HIGH_RATE_CAPACITY);
+      if (snapshots.isEmpty()) {
+        backOffHighRateFlush();
+        return;
+      }
+      int count = snapshots.size();
+      reconsiderHighRateFlushInterval(count);
+      uploadPayloads(snapshots, tags);
+    } while (!highRateSnapshots.isEmpty());
+  }
+
+  public HttpUrl getUrl() {
+    return snapshotUploader.getUrl();
+  }
+
+  public long remainingCapacity() {
+    return lowRateSnapshots.remainingCapacity();
+  }
+
+  public boolean addLowRate(Snapshot snapshot) {
+    return lowRateSnapshots.offer(snapshot);
+  }
+
+  public boolean addHighRate(Snapshot snapshot) {
+    return highRateSnapshots.offer(snapshot);
+  }
+
+  long getCurrentHighRateFlushInterval() {
+    return currentHighRateFlushInterval;
+  }
+
+  private void backOffHighRateFlush() {
+    long interval = currentHighRateFlushInterval;
+    currentHighRateFlushInterval =
+        Math.min(interval + HIGH_RATE_STEP_SIZE, HIGH_RATE_MAX_FLUSH_INTERVAL);
+    if (interval != currentHighRateFlushInterval) {
+      highRateReschedule();
+    }
+  }
+
+  private void reconsiderHighRateFlushInterval(int snapshotCount) {
+    long interval = currentHighRateFlushInterval;
+    if (snapshotCount == HIGH_RATE_CAPACITY) {
+      currentHighRateFlushInterval = HIGH_RATE_MIN_FLUSH_INTERVAL;
+    } else if (snapshotCount > HIGH_RATE_CAPACITY * 3 / 4) {
+      currentHighRateFlushInterval = Math.max(interval / 4, HIGH_RATE_MIN_FLUSH_INTERVAL);
+    } else if (snapshotCount > HIGH_RATE_CAPACITY / 4) {
+      currentHighRateFlushInterval = Math.max(interval / 2, HIGH_RATE_MIN_FLUSH_INTERVAL);
+    } else if (snapshotCount > HIGH_RATE_CAPACITY / 10) {
+      currentHighRateFlushInterval =
+          Math.max(interval - HIGH_RATE_STEP_SIZE, HIGH_RATE_MIN_FLUSH_INTERVAL);
+    }
+    if (interval != currentHighRateFlushInterval) {
+      highRateReschedule();
+    }
+  }
+
+  private void highRateReschedule() {
+    if (!started.get()) {
+      return;
+    }
+    AgentTaskScheduler.Scheduled<SnapshotSink> localScheduled = this.highRateScheduled;
+    if (localScheduled != null) {
+      localScheduled.cancel();
+    }
+    LOGGER.debug(
+        "Rescheduling high rate debugger sink flush to {}ms", currentHighRateFlushInterval);
+    this.highRateScheduled =
+        highRateScheduler.scheduleAtFixedRate(
+            this::highRateFlush,
+            this,
+            currentHighRateFlushInterval,
+            currentHighRateFlushInterval,
+            TimeUnit.MILLISECONDS);
+  }
+
+  private List<String> getSerializedSnapshots(BlockingQueue<Snapshot> queue, int localBatchSize) {
     List<Snapshot> snapshots = new ArrayList<>();
-    this.snapshots.drainTo(snapshots, batchSize);
+    if (queue.remainingCapacity() == 0) {
+      localBatchSize = queue.size();
+    }
+    queue.drainTo(snapshots, localBatchSize);
     List<String> serializedSnapshots = new ArrayList<>();
+    boolean largeBatch = snapshots.size() > 10;
+    if (largeBatch) {
+      LOGGER.debug("Drained {} snapshots, remains {}", snapshots.size(), queue.size());
+    }
     for (Snapshot snapshot : snapshots) {
       try {
         String strSnapshot = serializeSnapshot(serviceName, snapshot);
         serializedSnapshots.add(strSnapshot);
-        LOGGER.debug("Sending snapshot for probe: {}", snapshot.getProbe().getId());
+        if (!largeBatch) {
+          LOGGER.debug("Sending snapshot for probe: {}", snapshot.getProbe().getId());
+        }
       } catch (Exception e) {
         ExceptionHelper.logException(LOGGER, e, "Error during snapshot serialization:");
       }
@@ -48,21 +177,7 @@ public class SnapshotSink {
     return serializedSnapshots;
   }
 
-  public List<Snapshot> getSnapshots() {
-    List<Snapshot> snapshots = new ArrayList<>();
-    this.snapshots.drainTo(snapshots, batchSize);
-    return snapshots;
-  }
-
-  public long remainingCapacity() {
-    return snapshots.remainingCapacity();
-  }
-
-  public boolean offer(Snapshot snapshot) {
-    return snapshots.offer(snapshot);
-  }
-
-  String serializeSnapshot(String serviceName, Snapshot snapshot) {
+  private String serializeSnapshot(String serviceName, Snapshot snapshot) {
     snapshot.getId(); // Ensure id is generated
     String str = DebuggerAgent.getSnapshotSerializer().serializeSnapshot(serviceName, snapshot);
     String prunedStr = SnapshotPruner.prune(str, MAX_SNAPSHOT_SIZE, 4);
@@ -73,5 +188,12 @@ public class SnapshotSink {
           prunedStr.length());
     }
     return prunedStr;
+  }
+
+  private void uploadPayloads(List<String> payloads, String tags) {
+    List<byte[]> batches = IntakeBatchHelper.createBatches(payloads);
+    for (byte[] batch : batches) {
+      snapshotUploader.upload(batch, tags);
+    }
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -55,6 +55,10 @@ public class SymbolSink {
     this.event = new BatchUploader.MultiPartContent(eventContent, "event", "event.json");
   }
 
+  public void stop() {
+    symbolUploader.shutdown();
+  }
+
   public boolean addScope(Scope jarScope) {
     ServiceVersion serviceVersion =
         new ServiceVersion(serviceName, env, version, "JAVA", Collections.singletonList(jarScope));

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -174,7 +174,7 @@ public class BatchUploader {
         debuggerMetrics.count("batch.uploaded", 1);
       } else {
         debuggerMetrics.count("request.queue.full", 1);
-        ratelimitedLogger.warn("Cannot upload batch data: too many enqueued requests!");
+        log.warn("Cannot upload batch data: too many enqueued requests!");
       }
     } catch (Exception ex) {
       debuggerMetrics.count("batch.upload.error", 1);
@@ -208,7 +208,7 @@ public class BatchUploader {
       log.debug("Uploading batch data size={} bytes", contentLength);
     }
     HttpUrl.Builder builder = urlBase.newBuilder();
-    if (!tags.isEmpty()) {
+    if (tags != null && !tags.isEmpty()) {
       builder.addQueryParameter("ddtags", tags);
     }
     Request.Builder requestBuilder = new Request.Builder().url(builder.build()).post(body);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ProbeInstrumentationTest.java
@@ -41,6 +41,11 @@ public class ProbeInstrumentationTest {
     }
 
     @Override
+    public void addHighRateSnapshot(Snapshot snapshot) {
+      snapshots.add(snapshot);
+    }
+
+    @Override
     public void skipSnapshot(String probeId, DebuggerContext.SkipCause cause) {}
 
     public List<Snapshot> getSnapshots() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SnapshotSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SnapshotSinkTest.java
@@ -1,0 +1,166 @@
+package com.datadog.debugger.sink;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.matches;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datadog.debugger.agent.DebuggerAgent;
+import com.datadog.debugger.agent.DebuggerAgentHelper;
+import com.datadog.debugger.agent.JsonSnapshotSerializer;
+import com.datadog.debugger.uploader.BatchUploader;
+import com.datadog.debugger.util.MoshiSnapshotTestHelper;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Types;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.debugger.Limits;
+import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import datadog.trace.bootstrap.debugger.ProbeLocation;
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SnapshotSinkTest {
+  private static final ProbeId PROBE_ID = new ProbeId("12fd-8490-c111-4374-ffde", 42);
+  private static final ProbeLocation PROBE_LOCATION =
+      new ProbeLocation("java.lang.String", "indexOf", null, null);
+
+  @Mock private Config config;
+  @Mock private BatchUploader batchUploader;
+  @Captor private ArgumentCaptor<byte[]> payloadCaptor;
+  private ProbeStatusSink probeStatusSink;
+  private String EXPECTED_SNAPSHOT_TAGS;
+
+  @BeforeEach
+  void setUp() {
+    JsonSnapshotSerializer jsonSnapshotSerializer = new JsonSnapshotSerializer();
+    DebuggerContext.initValueSerializer(jsonSnapshotSerializer);
+    DebuggerAgentHelper.injectSerializer(jsonSnapshotSerializer);
+    when(config.getHostName()).thenReturn("host-name");
+    when(config.getServiceName()).thenReturn("service-name");
+    when(config.getEnv()).thenReturn("test");
+    when(config.getVersion()).thenReturn("foo");
+    when(config.getDebuggerUploadBatchSize()).thenReturn(1);
+    when(config.getFinalDebuggerSnapshotUrl())
+        .thenReturn("http://localhost:8126/debugger/v1/input");
+
+    EXPECTED_SNAPSHOT_TAGS =
+        "^env:test,version:foo,debugger_version:\\d+\\.\\d+\\.\\d+[^~]*~[0-9a-f]+,agent_version:null,host_name:"
+            + config.getHostName()
+            + "$";
+    probeStatusSink = new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false);
+  }
+
+  @Test
+  public void addHighRateSnapshot() throws IOException {
+    SnapshotSink snapshotSink = createSnapshotSink();
+    snapshotSink.start();
+    Snapshot snapshot = createSnapshot();
+    snapshotSink.addHighRate(snapshot);
+    snapshotSink.highRateFlush(null);
+    verify(batchUploader).upload(payloadCaptor.capture(), matches(EXPECTED_SNAPSHOT_TAGS));
+    String strPayload = new String(payloadCaptor.getValue(), StandardCharsets.UTF_8);
+    System.out.println(strPayload);
+    JsonSnapshotSerializer.IntakeRequest intakeRequest = assertOneIntakeRequest(strPayload);
+    assertEquals("dd_debugger", intakeRequest.getDdsource());
+    assertEquals("service-name", intakeRequest.getService());
+    assertEquals("java.lang.String", intakeRequest.getLoggerName());
+    assertEquals("indexOf", intakeRequest.getLoggerMethod());
+    assertEquals(PROBE_ID.getId(), intakeRequest.getDebugger().getSnapshot().getProbe().getId());
+    assertEquals(
+        PROBE_LOCATION, intakeRequest.getDebugger().getSnapshot().getProbe().getLocation());
+    assertTrue(
+        intakeRequest
+            .getDebugger()
+            .getRuntimeId()
+            .matches("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"));
+  }
+
+  @Test
+  public void reconsiderDecreaseFlushInterval() {
+    SnapshotSink snapshotSink = createSnapshotSink();
+    long previousInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    assertEquals(SnapshotSink.HIGH_RATE_MAX_FLUSH_INTERVAL, previousInterval);
+    for (int i = 0; i < 1000; i++) {
+      snapshotSink.addHighRate(createSnapshot());
+    }
+    snapshotSink.highRateFlush(null); // interval / 4
+    long currentInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    assertEquals(previousInterval / 4, currentInterval);
+    previousInterval = currentInterval;
+    for (int i = 0; i < 520; i++) {
+      snapshotSink.addHighRate(createSnapshot());
+    }
+    snapshotSink.highRateFlush(null); // interval / 2
+    currentInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    assertEquals(previousInterval / 2, currentInterval);
+    previousInterval = currentInterval;
+    for (int i = 0; i < 110; i++) {
+      snapshotSink.addHighRate(createSnapshot());
+    }
+    snapshotSink.highRateFlush(null); // interval - HIGH_RATE_STEP_SIZE
+    currentInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    assertEquals(previousInterval - SnapshotSink.HIGH_RATE_STEP_SIZE, currentInterval);
+    previousInterval = currentInterval;
+    for (int i = 0; i < 1000; i++) {
+      snapshotSink.addHighRate(createSnapshot());
+    }
+    snapshotSink.highRateFlush(null); // interval / 4 => min
+    currentInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    assertEquals(SnapshotSink.HIGH_RATE_MIN_FLUSH_INTERVAL, currentInterval);
+  }
+
+  @Test
+  public void backoffFlushInterval() {
+    SnapshotSink snapshotSink = createSnapshotSink();
+    long previousInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    assertEquals(SnapshotSink.HIGH_RATE_MAX_FLUSH_INTERVAL, previousInterval);
+    for (int flushCount = 0; flushCount < 4; flushCount++) {
+      for (int i = 0; i < 1000; i++) {
+        snapshotSink.addHighRate(createSnapshot());
+      }
+      snapshotSink.highRateFlush(null); // interval / 4
+      previousInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    }
+    assertEquals(SnapshotSink.HIGH_RATE_MIN_FLUSH_INTERVAL, previousInterval);
+    previousInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    snapshotSink.highRateFlush(null); // backoff: interval + HIGH_RATE_STEP_SIZE
+    long currentInterval = snapshotSink.getCurrentHighRateFlushInterval();
+    assertEquals(previousInterval + SnapshotSink.HIGH_RATE_STEP_SIZE, currentInterval);
+  }
+
+  private SnapshotSink createSnapshotSink() {
+    String tags = DebuggerAgent.getDefaultTagsMergedWithGlobalTags(config);
+    return new SnapshotSink(config, tags, batchUploader);
+  }
+
+  private Snapshot createSnapshot() {
+    return new Snapshot(
+        Thread.currentThread(),
+        new ProbeImplementation.NoopProbeImplementation(PROBE_ID, PROBE_LOCATION),
+        Limits.DEFAULT_REFERENCE_DEPTH);
+  }
+
+  private JsonSnapshotSerializer.IntakeRequest assertOneIntakeRequest(String strPayload)
+      throws IOException {
+    ParameterizedType type =
+        Types.newParameterizedType(List.class, JsonSnapshotSerializer.IntakeRequest.class);
+    JsonAdapter<List<JsonSnapshotSerializer.IntakeRequest>> adapter =
+        MoshiSnapshotTestHelper.createMoshiSnapshot().adapter(type);
+    List<JsonSnapshotSerializer.IntakeRequest> intakeRequests = adapter.fromJson(strPayload);
+    assertEquals(1, intakeRequests.size());
+    return intakeRequests.get(0);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SnapshotSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SnapshotSinkTest.java
@@ -92,7 +92,7 @@ public class SnapshotSinkTest {
   public void reconsiderDecreaseFlushInterval() {
     SnapshotSink snapshotSink = createSnapshotSink();
     long previousInterval = snapshotSink.getCurrentHighRateFlushInterval();
-    assertEquals(SnapshotSink.HIGH_RATE_MAX_FLUSH_INTERVAL, previousInterval);
+    assertEquals(SnapshotSink.HIGH_RATE_MAX_FLUSH_INTERVAL_MS, previousInterval);
     for (int i = 0; i < 1000; i++) {
       snapshotSink.addHighRate(createSnapshot());
     }
@@ -119,14 +119,14 @@ public class SnapshotSinkTest {
     }
     snapshotSink.highRateFlush(null); // interval / 4 => min
     currentInterval = snapshotSink.getCurrentHighRateFlushInterval();
-    assertEquals(SnapshotSink.HIGH_RATE_MIN_FLUSH_INTERVAL, currentInterval);
+    assertEquals(SnapshotSink.HIGH_RATE_MIN_FLUSH_INTERVAL_MS, currentInterval);
   }
 
   @Test
   public void backoffFlushInterval() {
     SnapshotSink snapshotSink = createSnapshotSink();
     long previousInterval = snapshotSink.getCurrentHighRateFlushInterval();
-    assertEquals(SnapshotSink.HIGH_RATE_MAX_FLUSH_INTERVAL, previousInterval);
+    assertEquals(SnapshotSink.HIGH_RATE_MAX_FLUSH_INTERVAL_MS, previousInterval);
     for (int flushCount = 0; flushCount < 4; flushCount++) {
       for (int i = 0; i < 1000; i++) {
         snapshotSink.addHighRate(createSnapshot());
@@ -134,7 +134,7 @@ public class SnapshotSinkTest {
       snapshotSink.highRateFlush(null); // interval / 4
       previousInterval = snapshotSink.getCurrentHighRateFlushInterval();
     }
-    assertEquals(SnapshotSink.HIGH_RATE_MIN_FLUSH_INTERVAL, previousInterval);
+    assertEquals(SnapshotSink.HIGH_RATE_MIN_FLUSH_INTERVAL_MS, previousInterval);
     previousInterval = snapshotSink.getCurrentHighRateFlushInterval();
     snapshotSink.highRateFlush(null); // backoff: interval + HIGH_RATE_STEP_SIZE
     long currentInterval = snapshotSink.getCurrentHighRateFlushInterval();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TestSnapshotListener.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/TestSnapshotListener.java
@@ -27,4 +27,9 @@ public class TestSnapshotListener extends DebuggerSink {
   public void addSnapshot(Snapshot snapshot) {
     snapshots.add(snapshot);
   }
+
+  @Override
+  public void addHighRateSnapshot(Snapshot snapshot) {
+    snapshots.add(snapshot);
+  }
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
@@ -323,7 +323,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
   void testSamplingLogCustom() throws Exception {
     final int LOOP_COUNT = 1000;
     final String LOG_TEMPLATE = "log line {argInt} {argStr} {argDouble} {argMap} {argVar}";
-    final String EXPECTED_UPLOADS = "120";
+    final String EXPECTED_UPLOADS = "170";
     LogProbe probe =
         LogProbe.builder()
             .probeId(PROBE_ID)
@@ -337,7 +337,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
         createProcessBuilder(
                 logFilePath, "loopingFullMethod", EXPECTED_UPLOADS, String.valueOf(LOOP_COUNT))
             .start();
-    assertTrue(countSnapshots() < 120);
+    assertTrue(countSnapshots() < 200);
   }
 
   @Test

--- a/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
@@ -44,6 +44,7 @@ public final class AgentThreadFactory implements ThreadFactory {
 
     DATA_STREAMS_MONITORING("dd-data-streams-monitor"),
 
+    DEBUGGER_SNAPSHOT_SERIALIZER("dd-debugger-snapshot-serializer"),
     DEBUGGER_HTTP_DISPATCHER("dd-debugger-upload-http-dispatcher"),
 
     CI_SHELL_COMMAND("dd-ci-shell-command"),


### PR DESCRIPTION
# What Does This Do
We introduce a dedicated high rate queue with dedicated threads with better reactivity (max 100ms between polls). All non-capturing snapshots are added into this queue.

# Motivation
Historically, the Queue inside SnapshotSink was designed for a low rate number of snapshots (1 per second) and the consumer thread is the one shared with all other tasks (AgentTaskScheduler.INSTANCE). So the reactivity of the thread to consume the queue is not enough for handling up to 5000 snapshots/s allowed for log template probes. 

# Additional Notes

Jira ticket: [DEBUG-2499]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2499]: https://datadoghq.atlassian.net/browse/DEBUG-2499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ