### PR TITLE
Avoid NullPointerException when publishing SNS messages to phone numbers

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
@@ -58,8 +58,14 @@ public class SnsInterceptor extends RequestHandler2 {
       // the limit still applies here
       if (messageAttributes.size() < 10) {
         // Extract the topic name from the ARN for DSM
-        String topicName =
-            pRequest.getTopicArn() == null ? pRequest.getTargetArn() : pRequest.getTopicArn();
+        String topicName = pRequest.getTopicArn();
+        if (null == topicName) {
+          topicName = pRequest.getTargetArn();
+          if (null == topicName) {
+            return request; // request is to phone number, ignore for DSM
+          }
+        }
+
         topicName = topicName.substring(topicName.lastIndexOf(':') + 1);
 
         HashMap<String, MessageAttributeValue> modifiedMessageAttributes =

--- a/dd-java-agent/instrumentation/aws-java-sns-1.0/src/test/groovy/SnsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sns-1.0/src/test/groovy/SnsClientTest.groovy
@@ -211,7 +211,14 @@ abstract class SnsClientTest extends VersionedNamingTestBase {
     traceContextInJson['x-datadog-parent-id'] == sendSpan.spanId.toString()
     traceContextInJson['x-datadog-sampling-priority'] == "1"
     !traceContextInJson['dd-pathway-ctx-base64'].toString().isBlank()
+  }
 
+  def "SNS message to phone number doesn't leak exception"() {
+    when:
+    snsClient.publish(new PublishRequest().withPhoneNumber("+19995550123").withMessage('sometext'))
+
+    then:
+    noExceptionThrown()
   }
 }
 

--- a/dd-java-agent/instrumentation/aws-java-sns-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java-sns-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sns/SnsInterceptor.java
@@ -59,7 +59,14 @@ public class SnsInterceptor implements ExecutionInterceptor {
       // the limit still applies here
       if (request.messageAttributes().size() < 10) {
         // Get topic name for DSM
-        String snsTopicArn = request.topicArn() == null ? request.targetArn() : request.topicArn();
+        String snsTopicArn = request.topicArn();
+        if (null == snsTopicArn) {
+          snsTopicArn = request.targetArn();
+          if (null == snsTopicArn) {
+            return request; // request is to phone number, ignore for DSM
+          }
+        }
+
         String snsTopicName = snsTopicArn.substring(snsTopicArn.lastIndexOf(':') + 1);
         Map<String, MessageAttributeValue> modifiedMessageAttributes =
             new HashMap<>(request.messageAttributes());

--- a/dd-java-agent/instrumentation/aws-java-sns-2.0/src/test/groovy/SnsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sns-2.0/src/test/groovy/SnsClientTest.groovy
@@ -180,6 +180,14 @@ abstract class SnsClientTest extends VersionedNamingTestBase {
     traceContextInJson['x-datadog-sampling-priority'] == "1"
     !traceContextInJson['dd-pathway-ctx-base64'].toString().isBlank()
   }
+
+  def "SNS message to phone number doesn't leak exception"() {
+    when:
+    snsClient.publish { it.message("sometext").phoneNumber("+19995550123") }
+
+    then:
+    noExceptionThrown()
+  }
 }
 
 class SnsClientV0Test extends SnsClientTest {


### PR DESCRIPTION
# What Does This Do

Avoid NPE when only a phone number is provided in an SNS publish request

# Motivation

Both `topicArn` and `targetArn` are optional for SNS publish requests: https://docs.aws.amazon.com/sns/latest/api/API_Publish.html

# Additional Notes

`topicARN` is required for SNS publish batch requests: https://docs.aws.amazon.com/sns/latest/api/API_PublishBatch.html so we don't need to change that part of the code.

Jira ticket: [APMS-13002]


[APMS-13002]: https://datadoghq.atlassian.net/browse/APMS-13002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ