### PR TITLE
[🍒 7403] Fix unresolved field error when instrumenting Kafka 3.7 with Quarkus native

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
@@ -5,6 +5,7 @@ import static datadog.trace.util.Strings.getInternalName;
 
 import datadog.trace.agent.tooling.bytebuddy.memoize.MemoizedMatchers;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.FieldBackedContextAccessor;
 import datadog.trace.bootstrap.FieldBackedContextStores;
@@ -70,7 +71,7 @@ public final class FieldBackedContextInjector implements AsmVisitorWrapper {
       Type.getType(FieldBackedContextAccessor.class);
 
   /** Keeps track of injection requests for the class being transformed by the current thread. */
-  static final ThreadLocal<BitSet> INJECTED_STORE_IDS = new ThreadLocal<>();
+  static final ThreadLocal<Pair<String, BitSet>> INJECTED_STORE_IDS = new ThreadLocal<>();
 
   final boolean serialVersionUIDFieldInjection =
       InstrumenterConfig.get().isSerialVersionUIDFieldInjection();
@@ -129,7 +130,7 @@ public final class FieldBackedContextInjector implements AsmVisitorWrapper {
 
         // keep track of all injection requests for the class currently being transformed
         // because we need to switch between them in the generated getter/putter methods
-        int storeId = injectContextStore(keyClassName, contextClassName);
+        int storeId = injectContextStore(name, keyClassName, contextClassName);
         storeFieldName = CONTEXT_STORE_ACCESS_PREFIX + storeId;
 
         if (interfaces == null) {
@@ -484,26 +485,30 @@ public final class FieldBackedContextInjector implements AsmVisitorWrapper {
   }
 
   /** Requests injection of a context store for a key and context. */
-  static int injectContextStore(final String keyClassName, final String contextClassName) {
+  static int injectContextStore(
+      final String target, final String keyClassName, final String contextClassName) {
     int storeId = getContextStoreId(keyClassName, contextClassName);
 
-    BitSet injectedStoreIds = INJECTED_STORE_IDS.get();
-    if (null == injectedStoreIds) {
-      injectedStoreIds = new BitSet();
+    // collect a new set of store ids every time we see a new target
+    Pair<String, BitSet> injectedStoreIds = INJECTED_STORE_IDS.get();
+    if (null == injectedStoreIds || !target.equals(injectedStoreIds.getLeft())) {
+      injectedStoreIds = Pair.of(target, new BitSet());
       INJECTED_STORE_IDS.set(injectedStoreIds);
     }
-    injectedStoreIds.set(storeId);
+    injectedStoreIds.getRight().set(storeId);
 
     return storeId;
   }
 
   /** Returns all context store injection requests for the class being transformed. */
   static BitSet getInjectedContextStores() {
-    BitSet injectedStoreIds = INJECTED_STORE_IDS.get();
+    Pair<String, BitSet> injectedStoreIds = INJECTED_STORE_IDS.get();
     if (null != injectedStoreIds) {
       INJECTED_STORE_IDS.remove();
+      return injectedStoreIds.getRight();
+    } else {
+      return null;
     }
-    return injectedStoreIds;
   }
 
   private static final class SerialVersionUIDInjector


### PR DESCRIPTION
# What Does This Do

When an instrumentation fails the `visitEnd` method in `FieldBackedContextInjector` may not be called. This method is responsible for removing a thread local which collects the store ids injected so far, across all field-injectors of a class.

If the thread-local is not removed then collected store ids may leak across to another class, leading to getters/setters referring to a non-existent field. This doesn't cause an issue with most JVMs because that particular generated branch will never be called (since the class is not expected to hold that store). But it leads to an unresolved field on GraalVM/Quarkus because the native-image builder performs additional checks that fields exist.

# Additional Notes

The instrumentation failure in Kafka 3.7 that exposed this bug was:
```
java.lang.IllegalStateException: Cannot locate field named metadata for class org.apache.kafka.clients.consumer.KafkaConsumer
```
This will be fixed in a separate PR.

Jira ticket: [APMS-12871]


[APMS-12871]: https://datadoghq.atlassian.net/browse/APMS-12871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ