### PR TITLE
Fix test flakiness for redisson

### DIFF
--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/test/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/test/groovy/RedissonClientTest.groovy
@@ -53,15 +53,13 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
   }
 
   def setup() {
-    def cleanupSpan = runUnderTrace("cleanup") {
-      activeSpan()
-    }
-    TEST_WRITER.waitUntilReported(cleanupSpan)
     TEST_WRITER.start()
   }
 
   def cleanup() {
-    redissonClient.getKeys().flushdb()
+    try (def suppressScope = TEST_TRACER.muteTracing()) {
+      redissonClient.getKeys().flushdb()
+    }
   }
 
   def "bucket set command"() {

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/test/groovy/RedissonClientTest.groovy
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/test/groovy/RedissonClientTest.groovy
@@ -47,15 +47,13 @@ abstract class RedissonClientTest extends VersionedNamingTestBase {
   }
 
   def setup() {
-    def cleanupSpan = runUnderTrace("cleanup") {
-      activeSpan()
-    }
-    TEST_WRITER.waitUntilReported(cleanupSpan)
     TEST_WRITER.start()
   }
 
   def cleanup() {
-    redissonClient.getKeys().flushdb()
+    try (def suppressScope = TEST_TRACER.muteTracing()) {
+      redissonClient.getKeys().flushdb()
+    }
   }
   def "bucket set command"() {
     when:


### PR DESCRIPTION
# What Does This Do

Uses a blackhole to suppress the sync span generated on cleanup

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
