### PR TITLE
Add support for suspicious attacker blocking to appsec

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -8,6 +8,7 @@ import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_CUSTOM_BLOCKING_R
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_CUSTOM_RULES;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_DD_RULES;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_EXCLUSIONS;
+import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_EXCLUSION_DATA;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_IP_BLOCKING;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_SQLI;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_REQUEST_BLOCKING;
@@ -97,6 +98,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
         CAPABILITY_ASM_DD_RULES
             | CAPABILITY_ASM_IP_BLOCKING
             | CAPABILITY_ASM_EXCLUSIONS
+            | CAPABILITY_ASM_EXCLUSION_DATA
             | CAPABILITY_ASM_REQUEST_BLOCKING
             | CAPABILITY_ASM_USER_BLOCKING
             | CAPABILITY_ASM_CUSTOM_RULES
@@ -335,6 +337,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_DD_RULES
             | CAPABILITY_ASM_IP_BLOCKING
             | CAPABILITY_ASM_EXCLUSIONS
+            | CAPABILITY_ASM_EXCLUSION_DATA
             | CAPABILITY_ASM_REQUEST_BLOCKING
             | CAPABILITY_ASM_USER_BLOCKING
             | CAPABILITY_ASM_CUSTOM_RULES

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecData.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecData.java
@@ -1,0 +1,30 @@
+package com.datadog.appsec.config;
+
+import com.squareup.moshi.Json;
+import java.util.List;
+import java.util.Map;
+
+public class AppSecData {
+
+  @Json(name = "rules_data")
+  private List<Map<String, Object>> rules;
+
+  @Json(name = "exclusion_data")
+  private List<Map<String, Object>> exclusion;
+
+  public List<Map<String, Object>> getRules() {
+    return rules;
+  }
+
+  public void setRules(List<Map<String, Object>> rules) {
+    this.rules = rules;
+  }
+
+  public List<Map<String, Object>> getExclusion() {
+    return exclusion;
+  }
+
+  public void setExclusion(List<Map<String, Object>> exclusion) {
+    this.exclusion = exclusion;
+  }
+}

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecDataDeserializer.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecDataDeserializer.java
@@ -3,36 +3,25 @@ package com.datadog.appsec.config;
 import static com.datadog.appsec.config.AppSecConfig.MOSHI;
 
 import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.Types;
 import datadog.remoteconfig.ConfigurationDeserializer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
 import okio.Okio;
 
-public class AppSecDataDeserializer
-    implements ConfigurationDeserializer<List<Map<String, Object>>> {
+public class AppSecDataDeserializer implements ConfigurationDeserializer<AppSecData> {
   public static final AppSecDataDeserializer INSTANCE = new AppSecDataDeserializer();
 
-  private static final JsonAdapter<Map<String, List<Map<String, Object>>>> ADAPTER =
-      MOSHI.adapter(
-          Types.newParameterizedType(
-              Map.class,
-              String.class,
-              Types.newParameterizedType(
-                  List.class, Types.newParameterizedType(Map.class, String.class, Object.class))));
+  private static final JsonAdapter<AppSecData> ADAPTER = MOSHI.adapter(AppSecData.class);
 
   private AppSecDataDeserializer() {}
 
   @Override
-  public List<Map<String, Object>> deserialize(byte[] content) throws IOException {
+  public AppSecData deserialize(byte[] content) throws IOException {
     return deserialize(new ByteArrayInputStream(content));
   }
 
-  private List<Map<String, Object>> deserialize(InputStream is) throws IOException {
-    Map<String, List<Map<String, Object>>> cfg = ADAPTER.fromJson(Okio.buffer(Okio.source(is)));
-    return cfg.get("rules_data");
+  private AppSecData deserialize(InputStream is) throws IOException {
+    return ADAPTER.fromJson(Okio.buffer(Okio.source(is)));
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -22,6 +22,7 @@ import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_CUSTOM_BLOCKING_R
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_CUSTOM_RULES
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_DD_RULES
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_EXCLUSIONS
+import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_EXCLUSION_DATA
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_IP_BLOCKING
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_SQLI
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_REQUEST_BLOCKING
@@ -254,6 +255,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     1 * poller.addCapabilities(CAPABILITY_ASM_DD_RULES
       | CAPABILITY_ASM_IP_BLOCKING
       | CAPABILITY_ASM_EXCLUSIONS
+      | CAPABILITY_ASM_EXCLUSION_DATA
       | CAPABILITY_ASM_REQUEST_BLOCKING
       | CAPABILITY_ASM_USER_BLOCKING
       | CAPABILITY_ASM_CUSTOM_RULES
@@ -307,7 +309,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
           enabled     : false
         ]
       ]
-      casc.mergedAsmData == [[data: [], id: 'foo', type: '']]
+      casc.mergedAsmData.mergedData.rules == [[data: [], id: 'foo', type: '']]
     }, _)
 
     when:
@@ -398,6 +400,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     1 * poller.addCapabilities(CAPABILITY_ASM_DD_RULES
       | CAPABILITY_ASM_IP_BLOCKING
       | CAPABILITY_ASM_EXCLUSIONS
+      | CAPABILITY_ASM_EXCLUSION_DATA
       | CAPABILITY_ASM_REQUEST_BLOCKING
       | CAPABILITY_ASM_USER_BLOCKING
       | CAPABILITY_ASM_CUSTOM_RULES
@@ -430,7 +433,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     }
     mergedUpdateConfig.numberOfRules == 0
     mergedUpdateConfig.rawConfig['rules_override'].isEmpty() == false
-    mergedAsmData.isEmpty() == false
+    mergedAsmData.mergedData.rules.isEmpty() == false
 
     when:
     listeners.savedConfChangesListener.accept('asm_dd config', null, null)
@@ -447,7 +450,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
 
     mergedUpdateConfig.numberOfRules > 0
     mergedUpdateConfig.rawConfig['rules_override'].isEmpty() == true
-    mergedAsmData.isEmpty() == true
+    mergedAsmData.mergedData.rules.isEmpty() == true
   }
 
   void 'stopping appsec unsubscribes from the poller'() {
@@ -463,6 +466,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
       | CAPABILITY_ASM_DD_RULES
       | CAPABILITY_ASM_IP_BLOCKING
       | CAPABILITY_ASM_EXCLUSIONS
+      | CAPABILITY_ASM_EXCLUSION_DATA
       | CAPABILITY_ASM_REQUEST_BLOCKING
       | CAPABILITY_ASM_USER_BLOCKING
       | CAPABILITY_ASM_CUSTOM_RULES

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecDataDeserializerSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecDataDeserializerSpecification.groovy
@@ -39,7 +39,7 @@ class AppSecDataDeserializerSpecification extends Specification {
 
     then:
     result != null
-    result == [
+    result.rules == [
       [
         data: [
           [
@@ -55,8 +55,43 @@ class AppSecDataDeserializerSpecification extends Specification {
             value     : "3.3.3.3"
           ]
         ],
-        id: "blocked_ips",
+        id  : "blocked_ips",
         type: "ip_with_expiration"
+      ]
+    ]
+  }
+
+  void 'deserialize exclusions data'() {
+    final deser = AppSecDataDeserializer.INSTANCE
+    final input = """
+{
+  "exclusion_data": [
+    {
+      "id": "suspicious_ips_data_id",
+      "type": "ip_with_expiration",
+      "data": [
+        {
+          "value": "34.65.27.85"
+        }
+      ]
+    }
+  ]
+}
+    """
+
+    when:
+    def result = deser.deserialize(input.getBytes(StandardCharsets.UTF_8))
+
+    then:
+    result != null
+    result.exclusion == [
+      [
+        id  : "suspicious_ips_data_id",
+        type: "ip_with_expiration",
+        data: [[
+            value: "34.65.27.85"
+          ]],
+
       ]
     ]
   }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/MergedAsmDataSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/MergedAsmDataSpecification.groovy
@@ -2,10 +2,12 @@ package com.datadog.appsec.config
 
 import spock.lang.Specification
 
+import java.util.function.Function
+
 class MergedAsmDataSpecification extends Specification {
-  void 'merge of data without expiration'() {
+  void 'merge of data without expiration: #test'() {
     setup:
-    def cfg1 = [
+    def cfg1 = test.set.apply([
       [
         id: 'id1',
         type: 'type1',
@@ -16,8 +18,8 @@ class MergedAsmDataSpecification extends Specification {
         type: 'type1',
         data: [[value: 'foobar2']]
       ]
-    ]
-    def cfg2 = [
+    ])
+    def cfg2 = test.set.apply([
       [
         id: 'id2',
         type: 'type1',
@@ -28,12 +30,12 @@ class MergedAsmDataSpecification extends Specification {
         type: 'type1',
         data: [[value: 'foobar3']]
       ],
-    ]
+    ])
     def md = new MergedAsmData([cfg1: cfg1, cfg2: cfg2]).mergedData
-    md.sort({ a, b -> a['id'] <=> b['id'] })
+    test.get.apply(md).sort({ a, b -> a['id'] <=> b['id'] })
 
     expect:
-    md == [
+    test.get.apply(md) == [
       [
         id: 'id1',
         type: 'type1',
@@ -45,11 +47,14 @@ class MergedAsmDataSpecification extends Specification {
         data: [[value: 'foobar4']]
       ]
     ]
+
+    where:
+    test << testSuite()
   }
 
-  void 'merge of data with expiration'() {
+  void 'merge of data with expiration: #test'() {
     setup:
-    def cfg1 = [
+    def cfg1 =  test.set.apply([
       [
         id: 'id1',
         type: 'data_with_expiration',
@@ -63,31 +68,34 @@ class MergedAsmDataSpecification extends Specification {
         type: 'data_with_expiration',
         data: [[value: 'foobar1', expiration: 50], [value: 'foobar2'],]
       ]
-    ]
-    def cfg2 = [
+    ])
+    def cfg2 = test.set.apply([
       [
         id: 'id1',
         type: 'data_with_expiration',
         data: [[value: 'foobar2', expiration: 100]]
       ],
-    ]
+    ])
     def md = new MergedAsmData([cfg1: cfg1, cfg2: cfg2]).mergedData
-    md.sort({ a, b -> a['id'] <=> b['id'] })
+    test.get.apply(md).sort({ a, b -> a['id'] <=> b['id'] })
 
     expect:
-    md == [
+    test.get.apply(md) == [
       [
         id: 'id1',
         type: 'data_with_expiration',
         data: [[value: 'foobar2'], [value: 'foobar1', expiration: 50]]
       ]
     ]
+
+    where:
+    test << testSuite()
   }
 
-  void 'error due to mismatched type'() {
+  void 'error due to mismatched type: #test'() {
     when:
     new MergedAsmData([
-      cfg: [
+      cfg: test.set.apply([
         [
           id: 'foo',
           // type: null,
@@ -98,9 +106,30 @@ class MergedAsmDataSpecification extends Specification {
           type: 'bar',
           data: []
         ]
-      ]
+      ])
     ]).mergedData
     then:
     thrown MergedAsmData.InvalidAsmDataException
+
+    where:
+    test << testSuite()
+  }
+
+  private static List<Test> testSuite() {
+    return [
+      new Test(descr: 'rules_data', set: { payload -> new AppSecData(rules: payload) }, get: { AppSecData data -> data.rules }),
+      new Test(descr: 'exclusion_data', set: { payload -> new AppSecData(exclusion: payload) }, get: { AppSecData data -> data.exclusion })
+    ]
+  }
+
+  private static class Test {
+    String descr
+    Function<List<Map<String, Object>>, AppSecData> set
+    Function<AppSecData, List<Map<String, Object>>> get
+
+    @Override
+    String toString() {
+      return descr
+    }
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -2,6 +2,7 @@ package com.datadog.appsec.powerwaf
 
 import com.datadog.appsec.AppSecModule
 import com.datadog.appsec.config.AppSecConfig
+import com.datadog.appsec.config.AppSecData
 import com.datadog.appsec.config.AppSecModuleConfigurer
 import com.datadog.appsec.config.AppSecUserConfig
 import com.datadog.appsec.config.CurrentAppSecConfig
@@ -171,7 +172,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
         on_match: ['block2']
       ]
     ]
-    def ipData = [
+    def ipData = new AppSecData(rules: [
       [
         id  : 'ip_data',
         type: 'ip_with_expiration',
@@ -180,7 +181,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
             expiration: '0',
           ]]
       ]
-    ]
+    ])
     service.currentAppSecConfig.with {
       def dirtyStatus = userConfigs.addConfig(
         new AppSecUserConfig('b', ruleOverrides, actions, [], []))
@@ -249,7 +250,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     0 * _
 
     when: 'merges new waf data with the one in the rules config'
-    def newData = [
+    def newData = new AppSecData(rules: [
       [
         id  : 'blocked_users',
         type: 'data_with_expiration',
@@ -260,7 +261,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
           ]
         ]
       ]
-    ]
+    ])
     service.currentAppSecConfig.with {
       mergedAsmData.addConfig('c', newData)
       it.dirtyStatus.data = true
@@ -999,7 +1000,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     setupWithStubConfigService()
     AppSecModuleConfigurer.Reconfiguration reconf = Mock()
     ChangeableFlow flow = Mock()
-    def ipData = [
+    def ipData = new AppSecData(rules: [
       [
         id  : 'ip_data',
         type: 'ip_with_expiration',
@@ -1008,7 +1009,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
             expiration: '0',
           ]]
       ]
-    ]
+    ])
 
     when:
     service.currentAppSecConfig.with {
@@ -1051,7 +1052,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     setupWithStubConfigService()
     AppSecModuleConfigurer.Reconfiguration reconf = Mock()
     ChangeableFlow flow = Mock()
-    def ipData = [
+    def ipData = new AppSecData(rules: [
       [
         id  : 'ip_data',
         type: 'ip_with_expiration',
@@ -1060,7 +1061,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
             expiration: '0',
           ]]
       ]
-    ]
+    ])
 
     when: 'reconfigure with data and toggling'
     service.currentAppSecConfig.with {
@@ -1435,6 +1436,54 @@ class PowerWAFModuleSpecification extends DDSpecification {
     then:
     waf.rateLimiter.limitPerSec == 5
 
+  }
+
+  void 'suspicious attacker blocking'() {
+    given:
+    final flow = Mock(ChangeableFlow)
+    final reconf = Mock(AppSecModuleConfigurer.Reconfiguration)
+    final suspiciousIp = '34.65.27.85'
+    setupWithStubConfigService('rules_suspicious_attacker_blocking.json')
+    dataListener = pwafModule.dataSubscriptions.first()
+    ctx.closeAdditive()
+    final bundle = MapDataBundle.of(
+      KnownAddresses.REQUEST_INFERRED_CLIENT_IP,
+      suspiciousIp,
+      KnownAddresses.HEADERS_NO_COOKIES,
+      new CaseInsensitiveMap<List<String>>(['user-agent': ['Arachni/v1.5.1']])
+      )
+
+    when:
+    dataListener.onDataAvailable(flow, ctx, bundle, gwCtx)
+    ctx.closeAdditive()
+
+    then:
+    0 * flow.setAction(_)
+
+    when:
+    final ipData = new AppSecData(exclusion: [
+      [
+        id  : 'suspicious_ips_data_id',
+        type: 'ip_with_expiration',
+        data: [[value: suspiciousIp]]
+      ]
+    ])
+    service.currentAppSecConfig.with {
+      mergedAsmData.addConfig('suspicious_ips', ipData)
+      it.dirtyStatus.data = true
+      it.dirtyStatus.mergeFrom(dirtyStatus)
+
+      service.listeners['waf'].onNewSubconfig(it, reconf)
+      it.dirtyStatus.clearDirty()
+    }
+    dataListener.onDataAvailable(flow, ctx, bundle, gwCtx)
+    ctx.closeAdditive()
+
+    then:
+    1 * reconf.reloadSubscriptions()
+    1 * flow.setAction({ Flow.Action.RequestBlockingAction rba ->
+      rba.statusCode == 402 && rba.blockingContentType == BlockingContentType.AUTO
+    })
   }
 
   private Map<String, Object> getDefaultConfig() {

--- a/dd-java-agent/appsec/src/test/resources/rules_suspicious_attacker_blocking.json
+++ b/dd-java-agent/appsec/src/test/resources/rules_suspicious_attacker_blocking.json
@@ -1,0 +1,77 @@
+{
+  "version": "2.1",
+  "metadata": {
+    "rules_version": "rules_suspicious_attacker_blocking"
+  },
+  "actions": [
+    {
+      "id": "block_402",
+      "type": "block_request",
+      "parameters": {
+        "status_code": 402,
+        "type": "auto"
+      }
+    }
+  ],
+  "exclusions": [
+    {
+      "id": "exc-000-001",
+      "on_match": "block_402",
+      "conditions": [
+        {
+          "operator": "ip_match",
+          "parameters": {
+            "data": "suspicious_ips_data_id",
+            "inputs": [
+              {
+                "address": "http.client_ip"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "exclusion_data": [
+    {
+      "id": "suspicious_ips_data_id",
+      "type": "ip_with_expiration",
+      "data": [
+        {
+          "value": "127.0.0.1"
+        }
+      ]
+    }
+  ],
+  "rules": [
+    {
+      "id": "ua0-600-12x",
+      "name": "Arachni",
+      "tags": {
+        "type": "attack_tool",
+        "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "tool_name": "Arachni",
+        "confidence": "1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^Arachni\\/v"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    }
+  ]
+}


### PR DESCRIPTION
# What Does This Do
Adds the new `exclusion_data` feature to the WAF, this new property also belongs to the `ASM_DATA` remote config payload.

# Motivation
This PR adds a new feature called suspicious attacker blocking to appsec, which allows the ASM libraries to block specific attackers only when an attack has been detected. 

# Additional Notes
[RFC](https://docs.google.com/document/d/123wRO_ha5aZMzIXXJlGHobZrK8F4w5YuzyINncIQVLw/edit) describing the new feature.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-54438]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-54438]: https://datadoghq.atlassian.net/browse/APPSEC-54438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ