### PR TITLE
Add _dd.tracer_host to local root spans

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TagsAssert.groovy
@@ -83,6 +83,8 @@ class TagsAssert {
       // If runtime id is actually different here, it might indicate that
       // the Config class was loaded on multiple different class loaders.
       assert tags[DDTags.RUNTIME_ID_TAG] == Config.get().runtimeId
+      assertedTags.add(DDTags.TRACER_HOST)
+      assert tags[DDTags.TRACER_HOST] == Config.get().getHostName()
     } else {
       assert tags[DDTags.RUNTIME_ID_TAG] == null
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -50,6 +50,7 @@ public class DDTags {
 
   /* Tags below are for internal use only. */
   static final String INTERNAL_HOST_NAME = "_dd.hostname";
+  public static final String TRACER_HOST = "_dd.tracer_host";
   public static final String RUNTIME_ID_TAG = "runtime-id";
   public static final String RUNTIME_VERSION_TAG = "runtime_version";
   static final String SERVICE = "service";

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/RemoteHostnameAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/RemoteHostnameAdder.java
@@ -1,0 +1,23 @@
+package datadog.trace.core.tagprocessor;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
+import datadog.trace.core.DDSpanContext;
+import java.util.Map;
+
+public class RemoteHostnameAdder implements TagsPostProcessor {
+  private final Config config;
+
+  public RemoteHostnameAdder(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public Map<String, Object> processTags(
+      Map<String, Object> unsafeTags, DDSpanContext spanContext) {
+    if (spanContext.getSpanId() == spanContext.getRootSpanId()) {
+      unsafeTags.put(DDTags.TRACER_HOST, config.getHostName());
+    }
+    return unsafeTags;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessorFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessorFactory.java
@@ -6,15 +6,19 @@ import java.util.List;
 
 public final class TagsPostProcessorFactory {
   private static boolean addBaseService = true;
+  private static boolean addRemoteHostname = true;
 
   private static class Lazy {
     private static TagsPostProcessor create() {
-      final List<TagsPostProcessor> processors = new ArrayList<>(addBaseService ? 3 : 2);
+      final List<TagsPostProcessor> processors = new ArrayList<>(4);
       processors.add(new PeerServiceCalculator());
       if (addBaseService) {
         processors.add(new BaseServiceAdder(Config.get().getServiceName()));
       }
       processors.add(new QueryObfuscator(Config.get().getObfuscationQueryRegexp()));
+      if (addRemoteHostname) {
+        processors.add(new RemoteHostnameAdder(Config.get()));
+      }
       return new PostProcessorChain(
           processors.toArray(processors.toArray(new TagsPostProcessor[0])));
     }
@@ -35,10 +39,19 @@ public final class TagsPostProcessorFactory {
     addBaseService = enabled;
     Lazy.instance = Lazy.create();
   }
+  /**
+   * Mostly used for test purposes.
+   *
+   * @param enabled if false, {@link RemoteHostnameAdder} is not put in the chain.
+   */
+  public static void withAddRemoteHostname(boolean enabled) {
+    addRemoteHostname = enabled;
+    Lazy.instance = Lazy.create();
+  }
 
   /** Used for testing purposes. It reset the singleton and restore default options */
   public static void reset() {
     withAddBaseService(true);
-    Lazy.instance = Lazy.create();
+    withAddRemoteHostname(true);
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/test/DDCoreSpecification.groovy
@@ -28,6 +28,7 @@ abstract class DDCoreSpecification extends DDSpecification {
   @Override
   void setupSpec() {
     TagsPostProcessorFactory.withAddBaseService(false)
+    TagsPostProcessorFactory.withAddRemoteHostname(false)
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

This PR lazily adds the hostname to the tag `_dd.tracer_host` to every local root span.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
