### PR TITLE
Fix Gradle v8.9 instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListenerInjector.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListenerInjector.java
@@ -1,18 +1,16 @@
 package datadog.trace.instrumentation.gradle;
 
 import org.gradle.initialization.ClassLoaderRegistry;
-import org.gradle.internal.service.ServiceRegistration;
+import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.service.scopes.BuildScopeServices;
 
-public class CiVisibilityGradleListenerProvider {
-  private final ClassLoaderRegistry classLoaderRegistry;
+public class CiVisibilityGradleListenerInjector {
 
-  public CiVisibilityGradleListenerProvider(ClassLoaderRegistry classLoaderRegistry) {
-    this.classLoaderRegistry = classLoaderRegistry;
-  }
-
-  public void configure(ServiceRegistration serviceRegistration) {
-    Class<?> ciVisibilityGradleListener = loadCiVisibilityGradleListener();
-    serviceRegistration.add(ciVisibilityGradleListener);
+  public static void inject(ServiceRegistry parentServices, BuildScopeServices buildScopeServices) {
+    ClassLoaderRegistry classLoaderRegistry = parentServices.get(ClassLoaderRegistry.class);
+    Class<?> ciVisibilityGradleListener = loadCiVisibilityGradleListener(classLoaderRegistry);
+    buildScopeServices.register(
+        serviceRegistration -> serviceRegistration.add(ciVisibilityGradleListener));
   }
 
   /**
@@ -24,7 +22,7 @@ public class CiVisibilityGradleListenerProvider {
    * org.gradle.api.tasks.testing.Test} task), which is a plugin. Therefore, we cannot reference its
    * {@code Class} instance directly, and instead have to load it explicitly.
    */
-  private Class<?> loadCiVisibilityGradleListener() {
+  private static Class<?> loadCiVisibilityGradleListener(ClassLoaderRegistry classLoaderRegistry) {
     try {
       return classLoaderRegistry
           .getPluginsClassLoader()

--- a/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildScopeServicesInstrumentation.java
+++ b/dd-java-agent/instrumentation/gradle/src/main/groovy/datadog/trace/instrumentation/gradle/GradleBuildScopeServicesInstrumentation.java
@@ -10,7 +10,6 @@ import datadog.trace.api.Config;
 import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.BuildScopeServices;
 
@@ -36,7 +35,7 @@ public class GradleBuildScopeServicesInstrumentation extends InstrumenterModule.
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".CiVisibilityGradleListenerProvider",
+      packageName + ".CiVisibilityGradleListenerInjector",
     };
   }
 
@@ -55,9 +54,8 @@ public class GradleBuildScopeServicesInstrumentation extends InstrumenterModule.
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void afterConstructor(
         @Advice.This final BuildScopeServices buildScopeServices,
-        @Advice.Argument(0) final ServiceRegistry parent) {
-      ClassLoaderRegistry classLoaderRegistry = parent.get(ClassLoaderRegistry.class);
-      buildScopeServices.addProvider(new CiVisibilityGradleListenerProvider(classLoaderRegistry));
+        @Advice.Argument(0) final ServiceRegistry parentServices) {
+      CiVisibilityGradleListenerInjector.inject(parentServices, buildScopeServices);
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

Fixes Gradle instrumentation following release v8.9

# Additional Notes

Previous version of the code used `org.gradle.internal.service.DefaultServiceRegistry#addProvider(Object)` method to register CI Visibility plugin.
In Gradle v8.9 this method was replaced with `org.gradle.internal.service.DefaultServiceRegistry#addProvider(org.gradle.internal.service.ServiceRegistrationProvider)`.
The new `ServiceRegistrationProvider` interface is introduced in Gradle v8.9.

The fixed version of the code uses alternative service registration method which works both in v8.9 and in older versions.

Jira ticket: [SDTEST-566]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-566]: https://datadoghq.atlassian.net/browse/SDTEST-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ