### PR TITLE
Ensure RASP call sites are only installed with appsec fully enabled

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/java/datadog/trace/instrumentation/iastinstrumenter/IastInstrumentation.java
@@ -37,8 +37,12 @@ public class IastInstrumentation extends CallSiteInstrumentation {
 
   @Override
   public boolean isApplicable(final Set<TargetSystem> enabledSystems) {
-    return enabledSystems.contains(TargetSystem.IAST)
-        || (enabledSystems.contains(TargetSystem.APPSEC) && Config.get().isAppSecRaspEnabled());
+    return enabledSystems.contains(TargetSystem.IAST) || isRaspEnabled();
+  }
+
+  private boolean isRaspEnabled() {
+    return InstrumenterConfig.get().getAppSecActivation() == ProductActivation.FULLY_ENABLED
+        && Config.get().isAppSecRaspEnabled();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/test/groovy/IastInstrumentationTest.groovy
@@ -1,35 +1,10 @@
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.tooling.InstrumenterModule
-import datadog.trace.api.config.AppSecConfig
 import datadog.trace.api.config.IastConfig
 import datadog.trace.instrumentation.iastinstrumenter.IastHardcodedSecretListener
 import datadog.trace.instrumentation.iastinstrumenter.IastInstrumentation
 import net.bytebuddy.description.type.TypeDescription
 
 class IastInstrumentationTest extends AgentTestRunner {
-
-  void 'test Iast Instrumentation enablement'() {
-    given:
-    injectSysConfig(AppSecConfig.APPSEC_RASP_ENABLED, Boolean.toString(rasp))
-    final instrumentation = new IastInstrumentation()
-
-    when:
-    final enabled = instrumentation.isEnabled()
-    final applicable = instrumentation.isApplicable(enabledSystems as Set<InstrumenterModule.TargetSystem>)
-
-    then:
-    enabled
-    applicable == expected
-
-    where:
-    enabledSystems                                                                 | rasp  | expected
-    []                                                                             | false | false
-    [InstrumenterModule.TargetSystem.APPSEC]                                       | false | false
-    [InstrumenterModule.TargetSystem.IAST]                                         | false | true
-    [InstrumenterModule.TargetSystem.APPSEC]                                       | true  | true
-    [InstrumenterModule.TargetSystem.IAST, InstrumenterModule.TargetSystem.APPSEC] | false | true
-    [InstrumenterModule.TargetSystem.IAST, InstrumenterModule.TargetSystem.APPSEC] | true  | true
-  }
 
   void 'test Iast Instrumentation type matching'() {
     given:


### PR DESCRIPTION
# What Does This Do
Makes sure that RASP call sites are not installed unless appsec is explicitly enabled.

# Motivation
Call sites should be rolled on to customers which are explicitly setting appsec to active, once it's stable enough we will change it so it's enabled with appsec set as inactive.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
