### PR TITLE
Extend `contains` EL expression

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -56,6 +56,30 @@ public class WellKnownClasses {
         "java.util.concurrent.atomic.AtomicLong", WellKnownClasses::genericToString);
   }
 
+  private static final Set<String> EQUALS_SAFE_CLASSES = new HashSet<>();
+
+  static {
+    EQUALS_SAFE_CLASSES.add("java.lang.Class");
+    EQUALS_SAFE_CLASSES.add("java.lang.String");
+    EQUALS_SAFE_CLASSES.add("java.lang.Boolean");
+    EQUALS_SAFE_CLASSES.add("java.lang.Integer");
+    EQUALS_SAFE_CLASSES.add("java.lang.Long");
+    EQUALS_SAFE_CLASSES.add("java.lang.Double");
+    EQUALS_SAFE_CLASSES.add("java.lang.Character");
+    EQUALS_SAFE_CLASSES.add("java.lang.Byte");
+    EQUALS_SAFE_CLASSES.add("java.lang.Float");
+    EQUALS_SAFE_CLASSES.add("java.lang.Short");
+    EQUALS_SAFE_CLASSES.add("java.math.BigDecimal");
+    EQUALS_SAFE_CLASSES.add("java.math.BigInteger");
+    EQUALS_SAFE_CLASSES.add("java.time.Duration");
+    EQUALS_SAFE_CLASSES.add("java.time.Instant");
+    EQUALS_SAFE_CLASSES.add("java.time.LocalTime");
+    EQUALS_SAFE_CLASSES.add("java.time.LocalDate");
+    EQUALS_SAFE_CLASSES.add("java.time.LocalDateTime");
+    EQUALS_SAFE_CLASSES.add("java.util.UUID");
+    EQUALS_SAFE_CLASSES.add("java.net.URI");
+  }
+
   private static final Set<String> STRING_PRIMITIVES =
       new HashSet<>(
           Arrays.asList(
@@ -191,6 +215,12 @@ public class WellKnownClasses {
 
   private static String genericToString(Object o) {
     return String.valueOf(o);
+  }
+
+  public static boolean isEqualsSafe(Class<?> clazz) {
+    return clazz.isPrimitive()
+        || clazz.isEnum()
+        || EQUALS_SAFE_CLASSES.contains(clazz.getTypeName());
   }
 
   private static class ThrowableFields {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/DSL.java
@@ -199,9 +199,8 @@ public class DSL {
     return new EndsWithExpression(valueExpression, str);
   }
 
-  public static StringPredicateExpression contains(
-      ValueExpression<?> valueExpression, StringValue str) {
-    return new ContainsExpression(valueExpression, str);
+  public static ContainsExpression contains(ValueExpression<?> target, ValueExpression<?> value) {
+    return new ContainsExpression(target, value);
   }
 
   public static StringPredicateExpression matches(

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java
@@ -6,6 +6,7 @@ import static com.squareup.moshi.JsonReader.Token.NUMBER;
 import static com.squareup.moshi.JsonReader.Token.STRING;
 
 import com.datadog.debugger.el.expressions.BooleanExpression;
+import com.datadog.debugger.el.expressions.ContainsExpression;
 import com.datadog.debugger.el.expressions.StringPredicateExpression;
 import com.datadog.debugger.el.expressions.ValueExpression;
 import com.datadog.debugger.el.values.StringValue;
@@ -250,7 +251,16 @@ public class JsonToExpressionConverter {
         }
       case "contains":
         {
-          return createStringPredicateExpression(reader, DSL::contains);
+          JsonReader.Token token = reader.peek();
+          if (token != BEGIN_ARRAY) {
+            throw new UnsupportedOperationException(
+                "Operation 'contains' expects the arguments to be defined as array");
+          }
+          reader.beginArray();
+          ContainsExpression expr =
+              DSL.contains(asValueExpression(reader), asValueExpression(reader));
+          reader.endArray();
+          return expr;
         }
       case "matches":
         {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/PrettyPrintVisitor.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/PrettyPrintVisitor.java
@@ -75,7 +75,11 @@ public class PrettyPrintVisitor implements Visitor<String> {
 
   @Override
   public String visit(ContainsExpression containsExpression) {
-    return stringPredicateExpression(containsExpression);
+    return "contains("
+        + nullSafeAccept(containsExpression.getTarget())
+        + ", "
+        + nullSafeAccept(containsExpression.getValue())
+        + ")";
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ContainsExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ContainsExpression.java
@@ -1,15 +1,61 @@
 package com.datadog.debugger.el.expressions;
 
+import com.datadog.debugger.el.EvaluationException;
+import com.datadog.debugger.el.PrettyPrintVisitor;
+import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
-import com.datadog.debugger.el.values.StringValue;
+import com.datadog.debugger.el.values.CollectionValue;
+import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 
-public class ContainsExpression extends StringPredicateExpression {
-  public ContainsExpression(ValueExpression<?> sourceString, StringValue str) {
-    super(sourceString, str, String::contains, "contains");
+public class ContainsExpression implements BooleanExpression {
+  private final ValueExpression<?> target;
+  private final ValueExpression<?> value;
+
+  public ContainsExpression(ValueExpression<?> target, ValueExpression<?> value) {
+    this.target = target != null ? target : ValueExpression.NULL;
+    this.value = value;
+  }
+
+  @Override
+  public Boolean evaluate(ValueReferenceResolver valueRefResolver) {
+    Value<?> targetValue = target.evaluate(valueRefResolver);
+    if (targetValue.isUndefined()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for undefined value", PrettyPrintVisitor.print(this));
+    }
+    if (targetValue.isNull()) {
+      throw new EvaluationException(
+          "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
+    }
+    Value<?> val = value.evaluate(valueRefResolver);
+    if (val.isUndefined() || val.isNull()) {
+      return false;
+    }
+    if (targetValue.getValue() instanceof String) {
+      String targetStr = (String) targetValue.getValue();
+      if (val.getValue() instanceof String) {
+        String valStr = (String) val.getValue();
+        return targetStr.contains(valStr);
+      }
+      throw new EvaluationException(
+          "Cannot evaluate the expression for non-string value", PrettyPrintVisitor.print(this));
+    }
+    if (targetValue instanceof CollectionValue) {
+      return ((CollectionValue<?>) targetValue).contains(val);
+    }
+    return Boolean.FALSE;
   }
 
   @Override
   public <R> R accept(Visitor<R> visitor) {
     return visitor.visit(this);
+  }
+
+  public ValueExpression<?> getTarget() {
+    return target;
+  }
+
+  public ValueExpression<?> getValue() {
+    return value;
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ContainsExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/ContainsExpression.java
@@ -13,7 +13,7 @@ public class ContainsExpression implements BooleanExpression {
 
   public ContainsExpression(ValueExpression<?> target, ValueExpression<?> value) {
     this.target = target != null ? target : ValueExpression.NULL;
-    this.value = value;
+    this.value = value != null ? value : ValueExpression.NULL;
   }
 
   @Override
@@ -28,7 +28,7 @@ public class ContainsExpression implements BooleanExpression {
           "Cannot evaluate the expression for null value", PrettyPrintVisitor.print(this));
     }
     Value<?> val = value.evaluate(valueRefResolver);
-    if (val.isUndefined() || val.isNull()) {
+    if (val.isUndefined()) {
       return false;
     }
     if (targetValue.getValue() instanceof String) {
@@ -41,7 +41,11 @@ public class ContainsExpression implements BooleanExpression {
           "Cannot evaluate the expression for non-string value", PrettyPrintVisitor.print(this));
     }
     if (targetValue instanceof CollectionValue) {
-      return ((CollectionValue<?>) targetValue).contains(val);
+      try {
+        return ((CollectionValue<?>) targetValue).contains(val);
+      } catch (RuntimeException ex) {
+        throw new EvaluationException(ex.getMessage(), PrettyPrintVisitor.print(this));
+      }
     }
     return Boolean.FALSE;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/CollectionValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/CollectionValue.java
@@ -40,6 +40,11 @@ public interface CollectionValue<T> extends Value<T> {
         public boolean isNull() {
           return false;
         }
+
+        @Override
+        public boolean contains(Value<?> val) {
+          return false;
+        }
       };
 
   CollectionValue<?> NULL =
@@ -73,6 +78,11 @@ public interface CollectionValue<T> extends Value<T> {
         public boolean isNull() {
           return true;
         }
+
+        @Override
+        public boolean contains(Value<?> val) {
+          return false;
+        }
       };
 
   boolean isEmpty();
@@ -80,4 +90,6 @@ public interface CollectionValue<T> extends Value<T> {
   int count();
 
   Value<?> get(Object key);
+
+  boolean contains(Value<?> val);
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -134,7 +134,7 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
   public boolean contains(Value<?> val) {
     if (listHolder instanceof Collection) {
       if (WellKnownClasses.isSafe((Collection<?>) listHolder)) {
-        return ((Collection<?>) listHolder).contains(val.getValue());
+        return ((Collection<?>) listHolder).contains(val.isNull() ? null : val.getValue());
       }
       throw new RuntimeException(
           "Unsupported Collection class: " + listHolder.getClass().getTypeName());
@@ -142,12 +142,13 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
     if (arrayHolder != null) {
       int count = Array.getLength(arrayHolder);
       if (arrayType.isPrimitive()) {
-        if (val.getValue() == null) {
-          return false;
+        if (val.getValue() == null || val.isNull()) {
+          throw new RuntimeException("Cannot compare null with primitive array");
         }
         if (arrayType == byte.class) {
+          byte byteValue = (Byte) val.getValue();
           for (int i = 0; i < count; i++) {
-            if (Array.getByte(arrayHolder, i) == (Byte) val.getValue()) {
+            if (Array.getByte(arrayHolder, i) == byteValue) {
               return true;
             }
           }
@@ -156,57 +157,74 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
           if (strValue.isEmpty()) {
             return false;
           }
+          char charValue = strValue.charAt(0);
           for (int i = 0; i < count; i++) {
-            if (Array.getChar(arrayHolder, i) == strValue.charAt(0)) {
+            if (Array.getChar(arrayHolder, i) == charValue) {
               return true;
             }
           }
         } else if (arrayType == short.class) {
+          int shortValue = ((Number) val.getValue()).intValue();
           for (int i = 0; i < count; i++) {
-            if (Array.getShort(arrayHolder, i) == ((Number) val.getValue()).intValue()) {
+            if (Array.getShort(arrayHolder, i) == shortValue) {
               return true;
             }
           }
         } else if (arrayType == int.class) {
+          int intValue = ((Number) val.getValue()).intValue();
           for (int i = 0; i < count; i++) {
-            if (Array.getInt(arrayHolder, i) == ((Number) val.getValue()).intValue()) {
+            if (Array.getInt(arrayHolder, i) == intValue) {
               return true;
             }
           }
         } else if (arrayType == long.class) {
+          long longValue = (Long) val.getValue();
           for (int i = 0; i < count; i++) {
-            if (Array.getLong(arrayHolder, i) == (Long) val.getValue()) {
+            if (Array.getLong(arrayHolder, i) == longValue) {
               return true;
             }
           }
         } else if (arrayType == float.class) {
+          float floatValue = (Float) val.getValue();
           for (int i = 0; i < count; i++) {
-            if (Array.getFloat(arrayHolder, i) == (Float) val.getValue()) {
+            if (Array.getFloat(arrayHolder, i) == floatValue) {
               return true;
             }
           }
         } else if (arrayType == double.class) {
+          double doubleValue = (Double) val.getValue();
           for (int i = 0; i < count; i++) {
-            if (Array.getDouble(arrayHolder, i) == (Double) val.getValue()) {
+            if (Array.getDouble(arrayHolder, i) == doubleValue) {
               return true;
             }
           }
         } else if (arrayType == boolean.class) {
+          boolean booleanValue = (Boolean) val.getValue();
           for (int i = 0; i < count; i++) {
-            if (Array.getBoolean(arrayHolder, i) == (Boolean) val.getValue()) {
+            if (Array.getBoolean(arrayHolder, i) == booleanValue) {
               return true;
             }
           }
         }
         return false;
       }
-      for (int i = 0; i < count; i++) {
-        Object cellValue = Array.get(arrayHolder, i);
-        if (cellValue != null && cellValue.equals(val.getValue())) {
-          return true;
+      Object objValue = val.getValue();
+      if (objValue == null || val.isNull()) {
+        for (int i = 0; i < count; i++) {
+          if (Array.get(arrayHolder, i) == null) {
+            return true;
+          }
+        }
+        return false;
+      }
+      if (WellKnownClasses.isEqualsSafe(objValue.getClass())) {
+        for (int i = 0; i < count; i++) {
+          if (objValue.equals(Array.get(arrayHolder, i))) {
+            return true;
+          }
         }
       }
-      return false;
+      throw new RuntimeException("Unsupported value class: " + objValue.getClass().getTypeName());
     }
     return false;
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -131,6 +131,87 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
   }
 
   @Override
+  public boolean contains(Value<?> val) {
+    if (listHolder instanceof Collection) {
+      if (WellKnownClasses.isSafe((Collection<?>) listHolder)) {
+        return ((Collection<?>) listHolder).contains(val.getValue());
+      }
+      throw new RuntimeException(
+          "Unsupported Collection class: " + listHolder.getClass().getTypeName());
+    }
+    if (arrayHolder != null) {
+      int count = Array.getLength(arrayHolder);
+      if (arrayType.isPrimitive()) {
+        if (val.getValue() == null) {
+          return false;
+        }
+        if (arrayType == byte.class) {
+          for (int i = 0; i < count; i++) {
+            if (Array.getByte(arrayHolder, i) == (Byte) val.getValue()) {
+              return true;
+            }
+          }
+        } else if (arrayType == char.class) {
+          String strValue = (String) val.getValue();
+          if (strValue.isEmpty()) {
+            return false;
+          }
+          for (int i = 0; i < count; i++) {
+            if (Array.getChar(arrayHolder, i) == strValue.charAt(0)) {
+              return true;
+            }
+          }
+        } else if (arrayType == short.class) {
+          for (int i = 0; i < count; i++) {
+            if (Array.getShort(arrayHolder, i) == ((Number) val.getValue()).intValue()) {
+              return true;
+            }
+          }
+        } else if (arrayType == int.class) {
+          for (int i = 0; i < count; i++) {
+            if (Array.getInt(arrayHolder, i) == ((Number) val.getValue()).intValue()) {
+              return true;
+            }
+          }
+        } else if (arrayType == long.class) {
+          for (int i = 0; i < count; i++) {
+            if (Array.getLong(arrayHolder, i) == (Long) val.getValue()) {
+              return true;
+            }
+          }
+        } else if (arrayType == float.class) {
+          for (int i = 0; i < count; i++) {
+            if (Array.getFloat(arrayHolder, i) == (Float) val.getValue()) {
+              return true;
+            }
+          }
+        } else if (arrayType == double.class) {
+          for (int i = 0; i < count; i++) {
+            if (Array.getDouble(arrayHolder, i) == (Double) val.getValue()) {
+              return true;
+            }
+          }
+        } else if (arrayType == boolean.class) {
+          for (int i = 0; i < count; i++) {
+            if (Array.getBoolean(arrayHolder, i) == (Boolean) val.getValue()) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+      for (int i = 0; i < count; i++) {
+        Object cellValue = Array.get(arrayHolder, i);
+        if (cellValue != null && cellValue.equals(val.getValue())) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return false;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
@@ -101,10 +101,24 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
     return (Value<?>) mapHolder;
   }
 
+  @Override
+  public boolean contains(Value<?> val) {
+    if (mapHolder instanceof Map) {
+      if (WellKnownClasses.isSafe((Map<?, ?>) mapHolder)) {
+        Map<?, ?> map = (Map<?, ?>) mapHolder;
+        return map.containsKey(val.getValue());
+      }
+      throw new RuntimeException("Unsupported Map class: " + mapHolder.getClass().getTypeName());
+    }
+    return false;
+  }
+
+  @Override
   public boolean isNull() {
     return mapHolder == null || (mapHolder instanceof Value && ((Value<?>) mapHolder).isNull());
   }
 
+  @Override
   public boolean isUndefined() {
     return mapHolder instanceof Value && ((Value<?>) mapHolder).isUndefined();
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/MapValue.java
@@ -106,7 +106,14 @@ public final class MapValue implements CollectionValue<Object>, ValueExpression<
     if (mapHolder instanceof Map) {
       if (WellKnownClasses.isSafe((Map<?, ?>) mapHolder)) {
         Map<?, ?> map = (Map<?, ?>) mapHolder;
-        return map.containsKey(val.getValue());
+        if (val == null || val.isNull()) {
+          return map.containsKey(null);
+        }
+        if (WellKnownClasses.isEqualsSafe(val.getValue().getClass())) {
+          return map.containsKey(val.getValue());
+        }
+        throw new RuntimeException(
+            "Unsupported key class: " + val.getValue().getClass().getTypeName());
       }
       throw new RuntimeException("Unsupported Map class: " + mapHolder.getClass().getTypeName());
     }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
@@ -86,7 +86,14 @@ public class SetValue implements CollectionValue<Object>, ValueExpression<SetVal
   public boolean contains(Value<?> val) {
     if (setHolder instanceof Set) {
       if (WellKnownClasses.isSafe((Collection<?>) setHolder)) {
-        return ((Set<?>) setHolder).contains(val.getValue());
+        if (val == null || val.isNull()) {
+          return ((Set<?>) setHolder).contains(null);
+        }
+        if (WellKnownClasses.isEqualsSafe(val.getValue().getClass())) {
+          return ((Set<?>) setHolder).contains(val.getValue());
+        }
+        throw new RuntimeException(
+            "Unsupported value class: " + val.getValue().getClass().getTypeName());
       }
       throw new RuntimeException("Unsupported Set class: " + setHolder.getClass().getTypeName());
     }

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/SetValue.java
@@ -83,6 +83,17 @@ public class SetValue implements CollectionValue<Object>, ValueExpression<SetVal
   }
 
   @Override
+  public boolean contains(Value<?> val) {
+    if (setHolder instanceof Set) {
+      if (WellKnownClasses.isSafe((Collection<?>) setHolder)) {
+        return ((Set<?>) setHolder).contains(val.getValue());
+      }
+      throw new RuntimeException("Unsupported Set class: " + setHolder.getClass().getTypeName());
+    }
+    return false;
+  }
+
+  @Override
   public <R> R accept(Visitor<R> visitor) {
     return visitor.visit(this);
   }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/ProbeConditionTest.java
@@ -283,6 +283,25 @@ public class ProbeConditionTest {
     }
   }
 
+  @Test
+  public void containsExpressions() {
+    class Obj {
+      String str = "hello";
+      String[] arrayStr = new String[] {"foo", "hello", "bar"};
+      Map<String, String> mapStr = new HashMap<>();
+
+      {
+        mapStr.put("foo", "bar");
+        mapStr.put("hello", "bar");
+      }
+    }
+    List<String> lines = loadLinesFromResource("/contains_expressions.txt");
+    for (String line : lines) {
+      ValueReferenceResolver ctx = RefResolverHelper.createResolver(new Obj());
+      assertTrue(load(line).execute(ctx));
+    }
+  }
+
   private static ProbeCondition loadFromResource(String resourcePath) throws IOException {
     InputStream input = ProbeConditionTest.class.getResourceAsStream(resourcePath);
     Moshi moshi =

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ContainsExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ContainsExpressionTest.java
@@ -9,10 +9,36 @@ import com.datadog.debugger.el.RefResolverHelper;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.Values;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ContainsExpressionTest {
   private final ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
+
+  private List<String> list = Arrays.asList("foo", "bar", "baz");
+  private String[] arrayStr = new String[] {"foo", "bar", "baz"};
+  private int[] arrayInt = new int[] {1, 2, 3};
+  private char[] arrayChar = new char[] {'a', 'b', 'c'};
+  private long[] arrayLong = new long[] {1, 2, 3};
+  private double[] arrayDouble = new double[] {1, 2, 3};
+  private Map<String, String> mapStr = new HashMap<>();
+
+  {
+    mapStr.put("foo", "bar");
+    mapStr.put("bar", "baz");
+  }
+
+  private Set<String> setStr = new HashSet<>();
+
+  {
+    setStr.add("foo");
+    setStr.add("bar");
+  }
 
   @Test
   void nullExpression() {
@@ -43,5 +69,49 @@ class ContainsExpressionTest {
     expression = new ContainsExpression(DSL.value("abc"), new StringValue("dc"));
     assertFalse(expression.evaluate(resolver));
     assertEquals("contains(\"abc\", \"dc\")", print(expression));
+  }
+
+  @Test
+  void listExpression() {
+    ContainsExpression expression = new ContainsExpression(DSL.ref("list"), DSL.value("bar"));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(list, \"bar\")", print(expression));
+  }
+
+  @Test
+  void arrayExpression() {
+    ContainsExpression expression = new ContainsExpression(DSL.ref("arrayStr"), DSL.value("bar"));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(arrayStr, \"bar\")", print(expression));
+
+    expression = new ContainsExpression(DSL.ref("arrayInt"), DSL.value(2));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(arrayInt, 2)", print(expression));
+
+    expression = new ContainsExpression(DSL.ref("arrayChar"), DSL.value("b"));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(arrayChar, \"b\")", print(expression));
+
+    expression = new ContainsExpression(DSL.ref("arrayLong"), DSL.value(2));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(arrayLong, 2)", print(expression));
+
+    expression = new ContainsExpression(DSL.ref("arrayDouble"), DSL.value(2.0));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(arrayDouble, 2.0)", print(expression));
+  }
+
+  @Test
+  void mapExpression() {
+    ContainsExpression expression = new ContainsExpression(DSL.ref("mapStr"), DSL.value("bar"));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(mapStr, \"bar\")", print(expression));
+  }
+
+  @Test
+  void setExpression() {
+    ContainsExpression expression = new ContainsExpression(DSL.ref("setStr"), DSL.value("bar"));
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(setStr, \"bar\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ContainsExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/ContainsExpressionTest.java
@@ -21,7 +21,9 @@ class ContainsExpressionTest {
   private final ValueReferenceResolver resolver = RefResolverHelper.createResolver(this);
 
   private List<String> list = Arrays.asList("foo", "bar", "baz");
+  private List<String> listWithNull = Arrays.asList("foo", null, "baz");
   private String[] arrayStr = new String[] {"foo", "bar", "baz"};
+  private String[] arrayStrWithNull = new String[] {"foo", null, "bar"};
   private int[] arrayInt = new int[] {1, 2, 3};
   private char[] arrayChar = new char[] {'a', 'b', 'c'};
   private long[] arrayLong = new long[] {1, 2, 3};
@@ -33,11 +35,25 @@ class ContainsExpressionTest {
     mapStr.put("bar", "baz");
   }
 
+  private Map<String, String> mapStrWithNull = new HashMap<>();
+
+  {
+    mapStrWithNull.put("foo", "bar");
+    mapStrWithNull.put(null, "baz");
+  }
+
   private Set<String> setStr = new HashSet<>();
 
   {
     setStr.add("foo");
     setStr.add("bar");
+  }
+
+  private Set<String> setStrWithNull = new HashSet<>();
+
+  {
+    setStrWithNull.add("foo");
+    setStrWithNull.add(null);
   }
 
   @Test
@@ -69,6 +85,12 @@ class ContainsExpressionTest {
     expression = new ContainsExpression(DSL.value("abc"), new StringValue("dc"));
     assertFalse(expression.evaluate(resolver));
     assertEquals("contains(\"abc\", \"dc\")", print(expression));
+
+    ContainsExpression nullValExpression = new ContainsExpression(DSL.value("abcd"), null);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> nullValExpression.evaluate(resolver));
+    assertEquals("Cannot evaluate the expression for non-string value", exception.getMessage());
+    assertEquals("contains(\"abcd\", null)", print(nullValExpression));
   }
 
   @Test
@@ -76,6 +98,10 @@ class ContainsExpressionTest {
     ContainsExpression expression = new ContainsExpression(DSL.ref("list"), DSL.value("bar"));
     assertTrue(expression.evaluate(resolver));
     assertEquals("contains(list, \"bar\")", print(expression));
+
+    expression = new ContainsExpression(DSL.ref("listWithNull"), null);
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(listWithNull, null)", print(expression));
   }
 
   @Test
@@ -99,6 +125,16 @@ class ContainsExpressionTest {
     expression = new ContainsExpression(DSL.ref("arrayDouble"), DSL.value(2.0));
     assertTrue(expression.evaluate(resolver));
     assertEquals("contains(arrayDouble, 2.0)", print(expression));
+
+    expression = new ContainsExpression(DSL.ref("arrayStrWithNull"), null);
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(arrayStrWithNull, null)", print(expression));
+
+    ContainsExpression primitiveNullExpression = new ContainsExpression(DSL.ref("arrayInt"), null);
+    EvaluationException exception =
+        assertThrows(EvaluationException.class, () -> primitiveNullExpression.evaluate(resolver));
+    assertEquals("Cannot compare null with primitive array", exception.getMessage());
+    assertEquals("contains(arrayInt, null)", print(primitiveNullExpression));
   }
 
   @Test
@@ -106,6 +142,10 @@ class ContainsExpressionTest {
     ContainsExpression expression = new ContainsExpression(DSL.ref("mapStr"), DSL.value("bar"));
     assertTrue(expression.evaluate(resolver));
     assertEquals("contains(mapStr, \"bar\")", print(expression));
+
+    expression = new ContainsExpression(DSL.ref("mapStrWithNull"), null);
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(mapStrWithNull, null)", print(expression));
   }
 
   @Test
@@ -113,5 +153,9 @@ class ContainsExpressionTest {
     ContainsExpression expression = new ContainsExpression(DSL.ref("setStr"), DSL.value("bar"));
     assertTrue(expression.evaluate(resolver));
     assertEquals("contains(setStr, \"bar\")", print(expression));
+
+    expression = new ContainsExpression(DSL.ref("setStrWithNull"), null);
+    assertTrue(expression.evaluate(resolver));
+    assertEquals("contains(setStrWithNull, null)", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/resources/contains_expressions.txt
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/resources/contains_expressions.txt
@@ -1,0 +1,5 @@
+{"dsl": "", "json": {"contains": [{"ref": "str"}, "ell"]}}
+{"dsl": "", "json": {"contains": [{"ref": "str"}, {"ref": "str"}]}}
+{"dsl": "", "json": {"contains": [{"ref": "arrayStr"}, {"ref": "str"}]}}
+{"dsl": "", "json": {"contains": [{"ref": "mapStr"}, {"ref": "str"}]}}
+{"dsl": "", "json": {"contains": [{"ref": "mapStr"}, {"index": [{"ref": "arrayStr"}, 1]}]}}


### PR DESCRIPTION
# What Does This Do
Add support for array/list/map/set of the `contains` EL expression when calling `contains` on array/list or set it will iterate on all elements to find it. On Maps we are using the `containsKey` method.

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2488]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2488]: https://datadoghq.atlassian.net/browse/DEBUG-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ