### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yaml
+++ b/.github/workflows/add-milestone-to-pull-requests.yaml
@@ -9,7 +9,8 @@ jobs:
   add_milestone_to_merged:
     name: Add milestone to merged pull requests
     permissions:
-      issues: write # Required to update the milestone of a pull request
+      issues: read # Required to list milestones
+      pull-requests: write # Required to update the milestone of a pull request
     if: github.event.pull_request.merged && github.event.pull_request.milestone == null
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# What Does This Do

This PR fixes workflow permission regression introduced by #7531 

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [VULN-8166]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[VULN-8166]: https://datadoghq.atlassian.net/browse/VULN-8166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ