### PR TITLE
Add k6 + petclinic macrobenchmark

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
   - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
   - local: ".gitlab/benchmarks.yml"
+  - local: ".gitlab/macrobenchmarks.yml"
   - local: ".gitlab/exploration-tests.yml"
   - local: ".gitlab/ci-visibility-tests.yml"
   - local: ".gitlab/single-step-instrumentation-tests.yml"
@@ -11,6 +12,7 @@ stages:
   - package
   - deploy
   - benchmarks
+  - macrobenchmarks
   - exploration-tests
   - ci-visibility-tests
   - single-step-instrumentation-tests

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -1,13 +1,10 @@
-variables:
-  BASE_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-java-benchmarks
-
 .benchmarks:
   stage: benchmarks
   when: on_success
   interruptible: true
   timeout: 1h
   tags: ["runner:apm-k8s-tweaked-metal"]
-  image: $BASE_CI_IMAGE
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-java-benchmarks
   needs: [ "build" ]
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && mkdir -p "${ARTIFACTS_DIR}"
@@ -138,66 +135,3 @@ debugger-benchmarks:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME # The branch or tag name for which project is built.
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-
-.macrobenchmarks:
-  stage: benchmarks
-  rules:
-    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
-      when: always
-    - when: manual
-  tags: ["runner:apm-k8s-same-cpu"]
-  needs: ["build"]
-  interruptible: true
-  timeout: 1h
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-java-petclinic
-  script:
-    - git clone --branch java/petclinic https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
-    - ./steps/run-benchmarks.sh
-  artifacts:
-    name: "artifacts"
-    when: always
-    paths:
-      - artifacts/
-    expire_in: 3 months
-  variables:
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: benchmarking-platform
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-
-    K6_OPTIONS_WARMUP_RATE: 2000
-    K6_OPTIONS_WARMUP_DURATION: 5m
-    K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s
-    K6_OPTIONS_WARMUP_PRE_ALLOCATED_VUS: 4
-    K6_OPTIONS_WARMUP_MAX_VUS: 4
-
-    K6_OPTIONS_NORMAL_OPERATION_RATE: 1500
-    K6_OPTIONS_NORMAL_OPERATION_DURATION: 10m
-    K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 10s
-    K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
-    K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4
-
-    K6_OPTIONS_HIGH_LOAD_RATE: 4000
-    K6_OPTIONS_HIGH_LOAD_DURATION: 5m
-    K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 10s
-    K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
-    K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
-
-baseline:
-  extends: .macrobenchmarks
-  variables:
-    BP_BENCHMARKS_CONFIGURATION: baseline
-    TRACER_OPTS: -Ddd.service=bp-java-petclinic
-    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M
-
-only-tracing:
-  extends: .macrobenchmarks
-  variables:
-    BP_BENCHMARKS_CONFIGURATION: only-tracing
-    TRACER_OPTS: -javaagent:/app/dd-java-agent.jar -Ddd.env=${BP_BENCHMARKS_CONFIGURATION} -Ddd.service=bp-java-petclinic
-    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M
-
-otel-latest:
-  extends: .macrobenchmarks
-  variables:
-    BP_BENCHMARKS_CONFIGURATION: otel-latest
-    TRACER_OPTS: -javaagent:/app/otel-java-agent.jar -Ddd.env=otel-latest -Ddd.service=bp-java-petclinic
-    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -138,3 +138,66 @@ debugger-benchmarks:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME # The branch or tag name for which project is built.
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA # The commit revision the project is built for.
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+.macrobenchmarks:
+  stage: benchmarks
+  rules:
+    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
+      when: always
+    - when: manual
+  tags: ["runner:apm-k8s-same-cpu"]
+  needs: ["build"]
+  interruptible: true
+  timeout: 1h
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-java-petclinic
+  script:
+    - git clone --branch java/petclinic https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - ./steps/run-benchmarks.sh
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 3 months
+  variables:
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: benchmarking-platform
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+    K6_OPTIONS_WARMUP_RATE: 2000
+    K6_OPTIONS_WARMUP_DURATION: 5m
+    K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s
+    K6_OPTIONS_WARMUP_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_WARMUP_MAX_VUS: 4
+
+    K6_OPTIONS_NORMAL_OPERATION_RATE: 1500
+    K6_OPTIONS_NORMAL_OPERATION_DURATION: 10m
+    K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 10s
+    K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4
+
+    K6_OPTIONS_HIGH_LOAD_RATE: 4000
+    K6_OPTIONS_HIGH_LOAD_DURATION: 5m
+    K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 10s
+    K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
+
+baseline:
+  extends: .macrobenchmarks
+  variables:
+    BP_BENCHMARKS_CONFIGURATION: baseline
+    TRACER_OPTS: -Ddd.service=bp-java-petclinic
+    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M
+
+only-tracing:
+  extends: .macrobenchmarks
+  variables:
+    BP_BENCHMARKS_CONFIGURATION: only-tracing
+    TRACER_OPTS: -javaagent:/app/dd-java-agent.jar -Ddd.env=${BP_BENCHMARKS_CONFIGURATION} -Ddd.service=bp-java-petclinic
+    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M
+
+otel-latest:
+  extends: .macrobenchmarks
+  variables:
+    BP_BENCHMARKS_CONFIGURATION: otel-latest
+    TRACER_OPTS: -javaagent:/app/otel-java-agent.jar -Ddd.env=otel-latest -Ddd.service=bp-java-petclinic
+    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -1,6 +1,5 @@
-
 .macrobenchmarks:
-  stage: benchmarks
+  stage: macrobenchmarks
   rules:
     - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
       when: always

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -19,7 +19,6 @@
       - artifacts/
     expire_in: 3 months
   variables:
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: benchmarking-platform
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
     K6_OPTIONS_WARMUP_RATE: 2000

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -38,6 +38,14 @@
     K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 10s
     K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
     K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
+  retry:
+    max: 2
+    when:
+      - unknown_failure
+      - data_integrity_failure
+      - runner_system_failure
+      - scheduler_failure
+      - api_failure
 
 baseline:
   extends: .macrobenchmarks

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -1,0 +1,63 @@
+
+.macrobenchmarks:
+  stage: benchmarks
+  rules:
+    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
+      when: always
+    - when: manual
+  tags: ["runner:apm-k8s-same-cpu"]
+  needs: ["build"]
+  interruptible: true
+  timeout: 1h
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-java-petclinic
+  script:
+    - git clone --branch java/petclinic https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - ./steps/run-benchmarks.sh
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - artifacts/
+    expire_in: 3 months
+  variables:
+    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: benchmarking-platform
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+    K6_OPTIONS_WARMUP_RATE: 2000
+    K6_OPTIONS_WARMUP_DURATION: 5m
+    K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s
+    K6_OPTIONS_WARMUP_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_WARMUP_MAX_VUS: 4
+
+    K6_OPTIONS_NORMAL_OPERATION_RATE: 1500
+    K6_OPTIONS_NORMAL_OPERATION_DURATION: 10m
+    K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 10s
+    K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4
+
+    K6_OPTIONS_HIGH_LOAD_RATE: 4000
+    K6_OPTIONS_HIGH_LOAD_DURATION: 5m
+    K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 10s
+    K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
+
+baseline:
+  extends: .macrobenchmarks
+  variables:
+    BP_BENCHMARKS_CONFIGURATION: baseline
+    TRACER_OPTS: -Ddd.service=bp-java-petclinic
+    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M
+
+only-tracing:
+  extends: .macrobenchmarks
+  variables:
+    BP_BENCHMARKS_CONFIGURATION: only-tracing
+    TRACER_OPTS: -javaagent:/app/dd-java-agent.jar -Ddd.env=${BP_BENCHMARKS_CONFIGURATION} -Ddd.service=bp-java-petclinic
+    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M
+
+otel-latest:
+  extends: .macrobenchmarks
+  variables:
+    BP_BENCHMARKS_CONFIGURATION: otel-latest
+    TRACER_OPTS: -javaagent:/app/otel-java-agent.jar -Ddd.env=otel-latest -Ddd.service=bp-java-petclinic
+    JAVA_OPTS: -javaagent:/app/memcheck/stability-testing-memwatch.jar -Xmx128M

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -16,7 +16,7 @@
     name: "artifacts"
     when: always
     paths:
-      - artifacts/
+      - platform/artifacts/
     expire_in: 3 months
   variables:
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"


### PR DESCRIPTION
# What Does This Do

Add k6 + petclinic macrobenchmark that measures:
 * CPU and RSS Usage;
 * JVM internal metrics like young cycles, old gen size, metaspace size, etc.;
 * Latency;
 * Throughput.

The benchmark runs on every master branch commit automatically, and manually runnable on PR branches.

There are 3 variants at the moment:
 * baseline -- uninstrumented application;
 * only-tracing -- application instrumented with DD Java agent;
 * otel-latest -- application instrumented with latest OTel agent.

# Motivation

Add performance testing coverage for JVM metrics and CPU / RSS usage in case of simple macrobenchmarks.

# Additional Notes

The work is based on @nayeem-kamal 's original ben-runner petclinic macrobenchmark, but couple of things were changed:
 * Instead of H2 database, PostgreSQL is used;
 * Warmup phase was added;
 * The benchmark was updated to use modern bp-runner instead of legacy ben-runner;
 * Datadog dashboard was simplified and updated.