### PR TITLE
Enable telemetry logs by default

### DIFF
--- a/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
+++ b/dd-java-agent/agent-logging/src/main/java/datadog/trace/logging/ddlogger/DDLoggerFactory.java
@@ -91,20 +91,10 @@ public class DDLoggerFactory implements ILoggerFactory, LogLevelSwitcher {
   // DDLoggerFactory can be called at very early stage, before Config is loaded
   // So to get property/env we use this custom function
   private static boolean isLogCollectionEnabled() {
-    // FIXME: For the initial rollout, we default log collection to true for IAST, Dynamic
-    // Instrumentation, and CI Visibility
-    // FIXME: For progressive rollout, we include by default Java < 11 hosts as product independent
-    // FIXME: sample users.
-    // FIXME: This should be removed once we default to true.
-    final boolean defaultValue =
-        isFlagEnabled("dd.iast.enabled", "DD_IAST_ENABLED", false)
-            || isFlagEnabled("dd.appsec.enabled", "DD_APPSEC_ENABLED", false)
-            || isFlagEnabled("dd.civisibility.enabled", "DD_CIVISIBILITY_ENABLED", false)
-            || isFlagEnabled(
-                "dd.dynamic.instrumentation.enabled", "DD_DYNAMIC_INSTRUMENTATION_ENABLED", false)
-            || !Platform.isJavaVersionAtLeast(11);
     return isFlagEnabled(
-        "dd.telemetry.log-collection.enabled", "DD_TELEMETRY_LOG_COLLECTION_ENABLED", defaultValue);
+            "dd.instrumentation.telemetry.enabled", "DD_INSTRUMENTATION_TELEMETRY_ENABLED", true)
+        && isFlagEnabled(
+            "dd.telemetry.log-collection.enabled", "DD_TELEMETRY_LOG_COLLECTION_ENABLED", true);
   }
 
   private static boolean isFlagEnabled(

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1676,6 +1676,11 @@ public class Config {
     telemetryMetricsEnabled =
         configProvider.getBoolean(GeneralConfig.TELEMETRY_METRICS_ENABLED, true);
 
+    isTelemetryLogCollectionEnabled =
+        instrumenterConfig.isTelemetryEnabled()
+            && configProvider.getBoolean(
+                TELEMETRY_LOG_COLLECTION_ENABLED, DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED);
+
     isTelemetryDependencyServiceEnabled =
         configProvider.getBoolean(
             TELEMETRY_DEPENDENCY_COLLECTION_ENABLED,
@@ -2006,24 +2011,6 @@ public class Config {
 
     debuggerThirdPartyIncludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_INCLUDES));
     debuggerThirdPartyExcludes = tryMakeImmutableSet(configProvider.getList(THIRD_PARTY_EXCLUDES));
-
-    // FIXME: For the initial rollout, we default log collection to true for IAST and CI Visibility
-    // users.
-    // FIXME: For progressive rollout, we include by default Java < 11 hosts as product independent
-    // sample users.
-    // FIXME:This should be removed once we default to true, and then it can also be moved up
-    // together with the rest of telemetry config.
-    final boolean telemetryLogCollectionEnabledDefault =
-        instrumenterConfig.isTelemetryEnabled()
-                && (instrumenterConfig.getAppSecActivation() == ProductActivation.FULLY_ENABLED
-                    || instrumenterConfig.getIastActivation() == ProductActivation.FULLY_ENABLED
-                    || instrumenterConfig.isCiVisibilityEnabled()
-                    || debuggerEnabled
-                    || !Platform.isJavaVersionAtLeast(11))
-            || DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED;
-    isTelemetryLogCollectionEnabled =
-        configProvider.getBoolean(
-            TELEMETRY_LOG_COLLECTION_ENABLED, telemetryLogCollectionEnabledDefault);
 
     awsPropagationEnabled = isPropagationEnabled(true, "aws", "aws-sdk");
     sqsPropagationEnabled = isPropagationEnabled(true, "sqs");


### PR DESCRIPTION
# What Does This Do
Enable telemetry logs by default. These were already enabled by default for services using JDK 8, Code Security (IAST), Dynamic Instrumentation, or CI Visibility. They will be enabled for all services from now on.

Users who want to opt out can set `-Ddd.telemetry.log-collection.enabled=false` (system property) or `DD_TELEMETRY_LOG_COLLECTION_ENABLED=false` (environment variable).

Note that these are not application logs, but internal dd-trace-java logs which we use for troubleshooting. They are heavily redacted by sending only the log formats and not log parameters (e.g. when we do `log.error("An error happened at url: {}", url)`), we will send just `"An error happened at url: {}"`, without any placeholder substitution. We also send error stacktraces, including exception type (but not exception message), and any stackframes from dd-trace-java itself or the standard library.

# Motivation
We use these logs to proactively detect and fix dd-trace-java bugs.

# Additional Notes

Previous activation milestones:

* https://github.com/datadog/dd-trace-java/pull/7017
* https://github.com/datadog/dd-trace-java/pull/7475
* https://github.com/datadog/dd-trace-java/pull/7534

Jira: [APPSEC-53432](https://datadoghq.atlassian.net/browse/APPSEC-53432)

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~


[APPSEC-53432]: https://datadoghq.atlassian.net/browse/APPSEC-53432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ