### PR TITLE
Avoid RemoteHostnameAdder.config resolution error when building Quarkus native images

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/RemoteHostnameAdder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/RemoteHostnameAdder.java
@@ -1,22 +1,22 @@
 package datadog.trace.core.tagprocessor;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.core.DDSpanContext;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public class RemoteHostnameAdder implements TagsPostProcessor {
-  private final Config config;
+  private final Supplier<String> hostnameSupplier;
 
-  public RemoteHostnameAdder(Config config) {
-    this.config = config;
+  public RemoteHostnameAdder(Supplier<String> hostnameSupplier) {
+    this.hostnameSupplier = hostnameSupplier;
   }
 
   @Override
   public Map<String, Object> processTags(
       Map<String, Object> unsafeTags, DDSpanContext spanContext) {
     if (spanContext.getSpanId() == spanContext.getRootSpanId()) {
-      unsafeTags.put(DDTags.TRACER_HOST, config.getHostName());
+      unsafeTags.put(DDTags.TRACER_HOST, hostnameSupplier.get());
     }
     return unsafeTags;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessorFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/tagprocessor/TagsPostProcessorFactory.java
@@ -17,7 +17,7 @@ public final class TagsPostProcessorFactory {
       }
       processors.add(new QueryObfuscator(Config.get().getObfuscationQueryRegexp()));
       if (addRemoteHostname) {
-        processors.add(new RemoteHostnameAdder(Config.get()));
+        processors.add(new RemoteHostnameAdder(Config.get().getHostNameSupplier()));
       }
       return new PostProcessorChain(
           processors.toArray(processors.toArray(new TagsPostProcessor[0])));

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -540,6 +540,7 @@ import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
@@ -585,6 +586,10 @@ public class Config {
 
   static class HostNameHolder {
     static final String hostName = initHostName();
+
+    public static String getHostName() {
+      return hostName;
+    }
   }
 
   private final boolean runtimeIdEnabled;
@@ -2270,6 +2275,10 @@ public class Config {
 
   public String getHostName() {
     return HostNameHolder.hostName;
+  }
+
+  public Supplier<String> getHostNameSupplier() {
+    return HostNameHolder::getHostName;
   }
 
   public String getServiceName() {


### PR DESCRIPTION
# What Does This Do

Avoid hard-reference to `Config` in `RemoteHostnameAdder` because it causes issues with Quarkus + GraalVM.

Instead we use the `Supplier` API to keep the hostname lookup lazy while avoiding eager analysis of the `Config` class.
Note we deliberately avoid using a method-reference to `Config` because that can also lead to unexpected resolution.

# Motivation

The `Config` class contains all configuration data after the point at which instrumentation is configured (configuration that affects which instrumentation is applied must go in `InstrumenterConfig` which ends up baked into the final native image.)

Because we want to re-run `Config` whenever the native-image executes we must be careful not to refer to that type in certain types that get eagerly loaded during the native-image build. That's why `InstrumenterConfig` exists, so code controlling what instrumentation is applied can refer to that and avoid `Config`.
