### PR TITLE
Fix flaky test on TomcatServlet3TestAsync

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -199,6 +199,8 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
 
     and:
     assertTraces(count) {
+      Set<Tuple2<String, String>> loggedSpanIds = accessLogValue.loggedIds.toSet()
+      assert loggedSpanIds.size() == count
       (1..count).eachWithIndex { val, i ->
         trace(spanCount(SUCCESS)) {
           sortSpansByStart()
@@ -212,9 +214,8 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
           }
         }
 
-        def (String traceId, String spanId) = accessLogValue.loggedIds[i]
-        assert trace(i).get(0).traceId.toString() == traceId
-        assert trace(i).get(0).spanId.toString() == spanId
+        def ids = new Tuple2(trace(i).get(0).localRootSpan.traceId.toString(), trace(i).get(0).localRootSpan.spanId.toString())
+        assert ids in loggedSpanIds
       }
     }
 
@@ -250,8 +251,8 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
       }
 
       def (String traceId, String spanId) = accessLogValue.loggedIds[0]
-      assert trace(0).get(0).traceId.toString() == traceId
-      assert trace(0).get(0).spanId.toString() == spanId
+      assert trace(0).get(0).localRootSpan.traceId.toString() == traceId
+      assert trace(0).get(0).localRootSpan.spanId.toString() == spanId
     }
 
     where:


### PR DESCRIPTION
# What Does This Do
Under high load, the order of spans by duration might be altered. Make sure we check local root spans, and that we allow for different order in traces and access logs.

# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
