### PR TITLE
Prevent NPE when deleting OpenTracing baggage

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -641,14 +641,18 @@ public class DDSpanContext
   }
 
   public void setBaggageItem(final String key, final String value) {
-    if (baggageItems == EMPTY_BAGGAGE) {
-      synchronized (this) {
-        if (baggageItems == EMPTY_BAGGAGE) {
-          baggageItems = new ConcurrentHashMap<>(4);
+    if (value == null) {
+      baggageItems.remove(key);
+    } else {
+      if (baggageItems == EMPTY_BAGGAGE) {
+        synchronized (this) {
+          if (baggageItems == EMPTY_BAGGAGE) {
+            baggageItems = new ConcurrentHashMap<>(4);
+          }
         }
       }
+      baggageItems.put(key, value);
     }
-    baggageItems.put(key, value);
   }
 
   public String getBaggageItem(final String key) {


### PR DESCRIPTION
# What Does This Do

Prevent NPE when deleting baggage value by `setBaggageItem("key", null)`

# Motivation
NPE when trying to remove a baggage item.

```
java.lang.NullPointerException: null
	at java.base/java.util.concurrent.ConcurrentHashMap.putVal(Unknown Source)
	at java.base/java.util.concurrent.ConcurrentHashMap.put(Unknown Source)
	at datadog.trace.agent.core.DDSpanContext.setBaggageItem(DDSpanContext.java:651)
	at datadog.trace.agent.core.DDSpan.setBaggageItem(DDSpan.java:514)
	at datadog.trace.agent.core.DDSpan.setBaggageItem(DDSpan.java:50)
	at datadog.trace.instrumentation.opentracing32.OTSpan.setBaggageItem(OTSpan.java:122)
	at datadog.trace.instrumentation.opentracing32.OTSpan.setBaggageItem(OTSpan.java:17)
	at com.mycomp.tracing.OpenTracingBusinessContextStore.clearBaggageItem(OpenTracingBusinessContextStore.java:55)
```

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
