### PR TITLE
Spring scheduling: ensure spans have no parent

### DIFF
--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
@@ -1,16 +1,20 @@
 package datadog.trace.instrumentation.springscheduling;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
 import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.DECORATE;
 import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.SCHEDULED_CALL;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 
 public class SpringSchedulingRunnableWrapper implements Runnable {
+  private static final boolean LEGACY_TRACING =
+      Config.get().isLegacyTracingEnabled(false, "spring-scheduling");
   private final Runnable runnable;
 
   private SpringSchedulingRunnableWrapper(final Runnable runnable) {
@@ -19,22 +23,24 @@ public class SpringSchedulingRunnableWrapper implements Runnable {
 
   @Override
   public void run() {
-    final AgentSpan span = startSpan(SCHEDULED_CALL);
-    DECORATE.afterStart(span);
+    try (AgentScope closeMe = LEGACY_TRACING ? null : activateSpan(noopSpan())) {
+      final AgentSpan span = startSpan(SCHEDULED_CALL);
+      DECORATE.afterStart(span);
 
-    try (final AgentScope scope = activateSpan(span)) {
-      DECORATE.onRun(span, runnable);
-      scope.setAsyncPropagation(true);
+      try (final AgentScope scope = activateSpan(span)) {
+        DECORATE.onRun(span, runnable);
+        scope.setAsyncPropagation(true);
 
-      try {
-        runnable.run();
-      } catch (final Throwable throwable) {
-        DECORATE.onError(span, throwable);
-        throw throwable;
+        try {
+          runnable.run();
+        } catch (final Throwable throwable) {
+          DECORATE.onError(span, throwable);
+          throw throwable;
+        }
+      } finally {
+        DECORATE.beforeFinish(span);
+        span.finish();
       }
-    } finally {
-      DECORATE.beforeFinish(span);
-      span.finish();
     }
   }
 

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/test/java/SchedulingConfig.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/test/java/SchedulingConfig.java
@@ -1,0 +1,95 @@
+import static datadog.trace.agent.test.utils.TraceUtils.runnableUnderTrace;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.ScheduledFuture;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+public class SchedulingConfig implements SchedulingConfigurer {
+  static class TracingTaskScheduler implements TaskScheduler {
+    final ThreadPoolTaskScheduler scheduler;
+
+    TracingTaskScheduler() {
+      scheduler = new ThreadPoolTaskScheduler();
+      scheduler.initialize();
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Duration delay) {
+      return scheduler.scheduleWithFixedDelay(() -> runnableUnderTrace("parent", task), delay);
+    }
+
+    @Override
+    public Clock getClock() {
+      return Clock.systemUTC();
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable task, Instant startTime) {
+      return scheduler.schedule(() -> runnableUnderTrace("parent", task), startTime);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(
+        Runnable task, Instant startTime, Duration period) {
+      return scheduler.scheduleAtFixedRate(
+          () -> runnableUnderTrace("parent", task), startTime, period);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Duration period) {
+      return scheduler.scheduleAtFixedRate(() -> runnableUnderTrace("parent", task), period);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(
+        Runnable task, Instant startTime, Duration delay) {
+      return scheduler.scheduleWithFixedDelay(
+          () -> runnableUnderTrace("parent", task), startTime, delay);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable runnable, Trigger trigger) {
+      return scheduler.schedule(() -> runnableUnderTrace("parent", runnable), trigger);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable runnable, Date date) {
+      return scheduler.schedule(() -> runnableUnderTrace("parent", runnable), date);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, Date date, long l) {
+      return scheduler.scheduleAtFixedRate(() -> runnableUnderTrace("parent", runnable), date, l);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable runnable, long l) {
+      return scheduler.scheduleAtFixedRate(() -> runnableUnderTrace("parent", runnable), l);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, Date date, long l) {
+      return scheduler.scheduleWithFixedDelay(
+          () -> runnableUnderTrace("parent", runnable), date, l);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable, long l) {
+      return scheduler.scheduleWithFixedDelay(() -> runnableUnderTrace("parent", runnable), l);
+    }
+  }
+
+  @Override
+  public void configureTasks(ScheduledTaskRegistrar scheduledTaskRegistrar) {
+    scheduledTaskRegistrar.setTaskScheduler(new TracingTaskScheduler());
+  }
+}


### PR DESCRIPTION
# What Does This Do

According to our tests the spring scheduling spans should have no parent. This PR ensure that the spans are created with a noop parent scope. Temporary, I also added a way to restore the old behaviour (that's nondeterministic anyway) by
* the sys prop `-Ddd.spring-scheduling.legacy.tracing.enabled=true`
* the env `DD_SPRING_SCHEDULING_LEGACY_TRACING_ENABLED=true`

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
