### PR TITLE
Fix `instanceof` as predicate for value expression

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -46,7 +46,8 @@ public class JsonToExpressionConverter {
               "startsWith",
               "endsWith",
               "contains",
-              "matches"));
+              "matches",
+              "instanceof"));
 
   @FunctionalInterface
   interface BinaryPredicateExpressionFunction<T extends Expression> {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ValueScriptTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ValueScriptTest.java
@@ -1,0 +1,106 @@
+package com.datadog.debugger.el;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.squareup.moshi.Moshi;
+import datadog.trace.bootstrap.debugger.el.Values;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import okio.Okio;
+import org.junit.jupiter.api.Test;
+
+public class ValueScriptTest {
+
+  static class Obj {
+    String str = "hello";
+    int i = 10;
+    List<String> list = Arrays.asList("a", "b", "c");
+    long l = 100_000_000_000L;
+    float f = 2.5F;
+    double d = 3.14D;
+    char c = 'a';
+  }
+
+  @Test
+  public void predicates() {
+    ValueScript valueScript = loadFromResource("/test_value_expr_01.json");
+    valueScript.execute(RefResolverHelper.createResolver(new Obj()));
+  }
+
+  @Test
+  public void topLevelPredicates() {
+    List<String> lines = loadLinesFromResource("/test_one_liner_value_expr_01.txt");
+    for (String line : lines) {
+      ValueScript valueScript = load(line);
+      assertEquals(
+          Boolean.TRUE,
+          valueScript.execute(RefResolverHelper.createResolver(new Obj())).getValue(),
+          line);
+    }
+  }
+
+  @Test
+  public void topLevelPrimitives() {
+    Object[] expectedValues =
+        new Object[] {
+          "hello",
+          "hello",
+          10L,
+          100_000_000_000L,
+          2.5D,
+          3.14D,
+          "a",
+          "b",
+          5L,
+          3L,
+          "el",
+          Values.NULL_OBJECT,
+          Boolean.TRUE,
+          Boolean.FALSE
+        };
+    List<String> lines = loadLinesFromResource("/test_one_liner_value_expr_02.txt");
+    int i = 0;
+    for (String line : lines) {
+      ValueScript valueScript = load(line);
+      assertEquals(
+          expectedValues[i],
+          valueScript.execute(RefResolverHelper.createResolver(new Obj())).getValue(),
+          line);
+      i++;
+    }
+  }
+
+  private static List<String> loadLinesFromResource(String resourcePath) {
+    try (InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath)) {
+      BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+      return reader.lines().collect(Collectors.toList());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load resource: " + resourcePath, e);
+    }
+  }
+
+  private static ValueScript loadFromResource(String resourcePath) {
+    try (InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath)) {
+      Moshi moshi =
+          new Moshi.Builder().add(ValueScript.class, new ValueScript.ValueScriptAdapter()).build();
+      return moshi.adapter(ValueScript.class).fromJson(Okio.buffer(Okio.source(input)));
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load resource: " + resourcePath, e);
+    }
+  }
+
+  private static ValueScript load(String json) {
+    try {
+      Moshi moshi =
+          new Moshi.Builder().add(ValueScript.class, new ValueScript.ValueScriptAdapter()).build();
+      return moshi.adapter(ValueScript.class).fromJson(json);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load json: " + json, e);
+    }
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ValueScriptTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ValueScriptTest.java
@@ -29,7 +29,8 @@ public class ValueScriptTest {
   @Test
   public void predicates() {
     ValueScript valueScript = loadFromResource("/test_value_expr_01.json");
-    valueScript.execute(RefResolverHelper.createResolver(new Obj()));
+    assertEquals(
+        Boolean.TRUE, valueScript.execute(RefResolverHelper.createResolver(new Obj())).getValue());
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_one_liner_value_expr_01.txt
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_one_liner_value_expr_01.txt
@@ -1,0 +1,21 @@
+{"dsl": "", "json": {"eq": [{"ref": "i"}, 10]}}
+{"dsl": "", "json": {"==": [{"ref": "i"}, 10]}}
+{"dsl": "", "json": {"lt": [{"ref": "i"}, 11]}}
+{"dsl": "", "json": {"<": [{"ref": "i"}, 11]}}
+{"dsl": "", "json": {"le": [{"ref": "i"}, 10]}}
+{"dsl": "", "json": {"<=": [{"ref": "i"}, 10]}}
+{"dsl": "", "json": {"gt": [{"ref": "i"}, 0]}}
+{"dsl": "", "json": {">": [{"ref": "i"}, 0]}}
+{"dsl": "", "json": {"ge": [{"ref": "i"}, 10]}}
+{"dsl": "", "json": {">=": [{"ref": "i"}, 10]}}
+{"dsl": "", "json": {"not": {"eq": [{"ref": "i"}, 0]}}}
+{"dsl": "", "json": {"neq": [{"ref": "i"}, 0]}}
+{"dsl": "", "json": {"!=": [{"ref": "i"}, 0]}}
+{"dsl": "", "json": {"not": {"isEmpty": {"ref": "list"}}}}
+{"dsl": "", "json": {"hasAny": [{"ref": "list"}, {"eq": [{"ref": "@it"}, "a"]}]}}
+{"dsl": "", "json": {"hasAll": [{"ref": "list"}, {"neq": [{"ref": "@it"}, "d"]}]}}
+{"dsl": "", "json": {"startsWith": [{"ref": "str"}, "hel"]}}
+{"dsl": "", "json": {"endsWith": [{"ref": "str"}, "llo"]}}
+{"dsl": "", "json": {"contains": [{"ref": "str"}, "ll"]}}
+{"dsl": "", "json": {"matches": [{"ref": "str"}, "[helo]+"]}}
+{"dsl": "", "json": {"instanceof": [{"ref": "str"}, "java.lang.String"]}}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_one_liner_value_expr_02.txt
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_one_liner_value_expr_02.txt
@@ -1,0 +1,14 @@
+{"dsl": "", "json": {"ref": "str"}}
+{"dsl": "", "json": {"getmember": [{"ref": "this"}, "str"]}}
+{"dsl": "", "json": {"ref": "i"}}
+{"dsl": "", "json": {"ref": "l"}}
+{"dsl": "", "json": {"ref": "f"}}
+{"dsl": "", "json": {"ref": "d"}}
+{"dsl": "", "json": {"ref": "c"}}
+{"dsl": "", "json": {"index": [{"ref": "list"}, 1]}}
+{"dsl": "", "json": {"len": {"ref": "str"}}}
+{"dsl": "", "json": {"count": {"ref": "list"}}}
+{"dsl": "", "json": {"substring": [{"ref": "str"}, 1, 3]}}
+{"dsl": "", "json": null}
+{"dsl": "", "json": true}
+{"dsl": "", "json": false}

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_value_expr_01.json
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/test_value_expr_01.json
@@ -1,0 +1,32 @@
+{
+  "dsl": "",
+  "json": {
+    "and": [
+      {
+        "or": [
+          {"eq": [{"ref": "i"}, 10]},
+          {"==": [{"ref": "i"}, 10]},
+          {"lt": [{"ref": "i"}, 11]},
+          {"<": [{"ref": "i"}, 11]},
+          {"le": [{"ref": "i"}, 10]},
+          {"<=": [{"ref": "i"}, 10]},
+          {"gt": [{"ref": "i"}, 0]},
+          {">": [{"ref": "i"}, 0]},
+          {"ge": [{"ref": "i"}, 10]},
+          {">=": [{"ref": "i"}, 10]},
+          {"not": {"eq": [{"ref": "i"}, 0]}},
+          {"neq": [{"ref": "i"}, 0]},
+          {"!=": [{"ref": "i"}, 0]},
+          {"not": {"isEmpty": {"ref": "list"}}},
+          {"hasAny": [{"ref": "list"}, {"eq": [{"ref": "@it"}, "a"]}]},
+          {"hasAll": [{"ref": "list"}, {"neq": [{"ref": "@it"}, "d"]}]},
+          {"startsWith": [{"ref": "str"}, "hel"]},
+          {"endsWith": [{"ref": "str"}, "llo"]},
+          {"contains": [{"ref": "str"}, "ll"]},
+          {"matches": [{"ref": "str"}, "[helo]+"]},
+          {"instanceof": [{"ref": "str"}, "java.lang.String"]}
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# What Does This Do
Add `instanceof` among the predicate functions when parsing value expressions.
Add test for parsing top level value expressions

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2527]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2527]: https://datadoghq.atlassian.net/browse/DEBUG-2527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ