### PR TITLE
Fix grpc server error mark

### DIFF
--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/client/GrpcClientDecorator.java
@@ -115,10 +115,7 @@ public class GrpcClientDecorator extends ClientDecorator {
 
     // TODO why is there a mismatch between client / server for calling the onError method?
     onError(span, status.getCause());
-    if (CLIENT_ERROR_STATUSES.get(status.getCode().value())) {
-      span.setError(true);
-    }
-
+    span.setError(CLIENT_ERROR_STATUSES.get(status.getCode().value()));
     return span;
   }
 }

--- a/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/main/java/datadog/trace/instrumentation/armeria/grpc/server/GrpcServerDecorator.java
@@ -14,6 +14,8 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ServerDecorator;
 import io.grpc.ServerCall;
 import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 import java.util.BitSet;
 import java.util.LinkedHashMap;
 import java.util.function.Function;
@@ -97,15 +99,27 @@ public class GrpcServerDecorator extends ServerDecorator {
     return span;
   }
 
-  public AgentSpan onClose(final AgentSpan span, final Status status) {
+  public AgentSpan onStatus(final AgentSpan span, final Status status) {
     span.setTag("status.code", status.getCode().name());
     span.setTag("status.description", status.getDescription());
+    return span.setError(SERVER_ERROR_STATUSES.get(status.getCode().value()));
+  }
 
-    if (SERVER_ERROR_STATUSES.get(status.getCode().value())) {
+  public AgentSpan onClose(final AgentSpan span, final Status status) {
+    if (status.getCause() != null) {
       onError(span, status.getCause());
-      span.setError(true);
     }
+    return onStatus(span, status);
+  }
 
+  @Override
+  public AgentSpan onError(AgentSpan span, Throwable throwable) {
+    super.onError(span, throwable);
+    if (throwable instanceof StatusRuntimeException) {
+      onStatus(span, ((StatusRuntimeException) throwable).getStatus());
+    } else if (throwable instanceof StatusException) {
+      onStatus(span, ((StatusException) throwable).getStatus());
+    }
     return span;
   }
 }

--- a/dd-java-agent/instrumentation/armeria-grpc/src/test/groovy/ArmeriaGrpcTest.groovy
+++ b/dd-java-agent/instrumentation/armeria-grpc/src/test/groovy/ArmeriaGrpcTest.groovy
@@ -1,3 +1,5 @@
+import static datadog.trace.api.config.TraceInstrumentationConfig.GRPC_SERVER_ERROR_STATUSES
+
 import com.google.common.util.concurrent.ListenableFuture
 import com.linecorp.armeria.client.Clients
 import com.linecorp.armeria.common.SessionProtocol
@@ -74,6 +76,7 @@ abstract class ArmeriaGrpcTest extends VersionedNamingTestBase {
     // here to trigger wrapping to record scheduling time - the logic is trivial so it's enough to verify
     // that ClassCastExceptions do not arise from the wrapping
     injectSysConfig("dd.profiling.enabled", "true")
+    injectSysConfig(GRPC_SERVER_ERROR_STATUSES, "2-14", true)
   }
 
   @Override
@@ -436,12 +439,14 @@ abstract class ArmeriaGrpcTest extends VersionedNamingTestBase {
           resourceName "example.Greeter/SayHello"
           spanType DDSpanTypes.RPC
           childOf trace(0).get(0)
-          errored true
+          errored errorFlag
           measured true
           tags {
             "$Tags.COMPONENT" "armeria-grpc-server"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             errorTags error.class, error.message
+            "status.code" "${status.code.name()}"
+            "status.description"  { it == null || String}
             "canceled" { true } // 1.0.0 handles cancellation incorrectly so accesting any value
             if ({ isDataStreamsEnabled() }) {
               "$DDTags.PATHWAY_HASH" { String }
@@ -470,13 +475,15 @@ abstract class ArmeriaGrpcTest extends VersionedNamingTestBase {
     serverRule.stop().get()
 
     where:
-    name                          | status
-    "Runtime - cause"             | Status.UNKNOWN.withCause(new RuntimeException("some error"))
-    "Status - cause"              | Status.PERMISSION_DENIED.withCause(new RuntimeException("some error"))
-    "StatusRuntime - cause"       | Status.UNIMPLEMENTED.withCause(new RuntimeException("some error"))
-    "Runtime - description"       | Status.UNKNOWN.withDescription("some description")
-    "Status - description"        | Status.PERMISSION_DENIED.withDescription("some description")
-    "StatusRuntime - description" | Status.UNIMPLEMENTED.withDescription("some description")
+    name                                    | status                                                                  | errorFlag
+    "Runtime - cause"                       | Status.UNKNOWN.withCause(new RuntimeException("some error"))            | true
+    "Status - cause"                        | Status.PERMISSION_DENIED.withCause(new RuntimeException("some error"))  | true
+    "StatusRuntime - cause"                 | Status.UNIMPLEMENTED.withCause(new RuntimeException("some error"))      | true
+    "Runtime - description"                 | Status.UNKNOWN.withDescription("some description")                      | true
+    "Status - description"                  | Status.PERMISSION_DENIED.withDescription("some description")            | true
+    "StatusRuntime - description"           | Status.UNIMPLEMENTED.withDescription("some description")                | true
+    "StatusRuntime - Not errored no cause"   | Status.fromCodeValue(15).withDescription("some description")           | false
+    "StatusRuntime - Not errored with cause" | Status.fromCodeValue(15).withCause(new RuntimeException("some error")) | false
   }
 
   def "skip binary headers"() {
@@ -672,7 +679,7 @@ abstract class ArmeriaGrpcDataStreamsEnabledForkedTest extends ArmeriaGrpcTest {
   }
 }
 
-class ArmeriaGrpcDataStreamsEnabledV0ForkedTest extends ArmeriaGrpcDataStreamsEnabledForkedTest {
+class ArmeriaGrpcDataStreamsEnabledV0Test extends ArmeriaGrpcDataStreamsEnabledForkedTest {
 
   @Override
   int version() {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -115,10 +115,7 @@ public class GrpcClientDecorator extends ClientDecorator {
 
     // TODO why is there a mismatch between client / server for calling the onError method?
     onError(span, status.getCause());
-    if (CLIENT_ERROR_STATUSES.get(status.getCode().value())) {
-      span.setError(true);
-    }
-
+    span.setError(CLIENT_ERROR_STATUSES.get(status.getCode().value()));
     return span;
   }
 }

--- a/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/main/java/datadog/trace/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -14,6 +14,8 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ServerDecorator;
 import io.grpc.ServerCall;
 import io.grpc.Status;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 import java.util.BitSet;
 import java.util.LinkedHashMap;
 import java.util.function.Function;
@@ -97,15 +99,27 @@ public class GrpcServerDecorator extends ServerDecorator {
     return span;
   }
 
-  public AgentSpan onClose(final AgentSpan span, final Status status) {
+  public AgentSpan onStatus(final AgentSpan span, final Status status) {
     span.setTag("status.code", status.getCode().name());
     span.setTag("status.description", status.getDescription());
+    return span.setError(SERVER_ERROR_STATUSES.get(status.getCode().value()));
+  }
 
-    if (SERVER_ERROR_STATUSES.get(status.getCode().value())) {
+  public AgentSpan onClose(final AgentSpan span, final Status status) {
+    if (status.getCause() != null) {
       onError(span, status.getCause());
-      span.setError(true);
     }
+    return onStatus(span, status);
+  }
 
+  @Override
+  public AgentSpan onError(AgentSpan span, Throwable throwable) {
+    super.onError(span, throwable);
+    if (throwable instanceof StatusRuntimeException) {
+      onStatus(span, ((StatusRuntimeException) throwable).getStatus());
+    } else if (throwable instanceof StatusException) {
+      onStatus(span, ((StatusException) throwable).getStatus());
+    }
     return span;
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR fixes the way the grpc server spans are marked as errored. 

In fact, in case a server service was returning a status through a `StatusException` or `StatusRuntimeException`, the span was marked as errored (because `onError` generally does it) despite the fact  that `dd.grpc.server.error.statuses` was excluding it.

Now the `setError` on the span is called always. For info, a similar issue occurred for the http server decorator in the past and was due to the same buggy setError conditional logic.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-12919]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-12919]: https://datadoghq.atlassian.net/browse/APMS-12919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ