### PR TITLE
Adjust CircleCI resource classes

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -660,7 +660,8 @@ jobs:
           - DD_POOL_TRACE_CHECK_FAILURES=true
           - DD_DISABLE_ERROR_RESPONSES=true
           - ENABLED_CHECKS=trace_content_length,trace_stall,meta_tracer_version_header,trace_count_header,trace_peer_service,trace_dd_service
-    resource_class: xlarge
+    # TODO: merge xlarge_tests and tests? or rename this?
+    resource_class: large
 
 
   # The only way to do fan-in in CircleCI seems to have a proper job, so let's have one that
@@ -1099,8 +1100,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      parallelism: 4
-      maxWorkers: 4
+      parallelism: 8
+      maxWorkers: 2
       matrix:
         <<: *test_matrix
 
@@ -1113,8 +1114,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      parallelism: 4
-      maxWorkers: 4
+      parallelism: 8
+      maxWorkers: 2
       testJvm: "8"
 
   - xlarge_tests:
@@ -1127,8 +1128,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: latestdep
-      parallelism: 4
-      maxWorkers: 4
+      parallelism: 8
+      maxWorkers: 2
       testJvm: "8"
 
   - xlarge_tests:
@@ -1141,8 +1142,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: latestdep
-      parallelism: 4
-      maxWorkers: 4
+      parallelism: 8
+      maxWorkers: 2
       testJvm: "17"
 
   - xlarge_tests:
@@ -1155,8 +1156,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: latestdep
-      parallelism: 4
-      maxWorkers: 4
+      parallelism: 8
+      maxWorkers: 2
       testJvm: "21"
 
 {% if flaky %}
@@ -1184,8 +1185,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      parallelism: 2
-      maxWorkers: 4
+      parallelism: 4
+      maxWorkers: 2
       testJvm: "8"
 
   - tests:

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1100,7 +1100,7 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      parallelism: 8
+      parallelism: 12
       maxWorkers: 3
       matrix:
         <<: *test_matrix
@@ -1114,7 +1114,7 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      parallelism: 8
+      parallelism: 12
       maxWorkers: 3
       testJvm: "8"
 
@@ -1128,7 +1128,7 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: latestdep
-      parallelism: 8
+      parallelism: 12
       maxWorkers: 3
       testJvm: "8"
 
@@ -1142,7 +1142,7 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: latestdep
-      parallelism: 8
+      parallelism: 12
       maxWorkers: 3
       testJvm: "17"
 
@@ -1156,7 +1156,7 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: latestdep
-      parallelism: 8
+      parallelism: 12
       maxWorkers: 3
       testJvm: "21"
 
@@ -1185,7 +1185,7 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      parallelism: 8
+      parallelism: 12
       maxWorkers: 4
       testJvm: "8"
 

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1101,7 +1101,7 @@ build_test_jobs: &build_test_jobs
       stage: instrumentation
       cacheType: inst
       parallelism: 8
-      maxWorkers: 2
+      maxWorkers: 3
       matrix:
         <<: *test_matrix
 
@@ -1115,7 +1115,7 @@ build_test_jobs: &build_test_jobs
       stage: instrumentation
       cacheType: inst
       parallelism: 8
-      maxWorkers: 2
+      maxWorkers: 3
       testJvm: "8"
 
   - xlarge_tests:
@@ -1129,7 +1129,7 @@ build_test_jobs: &build_test_jobs
       stage: instrumentation
       cacheType: latestdep
       parallelism: 8
-      maxWorkers: 2
+      maxWorkers: 3
       testJvm: "8"
 
   - xlarge_tests:
@@ -1143,7 +1143,7 @@ build_test_jobs: &build_test_jobs
       stage: instrumentation
       cacheType: latestdep
       parallelism: 8
-      maxWorkers: 2
+      maxWorkers: 3
       testJvm: "17"
 
   - xlarge_tests:
@@ -1157,7 +1157,7 @@ build_test_jobs: &build_test_jobs
       stage: instrumentation
       cacheType: latestdep
       parallelism: 8
-      maxWorkers: 2
+      maxWorkers: 3
       testJvm: "21"
 
 {% if flaky %}
@@ -1185,8 +1185,8 @@ build_test_jobs: &build_test_jobs
       triggeredBy: *instrumentation_modules
       stage: instrumentation
       cacheType: inst
-      parallelism: 4
-      maxWorkers: 2
+      parallelism: 8
+      maxWorkers: 4
       testJvm: "8"
 
   - tests:

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -92,7 +92,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevi
 @SuppressWarnings('UnnecessaryDotClass')
 @RunWith(SpockRunner.class)
 abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.Listener {
-  private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(40)
+  private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(20)
 
   protected static final Instrumentation INSTRUMENTATION = ByteBuddyAgent.getInstrumentation()
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.groovy
@@ -92,7 +92,7 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.closePrevi
 @SuppressWarnings('UnnecessaryDotClass')
 @RunWith(SpockRunner.class)
 abstract class AgentTestRunner extends DDSpecification implements AgentBuilder.Listener {
-  private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(10)
+  private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(40)
 
   protected static final Instrumentation INSTRUMENTATION = ByteBuddyAgent.getInstrumentation()
 


### PR DESCRIPTION
# What Does This Do
See [Circle CI's price list](https://circleci.com/pricing/price-list/). Linux VM / (x86) Remote Docker's xlarge has 8 CPUs for 100 credits/min (12.5 credits per CPU/min), large has 4 CPUs for 20 credits/min (5 credits per CPU/min). So:

* Change instrumentation test jobs from `xlarge` to `large` resource class.
* Increase parallelism from 4 to 12 (still cheaper job/minute).
* Set workers to 3. This is a higher worker per CPU ratio than before, leading to better resource utilization, but also more flaky tests being triggered because of high load. I'm opening separate PRs to fix flaky tests resulting from this change:
  * https://github.com/DataDog/dd-trace-java/pull/7598
  * https://github.com/DataDog/dd-trace-java/pull/7551
  * https://github.com/DataDog/dd-trace-java/pull/7550
  * https://github.com/DataDog/dd-trace-java/pull/7625
  * https://github.com/DataDog/dd-trace-java/pull/7627
* Increase timeout when waiting for traces, to cope with the extra load.
* With these parameters (resource class, job parallelism, and workers), on a cursory check, we can expect a 10%-25% cost decrease in PRs per fresh pipeline run (didn't measure in master), and PR pipeline time being reduced by ~7 minutes.

# Additional Notes
Next in the pipeline: test tasks that gradle does not parallelize within the same subproject now dominate wall clock time in instrumentation test jobs. This is supposed to be eventually fixed by enabling Gradle's configuration cache.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
