### PR TITLE
Add shutdown hook to finish the spark application trace

### DIFF
--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -10,6 +10,7 @@ import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.SpanLink;
+import datadog.trace.util.AgentThreadFactory;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -132,7 +133,8 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
     // - no access to the exit code
     Runtime.getRuntime()
         .addShutdownHook(
-            new Thread(
+            AgentThreadFactory.newAgentThread(
+                AgentThreadFactory.AgentThread.DATA_JOBS_MONITORING_SHUTDOWN_HOOK,
                 () -> {
                   if (!applicationEnded) {
                     log.info("Finishing application trace from shutdown hook");

--- a/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
+++ b/internal-api/src/main/java/datadog/trace/util/AgentThreadFactory.java
@@ -42,6 +42,8 @@ public final class AgentThreadFactory implements ThreadFactory {
 
     PROCESS_SUPERVISOR("dd-process-supervisor"),
 
+    DATA_JOBS_MONITORING_SHUTDOWN_HOOK("dd-data-jobs-shutdown-hook"),
+
     DATA_STREAMS_MONITORING("dd-data-streams-monitor"),
 
     DEBUGGER_SNAPSHOT_SERIALIZER("dd-debugger-snapshot-serializer"),


### PR DESCRIPTION
# What Does This Do

Add shutdown hook to finish the application span from a shutdown hook, in case where the JVM is shutdown using `System.exit(code)`

# Motivation

Spans not being send to Datadog when JVM is exited with `System.exit(code)`

# Additional Notes

Jira ticket: https://datadoghq.atlassian.net/browse/DJM-379

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
