### PR TITLE
Fix tracing skipped suites in MUnit 1.0.1

### DIFF
--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/build.gradle
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/build.gradle
@@ -5,7 +5,7 @@ muzzle {
   pass {
     group = 'org.scalameta'
     module = 'munit_2.13'
-    versions = '[0.7.28,1.0.0]'
+    versions = '[0.7.28,)'
   }
 }
 
@@ -28,10 +28,7 @@ dependencies {
   testImplementation group: 'org.scala-lang', name: 'scala-library', version: '2.13.10'
   testImplementation group: 'org.scalameta', name: 'munit_2.13', version: '0.7.28'
 
-  // latest version as of august 2024 is 1.0.1, but that version changes which notifications are sent when a test is skipped,
-  // making the tests fail. See https://github.com/scalameta/munit/issues/813 and https://github.com/DataDog/dd-trace-java/pull/7502/commits/ecda25e
-  // TODO replace the fixed version with '+' once the github issue is resolved OR the code/tests are updated to accept the new behavior.
-  latestDepTestImplementation group: 'org.scalameta', name: 'munit_2.13', version: '1.0.0'
+  latestDepTestImplementation group: 'org.scalameta', name: 'munit_2.13', version: '+'
 }
 
 compileTestGroovy {


### PR DESCRIPTION
# What Does This Do

Fixes tracing of skipped suites in MUnit 1.0.1

# Additional Notes

In MUnit 1.0.1 release a different set of events is fired for skipped test suites.
Previous versions of the framework fixed start/ignore/finish events for such suites.
The new version of the framework only fires the ignore event.

This appears to be an accidental side-effect of an unrelated change, and an [issue](https://github.com/scalameta/munit/issues/813) was reported in the framework repo.
It does not look, however, like this is getting fixed any time soon, so a workaround is introduced in the tracer.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-843]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-843]: https://datadoghq.atlassian.net/browse/SDTEST-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ