### PR TITLE
Fix milestone parsing for PR assignment

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yaml
+++ b/.github/workflows/add-milestone-to-pull-requests.yaml
@@ -34,14 +34,15 @@ jobs:
               // Pick the milestone with the highest version as title using semver
               milestoneNumber = response.data
                 .map(milestone => {
-                  const versionNumbers = milestone.title.match(/^\d+\.\d+\.\d+$/)
+                  // Parse version title as semver "<major>.<minor>.<patch>"
+                  const versionNumbers = milestone.title.match(/^(\d+)\.(\d+)\.(\d+)$/)
                   if (versionNumbers == null) {
                     return null
                   }
                   milestone.version = {
-                    majonr: parseInt(versionNumbers[0]),
-                    minor: parseInt(versionNumbers[1]),
-                    patch: parseInt(versionNumbers[2])
+                    major: parseInt(versionNumbers[1]),
+                    minor: parseInt(versionNumbers[2]),
+                    patch: parseInt(versionNumbers[3])
                   }
                   return milestone
                 })


### PR DESCRIPTION
# What Does This Do

This PR fixes some issues how the CI retrieves the milestone to assign to PRs.

# Motivation

When multiple milestones are open, it (obviously) picks the wrong one 😞 

# Additional Notes

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
