### PR TITLE
Add smoke test for Exception Replay

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -89,6 +89,8 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
     } else {
       if (exceptionProbeManager.createProbesForException(innerMostException.getStackTrace())) {
         AgentTaskScheduler.INSTANCE.execute(() -> applyExceptionConfiguration(fingerprint));
+      } else {
+        LOGGER.debug("No probe created for exception: {}", innerMostException.toString());
       }
     }
   }

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/ServerDebuggerTestApplication.java
@@ -102,7 +102,11 @@ public class ServerDebuggerTestApplication {
       throw new RuntimeException("cannot find method: " + methodName);
     }
     System.out.println("Executing method: " + methodName);
-    method.accept(arg);
+    try {
+      method.accept(arg);
+    } catch (Throwable ex) {
+      ex.printStackTrace();
+    }
     System.out.println("Executed");
   }
 
@@ -130,7 +134,13 @@ public class ServerDebuggerTestApplication {
     map.put("key1", "val1");
     map.put("key2", "val2");
     map.put("key3", "val3");
-    tracedMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
+    if ("oops".equals(arg)) {
+      tracedMethodWithException(42, "foobar", 3.42, map, "var1", "var2", "var3");
+    } else if ("deepOops".equals(arg)) {
+      tracedMethodWithDeepException1(42, "foobar", 3.42, map, "var1", "var2", "var3");
+    } else {
+      tracedMethod(42, "foobar", 3.42, map, "var1", "var2", "var3");
+    }
   }
 
   private static void runLoopingTracedMethod(String arg) {
@@ -173,6 +183,36 @@ public class ServerDebuggerTestApplication {
       ex.printStackTrace();
       return null;
     }
+  }
+
+  private static void tracedMethodWithException(
+      int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
+    throw new RuntimeException("oops");
+  }
+
+  private static void tracedMethodWithDeepException1(
+      int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
+    tracedMethodWithDeepException2(argInt, argStr, argDouble, argMap, argVar);
+  }
+
+  private static void tracedMethodWithDeepException2(
+      int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
+    tracedMethodWithDeepException3(argInt, argStr, argDouble, argMap, argVar);
+  }
+
+  private static void tracedMethodWithDeepException3(
+      int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
+    tracedMethodWithDeepException4(argInt, argStr, argDouble, argMap, argVar);
+  }
+
+  private static void tracedMethodWithDeepException4(
+      int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
+    tracedMethodWithDeepException5(argInt, argStr, argDouble, argMap, argVar);
+  }
+
+  private static void tracedMethodWithDeepException5(
+      int argInt, String argStr, double argDouble, Map<String, String> argMap, String... argVar) {
+    tracedMethodWithException(argInt, argStr, argDouble, argMap, argVar);
   }
 
   private static class AppDispatcher extends Dispatcher {

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/TestApplicationHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/TestApplicationHelper.java
@@ -17,6 +17,8 @@ public class TestApplicationHelper {
       "[main] DEBUG com.datadog.debugger.agent.DebuggerTransformer - Generating bytecode for class: %s";
   private static final String INSTRUMENTATION_DONE_BCKG_THREAD =
       "[dd-remote-config] DEBUG com.datadog.debugger.agent.DebuggerTransformer - Generating bytecode for class: %s";
+  private static final String INSTRUMENTATION_DONE_TASK_THREAD =
+      "[dd-task-scheduler] DEBUG com.datadog.debugger.agent.DebuggerTransformer - Generating bytecode for class: %s";
   private static final String RENTRANSFORMATION_CLASS =
       "[dd-remote-config] INFO com.datadog.debugger.agent.ConfigurationUpdater - Re-transforming class: %s";
   private static final String RETRANSFORMATION_DONE =
@@ -55,6 +57,9 @@ public class TestApplicationHelper {
             // instrumentation is done by background thread, need to wait for end of
             // re-transformation
             if (line.contains(String.format(INSTRUMENTATION_DONE_BCKG_THREAD, className))) {
+              generatingByteCode.set(true);
+            }
+            if (line.contains(String.format(INSTRUMENTATION_DONE_TASK_THREAD, className))) {
               generatingByteCode.set(true);
             }
           } else {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -145,8 +145,8 @@ public abstract class BaseIntegrationTest {
         Arrays.asList(
             "-Ddd.service.name=" + getAppId(),
             "-Ddd.profiling.enabled=false",
-            "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
-            "-Dorg.slf4j.simpleLogger.defaultLogLevel=info",
+            // "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
+            "-Ddatadog.slf4j.simpleLogger.log.com.datadog.debugger=debug",
             "-Ddd.jmxfetch.start-delay=0",
             "-Ddd.jmxfetch.enabled=false",
             "-Ddd.dynamic.instrumentation.enabled=true",
@@ -305,6 +305,10 @@ public abstract class BaseIntegrationTest {
 
   protected void registerTraceListener(Consumer<DecodedTrace> listener) {
     traceListeners.add(listener);
+  }
+
+  protected void resetTraceListener() {
+    traceListeners.clear();
   }
 
   protected void registerProbeStatusListener(Consumer<ProbeStatus> listener) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -145,7 +145,7 @@ public abstract class BaseIntegrationTest {
         Arrays.asList(
             "-Ddd.service.name=" + getAppId(),
             "-Ddd.profiling.enabled=false",
-            // "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
+            "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=info",
             "-Ddatadog.slf4j.simpleLogger.log.com.datadog.debugger=debug",
             "-Ddd.jmxfetch.start-delay=0",
             "-Ddd.jmxfetch.enabled=false",

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ExceptionDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ExceptionDebuggerIntegrationTest.java
@@ -1,0 +1,193 @@
+package datadog.smoketest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.datadog.debugger.sink.Snapshot;
+import datadog.trace.api.Platform;
+import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.test.agent.decoder.DecodedSpan;
+import datadog.trace.test.agent.decoder.DecodedTrace;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+public class ExceptionDebuggerIntegrationTest extends ServerAppDebuggerIntegrationTest {
+
+  private String snapshotId0;
+  private String snapshotId1;
+  private String snapshotId2;
+  private boolean traceReceived;
+  private boolean snapshotReceived;
+  private Map<String, Snapshot> snapshots = new HashMap<>();
+
+  @Override
+  protected ProcessBuilder createProcessBuilder(Path logFilePath, String... params) {
+    List<String> commandParams = getDebuggerCommandParams();
+    commandParams.add("-Ddd.trace.enabled=true"); // explicitly enable tracer
+    commandParams.add("-Ddd.exception.replay.enabled=true"); // enable exception replay
+    commandParams.add("-Ddd.internal.exception.replay.only.local.root=false"); // for all spans
+    commandParams.add("-Ddd.third.party.excludes=datadog.smoketest");
+    return ProcessBuilderHelper.createProcessBuilder(
+        commandParams, logFilePath, getAppClass(), params);
+  }
+
+  @Test
+  @DisplayName("testSimpleSingleFrameException")
+  @DisabledIf(
+      value = "datadog.trace.api.Platform#isJ9",
+      disabledReason = "we cannot get local variable debug info")
+  void testSimpleSingleFrameException() throws Exception {
+    execute(appUrl, TRACED_METHOD_NAME, "oops"); // instrumenting first exception
+    waitForInstrumentation(appUrl);
+    execute(appUrl, TRACED_METHOD_NAME, "oops"); // collecting snapshots and sending them
+    registerTraceListener(this::receiveExceptionReplayTrace);
+    registerSnapshotListener(this::receiveSnapshot);
+    processRequests(
+        () -> {
+          if (traceReceived && snapshotReceived && snapshots.containsKey(snapshotId0)) {
+            Snapshot snapshot = snapshots.get(snapshotId0);
+            assertNotNull(snapshot);
+            assertEquals(
+                "oops", snapshot.getCaptures().getReturn().getCapturedThrowable().getMessage());
+            assertFullMethodCaptureArgs(snapshot.getCaptures().getReturn());
+            return true;
+          }
+          return false;
+        });
+  }
+
+  @Test
+  @DisplayName("testNoSubsequentCaptureAfterFirst")
+  @DisabledIf(
+      value = "datadog.trace.api.Platform#isJ9",
+      disabledReason = "we cannot get local variable debug info")
+  void testNoSubsequentCaptureAfterFirst() throws Exception {
+    testSimpleSingleFrameException();
+    resetSnapshotsAndTraces();
+    // we should not receive any more snapshots after the first one
+    execute(appUrl, TRACED_METHOD_NAME, "oops"); // no snapshot should be sent
+    registerTraceListener(
+        decodedTrace -> {
+          for (DecodedSpan span : decodedTrace.getSpans()) {
+            if (isTracedFullMethodSpan(span)) {
+              assertFalse(span.getMeta().containsKey("error.debug_info_captured"));
+              assertFalse(span.getMeta().containsKey("_dd.debug.error.0.snapshot_id"));
+              traceReceived = true;
+            }
+          }
+        });
+    processRequests(() -> traceReceived && !snapshotReceived);
+  }
+
+  @Test
+  @DisplayName("test3CapturedFrames")
+  @DisabledIf(
+      value = "datadog.trace.api.Platform#isJ9",
+      disabledReason = "we cannot get local variable debug info")
+  void test3CapturedFrames() throws Exception {
+    execute(appUrl, TRACED_METHOD_NAME, "deepOops"); // instrumenting first exception
+    waitForInstrumentation(appUrl);
+    execute(appUrl, TRACED_METHOD_NAME, "deepOops"); // collecting snapshots and sending them
+    registerTraceListener(this::receiveExceptionReplayTrace);
+    registerSnapshotListener(this::receiveSnapshot);
+    processRequests(
+        () -> {
+          if (traceReceived
+              && snapshotReceived
+              && snapshots.containsKey(snapshotId0)
+              && snapshots.containsKey(snapshotId1)
+              && snapshots.containsKey(snapshotId2)) {
+            // java.lang.RuntimeException: oops
+            //   at
+            // datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithException(ServerDebuggerTestApplication.java:190)
+            //   at
+            // datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithDeepException5(ServerDebuggerTestApplication.java:210)
+            //   at
+            // datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithDeepException4(ServerDebuggerTestApplication.java:206)
+            //   at
+            // datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithDeepException3(ServerDebuggerTestApplication.java:202)
+            //   at
+            // datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithDeepException2(ServerDebuggerTestApplication.java:198)
+            //   at
+            // datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithDeepException1(ServerDebuggerTestApplication.java:194)
+            //   at
+            // datadog.smoketest.debugger.ServerDebuggerTestApplication.runTracedMethod(ServerDebuggerTestApplication.java:140)
+            // snapshot 0
+            Snapshot snapshot = snapshots.get(snapshotId0);
+            assertNotNull(snapshot);
+            assertEquals(
+                "oops", snapshot.getCaptures().getReturn().getCapturedThrowable().getMessage());
+            assertEquals(
+                "datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithException",
+                snapshot.getStack().get(0).getFunction());
+            assertFullMethodCaptureArgs(snapshot.getCaptures().getReturn());
+            // snapshot 1
+            snapshot = snapshots.get(snapshotId1);
+            assertEquals(
+                "oops", snapshot.getCaptures().getReturn().getCapturedThrowable().getMessage());
+            assertEquals(
+                "datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithDeepException5",
+                snapshot.getStack().get(0).getFunction());
+            assertFullMethodCaptureArgs(snapshot.getCaptures().getReturn());
+            // snapshot 2
+            snapshot = snapshots.get(snapshotId2);
+            assertEquals(
+                "oops", snapshot.getCaptures().getReturn().getCapturedThrowable().getMessage());
+            assertEquals(
+                "datadog.smoketest.debugger.ServerDebuggerTestApplication.tracedMethodWithDeepException4",
+                snapshot.getStack().get(0).getFunction());
+            assertFullMethodCaptureArgs(snapshot.getCaptures().getReturn());
+            return true;
+          }
+          return false;
+        });
+  }
+
+  private void resetSnapshotsAndTraces() {
+    resetTraceListener();
+    traceReceived = false;
+    snapshotReceived = false;
+    snapshots.clear();
+    snapshotId0 = null;
+    snapshotId1 = null;
+    snapshotId2 = null;
+  }
+
+  private void assertFullMethodCaptureArgs(CapturedContext context) {
+    if (Platform.isJ9()) {
+      // skip for J9/OpenJ9 as we cannot get local variable debug info.
+      return;
+    }
+    assertCaptureArgs(context, "argInt", "int", "42");
+    assertCaptureArgs(context, "argStr", "java.lang.String", "foobar");
+    assertCaptureArgs(context, "argDouble", "double", "3.42");
+    assertCaptureArgs(context, "argMap", "java.util.HashMap", "{key1=val1, key2=val2, key3=val3}");
+    assertCaptureArgs(context, "argVar", "java.lang.String[]", "[var1, var2, var3]");
+  }
+
+  private void receiveExceptionReplayTrace(DecodedTrace decodedTrace) {
+    for (DecodedSpan span : decodedTrace.getSpans()) {
+      if (isTracedFullMethodSpan(span) && span.getMeta().containsKey("error.debug_info_captured")) {
+        // assert that we have received the trace with ER tags only once
+        assertNull(snapshotId0);
+        snapshotId0 = span.getMeta().get("_dd.debug.error.0.snapshot_id");
+        snapshotId1 = span.getMeta().get("_dd.debug.error.1.snapshot_id");
+        snapshotId2 = span.getMeta().get("_dd.debug.error.2.snapshot_id");
+        assertFalse(traceReceived);
+        traceReceived = true;
+      }
+    }
+  }
+
+  private void receiveSnapshot(Snapshot snapshot) {
+    snapshots.put(snapshot.getId(), snapshot);
+    snapshotReceived = true;
+  }
+}

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ServerAppDebuggerIntegrationTest.java
@@ -9,6 +9,7 @@ import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.sink.Snapshot;
 import com.squareup.moshi.JsonAdapter;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.test.agent.decoder.DecodedSpan;
 import datadog.trace.util.TagsHelper;
 import java.io.EOFException;
 import java.io.IOException;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
 public class ServerAppDebuggerIntegrationTest extends BaseIntegrationTest {
-  private static final String SERVER_DEBUGGER_TEST_APP_CLASS =
+  protected static final String SERVER_DEBUGGER_TEST_APP_CLASS =
       "datadog.smoketest.debugger.ServerDebuggerTestApplication";
   protected static final String CONTROL_URL = "/control";
   protected static final ProbeId PROBE_ID = new ProbeId("123356536", 0);
@@ -171,5 +172,10 @@ public class ServerAppDebuggerIntegrationTest extends BaseIntegrationTest {
   protected void sendRequest(String url) throws IOException {
     Request request = new Request.Builder().url(url).get().build();
     try (Response response = httpClient.newCall(request).execute()) {}
+  }
+
+  protected boolean isTracedFullMethodSpan(DecodedSpan span) {
+    return span.getName().equals("trace.annotation")
+        && span.getResource().equals("ServerDebuggerTestApplication.runTracedMethod");
   }
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanDecorationProbesIntegrationTests.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanDecorationProbesIntegrationTests.java
@@ -260,11 +260,6 @@ public class SpanDecorationProbesIntegrationTests extends ServerAppDebuggerInteg
     processRequests(() -> count.get() >= 100);
   }
 
-  private boolean isTracedFullMethodSpan(DecodedSpan span) {
-    return span.getName().equals("trace.annotation")
-        && span.getResource().equals("ServerDebuggerTestApplication.runTracedMethod");
-  }
-
   private SpanDecorationProbe.Decoration createDecoration(String tagName, String valueDsl) {
     List<SpanDecorationProbe.Tag> tags =
         Arrays.asList(


### PR DESCRIPTION
# What Does This Do
Verifies that basic Exception Replay is working as expected using a
`@trace` annotation
No new capture after the first one for an hour and only 3 frames are
captured

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2735]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2735]: https://datadoghq.atlassian.net/browse/DEBUG-2735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ