### PR TITLE
Refactor UntrustedDeserializationModule to be more generic

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UntrustedDeserializationModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/sink/UntrustedDeserializationModuleImpl.java
@@ -3,7 +3,6 @@ package com.datadog.iast.sink;
 import com.datadog.iast.Dependencies;
 import com.datadog.iast.model.VulnerabilityType;
 import datadog.trace.api.iast.sink.UntrustedDeserializationModule;
-import java.io.InputStream;
 import javax.annotation.Nullable;
 
 public class UntrustedDeserializationModuleImpl extends SinkModuleBase
@@ -14,10 +13,10 @@ public class UntrustedDeserializationModuleImpl extends SinkModuleBase
   }
 
   @Override
-  public void onInputStream(@Nullable InputStream is) {
-    if (is == null) {
+  public void onObject(@Nullable Object object) {
+    if (object == null) {
       return;
     }
-    checkInjection(VulnerabilityType.UNTRUSTED_DESERIALIZATION, is);
+    checkInjection(VulnerabilityType.UNTRUSTED_DESERIALIZATION, object);
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UntrustedDeserializationModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/sink/UntrustedDeserializationModuleTest.groovy
@@ -22,9 +22,9 @@ class UntrustedDeserializationModuleTest extends IastModuleImplTestBase {
     return Mock(Reporter)
   }
 
-  void 'test null value'() {
+  void 'test null value with object null'() {
     when:
-    module.onInputStream(null)
+    module.onObject(null)
 
     then:
     0 * _
@@ -32,19 +32,19 @@ class UntrustedDeserializationModuleTest extends IastModuleImplTestBase {
 
   void 'test untrusted deserialization detection' () {
     setup:
-    def inputStream = Mock(InputStream)
+    def object = Mock(Object)
 
     when:
-    module.onInputStream(inputStream)
+    module.onObject(object)
 
-    then: 'without tainted input stream'
+    then: 'without tainted object'
     0 * reporter.report(_, _)
 
     when:
-    taint(inputStream)
-    module.onInputStream(inputStream)
+    taint(object)
+    module.onObject(object)
 
-    then: 'with tainted input stream'
+    then: 'with tainted object'
     1 * reporter.report(_, { Vulnerability vul -> vul.type == VulnerabilityType.UNTRUSTED_DESERIALIZATION})
   }
 

--- a/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/ObjectInputStreamCallSite.java
+++ b/dd-java-agent/instrumentation/java-io/src/main/java/datadog/trace/instrumentation/java/lang/ObjectInputStreamCallSite.java
@@ -18,7 +18,7 @@ public class ObjectInputStreamCallSite {
 
     if (module != null) {
       try {
-        module.onInputStream(is);
+        module.onObject(is);
       } catch (Throwable e) {
         module.onUnexpectedException("before constructor untrusted threw", e);
       }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ObjectInputStreamCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/ObjectInputStreamCallSiteTest.groovy
@@ -12,7 +12,7 @@ class ObjectInputStreamCallSiteTest extends AgentTestRunner {
     injectSysConfig('dd.iast.enabled', 'true')
   }
 
-  void 'test onInputStream'() {
+  void 'test onObject'() {
     setup:
     final module = Mock(UntrustedDeserializationModule)
     InstrumentationBridge.registerIastModule(module)
@@ -23,6 +23,6 @@ class ObjectInputStreamCallSiteTest extends AgentTestRunner {
     TestObjectInputStreamSuite.init(inputStream)
 
     then:
-    1 * module.onInputStream(_)
+    1 * module.onObject(_)
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/sink/UntrustedDeserializationModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/sink/UntrustedDeserializationModule.java
@@ -1,10 +1,9 @@
 package datadog.trace.api.iast.sink;
 
 import datadog.trace.api.iast.IastModule;
-import java.io.InputStream;
 import javax.annotation.Nullable;
 
 public interface UntrustedDeserializationModule extends IastModule {
 
-  void onInputStream(@Nullable InputStream is);
+  void onObject(@Nullable Object object);
 }


### PR DESCRIPTION
# What Does This Do
Refactors the UntrustedDeserializationModule to a more generic call.

# Motivation
We want to avoid having the same function duplicated for different types of objects such as InputStream, Reader, Strings...

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-54452]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-54452]: https://datadoghq.atlassian.net/browse/APPSEC-54452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ