### PR TITLE
Google PubSub: implement switchable legacy tracing mode

### DIFF
--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
@@ -9,6 +9,7 @@ import static datadog.trace.core.datastreams.TagsProcessor.TYPE_TAG;
 
 import com.google.protobuf.Timestamp;
 import com.google.pubsub.v1.PubsubMessage;
+import datadog.trace.api.Config;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
@@ -75,13 +76,19 @@ public class PubSubDecorator extends MessagingClientDecorator {
       new PubSubDecorator(
           Tags.SPAN_KIND_PRODUCER,
           InternalSpanTypes.MESSAGE_PRODUCER,
-          SpanNaming.instance().namingSchema().messaging().outboundService(PUBSUB, true));
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .outboundService(PUBSUB, Config.get().isGooglePubSubLegacyTracingEnabled()));
 
   public static final PubSubDecorator CONSUMER_DECORATE =
       new PubSubDecorator(
           Tags.SPAN_KIND_CONSUMER,
           InternalSpanTypes.MESSAGE_CONSUMER,
-          SpanNaming.instance().namingSchema().messaging().inboundService(PUBSUB, true));
+          SpanNaming.instance()
+              .namingSchema()
+              .messaging()
+              .inboundService(PUBSUB, Config.get().isGooglePubSubLegacyTracingEnabled()));
   private final String spanKind;
   private final CharSequence spanType;
   private final String serviceName;

--- a/dd-java-agent/instrumentation/google-pubsub/src/test/groovy/PubSubTest.groovy
+++ b/dd-java-agent/instrumentation/google-pubsub/src/test/groovy/PubSubTest.groovy
@@ -327,6 +327,19 @@ class PubSubNamingV0Test extends PubSubTest {
   }
 }
 
+class PubSubNamingV0NoLegacyTracingForkedTest extends PubSubNamingV0Test {
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig("dd.google-pubsub.legacy.tracing.enabled", "false")
+  }
+
+  @Override
+  String service() {
+    "A-service"
+  }
+}
+
 
 class PubSubNamingV1ForkedTest extends PubSubTest {
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -4046,6 +4046,11 @@ public class Config {
         && isLegacyTracingEnabled(true, "kafka");
   }
 
+  public boolean isGooglePubSubLegacyTracingEnabled() {
+    return SpanNaming.instance().namingSchema().allowInferredServices()
+        && isLegacyTracingEnabled(true, "google-pubsub");
+  }
+
   public boolean isTimeInQueueEnabled(
       final boolean defaultEnabled, final String... integrationNames) {
     return SpanNaming.instance().namingSchema().allowInferredServices()


### PR DESCRIPTION
# What Does This Do

Google pubsub was lacking of the possibility to turn off the legacy tracing mode. When off, the consumer will use the value of `DD_SERVICE` instead that `google-pubsub` as a service name.

The feature can be activated by:
* A system property `-Ddd.google-pubsub.legacy.tracing.enabled=false`
* An environment variable `DD_GOOGLE_PUBSUB_LEGACY_TRACING_ENABLED=false`


# Motivation

see #7209 

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
