### PR TITLE
Do not fail profiler smoke tests on macos

### DIFF
--- a/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
+++ b/dd-smoke-tests/profiling-integration-tests/src/test/java/datadog/smoketest/CodeHotspotsTest.java
@@ -6,6 +6,7 @@ import static datadog.smoketest.SmokeTestUtils.createProcessBuilder;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.openjdk.jmc.common.item.Attribute.attr;
 import static org.openjdk.jmc.common.unit.UnitLookup.NUMBER;
 import static org.openjdk.jmc.common.unit.UnitLookup.PLAIN_TEXT;
@@ -63,10 +64,9 @@ public final class CodeHotspotsTest {
 
   @BeforeAll
   static void setupAll() throws Exception {
-    if (Platform.isMac() && System.getenv("TEST_LIBDDPROF") == null) {
-      throw new UnsupportedOperationException(
-          "Set TEST_LIBDDPROF env variable to point to MacOS version of libjavaProfiler.so, and rerun.");
-    }
+    assumeFalse(
+        Platform.isMac() || System.getenv("TEST_LIBDDPROF") == null,
+        "Test skipped. Set TEST_LIBDDPROF env variable to point to MacOS version of libjavaProfiler.so, and rerun.");
     Files.createDirectories(LOG_FILE_BASE);
   }
 


### PR DESCRIPTION
# What Does This Do
Makes the profiling smoke tests nicer towards mac users

# Motivation
Let's not fail the test - rather log an explanatory message and skip if the requirements are not fulfilled.

# Additional Notes
I haven't opened a JIRA ticket for this trivial change.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
