### PR TITLE
Enable WAF generate_stack action by default

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -477,11 +477,14 @@ public class PowerWAFModule implements AppSecModule {
           } else if ("redirect_request".equals(actionInfo.type)) {
             Flow.Action.RequestBlockingAction rba = createRedirectRequestAction(actionInfo);
             flow.setAction(rba);
-          } else if ("generate_stack".equals(actionInfo.type)
-              && Config.get().isAppSecStackTraceEnabled()) {
-            String stackId = (String) actionInfo.parameters.get("stack_id");
-            StackTraceEvent stackTraceEvent = createExploitStackTraceEvent(stackId);
-            reqCtx.reportStackTrace(stackTraceEvent);
+          } else if ("generate_stack".equals(actionInfo.type)) {
+            if (Config.get().isAppSecStackTraceEnabled()) {
+              String stackId = (String) actionInfo.parameters.get("stack_id");
+              StackTraceEvent stackTraceEvent = createExploitStackTraceEvent(stackId);
+              reqCtx.reportStackTrace(stackTraceEvent);
+            } else {
+              log.debug("Ignoring action with type generate_stack (disabled by config)");
+            }
           } else {
             log.info("Ignoring action with type {}", actionInfo.type);
           }

--- a/dd-java-agent/appsec/src/test/resources/test_multi_config.json
+++ b/dd-java-agent/appsec/src/test/resources/test_multi_config.json
@@ -3803,7 +3803,33 @@
         }
       ],
       "transformers": [],
-      "on_match": ["block", "stack_trace"]
+      "on_match": ["block"]
+    },
+    {
+      "id": "generate-stacktrace-on-scanner",
+      "name": "Arachni",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^Arachni\\/generate-stacktrace"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": [],
+      "on_match": ["stack_trace"]
     },
     {
       "id": "ua0-600-13x",

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -295,6 +295,9 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       }
     }
     assert trigger != null, 'test trigger not found'
+    rootSpan.span.metaStruct != null
+    def stack = rootSpan.span.metaStruct.get('_dd.stack')
+    assert stack != null, 'stack is not set'
   }
 
   void 'rasp blocks on sql injection'() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -103,7 +103,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_API_SECURITY_ENABLED = false;
   static final float DEFAULT_API_SECURITY_REQUEST_SAMPLE_RATE = 0.1f; // 10 %
   static final boolean DEFAULT_APPSEC_RASP_ENABLED = false;
-  static final boolean DEFAULT_APPSEC_STACK_TRACE_ENABLED = false;
+  static final boolean DEFAULT_APPSEC_STACK_TRACE_ENABLED = true;
   static final int DEFAULT_APPSEC_MAX_STACK_TRACES = 2;
   static final int DEFAULT_APPSEC_MAX_STACK_TRACE_DEPTH = 32;
   static final String DEFAULT_IAST_ENABLED = "false";

--- a/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/DecodedSpan.java
+++ b/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/DecodedSpan.java
@@ -23,6 +23,8 @@ public interface DecodedSpan {
 
   Map<String, String> getMeta();
 
+  Map<String, Object> getMetaStruct();
+
   Map<String, Number> getMetrics();
 
   String getType();

--- a/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v05/raw/SpanV05.java
+++ b/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v05/raw/SpanV05.java
@@ -188,6 +188,11 @@ public class SpanV05 implements DecodedSpan {
     return meta;
   }
 
+  public Map<String, Object> getMetaStruct() {
+    // XXX: meta_struct is not supported in v0.5.
+    return null;
+  }
+
   public Map<String, Number> getMetrics() {
     return metrics;
   }


### PR DESCRIPTION
# What Does This Do
Enable `generate_stack` WAF action by default. These will only be emitted by RASP (aka Exploit Prevention) at the moment.

To support smoke tests, also added support to decode meta_struct in SpanV04.

# Motivation
There is little reason for anyone to disable this, except the need to troubleshoot or workaround a bug.

This PR is part of enabling RASP for AppSec users.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [APPSEC-53837](https://datadoghq.atlassian.net/browse/APPSEC-53837) (partially)

[APPSEC-53837]: https://datadoghq.atlassian.net/browse/APPSEC-53837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ