### PR TITLE
Disabled flaky tests for IBM JVM

### DIFF
--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeStateIntegrationTest.java
@@ -126,6 +126,7 @@ public class ProbeStateIntegrationTest extends ServerAppDebuggerIntegrationTest 
 
   @Test
   @DisplayName("testProbeStatusError")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   public void testProbeStatusError() throws Exception {
     LogProbe logProbe =
         LogProbe.builder()

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanDecorationProbesIntegrationTests.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanDecorationProbesIntegrationTests.java
@@ -116,6 +116,7 @@ public class SpanDecorationProbesIntegrationTests extends ServerAppDebuggerInteg
 
   @Test
   @DisplayName("testMethodSimpleTagValueError")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   void testMethodSimpleTagValueError() throws Exception {
     SpanDecorationProbe spanDecorationProbe =
         SpanDecorationProbe.builder()
@@ -152,6 +153,7 @@ public class SpanDecorationProbesIntegrationTests extends ServerAppDebuggerInteg
 
   @Test
   @DisplayName("testMethodSimpleTagConditionError")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   void testMethodSimpleTagConditionError() throws Exception {
     SpanDecorationProbe spanDecorationProbe =
         SpanDecorationProbe.builder()
@@ -190,6 +192,7 @@ public class SpanDecorationProbesIntegrationTests extends ServerAppDebuggerInteg
 
   @Test
   @DisplayName("testMethodMultiTagValueError")
+  @DisabledIf(value = "datadog.trace.api.Platform#isJ9", disabledReason = "Flaky on J9 JVMs")
   void testMethodMultiTagValueError() throws Exception {
     List<SpanDecorationProbe.Decoration> decorations =
         Arrays.asList(


### PR DESCRIPTION
# What Does This Do

# Motivation
Falky tests

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
