### PR TITLE
[🍒 7435] Fix Cucumber JUnit 4 instrumentation to correctly handle feature and scenario names with brackets

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -132,6 +132,14 @@ public class TestEventsHandlerImpl<SuiteKey, TestKey>
     }
 
     TestSuiteImpl testSuite = inProgressTestSuites.get(suiteDescriptor);
+    if (testSuite == null) {
+      throw new IllegalStateException(
+          "Could not find test suite with descriptor "
+              + suiteDescriptor
+              + "; test descriptor: "
+              + descriptor);
+    }
+
     TestImpl test = testSuite.testStart(testName, testParameters, testMethod, null);
 
     TestIdentifier thisTest = new TestIdentifier(testSuiteName, testName, testParameters, null);

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/CucumberTracingListener.java
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/CucumberTracingListener.java
@@ -66,7 +66,7 @@ public class CucumberTracingListener extends TracingListener {
   @Override
   public void testStarted(final Description description) {
     String testSuiteName = CucumberUtils.getTestSuiteNameForScenario(description);
-    String testName = description.getMethodName();
+    String testName = CucumberUtils.getTestNameForScenario(description);
     List<String> categories = getCategories(description);
 
     TestRetryPolicy retryPolicy = retryPolicies.get(description);
@@ -159,7 +159,7 @@ public class CucumberTracingListener extends TracingListener {
       TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestSuiteFinish(suiteDescriptor);
     } else {
       String testSuiteName = CucumberUtils.getTestSuiteNameForScenario(description);
-      String testName = description.getMethodName();
+      String testName = CucumberUtils.getTestNameForScenario(description);
       List<String> categories = getCategories(description);
       TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestIgnore(
           new TestSuiteDescriptor(testSuiteName, null),

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/groovy/CucumberTest.groovy
@@ -28,6 +28,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
       "org/example/cucumber/calculator/basic_arithmetic.feature",
       "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
     ]                                                                                                                  | 3
+    "test-name-with-brackets"             | ["org/example/cucumber/calculator/name_with_brackets.feature"]             | 2
   }
 
   def "test ITR #testcaseName"() {

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/org/example/cucumber/calculator/name_with_brackets.feature
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/org/example/cucumber/calculator/name_with_brackets.feature
@@ -1,0 +1,10 @@
+@foo
+Feature: This (Name) Has Bracket Characters
+
+  Background: A Calculator
+    Given a calculator I just turned on
+
+  Scenario: Addition (Has) Brackets Too
+  # Try to change one of the values below to provoke a failure
+    When I add 4 and 5
+    Then the result is 9

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-name-with-brackets/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-name-with-brackets/coverages.ftl
@@ -1,0 +1,8 @@
+[ {
+  "test_session_id" : ${content_test_session_id},
+  "test_suite_id" : ${content_test_suite_id},
+  "span_id" : ${content_span_id},
+  "files" : [ {
+    "filename" : "org/example/cucumber/calculator/name_with_brackets.feature"
+  } ]
+} ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-name-with-brackets/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-name-with-brackets/events.ftl
@@ -55,7 +55,6 @@
     },
     "meta" : {
       "os.architecture" : ${content_meta_os_architecture},
-      "_dd.tracer_host" : "COMP-QG19F24WGY",
       "test.module" : "cucumber-junit-4",
       "test.status" : "pass",
       "language" : "jvm",
@@ -98,7 +97,6 @@
     "meta" : {
       "test.type" : "test",
       "os.architecture" : ${content_meta_os_architecture},
-      "_dd.tracer_host" : "COMP-QG19F24WGY",
       "test.status" : "pass",
       "language" : "jvm",
       "runtime.name" : ${content_meta_runtime_name},

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-name-with-brackets/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-name-with-brackets/events.ftl
@@ -1,0 +1,153 @@
+[ {
+  "type" : "test_suite_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_suite",
+    "resource" : "classpath:org/example/cucumber/calculator/name_with_brackets.feature:This (Name) Has Bracket Characters",
+    "start" : ${content_start},
+    "duration" : ${content_duration},
+    "error" : 0,
+    "metrics" : { },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "span.kind" : "test_suite_end",
+      "test.suite" : "classpath:org/example/cucumber/calculator/name_with_brackets.feature:This (Name) Has Bracket Characters",
+      "runtime.version" : ${content_meta_runtime_version},
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test",
+  "version" : 2,
+  "content" : {
+    "trace_id" : ${content_trace_id},
+    "span_id" : ${content_span_id},
+    "parent_id" : ${content_parent_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test",
+    "resource" : "classpath:org/example/cucumber/calculator/name_with_brackets.feature:This (Name) Has Bracket Characters.Addition (Has) Brackets Too",
+    "start" : ${content_start_2},
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "metrics" : {
+      "process_id" : ${content_metrics_process_id},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0
+    },
+    "meta" : {
+      "os.architecture" : ${content_meta_os_architecture},
+      "_dd.tracer_host" : "COMP-QG19F24WGY",
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "language" : "jvm",
+      "runtime.name" : ${content_meta_runtime_name},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "test.name" : "Addition (Has) Brackets Too",
+      "span.kind" : "test",
+      "test.suite" : "classpath:org/example/cucumber/calculator/name_with_brackets.feature:This (Name) Has Bracket Characters",
+      "runtime.version" : ${content_meta_runtime_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "test.type" : "test",
+      "test.traits" : "{\"category\":[\"foo\"]}",
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "component" : "junit",
+      "_dd.profiling.ctx" : "test",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test_session_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_session",
+    "resource" : "cucumber-junit-4",
+    "start" : ${content_start_3},
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "metrics" : {
+      "process_id" : ${content_metrics_process_id},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0
+    },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "_dd.tracer_host" : "COMP-QG19F24WGY",
+      "test.status" : "pass",
+      "language" : "jvm",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "_dd.profiling.ctx" : "test",
+      "span.kind" : "test_session_end",
+      "runtime.version" : ${content_meta_runtime_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "test.command" : "cucumber-junit-4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test_module_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_module",
+    "resource" : "cucumber-junit-4",
+    "start" : ${content_start_4},
+    "duration" : ${content_duration_4},
+    "error" : 0,
+    "metrics" : { },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "span.kind" : "test_module_end",
+      "runtime.version" : ${content_meta_runtime_version},
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+} ]


### PR DESCRIPTION
Cherry pick #7446

# What Does This Do

Fixes Cucumber JUnit 4 instrumentation to correctly work if the name of traced feature/scenario contains bracket characters.

# Additional Notes

Previously the instrumentation logic relied on standard `Description.getClassName()` and `Description.getMethodName()` methods available in JUnit 4.
The problem is how these method are implemented: the description instance only stores a single string that combines the name of the class and method (or feature and scenario in case of cucumber). Brackets are used to separate the name of the class from the name of the method, the resulting string looks like this: `MethodName(ClassName)`.
The methods' implementation uses a regex to split the string into parts, and it doesn't work correctly if any of the parts contains bracket characters.

To circumvent this, a separate utility method was implemented, that counts opening and closing brackets to determine where the class name ends.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [CIVIS-10212]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-10212]: https://datadoghq.atlassian.net/browse/CIVIS-10212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ