### PR TITLE
Enable telemetry logs for services using AppSec

### DIFF
--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
@@ -91,12 +91,14 @@ public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher {
   // DDLoggerFactory can be called at very early stage, before Config is loaded
   // So to get property/env we use this custom function
   private static boolean isLogCollectionEnabled() {
-    // FIXME: For the initial rollout, we default log collection to true for IAST and CI Visibility
+    // FIXME: For the initial rollout, we default log collection to true for IAST, Dynamic
+    // Instrumentation, and CI Visibility
     // FIXME: For progressive rollout, we include by default Java < 11 hosts as product independent
     // FIXME: sample users.
     // FIXME: This should be removed once we default to true.
     final boolean defaultValue =
         isFlagEnabled("dd.iast.enabled", "DD_IAST_ENABLED", false)
+            || isFlagEnabled("dd.appsec.enabled", "DD_APPSEC_ENABLED", false)
             || isFlagEnabled("dd.civisibility.enabled", "DD_CIVISIBILITY_ENABLED", false)
             || isFlagEnabled(
                 "dd.dynamic.instrumentation.enabled", "DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -2012,7 +2012,8 @@ public class Config {
     // together with the rest of telemetry config.
     final boolean telemetryLogCollectionEnabledDefault =
         instrumenterConfig.isTelemetryEnabled()
-                && (instrumenterConfig.getIastActivation() == ProductActivation.FULLY_ENABLED
+                && (instrumenterConfig.getAppSecActivation() == ProductActivation.FULLY_ENABLED
+                    || instrumenterConfig.getIastActivation() == ProductActivation.FULLY_ENABLED
                     || instrumenterConfig.isCiVisibilityEnabled()
                     || debuggerEnabled
                     || !Platform.isJavaVersionAtLeast(11))


### PR DESCRIPTION
# What Does This Do
Default telemetry logs to enabled for services with `DD_APPSEC_ENABLED=true`.

# Motivation
As we rollout Exploit Prevention, we'd like to be sure to catch any unexpected error.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
