### PR TITLE
Enable profiling startForceFirst silently for native image builds

### DIFF
--- a/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
+++ b/dd-java-agent/agent-profiling/src/main/java/com/datadog/profiling/agent/ProfilingAgent.java
@@ -92,9 +92,9 @@ public class ProfilingAgent {
       final ConfigProvider configProvider = ConfigProvider.getInstance();
 
       boolean startForceFirst =
-          configProvider.getBoolean(
-              PROFILING_START_FORCE_FIRST,
-              Platform.isNativeImage() || PROFILING_START_FORCE_FIRST_DEFAULT);
+          Platform.isNativeImage()
+              || configProvider.getBoolean(
+                  PROFILING_START_FORCE_FIRST, PROFILING_START_FORCE_FIRST_DEFAULT);
 
       if (!isStartForceFirstSafe()) {
         log.debug(


### PR DESCRIPTION
# What Does This Do
This turns on the `dd.profiling.start_force_first` config setting silently when the profiler is baked into a Graal native image.

# Motivation
Without this flag specified, the profiling integration will fail silently. The flag itself is relevant to older, non-Graal JVMs (for historical reasons). Docs do not mention this requirement at the moment.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [[PROF-10457](https://datadoghq.atlassian.net/browse/PROF-10457)]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-10457]: https://datadoghq.atlassian.net/browse/PROF-10457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ