### PR TITLE
Apache http client 4: do not copy all request headers on redirect

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/propagation/AgentTextMapPropagator.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/propagation/AgentTextMapPropagator.java
@@ -11,6 +11,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context.Extracted;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
+import datadog.trace.util.PropagationUtils;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceState;
@@ -18,7 +19,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
-import java.util.Arrays;
 import java.util.Collection;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -29,23 +29,7 @@ public class AgentTextMapPropagator implements TextMapPropagator {
 
   public AgentTextMapPropagator() {
     // Cannot suppose the current injector from AgentTracer so declare them all
-    this.fields =
-        Arrays.asList(
-            // W3C headers
-            "traceparent",
-            "tracestate",
-            // DD headers
-            "x-datadog-trace-id",
-            "x-datadog-parent-id",
-            "x-datadog-sampling-priority",
-            "x-datadog-origin",
-            "x-datadog-tags",
-            // B3 single headers
-            "X-B3-TraceId",
-            "X-B3-SpanId",
-            "X-B3-Sampled",
-            // B3 multi header
-            "b3");
+    this.fields = PropagationUtils.getAllHeaders();
   }
 
   @Override

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/propagation/AgentTextMapPropagator.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/context/propagation/AgentTextMapPropagator.java
@@ -25,16 +25,10 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 public class AgentTextMapPropagator implements TextMapPropagator {
-  private final Collection<String> fields;
-
-  public AgentTextMapPropagator() {
-    // Cannot suppose the current injector from AgentTracer so declare them all
-    this.fields = PropagationUtils.getAllHeaders();
-  }
 
   @Override
   public Collection<String> fields() {
-    return this.fields;
+    return PropagationUtils.KNOWN_PROPAGATION_HEADERS;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
@@ -9,7 +9,6 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.util.PropagationUtils;
-import java.util.Collection;
 import java.util.Locale;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -83,9 +82,9 @@ public class ApacheHttpClientRedirectInstrumentation extends InstrumenterModule.
           redirect.setHeaders(((HttpRequestWrapper) original).getOriginal().getAllHeaders());
         }
       } else {
-        final Collection<String> ddHeaders = PropagationUtils.getAllHeaders();
         for (final Header header : original.getAllHeaders()) {
-          if (ddHeaders.contains(header.getName().toLowerCase(Locale.ROOT))) {
+          if (PropagationUtils.KNOWN_PROPAGATION_HEADERS.contains(
+              header.getName().toLowerCase(Locale.ROOT))) {
             if (!redirect.containsHeader(header.getName())) {
               redirect.setHeader(header.getName(), header.getValue());
             }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
@@ -8,6 +8,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.util.PropagationUtils;
+import java.util.Collection;
 import java.util.Locale;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -15,6 +17,8 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpRequestWrapper;
+import org.apache.http.protocol.HttpContext;
 
 /**
  * Early versions don't copy headers over on redirect. This instrumentation copies our headers over
@@ -26,7 +30,7 @@ public class ApacheHttpClientRedirectInstrumentation extends InstrumenterModule.
     implements Instrumenter.ForTypeHierarchy {
 
   public ApacheHttpClientRedirectInstrumentation() {
-    super("httpasyncclient", "apache-httpasyncclient");
+    super("httpasyncclient", "apache-httpasyncclient", "httpclient-redirect");
   }
 
   @Override
@@ -44,32 +48,41 @@ public class ApacheHttpClientRedirectInstrumentation extends InstrumenterModule.
     transformer.applyAdvice(
         isMethod()
             .and(named("getRedirect"))
-            .and(takesArgument(0, named("org.apache.http.HttpRequest"))),
+            .and(takesArgument(2, named("org.apache.http.protocol.HttpContext"))),
         ApacheHttpClientRedirectInstrumentation.class.getName() + "$ClientRedirectAdvice");
   }
 
   public static class ClientRedirectAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     private static void onAfterExecute(
-        @Advice.Argument(value = 0) final HttpRequest original,
+        @Advice.Argument(value = 2) final HttpContext context,
         @Advice.Return(typing = Assigner.Typing.DYNAMIC) final HttpRequest redirect) {
       if (redirect == null) {
         return;
       }
+      Object originalRequest = context.getAttribute("http.request");
+      if (!(originalRequest instanceof HttpRequest)) {
+        return;
+      }
+      HttpRequest original = (HttpRequest) originalRequest;
+
       // Apache HttpClient 4.0.1+ copies headers from original to redirect only
       // if redirect headers are empty. Because we add headers
       // "x-datadog-" and "x-b3-" to redirect: it means redirect headers never
       // will be empty. So in case if not-instrumented redirect had no headers,
       // we just copy all not set headers from original to redirect (doing same
       // thing as apache httpclient does).
-      if (!redirect.headerIterator().hasNext()) {
+      if (!redirect.headerIterator().hasNext() && original instanceof HttpRequestWrapper) {
         // redirect didn't have other headers besides tracing, so we need to do copy
         // (same work as Apache HttpClient 4.0.1+ does w/o instrumentation)
-        redirect.setHeaders(original.getAllHeaders());
+        // We should use the initial request because the wrapped one might contain more headers
+        // (i.e.
+        // Host) we do not want to copy
+        redirect.setHeaders(((HttpRequestWrapper) original).getOriginal().getAllHeaders());
       } else {
+        final Collection<String> ddHeaders = PropagationUtils.getAllHeaders();
         for (final Header header : original.getAllHeaders()) {
-          final String name = header.getName().toLowerCase(Locale.ROOT);
-          if (name.startsWith("x-datadog-") || name.startsWith("x-b3-")) {
+          if (ddHeaders.contains(header.getName().toLowerCase(Locale.ROOT))) {
             if (!redirect.containsHeader(header.getName())) {
               redirect.setHeader(header.getName(), header.getValue());
             }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/build.gradle
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'
   testImplementation(testFixtures(project(':dd-java-agent:agent-iast')))
   testImplementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'
-
+  testImplementation(project(':dd-java-agent:instrumentation:apache-httpasyncclient-4'))
   // to instrument the integration test
   iastIntegrationTestImplementation(testFixtures(project(':dd-java-agent:agent-iast')))
   iastIntegrationTestImplementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.0'

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -140,6 +140,7 @@ excludedClassesCoverage += [
   "datadog.trace.util.PidHelper",
   "datadog.trace.util.PidHelper.Fallback",
   "datadog.trace.util.ProcessUtils",
+  "datadog.trace.util.PropagationUtils",
   "datadog.trace.util.UnsafeUtils",
   "datadog.trace.api.ConfigCollector",
   "datadog.trace.api.Config.HostNameHolder",

--- a/internal-api/src/main/java/datadog/trace/util/PropagationUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/PropagationUtils.java
@@ -6,7 +6,11 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 
 public class PropagationUtils {
-  private static final Collection<String> KNOWN_PROPAGATION_HEADERS =
+  private PropagationUtils() {
+    // avoid constructing instances of this class.
+  }
+
+  public static final Collection<String> KNOWN_PROPAGATION_HEADERS =
       Collections.unmodifiableCollection(
           new LinkedHashSet<>(
               Arrays.asList(
@@ -20,13 +24,9 @@ public class PropagationUtils {
                   "x-datadog-origin",
                   "x-datadog-tags",
                   // B3 single headers
-                  "X-B3-TraceId",
-                  "X-B3-SpanId",
-                  "X-B3-Sampled",
+                  "x-b3-traceid",
+                  "x-b3-spanid",
+                  "x-b3-sampled",
                   // B3 multi header
                   "b3")));
-
-  public static Collection<String> getAllHeaders() {
-    return ALL_HEADERS;
-  }
 }

--- a/internal-api/src/main/java/datadog/trace/util/PropagationUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/PropagationUtils.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 
 public class PropagationUtils {
-  private static final Collection<String> ALL_HEADERS =
+  private static final Collection<String> KNOWN_PROPAGATION_HEADERS =
       Collections.unmodifiableCollection(
           new LinkedHashSet<>(
               Arrays.asList(

--- a/internal-api/src/main/java/datadog/trace/util/PropagationUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/PropagationUtils.java
@@ -10,6 +10,7 @@ public class PropagationUtils {
     // avoid constructing instances of this class.
   }
 
+  /** The list of the known propagation headers. They must be lowercased. */
   public static final Collection<String> KNOWN_PROPAGATION_HEADERS =
       Collections.unmodifiableCollection(
           new LinkedHashSet<>(

--- a/internal-api/src/main/java/datadog/trace/util/PropagationUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/PropagationUtils.java
@@ -1,0 +1,32 @@
+package datadog.trace.util;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+
+public class PropagationUtils {
+  private static final Collection<String> ALL_HEADERS =
+      Collections.unmodifiableCollection(
+          new LinkedHashSet<>(
+              Arrays.asList(
+                  // W3C headers
+                  "traceparent",
+                  "tracestate",
+                  // DD headers
+                  "x-datadog-trace-id",
+                  "x-datadog-parent-id",
+                  "x-datadog-sampling-priority",
+                  "x-datadog-origin",
+                  "x-datadog-tags",
+                  // B3 single headers
+                  "X-B3-TraceId",
+                  "X-B3-SpanId",
+                  "X-B3-Sampled",
+                  // B3 multi header
+                  "b3")));
+
+  public static Collection<String> getAllHeaders() {
+    return ALL_HEADERS;
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR avoids copying the original request headers when a redirect happen. The issue here is that the original request may contain headers like `Host`. In this case, if we copy it on the redirected one, apache http client will keep this one (which might be wrong).
This PR takes the request instead from the context. That request is always a Wrapped request. Having access to the wrapped request we can get the original one that contains only the headers manually added (by the user and by us) but not added by the library itself (i.e. Host, Content-Type, ...)

I also added the tag `httpclient-redirect` to that instrumentation in order to unplug easily in case of issues

# Motivation

# Additional Notes

Jira ticket: [APMS-12746]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-12746]: https://datadoghq.atlassian.net/browse/APMS-12746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ