### PR TITLE
Fix Exploit Prevention capability announcement on remote config

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -13,6 +13,7 @@ import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_HEADER_FINGERPRIN
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_IP_BLOCKING;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_NETWORK_FINGERPRINT;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_SQLI;
+import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_SSRF;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_REQUEST_BLOCKING;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_TRUSTED_IPS;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_USER_BLOCKING;
@@ -97,7 +98,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
 
     this.configurationPoller.addConfigurationEndListener(applyRemoteConfigListener);
 
-    this.configurationPoller.addCapabilities(
+    long capabilities =
         CAPABILITY_ASM_DD_RULES
             | CAPABILITY_ASM_IP_BLOCKING
             | CAPABILITY_ASM_EXCLUSIONS
@@ -107,12 +108,16 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_CUSTOM_RULES
             | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
             | CAPABILITY_ASM_TRUSTED_IPS
-            | CAPABILITY_ASM_RASP_SQLI
             | CAPABILITY_ENDPOINT_FINGERPRINT
             // TODO enable when usr.id and usr.session_id addresses are added
             // | CAPABILITY_ASM_SESSION_FINGERPRINT
             | CAPABILITY_ASM_NETWORK_FINGERPRINT
-            | CAPABILITY_ASM_HEADER_FINGERPRINT);
+            | CAPABILITY_ASM_HEADER_FINGERPRINT;
+    if (tracerConfig.isAppSecRaspEnabled()) {
+      capabilities |= CAPABILITY_ASM_RASP_SQLI;
+      capabilities |= CAPABILITY_ASM_RASP_SSRF;
+    }
+    this.configurationPoller.addCapabilities(capabilities);
   }
 
   private void subscribeRulesAndData() {
@@ -353,6 +358,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_TRUSTED_IPS
             | CAPABILITY_ASM_API_SECURITY_SAMPLE_RATE
             | CAPABILITY_ASM_RASP_SQLI
+            | CAPABILITY_ASM_RASP_SSRF
             | CAPABILITY_ASM_AUTO_USER_INSTRUM_MODE
             | CAPABILITY_ENDPOINT_FINGERPRINT
             // TODO enable when usr.id and usr.session_id addresses are added

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -27,6 +27,7 @@ import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_HEADER_FINGERPRIN
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_IP_BLOCKING
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_NETWORK_FINGERPRINT
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_SQLI
+import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_SSRF
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_REQUEST_BLOCKING
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_TRUSTED_IPS
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_USER_BLOCKING
@@ -197,6 +198,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     configurer.commit()
 
     then:
+    1 * config.isAppSecRaspEnabled() >> true
     1 * config.getAppSecRulesFile() >> null
     1 * config.getAppSecActivation() >> ProductActivation.ENABLED_INACTIVE
     1 * poller.addListener(Product.ASM_FEATURES, _, _) >> {
@@ -233,6 +235,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     configurer.commit()
 
     then:
+    1 * config.isAppSecRaspEnabled() >> true
     1 * config.getAppSecRulesFile() >> null
     1 * config.getAppSecActivation() >> ProductActivation.ENABLED_INACTIVE
     1 * poller.addListener(Product.ASM_DD, _, _) >> {
@@ -265,6 +268,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
       | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
       | CAPABILITY_ASM_TRUSTED_IPS
       | CAPABILITY_ASM_RASP_SQLI
+      | CAPABILITY_ASM_RASP_SSRF
       | CAPABILITY_ENDPOINT_FINGERPRINT
       // | CAPABILITY_ASM_SESSION_FINGERPRINT
       | CAPABILITY_ASM_NETWORK_FINGERPRINT
@@ -382,6 +386,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
     configurer.commit()
 
     then:
+    1 * config.isAppSecRaspEnabled() >> true
     1 * config.getAppSecRulesFile() >> null
     1 * config.getAppSecActivation() >> ProductActivation.ENABLED_INACTIVE
     1 * poller.addListener(Product.ASM_DD, _, _) >> {
@@ -414,6 +419,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
       | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
       | CAPABILITY_ASM_TRUSTED_IPS
       | CAPABILITY_ASM_RASP_SQLI
+      | CAPABILITY_ASM_RASP_SSRF
       | CAPABILITY_ENDPOINT_FINGERPRINT
       // | CAPABILITY_ASM_SESSION_FINGERPRINT
       | CAPABILITY_ASM_NETWORK_FINGERPRINT
@@ -485,6 +491,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
       | CAPABILITY_ASM_TRUSTED_IPS
       | CAPABILITY_ASM_API_SECURITY_SAMPLE_RATE
       | CAPABILITY_ASM_RASP_SQLI
+      | CAPABILITY_ASM_RASP_SSRF
       | CAPABILITY_ASM_AUTO_USER_INSTRUM_MODE
       | CAPABILITY_ENDPOINT_FINGERPRINT
       // | CAPABILITY_ASM_SESSION_FINGERPRINT


### PR DESCRIPTION
# What Does This Do
Fix Exploit Prevention (aka RASP) capability announcement for remote configuration. For v1.39.0, this has been addressed in the backend with a capability override. For v1.40.0+, we'll properly announce the capabilities, including not announcing them if the user sets `DD_APPSEC_RASP_ENABLED=false`.

# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
