### PR TITLE
Fix Gradle Daemon process detection

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/ProcessHierarchyUtils.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/ProcessHierarchyUtils.java
@@ -38,7 +38,11 @@ public abstract class ProcessHierarchyUtils {
   }
 
   private static boolean isGradleDaemon() {
-    return ClassLoader.getSystemClassLoader().getResource("org/gradle/launcher/daemon/") != null;
+    return ClassLoader.getSystemClassLoader()
+                .getResource("org/gradle/launcher/daemon/bootstrap/GradleDaemon.class")
+            != null
+        // double-check this is not a Gradle Worker
+        && System.getProperties().getProperty("org.gradle.internal.worker.tmpdir") == null;
   }
 
   public static long getParentSessionId() {


### PR DESCRIPTION
# What Does This Do

Fixes the logic that determines whether the tracer is attached to a JVM that runs Gradle Daemon.

# Additional Notes

Previous version of the logic only relied on `org/gradle/launcher/daemon/` package being present on the classpath.
This failed when the traced process was a Gradle Worker that ran tests for a Gradle Plugin (and as a consequence had plugin API classes on its classpath, some of which lived in `org/gradle/launcher/daemon/` package).

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [CIVIS-10218]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[CIVIS-10218]: https://datadoghq.atlassian.net/browse/CIVIS-10218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ