### PR TITLE
[🍒 7404] Fix ClassNotFoundException: net.jpountz.lz4.LZ4JavaSafeCompressor when instrumenting Kafka 3.7 with Quarkus native

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -48,8 +48,9 @@ ext.generalShadowJarConfig = {
 
   // Prevents conflict with other SLF4J instances. Important for premain.
   relocate 'org.slf4j', 'datadog.slf4j'
-  // Prevents conflict with other JCTools instances
+  // Prevent conflicts with flat class-path when using GraalVM native-images
   relocate 'org.jctools', 'datadog.jctools'
+  relocate 'net.jpountz', 'datadog.jpountz'
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'datadog.trace.bootstrap.PatchLogger'
 


### PR DESCRIPTION
# What Does This Do

Relocate embedded `jpountz` classes to avoid conflict with flat class-path when using GraalVM native-images.

In this case both the Java tracer and Kafka 3.7 contained `net.jpountz` LZ4 classes at slightly different versions.

Jira ticket: [APMS-12871]


[APMS-12871]: https://datadoghq.atlassian.net/browse/APMS-12871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ