### PR TITLE
Add separate test suite for Avro for java 8

### DIFF
--- a/dd-java-agent/instrumentation/avro/build.gradle
+++ b/dd-java-agent/instrumentation/avro/build.gradle
@@ -1,3 +1,6 @@
+ext {
+  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_11
+}
 muzzle {
   pass {
     group = 'org.apache.avro'
@@ -10,19 +13,21 @@ muzzle {
 apply from: "$rootDir/gradle/java.gradle"
 
 addTestSuiteForDir('latestDepTest','test')
-ext {
-  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_11
-}
+addTestSuiteForDir('latestDepTest8','test')
 dependencies {
   compileOnly group: 'org.apache.avro', name: 'avro', version: '1.11.3'
   testImplementation group: 'org.apache.avro', name: 'avro', version: '1.11.3'
   latestDepTestImplementation group: 'org.apache.avro', name: 'avro', version: '1.+'
+  //Java 8 tests do not work after version 1.11.3
+  latestDepTest8Implementation group: 'org.apache.avro', name: 'avro', version: '1.11.3'
 
   compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.1'
   testImplementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.1'
   latestDepTestImplementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.+'
+  latestDepTest8Implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.+'
 
   compileOnly group: 'org.apache.avro', name: 'avro-mapred', version: '1.11.3'
   testImplementation group: 'org.apache.avro', name: 'avro-mapred', version: '1.11.3'
   latestDepTestImplementation group: 'org.apache.avro', name: 'avro-mapred', version: '1.11.3'
+  latestDepTest8Implementation group: 'org.apache.avro', name: 'avro-mapred', version: '1.11.3'
 }


### PR DESCRIPTION
# What Does This Do
Creates a separate test suite for Java 8 for Avro because there are class version errors after version 1.11.3 of Avro.
# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
