### PR TITLE
Avoid StringBuilder.append(String) for single character

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -322,7 +322,7 @@ public class DebuggerSinkTest {
     DebuggerSink sink = createDebuggerSink(diagnosticUploader, false);
     StringBuilder largeMessageBuilder = new StringBuilder(100_001);
     for (int i = 0; i < 100_000; i++) {
-      largeMessageBuilder.append("f");
+      largeMessageBuilder.append('f');
     }
     String largeMessage = largeMessageBuilder.toString();
     for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
This PR was created by Datadog to remediate the following rule violations:
- :orange_circle: [java-best-practices/sb-append-char](https://dd-dev-local.datad0g.com/ci/code-analysis/github.com%2Fdatadog%2Fdd-trace-java/malvarez%2Fappsec-free-memmory/cb17622578860ea25a052b5f75a84e5b1b0e0c4f/?staticAnalysisId=)