### PR TITLE
fix freeze context only for capturing line probe

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -553,9 +553,6 @@ public class LogProbe extends ProbeDefinition {
     if (status.shouldSend()) {
       snapshot.setTraceId(lineContext.getTraceId());
       snapshot.setSpanId(lineContext.getSpanId());
-      if (isCaptureSnapshot()) {
-        snapshot.addLine(lineContext, line);
-      }
       snapshot.setMessage(status.getMessage());
       shouldCommit = true;
     }
@@ -564,9 +561,12 @@ public class LogProbe extends ProbeDefinition {
       shouldCommit = true;
     }
     if (shouldCommit) {
-      // freeze context just before commit because line probes have only one context
-      Duration timeout = Duration.of(Config.get().getDebuggerCaptureTimeout(), ChronoUnit.MILLIS);
-      lineContext.freeze(new TimeoutChecker(timeout));
+      if (isCaptureSnapshot()) {
+        // freeze context just before commit because line probes have only one context
+        Duration timeout = Duration.of(Config.get().getDebuggerCaptureTimeout(), ChronoUnit.MILLIS);
+        lineContext.freeze(new TimeoutChecker(timeout));
+        snapshot.addLine(lineContext, line);
+      }
       commitSnapshot(snapshot, sink);
       return;
     }


### PR DESCRIPTION
# What Does This Do
non-capturing line probe should not freeze line context because it is useless and too expensive (add overhead)

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2698]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
