### PR TITLE
Fix Cucumber JUnit 4 instrumentation to support empty scenario names

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/groovy/CucumberTest.groovy
@@ -29,6 +29,7 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
       "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
     ]                                                                                                                  | 3
     "test-name-with-brackets"             | ["org/example/cucumber/calculator/name_with_brackets.feature"]             | 2
+    "test-empty-name-${version()}"        | ["org/example/cucumber/calculator/empty_scenario_name.feature"]            | 2
   }
 
   def "test ITR #testcaseName"() {

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/org/example/cucumber/calculator/empty_scenario_name.feature
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/org/example/cucumber/calculator/empty_scenario_name.feature
@@ -1,0 +1,10 @@
+@foo
+Feature:
+
+  Background: A Calculator
+    Given a calculator I just turned on
+
+  Scenario:
+  # Try to change one of the values below to provoke a failure
+    When I add 4 and 5
+    Then the result is 9

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-5.4.0/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-5.4.0/coverages.ftl
@@ -1,0 +1,8 @@
+[ {
+  "test_session_id" : ${content_test_session_id},
+  "test_suite_id" : ${content_test_suite_id},
+  "span_id" : ${content_span_id},
+  "files" : [ {
+    "filename" : "org/example/cucumber/calculator/empty_scenario_name.feature"
+  } ]
+} ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-5.4.0/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-5.4.0/events.ftl
@@ -1,0 +1,153 @@
+[ {
+  "type" : "test_suite_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_suite",
+    "resource" : "classpath:org/example/cucumber/calculator/empty_scenario_name.feature:EMPTY_NAME",
+    "start" : ${content_start},
+    "duration" : ${content_duration},
+    "error" : 0,
+    "metrics" : { },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "span.kind" : "test_suite_end",
+      "test.suite" : "classpath:org/example/cucumber/calculator/empty_scenario_name.feature:EMPTY_NAME",
+      "runtime.version" : ${content_meta_runtime_version},
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test",
+  "version" : 2,
+  "content" : {
+    "trace_id" : ${content_trace_id},
+    "span_id" : ${content_span_id},
+    "parent_id" : ${content_parent_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test",
+    "resource" : "classpath:org/example/cucumber/calculator/empty_scenario_name.feature:EMPTY_NAME.EMPTY_NAME",
+    "start" : ${content_start_2},
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "metrics" : {
+      "process_id" : ${content_metrics_process_id},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0
+    },
+    "meta" : {
+      "os.architecture" : ${content_meta_os_architecture},
+      "_dd.tracer_host" : "COMP-QG19F24WGY",
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "language" : "jvm",
+      "runtime.name" : ${content_meta_runtime_name},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "test.name" : "EMPTY_NAME",
+      "span.kind" : "test",
+      "test.suite" : "classpath:org/example/cucumber/calculator/empty_scenario_name.feature:EMPTY_NAME",
+      "runtime.version" : ${content_meta_runtime_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "test.type" : "test",
+      "test.traits" : "{\"category\":[\"foo\"]}",
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "component" : "junit",
+      "_dd.profiling.ctx" : "test",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test_session_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_session",
+    "resource" : "cucumber-junit-4",
+    "start" : ${content_start_3},
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "metrics" : {
+      "process_id" : ${content_metrics_process_id},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0
+    },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "_dd.tracer_host" : "COMP-QG19F24WGY",
+      "test.status" : "pass",
+      "language" : "jvm",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "_dd.profiling.ctx" : "test",
+      "span.kind" : "test_session_end",
+      "runtime.version" : ${content_meta_runtime_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "test.command" : "cucumber-junit-4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test_module_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_module",
+    "resource" : "cucumber-junit-4",
+    "start" : ${content_start_4},
+    "duration" : ${content_duration_4},
+    "error" : 0,
+    "metrics" : { },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "span.kind" : "test_module_end",
+      "runtime.version" : ${content_meta_runtime_version},
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+} ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-5.4.0/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-5.4.0/events.ftl
@@ -55,7 +55,6 @@
     },
     "meta" : {
       "os.architecture" : ${content_meta_os_architecture},
-      "_dd.tracer_host" : "COMP-QG19F24WGY",
       "test.module" : "cucumber-junit-4",
       "test.status" : "pass",
       "language" : "jvm",
@@ -98,7 +97,6 @@
     "meta" : {
       "test.type" : "test",
       "os.architecture" : ${content_meta_os_architecture},
-      "_dd.tracer_host" : "COMP-QG19F24WGY",
       "test.status" : "pass",
       "language" : "jvm",
       "runtime.name" : ${content_meta_runtime_name},

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-latest/coverages.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-latest/coverages.ftl
@@ -1,0 +1,8 @@
+[ {
+  "test_session_id" : ${content_test_session_id},
+  "test_suite_id" : ${content_test_suite_id},
+  "span_id" : ${content_span_id},
+  "files" : [ {
+    "filename" : "org/example/cucumber/calculator/empty_scenario_name.feature"
+  } ]
+} ]

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-latest/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-latest/events.ftl
@@ -55,7 +55,6 @@
     },
     "meta" : {
       "os.architecture" : ${content_meta_os_architecture},
-      "_dd.tracer_host" : "COMP-QG19F24WGY",
       "test.module" : "cucumber-junit-4",
       "test.status" : "pass",
       "language" : "jvm",
@@ -98,7 +97,6 @@
     "meta" : {
       "test.type" : "test",
       "os.architecture" : ${content_meta_os_architecture},
-      "_dd.tracer_host" : "COMP-QG19F24WGY",
       "test.status" : "pass",
       "language" : "jvm",
       "runtime.name" : ${content_meta_runtime_name},

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-latest/events.ftl
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/resources/test-empty-name-latest/events.ftl
@@ -1,0 +1,153 @@
+[ {
+  "type" : "test_suite_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_suite",
+    "resource" : "classpath:org/example/cucumber/calculator/empty_scenario_name.feature:EMPTY_NAME",
+    "start" : ${content_start},
+    "duration" : ${content_duration},
+    "error" : 0,
+    "metrics" : { },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "span.kind" : "test_suite_end",
+      "test.suite" : "classpath:org/example/cucumber/calculator/empty_scenario_name.feature:EMPTY_NAME",
+      "runtime.version" : ${content_meta_runtime_version},
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test",
+  "version" : 2,
+  "content" : {
+    "trace_id" : ${content_trace_id},
+    "span_id" : ${content_span_id},
+    "parent_id" : ${content_parent_id},
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "test_suite_id" : ${content_test_suite_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test",
+    "resource" : "classpath:org/example/cucumber/calculator/empty_scenario_name.feature:EMPTY_NAME.LINE:7",
+    "start" : ${content_start_2},
+    "duration" : ${content_duration_2},
+    "error" : 0,
+    "metrics" : {
+      "process_id" : ${content_metrics_process_id},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0
+    },
+    "meta" : {
+      "os.architecture" : ${content_meta_os_architecture},
+      "_dd.tracer_host" : "COMP-QG19F24WGY",
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "language" : "jvm",
+      "runtime.name" : ${content_meta_runtime_name},
+      "os.platform" : ${content_meta_os_platform},
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "test.name" : "LINE:7",
+      "span.kind" : "test",
+      "test.suite" : "classpath:org/example/cucumber/calculator/empty_scenario_name.feature:EMPTY_NAME",
+      "runtime.version" : ${content_meta_runtime_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "test.type" : "test",
+      "test.traits" : "{\"category\":[\"foo\"]}",
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "component" : "junit",
+      "_dd.profiling.ctx" : "test",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test_session_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_session",
+    "resource" : "cucumber-junit-4",
+    "start" : ${content_start_3},
+    "duration" : ${content_duration_3},
+    "error" : 0,
+    "metrics" : {
+      "process_id" : ${content_metrics_process_id},
+      "_dd.profiling.enabled" : 0,
+      "_dd.trace_span_attribute_schema" : 0
+    },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "_dd.tracer_host" : "COMP-QG19F24WGY",
+      "test.status" : "pass",
+      "language" : "jvm",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "_dd.profiling.ctx" : "test",
+      "span.kind" : "test_session_end",
+      "runtime.version" : ${content_meta_runtime_version},
+      "runtime-id" : ${content_meta_runtime_id},
+      "test.command" : "cucumber-junit-4",
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+}, {
+  "type" : "test_module_end",
+  "version" : 1,
+  "content" : {
+    "test_session_id" : ${content_test_session_id},
+    "test_module_id" : ${content_test_module_id},
+    "service" : "worker.org.gradle.process.internal.worker.gradleworkermain",
+    "name" : "junit.test_module",
+    "resource" : "cucumber-junit-4",
+    "start" : ${content_start_4},
+    "duration" : ${content_duration_4},
+    "error" : 0,
+    "metrics" : { },
+    "meta" : {
+      "test.type" : "test",
+      "os.architecture" : ${content_meta_os_architecture},
+      "test.module" : "cucumber-junit-4",
+      "test.status" : "pass",
+      "runtime.name" : ${content_meta_runtime_name},
+      "runtime.vendor" : ${content_meta_runtime_vendor},
+      "env" : "none",
+      "os.platform" : ${content_meta_os_platform},
+      "dummy_ci_tag" : "dummy_ci_tag_value",
+      "os.version" : ${content_meta_os_version},
+      "library_version" : ${content_meta_library_version},
+      "component" : "junit",
+      "span.kind" : "test_module_end",
+      "runtime.version" : ${content_meta_runtime_version},
+      "test.framework_version" : ${content_meta_test_framework_version},
+      "test.framework" : "cucumber"
+    }
+  }
+} ]


### PR DESCRIPTION
# What Does This Do

Fixes Cucumber JUnit 4 instrumentation to correctly work with scenarios that have no name.

# Additional Notes

It is possible to declare a Cucumber scenario that has an empty name (this only works for JUnit4-backed Cucumber):
```
Feature: Name of the feature

  Scenario:
  ...
```

If the feature contains multiple scenarios that do not have names, Cucumber will assign synthetic names for them (`#1`, `#2`, etc).

However, if there is only one such scenario, its name will remain empty.
This causes problems in the backend, because scenario name maps to test name, and the latter is needed to calculate test fingerprint.

The solution is to update the tracing logic to generate synthetic names in case Cucumber does not do it.
The logic will try to calculate the line where scenario is declared and use that as the name (`LINE:123`) and if that fails an hard-coded string (`EMPTY_NAME`) is used.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-700]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-700]: https://datadoghq.atlassian.net/browse/SDTEST-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ