### PR TITLE
Tweak telemetry log stacktrace redaction for error tracking compatibility

### DIFF
--- a/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/log/LogPeriodicAction.java
@@ -105,9 +105,9 @@ public class LogPeriodicAction implements TelemetryRunnable.TelemetryPeriodicAct
 
   private static void writePendingRedacted(final StringBuilder result, final int pendingRedacted) {
     if (pendingRedacted == 1) {
-      result.append("  at ").append("[redacted]\n");
+      result.append("  at ").append("(redacted)\n");
     } else if (pendingRedacted > 1) {
-      result.append("  at [redacted: ").append(pendingRedacted).append(" frames]\n");
+      result.append("  at (redacted: ").append(pendingRedacted).append(" frames)\n");
     }
   }
 }

--- a/telemetry/src/test/groovy/datadog/telemetry/log/LogPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/log/LogPeriodicActionTest.groovy
@@ -131,11 +131,11 @@ class LogPeriodicActionTest extends DDSpecification {
     0 * _
     logMessage.getMessage() == 'test'
     logMessage.getStackTrace() == "${MutableException.canonicalName}\n" +
-      "  at [redacted]\n" +
+      "  at (redacted)\n" +
       "  at java.MyClass.method(file:42)\n" +
-      "  at [redacted]\n" +
+      "  at (redacted)\n" +
       "  at datadog.MyClass.method(file:42)\n" +
-      "  at [redacted: 2 frames]\n"
+      "  at (redacted: 2 frames)\n"
   }
 
   static class MutableException extends Exception {


### PR DESCRIPTION
# What Does This Do

Tweak our stackframe redaction format to make it compatible with current error tracking parser.

# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
