### PR TITLE
Replace segments with bitmaps in per-test code coverage

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/file/FileCoverageStore.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/file/FileCoverageStore.java
@@ -86,7 +86,7 @@ public class FileCoverageStore extends ConcurrentCoverageStore<FileProbes> {
 
       List<TestReportFileEntry> fileEntries = new ArrayList<>(coveredPaths.size());
       for (String path : coveredPaths) {
-        fileEntries.add(new TestReportFileEntry(path, Collections.emptyList()));
+        fileEntries.add(new TestReportFileEntry(path, null));
       }
 
       TestReport report = new TestReport(testSessionId, testSuiteId, testSpanId, fileEntries);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/SourceAnalyzer.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/SourceAnalyzer.java
@@ -1,17 +1,16 @@
 package datadog.trace.civisibility.coverage.line;
 
-import datadog.trace.api.civisibility.coverage.TestReportFileEntry;
-import java.util.List;
+import java.util.BitSet;
 import org.jacoco.core.analysis.IClassCoverage;
 import org.jacoco.core.analysis.ICounter;
 import org.jacoco.core.analysis.ICoverageVisitor;
 
 public class SourceAnalyzer implements ICoverageVisitor {
 
-  private final List<TestReportFileEntry.Segment> segments;
+  private final BitSet coveredLines;
 
-  public SourceAnalyzer(List<TestReportFileEntry.Segment> segments) {
-    this.segments = segments;
+  public SourceAnalyzer(BitSet coveredLines) {
+    this.coveredLines = coveredLines;
   }
 
   @Override
@@ -26,17 +25,10 @@ public class SourceAnalyzer implements ICoverageVisitor {
     }
 
     int lastLine = coverage.getLastLine();
-    int line = firstLine;
-    while (line <= lastLine) {
-      if (coverage.getLine(line).getStatus() >= ICounter.FULLY_COVERED) {
-        int start = line++;
-        while (line <= lastLine && coverage.getLine(line).getStatus() >= ICounter.FULLY_COVERED) {
-          line++;
-        }
-        segments.add(new TestReportFileEntry.Segment(start, -1, line - 1, -1, -1));
 
-      } else {
-        line++;
+    for (int line = firstLine; line <= lastLine; line++) {
+      if (coverage.getLine(line).getStatus() >= ICounter.FULLY_COVERED) {
+        coveredLines.set(line);
       }
     }
   }

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-known-test/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-known-test/coverages.ftl
@@ -3,7 +3,6 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-new-scenario-outline-5.4.0/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-new-scenario-outline-5.4.0/coverages.ftl
@@ -3,63 +3,55 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_6},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_7},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_8},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-new-scenario-outline-latest/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-new-scenario-outline-latest/coverages.ftl
@@ -3,63 +3,55 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_6},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_7},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_8},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-new-slow-test/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-new-slow-test/coverages.ftl
@@ -3,15 +3,13 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_slow.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_slow.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_slow.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_slow.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-new-test/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-efd-new-test/coverages.ftl
@@ -3,23 +3,20 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-failure/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-failure/coverages.ftl
@@ -3,7 +3,6 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-multiple-features-5.4.0/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-multiple-features-5.4.0/coverages.ftl
@@ -3,15 +3,13 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id_2},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-multiple-features-latest/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-multiple-features-latest/coverages.ftl
@@ -3,15 +3,13 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id_2},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-retry-failure/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-retry-failure/coverages.ftl
@@ -3,39 +3,34 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-retry-scenario-outline-5.4.0/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-retry-scenario-outline-5.4.0/coverages.ftl
@@ -3,63 +3,55 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_6},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_7},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_8},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-retry-scenario-outline-latest/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-retry-scenario-outline-latest/coverages.ftl
@@ -3,31 +3,27 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-scenario-outline-5.4.0/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-scenario-outline-5.4.0/coverages.ftl
@@ -3,31 +3,27 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-scenario-outline-latest/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-scenario-outline-latest/coverages.ftl
@@ -3,31 +3,27 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-succeed/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-succeed/coverages.ftl
@@ -3,7 +3,6 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-known-test/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-known-test/coverages.ftl
@@ -3,7 +3,6 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-new-scenario-outline-5.4.0/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-new-scenario-outline-5.4.0/coverages.ftl
@@ -3,63 +3,55 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_6},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_7},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_8},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-new-scenario-outline-latest/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-new-scenario-outline-latest/coverages.ftl
@@ -3,63 +3,55 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_6},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_7},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_8},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-new-slow-test/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-new-slow-test/coverages.ftl
@@ -3,15 +3,13 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_slow.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_slow.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_slow.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_slow.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-new-test/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-efd-new-test/coverages.ftl
@@ -3,23 +3,20 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-failed-scenario-outline-5.4.0/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-failed-scenario-outline-5.4.0/coverages.ftl
@@ -3,47 +3,41 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_6},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-failed-scenario-outline-latest/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-failed-scenario-outline-latest/coverages.ftl
@@ -3,47 +3,41 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_6},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-failed-then-succeed/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-failed-then-succeed/coverages.ftl
@@ -3,23 +3,20 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-failed/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-failed/coverages.ftl
@@ -3,7 +3,6 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-parallel/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-parallel/coverages.ftl
@@ -3,15 +3,13 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id_2},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_skipped.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_skipped.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-retry-failed/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-retry-failed/coverages.ftl
@@ -3,39 +3,34 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_5},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-scenario-outline-5.4.0/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-scenario-outline-5.4.0/coverages.ftl
@@ -3,31 +3,27 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_3},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_4},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-scenario-outline-latest/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-scenario-outline-latest/coverages.ftl
@@ -1,31 +1,27 @@
 [ {
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ],
   "span_id" : ${content_span_id_3},
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id}
 }, {
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ],
   "span_id" : ${content_span_id_4},
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id}
 }, {
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ],
   "span_id" : ${content_span_id},
   "test_session_id" : ${content_test_session_id},
   "test_suite_id" : ${content_test_suite_id}
 }, {
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"
   } ],
   "span_id" : ${content_span_id_2},
   "test_session_id" : ${content_test_session_id},

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-skipped/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-skipped/coverages.ftl
@@ -3,7 +3,6 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id_2},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic_skipped.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic_skipped.feature"
   } ]
 } ]

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-succeed/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/resources/test-succeed/coverages.ftl
@@ -3,7 +3,6 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "org/example/cucumber/calculator/basic_arithmetic.feature"
   } ]
 } ]

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-5/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-junit-5/coverages.ftl
@@ -4,9 +4,9 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "ABg="
   }, {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   } ]
 } ]

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-legacy-instrumentation/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-legacy-instrumentation/coverages.ftl
@@ -4,9 +4,9 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "ABg="
   }, {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   } ]
 } ]

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-legacy-instrumentation/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-legacy-instrumentation/coverages.ftl
@@ -4,10 +4,10 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 10, -1, 11, -1, -1 ] ]
+    "bitmap" : "gAw="
   }, {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
@@ -15,9 +15,9 @@
   "span_id" : ${content_span_id_2},
   "files" : [ {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 8, -1, 8, -1, -1 ] ]
+    "bitmap" : "AAE="
   }, {
     "filename" : "src/test/java/datadog/smoke/TestSucceedJunit5.java",
-    "segments" : [ [ 10, -1, 11, -1, -1 ] ]
+    "bitmap" : "AAw="
   } ]
 } ]

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-new-instrumentation/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-forks-new-instrumentation/coverages.ftl
@@ -4,10 +4,10 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 10, -1, 11, -1, -1 ] ]
+    "bitmap" : "gAw="
   }, {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
@@ -15,9 +15,9 @@
   "span_id" : ${content_span_id_2},
   "files" : [ {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 8, -1, 8, -1, -1 ] ]
+    "bitmap" : "AAE="
   }, {
     "filename" : "src/test/java/datadog/smoke/TestSucceedJunit5.java",
-    "segments" : [ [ 10, -1, 11, -1, -1 ] ]
+    "bitmap" : "AAw="
   } ]
 } ]

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-module-legacy-instrumentation/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-module-legacy-instrumentation/coverages.ftl
@@ -4,7 +4,7 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "submodule-a/src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "ABg="
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
@@ -12,6 +12,6 @@
   "span_id" : ${content_span_id_2},
   "files" : [ {
     "filename" : "submodule-b/src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "ABg="
   } ]
 } ]

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-module-new-instrumentation/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-multi-module-new-instrumentation/coverages.ftl
@@ -4,7 +4,7 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "submodule-a/src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "ABg="
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
@@ -12,6 +12,6 @@
   "span_id" : ${content_span_id_2},
   "files" : [ {
     "filename" : "submodule-b/src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "ABg="
   } ]
 } ]

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-new-instrumentation/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-new-instrumentation/coverages.ftl
@@ -4,9 +4,9 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "ABg="
   }, {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   } ]
 } ]

--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-old-gradle/coverages.ftl
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-old-gradle/coverages.ftl
@@ -4,6 +4,6 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "ABg="
   } ]
 } ]

--- a/dd-smoke-tests/maven/src/test/resources/test_failed_maven_run_flaky_retries/coverages.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_failed_maven_run_flaky_retries/coverages.ftl
@@ -4,10 +4,10 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   }, {
     "filename" : "src/test/java/datadog/smoke/TestFailed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 11, -1, 11, -1, -1 ] ]
+    "bitmap" : "gAg="
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
@@ -15,10 +15,10 @@
   "span_id" : ${content_span_id_2},
   "files" : [ {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   }, {
     "filename" : "src/test/java/datadog/smoke/TestFailed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 11, -1, 11, -1, -1 ] ]
+    "bitmap" : "gAg="
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
@@ -26,10 +26,10 @@
   "span_id" : ${content_span_id_3},
   "files" : [ {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   }, {
     "filename" : "src/test/java/datadog/smoke/TestFailed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 11, -1, 11, -1, -1 ] ]
+    "bitmap" : "gAg="
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
@@ -37,10 +37,10 @@
   "span_id" : ${content_span_id_4},
   "files" : [ {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   }, {
     "filename" : "src/test/java/datadog/smoke/TestFailed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 11, -1, 11, -1, -1 ] ]
+    "bitmap" : "gAg="
   } ]
 }, {
   "test_session_id" : ${content_test_session_id},
@@ -48,9 +48,9 @@
   "span_id" : ${content_span_id_5},
   "files" : [ {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   }, {
     "filename" : "src/test/java/datadog/smoke/TestFailed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 11, -1, 11, -1, -1 ] ]
+    "bitmap" : "gAg="
   } ]
 } ]

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run/coverages.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run/coverages.ftl
@@ -4,9 +4,9 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "gBg="
   }, {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   } ]
 } ]

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_builtin_coverage/coverages.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_builtin_coverage/coverages.ftl
@@ -3,10 +3,8 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ ]
+    "filename" : "src/test/java/datadog/smoke/TestSucceed.java"
   }, {
-    "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ ]
+    "filename" : "src/main/java/datadog/smoke/Calculator.java"
   } ]
 } ]

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_surefire_3_0_0/coverages.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_surefire_3_0_0/coverages.ftl
@@ -4,9 +4,9 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "gBg="
   }, {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   } ]
 } ]

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_arg_line_property/coverages.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_arg_line_property/coverages.ftl
@@ -3,7 +3,6 @@
   "test_suite_id" : ${content_test_suite_id},
   "span_id" : ${content_span_id},
   "files" : [ {
-    "filename" : "src/test/java/datadog/smoke/TestSucceedPropertyAssertion.java",
-    "segments" : [ ]
+    "filename" : "src/test/java/datadog/smoke/TestSucceedPropertyAssertion.java"
   } ]
 } ]

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_cucumber/coverages.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_cucumber/coverages.ftl
@@ -4,9 +4,8 @@
   "span_id" : ${content_parent_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/calculator/CalculatorSteps.java",
-    "segments" : [ [ 13, -1, 13, -1, -1 ], [ 19, -1, 20, -1, -1 ], [ 24, -1, 27, -1, -1 ], [ 30, -1, 34, -1, -1 ], [ 36, -1, 40, -1, -1 ], [ 42, -1, 43, -1, -1 ], [ 49, -1, 51, -1, -1 ], [ 53, -1, 53, -1, -1 ], [ 56, -1, 56, -1, -1 ] ]
+    "bitmap" : "ACAYz/cNLgE="
   }, {
-    "filename" : "src/test/resources/datadog/smoke/basic_arithmetic.feature",
-    "segments" : [ ]
+    "filename" : "src/test/resources/datadog/smoke/basic_arithmetic.feature"
   } ]
 } ]

--- a/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_jacoco_and_argline/coverages.ftl
+++ b/dd-smoke-tests/maven/src/test/resources/test_successful_maven_run_with_jacoco_and_argline/coverages.ftl
@@ -4,9 +4,9 @@
   "span_id" : ${content_span_id},
   "files" : [ {
     "filename" : "src/test/java/datadog/smoke/TestSucceed.java",
-    "segments" : [ [ 7, -1, 7, -1, -1 ], [ 11, -1, 12, -1, -1 ] ]
+    "bitmap" : "gBg="
   }, {
     "filename" : "src/main/java/datadog/smoke/Calculator.java",
-    "segments" : [ [ 5, -1, 5, -1, -1 ] ]
+    "bitmap" : "IA=="
   } ]
 } ]

--- a/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCovMapperV2Test.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/civisibility/writer/ddintake/CiTestCovMapperV2Test.groovy
@@ -27,7 +27,9 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
 
   def "test writes message"() {
     given:
-    def trace = givenTrace(new TestReport(1, 2, 3, [new TestReportFileEntry("source", [new TestReportFileEntry.Segment(4, -1, 4, -1, 11)])]))
+    def trace = givenTrace(new TestReport(1, 2, 3, [new TestReportFileEntry("source", BitSet.valueOf(new long[] {
+        3, 5, 8
+      }))]))
 
     when:
     def message = getMappedMessage(trace)
@@ -43,7 +45,7 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
           files          : [
             [
               filename: "source",
-              segments: [[4, -1, 4, -1, 11]]
+              bitmap: [3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 8]
             ]
           ]
         ]
@@ -54,14 +56,12 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
   def "test writes message with multiple files and multiple lines"() {
     given:
     def trace = givenTrace(new TestReport(1, 2, 3, [
-      new TestReportFileEntry("sourceA", [
-        new TestReportFileEntry.Segment(4, -1, 4, -1, 1),
-        new TestReportFileEntry.Segment(5, -1, 5, -1, 1)
-      ]),
-      new TestReportFileEntry("sourceB", [
-        new TestReportFileEntry.Segment(20, -1, 20, -1, 1),
-        new TestReportFileEntry.Segment(21, -1, 21, -1, 1)
-      ])
+      new TestReportFileEntry("sourceA", BitSet.valueOf(new long[] {
+        3, 5, 8
+      })),
+      new TestReportFileEntry("sourceB", BitSet.valueOf(new long[] {
+        1, 255, 7
+      }))
     ]))
 
     when:
@@ -78,11 +78,11 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
           files          : [
             [
               filename: "sourceA",
-              segments: [[4, -1, 4, -1, 1], [5, -1, 5, -1, 1]]
+              bitmap:[3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 8]
             ],
             [
               filename: "sourceB",
-              segments: [[20, -1, 20, -1, 1], [21, -1, 21, -1, 1]]
+              bitmap:[1, 0, 0, 0, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 0, 0, 7]
             ]
           ]
         ]
@@ -93,13 +93,17 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
   def "test writes message with multiple reports"() {
     given:
     def trace = givenTrace(
-      new TestReport(1, 2, 3, [
-        new TestReportFileEntry("sourceA", [new TestReportFileEntry.Segment(14, -1, 14, -1, 1),])
-      ]),
-      new TestReport(1, 2, 4, [
-        new TestReportFileEntry("sourceB", [new TestReportFileEntry.Segment(24, -1, 24, -1, 1),])
-      ]),
-      )
+    new TestReport(1, 2, 3, [
+      new TestReportFileEntry("sourceA", BitSet.valueOf(new long[] {
+        2, 17, 41
+      }))
+    ]),
+    new TestReport(1, 2, 4, [
+      new TestReportFileEntry("sourceB", BitSet.valueOf(new long[] {
+        11, 13, 55
+      }))
+    ]),
+    )
 
     when:
     def message = getMappedMessage(trace)
@@ -115,7 +119,7 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
           files          : [
             [
               filename: "sourceA",
-              segments: [[14, -1, 14, -1, 1]]
+              bitmap:[2, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 41]
             ]
           ]
         ],
@@ -126,7 +130,7 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
           files          : [
             [
               filename: "sourceB",
-              segments: [[24, -1, 24, -1, 1]]
+              bitmap:[11, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 55]
             ]
           ]
         ]
@@ -136,7 +140,9 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
 
   def "skips spans that have no reports"() {
     given:
-    def trace = givenTrace(null, new TestReport(1, 2, 3, [new TestReportFileEntry("source", [new TestReportFileEntry.Segment(4, -1, 4, -1, 11)])]), null)
+    def trace = givenTrace(null, new TestReport(1, 2, 3, [new TestReportFileEntry("source", BitSet.valueOf(new long[] {
+        83, 25, 48
+      }))]), null)
 
     when:
     def message = getMappedMessage(trace)
@@ -152,7 +158,7 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
           files          : [
             [
               filename: "source",
-              segments: [[4, -1, 4, -1, 11]]
+              bitmap:[83, 0, 0, 0, 0, 0, 0, 0, 25, 0, 0, 0, 0, 0, 0, 0, 48]
             ]
           ]
         ]
@@ -163,11 +169,13 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
   def "skips empty reports"() {
     given:
     def trace = givenTrace(
-      new TestReport(1, 2, 3, [
-        new TestReportFileEntry("source", [new TestReportFileEntry.Segment(4, -1, 4, -1, 11)])
-      ]),
-      new TestReport(1, 2, 4, [])
-      )
+    new TestReport(1, 2, 3, [
+      new TestReportFileEntry("source", BitSet.valueOf(new long[] {
+        33, 53, 87
+      }))
+    ]),
+    new TestReport(1, 2, 4, [])
+    )
 
     when:
     def message = getMappedMessage(trace)
@@ -183,7 +191,7 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
           files          : [
             [
               filename: "source",
-              segments: [[4, -1, 4, -1, 11]]
+              bitmap:[33, 0, 0, 0, 0, 0, 0, 0, 53, 0, 0, 0, 0, 0, 0, 0, 87]
             ]
           ]
         ]
@@ -195,7 +203,9 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
     given:
     def trace = new ArrayList()
 
-    def report = new TestReport(1, 2, 3, [new TestReportFileEntry("source", [new TestReportFileEntry.Segment(4, -1, 4, -1, 11)])])
+    def report = new TestReport(1, 2, 3, [new TestReportFileEntry("source", BitSet.valueOf(new long[] {
+        3, 5, 8
+      }))])
 
     trace.add(buildSpan(0, InternalSpanTypes.TEST, PropagationTags.factory().empty(), [:], PrioritySampling.SAMPLER_KEEP, new DummyTestContext(new DummyReportHolder(report))))
     trace.add(buildSpan(0, "testChild", PropagationTags.factory().empty(), [:], PrioritySampling.SAMPLER_KEEP, new DummyTestContext(new DummyReportHolder(report))))
@@ -214,7 +224,7 @@ class CiTestCovMapperV2Test extends DDCoreSpecification {
           files          : [
             [
               filename: "source",
-              segments: [[4, -1, 4, -1, 11]]
+              bitmap:[3, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 8]
             ]
           ]
         ]

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -99,7 +99,6 @@ excludedClassesCoverage += [
   "datadog.trace.api.civisibility.coverage.NoOpProbes",
   "datadog.trace.api.civisibility.coverage.TestReport",
   "datadog.trace.api.civisibility.coverage.TestReportFileEntry",
-  "datadog.trace.api.civisibility.coverage.TestReportFileEntry.Segment",
   "datadog.trace.api.civisibility.events.BuildEventsHandler.ModuleInfo",
   "datadog.trace.api.civisibility.events.TestDescriptor",
   "datadog.trace.api.civisibility.events.TestSuiteDescriptor",

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/coverage/TestReportFileEntry.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/coverage/TestReportFileEntry.java
@@ -1,24 +1,24 @@
 package datadog.trace.api.civisibility.coverage;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.BitSet;
+import javax.annotation.Nullable;
 
 public class TestReportFileEntry {
   private final String sourceFileName;
-  private final List<Segment> segments;
+  private final @Nullable BitSet coveredLines;
 
-  public TestReportFileEntry(String sourceFileName, List<Segment> segments) {
+  public TestReportFileEntry(String sourceFileName, @Nullable BitSet coveredLines) {
     this.sourceFileName = sourceFileName;
-    this.segments = segments;
+    this.coveredLines = coveredLines;
   }
 
   public String getSourceFileName() {
     return sourceFileName;
   }
 
-  public Collection<Segment> getSegments() {
-    return segments;
+  @Nullable
+  public BitSet getCoveredLines() {
+    return coveredLines;
   }
 
   @Override
@@ -27,65 +27,7 @@ public class TestReportFileEntry {
         + "sourceFileName='"
         + sourceFileName
         + "', lines=["
-        + segments.stream().map(s -> String.valueOf(s.startLine)).collect(Collectors.joining(","))
+        + coveredLines
         + "]}";
-  }
-
-  public static class Segment implements Comparable<Segment> {
-    private final int startLine;
-    private final int startColumn;
-    private final int endLine;
-    private final int endColumn;
-    private final int numberOfExecutions;
-
-    public Segment(
-        int startLine, int startColumn, int endLine, int endColumn, int numberOfExecutions) {
-      this.startLine = startLine;
-      this.startColumn = startColumn;
-      this.endLine = endLine;
-      this.endColumn = endColumn;
-      this.numberOfExecutions = numberOfExecutions;
-    }
-
-    public int getStartLine() {
-      return startLine;
-    }
-
-    public int getStartColumn() {
-      return startColumn;
-    }
-
-    public int getEndLine() {
-      return endLine;
-    }
-
-    public int getEndColumn() {
-      return endColumn;
-    }
-
-    public int getNumberOfExecutions() {
-      return numberOfExecutions;
-    }
-
-    @Override
-    public int compareTo(Segment segment) {
-      return startLine - segment.startLine;
-    }
-
-    @Override
-    public String toString() {
-      return "Segment{"
-          + "startLine="
-          + startLine
-          + ", startColumn="
-          + startColumn
-          + ", endLine="
-          + endLine
-          + ", endColumn="
-          + endColumn
-          + ", numberOfExecutions="
-          + numberOfExecutions
-          + '}';
-    }
   }
 }


### PR DESCRIPTION
# What Does This Do

Changes the format of per-test code coverage: instead of a list of covered segments (`[startLine, endLine]`) a base64-encoded bit vector of covered lines is introduced.

# Motivation

As agreed with the backend. The new format is more space-efficient and easier to work with.

Jira ticket: [SDTEST-112]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-112]: https://datadoghq.atlassian.net/browse/SDTEST-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ