### PR TITLE
Mute internal process start

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/PidHelper.java
+++ b/internal-api/src/main/java/datadog/trace/util/PidHelper.java
@@ -1,6 +1,8 @@
 package datadog.trace.util;
 
 import datadog.trace.api.Platform;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.context.TraceScope;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -66,7 +68,7 @@ public final class PidHelper {
     // any time -
     //  also, no guarantee it will work with all JVMs
     ProcessBuilder pb = new ProcessBuilder("jps");
-    try {
+    try (TraceScope ignored = AgentTracer.get().muteTracing()) {
       Process p = pb.start();
       if (p.waitFor(500, TimeUnit.MILLISECONDS)) {
         if (p.exitValue() == 0) {

--- a/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
+++ b/internal-api/src/main/java/datadog/trace/util/ProcessSupervisor.java
@@ -7,6 +7,8 @@ import static datadog.trace.util.ProcessSupervisor.Health.HEALTHY;
 import static datadog.trace.util.ProcessSupervisor.Health.INTERRUPTED;
 import static datadog.trace.util.ProcessSupervisor.Health.READY_TO_START;
 
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.context.TraceScope;
 import java.io.Closeable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +109,9 @@ public class ProcessSupervisor implements Closeable {
   private void startProcessAndWait() throws Exception {
     if (currentProcess == null) {
       log.debug("Starting process: [{}]", imageName);
-      currentProcess = processBuilder.start();
+      try (TraceScope ignored = AgentTracer.get().muteTracing()) {
+        currentProcess = processBuilder.start();
+      }
       currentHealth = HEALTHY;
       faults = 0;
     }


### PR DESCRIPTION
# What Does This Do

This PR avoids reporting to customers internal process start.

# Motivation

Avoid reporting internal spans.
Avoid issues with unexpected spans during tests too.

# Additional Notes

Need to revert https://github.com/DataDog/system-tests/pull/2973

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
