### PR TITLE
Fix Gradle dependency automation

### DIFF
--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -8,16 +8,26 @@ jobs:
   update-gradle-dependencies:
     runs-on: ubuntu-latest
     name: Update Gradle dependencies
+    permissions:
+      # Commit and push changes to a new branch
+      contents: write
+      # Create a pull request
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # 4.1.6
         with:
           submodules: 'recursive'
+      - name: Download ghcommit CLI
+        run: |
+          curl https://github.com/planetscale/ghcommit/releases/download/v0.1.48/ghcommit_linux_amd64 -o /usr/local/bin/ghcommit -L
+          chmod +x /usr/local/bin/ghcommit
       - name: Pick a branch name
         run: echo "BRANCH_NAME=ci/update-gradle-dependencies-$(date +'%Y%m%d')" >> $GITHUB_ENV
       - name: Create branch
         run: |
           git checkout -b $BRANCH_NAME
+          git push -u origin $BRANCH_NAME --force
       - name: Update Gradle dependencies
         run: |
           GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx2G -Xms2G'" \
@@ -27,17 +37,41 @@ jobs:
           JAVA_17_HOME=$JAVA_HOME_17_X64 \
           JAVA_21_HOME=$JAVA_HOME_21_X64 \
           ./gradlew resolveAndLockAll --write-locks --parallel --stacktrace --no-daemon --max-workers=4
+      - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          GH_ADD_ARGS=""
+          COUNT=0
+          BRANCH_HEAD=$(git rev-parse HEAD)
+          for lockfile in $(git status --porcelain=v1 | awk '{ print $NF }'); do
+            echo "Found lockfile: $lockfile"
+            GH_ADD_ARGS="$GH_ADD_ARGS --add $lockfile"
+            COUNT=$((COUNT+1))
+            if [ $COUNT -eq 10 ]; then
+              echo "Creating a commit to $BRANCH_NAME@$BRANCH_HEAD with $GH_ADD_ARGS"
+              OUTPUT=$(ghcommit --repository ${{ github.repository }} --branch $BRANCH_NAME --sha $BRANCH_HEAD $GH_ADD_ARGS --message "chore: Update Gradle dependencies" 2>&1)
+              echo $OUTPUT
+              if [[ $OUTPUT != *"Success. New commit"* ]]; then
+                exit 1
+              fi
+              BRANCH_HEAD=${OUTPUT##*/}
+              echo "ghcommit output: $OUTPUT"
+              GH_ADD_ARGS=""
+              COUNT=0
+            fi
+          done
+          if [ $COUNT -gt 0 ]; then
+            echo "Creating a commit to $BRANCH_NAME@$BRANCH_HEAD with $GH_ADD_ARGS"
+            ghcommit --repository ${{ github.repository }} --branch $BRANCH_NAME --sha $BRANCH_HEAD $GH_ADD_ARGS --message "chore: Update Gradle dependencies"
+          fi
       - name: Create pull request
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "**/gradle.lockfile"
-          git commit -m "chore: Update Gradle dependencies"
-          git push -u origin $BRANCH_NAME
           gh pr create --title "Update Gradle dependencies" \
-            --body "This PR updates the Gradle dependencies" \
+            --body "This PR updates the Gradle dependencies.  \n:warning: Don't forget to squash commits before merging :warning:" \
             --base master \
+            --head $BRANCH_NAME \
             --label "tag: dependencies" \
             --label "tag: no release notes"


### PR DESCRIPTION
# What Does This Do

This PR should fix the gradle dependency automation by creating signed commit.
It also brings permissions configuration for the coming permission limitation.

# Motivation

The original solution was creating non-signed commits that can't be merged 😞 

# Additional Notes

This uses a rather complicated setup that leverages a CLI tool to make GraphQL calls to create commits on a remote branch.
As the new file content must be (base64) encoded and added to the GraphQL mutation query payload, I had to:
* split the changes into multiple commits, 
* fetch the new commits sha in order to keep adding child commits.

Then, create a PR using another CLI to target master from the built branch.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
