### PR TITLE
Fix freemarker test with newer versions

### DIFF
--- a/dd-java-agent/instrumentation/freemarker/freemarker-2.3.24/src/test/groovy/datadog/trace/instrumentation/freemarker24/ObjectWrapperInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/freemarker/freemarker-2.3.24/src/test/groovy/datadog/trace/instrumentation/freemarker24/ObjectWrapperInstrumentationTest.groovy
@@ -6,7 +6,6 @@ import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.propagation.PropagationModule
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.TagContext
-import freemarker.template.Configuration
 import freemarker.template.DefaultObjectWrapper
 
 class ObjectWrapperInstrumentationTest extends  AgentTestRunner {
@@ -32,7 +31,7 @@ class ObjectWrapperInstrumentationTest extends  AgentTestRunner {
     given:
     final module = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(module)
-    final objectWrapper = new DefaultObjectWrapper(Configuration.VERSION_2_3_32)
+    final objectWrapper = new DefaultObjectWrapper()
     final String wrapped = "test"
 
     when:


### PR DESCRIPTION
# What Does This Do
Fix the test with newer versions of freemarker

# Motivation
This is motivated by an upgrade of the freemarker latest version that was showing error in the specific test

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
