### PR TITLE
Retry JettyServlet3ServeFromAsyncTimeout on socket timeout

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -13,6 +13,8 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.server.session.SessionHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
+import spock.lang.Retry
+
 import javax.servlet.AsyncEvent
 import javax.servlet.AsyncListener
 import javax.servlet.Servlet
@@ -510,6 +512,8 @@ class ServeFromOnAsyncTimeout extends AbstractHttpServlet {
   }
 }
 
+//@Flaky("Fails with timeout very often under high load")
+@Retry(exceptions = SocketTimeoutException, count = 3, delay = 500, mode = Retry.Mode.SETUP_FEATURE_CLEANUP)
 class JettyServlet3ServeFromAsyncTimeout extends JettyServlet3Test {
   @Override
   Class<Servlet> servlet() {


### PR DESCRIPTION
# What Does This Do
Retry tests in `JettyServlet3ServeFromAsyncTimeout` when there's a `SocketTimeoutException`. This needs to be done with `SETUP_FEATURE_CLEANUP` to ensure that cleanup is run, and leftover spans do not leak between iterations.

# Motivation
This test suite is, by far, the most flaky in our test suites. However, being in a very widely used code path, I'm reluctant to simply mark as `@Flaky` and hide any regression here.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
