### PR TITLE
Fix nightly deploys

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,9 +84,6 @@ build_with_cache:
     <<: *default_cache
     policy: push
 
-deploy_to_reliability_env:
-  stage: publish
-
 deploy_to_profiling_backend:
   stage: publish
   needs: [ build ]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,10 +17,15 @@ stages:
   - ci-visibility-tests
   - generate-signing-key
 
+workflow:
+  rules:
+    - if: $POPULATE_CACHE == "true"
+      variables:
+        SKIP_SHARED_PIPELINE: "true"
+
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   BUILD_JOB_NAME: "build"
-  SKIP_SHARED_PIPELINE: $POPULATE_CACHE
 
 .common: &common
   tags: [ "runner:main", "size:large" ]
@@ -161,6 +166,8 @@ deploy_to_sonatype:
   stage: publish
   needs: [ build ]
   rules:
+    - if: '$POPULATE_CACHE'
+      when: never
     - if: '$CI_COMMIT_BRANCH == "master"'
       when: on_success
     # Do not deploy release candidate versions

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ workflow:
     - if: $POPULATE_CACHE == "true"
       variables:
         SKIP_SHARED_PIPELINE: "true"
+    - when: always
 
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,10 +58,6 @@ variables:
 build: &build
   <<: *gradle_build
   stage: build
-  rules:
-    - if: '$POPULATE_CACHE'
-      when: never
-    - when: on_success
   script:
     - ./gradlew clean :dd-java-agent:shadowJar :dd-trace-api:jar :dd-trace-ot:shadowJar $GRADLE_ARGS
     - echo UPSTREAM_TRACER_VERSION=$(java -jar workspace/dd-java-agent/build/libs/*.jar) >> upstream.env

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -1,6 +1,8 @@
 .macrobenchmarks:
   stage: macrobenchmarks
   rules:
+    - if: $POPULATE_CACHE
+      when: never
     - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
       when: always
     - when: manual

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -6,6 +6,7 @@
     - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
       when: always
     - when: manual
+      allow_failure: true
   tags: ["runner:apm-k8s-same-cpu"]
   needs: ["build"]
   interruptible: true


### PR DESCRIPTION
# What Does This Do
Fixes the schedule deploy:
* The previous `SKIP_SHARED_PIPELINE: $POPULATE_CACHE` variable assignment doesn't work. It needs to be done as a workflow rule
* The `macrobenchmarks` and `deploy_to_sonatype` jobs depended on `build` which was not available during nightly jobs

Additionally:
* I changed the nightly to run `build` in addition to `build_with_cache` so any dependency issues won't bork the build in the future

# Motivation
The nightly deploy has been broken for months despite occasional efforts to fix it

# Additional Notes
I tested this be creating a scheduled job with `POPULATE_CACHE=true` and ensuring everything works as expected

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
