### PR TITLE
Add exclusions for openid4java and seasar frameworks

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -252,6 +252,7 @@
 1 org.mongodb.*
 1 org.mortbay.*
 1 org.objectweb.*
+1 org.openid4java.*
 # Weak randomness false positive on HotspotUnsafe.guessAlignment
 1 org.openjdk.jol.vm.*
 # Weak randomness false positive on RandomIdGenerator.generateTraceId
@@ -273,6 +274,7 @@
 1 org.relaxng.*
 1 org.renjin.*
 1 org.richfaces.*
+1 org.seasar.*
 1 org.slf4j.*
 1 org.springdoc.*
 1 org.springframework.*


### PR DESCRIPTION
# What Does This Do
Adds IAST exclusions for `org.openid4java` and `org.seasar`

# Motivation
We've seen issues in one customer related to classes that get instrumented by IAST, since it provides no value it's better to exclude them.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
