### PR TITLE
Fix dependency lock update workflow

### DIFF
--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add **/gradle.lockfile
+          git add "**/gradle.lockfile"
           git commit -m "chore: Update Gradle dependencies"
           git push -u origin $BRANCH_NAME
           gh pr create --title "Update Gradle dependencies" \


### PR DESCRIPTION
# What Does This Do

This PR should fix the workflow that automates the dependency lock update.

# Motivation

Workflow failed to create commit and PR.

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
