### PR TITLE
Add support for session fingerprints to the WAF

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/AppSecConfigServiceImpl.java
@@ -16,6 +16,7 @@ import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_LFI;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_SQLI;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_RASP_SSRF;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_REQUEST_BLOCKING;
+import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_SESSION_FINGERPRINT;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_TRUSTED_IPS;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_USER_BLOCKING;
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ENDPOINT_FINGERPRINT;
@@ -110,8 +111,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_CUSTOM_BLOCKING_RESPONSE
             | CAPABILITY_ASM_TRUSTED_IPS
             | CAPABILITY_ENDPOINT_FINGERPRINT
-            // TODO enable when usr.id and usr.session_id addresses are added
-            // | CAPABILITY_ASM_SESSION_FINGERPRINT
+            | CAPABILITY_ASM_SESSION_FINGERPRINT
             | CAPABILITY_ASM_NETWORK_FINGERPRINT
             | CAPABILITY_ASM_HEADER_FINGERPRINT;
     if (tracerConfig.isAppSecRaspEnabled()) {
@@ -364,8 +364,7 @@ public class AppSecConfigServiceImpl implements AppSecConfigService {
             | CAPABILITY_ASM_RASP_LFI
             | CAPABILITY_ASM_AUTO_USER_INSTRUM_MODE
             | CAPABILITY_ENDPOINT_FINGERPRINT
-            // TODO enable when usr.id and usr.session_id addresses are added
-            // | CAPABILITY_ASM_SESSION_FINGERPRINT
+            | CAPABILITY_ASM_SESSION_FINGERPRINT
             | CAPABILITY_ASM_NETWORK_FINGERPRINT
             | CAPABILITY_ASM_HEADER_FINGERPRINT);
     this.configurationPoller.removeListeners(Product.ASM_DD);

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -111,6 +111,8 @@ public interface KnownAddresses {
 
   Address<String> USER_ID = new Address<>("usr.id");
 
+  Address<String> SESSION_ID = new Address<>("usr.session_id");
+
   /** The URL of a network resource being requested (outgoing request) */
   Address<String> IO_NET_URL = new Address<>("server.io.net.url");
 
@@ -124,6 +126,12 @@ public interface KnownAddresses {
   Address<String> DB_SQL_QUERY = new Address<>("server.db.statement");
 
   Address<Map<String, Object>> WAF_CONTEXT_PROCESSOR = new Address<>("waf.context.processor");
+
+  /** Login failure business event */
+  Address<String> LOGIN_FAILURE = new Address<>("server.business_logic.users.login.failure");
+
+  /** Login success business event */
+  Address<String> LOGIN_SUCCESS = new Address<>("server.business_logic.users.login.success");
 
   static Address<?> forName(String name) {
     switch (name) {
@@ -181,6 +189,8 @@ public interface KnownAddresses {
         return SERVER_GRAPHQL_ALL_RESOLVERS;
       case "usr.id":
         return USER_ID;
+      case "usr.session_id":
+        return SESSION_ID;
       case "server.io.net.url":
         return IO_NET_URL;
       case "server.io.fs.file":
@@ -191,6 +201,10 @@ public interface KnownAddresses {
         return DB_SQL_QUERY;
       case "waf.context.processor":
         return WAF_CONTEXT_PROCESSOR;
+      case "server.business_logic.users.login.success":
+        return LOGIN_SUCCESS;
+      case "server.business_logic.users.login.failure":
+        return LOGIN_FAILURE;
       default:
         return null;
     }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/event/data/KnownAddresses.java
@@ -125,13 +125,13 @@ public interface KnownAddresses {
   /** The SQL query being executed */
   Address<String> DB_SQL_QUERY = new Address<>("server.db.statement");
 
-  Address<Map<String, Object>> WAF_CONTEXT_PROCESSOR = new Address<>("waf.context.processor");
-
   /** Login failure business event */
   Address<String> LOGIN_FAILURE = new Address<>("server.business_logic.users.login.failure");
 
   /** Login success business event */
   Address<String> LOGIN_SUCCESS = new Address<>("server.business_logic.users.login.success");
+
+  Address<Map<String, Object>> WAF_CONTEXT_PROCESSOR = new Address<>("waf.context.processor");
 
   static Address<?> forName(String name) {
     switch (name) {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/user/AppSecEventTrackerImpl.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/user/AppSecEventTrackerImpl.java
@@ -3,14 +3,24 @@ package com.datadog.appsec.user;
 import static datadog.trace.api.UserIdCollectionMode.ANONYMIZATION;
 import static datadog.trace.api.UserIdCollectionMode.DISABLED;
 import static datadog.trace.api.UserIdCollectionMode.SDK;
+import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 import static datadog.trace.util.Strings.toHexString;
 
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.api.UserIdCollectionMode;
 import datadog.trace.api.appsec.AppSecEventTracker;
+import datadog.trace.api.function.TriFunction;
+import datadog.trace.api.gateway.BlockResponseFunction;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.EventType;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.api.telemetry.WafMetricCollector;
 import datadog.trace.bootstrap.ActiveSubsystems;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.security.MessageDigest;
@@ -54,7 +64,7 @@ public class AppSecEventTrackerImpl extends AppSecEventTracker {
     if (segment == null) {
       return;
     }
-    onUserId(mode, segment, userId);
+    onUserId(mode, segment, userId, EVENTS.userId());
     onEvent(mode, segment, "users.signup", false, metadata);
   }
 
@@ -65,7 +75,7 @@ public class AppSecEventTrackerImpl extends AppSecEventTracker {
     if (segment == null) {
       return;
     }
-    onUserId(mode, segment, userId);
+    onUserId(mode, segment, userId, EVENTS.loginSuccess());
     onEvent(mode, segment, "users.login.success", false, metadata);
   }
 
@@ -79,7 +89,7 @@ public class AppSecEventTrackerImpl extends AppSecEventTracker {
     if (segment == null) {
       return;
     }
-    onUserId(mode, segment, userId, LOGIN_FAILURE_USER_ID_EXTRA_TAG);
+    onUserId(mode, segment, userId, EVENTS.loginFailure(), LOGIN_FAILURE_USER_ID_EXTRA_TAG);
     onEvent(mode, segment, "users.login.failure", false, metadata);
     if (exists != null) {
       segment.setTagTop(LOGIN_FAILURE_NO_USER_TAG, exists, false);
@@ -104,14 +114,36 @@ public class AppSecEventTrackerImpl extends AppSecEventTracker {
       @Nonnull final UserIdCollectionMode mode,
       final TraceSegment segment,
       final String userId,
+      final EventType<TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>>> event,
       final String... extraTags) {
-    if (mode == SDK || !hasSdkEvent(segment)) {
-      String finalUserId = mode == ANONYMIZATION ? anonymize(userId) : userId;
-      segment.setTagTop("usr.id", finalUserId);
-      segment.setTagTop(USER_COLLECTION_MODE_TAG, mode.shortName());
-      for (String tag : extraTags) {
-        segment.setTagTop(tag, finalUserId, false);
+    if (mode != SDK && isSdkCollectedUser(segment)) {
+      return; // do not overwrite users set by the SDK
+    }
+    final String finalUserId = mode == ANONYMIZATION ? anonymize(userId) : userId;
+    for (String tag : extraTags) {
+      segment.setTagTop(tag, finalUserId, false);
+    }
+    final AgentSpan span = tracer().activeSpan();
+    if (span == null) {
+      return;
+    }
+    final RequestContext ctx = span.getRequestContext();
+    if (ctx == null) {
+      return;
+    }
+    final Flow<Void> flow = callIGCallbackUserId(tracer().activeSpan(), mode, finalUserId, event);
+    final Flow.Action action = flow.getAction();
+    if (action instanceof Flow.Action.RequestBlockingAction) {
+      final BlockResponseFunction brf = ctx.getBlockResponseFunction();
+      if (brf != null) {
+        Flow.Action.RequestBlockingAction rba = (Flow.Action.RequestBlockingAction) action;
+        brf.tryCommitBlockingResponse(
+            ctx.getTraceSegment(),
+            rba.getStatusCode(),
+            rba.getBlockingContentType(),
+            rba.getExtraHeaders());
       }
+      throw new BlockingException("Blocked request (for user id)");
     }
   }
 
@@ -151,10 +183,10 @@ public class AppSecEventTrackerImpl extends AppSecEventTracker {
     if (!isEnabled(mode)) {
       return null;
     }
-    return getSegment();
+    return tracer().getTraceSegment();
   }
 
-  protected boolean hasSdkEvent(final TraceSegment segment) {
+  protected boolean isSdkCollectedUser(final TraceSegment segment) {
     if (segment == null) {
       return false;
     }
@@ -189,7 +221,28 @@ public class AppSecEventTrackerImpl extends AppSecEventTracker {
     return ANON_PREFIX + toHexString(hash);
   }
 
-  protected TraceSegment getSegment() {
-    return AgentTracer.get().getTraceSegment();
+  @SuppressWarnings("UnusedReturnValue")
+  private Flow<Void> callIGCallbackUserId(
+      final AgentSpan span,
+      final UserIdCollectionMode mode,
+      final String userId,
+      final EventType<TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>>>
+          event) {
+    final CallbackProvider cbp = tracer().getCallbackProvider(RequestContextSlot.APPSEC);
+    final RequestContext requestContext = span.getRequestContext();
+    if (cbp == null || requestContext == null) {
+      return Flow.ResultFlow.empty();
+    }
+    final TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>> addrCallback =
+        cbp.getCallback(event);
+    if (addrCallback == null) {
+      return Flow.ResultFlow.empty();
+    }
+    return addrCallback.apply(requestContext, mode, userId);
+  }
+
+  // Extract this to allow for easier testing
+  protected AgentTracer.TracerAPI tracer() {
+    return AgentTracer.get();
   }
 }

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/config/AppSecConfigServiceImplSpecification.groovy
@@ -33,6 +33,7 @@ import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_REQUEST_BLOCKING
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_TRUSTED_IPS
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_USER_BLOCKING
 import static datadog.remoteconfig.Capabilities.CAPABILITY_ENDPOINT_FINGERPRINT
+import static datadog.remoteconfig.Capabilities.CAPABILITY_ASM_SESSION_FINGERPRINT
 import static datadog.remoteconfig.PollingHinterNoop.NOOP
 import static datadog.trace.api.UserIdCollectionMode.ANONYMIZATION
 import static datadog.trace.api.UserIdCollectionMode.DISABLED
@@ -272,7 +273,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
       | CAPABILITY_ASM_RASP_SSRF
       | CAPABILITY_ASM_RASP_LFI
       | CAPABILITY_ENDPOINT_FINGERPRINT
-      // | CAPABILITY_ASM_SESSION_FINGERPRINT
+      | CAPABILITY_ASM_SESSION_FINGERPRINT
       | CAPABILITY_ASM_NETWORK_FINGERPRINT
       | CAPABILITY_ASM_HEADER_FINGERPRINT)
     0 * _._
@@ -424,7 +425,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
       | CAPABILITY_ASM_RASP_SSRF
       | CAPABILITY_ASM_RASP_LFI
       | CAPABILITY_ENDPOINT_FINGERPRINT
-      // | CAPABILITY_ASM_SESSION_FINGERPRINT
+      | CAPABILITY_ASM_SESSION_FINGERPRINT
       | CAPABILITY_ASM_NETWORK_FINGERPRINT
       | CAPABILITY_ASM_HEADER_FINGERPRINT)
     0 * _._
@@ -498,7 +499,7 @@ class AppSecConfigServiceImplSpecification extends DDSpecification {
       | CAPABILITY_ASM_RASP_LFI
       | CAPABILITY_ASM_AUTO_USER_INSTRUM_MODE
       | CAPABILITY_ENDPOINT_FINGERPRINT
-      // | CAPABILITY_ASM_SESSION_FINGERPRINT
+      | CAPABILITY_ASM_SESSION_FINGERPRINT
       | CAPABILITY_ASM_NETWORK_FINGERPRINT
       | CAPABILITY_ASM_HEADER_FINGERPRINT)
     4 * poller.removeListeners(_)

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/event/data/KnownAddressesSpecification.groovy
@@ -36,13 +36,16 @@ class KnownAddressesSpecification extends Specification {
       'server.db.system',
       'server.db.statement',
       'usr.id',
+      'usr.session_id',
+      'server.business_logic.users.login.failure',
+      'server.business_logic.users.login.success',
       'waf.context.processor',
     ]
   }
 
   void 'number of known addresses is expected number'() {
     expect:
-    Address.instanceCount() == 32
+    Address.instanceCount() == 35
     KnownAddresses.WAF_CONTEXT_PROCESSOR.serial == Address.instanceCount() - 1
   }
 }

--- a/dd-java-agent/appsec/src/test/resources/fingerprint_config.json
+++ b/dd-java-agent/appsec/src/test/resources/fingerprint_config.json
@@ -79,7 +79,52 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "processor-004",
+      "generator": "session_fingerprint",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "fingerprint"
+                ]
+              }
+            ],
+            "value": true,
+            "type": "boolean"
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "cookies": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "session_id": [
+              {
+                "address": "usr.session_id"
+              }
+            ],
+            "user_id": [
+              {
+                "address": "usr.id"
+              }
+            ],
+            "output": "_dd.appsec.fp.session"
+          }
+        ]
+      },
+      "evaluate": false,
       "output": true
     }
   ]

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
@@ -61,17 +61,6 @@ public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Resp
   }
 
   @Override
-  protected String requestedSessionId(final Request request) {
-    final String requestedSessionId = request.getRequestedSessionId();
-    if (requestedSessionId != null) {
-      return requestedSessionId;
-    }
-    // this forces the loading of the requested session id
-    request.getSession(false);
-    return request.getRequestedSessionId();
-  }
-
-  @Override
   protected String[] instrumentationNames() {
     return new String[] {"grizzly"};
   }

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyDecorator.java
@@ -61,6 +61,17 @@ public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Resp
   }
 
   @Override
+  protected String requestedSessionId(final Request request) {
+    final String requestedSessionId = request.getRequestedSessionId();
+    if (requestedSessionId != null) {
+      return requestedSessionId;
+    }
+    // this forces the loading of the requested session id
+    request.getSession(false);
+    return request.getRequestedSessionId();
+  }
+
+  @Override
   protected String[] instrumentationNames() {
     return new String[] {"grizzly"};
   }

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyAsyncTest.groovy
@@ -1,5 +1,4 @@
 import datadog.appsec.api.blocking.Blocking
-import org.glassfish.grizzly.http.server.Request
 
 import javax.ws.rs.GET
 import javax.ws.rs.HeaderParam
@@ -7,13 +6,11 @@ import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
 import javax.ws.rs.container.AsyncResponse
 import javax.ws.rs.container.Suspended
-import javax.ws.rs.core.Context
 import javax.ws.rs.core.Response
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SESSION_ID
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.FORWARDED
@@ -118,21 +115,6 @@ class GrizzlyAsyncTest extends GrizzlyTest {
         try {
           controller(EXCEPTION) {
             throw new Exception(EXCEPTION.body)
-          }
-        } catch (Exception e) {
-          ar.resume(e)
-        }
-      }
-    }
-
-    @GET
-    @Path("session")
-    Response session(@Context Request request, @Suspended AsyncResponse ar) {
-      executor.execute {
-        try {
-          controller(SESSION_ID) {
-            final session = request.getSession(true)
-            ar.resume(Response.status(SESSION_ID.status).entity(session.idInternal).build())
           }
         } catch (Exception e) {
           ar.resume(e)

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
@@ -2,7 +2,6 @@ import datadog.appsec.api.blocking.Blocking
 import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.instrumentation.grizzly.GrizzlyDecorator
 import org.glassfish.grizzly.http.server.HttpServer
-import org.glassfish.grizzly.http.server.Request
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
 import org.glassfish.jersey.server.ResourceConfig
 
@@ -15,7 +14,6 @@ import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.container.ContainerRequestFilter
 import javax.ws.rs.container.ContainerResponseContext
 import javax.ws.rs.container.ContainerResponseFilter
-import javax.ws.rs.core.Context
 import javax.ws.rs.core.Response
 import javax.ws.rs.ext.ExceptionMapper
 import javax.ws.rs.ext.Provider
@@ -28,7 +26,6 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
-import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SESSION_ID
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
@@ -116,11 +113,6 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
     false
   }
 
-  @Override
-  boolean testSessionId() {
-    return true
-  }
-
   static class SimpleExceptionMapper implements ExceptionMapper<Throwable> {
 
     @Override
@@ -141,9 +133,6 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
 
   @Path("/")
   static class ServiceResource {
-
-    @Context
-    Request request
 
     @GET
     @Path("success")
@@ -219,15 +208,6 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
         throw new Exception(EXCEPTION.body)
       }
       return null
-    }
-
-    @GET
-    @Path("session")
-    Response session() {
-      controller(SESSION_ID) {
-        final session = request.getSession(true)
-        Response.status(SESSION_ID.status).entity(session.idInternal).build()
-      }
     }
   }
 

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyDecorator.java
@@ -89,6 +89,11 @@ public class LibertyDecorator
   }
 
   @Override
+  protected String requestedSessionId(final HttpServletRequest request) {
+    return request.getRequestedSessionId();
+  }
+
+  @Override
   public AgentSpan onResponseStatus(AgentSpan span, int status) {
     Integer currentStatus = (Integer) span.getTag(Tags.HTTP_STATUS);
     // do not set status if the tag is already there and it's an error span

--- a/dd-java-agent/instrumentation/liberty-20/src/test/groovy/datadog/trace/instrumentation/liberty20/Liberty20Test.groovy
+++ b/dd-java-agent/instrumentation/liberty-20/src/test/groovy/datadog/trace/instrumentation/liberty20/Liberty20Test.groovy
@@ -123,6 +123,11 @@ abstract class Liberty20Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testSessionId() {
+    true
+  }
+
+  @Override
   String expectedResourceName(ServerEndpoint endpoint, String method, URI address) {
     if (endpoint.path == '/not-found') {
       'GET /testapp/not-found'

--- a/dd-java-agent/instrumentation/liberty-20/src/webapp/java/datadog/trace/instrumentation/liberty20/AsyncServlet3.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/webapp/java/datadog/trace/instrumentation/liberty20/AsyncServlet3.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.liberty20;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_MULTIPART;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SESSION_ID;
 
 import datadog.trace.agent.test.base.HttpServerTest;
 import java.io.ByteArrayOutputStream;
@@ -48,6 +49,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
       "/async/encoded path query",
       "/async/encoded_query",
       "/async/user-block",
+      "/async/session",
     },
     asyncSupported = true)
 @MultipartConfig(
@@ -87,7 +89,9 @@ public class AsyncServlet3 extends HttpServlet {
       if (serverEndpoint == BODY_MULTIPART) {
         // needed to trigger reading the body on openliberty
         ((HttpServletRequest) req).getParts();
-      } else if (serverEndpoint == ERROR || serverEndpoint == QUERY_ENCODED_BOTH) {
+      } else if (serverEndpoint == ERROR
+          || serverEndpoint == QUERY_ENCODED_BOTH
+          || serverEndpoint == SESSION_ID) {
         delegate.service(req, res);
         return;
       }

--- a/dd-java-agent/instrumentation/liberty-20/src/webapp/java/datadog/trace/instrumentation/liberty20/PassthruSyncServlet3.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/webapp/java/datadog/trace/instrumentation/liberty20/PassthruSyncServlet3.java
@@ -34,6 +34,7 @@ import javax.servlet.http.HttpServletRequest;
       "/encoded path query",
       "/encoded_query",
       "/user-block",
+      "/session",
     })
 @MultipartConfig(
     maxFileSize = 10 * 1024 * 1024,

--- a/dd-java-agent/instrumentation/liberty-23/src/main/java/datadog/trace/instrumentation/liberty23/LibertyDecorator.java
+++ b/dd-java-agent/instrumentation/liberty-23/src/main/java/datadog/trace/instrumentation/liberty23/LibertyDecorator.java
@@ -89,6 +89,11 @@ public class LibertyDecorator
   }
 
   @Override
+  protected String requestedSessionId(final HttpServletRequest request) {
+    return request.getRequestedSessionId();
+  }
+
+  @Override
   public AgentSpan onResponseStatus(AgentSpan span, int status) {
     Integer currentStatus = (Integer) span.getTag(Tags.HTTP_STATUS);
     // do not set status if the tag is already there and it's an error span

--- a/dd-java-agent/instrumentation/liberty-23/src/test/groovy/datadog/trace/instrumentation/liberty23/Liberty23Test.groovy
+++ b/dd-java-agent/instrumentation/liberty-23/src/test/groovy/datadog/trace/instrumentation/liberty23/Liberty23Test.groovy
@@ -113,6 +113,11 @@ abstract class Liberty23Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testSessionId() {
+    true
+  }
+
+  @Override
   String expectedResourceName(ServerEndpoint endpoint, String method, URI address) {
     if (endpoint.path == '/not-found') {
       'GET /testapp/not-found'

--- a/dd-java-agent/instrumentation/liberty-23/src/webapp/java/datadog/trace/instrumentation/liberty23/AsyncServlet5.java
+++ b/dd-java-agent/instrumentation/liberty-23/src/webapp/java/datadog/trace/instrumentation/liberty23/AsyncServlet5.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.liberty23;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.BODY_MULTIPART;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR;
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH;
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SESSION_ID;
 
 import datadog.trace.agent.test.base.HttpServerTest;
 import jakarta.servlet.AsyncContext;
@@ -48,6 +49,7 @@ import java.util.Enumeration;
       "/async/encoded path query",
       "/async/encoded_query",
       "/async/user-block",
+      "/async/session",
     },
     asyncSupported = true)
 @MultipartConfig(
@@ -87,7 +89,9 @@ public class AsyncServlet5 extends HttpServlet {
       if (serverEndpoint == BODY_MULTIPART) {
         // needed to trigger reading the body on openliberty
         ((HttpServletRequest) req).getParts();
-      } else if (serverEndpoint == ERROR || serverEndpoint == QUERY_ENCODED_BOTH) {
+      } else if (serverEndpoint == ERROR
+          || serverEndpoint == QUERY_ENCODED_BOTH
+          || serverEndpoint == SESSION_ID) {
         delegate.service(req, res);
         return;
       }

--- a/dd-java-agent/instrumentation/liberty-23/src/webapp/java/datadog/trace/instrumentation/liberty23/PassthruSyncServlet5.java
+++ b/dd-java-agent/instrumentation/liberty-23/src/webapp/java/datadog/trace/instrumentation/liberty23/PassthruSyncServlet5.java
@@ -34,6 +34,7 @@ import java.util.Enumeration;
       "/encoded path query",
       "/encoded_query",
       "/user-block",
+      "/session",
     })
 @MultipartConfig(
     maxFileSize = 10 * 1024 * 1024,

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Decorator.java
@@ -28,6 +28,11 @@ public class Servlet2Decorator
   }
 
   @Override
+  protected String requestedSessionId(final HttpServletRequest request) {
+    return request.getRequestedSessionId();
+  }
+
+  @Override
   protected AgentPropagation.ContextVisitor<HttpServletRequest> getter() {
     return GETTER;
   }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -125,6 +125,12 @@ abstract class JettyServlet2Test extends HttpServerTest<Server> {
   }
 
   @Override
+  boolean testSessionId() {
+    // TODO enable when session id management is added to Jetty
+    false
+  }
+
+  @Override
   Map<String, Serializable> expectedExtraServerTags(ServerEndpoint endpoint) {
     ["servlet.path": endpoint.path, "servlet.context": "/$CONTEXT"]
   }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/TestServlet2.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/TestServlet2.groovy
@@ -13,6 +13,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SESSION_ID
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 
@@ -56,6 +57,11 @@ class TestServlet2 {
             break
           case EXCEPTION:
             throw new Exception(endpoint.body)
+          case SESSION_ID:
+            def session = req.getSession(true)
+            resp.status = endpoint.status
+            resp.writer.print(session.id)
+            break
         }
       }
     }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Decorator.java
@@ -71,6 +71,11 @@ public class Servlet3Decorator
   }
 
   @Override
+  protected String requestedSessionId(final HttpServletRequest request) {
+    return request.getRequestedSessionId();
+  }
+
+  @Override
   public AgentSpan onRequest(
       final AgentSpan span,
       final HttpServletRequest connection,

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -145,6 +145,12 @@ abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletCon
   }
 
   @Override
+  boolean testSessionId() {
+    // TODO enable when session id management is added to Jetty
+    false
+  }
+
+  @Override
   boolean hasResponseSpan(ServerEndpoint endpoint) {
     if (IS_LATEST) {
       return [NOT_FOUND, ERROR, REDIRECT].contains(endpoint)

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -40,6 +40,11 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
     true
   }
 
+  @Override
+  boolean testSessionId() {
+    true
+  }
+
   class TomcatServer implements HttpServer {
     def port = 0
     final Tomcat server

--- a/dd-java-agent/instrumentation/servlet/request-3/src/testFixtures/groovy/datadog/trace/instrumentation/servlet3/TestServlet3.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/testFixtures/groovy/datadog/trace/instrumentation/servlet3/TestServlet3.groovy
@@ -25,6 +25,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SESSION_ID
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.TIMEOUT_ERROR
@@ -117,6 +118,11 @@ class TestServlet3 {
             break
           case CUSTOM_EXCEPTION:
             throw new InputMismatchException(endpoint.body)
+          case SESSION_ID:
+            def session = req.getSession(true)
+            resp.status = endpoint.status
+            resp.writer.print(session.id)
+            break
         }
       }
     }
@@ -197,6 +203,12 @@ class TestServlet3 {
               resp.writer.print('should not be reached')
               context.complete()
               break
+            case SESSION_ID:
+              def session = req.getSession(true)
+              resp.status = endpoint.status
+              resp.writer.print(session.id)
+              context.complete()
+              break
           }
         }
       }
@@ -249,6 +261,11 @@ class TestServlet3 {
             case USER_BLOCK:
               Blocking.forUser('user-to-block').blockIfMatch()
               resp.writer.print('should not be reached')
+              break
+            case SESSION_ID:
+              def session = req.getSession(true)
+              resp.status = endpoint.status
+              resp.writer.print(session.id)
               break
           }
         }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/testFixtures/groovy/datadog/trace/instrumentation/servlet5/TestServlet5.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/testFixtures/groovy/datadog/trace/instrumentation/servlet5/TestServlet5.groovy
@@ -23,6 +23,7 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_QUERY
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
+import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SESSION_ID
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_BLOCK
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.forPath
@@ -96,6 +97,11 @@ class TestServlet5 extends HttpServlet {
           throw new Exception(endpoint.body)
         case CUSTOM_EXCEPTION:
           throw new InputMismatchException(endpoint.body)
+        case SESSION_ID:
+          def session = req.getSession(true)
+          resp.status = endpoint.status
+          resp.writer.print(session.id)
+          break
         default:
           resp.status = NOT_FOUND.status
           resp.writer.print(NOT_FOUND.body)

--- a/dd-java-agent/instrumentation/tomcat-5.5-common/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5-common/src/main/java/datadog/trace/instrumentation/tomcat/TomcatDecorator.java
@@ -84,6 +84,11 @@ public class TomcatDecorator
   }
 
   @Override
+  protected String requestedSessionId(final Request request) {
+    return request.getRequestedSessionId();
+  }
+
+  @Override
   public AgentSpan onRequest(
       final AgentSpan span,
       final Request connection,

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/latestDepTest/groovy/TomcatServletTest.groovy
@@ -57,6 +57,11 @@ class TomcatServletTest extends AbstractServletTest<Tomcat, Context> {
   }
 
   @Override
+  boolean testSessionId() {
+    true
+  }
+
+  @Override
   Map<String, Serializable> expectedExtraErrorInformation(ServerEndpoint endpoint) {
     if (endpoint.throwsException) {
       // Exception classes get wrapped in ServletException

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/test/groovy/TomcatServletTest.groovy
@@ -167,6 +167,11 @@ abstract class TomcatServletTest extends AbstractServletTest<Embedded, Context> 
     true
   }
 
+  @Override
+  boolean testSessionId() {
+    true
+  }
+
   boolean hasResponseSpan(ServerEndpoint endpoint) {
     def responseSpans = [REDIRECT, NOT_FOUND, ERROR, EXCEPTION, CUSTOM_EXCEPTION]
     return responseSpans.contains(endpoint)

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/OkHttpUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/OkHttpUtils.java
@@ -2,7 +2,15 @@ package datadog.trace.agent.test.utils;
 
 import datadog.trace.agent.test.server.http.TestHttpServer;
 import java.net.ProxySelector;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import okhttp3.Cookie;
+import okhttp3.CookieJar;
+import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -73,5 +81,34 @@ public class OkHttpUtils {
         .hostnameVerifier(server.getHostnameVerifier())
         .proxySelector(proxySelector)
         .build();
+  }
+
+  public static <E> CookieJar cookieJar(Function<HttpUrl, E> cookieKey) {
+    return new CustomCookieJar<>(cookieKey);
+  }
+
+  public static CookieJar cookieJar() {
+    return cookieJar(HttpUrl::host);
+  }
+
+  private static class CustomCookieJar<E> implements CookieJar {
+
+    private final ConcurrentHashMap<E, List<Cookie>> cookies;
+    private final Function<HttpUrl, E> key;
+
+    private CustomCookieJar(final Function<HttpUrl, E> key) {
+      this.key = key;
+      cookies = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void saveFromResponse(final HttpUrl httpUrl, final List<Cookie> list) {
+      cookies.computeIfAbsent(key.apply(httpUrl), k -> new ArrayList<>()).addAll(list);
+    }
+
+    @Override
+    public List<Cookie> loadForRequest(final HttpUrl httpUrl) {
+      return cookies.getOrDefault(key.apply(httpUrl), Collections.emptyList());
+    }
   }
 }

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -5,6 +5,10 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -75,5 +79,11 @@ public class WebController {
   public String lfiPath(@RequestParam("path") String path) {
     new File(System.getProperty("user.dir")).toPath().resolve(path);
     return "EXECUTED";
+  }
+
+  @RequestMapping("/session")
+  public ResponseEntity<String> session(final HttpServletRequest request) {
+    final HttpSession session = request.getSession(true);
+    return new ResponseEntity<>(session.getId(), HttpStatus.OK);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
+++ b/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
@@ -17,7 +17,7 @@ public abstract class AppSecEventTracker extends EventTracker {
 
   public static void setEventTracker(final AppSecEventTracker tracker) {
     INSTANCE = tracker;
-    GlobalTracer.setEventTracker(tracker);
+    GlobalTracer.setEventTracker(tracker == null ? EventTracker.NO_EVENT_TRACKER : tracker);
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/Events.java
@@ -1,5 +1,6 @@
 package datadog.trace.api.gateway;
 
+import datadog.trace.api.UserIdCollectionMode;
 import datadog.trace.api.function.TriConsumer;
 import datadog.trace.api.function.TriFunction;
 import datadog.trace.api.http.StoredBodySupplier;
@@ -257,6 +258,54 @@ public final class Events<D> {
   @SuppressWarnings("unchecked")
   public EventType<BiFunction<RequestContext, String, Flow<Void>>> fileLoaded() {
     return (EventType<BiFunction<RequestContext, String, Flow<Void>>>) FILE_LOADED;
+  }
+
+  static final int REQUEST_SESSION_ID = 21;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType REQUEST_SESSION = new ET<>("request.session", REQUEST_SESSION_ID);
+
+  /** The session id of a request */
+  @SuppressWarnings("unchecked")
+  public EventType<BiFunction<RequestContext, String, Flow<Void>>> requestSession() {
+    return (EventType<BiFunction<RequestContext, String, Flow<Void>>>) REQUEST_SESSION;
+  }
+
+  static final int USER_ID = 22;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType USER = new ET<>("user", USER_ID);
+
+  /** A user with the mode used for the collection */
+  @SuppressWarnings("unchecked")
+  public EventType<TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>>> userId() {
+    return (EventType<TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>>>) USER;
+  }
+
+  static final int LOGIN_SUCCESS_ID = 23;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType LOGIN_SUCCESS = new ET<>("login.success", LOGIN_SUCCESS_ID);
+
+  /** The logged user with the mode used for the collection */
+  @SuppressWarnings("unchecked")
+  public EventType<TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>>>
+      loginSuccess() {
+    return (EventType<TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>>>)
+        LOGIN_SUCCESS;
+  }
+
+  static final int LOGIN_FAILURE_ID = 24;
+
+  @SuppressWarnings("rawtypes")
+  private static final EventType LOGIN_FAILURE = new ET<>("login.failure", LOGIN_FAILURE_ID);
+
+  /** The user tha failed to log in with the mode used for the collection */
+  @SuppressWarnings("unchecked")
+  public EventType<TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>>>
+      loginFailure() {
+    return (EventType<TriFunction<RequestContext, UserIdCollectionMode, String, Flow<Void>>>)
+        LOGIN_FAILURE;
   }
 
   static final int MAX_EVENTS = nextId.get();

--- a/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/gateway/InstrumentationGatewayTest.java
@@ -208,6 +208,14 @@ public class InstrumentationGatewayTest {
     cbp.getCallback(events.networkConnection()).apply(null, null);
     ss.registerCallback(events.fileLoaded(), callback);
     cbp.getCallback(events.fileLoaded()).apply(null, null);
+    ss.registerCallback(events.userId(), callback);
+    cbp.getCallback(events.userId()).apply(null, null, null);
+    ss.registerCallback(events.requestSession(), callback);
+    cbp.getCallback(events.requestSession()).apply(null, null);
+    ss.registerCallback(events.loginSuccess(), callback);
+    cbp.getCallback(events.loginSuccess()).apply(null, null, null);
+    ss.registerCallback(events.loginFailure(), callback);
+    cbp.getCallback(events.loginFailure()).apply(null, null, null);
     assertThat(callback.count).isEqualTo(Events.MAX_EVENTS);
   }
 
@@ -268,6 +276,14 @@ public class InstrumentationGatewayTest {
     cbp.getCallback(events.networkConnection()).apply(null, null);
     ss.registerCallback(events.fileLoaded(), throwback);
     cbp.getCallback(events.fileLoaded()).apply(null, null);
+    ss.registerCallback(events.userId(), throwback);
+    cbp.getCallback(events.userId()).apply(null, null, null);
+    ss.registerCallback(events.requestSession(), throwback);
+    cbp.getCallback(events.requestSession()).apply(null, null);
+    ss.registerCallback(events.loginSuccess(), throwback);
+    cbp.getCallback(events.loginSuccess()).apply(null, null, null);
+    ss.registerCallback(events.loginFailure(), throwback);
+    cbp.getCallback(events.loginFailure()).apply(null, null, null);
     assertThat(throwback.count).isEqualTo(Events.MAX_EVENTS);
   }
 


### PR DESCRIPTION
# What Does This Do
Add support for tracking the requested session ids for those frameworks supporting sessions. It also adds required WAF with the session ids to be able to generate session fingerprints.

# Motivation
Fingerprinting is a technique used to identify and track users through the use of available data which, when combined through a certain set of algorithms, can provide a unique fingerprint for said user.

# Additional Notes
See original [RFC](https://docs.google.com/document/d/1DivOa9XsCggmZVzMI57vyxH2_EBJ0-qqIkRHm_sEvSs/edit#heading=h.88xvn2cvs9dt)

# Contributor Checklist

- [ x Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [APPSEC-54838](https://datadoghq.atlassian.net/browse/APPSEC-54838)


[APPSEC-54838]: https://datadoghq.atlassian.net/browse/APPSEC-54838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ