### PR TITLE
Do not leak call depth threadlocal in jdbc instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -102,6 +102,7 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void stopSpan(
         @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+      CallDepthThreadLocalMap.decrementCallDepth(Statement.class);
       if (scope == null) {
         return;
       }
@@ -109,7 +110,6 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
       DECORATE.beforeFinish(scope.span());
       scope.close();
       scope.span().finish();
-      CallDepthThreadLocalMap.reset(Statement.class);
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

If the query info is missing, the jdbc advice onEnter is returning a null scope but the threadlocal for its calldepth is not reset.
That means that subsequent queries done on the same thread will not be traced because the calldepth threadlocal is dirty

# Motivation

# Additional Notes

Jira ticket: [APMS-12988]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-12988]: https://datadoghq.atlassian.net/browse/APMS-12988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ