### PR TITLE
Add support for Intersystems IRIS jdbc driver

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -787,7 +787,7 @@ public enum JDBCConnectionUrlParser {
     @Override
     DBInfo.Builder doParse(String jdbcUrl, DBInfo.Builder builder) {
       String url = jdbcUrl;
-      int firstSlash = url.indexOf('/', 13); // after jdbc://iris:/
+      int firstSlash = url.indexOf('/', "jdbc://iris:/".length());
       int nextSlash = url.indexOf('/', firstSlash + 1);
       if (nextSlash > firstSlash) {
         // strip the options and preserve only the url like part

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -781,6 +781,20 @@ public enum JDBCConnectionUrlParser {
       }
       return GENERIC_URL_LIKE.doParse(url, builder);
     }
+  },
+
+  IRIS("iris") {
+    @Override
+    DBInfo.Builder doParse(String jdbcUrl, DBInfo.Builder builder) {
+      String url = jdbcUrl;
+      int firstSlash = url.indexOf('/', 13); // after jdbc://iris:/
+      int nextSlash = url.indexOf('/', firstSlash + 1);
+      if (nextSlash > firstSlash) {
+        // strip the options and preserve only the url like part
+        url = url.substring(0, nextSlash);
+      }
+      return GENERIC_URL_LIKE.doParse(url, builder);
+    }
   };
 
   private static final Map<String, JDBCConnectionUrlParser> typeParsers = new HashMap<>();

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DefaultConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DefaultConnectionInstrumentation.java
@@ -41,6 +41,8 @@ public class DefaultConnectionInstrumentation extends AbstractConnectionInstrume
     "com.sap.db.jdbc.ConnectionSapDB",
     // IBM Informix
     "com.informix.jdbc.IfmxConnection",
+    // Intersystems IRIS
+    "com.intersystems.jdbc.IRISConnection",
     // for testing purposes
     "test.TestConnection"
   };

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -117,6 +117,9 @@ public final class PreparedStatementInstrumentation extends AbstractPreparedStat
     "software.aws.rds.jdbc.mysql.shading.com.mysql.cj.JdbcCallableStatement",
     // IBM Informix
     "com.informix.jdbc.IfxPreparedStatement",
+    // Intersystems IRIS
+    "com.intersystems.jdbc.IRISPreparedStatement",
+    "com.intersystems.jdbc.IRISCallableStatement",
     // for testing purposes
     "test.TestPreparedStatement"
   };

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCConnectionUrlParserTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCConnectionUrlParserTest.groovy
@@ -200,6 +200,10 @@ class JDBCConnectionUrlParserTest extends AgentTestRunner {
 
     // redshift
     "jdbc:redshift://redshift-cluster-1.c7arcolffyvk.us-east-2.redshift.amazonaws.com:5439/dev"                                                                                                                                                 | null     | "redshift"   | null          | null          | "redshift-cluster-1.c7arcolffyvk.us-east-2.redshift.amazonaws.com"  | 5439  | "redshift-cluster-1"               | "dev"
+    // Intersys IRIS
+    "jdbc:IRIS://dbhostname:1972/namespace"                                                                                                                                                                                                     | null     | "iris"       | null          | null          | "dbhostname"  | 1972  | null               | "namespace"
+    "jdbc:IRIS://dbhostname:1972/namespace/+myjdbc.log"                                                                                                                                                                                                     | null     | "iris"       | null          | null          | "dbhostname"  | 1972  | null               | "namespace"
+    "jdbc:IRIS://dbhostname:1972/namespace/::false"                                                                                                                                                                                             | null     | "iris"       | null          | null          | "dbhostname"  | 1972  | null               | "namespace"
 
     expected = new DBInfo.Builder().type(type).subtype(subtype).user(user).instance(instance).db(db).host(host).port(port).build()
   }


### PR DESCRIPTION
# What Does This Do

Add support for connection parsing and prepared statement tracing for intersystems jdbc driver.

The documentation for the connection url: https://docs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=BJAVA_connecting#BJAVA_connecting_create_url_parms

# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-13205]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-13205]: https://datadoghq.atlassian.net/browse/APMS-13205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ