### PR TITLE
Remove commons-fileupload2 references

### DIFF
--- a/dd-java-agent/instrumentation/commons-fileupload/build.gradle
+++ b/dd-java-agent/instrumentation/commons-fileupload/build.gradle
@@ -3,8 +3,6 @@ apply from: "$rootDir/gradle/java.gradle"
 addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
-  compileOnly group: 'org.apache.commons', name: 'commons-fileupload2', version: '2.0.0-M1'
-  testImplementation group: 'org.apache.commons', name: 'commons-fileupload2', version: '2.0.0-M1'
   testImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '7.0.0'
 
   compileOnly group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
@@ -12,6 +10,5 @@ dependencies {
   testImplementation group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
-  latestDepTestImplementation group: 'org.apache.commons', name: 'commons-fileupload2', version: '+'
   latestDepTestImplementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.+'
 }

--- a/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/MultipartInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/MultipartInstrumentationTest.groovy
@@ -26,7 +26,7 @@ class MultipartInstrumentationTest extends AgentTestRunner {
     InstrumentationBridge.clearIastModules()
   }
 
-  void 'test commons fileupload2 ParameterParser.parse'() {
+  void 'test commons fileupload ParameterParser.parse'() {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)


### PR DESCRIPTION
# What Does This Do
This removes references to the commons-fileupload2 library is not being use at the moment

# Motivation
Make coherence between naming and classes

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-54157]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-54157]: https://datadoghq.atlassian.net/browse/APPSEC-54157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ