### PR TITLE
Fix EL function behavior for null values

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.ListValue;
@@ -23,12 +25,17 @@ public final class HasAllExpression extends MatchingExpression {
   @Override
   public Boolean evaluate(ValueReferenceResolver valueRefResolver) {
     if (valueExpression == null) {
-      return Boolean.FALSE;
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
     }
-
     Value<?> value = valueExpression.evaluate(valueRefResolver);
     if (value.isUndefined()) {
-      return Boolean.FALSE;
+      throw new EvaluationException(
+          "Cannot evaluate the expression for undefined value", PrettyPrintVisitor.print(this));
+    }
+    if (value.isNull()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
     }
     if (value instanceof ListValue) {
       ListValue collection = (ListValue) value;

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAnyExpression.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.ListValue;
@@ -24,15 +26,17 @@ public final class HasAnyExpression extends MatchingExpression {
   @Override
   public Boolean evaluate(ValueReferenceResolver valueRefResolver) {
     if (valueExpression == null) {
-      return Boolean.FALSE;
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
     }
     Value<?> value = valueExpression.evaluate(valueRefResolver);
     if (value.isUndefined()) {
-      return Boolean.FALSE;
+      throw new EvaluationException(
+          "Cannot evaluate the expression for undefined value", PrettyPrintVisitor.print(this));
     }
     if (value.isNull()) {
-      // always return FALSE for null values
-      return Boolean.FALSE;
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
     }
     if (value instanceof ListValue) {
       ListValue collection = (ListValue) value;

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IndexExpression.java
@@ -22,8 +22,13 @@ public class IndexExpression implements ValueExpression<Value<?>> {
   @Override
   public Value<?> evaluate(ValueReferenceResolver valueRefResolver) {
     Value<?> targetValue = target.evaluate(valueRefResolver);
-    if (targetValue == Value.undefined()) {
-      return targetValue;
+    if (targetValue.isUndefined()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for undefined value", PrettyPrintVisitor.print(this));
+    }
+    if (targetValue.isNull()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
     }
     Value<?> result = Value.undefinedValue();
     Value<?> keyValue = key.evaluate(valueRefResolver);

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IsEmptyExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/IsEmptyExpression.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.CollectionValue;
@@ -20,8 +22,13 @@ public final class IsEmptyExpression implements BooleanExpression {
   @Override
   public Boolean evaluate(ValueReferenceResolver valueRefResolver) {
     Value<?> value = valueExpression.evaluate(valueRefResolver);
-    if (value.isNull() || value.isUndefined()) {
-      return Boolean.TRUE;
+    if (value.isUndefined()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for undefined value", PrettyPrintVisitor.print(this));
+    }
+    if (value.isNull()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
     }
     if (value instanceof CollectionValue) {
       return ((CollectionValue<?>) value).isEmpty();

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/LenExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/LenExpression.java
@@ -31,9 +31,9 @@ public final class LenExpression implements ValueExpression<Value<? extends Numb
     Value<?> materialized = source == null ? Value.nullValue() : source.evaluate(valueRefResolver);
     try {
       if (materialized.isNull()) {
-        return (NumericValue) Value.of(-1);
+        throw new RuntimeException("Cannot evaluate the expression for null value");
       } else if (materialized.isUndefined()) {
-        return (NumericValue) Value.of(0);
+        throw new RuntimeException("Cannot evaluate the expression for undefined value");
       } else if (materialized instanceof StringValue) {
         return (NumericValue) Value.of(((StringValue) materialized).length());
       } else if (materialized instanceof CollectionValue) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/StringPredicateExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/StringPredicateExpression.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.PrettyPrintVisitor;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -26,6 +28,14 @@ public class StringPredicateExpression implements BooleanExpression {
   public Boolean evaluate(ValueReferenceResolver valueRefResolver) {
     Value<?> sourceValue =
         sourceString != null ? sourceString.evaluate(valueRefResolver) : Value.nullValue();
+    if (sourceValue.isUndefined()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for undefined value", PrettyPrintVisitor.print(this));
+    }
+    if (sourceValue.isNull()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
+    }
     if (sourceValue.getValue() instanceof String) {
       String sourceStr = (String) sourceValue.getValue();
       return predicate.test(sourceStr, str.getValue());

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -11,8 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import okio.Okio;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +35,7 @@ public class ProbeConditionTest {
 
   @Test
   void testExecuteCondition() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_01.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_01.json");
     class Obj1 {
       Collection<String> tags = Arrays.asList("hello", "world", "ko");
       private int field = 10;
@@ -53,7 +56,7 @@ public class ProbeConditionTest {
 
   @Test
   void testGetMember() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_04.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_04.json");
     class Obj {
       Container container = new Container("hello");
     }
@@ -75,7 +78,7 @@ public class ProbeConditionTest {
 
   @Test
   void testComparisonOperators() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_05.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_05.json");
     class Obj {
       int intField1 = 42;
       String strField = "foo";
@@ -86,7 +89,7 @@ public class ProbeConditionTest {
 
   @Test
   void testNullLiteral() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_06.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_06.json");
     class Obj {
       Object objField = new Object();
     }
@@ -98,7 +101,7 @@ public class ProbeConditionTest {
 
   @Test
   void testIndex() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_07.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_07.json");
     Map<String, String> strMap = new HashMap<>();
     class Obj {
       int[] intArray = new int[] {1, 1, 1};
@@ -118,7 +121,7 @@ public class ProbeConditionTest {
 
   @Test
   void testStringOperation() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_08.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_08.json");
     class Obj {
       String strField = "foobar";
     }
@@ -140,7 +143,7 @@ public class ProbeConditionTest {
 
   @Test
   void testJsonParsing() throws IOException {
-    ProbeCondition probeCondition = load("/test_conditional_02.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_02.json");
     class Obj {
       Collection<String> vets = Arrays.asList("vet1", "vet2", "vet3");
     }
@@ -152,8 +155,8 @@ public class ProbeConditionTest {
 
   @Test
   void testEquals() throws IOException {
-    ProbeCondition probeCondition1 = load("/test_conditional_01.json");
-    ProbeCondition probeCondition2 = load("/test_conditional_01.json");
+    ProbeCondition probeCondition1 = loadFromResource("/test_conditional_01.json");
+    ProbeCondition probeCondition2 = loadFromResource("/test_conditional_01.json");
 
     assertEquals(probeCondition1, probeCondition1);
     assertEquals(probeCondition1, probeCondition2);
@@ -163,8 +166,8 @@ public class ProbeConditionTest {
 
   @Test
   void testHashCode() throws IOException {
-    ProbeCondition probeCondition1 = load("/test_conditional_01.json");
-    ProbeCondition probeCondition2 = load("/test_conditional_01.json");
+    ProbeCondition probeCondition1 = loadFromResource("/test_conditional_01.json");
+    ProbeCondition probeCondition2 = loadFromResource("/test_conditional_01.json");
 
     Map<ProbeCondition, Boolean> map = new HashMap<>();
     map.put(probeCondition1, true);
@@ -177,13 +180,14 @@ public class ProbeConditionTest {
   void testIncorrectSyntax() {
     UnsupportedOperationException ex =
         assertThrows(
-            UnsupportedOperationException.class, () -> load("/test_conditional_03_error.json"));
+            UnsupportedOperationException.class,
+            () -> loadFromResource("/test_conditional_03_error.json"));
     assertEquals("Unsupported operation 'gte'", ex.getMessage());
   }
 
   @Test
   void redaction() throws IOException {
-    ProbeCondition probeCondition = load("/test_conditional_09.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_09.json");
     Map<String, Object> args = new HashMap<>();
     args.put("password", "secret123");
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(args, null);
@@ -196,7 +200,7 @@ public class ProbeConditionTest {
 
   @Test
   void stringPrimitives() throws IOException {
-    ProbeCondition probeCondition = load("/test_conditional_10.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_10.json");
     Map<String, Object> args = new HashMap<>();
     args.put("uuid", UUID.fromString("a3cbe9e7-edd3-4bef-8e5b-59bfcb04cf91"));
     args.put("duration", Duration.ofSeconds(42));
@@ -207,7 +211,7 @@ public class ProbeConditionTest {
 
   @Test
   void testBooleanOperation() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_11.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_11.json");
     class Obj {
       String strField = "foobar";
       String emptyStr = "";
@@ -222,7 +226,7 @@ public class ProbeConditionTest {
 
   @Test
   void testLiterals() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_13.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_13.json");
     class Obj {
       boolean boolVal = true;
       int intVal = 1;
@@ -238,7 +242,7 @@ public class ProbeConditionTest {
 
   @Test
   void testLenCount() throws Exception {
-    ProbeCondition probeCondition = load("/test_conditional_14.json");
+    ProbeCondition probeCondition = loadFromResource("/test_conditional_14.json");
     class Obj {
       int[] intArray = new int[] {1, 1, 1};
       String[] strArray = new String[] {"foo", "bar"};
@@ -265,13 +269,48 @@ public class ProbeConditionTest {
     assertTrue(probeCondition.execute(ctx));
   }
 
-  private static ProbeCondition load(String resourcePath) throws IOException {
+  @Test
+  public void nullExpressions() {
+    class Obj {
+      Object field = null;
+    }
+    List<String> lines = loadLinesFromResource("/null_expressions.txt");
+    for (String line : lines) {
+      ValueReferenceResolver ctx = RefResolverHelper.createResolver(new Obj());
+      EvaluationException ex =
+          assertThrows(EvaluationException.class, () -> load(line).execute(ctx));
+      assertEquals("Cannot evaluate the expression for null value", ex.getMessage(), line);
+    }
+  }
+
+  private static ProbeCondition loadFromResource(String resourcePath) throws IOException {
     InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath);
     Moshi moshi =
         new Moshi.Builder()
             .add(ProbeCondition.class, new ProbeCondition.ProbeConditionJsonAdapter())
             .build();
     return moshi.adapter(ProbeCondition.class).fromJson(Okio.buffer(Okio.source(input)));
+  }
+
+  private static List<String> loadLinesFromResource(String resourcePath) {
+    try (InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath)) {
+      BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+      return reader.lines().collect(Collectors.toList());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load resource: " + resourcePath, e);
+    }
+  }
+
+  private static ProbeCondition load(String json) {
+    try {
+      Moshi moshi =
+          new Moshi.Builder()
+              .add(ProbeCondition.class, new ProbeCondition.ProbeConditionJsonAdapter())
+              .build();
+      return moshi.adapter(ProbeCondition.class).fromJson(json);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to load json: " + json, e);
+    }
   }
 
   static class Container {

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ContainsExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ContainsExpressionTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -16,7 +17,9 @@ class ContainsExpressionTest {
   @Test
   void nullExpression() {
     ContainsExpression expression = new ContainsExpression(null, null);
-    assertFalse(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
     assertEquals("contains(null, null)", print(expression));
   }
 
@@ -24,7 +27,9 @@ class ContainsExpressionTest {
   void undefinedExpression() {
     ContainsExpression expression =
         new ContainsExpression(DSL.value(Values.UNDEFINED_OBJECT), new StringValue(null));
-    assertFalse(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("contains(UNDEFINED, \"null\")", print(expression));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/EndsWithExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/EndsWithExpressionTest.java
@@ -3,9 +3,11 @@ package com.datadog.debugger.el.expressions;
 import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -18,7 +20,9 @@ class EndsWithExpressionTest {
   @Test
   void nullExpression() {
     EndsWithExpression expression = new EndsWithExpression(null, null);
-    assertFalse(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
     assertEquals("endsWith(null, null)", print(expression));
   }
 
@@ -26,7 +30,9 @@ class EndsWithExpressionTest {
   void undefinedExpression() {
     EndsWithExpression expression =
         new EndsWithExpression(DSL.value(Values.UNDEFINED_OBJECT), new StringValue(null));
-    assertFalse(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("endsWith(UNDEFINED, \"null\")", print(expression));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
@@ -23,13 +24,18 @@ class HasAllExpressionTest {
   @Test
   void testNullPredicate() {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
-    HasAllExpression expression = new HasAllExpression(null, null);
-    assertFalse(expression.evaluate(resolver));
-    assertEquals("hasAll(null, true)", print(expression));
-    expression = new HasAllExpression(value(Values.UNDEFINED_OBJECT), null);
-    assertFalse(expression.evaluate(resolver));
-    assertEquals("hasAll(UNDEFINED, true)", print(expression));
-    expression = new HasAllExpression(value(this), null);
+    HasAllExpression nullExpression = new HasAllExpression(null, null);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> nullExpression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAll(null, true)", print(nullExpression));
+    HasAllExpression undefinedExpression =
+        new HasAllExpression(value(Values.UNDEFINED_OBJECT), null);
+    exception =
+        assertThrows(EvaluationException.class, () -> undefinedExpression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
+    assertEquals("hasAll(UNDEFINED, true)", print(undefinedExpression));
+    HasAllExpression expression = new HasAllExpression(value(this), null);
     assertTrue(expression.evaluate(resolver));
     assertEquals(
         "hasAll(com.datadog.debugger.el.expressions.HasAllExpressionTest, true)",
@@ -45,32 +51,41 @@ class HasAllExpressionTest {
   @Test
   void testNullHasAll() {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(this);
-    HasAllExpression expression = all(null, TRUE);
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(null, true)", print(expression));
+    HasAllExpression nullExpression1 = all(null, TRUE);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> nullExpression1.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAll(null, true)", print(nullExpression1));
 
-    expression = all(null, FALSE);
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(null, false)", print(expression));
+    HasAllExpression nullExpression2 = all(null, FALSE);
+    exception = assertThrows(EvaluationException.class, () -> nullExpression2.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAll(null, false)", print(nullExpression2));
 
-    expression = all(null, eq(ref("testField"), value(10)));
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(null, testField == 10)", print(expression));
+    HasAllExpression nullExpression3 = all(null, eq(ref("testField"), value(10)));
+    exception = assertThrows(EvaluationException.class, () -> nullExpression3.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAll(null, testField == 10)", print(nullExpression3));
   }
 
   @Test
   void testUndefinedHasAll() {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(this);
-    HasAllExpression expression = all(value(Values.UNDEFINED_OBJECT), TRUE);
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(UNDEFINED, true)", print(expression));
+    HasAllExpression undefinedExpression = all(value(Values.UNDEFINED_OBJECT), TRUE);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> undefinedExpression.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
+    assertEquals("hasAll(UNDEFINED, true)", print(undefinedExpression));
 
-    expression = all(null, FALSE);
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAll(null, false)", print(expression));
+    HasAllExpression nullExpression = all(null, FALSE);
+    exception = assertThrows(EvaluationException.class, () -> nullExpression.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAll(null, false)", print(nullExpression));
 
-    expression = all(value(Values.UNDEFINED_OBJECT), eq(ref("testField"), value(10)));
-    assertFalse(expression.evaluate(ctx));
+    HasAllExpression expression =
+        all(value(Values.UNDEFINED_OBJECT), eq(ref("testField"), value(10)));
+    exception = assertThrows(EvaluationException.class, () -> expression.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("hasAll(UNDEFINED, testField == 10)", print(expression));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
@@ -5,6 +5,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.ObjectValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -22,13 +23,18 @@ class HasAnyExpressionTest {
   @Test
   void testNullPredicate() {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
-    HasAnyExpression expression = new HasAnyExpression(null, null);
-    assertFalse(expression.evaluate(resolver));
-    assertEquals("hasAny(null, true)", print(expression));
-    expression = new HasAnyExpression(value(Values.UNDEFINED_OBJECT), null);
-    assertFalse(expression.evaluate(resolver));
-    assertEquals("hasAny(UNDEFINED, true)", print(expression));
-    expression = new HasAnyExpression(value(this), null);
+    HasAnyExpression nullExpression = new HasAnyExpression(null, null);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> nullExpression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAny(null, true)", print(nullExpression));
+    HasAnyExpression undefinedExpression =
+        new HasAnyExpression(value(Values.UNDEFINED_OBJECT), null);
+    exception =
+        assertThrows(EvaluationException.class, () -> undefinedExpression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
+    assertEquals("hasAny(UNDEFINED, true)", print(undefinedExpression));
+    HasAnyExpression expression = new HasAnyExpression(value(this), null);
     assertTrue(expression.evaluate(resolver));
     assertEquals(
         "hasAny(com.datadog.debugger.el.expressions.HasAnyExpressionTest, true)",
@@ -44,33 +50,42 @@ class HasAnyExpressionTest {
   @Test
   void testNullHasAny() {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(this);
-    HasAnyExpression expression = any(null, BooleanExpression.TRUE);
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(null, true)", print(expression));
+    HasAnyExpression nullExpression1 = any(null, BooleanExpression.TRUE);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> nullExpression1.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAny(null, true)", print(nullExpression1));
 
-    expression = any(null, BooleanExpression.FALSE);
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(null, false)", print(expression));
+    HasAnyExpression nullExpression2 = any(null, BooleanExpression.FALSE);
+    exception = assertThrows(EvaluationException.class, () -> nullExpression2.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAny(null, false)", print(nullExpression2));
 
-    expression = any(null, eq(ref("testField"), value(10)));
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(null, testField == 10)", print(expression));
+    HasAnyExpression nullExpression3 = any(null, eq(ref("testField"), value(10)));
+    exception = assertThrows(EvaluationException.class, () -> nullExpression3.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAny(null, testField == 10)", print(nullExpression3));
   }
 
   @Test
   void testUndefinedHasAny() {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(this);
-    HasAnyExpression expression = any(value(Values.UNDEFINED_OBJECT), TRUE);
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(UNDEFINED, true)", print(expression));
+    HasAnyExpression undefinedExpression = any(value(Values.UNDEFINED_OBJECT), TRUE);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> undefinedExpression.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
+    assertEquals("hasAny(UNDEFINED, true)", print(undefinedExpression));
 
-    expression = any(null, FALSE);
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(null, false)", print(expression));
+    HasAnyExpression nullExpression = any(null, FALSE);
+    exception = assertThrows(EvaluationException.class, () -> nullExpression.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("hasAny(null, false)", print(nullExpression));
 
-    expression = any(value(Values.UNDEFINED_OBJECT), eq(ref("testField"), value(10)));
-    assertFalse(expression.evaluate(ctx));
-    assertEquals("hasAny(UNDEFINED, testField == 10)", print(expression));
+    HasAnyExpression undefinedExpression2 =
+        any(value(Values.UNDEFINED_OBJECT), eq(ref("testField"), value(10)));
+    exception = assertThrows(EvaluationException.class, () -> undefinedExpression2.evaluate(ctx));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
+    assertEquals("hasAny(UNDEFINED, testField == 10)", print(undefinedExpression2));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IndexExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IndexExpressionTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static com.datadog.debugger.el.TestHelper.setFieldInConfig;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RedactedException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.Value;
@@ -76,7 +77,10 @@ class IndexExpressionTest {
   @Test
   void undefined() {
     IndexExpression expr = new IndexExpression(ValueExpression.UNDEFINED, new NumericValue(1));
-    assertEquals(Value.undefined(), expr.evaluate(RefResolverHelper.createResolver(this)));
+    EvaluationException exception =
+        assertThrows(
+            EvaluationException.class, () -> expr.evaluate(RefResolverHelper.createResolver(this)));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsEmptyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsEmptyExpressionTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.values.BooleanValue;
@@ -22,22 +23,28 @@ class IsEmptyExpressionTest {
   @Test
   void testNullValue() {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
-    IsEmptyExpression expression = new IsEmptyExpression(null);
-    assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(null)", print(expression));
-    expression = new IsEmptyExpression(DSL.value(Values.NULL_OBJECT));
-    assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(null)", print(expression));
-    expression = new IsEmptyExpression(DSL.value(Value.nullValue()));
-    assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(com.datadog.debugger.el.values.NullValue)", print(expression));
+    IsEmptyExpression expression1 = new IsEmptyExpression(null);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression1.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("isEmpty(null)", print(expression1));
+    IsEmptyExpression expression2 = new IsEmptyExpression(DSL.value(Values.NULL_OBJECT));
+    exception = assertThrows(EvaluationException.class, () -> expression2.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("isEmpty(null)", print(expression2));
+    IsEmptyExpression expression3 = new IsEmptyExpression(DSL.value(Value.nullValue()));
+    exception = assertThrows(EvaluationException.class, () -> expression3.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("isEmpty(com.datadog.debugger.el.values.NullValue)", print(expression3));
   }
 
   @Test
   void testUndefinedValue() {
     ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
     IsEmptyExpression expression = new IsEmptyExpression(DSL.value(Values.UNDEFINED_OBJECT));
-    assertTrue(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("isEmpty(UNDEFINED)", print(expression));
   }
 
@@ -54,9 +61,9 @@ class IsEmptyExpressionTest {
     expression = new IsEmptyExpression(one);
     assertFalse(expression.evaluate(resolver));
     assertEquals("isEmpty(1)", print(expression));
-    expression = new IsEmptyExpression(none);
-    assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(null)", print(expression));
+    IsEmptyExpression nullExpression = new IsEmptyExpression(none);
+    assertThrows(EvaluationException.class, () -> nullExpression.evaluate(resolver));
+    assertEquals("isEmpty(null)", print(nullExpression));
   }
 
   @Test
@@ -72,9 +79,11 @@ class IsEmptyExpressionTest {
     expression = new IsEmptyExpression(no);
     assertFalse(expression.evaluate(resolver));
     assertEquals("isEmpty(false)", print(expression));
-    expression = new IsEmptyExpression(none);
-    assertTrue(expression.evaluate(resolver));
-    assertEquals("isEmpty(null)", print(expression));
+    IsEmptyExpression nullExpression = new IsEmptyExpression(none);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> nullExpression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
+    assertEquals("isEmpty(null)", print(nullExpression));
   }
 
   @Test
@@ -92,7 +101,9 @@ class IsEmptyExpressionTest {
     assertEquals("isEmpty(\"Hello World\")", print(isEmpty1));
     assertTrue(isEmpty2.evaluate(resolver));
     assertEquals("isEmpty(\"\")", print(isEmpty2));
-    assertTrue(isEmpty3.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> isEmpty3.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
     assertEquals("isEmpty(\"null\")", print(isEmpty3));
   }
 
@@ -117,9 +128,12 @@ class IsEmptyExpressionTest {
     assertEquals("isEmpty(List)", print(isEmpty1));
     assertTrue(isEmpty2.evaluate(resolver));
     assertEquals("isEmpty(List)", print(isEmpty2));
-    assertTrue(isEmpty3.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> isEmpty3.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
     assertEquals("isEmpty(null)", print(isEmpty3));
-    assertTrue(isEmpty4.evaluate(resolver));
+    exception = assertThrows(EvaluationException.class, () -> isEmpty4.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("isEmpty(null)", print(isEmpty4));
     assertFalse(isEmpty5.evaluate(resolver));
     assertEquals("isEmpty(Set)", print(isEmpty5));
@@ -144,9 +158,12 @@ class IsEmptyExpressionTest {
     assertEquals("isEmpty(Map)", print(isEmpty1));
     assertTrue(isEmpty2.evaluate(resolver));
     assertEquals("isEmpty(Map)", print(isEmpty2));
-    assertTrue(isEmpty3.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> isEmpty3.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
     assertEquals("isEmpty(null)", print(isEmpty3));
-    assertTrue(isEmpty4.evaluate(resolver));
+    exception = assertThrows(EvaluationException.class, () -> isEmpty4.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("isEmpty(null)", print(isEmpty4));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/LenExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/LenExpressionTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
@@ -18,14 +19,18 @@ class LenExpressionTest {
   @Test
   void nullExpression() {
     LenExpression expression = new LenExpression(null);
-    assertEquals(-1L, expression.evaluate(resolver).getValue());
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver).getValue());
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
     assertEquals("len(null)", print(expression));
   }
 
   @Test
   void undefinedExpression() {
     LenExpression expression = new LenExpression(DSL.value(Values.UNDEFINED_OBJECT));
-    assertEquals(0L, expression.evaluate(resolver).getValue());
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver).getValue());
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("len(UNDEFINED)", print(expression));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/MatchesExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/MatchesExpressionTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -16,7 +17,9 @@ class MatchesExpressionTest {
   @Test
   void nullExpression() {
     MatchesExpression expression = new MatchesExpression(null, null);
-    assertFalse(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
     assertEquals("matches(null, null)", print(expression));
   }
 
@@ -24,7 +27,9 @@ class MatchesExpressionTest {
   void undefinedExpression() {
     MatchesExpression expression =
         new MatchesExpression(DSL.value(Values.UNDEFINED_OBJECT), new StringValue(null));
-    assertFalse(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("matches(UNDEFINED, \"null\")", print(expression));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/StartsWithExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/StartsWithExpressionTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.el.PrettyPrintVisitor.print;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
@@ -16,7 +17,9 @@ class StartsWithExpressionTest {
   @Test
   void nullExpression() {
     StartsWithExpression expression = new StartsWithExpression(null, null);
-    assertFalse(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for null value", exception.getMessage());
     assertEquals("startsWith(null, null)", print(expression));
   }
 
@@ -24,7 +27,9 @@ class StartsWithExpressionTest {
   void undefinedExpression() {
     StartsWithExpression expression =
         new StartsWithExpression(DSL.value(Values.UNDEFINED_OBJECT), new StringValue(null));
-    assertFalse(expression.evaluate(resolver));
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> expression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for undefined value", exception.getMessage());
     assertEquals("startsWith(UNDEFINED, \"null\")", print(expression));
   }
 

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/null_expressions.txt
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/null_expressions.txt
@@ -1,0 +1,20 @@
+{"dsl": "", "json": {"eq": [{"len": null}, 0]}}
+{"dsl": "", "json": {"eq": [{"count": null}, 0]}}
+{"dsl": "", "json": {"eq": [{"len": {"ref": "field"}}, 0]}}
+{"dsl": "", "json": {"eq": [{"count": {"ref": "field"}}, 0]}}
+{"dsl": "", "json": {"hasAny": [null, {"eq": [{"ref": "@it"}, 0]}]}}
+{"dsl": "", "json": {"hasAll": [null, {"eq": [{"ref": "@it"}, 0]}]}}
+{"dsl": "", "json": {"hasAny": [{"ref": "field"}, {"eq": [{"ref": "@it"}, 0]}]}}
+{"dsl": "", "json": {"hasAll": [{"ref": "field"}, {"eq": [{"ref": "@it"}, 0]}]}}
+{"dsl": "", "json": {"isEmpty": null}}
+{"dsl": "", "json": {"isEmpty": {"ref": "field"}}}
+{"dsl": "", "json": {"eq": [{"index": [null, 0]}, 0]}}
+{"dsl": "", "json": {"eq": [{"index": [{"ref": "field"}, 0]}, 0]}}
+{"dsl": "", "json": {"startsWith": [null, "foo"]}}
+{"dsl": "", "json": {"startsWith": [{"ref": "field"}, "foo"]}}
+{"dsl": "", "json": {"endsWith": [null, "foo"]}}
+{"dsl": "", "json": {"endsWith": [{"ref": "field"}, "foo"]}}
+{"dsl": "", "json": {"contains": [null, "foo"]}}
+{"dsl": "", "json": {"contains": [{"ref": "field"}, "foo"]}}
+{"dsl": "", "json": {"matches": [null, "foo"]}}
+{"dsl": "", "json": {"matches": [{"ref": "field"}, "foo"]}}


### PR DESCRIPTION
# What Does This Do
Change behavior to send evaluation error when value is null for
- len/count
- hasAny
- hasAll
- isEmpty
- index
- string predicates (startsWith, endsWith, contains, matches)

# Motivation
Conformance with other client libraries

# Additional Notes

Jira ticket: [DEBUG-2487]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2487]: https://datadoghq.atlassian.net/browse/DEBUG-2487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ