### PR TITLE
Add exception_hash tag for span

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -26,6 +26,8 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExceptionDebugger.class);
   public static final String DD_DEBUG_ERROR_PREFIX = "_dd.debug.error.";
   public static final String DD_DEBUG_ERROR_EXCEPTION_ID = DD_DEBUG_ERROR_PREFIX + "exception_id";
+  public static final String DD_DEBUG_ERROR_EXCEPTION_HASH =
+      DD_DEBUG_ERROR_PREFIX + "exception_hash";
   public static final String ERROR_DEBUG_INFO_CAPTURED = "error.debug_info_captured";
   public static final String SNAPSHOT_ID_TAG_FMT = DD_DEBUG_ERROR_PREFIX + "%d.snapshot_id";
 
@@ -84,7 +86,7 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
         LOGGER.debug("Unable to find state for throwable: {}", innerMostException.toString());
         return;
       }
-      processSnapshotsAndSetTags(t, span, state, innerMostException);
+      processSnapshotsAndSetTags(t, span, state, innerMostException, fingerprint);
       exceptionProbeManager.updateLastCapture(fingerprint);
     } else {
       if (exceptionProbeManager.createProbesForException(innerMostException.getStackTrace())) {
@@ -101,7 +103,11 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
   }
 
   private static void processSnapshotsAndSetTags(
-      Throwable t, AgentSpan span, ThrowableState state, Throwable innerMostException) {
+      Throwable t,
+      AgentSpan span,
+      ThrowableState state,
+      Throwable innerMostException,
+      String fingerprint) {
     if (span.getTag(DD_DEBUG_ERROR_EXCEPTION_ID) != null) {
       LOGGER.debug("Clear previous frame tags");
       // already set for this span, clear the frame tags
@@ -141,6 +147,7 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
           DD_DEBUG_ERROR_EXCEPTION_ID,
           state.getExceptionId());
       span.setTag(ERROR_DEBUG_INFO_CAPTURED, true);
+      span.setTag(DD_DEBUG_ERROR_EXCEPTION_HASH, fingerprint);
     }
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeInstrumentationTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.exception;
 
 import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CONFIG;
+import static com.datadog.debugger.exception.DefaultExceptionDebugger.DD_DEBUG_ERROR_EXCEPTION_HASH;
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.DD_DEBUG_ERROR_EXCEPTION_ID;
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.ERROR_DEBUG_INFO_CAPTURED;
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.SNAPSHOT_ID_TAG_FMT;
@@ -135,6 +136,7 @@ public class ExceptionProbeInstrumentationTest {
         location.getType() + "." + location.getMethod(), snapshot0.getStack().get(0).getFunction());
     MutableSpan span = traceInterceptor.getFirstSpan();
     assertEquals(snapshot0.getExceptionId(), span.getTags().get(DD_DEBUG_ERROR_EXCEPTION_ID));
+    assertEquals(fingerprint, span.getTags().get(DD_DEBUG_ERROR_EXCEPTION_HASH));
     assertEquals(Boolean.TRUE, span.getTags().get(ERROR_DEBUG_INFO_CAPTURED));
     assertEquals(snapshot0.getId(), span.getTags().get(String.format(SNAPSHOT_ID_TAG_FMT, 0)));
     assertEquals(1, probeSampler.getCallCount());


### PR DESCRIPTION
# What Does This Do
For Exception Replay we add also the `_dd.debug.error.exception_hash`
 tag along with exception_id and snapshot ids

# Motivation
fix system tests 

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2787]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2787]: https://datadoghq.atlassian.net/browse/DEBUG-2787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ