### PR TITLE
Fix local var hoisting

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -569,7 +569,9 @@ public class DebuggerTransformer implements ClassFileTransformer {
       // Log and span decoration probe shared the same instrumentor: CaptureContextInstrumentor
       // and therefore need to be instrumented once
       // note: exception probes are log probes and are handled the same way
-      if (definition instanceof LogProbe || definition instanceof SpanDecorationProbe) {
+      if (definition instanceof LogProbe
+          || definition instanceof SpanDecorationProbe
+          || definition instanceof DebuggerProbe) {
         if (definition instanceof ExceptionProbe) {
           if (addedExceptionProbe) {
             continue;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -54,6 +54,7 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldInsnNode;
 import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.IincInsnNode;
 import org.objectweb.asm.tree.InsnList;
 import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.JumpInsnNode;
@@ -459,75 +460,175 @@ public class CapturedContextInstrumentor extends Instrumentor {
   }
 
   // Initialize and hoist local variables to the top of the method
-  // if there is name conflict, do nothing for the conflicting local variable
+  // if there is name/slot conflict, do nothing for the conflicting local variable
   private Collection<LocalVariableNode> initAndHoistLocalVars(InsnList insnList) {
     if (methodNode.localVariables == null || methodNode.localVariables.isEmpty()) {
       return Collections.emptyList();
     }
     Map<String, LocalVariableNode> localVarsByName = new HashMap<>();
-    Set<String> duplicateNames = new HashSet<>();
+    Map<Integer, LocalVariableNode> localVarsBySlot = new HashMap<>();
+    Map<String, List<LocalVariableNode>> hoistableVarByName = new HashMap<>();
     for (LocalVariableNode localVar : methodNode.localVariables) {
       int idx = localVar.index - localVarBaseOffset;
       if (idx < argOffset) {
         // this is an argument
         continue;
       }
-      if (!checkDuplicateLocalVar(localVar, localVarsByName)) {
-        duplicateNames.add(localVar.name);
+      checkHoistableLocalVar(localVar, localVarsByName, localVarsBySlot, hoistableVarByName);
+    }
+    // hoist vars
+    List<LocalVariableNode> results = new ArrayList<>();
+    for (Map.Entry<String, List<LocalVariableNode>> entry : hoistableVarByName.entrySet()) {
+      List<LocalVariableNode> hoistableVars = entry.getValue();
+      LocalVariableNode newVarNode;
+      if (hoistableVars.size() > 1) {
+        // merge variables
+        String name = hoistableVars.get(0).name;
+        String desc = hoistableVars.get(0).desc;
+        Type localVarType = getType(desc);
+        int newSlot = newVar(localVarType); // new slot for the local variable
+        newVarNode = new LocalVariableNode(name, desc, null, null, null, newSlot);
+        Set<LabelNode> endLabels = new HashSet<>();
+        for (LocalVariableNode localVar : hoistableVars) {
+          // rewrite each usage of the old var to the new slot
+          rewriteLocalVarInsn(localVar, localVar.index, newSlot);
+          endLabels.add(localVar.end);
+        }
+        hoistVar(insnList, newVarNode);
+        newVarNode.end = findLatestLabel(methodNode.instructions, endLabels);
+        // remove previous local variables
+        methodNode.localVariables.removeIf(hoistableVars::contains);
+        methodNode.localVariables.add(newVarNode);
+      } else {
+        // hoist the single variable and rewrite all its local var instructions
+        newVarNode = hoistableVars.get(0);
+        int oldIndex = newVarNode.index;
+        newVarNode.index = newVar(getType(newVarNode.desc)); // new slot for the local variable
+        rewriteLocalVarInsn(newVarNode, oldIndex, newVarNode.index);
+        hoistVar(insnList, newVarNode);
       }
+      results.add(newVarNode);
     }
-    for (String name : duplicateNames) {
-      localVarsByName.remove(name);
-    }
-    for (LocalVariableNode localVar : localVarsByName.values()) {
-      Type localVarType = getType(localVar.desc);
-      switch (localVarType.getSort()) {
-        case Type.BOOLEAN:
-        case Type.CHAR:
-        case Type.BYTE:
-        case Type.SHORT:
-        case Type.INT:
-          insnList.add(new InsnNode(Opcodes.ICONST_0));
-          break;
-        case Type.LONG:
-          insnList.add(new InsnNode(Opcodes.LCONST_0));
-          break;
-        case Type.FLOAT:
-          insnList.add(new InsnNode(Opcodes.FCONST_0));
-          break;
-        case Type.DOUBLE:
-          insnList.add(new InsnNode(Opcodes.DCONST_0));
-          break;
-        default:
-          insnList.add(new InsnNode(Opcodes.ACONST_NULL));
-          break;
-      }
-      insnList.add(new VarInsnNode(localVarType.getOpcode(Opcodes.ISTORE), localVar.index));
-    }
-    return localVarsByName.values();
+    return results;
   }
 
-  private boolean checkDuplicateLocalVar(
-      LocalVariableNode localVar, Map<String, LocalVariableNode> localVarsByName) {
-    LocalVariableNode previousVar = localVarsByName.putIfAbsent(localVar.name, localVar);
-    if (previousVar == null) {
-      return true;
+  private LabelNode findLatestLabel(InsnList instructions, Set<LabelNode> endLabels) {
+    for (AbstractInsnNode insn = instructions.getLast(); insn != null; insn = insn.getPrevious()) {
+      if (insn instanceof LabelNode && endLabels.contains(insn)) {
+        return (LabelNode) insn;
+      }
     }
-    // there are multiple local variables with the same name
-    // checking type to see if they  are compatible
-    Type previousType = getType(previousVar.desc);
-    Type currentType = getType(localVar.desc);
-    if (!ASMHelper.isStoreCompatibleType(previousType, currentType)) {
-      reportWarning(
-          "Local variable "
-              + localVar.name
-              + " has multiple definitions with incompatible types: "
-              + previousVar.desc
-              + " and "
-              + localVar.desc);
-      return false;
+    return null;
+  }
+
+  private void hoistVar(InsnList insnList, LocalVariableNode varNode) {
+    LabelNode labelNode = new LabelNode(); // new start label for the local variable
+    insnList.add(labelNode);
+    varNode.start = labelNode; // update the start label of the local variable
+    Type localVarType = getType(varNode.desc);
+    addStore0Insn(insnList, varNode, localVarType);
+  }
+
+  private static void addStore0Insn(
+      InsnList insnList, LocalVariableNode localVar, Type localVarType) {
+    switch (localVarType.getSort()) {
+      case Type.BOOLEAN:
+      case Type.CHAR:
+      case Type.BYTE:
+      case Type.SHORT:
+      case Type.INT:
+        insnList.add(new InsnNode(Opcodes.ICONST_0));
+        break;
+      case Type.LONG:
+        insnList.add(new InsnNode(Opcodes.LCONST_0));
+        break;
+      case Type.FLOAT:
+        insnList.add(new InsnNode(Opcodes.FCONST_0));
+        break;
+      case Type.DOUBLE:
+        insnList.add(new InsnNode(Opcodes.DCONST_0));
+        break;
+      default:
+        insnList.add(new InsnNode(Opcodes.ACONST_NULL));
+        break;
     }
-    return true;
+    insnList.add(new VarInsnNode(localVarType.getOpcode(Opcodes.ISTORE), localVar.index));
+  }
+
+  private void checkHoistableLocalVar(
+      LocalVariableNode localVar,
+      Map<String, LocalVariableNode> localVarsByName,
+      Map<Integer, LocalVariableNode> localVarsBySlot,
+      Map<String, List<LocalVariableNode>> hoistableVarByName) {
+    LocalVariableNode previousVarBySlot = localVarsBySlot.putIfAbsent(localVar.index, localVar);
+    LocalVariableNode previousVarByName = localVarsByName.putIfAbsent(localVar.name, localVar);
+    if (previousVarBySlot != null) {
+      if (previousVarBySlot.name.equals(localVar.name)) {
+        // there are multiple local variables with the same name and slot
+        // we cannot hoist the 2 variables
+        reportWarning(
+            "Local variable "
+                + localVar.name
+                + " has multiple definitions with the same name and slot: "
+                + previousVarBySlot.name
+                + " and "
+                + localVar.name);
+        // remove name from hoistable
+        hoistableVarByName.remove(localVar.name);
+        return; // no need to test previousVarByName, we know it is the same
+      }
+      // there are multiple local variables with the same slot but different names
+      // by hoisting in a new slot, we can avoid the conflict
+      hoistableVarByName.computeIfAbsent(localVar.name, k -> new ArrayList<>()).add(localVar);
+    }
+    if (previousVarByName != null) {
+      // there are multiple local variables with the same name
+      // checking type to see if they are compatible
+      Type previousType = getType(previousVarByName.desc);
+      Type currentType = getType(localVar.desc);
+      if (!ASMHelper.isStoreCompatibleType(previousType, currentType)) {
+        reportWarning(
+            "Local variable "
+                + localVar.name
+                + " has multiple definitions with incompatible types: "
+                + previousVarByName.desc
+                + " and "
+                + localVar.desc);
+        // remove name from hoistable
+        hoistableVarByName.remove(localVar.name);
+        return;
+      }
+      // Merge variables because compatible type
+    }
+    // by default, there is no conflict => hoistable
+    hoistableVarByName.computeIfAbsent(localVar.name, k -> new ArrayList<>()).add(localVar);
+  }
+
+  private void rewriteLocalVarInsn(LocalVariableNode localVar, int oldSlot, int newSlot) {
+    // previous insn could be a store to index that need to be rewritten as well
+    AbstractInsnNode previous = localVar.start.getPrevious();
+    if (previous instanceof VarInsnNode) {
+      VarInsnNode varInsnNode = (VarInsnNode) previous;
+      if (varInsnNode.var == oldSlot) {
+        varInsnNode.var = newSlot;
+      }
+    }
+    for (AbstractInsnNode insn = localVar.start;
+        insn != null && insn != localVar.end;
+        insn = insn.getNext()) {
+      if (insn instanceof VarInsnNode) {
+        VarInsnNode varInsnNode = (VarInsnNode) insn;
+        if (varInsnNode.var == oldSlot) {
+          varInsnNode.var = newSlot;
+        }
+      }
+      if (insn instanceof IincInsnNode) {
+        IincInsnNode iincInsnNode = (IincInsnNode) insn;
+        if (iincInsnNode.var == oldSlot) {
+          iincInsnNode.var = newSlot;
+        }
+      }
+    }
   }
 
   private void createInProbeFinallyHandler(LabelNode inProbeStartLabel, LabelNode inProbeEndLabel) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -563,20 +563,6 @@ public class CapturedContextInstrumentor extends Instrumentor {
     LocalVariableNode previousVarBySlot = localVarsBySlot.putIfAbsent(localVar.index, localVar);
     LocalVariableNode previousVarByName = localVarsByName.putIfAbsent(localVar.name, localVar);
     if (previousVarBySlot != null) {
-      if (previousVarBySlot.name.equals(localVar.name)) {
-        // there are multiple local variables with the same name and slot
-        // we cannot hoist the 2 variables
-        reportWarning(
-            "Local variable "
-                + localVar.name
-                + " has multiple definitions with the same name and slot: "
-                + previousVarBySlot.name
-                + " and "
-                + localVar.name);
-        // remove name from hoistable
-        hoistableVarByName.remove(localVar.name);
-        return; // no need to test previousVarByName, we know it is the same
-      }
       // there are multiple local variables with the same slot but different names
       // by hoisting in a new slot, we can avoid the conflict
       hoistableVarByName.computeIfAbsent(localVar.name, k -> new ArrayList<>()).add(localVar);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1823,11 +1823,12 @@ public class CapturedSnapshotTest {
     //        0      79     0  this   Lcom/datadog/debugger/CapturedSnapshot31;
     //        0      79     1   arg   Ljava/lang/String;
     //        2      77     2 localVarL0   I
-    assertEquals(5, snapshot.getCaptures().getReturn().getLocals().size());
+    assertEquals(6, snapshot.getCaptures().getReturn().getLocals().size());
     assertCaptureLocals(snapshot.getCaptures().getReturn(), "localVarL0", "int", "0");
     assertCaptureLocals(snapshot.getCaptures().getReturn(), "localVarL1", "int", "1");
     assertCaptureLocals(snapshot.getCaptures().getReturn(), "localVarL2", "int", "2");
     assertCaptureLocals(snapshot.getCaptures().getReturn(), "localVarL3", "int", "3");
+    assertCaptureLocals(snapshot.getCaptures().getReturn(), "localVarL4", "int", "4");
   }
 
   @Test
@@ -1842,8 +1843,26 @@ public class CapturedSnapshotTest {
     int result = Reflect.onClass(testClass).call("main", "illegalState").get();
     assertEquals(0, result);
     Snapshot snapshot = assertOneSnapshot(listener);
-    // no local vars captured for the exception
-    assertEquals(1, snapshot.getCaptures().getReturn().getLocals().size());
+    assertEquals(2, snapshot.getCaptures().getReturn().getLocals().size());
+    Map<String, String> expectedFields = new HashMap<>();
+    expectedFields.put("detailMessage", "state");
+    assertCaptureLocals(
+        snapshot.getCaptures().getReturn(),
+        "ex",
+        IllegalStateException.class.getTypeName(),
+        expectedFields);
+    listener.snapshots.clear();
+    result = Reflect.onClass(testClass).call("main", "illegalArgument").get();
+    assertEquals(0, result);
+    snapshot = assertOneSnapshot(listener);
+    assertEquals(2, snapshot.getCaptures().getReturn().getLocals().size());
+    expectedFields = new HashMap<>();
+    expectedFields.put("detailMessage", "argument");
+    assertCaptureLocals(
+        snapshot.getCaptures().getReturn(),
+        "ex",
+        IllegalArgumentException.class.getTypeName(),
+        expectedFields);
   }
 
   @Test
@@ -1876,6 +1895,8 @@ public class CapturedSnapshotTest {
     int result = Reflect.onClass(testClass).call("main", "duplicateLocalDifferentScope").get();
     assertEquals(28, result);
     Snapshot snapshot = assertOneSnapshot(listener);
+    assertCaptureLocals(
+        snapshot.getCaptures().getReturn(), "ch", Character.TYPE.getTypeName(), "e");
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot31.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot31.java
@@ -12,8 +12,14 @@ public class CapturedSnapshot31 {
     if ("deepScopes".equals(arg)) {
       return new CapturedSnapshot31().deepScopes(arg);
     }
+    if ("overlappingSlots".equals(arg)) {
+      return new CapturedSnapshot31().overlappingSlots(arg);
+    }
     if (arg.startsWith("illegal")) {
       return new CapturedSnapshot31().caughtException(arg);
+    }
+    if ("duplicateLocalDifferentScope".equals(arg)) {
+      return new CapturedSnapshot31().duplicateLocalDifferentScope(arg);
     }
     return 0;
   }
@@ -79,6 +85,53 @@ public class CapturedSnapshot31 {
     } catch (IllegalArgumentException ex) {
       ex.printStackTrace();
       return 0;
+    }
+  }
+
+//  LocalVariableTable:
+//        Start  Length  Slot  Name   Signature
+//           15      22     3 subStr   Ljava/lang/String;
+//            2      41     2     i   I
+//           60      36     3     i   C
+//          105      10     3     i   Ljava/lang/Object;
+//            0     120     0  this   Lcom/datadog/debugger/CapturedSnapshot31;
+//            0     120     1   arg   Ljava/lang/String;
+//           50      70     2 subStr   Ljava/lang/String;
+  private int overlappingSlots(String arg) {
+    for (int i = 0; i < 10; i++) {
+      String subStr = arg.substring(0, 2);
+      arg += subStr.length();
+    }
+    String subStr = arg.substring(0, 5);
+    if (subStr != null) {
+      char i = arg.charAt(0);
+      if (i == 0) {
+        throw new IllegalArgumentException("Illegal option name '" + i + "'");
+      }
+    } else {
+      Object i = arg.substring(3);
+      System.out.println(i.toString());
+    }
+    return subStr.length();
+  }
+
+  private int duplicateLocalDifferentScope(String arg) {
+    if (arg == null) {
+      return 0;
+    } else {
+      if (arg.length() == 1) {
+        char ch = arg.charAt(0);
+        if (ch == 1) {
+          throw new IllegalArgumentException("Illegal option name '" + ch + "'");
+        }
+      } else {
+        for (char ch : arg.toCharArray()) {
+          if (ch == 1) {
+            throw new IllegalArgumentException("The option '" + arg + "' contains an illegal character : '" + ch + "'");
+          }
+        }
+      }
+      return arg.length();
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
Rewrite the algorithm for hoisting local vars:
Go through all local vars defined in the method and determine by name all local var that are hoistable.
local vars are hoistable if there is no conflict by slot or by name with another.
If conflict by slot and same name we cancel hoisting for this name. if
 name is different we allocating a new slot for one of the local.
If conflict by name and type are not compatible we cancel hoisting for this name. If type compatible, we can add in hoistable list. Then we are considering all hoistable variables by name and if there are multiple occurrence for a name, we are merging those variables in a new slot and rewrite var instructions to use this new slot. if only one variable we just assign a new slot and rewrite the instructions in the range.

# Motivation
Fixing issues since #7548 

# Additional Notes
Tested against exploration tests

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2841]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2841]: https://datadoghq.atlassian.net/browse/DEBUG-2841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ