### PR TITLE
Reset call depth counter if query is blocked

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -120,6 +120,7 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
         // if we can't get the connection for any reason
         return null;
       } catch (BlockingException e) {
+        CallDepthThreadLocalMap.reset(Statement.class);
         // re-throw blocking exceptions
         throw e;
       } catch (Throwable e) {


### PR DESCRIPTION
# What Does This Do
Reset call depth counter in `StatementInstrumentation` if query with SQL-injection is blocked.

# Motivation
In case of multiple blocking of sql queries, an error occurred leading to blocking failure

# Additional Notes

Jira ticket: [APPSEC-47228]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-47228]: https://datadoghq.atlassian.net/browse/APPSEC-47228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ