### PR TITLE
Improve test scenario name uniqueness

### DIFF
--- a/dd-java-agent/instrumentation/classloading/jsr14-testing/src/test/groovy/Jsr14ClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/classloading/jsr14-testing/src/test/groovy/Jsr14ClassloadingTest.groovy
@@ -2,7 +2,7 @@ import datadog.trace.agent.test.AgentTestRunner
 import test.jsr14.Jsr14ClassLoader
 
 class Jsr14ClassloadingTest extends AgentTestRunner {
-  def "OSGI delegates to bootstrap class loader for agent classes"() {
+  def "OSGI delegates to bootstrap class loader for agent classes using #args args"() {
     when:
     def clazz
     if (args == 1) {

--- a/dd-java-agent/instrumentation/classloading/osgi-testing/src/test/groovy/OSGIClassloadingTest.groovy
+++ b/dd-java-agent/instrumentation/classloading/osgi-testing/src/test/groovy/OSGIClassloadingTest.groovy
@@ -8,7 +8,7 @@ import org.eclipse.osgi.internal.loader.classpath.ClasspathManager
 import org.eclipse.osgi.storage.BundleInfo
 
 class OSGIClassloadingTest extends AgentTestRunner {
-  def "OSGI delegates to bootstrap class loader for agent classes"() {
+  def "OSGI delegates to bootstrap class loader for agent classes #loaderName using #args args"() {
     when:
     def clazz
     if (args == 1) {
@@ -27,6 +27,7 @@ class OSGIClassloadingTest extends AgentTestRunner {
     new TestClassLoader()                                    | 2
     new BundleWiringImpl.BundleClassLoader(null, null, null) | 1
     new BundleWiringImpl.BundleClassLoader(null, null, null) | 2
+    loaderName = loader.class.simpleName
   }
 
   static class TestClassLoader extends ModuleClassLoader {


### PR DESCRIPTION
# What Does This Do

This PR improves test scenario name uniqueness by avoiding using toString() in test name that generates random scenario name.

# Motivation

Avoid such reporting issue in our backend:
![image](https://github.com/user-attachments/assets/642ff9c3-dc69-4ab7-8284-aaf325b0e369)

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
