### PR TITLE
Improve exception handling in full mode for SQL Server

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/JDBCDecorator.java
@@ -267,7 +267,6 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
         AgentTracer.get().buildSpan("set context_info").withTag("dd.instrumentation", true).start();
     DECORATE.afterStart(instrumentationSpan);
     DECORATE.onConnection(instrumentationSpan, dbInfo);
-    PreparedStatement instrumentationStatement = null;
     try (AgentScope scope = activateSpan(instrumentationSpan)) {
       final byte samplingDecision =
           (byte) (instrumentationSpan.forceSamplingDecision() > 0 ? 1 : 0);
@@ -284,9 +283,8 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
       byteBuffer.putLong(traceId.toLong());
       final byte[] contextInfo = byteBuffer.array();
       String instrumentationSql = "set context_info ?";
-      try (PreparedStatement instrumentStatement =
+      try (PreparedStatement instrumentationStatement =
           connection.prepareStatement(instrumentationSql)) {
-        instrumentationStatement = connection.prepareStatement(instrumentationSql);
         instrumentationStatement.setBytes(1, contextInfo);
         DECORATE.onStatement(instrumentationSpan, instrumentationSql);
         instrumentationStatement.execute();


### PR DESCRIPTION
# What Does This Do

Improve the readability by localizing exception handling. 

# Motivation

# Additional Notes

Following @dougqh 's [recommendation](https://github.com/DataDog/dd-trace-java/pull/7186#discussion_r1707539484). 

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
