### PR TITLE
Change Gradle task ordering to fix build issues with dd-smoke-tests

### DIFF
--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -95,6 +95,14 @@ tasks.sourcesJar{
   dependsOn 'unzip'
 }
 
+tasks.forbiddenApisMain {
+  dependsOn 'unzip'
+}
+
+tasks.spotbugsMain {
+  dependsOn 'unzip'
+}
+
 tasks.matching({it.name.startsWith('compileTest')}).configureEach {
   dependsOn 'war', 'bootWar', 'unzip'
 }

--- a/dd-smoke-tests/wildfly/build.gradle
+++ b/dd-smoke-tests/wildfly/build.gradle
@@ -103,6 +103,10 @@ tasks.register("unzip", Copy) {
   onlyIf { !project.rootProject.hasProperty("skipTests") }
 }
 
+tasks.withType(Jar).configureEach {
+  dependsOn tasks.unzip
+}
+
 tasks.register("deploy", Copy) {
   dependsOn tasks.unzip
   from "${appBuildDir}/libs/wildfly-spring-ear-smoketest.ear"


### PR DESCRIPTION
# What Does This Do
Adds task ordering for certain sections of dd-smoke-tests

# Motivation

Consistently getting errors with `dd-smoke-tests:springboot-tomcat:forbiddenApisMain` when trying to build a clean version of dd-trace-java from master branch (`./gradlew clean build`), following the https://github.com/DataDog/dd-trace-java/blob/master/BUILDING.md instructions.

- possible solution/ thought that task ordering was causing the error, tried to add these changes to ordering 

```
FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain' (type 'CheckForbiddenApis').
  - Gradle detected a problem with the following location: '/Users/jordan.wong/dd-trace-java/dd-smoke-tests/springboot-tomcat/build/classes/java/main'
    
    Reason: Task ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain' uses this output of task ':dd-smoke-tests:springboot-tomcat:unzip' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':dd-smoke-tests:springboot-tomcat:unzip' as an input of ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain'.
      2. Declare an explicit dependency on ':dd-smoke-tests:springboot-tomcat:unzip' from ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':dd-smoke-tests:springboot-tomcat:unzip' from ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.4/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
  - Gradle detected a problem with the following location: '/Users/jordan.wong/dd-trace-java/dd-smoke-tests/springboot-tomcat/build/classes/groovy/main'.
    
    Reason: Task ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain' uses this output of task ':dd-smoke-tests:springboot-tomcat:unzip' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':dd-smoke-tests:springboot-tomcat:unzip' as an input of ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain'.
      2. Declare an explicit dependency on ':dd-smoke-tests:springboot-tomcat:unzip' from ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain' using Task#dependsOn.
      3. Declare an explicit dependency on ':dd-smoke-tests:springboot-tomcat:unzip' from ':dd-smoke-tests:springboot-tomcat:forbiddenApisMain' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.4/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

# Additional Notes
- `./gradlew clean assemble` works

- after making the changes in this PR to attempt to fix the `forbiddenApisMain` with task ordering, the `forbiddenApisMain` error goes away, but I get the following error with "coverage ratio":
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':dd-java-agent:agent-profiling:profiling-controller:jacocoTestCoverageVerification'.
> Rule violated for class com.datadog.profiling.controller.ControllerContext.Snapshot: instructions covered ratio is 0.0, but expected minimum is 0.8
  Rule violated for class com.datadog.profiling.controller.Controller: instructions covered ratio is 0.0, but expected minimum is 0.8
  Rule violated for class com.datadog.profiling.controller.ProfilerSettingsSupport.ProfilerActivationSetting: branches covered ratio is 0.5, but expected minimum is 0.8
  Rule violated for class com.datadog.profiling.controller.ProfilerSettingsSupport.ProfilerActivationSetting: instructions covered ratio is 0.7, but expected minimum is 0.8
  Rule violated for class com.datadog.profiling.controller.ControllerContext: instructions covered ratio is 0.0, but expected minimum is 0.8
```


# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
