### PR TITLE
Vertx: wrap internal routes to let the context propagate for blocking handlers

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.vertx_3_4.server;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -35,7 +36,7 @@ public class RouteHandlerInstrumentation extends InstrumenterModule.Tracing
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         isMethod()
-            .and(named("handler"))
+            .and(namedOneOf("handler", "blockingHandler"))
             .and(isPublic())
             .and(takesArgument(0, named("io.vertx.core.Handler"))),
         packageName + ".RouteHandlerWrapperAdvice");

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapper.java
@@ -9,43 +9,54 @@ import static datadog.trace.instrumentation.vertx_3_4.server.VertxDecorator.INST
 import datadog.trace.api.gateway.Flow;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.vertx.ext.web.impl.RouteImpl;
+import io.vertx.ext.web.impl.RouterImpl;
 
 public class RouteHandlerWrapper implements Handler<RoutingContext> {
-  private static final Logger log = LoggerFactory.getLogger(RouteHandlerWrapper.class);
   static final String PARENT_SPAN_CONTEXT_KEY = AgentSpan.class.getName() + ".parent";
   static final String HANDLER_SPAN_CONTEXT_KEY = AgentSpan.class.getName() + ".handler";
   static final String ROUTE_CONTEXT_KEY = "dd." + Tags.HTTP_ROUTE;
 
   private final Handler<RoutingContext> actual;
+  private final boolean spanStarter;
 
   public RouteHandlerWrapper(final Handler<RoutingContext> handler) {
     actual = handler;
+    // When mounting a sub router, the handler is a lambda in either RouterImpl or RouteImpl, so
+    // this skips that. This prevents routers from creating a span during handling. In the event
+    // a route is not found, without this code, a span would be created for the router when it
+    // shouldn't
+    String name = handler.getClass().getName();
+    spanStarter =
+        !(name.startsWith(RouterImpl.class.getName())
+            || name.startsWith(RouteImpl.class.getName()));
   }
 
   @Override
   public void handle(final RoutingContext routingContext) {
     AgentSpan span = routingContext.get(HANDLER_SPAN_CONTEXT_KEY);
     Flow.Action.RequestBlockingAction rba = null;
-    if (span == null) {
-      AgentSpan parentSpan = activeSpan();
-      routingContext.put(PARENT_SPAN_CONTEXT_KEY, parentSpan);
+    if (spanStarter) {
+      if (span == null) {
+        AgentSpan parentSpan = activeSpan();
+        routingContext.put(PARENT_SPAN_CONTEXT_KEY, parentSpan);
 
-      span = startSpan(INSTRUMENTATION_NAME);
-      routingContext.put(HANDLER_SPAN_CONTEXT_KEY, span);
+        span = startSpan(INSTRUMENTATION_NAME);
+        routingContext.put(HANDLER_SPAN_CONTEXT_KEY, span);
 
-      routingContext.response().endHandler(new EndHandlerWrapper(routingContext));
-      DECORATE.afterStart(span);
-      span.setResourceName(DECORATE.className(actual.getClass()));
+        routingContext.response().endHandler(new EndHandlerWrapper(routingContext));
+        DECORATE.afterStart(span);
+        span.setResourceName(DECORATE.className(actual.getClass()));
+      }
+
+      updateRoutingContextWithRoute(routingContext);
     }
-
-    updateRoutingContextWithRoute(routingContext);
-
-    try (final AgentScope scope = activateSpan(span)) {
+    try (final AgentScope scope =
+        span != null ? activateSpan(span) : AgentTracer.NoopAgentScope.INSTANCE) {
       scope.setAsyncPropagation(true);
       try {
         actual.handle(routingContext);

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapperAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapperAdvice.java
@@ -2,22 +2,12 @@ package datadog.trace.instrumentation.vertx_3_4.server;
 
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.impl.RouteImpl;
-import io.vertx.ext.web.impl.RouterImpl;
 import net.bytebuddy.asm.Advice;
 
 public class RouteHandlerWrapperAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static void wrapHandler(
       @Advice.Argument(value = 0, readOnly = false) Handler<RoutingContext> handler) {
-    // When mounting a sub router, the handler is a lambda in either RouterImpl or RouteImpl, so
-    // this skips that. This prevents routers from creating a span during handling. In the event
-    // a route is not found, without this code, a span would be created for the router when it
-    // shouldn't
-    String name = handler.getClass().getName();
-    if (!(name.startsWith(RouterImpl.class.getName())
-        || name.startsWith(RouteImpl.class.getName()))) {
-      handler = new RouteHandlerWrapper(handler);
-    }
+    handler = new RouteHandlerWrapper(handler);
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.vertx_4_0.server;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -41,7 +42,7 @@ public class RouteHandlerInstrumentation extends InstrumenterModule.Tracing
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         isMethod()
-            .and(named("handler"))
+            .and(namedOneOf("handler", "blockingHandler"))
             .and(isPublic())
             .and(takesArgument(0, named("io.vertx.core.Handler"))),
         packageName + ".RouteHandlerWrapperAdvice");

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -8,42 +8,49 @@ import static datadog.trace.instrumentation.vertx_4_0.server.VertxDecorator.INST
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.vertx.ext.web.impl.RouteImpl;
 
 public class RouteHandlerWrapper implements Handler<RoutingContext> {
-  private static final Logger log = LoggerFactory.getLogger(RouteHandlerWrapper.class);
   static final String PARENT_SPAN_CONTEXT_KEY = AgentSpan.class.getName() + ".parent";
   static final String HANDLER_SPAN_CONTEXT_KEY = AgentSpan.class.getName() + ".handler";
   static final String ROUTE_CONTEXT_KEY = "dd." + Tags.HTTP_ROUTE;
 
   private final Handler<RoutingContext> actual;
+  private final boolean spanStarter;
 
   public RouteHandlerWrapper(final Handler<RoutingContext> handler) {
     actual = handler;
+    // When mounting a sub router, the handler is a method reference to the routers handleContext
+    // method this skips that. This prevents routers from creating a span during handling. In the
+    // event a route is not found, without this code, a span would be created for the router when
+    // it shouldn't
+    spanStarter = !handler.getClass().getName().startsWith(RouteImpl.class.getName());
   }
 
   @Override
   public void handle(final RoutingContext routingContext) {
     AgentSpan span = routingContext.get(HANDLER_SPAN_CONTEXT_KEY);
-    if (span == null) {
-      AgentSpan parentSpan = activeSpan();
-      routingContext.put(PARENT_SPAN_CONTEXT_KEY, parentSpan);
+    if (spanStarter) {
+      if (span == null) {
+        AgentSpan parentSpan = activeSpan();
+        routingContext.put(PARENT_SPAN_CONTEXT_KEY, parentSpan);
 
-      span = startSpan(INSTRUMENTATION_NAME);
-      routingContext.put(HANDLER_SPAN_CONTEXT_KEY, span);
+        span = startSpan(INSTRUMENTATION_NAME);
+        routingContext.put(HANDLER_SPAN_CONTEXT_KEY, span);
 
-      routingContext.response().endHandler(new EndHandlerWrapper(routingContext));
-      DECORATE.afterStart(span);
-      span.setResourceName(DECORATE.className(actual.getClass()));
+        routingContext.response().endHandler(new EndHandlerWrapper(routingContext));
+        DECORATE.afterStart(span);
+        span.setResourceName(DECORATE.className(actual.getClass()));
+      }
+      updateRoutingContextWithRoute(routingContext);
     }
 
-    updateRoutingContextWithRoute(routingContext);
-
-    try (final AgentScope scope = activateSpan(span)) {
+    try (final AgentScope scope =
+        span != null ? activateSpan(span) : AgentTracer.NoopAgentScope.INSTANCE) {
       scope.setAsyncPropagation(true);
       try {
         actual.handle(routingContext);

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapperAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapperAdvice.java
@@ -2,19 +2,12 @@ package datadog.trace.instrumentation.vertx_4_0.server;
 
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.impl.RouteImpl;
 import net.bytebuddy.asm.Advice;
 
 public class RouteHandlerWrapperAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static void wrapHandler(
       @Advice.Argument(value = 0, readOnly = false) Handler<RoutingContext> handler) {
-    // When mounting a sub router, the handler is a method reference to the routers handleContext
-    // method this skips that. This prevents routers from creating a span during handling. In the
-    // event a route is not found, without this code, a span would be created for the router when
-    // it shouldn't
-    if (!handler.getClass().getName().startsWith(RouteImpl.class.getName())) {
-      handler = new RouteHandlerWrapper(handler);
-    }
+    handler = new RouteHandlerWrapper(handler);
   }
 }


### PR DESCRIPTION
# What Does This Do

When doing `blockingHandler` vertx create a inner route that we do not wrap. because of this the context is not propagated hence the span generated while executing this handler are attached to the wrong trace/parent

This PR makes sure that all the handlers can activate the right scope by using the one created for the route stored in the routing context

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
