### PR TITLE
Upgrade spotbugs to 4.8.2 and avoid configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
   id "datadog.dependency-locking"
 
   id "com.diffplug.spotless" version "6.13.0"
-  id 'com.github.spotbugs' version '5.0.14'
+  id 'com.github.spotbugs' version '6.0.20' apply false
   id "de.thetaphi.forbiddenapis" version "3.5.1"
 
   id 'pl.allegro.tech.build.axion-release' version '1.14.4'

--- a/dd-java-agent/instrumentation/kotlin-coroutines/build.gradle
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/build.gradle
@@ -19,5 +19,5 @@ dependencies {
   testFixturesApi project(':dd-trace-api')
   testFixturesApi project(':dd-java-agent:instrumentation:trace-annotation')
   testFixturesApi project(':dd-java-agent:testing')
-  testFixturesApi 'com.github.spotbugs:spotbugs-annotations:4.2.0'
+  testFixturesApi "com.github.spotbugs:spotbugs-annotations:${libs.versions.spotbugs.get()}"
 }

--- a/dd-java-agent/instrumentation/ratpack-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/ratpack-1.5/build.gradle
@@ -15,7 +15,6 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   compileOnly group: 'io.ratpack', name: 'ratpack-core', version: '1.5.0'
-  compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.2.0'
 
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
   testImplementation group: 'io.ratpack', name: 'ratpack-groovy-test', version: '1.5.0'

--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -74,8 +74,6 @@ dependencies {
 
   implementation group: 'com.google.re2j', name: 're2j', version: '1.7'
 
-  compileOnly group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.2.0'
-
   // We have autoservices defined in test subtree, looks like we need this to be able to properly rebuild this
   testAnnotationProcessor libs.autoservice.processor
   testCompileOnly libs.autoservice.annotation

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ ddprof = "1.13.0"
 asm = "9.7"
 cafe_crypto = "0.1.0"
 lz4 = "1.7.1"
+spotbugs = "4.8.6"
 
 [libraries]
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }

--- a/gradle/spotbugFilters/exclude.xml
+++ b/gradle/spotbugFilters/exclude.xml
@@ -2,6 +2,14 @@
 <FindBugsFilter>
   <Match>
     <Or>
+      <!-- New in spotbugs 4.8.0: does not pass -->
+      <Bug pattern="CT_CONSTRUCTOR_THROW" />
+      <!-- New in spotbugs 4.8.0: does not pass -->
+      <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR" />
+      <!-- New in spotbugs 4.8.0: does not pass -->
+      <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE" />
+      <!-- New in spotbugs 4.8.6: does not pass -->
+      <Bug pattern="SING_SINGLETON_GETTER_NOT_SYNCHRONIZED" />
       <Class name="~com.datadog.debugger.util.WeakIdentityHashMap.*" />
       <Package name="io.sqreen.testapp.sampleapp" />
       <Package name="datadog.trace.bootstrap.instrumentation.decorator.http.utils" />

--- a/gradle/spotbugs.gradle
+++ b/gradle/spotbugs.gradle
@@ -1,57 +1,72 @@
-apply plugin: 'com.github.spotbugs'
-
-spotbugs {
-  ignoreFailures = true
-  excludeFilter = file("$rootDir/gradle/spotbugFilters/exclude.xml")
+buildscript {
+  repositories {
+    gradlePluginPortal()
+  }
+  dependencies {
+    classpath 'com.github.spotbugs:com.github.spotbugs.gradle.plugin:6.0.20'
+  }
 }
 
-// configure spotbugs for Main tasks and disable it for all other
-afterEvaluate {
-  tasks.withType(spotbugsMain.class).configureEach {
-    def name = it.name
-    if (name.endsWith("Main") || name.endsWith("Main_java11")) {
-      it.ignoreFailures = false
-      // detector documentation is in the following link:
-      // https://spotbugs-in-kengo-toda.readthedocs.io/en/lqc-list-detectors/detectors.html
-      it.omitVisitors = [
-        'DefaultEncodingDetector',
-        'DoInsideDoPrivileged',
-        'DontUseEnum',
-        'DroppedException',
-        'FindDeadLocalStores',
-        'FindHEmismatch',
-        'FindNullDeref',
-        'FindReturnRef',
-        'FindRunInvocations',
-        'FindUselessControlFlow',
-        'InitializationChain',
-        'LazyInit',
-        'LoadOfKnownNullValue',
-        'LostLoggerDueToWeakReference',
-        'MethodReturnCheck',
-        'MutableStaticFields',
-        'Naming',
-        'RuntimeExceptionCapture',
-        'SerializableIdiom',
-        'UnreadFields',
-      ]
-      it.reports {
-        html {
-          enabled = true
-          destination = file("$buildDir/reports/spotbugs/${name}.html")
-          stylesheet = 'fancy-hist.xsl'
+import com.github.spotbugs.snom.SpotBugsTask
+
+final shouldRunSpotbugs = !project.path.startsWith(":dd-smoke-tests")
+
+if (shouldRunSpotbugs) {
+  apply plugin: 'com.github.spotbugs'
+
+  spotbugs {
+    ignoreFailures = true
+    excludeFilter = file("$rootDir/gradle/spotbugFilters/exclude.xml")
+  }
+
+  // configure spotbugs for Main tasks and disable it for all other
+  afterEvaluate {
+    tasks.withType(SpotBugsTask).configureEach {
+      def name = it.name
+      if (name ==~ /.*Main(_java\d+)?/) {
+        it.ignoreFailures = false
+        // detector documentation is in the following link:
+        // https://spotbugs-in-kengo-toda.readthedocs.io/en/lqc-list-detectors/detectors.html
+        it.omitVisitors = [
+          'DefaultEncodingDetector',
+          'DoInsideDoPrivileged',
+          'DontUseEnum',
+          'DroppedException',
+          'FindDeadLocalStores',
+          'FindHEmismatch',
+          'FindNullDeref',
+          'FindReturnRef',
+          'FindRunInvocations',
+          'FindUselessControlFlow',
+          'InitializationChain',
+          'LazyInit',
+          'LoadOfKnownNullValue',
+          'LostLoggerDueToWeakReference',
+          'MethodReturnCheck',
+          'MutableStaticFields',
+          'Naming',
+          'RuntimeExceptionCapture',
+          'SerializableIdiom',
+          'UnreadFields',
+        ]
+        it.reports {
+          html {
+            enabled = true
+            destination = file("$buildDir/reports/spotbugs/${name}.html")
+            stylesheet = 'fancy-hist.xsl'
+          }
         }
+      } else {
+        it.enabled = false
       }
-    } else {
-      it.enabled = false
     }
   }
 }
 
 dependencies {
   compileOnly 'net.jcip:jcip-annotations:1.0'
-  compileOnly 'com.github.spotbugs:spotbugs-annotations:4.2.0'
+  compileOnly "com.github.spotbugs:spotbugs-annotations:${libs.versions.spotbugs.get()}"
 
   testImplementation 'net.jcip:jcip-annotations:1.0'
-  testImplementation 'com.github.spotbugs:spotbugs-annotations:4.2.0'
+  testImplementation "com.github.spotbugs:spotbugs-annotations:${libs.versions.spotbugs.get()}"
 }


### PR DESCRIPTION


# What Does This Do
* Upgrade spotbugs-gradle-plugin 6.0.20 and spotbugs 4.8.22
* Exclude new spotbugs rules that do not pass.
* Exclude smoke tests from spotbugs.
* Use version catalog for spotbugs version.
* Remove redundant spotbugs dependency.
* Include missing tasks (e.g. spotbugsMain_java8).
# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
