### PR TITLE
Make cws-tls use the same JNA dependency as instrumentations

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -117,9 +117,7 @@ includeSubprojShadowJar ':dd-java-agent:agent-iast', 'iast'
 includeSubprojShadowJar ':dd-java-agent:agent-debugger', 'debugger'
 includeSubprojShadowJar ':dd-java-agent:agent-ci-visibility', 'ci-visibility'
 includeSubprojShadowJar ':dd-java-agent:agent-logs-intake', 'logs-intake'
-if (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) {
-  includeSubprojShadowJar ':dd-java-agent:cws-tls', 'cws-tls'
-}
+includeSubprojShadowJar ':dd-java-agent:cws-tls', 'cws-tls'
 
 def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
   configurations = [project.configurations.sharedShadowInclude]
@@ -286,8 +284,7 @@ tasks.register('checkAgentJarSize').configure {
   doLast {
     // Arbitrary limit to prevent unintentional increases to the agent jar size
     // Raise or lower as required
-    def megs = (project.rootProject.hasProperty("agentIncludeCwsTls") && agentIncludeCwsTls) ? 30 : 29
-    assert shadowJar.archiveFile.get().getAsFile().length() <= megs * 1024 * 1024
+    assert shadowJar.archiveFile.get().getAsFile().length() <= 29 * 1024 * 1024
   }
 
   dependsOn "shadowJar"

--- a/dd-java-agent/cws-tls/build.gradle
+++ b/dd-java-agent/cws-tls/build.gradle
@@ -1,5 +1,3 @@
-// This component is only included in the Java Agent if the gradle property agentIncludeCwsTls is true
-
 plugins {
   id "com.github.johnrengelman.shadow"
 }
@@ -22,5 +20,6 @@ dependencies {
 
 shadowJar {
   dependencies deps.excludeShared
+  // exclude this since it's available in the instrumentation jar
+  exclude 'com/sun/jna/**/*'
 }
-


### PR DESCRIPTION
# What Does This Do

Makes the `cws-tls` module use the same JNA dependency as the instrumentations in the final packaged jar, and includes it by default.

# Motivation

The `cws-tls` module was not included by default since it was under development and added significantly to the overall jar size. The JNA dependency used has since been included by other instrumentations and the `cws-tls` module can now be included.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
