### PR TITLE
Fix tracer freeze when CI Visibility is enabled

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/DDAgentWriter.java
@@ -39,6 +39,8 @@ public class DDAgentWriter extends RemoteWriter {
     Monitoring monitoring = Monitoring.DISABLED;
     boolean traceAgentV05Enabled = Config.get().isTraceAgentV05Enabled();
     boolean metricsReportingEnabled = Config.get().isTracerMetricsEnabled();
+    private int flushTimeout = 1;
+    private TimeUnit flushTimeoutUnit = TimeUnit.SECONDS;
     boolean alwaysFlush = false;
 
     private DDAgentApi agentApi;
@@ -116,6 +118,12 @@ public class DDAgentWriter extends RemoteWriter {
       return this;
     }
 
+    public DDAgentWriterBuilder flushTimeout(int flushTimeout, TimeUnit flushTimeoutUnit) {
+      this.flushTimeout = flushTimeout;
+      this.flushTimeoutUnit = flushTimeoutUnit;
+      return this;
+    }
+
     public DDAgentWriterBuilder alwaysFlush(boolean alwaysFlush) {
       this.alwaysFlush = alwaysFlush;
       return this;
@@ -157,7 +165,13 @@ public class DDAgentWriter extends RemoteWriter {
               singleSpanSampler,
               null);
 
-      return new DDAgentWriter(traceProcessingWorker, dispatcher, healthMetrics, alwaysFlush);
+      return new DDAgentWriter(
+          traceProcessingWorker,
+          dispatcher,
+          healthMetrics,
+          flushTimeout,
+          flushTimeoutUnit,
+          alwaysFlush);
     }
   }
 
@@ -165,7 +179,9 @@ public class DDAgentWriter extends RemoteWriter {
       TraceProcessingWorker worker,
       PayloadDispatcher dispatcher,
       HealthMetrics healthMetrics,
+      int flushTimeout,
+      TimeUnit flushTimeoutUnit,
       boolean alwaysFlush) {
-    super(worker, dispatcher, healthMetrics, alwaysFlush);
+    super(worker, dispatcher, healthMetrics, flushTimeout, flushTimeoutUnit, alwaysFlush);
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/DDAgentWriterTest.groovy
@@ -35,7 +35,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
   def dispatcher = new PayloadDispatcherImpl(new DDAgentMapperDiscovery(discovery), api, monitor, monitoring)
 
   @Subject
-  def writer = new DDAgentWriter(worker, dispatcher, monitor, false)
+  def writer = new DDAgentWriter(worker, dispatcher, monitor, 1, TimeUnit.SECONDS, false)
 
   // Only used to create spans
   def dummyTracer = tracerBuilder().writer(new ListWriter()).build()
@@ -176,7 +176,7 @@ class DDAgentWriterTest extends DDCoreSpecification {
     def worker = Mock(TraceProcessingWorker)
     def monitor = Stub(HealthMetrics)
     def dispatcher = Mock(PayloadDispatcherImpl)
-    def writer = new DDAgentWriter(worker, dispatcher, monitor, false)
+    def writer = new DDAgentWriter(worker, dispatcher, monitor, 1, TimeUnit.SECONDS, false)
     def p0 = newSpan()
     p0.setSamplingPriority(PrioritySampling.SAMPLER_DROP)
     def trace = [p0, newSpan()]


### PR DESCRIPTION
# What Does This Do

Changes `TraceProcessingWorker#serializerThread` to always be a daemon thread (before the changes the thread was started as non-daemon if CI Visibility was enabled).

# Motivation

This thread runs an infinite loop, polling traces that are ready to be processed.
If it is not daemon the JVM will never exit, unless the thread is interrupted or `System#exit` is called.
Maven and Gradle do the latter, which is why the builds do not hang.
However, if CI Visibility is enabled in an app that does not call `System#exit`, the tracer will never exit.
The easiest way to reproduce is tracing something simple like `java -version`.

# Additional Notes

The reason for making this thread non-daemon was to allow it to flush all the pending traces before the build finishes.
However, this is redundant because the tracer shutdown sequence flushes the traces and waits for them to finish:

- `CoreTracer` creates and registers `ShutdownHook`
- Calling `System.exit` will trigger `ShutdownHook`
- `ShutdownHook` calls `CoreTracer#close`
- `CoreTracer#close` calls `Writer#flush`
- `Writer#flush` calls `TraceProcessingWorker#flush`
- `TraceProcessingWorker#flush` creates a `FlushEvent` and waits up to `RemoteWriter#flushTimeout` for the flush to finish

Jira ticket: [SDTEST-569]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-569]: https://datadoghq.atlassian.net/browse/SDTEST-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ