### PR TITLE
Implement a fallback method for getting effective JVM for Maven Surefire executions

### DIFF
--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenLifecycleParticipant.java
@@ -200,7 +200,7 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
           if (forkedJvmPath == null) {
             Plugin plugin = mojoExecution.getPlugin();
             String pluginKey = plugin.getKey();
-            LOGGER.warn(
+            LOGGER.debug(
                 "Could not determine forked JVM path for plugin {} execution {} in project {}",
                 pluginKey,
                 mojoExecution.getExecutionId(),


### PR DESCRIPTION
# What Does This Do

Implements a fallback method for getting effective JVM for a traced Maven Surefire plugin invocation.

# Additional Notes

The original logic looks up and invokes a private `getEffectiveJvm()` method from the plugin's configured MOJO - this is the method that Surefire plugin itself uses to determine the JVM to use for forking.
It is not always possible to look up the method and invoke it - one example is when the MOJO is proxied (although I could not reproduce this locally, this happens for some customers).

The fallback logic tries to follow the steps of the `getEffectiveJvm()` as closely as possible.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-723]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-723]: https://datadoghq.atlassian.net/browse/SDTEST-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ