### PR TITLE
Fix test selection logic with coverage

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1057,7 +1057,7 @@ build_test_jobs: &build_test_jobs
       name: z_test_<< matrix.testJvm >>_base
       triggeredBy: *core_modules
       gradleTarget: ":baseTest"
-      gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests -PskipDebuggerTests"
+      gradleParameters: "-PskipFlakyTests"
       stage: core
       cacheType: base
       parallelism: 4
@@ -1070,8 +1070,8 @@ build_test_jobs: &build_test_jobs
         - ok_to_test
       name: z_test_8_base
       triggeredBy: *core_modules
-      gradleTarget: :baseTest jacocoTestReport jacocoTestCoverageVerification
-      gradleParameters: "-PskipFlakyTests -PskipInstTests -PskipSmokeTests -PskipProfilingTests -PskipDebuggerTests"
+      gradleTarget: :baseTest
+      gradleParameters: "-PskipFlakyTests -PcheckCoverage"
       stage: core
       cacheType: base
       parallelism: 4

--- a/build.gradle
+++ b/build.gradle
@@ -165,8 +165,9 @@ allprojects { project ->
 }
 
 
-def testAggregate(String baseTaskName, includePrefixes, excludePrefixes, boolean coverage = false) {
+def testAggregate(String baseTaskName, includePrefixes, excludePrefixes, boolean forceCoverage = false) {
   def createRootTask = { rootTaskName, subProjTaskName ->
+    def coverage = forceCoverage || rootProject.hasProperty("checkCoverage")
     tasks.register(rootTaskName) { aggTest ->
       subprojects { subproject ->
         if (subproject.property("activePartition") && includePrefixes.any { subproject.path.startsWith(it) } && !excludePrefixes.any { subproject.path.startsWith(it) }) {

--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -73,15 +73,6 @@ jar {
   from sourceSets.main.output
 }
 
-tasks.withType(Test).configureEach {
-  onlyIf { !project.rootProject.hasProperty("skipDebuggerTests") }
-}
-
 // we want to test with no special reflective access (no --add-opens)
 ext.allowReflectiveAccessToJdk = false
 
-subprojects { Project subProj ->
-  subProj.tasks.withType(Test).configureEach { subTask ->
-    onlyIf { !project.rootProject.hasProperty("skipDebuggerTests") }
-  }
-}

--- a/dd-java-agent/agent-profiling/build.gradle
+++ b/dd-java-agent/agent-profiling/build.gradle
@@ -30,12 +30,6 @@ dependencies {
   testImplementation libs.bundles.mockito
 }
 
-subprojects { Project subProj ->
-  subProj.tasks.withType(Test).configureEach { subTask ->
-    onlyIf { !project.rootProject.hasProperty("skipProfilingTests") }
-  }
-}
-
 configurations {
   // exclude bootstrap dependencies from shadowJar
   runtime {

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -97,8 +97,6 @@ subprojects { Project subProj ->
         useJUnit()
       }
 
-      onlyIf { !project.rootProject.hasProperty("skipInstTests") }
-
       if (subTask.name in ['latestDepTest', 'latestDepForkedTest']) {
         subTask.jvmArgs '-Dtest.dd.latestDepTest=true'
       }

--- a/dd-smoke-tests/build.gradle
+++ b/dd-smoke-tests/build.gradle
@@ -19,8 +19,6 @@ subprojects { Project subProj ->
   subProj.tasks.withType(Test).configureEach { subTask ->
     dependsOn project(':dd-java-agent').tasks.named("shadowJar")
 
-    onlyIf { !project.rootProject.hasProperty("skipSmokeTests") }
-
     // Tests depend on this to know where to run things and what agent jar to use
     jvmArgs "-Ddatadog.smoketest.builddir=${buildDir}"
     jvmArgs "-Ddatadog.smoketest.agent.shadowJar.path=${project(':dd-java-agent').tasks.shadowJar.archiveFile.get()}"


### PR DESCRIPTION
# What Does This Do
The way we called jacoco tasks for gradle will trigger tests outside those selected by `:baseTests` at al. Remove explicit calls to these tasks from CI, and use a `-PcheckCoverage` property instead. When combined with `:baseTests`, it will run jacoco tasks only for the selected tests.

Remove legacy properties `-PskipInstTests`, `-PskipSmokeTests`, etc. These are now obsolete, and together with the above fix, they do not serve any purpose in CI anymore.

`:debuggerTest` have test coverage always enabled. This behavior is preserved.

# Motivation


# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
