### PR TITLE
Add Parameter to only inject data jobs for particular java commands

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -204,11 +204,11 @@ public class Agent {
 
     boolean dataJobsEnabled = isFeatureEnabled(AgentFeature.DATA_JOBS);
     if (dataJobsEnabled) {
-      String javaCommand = System.getProperty("sun.java.command");
-      if (isDataJobsSupported(javaCommand)) {
-        log.error(
-            "Data Jobs Monitoring is not compatible with non-spark command {}. dd-trace-java will not be installed",
-            javaCommand);
+      if (!isDataJobsSupported()) {
+        log.warn(
+            "Data Jobs Monitoring is not compatible with non-spark command {} based on command pattern {}. dd-trace-java will not be installed",
+            System.getProperty("sun.java.command"),
+            Config.get().getDataJobsCommandPattern());
         return;
       }
 
@@ -1316,15 +1316,16 @@ public class Agent {
     return BootstrapProxy.INSTANCE.getResource("jdk/jfr/Recording.class") != null;
   }
 
-  private static boolean isDataJobsSupported(String javaCommand) {
-    if (javaCommand == null) {
+  private static boolean isDataJobsSupported() {
+    String javaCommand = System.getProperty("sun.java.command");
+    String dataJobsCommandPattern = Config.get().getDataJobsCommandPattern();
+
+    if (null == javaCommand || null == dataJobsCommandPattern) {
+      // if sun.java.command somehow is not set or data jobs command pattern is not
+      // set, assume it's supported due to lack of info.
       return true;
     }
 
-    if (javaCommand.contains("org.apache.spark") || javaCommand.contains("com.databricks")) {
-      return true;
-    }
-
-    return false;
+    return javaCommand.matches(dataJobsCommandPattern);
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -204,6 +204,14 @@ public class Agent {
 
     boolean dataJobsEnabled = isFeatureEnabled(AgentFeature.DATA_JOBS);
     if (dataJobsEnabled) {
+      String javaCommand = System.getProperty("sun.java.command");
+      if (isDataJobsSupported(javaCommand)) {
+        log.error(
+            "Data Jobs Monitoring is not compatible with non-spark command {}. dd-trace-java will not be installed",
+            javaCommand);
+        return;
+      }
+
       log.info("Data Jobs Monitoring enabled, enabling spark integrations");
 
       setSystemPropertyDefault(
@@ -1306,5 +1314,17 @@ public class Agent {
     // nothing to do with JDK - but this should be safe because only thing this does is to delay
     // tracer install
     return BootstrapProxy.INSTANCE.getResource("jdk/jfr/Recording.class") != null;
+  }
+
+  private static boolean isDataJobsSupported(String javaCommand) {
+    if (javaCommand == null) {
+      return true;
+    }
+
+    if (javaCommand.contains("org.apache.spark") || javaCommand.contains("com.databricks")) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -204,11 +204,13 @@ public class Agent {
 
     boolean dataJobsEnabled = isFeatureEnabled(AgentFeature.DATA_JOBS);
     if (dataJobsEnabled) {
-      if (!isDataJobsSupported()) {
+      String javaCommand = System.getProperty("sun.java.command");
+      String dataJobsCommandPattern = Config.get().getDataJobsCommandPattern();
+      if (!isDataJobsSupported(javaCommand, dataJobsCommandPattern)) {
         log.warn(
             "Data Jobs Monitoring is not compatible with non-spark command {} based on command pattern {}. dd-trace-java will not be installed",
-            System.getProperty("sun.java.command"),
-            Config.get().getDataJobsCommandPattern());
+            javaCommand,
+            dataJobsCommandPattern);
         return;
       }
 
@@ -1316,10 +1318,7 @@ public class Agent {
     return BootstrapProxy.INSTANCE.getResource("jdk/jfr/Recording.class") != null;
   }
 
-  private static boolean isDataJobsSupported() {
-    String javaCommand = System.getProperty("sun.java.command");
-    String dataJobsCommandPattern = Config.get().getDataJobsCommandPattern();
-
+  private static boolean isDataJobsSupported(String javaCommand, String dataJobsCommandPattern) {
     if (null == javaCommand || null == dataJobsCommandPattern) {
       // if sun.java.command somehow is not set or data jobs command pattern is not
       // set, assume it's supported due to lack of info.

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -162,8 +162,7 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
       builder
           .withStartTimestamp(applicationStart.time() * 1000)
           .withTag("application_name", applicationStart.appName())
-          .withTag("spark_user", applicationStart.sparkUser())
-          .withTag("_dd.spark.java.command", System.getProperty("sun.java.command"));
+          .withTag("spark_user", applicationStart.sparkUser());
 
       if (applicationStart.appAttemptId().isDefined()) {
         builder.withTag("app_attempt_id", applicationStart.appAttemptId().get());
@@ -332,8 +331,7 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
         buildSparkSpan("spark.job", jobStart.properties())
             .withStartTimestamp(jobStart.time() * 1000)
             .withTag("job_id", jobStart.jobId())
-            .withTag("stage_count", getStageCount(jobStart))
-            .withTag("_dd.spark.java.command", System.getProperty("sun.java.command"));
+            .withTag("stage_count", getStageCount(jobStart));
 
     String batchKey = getStreamingBatchKey(jobStart.properties());
     Long sqlExecutionId = getSqlExecutionId(jobStart.properties());

--- a/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -162,7 +162,8 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
       builder
           .withStartTimestamp(applicationStart.time() * 1000)
           .withTag("application_name", applicationStart.appName())
-          .withTag("spark_user", applicationStart.sparkUser());
+          .withTag("spark_user", applicationStart.sparkUser())
+          .withTag("_dd.spark.java.command", System.getProperty("sun.java.command"));
 
       if (applicationStart.appAttemptId().isDefined()) {
         builder.withTag("app_attempt_id", applicationStart.appAttemptId().get());
@@ -331,7 +332,8 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
         buildSparkSpan("spark.job", jobStart.properties())
             .withStartTimestamp(jobStart.time() * 1000)
             .withTag("job_id", jobStart.jobId())
-            .withTag("stage_count", getStageCount(jobStart));
+            .withTag("stage_count", getStageCount(jobStart))
+            .withTag("_dd.spark.java.command", System.getProperty("sun.java.command"));
 
     String batchKey = getStreamingBatchKey(jobStart.properties());
     Long sqlExecutionId = getSqlExecutionId(jobStart.properties());

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -68,6 +68,7 @@ public final class GeneralConfig {
   public static final String INTERNAL_EXIT_ON_FAILURE = "trace.internal.exit.on.failure";
 
   public static final String DATA_JOBS_ENABLED = "data.jobs.enabled";
+  public static final String DATA_JOBS_COMMAND_PATTERN = "data.jobs.command.pattern";
 
   public static final String DATA_STREAMS_ENABLED = "data.streams.enabled";
   public static final String DATA_STREAMS_BUCKET_DURATION_SECONDS =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -249,6 +249,7 @@ import static datadog.trace.api.config.GeneralConfig.API_KEY_FILE;
 import static datadog.trace.api.config.GeneralConfig.APPLICATION_KEY;
 import static datadog.trace.api.config.GeneralConfig.APPLICATION_KEY_FILE;
 import static datadog.trace.api.config.GeneralConfig.AZURE_APP_SERVICES;
+import static datadog.trace.api.config.GeneralConfig.DATA_JOBS_COMMAND_PATTERN;
 import static datadog.trace.api.config.GeneralConfig.DATA_JOBS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.DATA_STREAMS_BUCKET_DURATION_SECONDS;
 import static datadog.trace.api.config.GeneralConfig.DATA_STREAMS_ENABLED;
@@ -935,6 +936,7 @@ public class Config {
   private final int cwsTlsRefresh;
 
   private final boolean dataJobsEnabled;
+  private final String dataJobsCommandPattern;
 
   private final boolean dataStreamsEnabled;
   private final float dataStreamsBucketDurationSeconds;
@@ -2078,6 +2080,7 @@ public class Config {
     cwsTlsRefresh = configProvider.getInteger(CWS_TLS_REFRESH, DEFAULT_CWS_TLS_REFRESH);
 
     dataJobsEnabled = configProvider.getBoolean(DATA_JOBS_ENABLED, DEFAULT_DATA_JOBS_ENABLED);
+    dataJobsCommandPattern = configProvider.getString(DATA_JOBS_COMMAND_PATTERN);
 
     dataStreamsEnabled =
         configProvider.getBoolean(DATA_STREAMS_ENABLED, DEFAULT_DATA_STREAMS_ENABLED);
@@ -3603,6 +3606,10 @@ public class Config {
     return dataJobsEnabled;
   }
 
+  public String getDataJobsCommandPattern() {
+    return dataJobsCommandPattern;
+  }
+
   /** @return A map of tags to be applied only to the local application root span. */
   public Map<String, Object> getLocalRootSpanTags() {
     final Map<String, String> runtimeTags = getRuntimeTags();
@@ -4757,6 +4764,8 @@ public class Config {
         + appSecRaspEnabled
         + ", dataJobsEnabled="
         + dataJobsEnabled
+        + ", dataJobsCommandPattern="
+        + dataJobsCommandPattern
         + ", appSecStandaloneEnabled="
         + appSecStandaloneEnabled
         + '}';


### PR DESCRIPTION
# What Does This Do

Add parameter `dd.data.jobs.command.pattern` to only inject the tracer on specific command pattern for Data Jobs

In the context of Data Jobs Monitoring, change the Java tracer to become more selective about which Java process to instrument when Data Jobs is enabled and a Java command regex pattern is specified. In runtime environment where we are not sure the command pattern to use, the java tracer should just behave as before by continuing the Agent start.

# Motivation
With single step instrumentation, Java tracer is injected for all Java processes, this is causing some initial system overhead as Java tracer starts in those JVMs. In resource limited environment, this can cause the host to be replaced due to high system load. For Data Jobs Monitoring, the Java tracer only cares about Spark process running the driver and executors, this newly added command pattern allows us to exit the Agent early if we don't think the process is Spark related and saving the overhead of increased System load.

# Additional Notes
* The environment variable to specify the data jobs Java command pattern (regex):`DD_DATA_JOBS_COMMAND_PATTERN`. 
* `DD_DATA_JOBS_COMMAND_PATTERN` only takes effects if `DD_DATA_JOBS_ENABLED` is set to `true`.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
