### PR TITLE
Add debug info to tainted objects to troubleshoot null ranges

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObject.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObject.java
@@ -73,9 +73,6 @@ public class TaintedObject extends WeakReference<Object> {
     if (ranges == null) {
       throw new IllegalArgumentException("ranges cannot be null");
     }
-    if (ranges.length == 0) {
-      throw new IllegalArgumentException("ranges cannot be empty");
-    }
     for (Range range : ranges) {
       if (range == null) {
         throw new IllegalArgumentException("found null range in " + Arrays.toString(ranges));

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectTest.groovy
@@ -54,7 +54,7 @@ class TaintedObjectTest extends Specification {
     where:
     ranges                                                                                                       | taint
     null                                                                                                         | false
-    []                                                                                                           | false
+    []                                                                                                           | true
     [new Range(0, 10, new Source(1 as byte, 'a', 'b'), 1), null]                                                 | false
     [new Range(0, 10, new Source(1 as byte, 'a', 'b'), 1), new Range(0, 10, new Source(2 as byte, 'a', 'b'), 1)] | true
   }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsLogTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsLogTest.groovy
@@ -79,5 +79,19 @@ class TaintedObjectsLogTest extends DDSpecification {
     taintedObjects.size() == 1
     taintedObjects.iterator().size() == 1
   }
+
+  void 'should not taint null ranges'() {
+    given:
+    IastSystem.DEBUG = true
+    logger.level = Level.ALL
+    TaintedObjects taintedObjects = taintedObjects()
+    final obj = 'A'
+
+    when:
+    taintedObjects.taint(obj, null)
+
+    then:
+    taintedObjects.empty
+  }
 }
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsTest.groovy
@@ -4,47 +4,28 @@ import ch.qos.logback.classic.Logger
 import ch.qos.logback.core.Appender
 import com.datadog.iast.model.Range
 import com.datadog.iast.model.Source
-import datadog.trace.api.Config
 import spock.lang.Specification
 
-import static datadog.trace.api.iast.SourceTypes.REQUEST_HEADER_NAME
-import static datadog.trace.api.iast.VulnerabilityMarks.NOT_MARKED
-
-class TaintedObjectTest extends Specification {
-
-  void 'test that tainted objects never go over the limit'() {
-    given:
-    final max = Config.get().iastMaxRangeCount
-    final ranges = (0..max + 1)
-    .collect { index -> new Range(index, 1, new Source(REQUEST_HEADER_NAME, 'a', 'b'), NOT_MARKED) }
-
-    when:
-    final tainted = new TaintedObject('test', ranges.toArray(new Range[0]))
-
-    then:
-    ranges.size() > max
-    tainted.ranges.size() == max
-    tainted.toString().contains("${tainted.ranges.size()} ranges")
-  }
+class TaintedObjectsTest extends Specification {
 
   void 'test that objects are not tainted if null ranges are provided'() {
     setup:
     def toTaint = UUID.randomUUID().toString()
-    def to = new TaintedObject(toTaint, Ranges.forCharSequence(toTaint, new Source(1 as byte, 'a', 'b'), NOT_MARKED))
-    def logger = TaintedObject.LOGGER as Logger
+    def to = TaintedObjects.build(TaintedMap.build(8))
+    def logger = TaintedObjects.LOGGER as Logger
     def appender = Mock(Appender<?>)
     logger.addAppender(appender)
 
     when:
-    to.setRanges(ranges as Range[])
+    to.taint(toTaint, ranges as Range[])
 
     then:
     noExceptionThrown()
     if (taint) {
-      to.ranges.length == ranges.size()
+      to.get(toTaint) != null
       0 * appender.doAppend(_)
     } else {
-      to.ranges.length == 1
+      to.get(toTaint) == null
       1 * appender.doAppend(_ as Object)
     }
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/taint/TaintedObjectsTest.groovy
@@ -35,7 +35,7 @@ class TaintedObjectsTest extends Specification {
     where:
     ranges                                                                                                       | taint
     null                                                                                                         | false
-    []                                                                                                           | false
+    []                                                                                                           | true
     [new Range(0, 10, new Source(1 as byte, 'a', 'b'), 1), null]                                                 | false
     [new Range(0, 10, new Source(1 as byte, 'a', 'b'), 1), new Range(0, 10, new Source(2 as byte, 'a', 'b'), 1)] | true
   }


### PR DESCRIPTION
# What Does This Do
Adds information to troubleshoot and issue with null values in ranges.

# Motivation
Recently we've starting receiving issues at:
```
afterAppend threw
java.lang.NullPointerException: <unknown>
  at com.datadog.iast.taint.Ranges.copyShift(Ranges.java:92)
  at com.datadog.iast.taint.Ranges.copyShift(Ranges.java:75)
  at com.datadog.iast.propagation.StringModuleImpl.onStringBuilderAppend(StringModuleImpl.java:117)
```

This PR should help us pinpoint the issue.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
