### PR TITLE
Free AppSecRequestContext resources when the request ends

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -11,6 +11,8 @@ import com.datadog.appsec.util.StandardizedLogging;
 import datadog.trace.api.Config;
 import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.api.internal.TraceSegment;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import io.sqreen.powerwaf.Additive;
 import io.sqreen.powerwaf.PowerwafContext;
 import io.sqreen.powerwaf.PowerwafMetrics;
@@ -89,7 +91,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private String savedRawURI;
   private final Map<String, List<String>> requestHeaders = new LinkedHashMap<>();
   private final Map<String, List<String>> responseHeaders = new LinkedHashMap<>();
-  private Map<String, List<String>> collectedCookies;
+  private volatile Map<String, List<String>> collectedCookies;
   private boolean finishedRequestHeaders;
   private boolean finishedResponseHeaders;
   private String peerAddress;
@@ -106,13 +108,13 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   private boolean convertedReqBodyPublished;
   private boolean respDataPublished;
   private boolean pathParamsPublished;
-  private Map<String, String> derivatives;
+  private volatile Map<String, String> derivatives;
 
   private final AtomicBoolean rateLimited = new AtomicBoolean(false);
   private volatile boolean throttled;
 
   // should be guarded by this
-  private Additive additive;
+  private volatile Additive additive;
   // set after additive is set
   private volatile PowerwafMetrics wafMetrics;
   private volatile PowerwafMetrics raspMetrics;
@@ -197,12 +199,14 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   }
 
   public void closeAdditive() {
-    synchronized (this) {
-      if (additive != null) {
-        try {
-          additive.close();
-        } finally {
-          additive = null;
+    if (additive != null) {
+      synchronized (this) {
+        if (additive != null) {
+          try {
+            additive.close();
+          } finally {
+            additive = null;
+          }
         }
       }
     }
@@ -419,19 +423,32 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   @Override
   public void close() {
-    synchronized (this) {
-      if (additive == null) {
-        return;
-      }
-    }
-
-    log.warn("WAF object had not been closed (probably missed request-end event)");
-    closeAdditive();
+    final AgentSpan span = AgentTracer.activeSpan();
+    close(span != null && span.isRequiresPostProcessing());
   }
 
   /* end interface for GatewayBridge */
 
   /* Should be accessible from the modules */
+
+  public void close(boolean requiresPostProcessing) {
+    if (additive != null || derivatives != null) {
+      log.warn("WAF object had not been closed (probably missed request-end event)");
+      closeAdditive();
+      derivatives = null;
+    }
+
+    // check if we might need to further post process data related to the span in order to not free
+    // related data
+    if (requiresPostProcessing) {
+      return;
+    }
+
+    collectedCookies = null;
+    requestHeaders.clear();
+    responseHeaders.clear();
+    persistentData.clear();
+  }
 
   /** @return the portion of the body read so far, if any */
   public CharSequence getStoredRequestBody() {
@@ -516,6 +533,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
       return false;
     }
     derivatives.forEach(traceSegment::setTagTop);
+    derivatives = null;
     return true;
   }
 

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -244,4 +244,32 @@ class AppSecRequestContextSpecification extends DDSpecification {
     0 * rateLimiter.isThrottled()
     result == result2
   }
+
+
+  void 'test that internal data is cleared on close'() {
+    setup:
+    final ctx = new AppSecRequestContext()
+    final fullCleanup = !postProcessing
+
+    when:
+    ctx.requestHeaders.put('Accept', ['*'])
+    ctx.responseHeaders.put('Content-Type', ['text/plain'])
+    ctx.collectedCookies = [cookie : ['test']]
+    ctx.persistentData.put(KnownAddresses.REQUEST_METHOD, 'GET')
+    ctx.derivatives = ['a': 'b']
+    ctx.additive = createAdditive()
+    ctx.close(postProcessing)
+
+    then:
+    ctx.additive == null
+    ctx.derivatives == null
+
+    ctx.requestHeaders.isEmpty() == fullCleanup
+    ctx.responseHeaders.isEmpty() == fullCleanup
+    ctx.cookies.isEmpty() == fullCleanup
+    ctx.persistentData.isEmpty() == fullCleanup
+
+    where:
+    postProcessing << [true, false]
+  }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/GatewayBridgeSpecification.groovy
@@ -8,6 +8,7 @@ import com.datadog.appsec.event.data.DataBundle
 import com.datadog.appsec.event.data.KnownAddresses
 import com.datadog.appsec.report.AppSecEvent
 import com.datadog.appsec.report.AppSecEventWrapper
+import datadog.trace.api.Config
 import datadog.trace.api.function.TriConsumer
 import datadog.trace.api.function.TriFunction
 import datadog.trace.api.gateway.BlockResponseFunction
@@ -137,7 +138,7 @@ class GatewayBridgeSpecification extends DDSpecification {
     1 * spanInfo.getTags() >> ['http.client_ip':'1.1.1.1']
     1 * mockAppSecCtx.transferCollectedEvents() >> [event]
     1 * mockAppSecCtx.peerAddress >> '2001::1'
-    1 * mockAppSecCtx.close()
+    1 * mockAppSecCtx.close(false)
     1 * traceSegment.setTagTop("_dd.appsec.enabled", 1)
     1 * traceSegment.setTagTop("_dd.runtime_family", "jvm")
     1 * traceSegment.setTagTop('appsec.event', true)

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -832,6 +832,11 @@ public class DDSpan
     }
   }
 
+  @Override
+  public boolean isRequiresPostProcessing() {
+    return context.isRequiresPostProcessing();
+  }
+
   // to be accessible in Spock spies, which the field wouldn't otherwise be
   public long getStartTimeNano() {
     return startTimeNano;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -141,6 +141,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo, ImplicitContextKeyed
 
   void addLink(AgentSpanLink link);
 
+  boolean isRequiresPostProcessing();
+
   @Override
   default ScopedContext storeInto(ScopedContext context) {
     return context.with(ScopedContextKey.SPAN_KEY, this);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -855,6 +855,11 @@ public class AgentTracer {
     public AgentSpan setMetaStruct(String field, Object value) {
       return this;
     }
+
+    @Override
+    public boolean isRequiresPostProcessing() {
+      return false;
+    }
   }
 
   public static final class NoopAgentScope implements AgentScope {


### PR DESCRIPTION
# What Does This Do
Free all retained data structures by the `AppSecRequestContext` when the request ends.

# Motivation
When the span holding the reference to the `AppSecRequestContext` is in pending state, there is a lot of data retained by AppSec (headers, cookies, addresses...) that are no longer required as they have already being flushed to the span. The only catch is for the cases were additional post processing is required (e.g. API security).

# Additional Notes
Screenshots with the retained sizes of `AppSecRequestContext`:
Before
![image](https://github.com/user-attachments/assets/0630c9d8-97d3-4b5a-a1e2-95d2c4850bbf)
After
![image](https://github.com/user-attachments/assets/6cf2c3a1-96ed-476a-8ebf-e0627d9fb9db)

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
