### PR TITLE
Update onboarding and k8s lib injection tests

### DIFF
--- a/.github/workflows/lib-injection.yaml
+++ b/.github/workflows/lib-injection.yaml
@@ -68,8 +68,8 @@ jobs:
     env:
       TEST_LIBRARY: java
       WEBLOG_VARIANT: dd-lib-java-init-test-app
-      DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
-      DOCKER_IMAGE_TAG: ${{ github.sha }}
+      LIB_INIT_IMAGE: ghcr.io/datadog/dd-trace-java/dd-lib-java-init:${{ github.sha }}
+      LIBRARY_INJECTION_TEST_APP_IMAGE: ghcr.io/datadog/system-tests/dd-lib-java-init-test-app:latest
       BUILDX_PLATFORMS: linux/amd64
     steps:
     - name: Checkout system tests
@@ -81,7 +81,7 @@ jobs:
       uses: ./.github/actions/install_runner 
 
     - name: Run K8s Lib Injection Tests
-      run: ./run.sh K8S_LIB_INJECTION_BASIC
+      run: ./run.sh K8S_LIBRARY_INJECTION_BASIC
 
     - name: Compress logs
       id: compress_logs

--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -43,8 +43,4 @@ onboarding_tests:
     - git clone https://git@github.com/DataDog/system-tests.git system-tests
     - cd system-tests
     - ./build.sh -i runner
-    - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env prod --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-skip-branches ubuntu18_amd64
-
-
-
-            
+    - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env prod --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-skip-branches ubuntu18_amd64   

--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -29,8 +29,7 @@ onboarding_tests:
   stage: single-step-instrumentation-tests
   needs: [ oci-internal-test-ecr-publish ]
   rules:
-    #TODO ENABLE THIS BEFORE MERGE- if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"
-    - if: $CI_PIPELINE_SOURCE == "push"
+      if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"
       when: on_success
   allow_failure: false
   variables:

--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -34,7 +34,6 @@ onboarding_tests:
   allow_failure: false
   variables:
     TEST_LIBRARY: java
-    ONBOARDING_FILTER_ENV: prod
     DD_INSTALLER_LIBRARY_VERSION: pipeline-${CI_PIPELINE_ID}
     SCENARIO: SIMPLE_INSTALLER_AUTO_INJECTION
   parallel:

--- a/.gitlab/single-step-instrumentation-tests.yml
+++ b/.gitlab/single-step-instrumentation-tests.yml
@@ -1,38 +1,5 @@
-.base_job_onboarding_tests:
-
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions/runner:a58cc31c
-  tags: ["arch:amd64"]
-  before_script:
-    # Setup AWS Credentials for dd-trace-rb.
-    - mkdir -p ~/.aws
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config
-    - export DD_API_KEY_ONBOARDING=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.dd-api-key-onboarding --with-decryption --query "Parameter.Value" --out text)
-    - export DD_APP_KEY_ONBOARDING=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.dd-app-key-onboarding --with-decryption --query "Parameter.Value" --out text)
-    - export ONBOARDING_AWS_INFRA_SUBNET_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.aws-infra-subnet-id --with-decryption --query "Parameter.Value" --out text)
-    - export ONBOARDING_AWS_INFRA_SECURITY_GROUPS_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.aws-infra-securiy-groups-id --with-decryption --query "Parameter.Value" --out text)
-    - export ONBOARDING_AWS_INFRA_IAM_INSTANCE_PROFILE=ec2InstanceRole
-    - export PULUMI_CONFIG_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.pulumi-config-passphrase --with-decryption --query "Parameter.Value" --out text) 
-    #Install plugins for PULUMI you need connect to gh. Sometimes this problem arises: GitHub rate limit exceeded
-    - export GITHUB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.gh-token --with-decryption --query "Parameter.Value" --out text) 
-    #Avoid dockerhub rate limits
-    - export DOCKER_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.docker-login --with-decryption --query "Parameter.Value" --out text) 
-    - export DOCKER_LOGIN_PASS=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-java.docker-login-pass --with-decryption --query "Parameter.Value" --out text) 
-
-    - export AWS_PROFILE=agent-qa-ci
-    - pulumi login --local #"s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
-    - pulumi plugin install resource command 0.7.2
-    - pulumi plugin install resource aws 5.41.0
-
-  after_script:
-    - echo "After onboarding script"
-    - cd system-tests
-    - mkdir -p reports
-    - cp -R logs_*/ reports/
-  
-  artifacts:
-      when: always
-      paths:
-        - system-tests/reports/
+include:
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/single-step-instrumentation-tests.yml
 
 oci-internal-publish:
   extends: .oci-internal-publish
@@ -57,32 +24,29 @@ oci-internal-test-ecr-publish:
     IMG_DESTINATIONS: apm-library-java-package:pipeline-${CI_PIPELINE_ID}
     IMG_REGISTRIES: agent-qa
 
-
 onboarding_tests:
-  extends: .base_job_onboarding_tests
+  extends: .base_job_onboarding
   stage: single-step-instrumentation-tests
-  needs: [ package, package-arm, oci-internal-test-ecr-publish ]
+  needs: [ oci-internal-test-ecr-publish ]
   rules:
-    - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"
+    #TODO ENABLE THIS BEFORE MERGE- if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == "master"
+    - if: $CI_PIPELINE_SOURCE == "push"
       when: on_success
   allow_failure: false
   variables:
     TEST_LIBRARY: java
     ONBOARDING_FILTER_ENV: prod
+    DD_INSTALLER_LIBRARY_VERSION: pipeline-${CI_PIPELINE_ID}
+    SCENARIO: SIMPLE_INSTALLER_AUTO_INJECTION
   parallel:
       matrix:
-        - ONBOARDING_FILTER_WEBLOG: [test-app-java]
-          SCENARIO: [SIMPLE_HOST_AUTO_INJECTION]
-        - ONBOARDING_FILTER_WEBLOG: [test-app-java-container,test-app-java-buildpack,test-app-java-alpine]
-          SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION]
-        - ONBOARDING_FILTER_WEBLOG: [test-app-java,test-app-java-container,test-app-java-buildpack,test-app-java-alpine]
-          SCENARIO: [INSTALLER_AUTO_INJECTION]
+        - ONBOARDING_FILTER_WEBLOG: [test-app-java, test-app-java-container, test-app-java-container-jdk15, test-app-java-alpine-libgcc, test-app-java-buildpack]         
   script:
     - git clone https://git@github.com/DataDog/system-tests.git system-tests
-    - cp packaging/*.rpm system-tests/binaries
-    - cp packaging/*.deb system-tests/binaries
-    - export DD_INSTALLER_LIBRARY_VERSION="pipeline-${CI_PIPELINE_ID}"
-    - ls system-tests/binaries
     - cd system-tests
     - ./build.sh -i runner
     - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env prod --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-skip-branches ubuntu18_amd64
+
+
+
+            


### PR DESCRIPTION
# What Does This Do
Update lib injection tests: onboarding (gitlab) and k8s (github)
# Motivation
- k8s lib injection: Remove deprecated scenario and use new simplified scenario
- onboarding: Avoid test deb and rpm packages. Test  the new datadog installer.
# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
