### PR TITLE
Improve Github automation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -98,7 +98,7 @@ _Action:_ Run GitHub CodeQL action, upload result to GitHub security tab and Dat
 
 _Trigger:_ Every week or manually.
 
-_Action:_ Update the Grade dependencies and their locking files.
+_Action:_ Create a PR updating the Grade dependencies and their locking files.
 
 _Recovery:_ Manually trigger the action again.
 

--- a/.github/workflows/add-milestone-to-pull-requests.yaml
+++ b/.github/workflows/add-milestone-to-pull-requests.yaml
@@ -57,13 +57,14 @@ jobs:
                   return a.version.patch - b.version.patch
                 })
                 .pop()?.number
-            } else if (base.startsWith('release/v')) {
-              // Pick the milestone with the same title as the base branch
-              const version = base.substring(9)
+            } else if (base.startsWith('release/v') && base.endsWith('.x')) {
+              // Extract the minor version related to the base branch (e.g. "release/v1.2.x" -> "1.2.")
+              const version = base.substring(9, base.length - 1)
+              // Pick the milestone with title matching the extracted version
               const versionMilestone = response.data
-                .find(milestone => milestone.title == version)
+                .find(milestone => milestone.title.startsWith(version))
               if (!versionMilestone) {
-                core.setFailed(`Version milestone not found: ${version}`)
+                core.setFailed(`Milestone not found for minor version: ${version}`)
               } else {
                 milestoneNumber = versionMilestone.number
               }

--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -70,7 +70,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh pr create --title "Update Gradle dependencies" \
-            --body "This PR updates the Gradle dependencies.  \n:warning: Don't forget to squash commits before merging :warning:" \
+            --body "This PR updates the Gradle dependencies. ⚠️ Don't forget to squash commits before merging. ⚠️" \
             --base master \
             --head $BRANCH_NAME \
             --label "tag: dependencies" \


### PR DESCRIPTION
# What Does This Do

This PR:
* Improves automatic milestone assignment to support patch release in addition to the original minor release.
* Fix formatting of the automatic Gradle dependency lock update PR description.

# Motivation

Cleaning and keeping stuff working

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
