### PR TITLE
Fix submodule update automation

### DIFF
--- a/.github/workflows/comment-on-submodule-update.yaml
+++ b/.github/workflows/comment-on-submodule-update.yaml
@@ -12,6 +12,7 @@ jobs:
   comment_on_submodule_update:
     permissions:
       issues: write # Required to create a comment on the pull request
+      pull-requests: write # Required to create a comment on the pull request
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# What Does This Do

Add pull_requests write permission to comment-on-submodule-update

# Motivation

The workflow execution broke with the recent default permission change.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
