### PR TITLE
Add protobuf collections as safe ones

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -160,6 +160,10 @@ public class WellKnownClasses {
       // All Collection implementations from JDK base module are considered as safe
       return true;
     }
+    if (className.startsWith("com.google.protobuf.")) {
+      // All Collection implementations from Google ProtoBuf are considered as safe
+      return true;
+    }
     return false;
   }
 
@@ -168,6 +172,10 @@ public class WellKnownClasses {
     String className = map.getClass().getTypeName();
     if (className.startsWith("java.")) {
       // All Map implementations from JDK base module are considered as safe
+      return true;
+    }
+    if (className.startsWith("com.google.protobuf.")) {
+      // All Map implementations from Google ProtoBuf are considered as safe
       return true;
     }
     return false;


### PR DESCRIPTION
# What Does This Do
protobuf collections used are specific ones implementing JDK interfaces. They are in-memory collection so it is safe to handle them like the JDK ones.
https://github.com/protocolbuffers/protobuf/tree/main/java/core/src/main/java/com/google/protobuf

# Motivation
DSM live payload feature

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2779]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2779]: https://datadoghq.atlassian.net/browse/DEBUG-2779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ