### PR TITLE
Support Span.addLink()

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/build.gradle
+++ b/dd-java-agent/agent-otel/otel-shim/build.gradle
@@ -5,7 +5,7 @@ minimumBranchCoverage = 0.0
 
 dependencies {
   // minimum OpenTelemetry API version this shim is compatible with
-  compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.4.0'
+  compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.37.0'
 
   implementation project(':internal-api')
 }

--- a/dd-java-agent/agent-otel/otel-shim/build.gradle
+++ b/dd-java-agent/agent-otel/otel-shim/build.gradle
@@ -5,7 +5,7 @@ minimumBranchCoverage = 0.0
 
 dependencies {
   // minimum OpenTelemetry API version this shim is compatible with
-  compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.37.0'
+  compileOnly group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.4.0'
 
   implementation project(':internal-api')
 }

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -81,7 +81,6 @@ public class OtelSpan implements Span {
     return this;
   }
 
-  //   @Override <- once io.opentelemetry.api upgrade takes effect
   public Span addLink(SpanContext spanContext) {
     if (spanContext != null && spanContext.isValid() && this.recording) {
       this.delegate.addLink(new OtelSpanLink(spanContext));
@@ -89,7 +88,6 @@ public class OtelSpan implements Span {
     return this;
   }
 
-  // @Override <- once io.opentelemetry.api upgrade takes effect
   public Span addLink(SpanContext spanContext, Attributes attributes) {
     if (spanContext != null && spanContext.isValid() && this.recording) {
       this.delegate.addLink(new OtelSpanLink(spanContext, attributes));

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -9,7 +9,6 @@ import static io.opentelemetry.api.trace.StatusCode.UNSET;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
 import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import io.opentelemetry.api.common.AttributeKey;
@@ -19,7 +18,6 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -29,7 +27,6 @@ public class OtelSpan implements Span {
   private final AgentSpan delegate;
   private StatusCode statusCode;
   private boolean recording;
-  private List<AgentSpanLink> links;
 
   public OtelSpan(AgentSpan delegate) {
     this.delegate = delegate;
@@ -38,7 +35,6 @@ public class OtelSpan implements Span {
     }
     this.statusCode = UNSET;
     this.recording = true;
-    this.links = new ArrayList<AgentSpanLink>();
   }
 
   public static Span invalid() {
@@ -85,7 +81,7 @@ public class OtelSpan implements Span {
     return this;
   }
 
-  // @Override
+  //   @Override <- once io.opentelemetry.api upgrade takes effect
   public Span addLink(SpanContext spanContext) {
     if (spanContext != null && spanContext.isValid() && this.recording) {
       this.delegate.addLink(new OtelSpanLink(spanContext));
@@ -93,7 +89,7 @@ public class OtelSpan implements Span {
     return this;
   }
 
-  // @Override
+  // @Override <- once io.opentelemetry.api upgrade takes effect
   public Span addLink(SpanContext spanContext, Attributes attributes) {
     if (spanContext != null && spanContext.isValid() && this.recording) {
       this.delegate.addLink(new OtelSpanLink(spanContext, attributes));

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.api.trace.StatusCode.UNSET;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
 import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import io.opentelemetry.api.common.AttributeKey;
@@ -18,6 +19,7 @@ import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -27,6 +29,7 @@ public class OtelSpan implements Span {
   private final AgentSpan delegate;
   private StatusCode statusCode;
   private boolean recording;
+  private List<AgentSpanLink> links;
 
   public OtelSpan(AgentSpan delegate) {
     this.delegate = delegate;
@@ -35,6 +38,7 @@ public class OtelSpan implements Span {
     }
     this.statusCode = UNSET;
     this.recording = true;
+    this.links = new ArrayList<AgentSpanLink>();
   }
 
   public static Span invalid() {
@@ -78,6 +82,22 @@ public class OtelSpan implements Span {
   @Override
   public Span addEvent(String name, Attributes attributes, long timestamp, TimeUnit unit) {
     // Not supported
+    return this;
+  }
+
+  // @Override
+  public Span addLink(SpanContext spanContext) {
+    if (spanContext != null && spanContext.isValid() && this.recording) {
+      this.delegate.addLink(new OtelSpanLink(spanContext));
+    }
+    return this;
+  }
+
+  // @Override
+  public Span addLink(SpanContext spanContext, Attributes attributes) {
+    if (spanContext != null && spanContext.isValid() && this.recording) {
+      this.delegate.addLink(new OtelSpanLink(spanContext, attributes));
+    }
     return this;
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/build.gradle
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/build.gradle
@@ -1,4 +1,4 @@
-def openTelemetryVersion = '1.4.0'
+def openTelemetryVersion = '1.37.0'
 
 muzzle {
   pass {

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -268,12 +268,13 @@ class OpenTelemetry14Test extends AgentTestRunner {
     }
   }
 
-  def "test multiple span links"() {
+  def "test multiple span links via SpanBuilder and Span"() {
     setup:
     def spanBuilder = tracer.spanBuilder("some-name")
 
     when:
     def links = []
+    // Add links on SpanBuilder
     0..9.each {
       def traceId = "1234567890abcdef1234567890abcde$it" as String
       def spanId = "fedcba098765432$it" as String
@@ -285,9 +286,10 @@ class OpenTelemetry14Test extends AgentTestRunner {
       spanBuilder.addLink(SpanContext.create(traceId, spanId, TraceFlags.getSampled(), traceState))
     }
     def span1 = spanBuilder.startSpan()
+    // Add links on Span
     10..19.each {
-      def traceId = "1234567890abcdef1234567890abcde$it" as String
-      def spanId = "fedcba098765432$it" as String
+      def traceId = "234567890abcdef1234567890abcde$it" as String
+      def spanId = "edcba098765432$it" as String
       def traceState = TraceState.builder().put('string-key', 'string-value'+it).build()
       links << """{ trace_id: "${traceId}",
         span_id: "${spanId}",
@@ -295,9 +297,8 @@ class OpenTelemetry14Test extends AgentTestRunner {
         tracestate: "string-key=string-value$it"}"""
       span1.addLink(SpanContext.create(traceId, spanId, TraceFlags.getSampled(), traceState))
     }
-    def expectedLinksTag = "[${links.join(',')}]" as String
-
     span1.end()
+    def expectedLinksTag = "[${links.join(',')}]" as String
 
     then:
     assertTraces(1) {

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/groovy/OpenTelemetry14Test.groovy
@@ -202,14 +202,14 @@ class OpenTelemetry14Test extends AgentTestRunner {
     setup:
     def traceId = "1234567890abcdef1234567890abcdef" as String
     def spanId = "fedcba0987654321" as String
-    def traceState = TraceState.builder().put("string-key1", "string-value1").build()
+    def traceState = TraceState.builder().put("string-key", "string-value").build()
 
     def expectedLinksTag = """
     [
       { trace_id: "${traceId}",
         span_id: "${spanId}",
         flags: 1,
-        tracestate: "string-key1=string-value1"}
+        tracestate: "string-key=string-value"}
     ]"""
 
     when:
@@ -238,8 +238,6 @@ class OpenTelemetry14Test extends AgentTestRunner {
     def traceId = "1234567890abcdef1234567890abcdef" as String
     def spanId = "fedcba0987654321" as String
     def traceState = TraceState.builder().put("string-key1", "string-value1").build()
-    //    def traceId2 = "234567890abcdef1234567890abcdef1" as String
-    //    def spanId2 = "edcba0987654321f"
 
     def expectedLinksTag = """
     [
@@ -364,7 +362,7 @@ class OpenTelemetry14Test extends AgentTestRunner {
     false       | Attributes.builder().put("string-key-array", "string-value1", "string-value2", "string-value3").put("long-key-array", 123456L, 1234567L, 12345678L).put("double-key-array", 1234.5D, 1234.56D, 1234.567D).put("boolean-key-array", true, false, true).build() | '{ string-key-array.0: "string-value1", string-key-array.1: "string-value2", string-key-array.2: "string-value3", long-key-array.0: "123456", long-key-array.1: "1234567", long-key-array.2: "12345678", double-key-array.0: "1234.5", double-key-array.1: "1234.56", double-key-array.2: "1234.567", boolean-key-array.0: "true", boolean-key-array.1: "false", boolean-key-array.2: "true" }'
   }
 
-  def "test SpanBuilder links trace state"() {
+  def "test span links trace state"() {
     setup:
     def traceId = "1234567890abcdef1234567890abcdef" as String
     def spanId = "fedcba0987654321" as String

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -112,7 +112,7 @@ public class DDSpan
    */
   private volatile int longRunningVersion = 0;
 
-  private final List<AgentSpanLink> links;
+  private List<AgentSpanLink> links;
 
   /**
    * Spans should be constructed using the builder, not by calling the constructor directly.


### PR DESCRIPTION
# What Does This Do
Supports adding span links to a span that's already been started. Up to this point, we only supported adding span links to a SpanBuilder.

# Motivation
[APMAPI-190](https://datadoghq.atlassian.net/browse/APMAPI-190)
Compliance with [opentelemetry-java 1.37.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.37.0), which added support for Span.addLink

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-190]: https://datadoghq.atlassian.net/browse/APMAPI-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ