### PR TITLE
Fix ordering of pathway tags for DSM

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -286,8 +286,8 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
     if (manualCheckpoint) {
       sortedTags.put(MANUAL_TAG, "true");
     }
-    sortedTags.put(TOPIC_TAG, target);
     sortedTags.put(TYPE_TAG, type);
+    sortedTags.put(TOPIC_TAG, target);
 
     this.injector.injectPathwayContext(
         span, carrier, DataStreamsContextCarrierAdapter.INSTANCE, sortedTags);


### PR DESCRIPTION
# What Does This Do
Fixes order of `edgeTags` in the AWS SDK as there are failing tests caused by the incorrect order being set here.
# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
