### PR TITLE
[🍒 7432] Avoid using stdout to report bootstrapping errors

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -116,7 +116,7 @@ public final class AgentBootstrap {
 
   private static boolean alreadyInitialized() {
     if (initialized) {
-      System.out.println(
+      System.err.println(
           "Warning: dd-java-agent is being initialized more than once. Please check that you are defining -javaagent:dd-java-agent.jar only once.");
       return true;
     }
@@ -125,7 +125,7 @@ public final class AgentBootstrap {
   }
 
   private static boolean lessThanJava8() {
-    return lessThanJava8(System.getProperty("java.version"), System.out);
+    return lessThanJava8(System.getProperty("java.version"), System.err);
   }
 
   // Reachable for testing
@@ -234,7 +234,7 @@ public final class AgentBootstrap {
         agentFiles.append(agentFile.getAbsolutePath());
         agentFiles.append('"');
       }
-      System.out.println(
+      System.err.println(
           "Info: multiple JVM agents detected, found "
               + agentFiles
               + ". Loading multiple APM/Tracing agent is not a recommended or supported configuration."
@@ -267,14 +267,14 @@ public final class AgentBootstrap {
       }
     }
 
-    System.out.println("Could not get bootstrap jar from code source, using -javaagent arg");
+    System.err.println("Could not get bootstrap jar from code source, using -javaagent arg");
     File javaagentFile = getAgentFileFromJavaagentArg(getAgentFilesFromVMArguments());
     if (javaagentFile != null) {
       URL ddJavaAgentJarURL = javaagentFile.toURI().toURL();
       return appendAgentToBootstrapClassLoaderSearch(inst, ddJavaAgentJarURL, javaagentFile);
     }
 
-    System.out.println(
+    System.err.println(
         "Could not get agent jar from -javaagent arg, using ClassLoader#getResource");
     javaagentFile = getAgentFileUsingClassLoaderLookup();
     if (!javaagentFile.isDirectory()) {
@@ -295,10 +295,10 @@ public final class AgentBootstrap {
 
   private static File getAgentFileFromJavaagentArg(List<File> agentFiles) {
     if (agentFiles.isEmpty()) {
-      System.out.println("Could not get bootstrap jar from -javaagent arg: no argument specified");
+      System.err.println("Could not get bootstrap jar from -javaagent arg: no argument specified");
       return null;
     } else if (agentFiles.size() > 1) {
-      System.out.println(
+      System.err.println(
           "Could not get bootstrap jar from -javaagent arg: multiple javaagents specified");
       return null;
     } else {
@@ -324,7 +324,7 @@ public final class AgentBootstrap {
           if (agentFile.exists() && agentFile.isFile()) {
             agentFiles.add(agentFile);
           } else {
-            System.out.println(
+            System.err.println(
                 "Could not get bootstrap jar from -javaagent arg: unable to find javaagent file: "
                     + agentFile);
           }
@@ -395,13 +395,13 @@ public final class AgentBootstrap {
 
     // Fallback to default
     try {
-      System.out.println(
+      System.err.println(
           "WARNING: Unable to get VM args through reflection. A custom java.util.logging.LogManager may not work correctly");
       return ManagementFactory.getRuntimeMXBean().getInputArguments();
     } catch (final Throwable t) {
       // Throws InvocationTargetException on modularized applications
       // with non-opened java.management module
-      System.out.println("WARNING: Unable to get VM args using managed beans");
+      System.err.println("WARNING: Unable to get VM args using managed beans");
     }
     return Collections.emptyList();
   }

--- a/test-published-dependencies/agent-logs-on-java-7/src/test/java/StartWithAgentTest.java
+++ b/test-published-dependencies/agent-logs-on-java-7/src/test/java/StartWithAgentTest.java
@@ -27,8 +27,8 @@ public class StartWithAgentTest {
     logProcessOutput(output, errors);
     assertEquals(0, exitCode, "Command failed with unexpected exit code");
     assertTrue(output.contains(expectedMessage), "Output does not contain '" + expectedMessage + "'");
-    assertTrue(output.stream().anyMatch(WARNING_PATTERN.asPredicate()), "Output does not contain line matching '" + WARNING_PATTERN + "'");
-    assertTrue(output.contains(UPGRADE_MESSAGE), "Output does not contain '" + UPGRADE_MESSAGE + "'");
+    assertTrue(errors.stream().anyMatch(WARNING_PATTERN.asPredicate()), "Output does not contain line matching '" + WARNING_PATTERN + "'");
+    assertTrue(errors.contains(UPGRADE_MESSAGE), "Output does not contain '" + UPGRADE_MESSAGE + "'");
   }
 
   @Test
@@ -50,8 +50,8 @@ public class StartWithAgentTest {
     logProcessOutput(output, errors);
     assertEquals(0, exitCode, "Command failed with unexpected exit code");
     assertTrue(output.contains(expectedMessage), "Output does not contain '" + expectedMessage + "'");
-    assertFalse(output.stream().anyMatch(WARNING_PATTERN.asPredicate()), "Output contains unexpected line matching '" + WARNING_PATTERN + "'");
-    assertFalse(output.contains(UPGRADE_MESSAGE), "Output contains unexpected line '" + UPGRADE_MESSAGE + "'");
+    assertFalse(errors.stream().anyMatch(WARNING_PATTERN.asPredicate()), "Output contains unexpected line matching '" + WARNING_PATTERN + "'");
+    assertFalse(errors.contains(UPGRADE_MESSAGE), "Output contains unexpected line '" + UPGRADE_MESSAGE + "'");
   }
 
   private static Process startAndWaitForJvmWithAgentForJava(String javaHomeEnv, String message) throws IOException {


### PR DESCRIPTION
# What Does This Do

This is a cherry-pick of https://github.com/DataDog/dd-trace-java/pull/7432.
This PR removes usage of `stdout` for reporting agent bootrapping errors.

# Motivation

Using `stdout` instead of `stderr` breaks CLI tools used in shell sub-commands if anything goes wrong.

# Additional Notes

Solves #7413

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
