### PR TITLE
Add support for Optional(Int|Double|Long)

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -9,6 +9,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -116,14 +119,26 @@ public class WellKnownClasses {
 
   private static final Map<String, Function<Object, CapturedContext.CapturedValue>>
       OPTIONAL_SPECIAL_FIELDS = new HashMap<>();
+  private static final Map<String, Function<Object, CapturedContext.CapturedValue>>
+      OPTIONALINT_SPECIAL_FIELDS = new HashMap<>();
+  private static final Map<String, Function<Object, CapturedContext.CapturedValue>>
+      OPTIONALDOUBLE_SPECIAL_FIELDS = new HashMap<>();
+  private static final Map<String, Function<Object, CapturedContext.CapturedValue>>
+      OPTIONALLONG_SPECIAL_FIELDS = new HashMap<>();
 
   static {
     OPTIONAL_SPECIAL_FIELDS.put("value", OptionalFields::value);
+    OPTIONALINT_SPECIAL_FIELDS.put("value", OptionalFields::valueInt);
+    OPTIONALDOUBLE_SPECIAL_FIELDS.put("value", OptionalFields::valueDouble);
+    OPTIONALLONG_SPECIAL_FIELDS.put("value", OptionalFields::valueLong);
   }
 
   static {
     SPECIAL_TYPE_ACCESS.put(StackTraceElement.class, STACKTRACEELEMENT_SPECIAL_FIELDS);
     SPECIAL_TYPE_ACCESS.put(Optional.class, OPTIONAL_SPECIAL_FIELDS);
+    SPECIAL_TYPE_ACCESS.put(OptionalInt.class, OPTIONALINT_SPECIAL_FIELDS);
+    SPECIAL_TYPE_ACCESS.put(OptionalDouble.class, OPTIONALDOUBLE_SPECIAL_FIELDS);
+    SPECIAL_TYPE_ACCESS.put(OptionalLong.class, OPTIONALLONG_SPECIAL_FIELDS);
   }
 
   private static final Map<String, Function<Object, CapturedContext.CapturedValue>>
@@ -336,6 +351,21 @@ public class WellKnownClasses {
     public static CapturedContext.CapturedValue value(Object o) {
       return CapturedContext.CapturedValue.of(
           "value", Object.class.getTypeName(), ((Optional<?>) o).orElse(null));
+    }
+
+    public static CapturedContext.CapturedValue valueInt(Object o) {
+      return CapturedContext.CapturedValue.of(
+          "value", Integer.TYPE.getTypeName(), ((OptionalInt) o).orElse(0));
+    }
+
+    public static CapturedContext.CapturedValue valueDouble(Object o) {
+      return CapturedContext.CapturedValue.of(
+          "value", Double.TYPE.getTypeName(), ((OptionalDouble) o).orElse(0.0));
+    }
+
+    public static CapturedContext.CapturedValue valueLong(Object o) {
+      return CapturedContext.CapturedValue.of(
+          "value", Long.TYPE.getTypeName(), ((OptionalLong) o).orElse(0L));
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -55,6 +55,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -299,6 +302,9 @@ public class SnapshotSerializationTest {
     URI uri = URI.create("https://www.datadoghq.com");
     Optional<Date> maybeDate = Optional.of(new Date());
     Optional<Object> empty = Optional.empty();
+    OptionalInt maybeInt = OptionalInt.of(42);
+    OptionalDouble maybeDouble = OptionalDouble.of(3.14);
+    OptionalLong maybeLong = OptionalLong.of(84);
     Exception ex = new IllegalArgumentException("invalid arg");
     StackTraceElement element = new StackTraceElement("Foo", "bar", "foo.java", 42);
   }
@@ -335,17 +341,35 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(objLocalFields, "atomicLong", AtomicLong.class.getTypeName(), "123");
     assertPrimitiveValue(
         objLocalFields, "uri", URI.class.getTypeName(), "https://www.datadoghq.com");
+    // maybeDate
     Map<String, Object> maybeDate = (Map<String, Object>) objLocalFields.get("maybeDate");
     assertComplexClass(maybeDate, Optional.class.getTypeName());
-    Map<String, Object> maybeUiidFields = (Map<String, Object>) maybeDate.get(FIELDS);
-    Map<String, Object> value = (Map<String, Object>) maybeUiidFields.get("value");
+    Map<String, Object> maybeDateFields = (Map<String, Object>) maybeDate.get(FIELDS);
+    Map<String, Object> value = (Map<String, Object>) maybeDateFields.get("value");
     assertComplexClass(value, Date.class.getTypeName());
+    // empty
     Map<String, Object> empty = (Map<String, Object>) objLocalFields.get("empty");
     assertComplexClass(empty, Optional.class.getTypeName());
     Map<String, Object> emptyFields = (Map<String, Object>) empty.get(FIELDS);
     value = (Map<String, Object>) emptyFields.get("value");
     assertEquals(Object.class.getTypeName(), value.get(TYPE));
     assertTrue((Boolean) value.get(IS_NULL));
+    // maybeInt
+    Map<String, Object> maybeInt = (Map<String, Object>) objLocalFields.get("maybeInt");
+    assertComplexClass(maybeInt, OptionalInt.class.getTypeName());
+    Map<String, Object> maybeIntFields = (Map<String, Object>) maybeInt.get(FIELDS);
+    assertPrimitiveValue(maybeIntFields, "value", "int", "42");
+    // maybeDouble
+    Map<String, Object> maybeDouble = (Map<String, Object>) objLocalFields.get("maybeDouble");
+    assertComplexClass(maybeDouble, OptionalDouble.class.getTypeName());
+    Map<String, Object> maybeDoubleFields = (Map<String, Object>) maybeDouble.get(FIELDS);
+    assertPrimitiveValue(maybeDoubleFields, "value", "double", "3.14");
+    // maybeLong
+    Map<String, Object> maybeLong = (Map<String, Object>) objLocalFields.get("maybeLong");
+    assertComplexClass(maybeLong, OptionalLong.class.getTypeName());
+    Map<String, Object> maybeLongFields = (Map<String, Object>) maybeLong.get(FIELDS);
+    assertPrimitiveValue(maybeLongFields, "value", "long", "84");
+    // ex
     Map<String, Object> ex = (Map<String, Object>) objLocalFields.get("ex");
     assertComplexClass(ex, IllegalArgumentException.class.getTypeName());
     Map<String, Object> exFields = (Map<String, Object>) ex.get(FIELDS);


### PR DESCRIPTION
# What Does This Do
We added special field access for Optional but forgot about specialized version for primitives: Int, Double and Long

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2777]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2777]: https://datadoghq.atlassian.net/browse/DEBUG-2777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ