### PR TITLE
Add EVENT_TYPE to the StackTraceEvent

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -18,6 +18,7 @@ import com.datadog.appsec.gateway.RateLimiter;
 import com.datadog.appsec.report.AppSecEvent;
 import com.datadog.appsec.stack_trace.StackTraceEvent;
 import com.datadog.appsec.stack_trace.StackTraceEvent.Frame;
+import com.datadog.appsec.stack_trace.StackTraceEventType;
 import com.datadog.appsec.util.StandardizedLogging;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -576,7 +577,8 @@ public class PowerWAFModule implements AppSecModule {
         return null;
       }
       List<Frame> result = generateUserCodeStackTrace();
-      return new StackTraceEvent(stackId, EXPLOIT_DETECTED_MSG, result);
+      return new StackTraceEvent(
+          stackId, StackTraceEventType.EXPLOIT, EXPLOIT_DETECTED_MSG, result);
     }
 
     /** Function generates stack trace of the user code (excluding datadog classes) */

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/stack_trace/StackTraceEvent.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/stack_trace/StackTraceEvent.java
@@ -5,12 +5,14 @@ import java.util.List;
 public class StackTraceEvent {
 
   public final String id;
+  public final StackTraceEventType type;
   public final String language = "java";
   public final String message;
   public final List<Frame> frames;
 
-  public StackTraceEvent(String id, String message, List<Frame> frames) {
+  public StackTraceEvent(String id, StackTraceEventType type, String message, List<Frame> frames) {
     this.id = id;
+    this.type = type;
     this.message = message;
     this.frames = frames;
   }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/stack_trace/StackTraceEventType.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/stack_trace/StackTraceEventType.java
@@ -1,0 +1,17 @@
+package com.datadog.appsec.stack_trace;
+
+public enum StackTraceEventType {
+  EXPLOIT("exploit"),
+  VULNERABILITY("vulnerability");
+
+  private final String name;
+
+  StackTraceEventType(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return this.name;
+  }
+}

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/gateway/AppSecRequestContextSpecification.groovy
@@ -7,6 +7,7 @@ import com.datadog.appsec.event.data.MapDataBundle
 import com.datadog.appsec.report.AppSecEvent
 import com.datadog.appsec.stack_trace.StackTraceCollection
 import com.datadog.appsec.stack_trace.StackTraceEvent
+import com.datadog.appsec.stack_trace.StackTraceEventType
 import com.datadog.appsec.test.StubAppSecConfigService
 import datadog.trace.test.util.DDSpecification
 import io.sqreen.powerwaf.Additive
@@ -126,7 +127,7 @@ class AppSecRequestContextSpecification extends DDSpecification {
     setup:
     StackTraceElement element = new StackTraceElement('class', 'method', 'file', 1)
     StackTraceEvent.Frame frame = new StackTraceEvent.Frame(element, 1)
-    StackTraceEvent event = new StackTraceEvent('id', 'message', [frame])
+    StackTraceEvent event = new StackTraceEvent('id', StackTraceEventType.EXPLOIT,'message', [frame])
 
     when:
     ctx.reportStackTrace(event)
@@ -135,6 +136,7 @@ class AppSecRequestContextSpecification extends DDSpecification {
     then:
     collection.exploit.size() == 1
     collection.exploit[0].id == 'id'
+    collection.exploit[0].type == StackTraceEventType.EXPLOIT
     collection.exploit[0].message == 'message'
     collection.exploit[0].language == 'java'
     collection.exploit[0].frames.size() == 1


### PR DESCRIPTION
# What Does This Do
This add a field to the StackTraceEvent where we can add the type of the event. That field was specified as optional in the RFC of Exploit Prevention for ASM Libraries. As the implementation before was only for RASP it wasn't needed. Next, we are going to add a new type that will be for IAST and we will need to have this field to identify the EVENT_TYPE.

# Motivation
We were missing this optional value

# Additional Notes
RFC that contains the event schema --> [[RFC] Exploit prevention in the ASM libraries](https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit?pli=1#heading=h.67byj8mrtklb)

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-11649]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-11649]: https://datadoghq.atlassian.net/browse/APPSEC-11649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ