### PR TITLE
Fix crash-tracking uploader script overwrite warning

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/ScriptInitializer.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/ScriptInitializer.java
@@ -249,21 +249,23 @@ public final class ScriptInitializer {
   private static void writeScript(
       InputStream template, Path scriptPath, String execClass, String crashFile)
       throws IOException {
-    try (BufferedReader br = new BufferedReader(new InputStreamReader(template))) {
-      try (BufferedWriter bw = Files.newBufferedWriter(scriptPath)) {
-        br.lines()
-            .map(
-                line -> {
-                  line = Strings.replace(line, "!AGENT_JAR!", execClass);
-                  if (crashFile != null) {
-                    line = Strings.replace(line, "!JAVA_ERROR_FILE!", crashFile);
-                  }
-                  return line;
-                })
-            .forEach(line -> writeLine(bw, line));
+    if (!Files.exists(scriptPath)) {
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(template))) {
+        try (BufferedWriter bw = Files.newBufferedWriter(scriptPath)) {
+          br.lines()
+              .map(
+                  line -> {
+                    line = Strings.replace(line, "!AGENT_JAR!", execClass);
+                    if (crashFile != null) {
+                      line = Strings.replace(line, "!JAVA_ERROR_FILE!", crashFile);
+                    }
+                    return line;
+                  })
+              .forEach(line -> writeLine(bw, line));
+        }
       }
+      Files.setPosixFilePermissions(scriptPath, PosixFilePermissions.fromString("r-xr-xr-x"));
     }
-    Files.setPosixFilePermissions(scriptPath, PosixFilePermissions.fromString("r-xr-xr-x"));
   }
 
   private static void writeLine(BufferedWriter bw, String line) {

--- a/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/ScriptInitializerTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/ScriptInitializerTest.java
@@ -68,6 +68,17 @@ public class ScriptInitializerTest {
     assertTrue(lines.stream().anyMatch(l -> l.contains(hsErrFile)));
   }
 
+  @Test
+  void testCrashUploaderInitializationExisting() throws IOException {
+    Path file = tempDir.resolve("dd_crash_uploader.sh");
+    Files.createFile(file);
+    ScriptInitializer.initializeCrashUploader(file.toString(), "/tmp/hs_err%p.log");
+    assertTrue(Files.exists(file), "File " + file + " should not have been removed");
+    assertTrue(
+        Files.readAllLines(file).isEmpty(),
+        "File " + file + " content should not have been modified");
+  }
+
   private static Stream<Arguments> crashTrackingScripts() {
     return Stream.of(
         Arguments.of("dd_crash_uploader.sh", ""),


### PR DESCRIPTION
# What Does This Do
It fixes a (embarrassing) bug in the crash uploader script initialization

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-10324]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-10324]: https://datadoghq.atlassian.net/browse/PROF-10324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ