### PR TITLE
Add severity tag to crash upload

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -279,6 +279,7 @@ public final class CrashUploader {
           writer.beginObject();
           writer.name("message").value(extractErrorStackTrace(message));
           writer.name("level").value("ERROR");
+          writer.name("tags").value("severity:crash");
           writer.endObject();
         }
         writer.endArray();

--- a/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/CrashUploaderTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/CrashUploaderTest.java
@@ -167,6 +167,7 @@ public class CrashUploaderTest {
     assertEquals(
         readFileAsString("redacted-stacktrace.txt"),
         event.get("payload").get(0).get("message").asText());
+    assertEquals("severity:crash", event.get("payload").get(0).get("tags").asText());
     // application:
     assertEquals(ENV, event.get("application").get("env").asText());
     assertEquals("jvm", event.get("application").get("language_name").asText());


### PR DESCRIPTION
# What Does This Do
Adds tags section to the crashtracking telemetry payload such that it is recognized by the crashtracking.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-10230]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-10230]: https://datadoghq.atlassian.net/browse/PROF-10230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ