### PR TITLE
Revert "Updated ASM rules to 1.13.1 (#7536)"

### DIFF
--- a/dd-java-agent/appsec/src/main/resources/default_config.json
+++ b/dd-java-agent/appsec/src/main/resources/default_config.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.13.1"
+    "rules_version": "1.13.0"
   },
   "rules": [
     {
@@ -6239,6 +6239,7 @@
     {
       "id": "rasp-930-100",
       "name": "Local file inclusion exploit",
+      "enabled": false,
       "tags": {
         "type": "lfi",
         "category": "vulnerability_trigger",
@@ -6287,6 +6288,7 @@
     {
       "id": "rasp-932-100",
       "name": "Shell injection exploit",
+      "enabled": false,
       "tags": {
         "type": "command_injection",
         "category": "vulnerability_trigger",
@@ -6335,6 +6337,7 @@
     {
       "id": "rasp-934-100",
       "name": "Server-side request forgery exploit",
+      "enabled": false,
       "tags": {
         "type": "ssrf",
         "category": "vulnerability_trigger",
@@ -6383,6 +6386,7 @@
     {
       "id": "rasp-942-100",
       "name": "SQL injection exploit",
+      "enabled": false,
       "tags": {
         "type": "sql_injection",
         "category": "vulnerability_trigger",


### PR DESCRIPTION
# What Does This Do

This reverts commit 44c20d2736298bc5eab9bdc868daeb3151104085 (https://github.com/DataDog/dd-trace-java/pull/7536).

# Motivation
Rollout of the Exploit Prevention rules enabled by default is delayed.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
