### PR TITLE
Add collection of local var for method probe

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -293,6 +293,30 @@ public class ASMHelper {
     return false;
   }
 
+  public static boolean isStoreCompatibleType(
+      org.objectweb.asm.Type previousType, org.objectweb.asm.Type currentType) {
+    if (previousType == null || currentType == null) {
+      return false;
+    }
+    if (previousType.getSort() == currentType.getSort()) {
+      return true;
+    }
+    int previousSort = widenIntType(previousType.getSort());
+    int currentSort = widenIntType(currentType.getSort());
+    return previousSort == currentSort;
+  }
+
+  private static int widenIntType(int sort) {
+    switch (sort) {
+      case org.objectweb.asm.Type.BOOLEAN:
+      case org.objectweb.asm.Type.BYTE:
+      case org.objectweb.asm.Type.CHAR:
+      case org.objectweb.asm.Type.SHORT:
+        return org.objectweb.asm.Type.INT;
+    }
+    return sort;
+  }
+
   /** Wraps ASM's {@link org.objectweb.asm.Type} with associated generic types */
   public static class Type {
     private final org.objectweb.asm.Type mainType;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -40,7 +40,12 @@ import datadog.trace.bootstrap.debugger.util.Redaction;
 import datadog.trace.util.Strings;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
@@ -67,6 +72,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
   private int exitContextVar = -1;
   private int timestampStartVar = -1;
   private int throwableListVar = -1;
+  private Collection<LocalVariableNode> unscopedLocalVars;
 
   public CapturedContextInstrumentor(
       ProbeDefinition definition,
@@ -386,6 +392,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
     if (methodNode.tryCatchBlocks.size() > 0) {
       throwableListVar = declareThrowableList(insnList);
     }
+    unscopedLocalVars = initLocalVars(insnList);
     insnList.add(contextInitLabel);
     if (definition instanceof SpanDecorationProbe
         && definition.getEvaluateAt() == MethodLocation.EXIT) {
@@ -449,6 +456,76 @@ public class CapturedContextInstrumentor extends Instrumentor {
     // stack []
     insnList.add(gotoNode);
     methodNode.instructions.insert(methodEnterLabel, insnList);
+  }
+
+  private Collection<LocalVariableNode> initLocalVars(InsnList insnList) {
+    if (methodNode.localVariables == null || methodNode.localVariables.isEmpty()) {
+      return Collections.emptyList();
+    }
+    Map<String, LocalVariableNode> localVarsByName = new HashMap<>();
+    Set<String> duplicateNames = new HashSet<>();
+    for (LocalVariableNode localVar : methodNode.localVariables) {
+      int idx = localVar.index - localVarBaseOffset;
+      if (idx < argOffset) {
+        // this is an argument
+        continue;
+      }
+      if (!checkDuplicateLocalVar(localVar, localVarsByName)) {
+        duplicateNames.add(localVar.name);
+      }
+    }
+    for (String name : duplicateNames) {
+      localVarsByName.remove(name);
+    }
+    for (LocalVariableNode localVar : localVarsByName.values()) {
+      Type localVarType = getType(localVar.desc);
+      switch (localVarType.getSort()) {
+        case Type.BOOLEAN:
+        case Type.CHAR:
+        case Type.BYTE:
+        case Type.SHORT:
+        case Type.INT:
+          insnList.add(new InsnNode(Opcodes.ICONST_0));
+          break;
+        case Type.LONG:
+          insnList.add(new InsnNode(Opcodes.LCONST_0));
+          break;
+        case Type.FLOAT:
+          insnList.add(new InsnNode(Opcodes.FCONST_0));
+          break;
+        case Type.DOUBLE:
+          insnList.add(new InsnNode(Opcodes.DCONST_0));
+          break;
+        default:
+          insnList.add(new InsnNode(Opcodes.ACONST_NULL));
+          break;
+      }
+      insnList.add(new VarInsnNode(localVarType.getOpcode(Opcodes.ISTORE), localVar.index));
+    }
+    return localVarsByName.values();
+  }
+
+  private boolean checkDuplicateLocalVar(
+      LocalVariableNode localVar, Map<String, LocalVariableNode> localVarsByName) {
+    LocalVariableNode previousVar = localVarsByName.putIfAbsent(localVar.name, localVar);
+    if (previousVar == null) {
+      return true;
+    }
+    // there are multiple local variables with the same name
+    // checking type to see if they  are compatible
+    Type previousType = getType(previousVar.desc);
+    Type currentType = getType(localVar.desc);
+    if (!ASMHelper.isStoreCompatibleType(previousType, currentType)) {
+      reportWarning(
+          "Local variable "
+              + localVar.name
+              + " has multiple definitions with incompatible types: "
+              + previousVar.desc
+              + " and "
+              + localVar.desc);
+      return false;
+    }
+    return true;
   }
 
   private void createInProbeFinallyHandler(LabelNode inProbeStartLabel, LabelNode inProbeEndLabel) {
@@ -554,15 +631,17 @@ public class CapturedContextInstrumentor extends Instrumentor {
     // stack: [capturedcontext]
     collectCorrelationInfo(insnList);
     // stack: [capturedcontext]
-    if (kind != Snapshot.Kind.UNHANDLED_EXCEPTION) {
-      /*
-       * It makes no sense collecting local variables for exceptions - the ones contributing to the exception
-       * are most likely to be outside of the scope in the exception handler block and there is no way to figure
-       * out the originating location just from bytecode.
-       */
-      collectLocalVariables(location, insnList);
-      // stack: [capturedcontext]
-    }
+    /*
+     * It makes no sense collecting local variables for exceptions - the ones contributing to the exception
+     * are most likely to be outside of the scope in the exception handler block and there is no way to figure
+     * out the originating location just from bytecode.
+     *
+     * However, it is very useful, in particular for Exception Debugging (Replay) to collect local variables.
+     * Thus, we are hoisting the local variable scope by initializing them at the beginning of the method
+     * with the method initLocalVars. It allows us to collect local variables at any point.
+     */
+    collectLocalVariables(location, insnList);
+    // stack: [capturedcontext]
     if (kind == Snapshot.Kind.RETURN) {
       collectReturnValue(location, insnList);
       // stack: [capturedcontext]
@@ -673,13 +752,23 @@ public class CapturedContextInstrumentor extends Instrumentor {
       // no local variables info - bail out
       return;
     }
-
+    Collection<LocalVariableNode> localVarNodes;
+    if (definition.isLineProbe()) {
+      localVarNodes = methodNode.localVariables;
+    } else {
+      localVarNodes = unscopedLocalVars;
+    }
     List<LocalVariableNode> applicableVars = new ArrayList<>();
-    for (LocalVariableNode variableNode : methodNode.localVariables) {
+    boolean isLineProbe = definition.isLineProbe();
+    for (LocalVariableNode variableNode : localVarNodes) {
       int idx = variableNode.index - localVarBaseOffset;
       if (idx >= argOffset) {
         // var is local not arg
-        if (ASMHelper.isInScope(methodNode, variableNode, location)) {
+        if (isLineProbe) {
+          if (ASMHelper.isInScope(methodNode, variableNode, location)) {
+            applicableVars.add(variableNode);
+          }
+        } else {
           applicableVars.add(variableNode);
         }
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/ASMHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/ASMHelperTest.java
@@ -6,6 +6,7 @@ import static com.datadog.debugger.instrumentation.ASMHelper.sortLocalVariables;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,6 +39,26 @@ public class ASMHelperTest {
         ensureSafeClassLoad(
             ASMHelperTest.class.getTypeName(), "", ASMHelperTest.class.getClassLoader());
     assertEquals(ASMHelperTest.class, clazz);
+  }
+
+  @Test
+  public void isStoreCompatibleType() {
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.INT_TYPE, Type.INT_TYPE));
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.INT_TYPE, Type.SHORT_TYPE));
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.INT_TYPE, Type.BYTE_TYPE));
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.INT_TYPE, Type.CHAR_TYPE));
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.INT_TYPE, Type.BOOLEAN_TYPE));
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.LONG_TYPE, Type.LONG_TYPE));
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.FLOAT_TYPE, Type.FLOAT_TYPE));
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE));
+    assertTrue(ASMHelper.isStoreCompatibleType(Types.OBJECT_TYPE, Type.getType(Object.class)));
+    assertTrue(ASMHelper.isStoreCompatibleType(Type.getType(Object.class), Types.OBJECT_TYPE));
+    assertTrue(
+        ASMHelper.isStoreCompatibleType(Type.getType(Object.class), Type.getType(String.class)));
+    assertTrue(
+        ASMHelper.isStoreCompatibleType(Type.getType(String.class), Type.getType(Object.class)));
+    assertTrue(
+        ASMHelper.isStoreCompatibleType(Type.getType(String.class), Type.getType(String.class)));
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot31.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot31.java
@@ -1,0 +1,63 @@
+package com.datadog.debugger;
+
+public class CapturedSnapshot31 {
+
+  public static int main(String arg) throws Exception {
+    if ("uncaughtException".equals(arg)) {
+      return new CapturedSnapshot31().uncaughtException(arg);
+    }
+    if ("localScopes".equals(arg)) {
+      return new CapturedSnapshot31().localScopes(arg);
+    }
+    if ("deepScopes".equals(arg)) {
+      return new CapturedSnapshot31().deepScopes(arg);
+    }
+    return 0;
+  }
+
+  private int uncaughtException(String arg) {
+    String varStr = arg + "foo";
+    if (varStr.endsWith("foo")) {
+      throw new RuntimeException("oops");
+    }
+    int len = varStr.length();
+    return len;
+  }
+
+  private int localScopes(String arg) {
+    if ("1".equals(arg)) {
+      String localVar = "foo";
+      return localVar.length();
+    } else {
+      int localVar = 42;
+      return localVar;
+    }
+  }
+
+  private int deepScopes(String arg) {
+    int localVarL0 = 0;
+    if ("deepScopes".equals(arg)) {
+      int localVarL1 = 1;
+      while (localVarL1 > 0) {
+        for (int localVarL2 = 2; localVarL2 < 3; localVarL2++) {
+          int localVarL3 = 3;
+          switch (localVarL3) {
+            case 1: {
+              int localVarL4 = 1;
+              return localVarL4;
+            }
+            case 2: {
+              int localVarL4 = 2;
+              return localVarL4;
+            }
+            default: {
+              int localVarL4 = 4;
+              return localVarL4;
+            }
+          }
+        }
+      }
+    }
+    return localVarL0;
+  }
+}


### PR DESCRIPTION
# What Does This Do
Collecting local var was disabled for method probe/unhanded exception because all local vars are not accessible/defined. But for Exception Debugging/Replay this is very useful to have. The solution is to hoist local variable at the top level of the method and initialize them to be able to capture them at any point of the method.
we are handling also the case of duplicate local var in different scope but with incompatible types

# Motivation
Collecting local vars even if uncaught exception

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2778]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
