### PR TITLE
[🍒 7430] Fix Maven instrumentation to support command-line plugin goals invocation

### DIFF
--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenProjectConfigurator.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenProjectConfigurator.java
@@ -97,6 +97,17 @@ class MavenProjectConfigurator {
     PlexusConfiguration mojoConfiguration = mojoDescriptor.getMojoConfiguration();
     PlexusConfiguration argLine = mojoConfiguration.getChild("argLine");
     argLine.setValue(updatedArgLine);
+
+    // needed for executions where argLine is configured in POM
+    Plugin plugin = mojoExecution.getPlugin();
+    Map<String, PluginExecution> pluginExecutions = plugin.getExecutionsAsMap();
+    PluginExecution pluginExecution = pluginExecutions.get(mojoExecution.getExecutionId());
+    if (pluginExecution != null) {
+      Xpp3Dom executionConfiguration = (Xpp3Dom) pluginExecution.getConfiguration();
+      Xpp3Dom updatedExecutionConfiguration =
+          MavenUtils.setConfigurationValue(updatedArgLine, executionConfiguration, "argLine");
+      pluginExecution.setConfiguration(updatedExecutionConfiguration);
+    }
   }
 
   void configureCompilerPlugin(MavenProject project, String compilerPluginVersion) {

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenProjectConfigurator.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenProjectConfigurator.java
@@ -17,6 +17,7 @@ import org.apache.maven.model.InputSource;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -80,11 +81,6 @@ class MavenProjectConfigurator {
     File agentJar = config.getCiVisibilityAgentJarFile();
     addedArgLine.append("-javaagent:").append(agentJar.toPath());
 
-    Plugin plugin = mojoExecution.getPlugin();
-    Map<String, PluginExecution> pluginExecutions = plugin.getExecutionsAsMap();
-    PluginExecution pluginExecution = pluginExecutions.get(mojoExecution.getExecutionId());
-    Xpp3Dom executionConfiguration = (Xpp3Dom) pluginExecution.getConfiguration();
-
     PlexusConfiguration argLineConfiguration = pomConfiguration.getChild("argLine");
     String existingArgLine = argLineConfiguration.getValue();
     String updatedArgLine =
@@ -97,9 +93,10 @@ class MavenProjectConfigurator {
             // (namely Jacoco's)
             addedArgLine;
 
-    Xpp3Dom updatedExecutionConfiguration =
-        MavenUtils.setConfigurationValue(updatedArgLine, executionConfiguration, "argLine");
-    pluginExecution.setConfiguration(updatedExecutionConfiguration);
+    MojoDescriptor mojoDescriptor = mojoExecution.getMojoDescriptor();
+    PlexusConfiguration mojoConfiguration = mojoDescriptor.getMojoConfiguration();
+    PlexusConfiguration argLine = mojoConfiguration.getChild("argLine");
+    argLine.setValue(updatedArgLine);
   }
 
   void configureCompilerPlugin(MavenProject project, String compilerPluginVersion) {


### PR DESCRIPTION
This is a cherry-pick of #7430 

# What Does This Do

Fixes Maven instrumentation to support tracing build commands that contain plugin goals (e.g. `surefire:test`) as opposed to regular lifecycle phases (e.g. `test`).

# Additional Notes

Logic that determines forked JVM path for tests execution is also updated to handle mojo executions that are proxies.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-691]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-691]: https://datadoghq.atlassian.net/browse/SDTEST-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ