### PR TITLE
Add watches support through probe tags

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -35,6 +35,7 @@ public class CapturedContext implements ValueReferenceResolver {
   private String spanId;
   private long duration;
   private final Map<String, Status> statusByProbeId = new LinkedHashMap<>();
+  private Map<String, CapturedValue> watches;
 
   public CapturedContext() {}
 
@@ -267,6 +268,10 @@ public class CapturedContext implements ValueReferenceResolver {
     return staticFields;
   }
 
+  public Map<String, CapturedValue> getWatches() {
+    return watches;
+  }
+
   public Limits getLimits() {
     return limits;
   }
@@ -288,6 +293,11 @@ public class CapturedContext implements ValueReferenceResolver {
    * instance representation into the corresponding string value.
    */
   public void freeze(TimeoutChecker timeoutChecker) {
+    if (watches != null) {
+      // freeze only watches
+      watches.values().forEach(capturedValue -> capturedValue.freeze(timeoutChecker));
+      return;
+    }
     if (arguments != null) {
       arguments.values().forEach(capturedValue -> capturedValue.freeze(timeoutChecker));
     }
@@ -381,6 +391,13 @@ public class CapturedContext implements ValueReferenceResolver {
       staticFields = new HashMap<>();
     }
     staticFields.put(name, value);
+  }
+
+  public void addWatch(CapturedValue value) {
+    if (watches == null) {
+      watches = new HashMap<>();
+    }
+    watches.put(value.name, value);
   }
 
   public static class Status {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -7,6 +7,7 @@ import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.agent.StringTemplateBuilder;
 import com.datadog.debugger.el.EvaluationException;
 import com.datadog.debugger.el.ProbeCondition;
+import com.datadog.debugger.el.Value;
 import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.instrumentation.CapturedContextInstrumentor;
 import com.datadog.debugger.instrumentation.DiagnosticMessage;
@@ -14,10 +15,12 @@ import com.datadog.debugger.instrumentation.InstrumentationResult;
 import com.datadog.debugger.instrumentation.MethodInfo;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.Snapshot;
+import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Types;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
@@ -29,9 +32,12 @@ import datadog.trace.bootstrap.debugger.ProbeImplementation;
 import datadog.trace.bootstrap.debugger.ProbeRateLimiter;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -249,6 +255,7 @@ public class LogProbe extends ProbeDefinition {
   private final String template;
   private final List<Segment> segments;
   private final boolean captureSnapshot;
+  private transient List<ValueScript> watches;
 
   @Json(name = "when")
   private final ProbeCondition probeCondition;
@@ -320,6 +327,35 @@ public class LogProbe extends ProbeDefinition {
     this.sampling = sampling;
   }
 
+  private static List<ValueScript> parseWatchesFromTags(Tag[] tags) {
+    if (tags == null || tags.length == 0) {
+      return Collections.emptyList();
+    }
+    List<ValueScript> result = new ArrayList<>();
+    for (Tag tag : tags) {
+      if ("dd_watches_dsl".equals(tag.getKey())) {
+        String ddWatches = tag.getValue();
+        // this for POC only, parsing is not robust!
+        String[] splitWatches = ddWatches.split(",");
+        for (String watchDef : splitWatches) {
+          // remove curly braces
+          String refPath = watchDef.substring(1, watchDef.length() - 1);
+          result.add(new ValueScript(ValueScript.parseRefPath(refPath), refPath));
+        }
+      } else if ("dd_watches_json".equals(tag.getKey())) {
+        String json = tag.getValue();
+        try {
+          ParameterizedType type = Types.newParameterizedType(List.class, ValueScript.class);
+          result.addAll(
+              MoshiHelper.createMoshiWatches().<List<ValueScript>>adapter(type).fromJson(json));
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+    return result;
+  }
+
   public LogProbe copy() {
     return new LogProbe(
         language,
@@ -345,6 +381,10 @@ public class LogProbe extends ProbeDefinition {
 
   public boolean isCaptureSnapshot() {
     return captureSnapshot;
+  }
+
+  public List<ValueScript> getWatches() {
+    return watches;
   }
 
   public ProbeCondition getProbeCondition() {
@@ -390,16 +430,53 @@ public class LogProbe extends ProbeDefinition {
       // sample if probe has condition and condition is true or has error
       sample(logStatus, methodLocation);
     }
-    if (logStatus.isSampled() && logStatus.getCondition()) {
-      StringTemplateBuilder logMessageBuilder = new StringTemplateBuilder(segments, LIMITS);
-      String msg = logMessageBuilder.evaluate(context, logStatus);
-      if (msg != null && msg.length() > LOG_MSG_LIMIT) {
-        StringBuilder sb = new StringBuilder(LOG_MSG_LIMIT + 3);
-        sb.append(msg, 0, LOG_MSG_LIMIT);
-        sb.append("...");
-        msg = sb.toString();
+    processMsgTemplate(context, logStatus);
+    processWatches(context, logStatus);
+  }
+
+  private void processMsgTemplate(CapturedContext context, LogStatus logStatus) {
+    if (!logStatus.isSampled() || !logStatus.getCondition()) {
+      return;
+    }
+    StringTemplateBuilder logMessageBuilder = new StringTemplateBuilder(segments, LIMITS);
+    String msg = logMessageBuilder.evaluate(context, logStatus);
+    if (msg != null && msg.length() > LOG_MSG_LIMIT) {
+      StringBuilder sb = new StringBuilder(LOG_MSG_LIMIT + 3);
+      sb.append(msg, 0, LOG_MSG_LIMIT);
+      sb.append("...");
+      msg = sb.toString();
+    }
+    logStatus.setMessage(msg);
+  }
+
+  private void processWatches(CapturedContext context, LogStatus logStatus) {
+    if (watches == null) {
+      watches = parseWatchesFromTags(tags);
+    }
+    if (watches.isEmpty()) {
+      return;
+    }
+    if (!logStatus.isSampled()) {
+      return;
+    }
+    for (ValueScript watch : watches) {
+      try {
+        Value<?> result = watch.execute(context);
+        if (result.isUndefined()) {
+          throw new EvaluationException("UNDEFINED", watch.getDsl());
+        }
+        if (result.isNull()) {
+          context.addWatch(
+              CapturedContext.CapturedValue.of(watch.getDsl(), Object.class.getTypeName(), null));
+        } else {
+          context.addWatch(
+              CapturedContext.CapturedValue.of(
+                  watch.getDsl(), Object.class.getTypeName(), result.getValue()));
+        }
+      } catch (EvaluationException ex) {
+        logStatus.addError(new EvaluationError(ex.getExpr(), ex.getMessage()));
+        logStatus.setLogTemplateErrors(true);
       }
-      logStatus.setMessage(msg);
     }
   }
 
@@ -759,6 +836,7 @@ public class LogProbe extends ProbeDefinition {
     private String template;
     private List<Segment> segments;
     private boolean captureSnapshot;
+    private List<ValueScript> watches;
     private ProbeCondition probeCondition;
     private Capture capture;
     private Sampling sampling;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiHelper.java
@@ -50,4 +50,8 @@ public class MoshiHelper {
   public static Moshi createMoshiSymbol() {
     return new Moshi.Builder().build();
   }
+
+  public static Moshi createMoshiWatches() {
+    return new Moshi.Builder().add(ValueScript.class, new ValueScript.ValueScriptAdapter()).build();
+  }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -37,6 +37,7 @@ public class MoshiSnapshotHelper {
   public static final String CAUGHT_EXCEPTIONS = "caughtExceptions";
   public static final String ARGUMENTS = "arguments";
   public static final String LOCALS = "locals";
+  public static final String WATCHES = "watches";
   public static final String THROWABLE = "throwable";
   public static final String STATIC_FIELDS = "staticFields";
   public static final String THIS = "this";
@@ -152,6 +153,20 @@ public class MoshiSnapshotHelper {
         return;
       }
       jsonWriter.beginObject();
+      if (capturedContext.getWatches() != null) {
+        // only watches are serialized into the snapshot
+        jsonWriter.name(WATCHES);
+        jsonWriter.beginObject();
+        SerializationResult resultWatches =
+            toJsonCapturedValues(
+                jsonWriter,
+                capturedContext.getWatches(),
+                capturedContext.getLimits(),
+                timeoutChecker);
+        jsonWriter.endObject(); // / watches
+        jsonWriter.endObject();
+        return;
+      }
       jsonWriter.name(ARGUMENTS);
       jsonWriter.beginObject();
       SerializationResult resultArgs =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -2422,6 +2422,36 @@ public class CapturedSnapshotTest {
     }
   }
 
+  @Test
+  public void watches() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot08";
+    LogProbe probe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "doit", null, null)
+            .evaluateAt(MethodLocation.EXIT)
+            .tags(
+                "dd_watches_dsl:{typed.fld.fld.msg},{nullTyped.fld}",
+                "dd_watches_json:[{\"dsl\":\"typed.fld.fld.msg_json\",\"json\":{\"getmember\":[{\"getmember\":[{\"getmember\":[{\"ref\":\"typed\"},\"fld\"]},\"fld\"]},\"msg\"]}}]")
+            .build();
+    TestSnapshotListener listener = installProbes(CLASS_NAME, probe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    int result = Reflect.onClass(testClass).call("main", "1").get();
+    assertEquals(3, result);
+    Snapshot snapshot = assertOneSnapshot(listener);
+    assertEquals(3, snapshot.getCaptures().getReturn().getWatches().size());
+    assertCaptureWatches(
+        snapshot.getCaptures().getReturn(),
+        "typed.fld.fld.msg",
+        String.class.getTypeName(),
+        "hello");
+    assertCaptureWatches(
+        snapshot.getCaptures().getReturn(), "nullTyped.fld", Object.class.getTypeName(), null);
+    assertCaptureWatches(
+        snapshot.getCaptures().getReturn(),
+        "typed.fld.fld.msg_json",
+        String.class.getTypeName(),
+        "hello");
+  }
+
   private TestSnapshotListener setupInstrumentTheWorldTransformer(String excludeFileName) {
     Config config = mock(Config.class);
     when(config.isDebuggerEnabled()).thenReturn(true);
@@ -2653,6 +2683,13 @@ public class CapturedSnapshotTest {
         assertEquals(entry.getValue(), String.valueOf(fieldCapturedValue.getValue()));
       }
     }
+  }
+
+  private void assertCaptureWatches(
+      CapturedContext context, String name, String typeName, String value) {
+    CapturedContext.CapturedValue watch = context.getWatches().get(name);
+    assertEquals(typeName, watch.getType());
+    assertEquals(value, MoshiSnapshotTestHelper.getValue(watch));
   }
 
   private void assertCaptureThrowable(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationTest.java
@@ -121,6 +121,11 @@ public class ConfigurationTest {
     ArrayList<LogProbe> logProbes = new ArrayList<>(config.getLogProbes());
     assertEquals(1, logProbes.size());
     LogProbe logProbe0 = logProbes.get(0);
+    assertEquals(2, logProbe0.getTags().length);
+    assertEquals("dd_watches_dsl", logProbe0.getTags()[0].getKey());
+    assertEquals("{object.objField.intField}", logProbe0.getTags()[0].getValue());
+    assertEquals("env", logProbe0.getTags()[1].getKey());
+    assertEquals("staging", logProbe0.getTags()[1].getValue());
     assertEquals(8, logProbe0.getSegments().size());
     assertEquals("this is a log line customized! uuid=", logProbe0.getSegments().get(0).getStr());
     assertEquals("uuid", logProbe0.getSegments().get(1).getExpr());

--- a/dd-java-agent/agent-debugger/src/test/resources/test_log_probe.json
+++ b/dd-java-agent/agent-debugger/src/test/resources/test_log_probe.json
@@ -14,6 +14,7 @@
     "created": "2021-03-31T13:26:52.519150+00:00",
     "active": true,
     "language": "java",
+    "tags": ["dd_watches_dsl:{object.objField.intField}", "env:staging"],
     "where": {
       "typeName": "VetController",
       "methodName": "showVetList"


### PR DESCRIPTION
# What Does This Do
Watches collect specific (deep) fields to add them exclusively into
the snapshot instead of locals/arguments/statics/...
Watches are defined using probe definition predefined tags:
 - `dd_watches_dsl`
 - `dd_watches_json`
 
When you just want to reference deep fields just `a.b.c` you can use the
dsl syntax (like Expression Language). But if you need more advanced
(accessing map or list, using filter, any, ... functions) you need to
use `dd_watches_json` and put the Json AST for Expression Language
(like log message template with segments).
Once the probe is executed, it interprets watches tags to evaluate the
expression then add it in the snapshot as special attributes `watches`.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2829]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2829]: https://datadoghq.atlassian.net/browse/DEBUG-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ