### PR TITLE
Fix null JvmInfo exception in Maven instrumentation

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/CachingJvmInfoFactory.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/CachingJvmInfoFactory.java
@@ -18,6 +18,11 @@ public class CachingJvmInfoFactory implements JvmInfoFactory {
 
   @Override
   public JvmInfo getJvmInfo(Path jvmExecutablePath) {
+    // DDCache does not support null keys.
+    if (jvmExecutablePath == null) {
+      // If we cannot determine forked JVM, we assume it is the same as current one.
+      return JvmInfo.CURRENT_JVM;
+    }
     return cache.computeIfAbsent(jvmExecutablePath, delegate::getJvmInfo);
   }
 }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
@@ -220,6 +220,7 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
   private String getEffectiveJvm(Mojo mojo) {
     Method getEffectiveJvmMethod = findGetEffectiveJvmMethod(mojo.getClass());
     if (getEffectiveJvmMethod == null) {
+      LOGGER.debug("Could not find getEffectiveJvm method in {} class", mojo.getClass().getName());
       return null;
     }
     getEffectiveJvmMethod.setAccessible(true);
@@ -241,13 +242,18 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
         return (String) jvmExecutable;
       } else if (jvmExecutable instanceof File) {
         return ((File) jvmExecutable).getAbsolutePath();
+      } else if (jvmExecutable == null) {
+        LOGGER.debug("Configured JVM executable is null");
+        return null;
       } else {
+        LOGGER.debug(
+            "Unexpected JVM executable type {}, returning null",
+            jvmExecutable.getClass().getName());
         return null;
       }
 
     } catch (Exception e) {
       LOGGER.debug("Error while getting effective JVM for mojo {}", mojo, e);
-      LOGGER.warn("Error while getting effective JVM");
       return null;
     }
   }


### PR DESCRIPTION
# What Does This Do

Updates Maven instrumentation logic that determines JVM used for tests execution.
If the JVM could not be determined, current JVM (the one running the parent Maven process) is assumed. 

# Additional Notes

The previous logic did not work correctly because the cache used for storing resolved JVMs does not support `null` keys (and `null` was used to indicate that JVM path could not be determined).

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
