### PR TITLE
Fix SymDB upload dropped requests

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -174,7 +174,8 @@ public class BatchUploader {
         debuggerMetrics.count("batch.uploaded", 1);
       } else {
         debuggerMetrics.count("request.queue.full", 1);
-        log.warn("Cannot upload batch data: too many enqueued requests!");
+        ratelimitedLogger.warn(
+            "Cannot upload batch data to {}: too many enqueued requests!", urlBase);
       }
     } catch (Exception ex) {
       debuggerMetrics.count("batch.upload.error", 1);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 class SymbolSinkTest {
 
   @Test
-  public void testFlush() {
+  public void testSimpleFlush() {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
@@ -36,6 +36,49 @@ class SymbolSinkTest {
     assertEquals(
         "{\"language\":\"JAVA\",\"scopes\":[{\"end_line\":0,\"scope_type\":\"JAR\",\"start_line\":0}],\"service\":\"service1\"}",
         new String(symbolContent.getContent()));
+  }
+
+  @Test
+  public void testMultiScopeFlush() {
+    SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
+    Config config = mock(Config.class);
+    when(config.getServiceName()).thenReturn("service1");
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock);
+    symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar1.jar", 0, 0).build());
+    symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar2.jar", 0, 0).build());
+    symbolSink.flush();
+    // only 1 request because we are batching the scopes
+    assertEquals(2, symbolUploaderMock.multiPartContents.size());
+    BatchUploader.MultiPartContent eventContent = symbolUploaderMock.multiPartContents.get(0);
+    assertEquals("event", eventContent.getPartName());
+    BatchUploader.MultiPartContent symbolContent = symbolUploaderMock.multiPartContents.get(1);
+    assertEquals("file", symbolContent.getPartName());
+    String strContent = new String(symbolContent.getContent());
+    assertTrue(strContent.contains("\"source_file\":\"jar1.jar\""));
+    assertTrue(strContent.contains("\"source_file\":\"jar2.jar\""));
+  }
+
+  @Test
+  public void testQueueFull() {
+    SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
+    Config config = mock(Config.class);
+    when(config.getServiceName()).thenReturn("service1");
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock);
+    for (int i = 0; i < SymbolSink.CAPACITY; i++) {
+      symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar1.jar", 0, 0).build());
+    }
+    assertEquals(0, symbolUploaderMock.multiPartContents.size());
+    // implicit flush because Q is full
+    symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar2.jar", 0, 0).build());
+    assertEquals(2, symbolUploaderMock.multiPartContents.size());
+    assertTrue(
+        new String(symbolUploaderMock.multiPartContents.get(1).getContent())
+            .contains("\"source_file\":\"jar1.jar\""));
+    symbolSink.flush();
+    assertEquals(4, symbolUploaderMock.multiPartContents.size());
+    assertTrue(
+        new String(symbolUploaderMock.multiPartContents.get(3).getContent())
+            .contains("\"source_file\":\"jar2.jar\""));
   }
 
   static class SymbolUploaderMock extends BatchUploader {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymbolExtractionTransformerTest.java
@@ -982,8 +982,8 @@ class SymbolExtractionTransformerTest {
     }
 
     @Override
-    public boolean addScope(Scope jarScope) {
-      return jarScopes.add(jarScope);
+    public void addScope(Scope jarScope) {
+      jarScopes.add(jarScope);
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
SymbolSink was emitting an upload requests for every scope added into the sink queue. As the queue was 1024 entries in capacity we could easily end up in a situation where more than 20 requests are made when draining the Q. to avoid that we are batching the scope together in a single larger upload request and ensure that the sink queue is flushed when full before adding new element and not losing any symbols.

# Motivation
avoid dropping SymDB requests

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2685]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2685]: https://datadoghq.atlassian.net/browse/DEBUG-2685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ