### PR TITLE
Add `Set` support for `hasAny`/`hasAll` expression

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
@@ -43,8 +43,8 @@ public final class HasAllExpression extends MatchingExpression {
     if (value instanceof ListValue) {
       ListValue collection = (ListValue) value;
       if (collection.isEmpty()) {
-        // always return FALSE for empty values
-        return Boolean.FALSE;
+        // always return TRUE for empty values (cf vacuous truth, see also Stream::allMatch)
+        return Boolean.TRUE;
       }
       int len = collection.count();
       for (int i = 0; i < len; i++) {
@@ -60,8 +60,8 @@ public final class HasAllExpression extends MatchingExpression {
     if (value instanceof MapValue) {
       MapValue map = (MapValue) value;
       if (map.isEmpty()) {
-        // always return FALSE for empty values
-        return Boolean.FALSE;
+        // always return TRUE for empty values (cf vacuous truth, see also Stream::allMatch)
+        return Boolean.TRUE;
       }
       for (Value<?> key : map.getKeys()) {
         Value<?> val = key.isUndefined() ? Value.undefinedValue() : map.get(key);
@@ -77,7 +77,8 @@ public final class HasAllExpression extends MatchingExpression {
     if (value instanceof SetValue) {
       SetValue set = (SetValue) value;
       if (set.isEmpty()) {
-        return Boolean.FALSE;
+        // always return TRUE for empty values (cf vacuous truth, see also Stream::allMatch)
+        return Boolean.TRUE;
       }
       Set<?> setHolder = (Set<?>) set.getSetHolder();
       if (WellKnownClasses.isSafe(setHolder)) {

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/expressions/HasAllExpression.java
@@ -6,9 +6,12 @@ import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.Visitor;
 import com.datadog.debugger.el.values.ListValue;
 import com.datadog.debugger.el.values.MapValue;
+import com.datadog.debugger.el.values.SetValue;
 import datadog.trace.bootstrap.debugger.el.ValueReferenceResolver;
 import datadog.trace.bootstrap.debugger.el.ValueReferences;
+import datadog.trace.bootstrap.debugger.util.WellKnownClasses;
 import java.util.Collections;
+import java.util.Set;
 
 /**
  * Checks a {@linkplain Value} against the given {@link BooleanExpression filter expression} to make
@@ -53,7 +56,8 @@ public final class HasAllExpression extends MatchingExpression {
         }
       }
       return Boolean.TRUE;
-    } else if (value instanceof MapValue) {
+    }
+    if (value instanceof MapValue) {
       MapValue map = (MapValue) value;
       if (map.isEmpty()) {
         // always return FALSE for empty values
@@ -69,11 +73,30 @@ public final class HasAllExpression extends MatchingExpression {
         }
       }
       return Boolean.TRUE;
-    } else {
-      return filterPredicateExpression.evaluate(
-          valueRefResolver.withExtensions(
-              Collections.singletonMap(ValueReferences.ITERATOR_EXTENSION_NAME, value)));
     }
+    if (value instanceof SetValue) {
+      SetValue set = (SetValue) value;
+      if (set.isEmpty()) {
+        return Boolean.FALSE;
+      }
+      Set<?> setHolder = (Set<?>) set.getSetHolder();
+      if (WellKnownClasses.isSafe(setHolder)) {
+        for (Object val : setHolder) {
+          if (!filterPredicateExpression.evaluate(
+              valueRefResolver.withExtensions(
+                  Collections.singletonMap(ValueReferences.ITERATOR_EXTENSION_NAME, val)))) {
+            return Boolean.FALSE;
+          }
+        }
+        return Boolean.TRUE;
+      }
+      throw new EvaluationException(
+          "Unsupported Set class: " + setHolder.getClass().getTypeName(),
+          PrettyPrintVisitor.print(this));
+    }
+    return filterPredicateExpression.evaluate(
+        valueRefResolver.withExtensions(
+            Collections.singletonMap(ValueReferences.ITERATOR_EXTENSION_NAME, value)));
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
@@ -15,7 +15,9 @@ import datadog.trace.bootstrap.debugger.el.Values;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class HasAllExpressionTest {
@@ -167,7 +169,7 @@ class HasAllExpressionTest {
   }
 
   @Test
-  void testMapHasAny() {
+  void testMapHasAll() {
     ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
     Map<String, String> valueMap = new HashMap<>();
     valueMap.put("a", "a");
@@ -189,6 +191,33 @@ class HasAllExpressionTest {
         all(
             targetExpression,
             eq(getMember(ref(ValueReferences.ITERATOR_REF), "value"), value("a")));
+    assertTrue(expression.evaluate(ctx));
+  }
+
+  @Test
+  void testSetHasAll() {
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    Set<String> valueSet = new HashSet<>();
+    valueSet.add("foo");
+    valueSet.add("bar");
+
+    ValueExpression<?> targetExpression = value(valueSet);
+
+    HasAllExpression expression = all(targetExpression, TRUE);
+    assertTrue(expression.evaluate(ctx));
+
+    expression = all(targetExpression, FALSE);
+    assertFalse(expression.evaluate(ctx));
+
+    expression = all(targetExpression, eq(ref(ValueReferences.ITERATOR_REF), value("key")));
+    assertFalse(expression.evaluate(ctx));
+
+    expression =
+        all(
+            targetExpression,
+            or(
+                eq(ref(ValueReferences.ITERATOR_REF), value("foo")),
+                eq(ref(ValueReferences.ITERATOR_REF), value("bar"))));
     assertTrue(expression.evaluate(ctx));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAllExpressionTest.java
@@ -220,4 +220,17 @@ class HasAllExpressionTest {
                 eq(ref(ValueReferences.ITERATOR_REF), value("bar"))));
     assertTrue(expression.evaluate(ctx));
   }
+
+  @Test
+  void emptiness() {
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    HasAllExpression expression = all(value(new String[] {}), TRUE);
+    assertTrue(expression.evaluate(ctx));
+    expression = all(value(Collections.emptyList()), TRUE);
+    assertTrue(expression.evaluate(ctx));
+    expression = all(value(Collections.emptyMap()), TRUE);
+    assertTrue(expression.evaluate(ctx));
+    expression = all(value(Collections.emptySet()), TRUE);
+    assertTrue(expression.evaluate(ctx));
+  }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
@@ -14,7 +14,9 @@ import datadog.trace.bootstrap.debugger.el.Values;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class HasAnyExpressionTest {
@@ -204,5 +206,31 @@ class HasAnyExpressionTest {
             eq(getMember(ref(ValueReferences.ITERATOR_REF), "value"), value("c")));
     assertFalse(expression.evaluate(ctx));
     assertEquals("hasAny(Map, @it.value == \"c\")", print(expression));
+  }
+
+  @Test
+  void testSetHasAny() {
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    Set<String> valueSet = new HashSet<>();
+    valueSet.add("foo");
+    valueSet.add("bar");
+
+    ValueExpression<?> targetExpression = DSL.value(valueSet);
+    HasAnyExpression expression = any(targetExpression, TRUE);
+    assertTrue(expression.evaluate(ctx));
+    assertEquals("hasAny(Set, true)", print(expression));
+
+    targetExpression = DSL.value(valueSet);
+    expression = any(targetExpression, FALSE);
+    assertFalse(expression.evaluate(ctx));
+    assertEquals("hasAny(Set, false)", print(expression));
+
+    expression = any(targetExpression, eq(ref(ValueReferences.ITERATOR_REF), value("foo")));
+    assertTrue(expression.evaluate(ctx));
+    assertEquals("hasAny(Set, @it == \"foo\")", print(expression));
+
+    expression = any(targetExpression, eq(ref(ValueReferences.ITERATOR_REF), value("key")));
+    assertFalse(expression.evaluate(ctx));
+    assertEquals("hasAny(Set, @it == \"key\")", print(expression));
   }
 }

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/HasAnyExpressionTest.java
@@ -233,4 +233,20 @@ class HasAnyExpressionTest {
     assertFalse(expression.evaluate(ctx));
     assertEquals("hasAny(Set, @it == \"key\")", print(expression));
   }
+
+  @Test
+  void emptiness() {
+    ValueReferenceResolver ctx = RefResolverHelper.createResolver(null, null);
+    HasAnyExpression expression = any(value(Collections.emptyList()), TRUE);
+    assertFalse(expression.evaluate(ctx));
+    assertEquals("hasAny(List, true)", print(expression));
+
+    expression = any(value(Collections.emptyMap()), TRUE);
+    assertFalse(expression.evaluate(ctx));
+    assertEquals("hasAny(Map, true)", print(expression));
+
+    expression = any(value(Collections.emptySet()), TRUE);
+    assertFalse(expression.evaluate(ctx));
+    assertEquals("hasAny(Set, true)", print(expression));
+  }
 }


### PR DESCRIPTION
# What Does This Do

# Motivation

# Additional Notes

Jira ticket: [DEBUG-2488]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2488]: https://datadoghq.atlassian.net/browse/DEBUG-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ