### PR TITLE
Do not skip ErrorReportValve.report in any case

### DIFF
--- a/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/ErrorReportValueAdvice.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/ErrorReportValueAdvice.java
@@ -15,8 +15,8 @@ import org.apache.catalina.connector.Response;
 
 public class ErrorReportValueAdvice {
 
-  @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
-  public static boolean onEnter(
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void onEnter(
       @Advice.Argument(value = 1) Response response,
       @Advice.Argument(value = 2) Throwable throwable,
       @Advice.Origin("#t") String className,
@@ -27,7 +27,7 @@ public class ErrorReportValueAdvice {
     // Do nothing if the response hasn't been explicitly marked as in error
     //    and that error has not been reported.
     if (statusCode < 400 || statusCode == 404 || !response.isError()) {
-      return true; // skip original method
+      return;
     }
     if (throwable != null) {
       // Report IAST
@@ -45,12 +45,12 @@ public class ErrorReportValueAdvice {
     final Config config = Config.get();
     if (config.getIastActivation() != ProductActivation.FULLY_ENABLED
         || !config.isIastStacktraceLeakSuppress()) {
-      return false;
+      return;
     }
 
     byte[] template = BlockingActionHelper.getTemplate(HTML);
     if (template == null) {
-      return false;
+      return;
     }
 
     try {
@@ -71,7 +71,5 @@ public class ErrorReportValueAdvice {
     } catch (IOException | IllegalStateException e) {
       // Ignore
     }
-
-    return false;
   }
 }

--- a/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/ErrorReportValueAdvice.java
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/src/main/java/datadog/trace/instrumentation/tomcat7/ErrorReportValueAdvice.java
@@ -15,7 +15,7 @@ import org.apache.catalina.connector.Response;
 
 public class ErrorReportValueAdvice {
 
-  @Advice.OnMethodEnter(skipOn = Advice.OnNonDefaultValue.class)
+  @Advice.OnMethodEnter(suppress = Throwable.class, skipOn = Advice.OnNonDefaultValue.class)
   public static boolean onEnter(
       @Advice.Argument(value = 1) Response response,
       @Advice.Argument(value = 2) Throwable throwable,


### PR DESCRIPTION
# What Does This Do
Initial advice skipped the original method on <400 http status code and responses not marked as errors. But we should not be changing the original behavior by default.

# Motivation

Ensure we do not change original application behavior by default, we should be passive unless blocking a request.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
