### PR TITLE
Add missing parallelization to z_test_8_ssi_smoke job

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1313,6 +1313,8 @@ build_test_jobs: &build_test_jobs
       gradleParameters: "-PskipFlakyTests"
       stage: smoke
       cacheType: smoke
+      parallelism: 4
+      maxWorkers: 3
       testJvm: "8"
 
   - fan_in:


### PR DESCRIPTION
# What Does This Do
Add missing parallelization to z_test_8_ssi_smoke job. Same parameters as the rest of smoke test job.

# Motivation
`z_test_8_ssi_smoke job` is taking 27 minutes, delaying the overall pipeline time.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
