### PR TITLE
Fix github artifact upload using explicit jar names

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,11 +236,9 @@ deploy_artifacts_to_github:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: on_success
-    - when: manual
-      allow_failure: true
-  # Requires the deploy_to_sonatype job to have run first as build cache is broken
+  # Requires the deploy_to_sonatype job to have run first the UP-TO-DATE gradle check across jobs is broken
   # This will deploy the artifacts built from the publishToSonatype task to the GitHub release
   needs:
     - job: deploy_to_sonatype
@@ -250,10 +248,11 @@ deploy_artifacts_to_github:
     - aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.gh_release_token --with-decryption --query "Parameter.Value" --out text > github-token.txt
     - gh auth login --with-token < github-token.txt
     - gh auth status  # Maybe helpful to have this output in logs?
-    - cp workspace/dd-java-agent/build/libs/dd-java-agent-*.jar workspace/dd-java-agent/build/libs/dd-java-agent.jar # we upload two filenames
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/*.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-api/build/libs/*.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-ot/build/libs/*.jar
+    - cp workspace/dd-java-agent/build/libs/dd-java-agent-${CI_COMMIT_TAG}.jar workspace/dd-java-agent/build/libs/dd-java-agent.jar # we upload two filenames
+    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent-${CI_COMMIT_TAG}.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-api/build/libs/dd-trace-api-${CI_COMMIT_TAG}.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-ot/build/libs/dd-trace-ot-${CI_COMMIT_TAG}.jar
 
 generate-lib-init-tag-values:
   tags: ["arch:amd64"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -248,11 +248,12 @@ deploy_artifacts_to_github:
     - aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.gh_release_token --with-decryption --query "Parameter.Value" --out text > github-token.txt
     - gh auth login --with-token < github-token.txt
     - gh auth status  # Maybe helpful to have this output in logs?
-    - cp workspace/dd-java-agent/build/libs/dd-java-agent-${CI_COMMIT_TAG}.jar workspace/dd-java-agent/build/libs/dd-java-agent.jar # we upload two filenames
+    - export VERSION=${CI_COMMIT_TAG##v} # remove "v" from front of tag to get version
+    - cp workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar workspace/dd-java-agent/build/libs/dd-java-agent.jar # we upload two filenames
     - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent-${CI_COMMIT_TAG}.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-api/build/libs/dd-trace-api-${CI_COMMIT_TAG}.jar
-    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-ot/build/libs/dd-trace-ot-${CI_COMMIT_TAG}.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-java-agent/build/libs/dd-java-agent-${VERSION}.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-api/build/libs/dd-trace-api-${VERSION}.jar
+    - gh release upload --clobber --repo DataDog/dd-trace-java $CI_COMMIT_TAG workspace/dd-trace-ot/build/libs/dd-trace-ot-${VERSION}.jar
 
 generate-lib-init-tag-values:
   tags: ["arch:amd64"]


### PR DESCRIPTION
# What Does This Do

Fixes the github artifact upload by using explicit file names

# Motivation
The previous way of using `*.jar` is broken because there are `-source.jar` and `-javadoc.jar` when using artifacts from the `deploy_to_sonotype` job. We know the exact name of the files because it is only run when there is an explicit `CI_COMMIT_TAG` set.

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
