### PR TITLE
Tag span metrics with 'otel.library' when we know it was created by an OTel extension

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelTracer.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelTracer.java
@@ -9,7 +9,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 class OtelTracer implements Tracer {
-  private static final String INSTRUMENTATION_NAME = "otel";
+  private static final String INSTRUMENTATION_NAME = otelInstrumentationName();
   private final AgentTracer.TracerAPI tracer;
   private final String instrumentationScopeName;
 
@@ -23,5 +23,13 @@ class OtelTracer implements Tracer {
     AgentTracer.SpanBuilder delegate =
         this.tracer.buildSpan(INSTRUMENTATION_NAME, SPAN_KIND_INTERNAL).withResourceName(spanName);
     return new OtelSpanBuilder(delegate);
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private static String otelInstrumentationName() {
+    // is this the bootstrap shim for drop-in support, or the shim for manual instrumentation?
+    return OtelTracer.class.getName().startsWith("datadog.trace.bootstrap")
+        ? "otel.library"
+        : "otel";
   }
 }


### PR DESCRIPTION
# Motivation

Helps distinguish span metrics from OTel extensions with those from manual OTel instrumentation.

# Additional Notes

Metrics for spans created manually via the OTel API continue to be tagged with 'otel'.

Jira ticket: [APMAPI-153]

[APMAPI-153]: https://datadoghq.atlassian.net/browse/APMAPI-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ