### PR TITLE
Automate Cloud Foundry repository update

### DIFF
--- a/.github/workflows/add-release-to-cloudfoundry.yaml
+++ b/.github/workflows/add-release-to-cloudfoundry.yaml
@@ -16,19 +16,35 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: echo "VERSION=$(echo ${TAG_NAME/#v/})" >> $GITHUB_OUTPUT
-      - name: Append release to Cloud Foundry repository
-        env:
-            VERSION: ${{ steps.get-release-version.outputs.VERSION }}
-            GH_TOKEN: ${{ github.token }}
+      - name: Get release URL
+        id: get-release-url
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b ci/cloudfoundry
-          echo "${VERSION}: https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar" >> index.yml
-          git add index.yml
-          git commit -m "chore: Add version ${VERSION} to Cloud Foundry"
-          git push -u origin ci/cloudfoundry --force
-          gh pr create \
-            --title "Add version ${VERSION} to Cloud Foundry" \
-            --body "This PR add the version ${VERSION} to Cloud Foundry.  Make sure [the JAR is online](https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${VERSION}/dd-java-agent-${VERSION}.jar) before merging." \
-            --base cloudfoundry
+          echo "URL=https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/${{ steps.get-release-version.outputs.VERSION }}/dd-java-agent-${{ steps.get-release-version.outputs.VERSION }}.jar" >> $GITHUB_OUTPUT
+      - name: Wait for the release to be available
+        run: |
+          TRY=0
+          MAX_TRIES=60 # Wait up to 30 minutes
+          DELAY=30
+          while [ $TRY -lt $MAX_TRIES ]; do
+            if curl -s -I ${{ steps.get-release-url.outputs.URL }} | grep -q "200 OK"; then
+              break
+            fi
+            echo "Waiting for the release to be available..."
+            sleep $DELAY
+            TRY=$((TRY+1))
+            if [ $TRY -eq $MAX_TRIES ]; then
+              echo "The release is not available after 30 mins. Aborting..."
+              exit 1
+            fi
+          done
+      - name: Append release to Cloud Foundry repository
+        run: |
+          echo "${{ steps.get-release-version.outputs.VERSION }}: ${{ steps.get-release-url.outputs.URL }}" >> index.yml
+      - name: Commit and push changes
+        uses: planetscale/ghcommit-action@b68767a2e130a71926b365322e62b583404a5e09 # v0.1.43
+        with:
+          commit_message: "chore: Add version ${{ steps.get-release-version.outputs.VERSION }} to Cloud Foundry"
+          repo: ${{ github.repository }}
+          branch: cloudfoundry
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# What Does This Do

This PR automates the Cloud Foundry repository update.
It won't use PR anymore but push a commit with the update as soon as the release is available on Maven Central.

# Motivation

Previously, it created a PR with a non-signed commit.
I decided to go for the final version right now and directly create commit (now signed) to the `cloudfoundry` branch. 

# Additional Notes

A new GitHub actions was allowed in the repository settings in order to create signed commit using the GitHub GraphQL API.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
