### PR TITLE
OpenTracing: mute tracing when activate a null span

### DIFF
--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -20,11 +20,8 @@ public class OTScopeManager implements ScopeManager {
 
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
-    if (null == span) {
-      return null;
-    }
 
-    final AgentSpan agentSpan = converter.toAgentSpan(span);
+    final AgentSpan agentSpan = span != null ? converter.toAgentSpan(span) : tracer.blackholeSpan();
     final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 
     return converter.toScope(agentScope, finishSpanOnClose);

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -317,19 +317,18 @@ class OpenTracing31Test extends AgentTestRunner {
     USER_DROP       | MANUAL            | USER_DROP
   }
 
-  def "tolerate null span activation"() {
+  def "null activation should mute tracing"() {
     when:
-    try {
-      tracer.scopeManager().activate(null, false)?.close()
-    } catch (Exception ignored) {}
+    def nullScope = tracer.scopeManager().activate(null, false)
 
-    // make sure scope stack has been left in a valid state
     Span testSpan = tracer.buildSpan("someOperation").start()
     Scope testScope = tracer.scopeManager().activate(testSpan, false)
     testSpan.finish()
     testScope.close()
+    nullScope.close()
 
     then:
+    assertTraces(0, {})
     assert tracer.scopeManager().active() == null
   }
 

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -25,11 +25,7 @@ public class OTScopeManager implements ScopeManager {
 
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
-    if (null == span) {
-      return null;
-    }
-
-    final AgentSpan agentSpan = converter.toAgentSpan(span);
+    final AgentSpan agentSpan = span != null ? converter.toAgentSpan(span) : tracer.blackholeSpan();
     final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 
     return converter.toScope(agentScope, finishSpanOnClose);

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -26,11 +26,7 @@ class OTScopeManager implements ScopeManager {
 
   @Override
   public Scope activate(final Span span, final boolean finishSpanOnClose) {
-    if (null == span) {
-      return null;
-    }
-
-    final AgentSpan agentSpan = converter.toAgentSpan(span);
+    final AgentSpan agentSpan = span != null ? converter.toAgentSpan(span) : tracer.blackholeSpan();
     final AgentScope agentScope = tracer.activateSpan(agentSpan, ScopeSource.MANUAL);
 
     return converter.toScope(agentScope, finishSpanOnClose);


### PR DESCRIPTION
# What Does This Do

This PR changes the current behaviour when activating null spans using the opentracing API or the opentelemetry's Opentracing wrapper.

Before this PR, we tolerated activating a null span but we returned a null scope, leaving the scope's stack unchanged. Differently, the opentelemetry implementation of the opentracing wrapper is pusing a noop scope on the stack, concretely causing the subsequent part of the trace to be muted.

In order to align us with OTEL, we're now activating a blackhole span when activating a null span with the opentracing APIs.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
