### PR TITLE
Allow enabling experimental JVMTI wallclock sampler (take 2)

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -412,11 +412,10 @@ public class DatadogProfilerConfig {
   }
 
   public static boolean useJvmtiWallclockSampler(ConfigProvider configProvider) {
-    return !isWallClockProfilerEnabled(configProvider)
-        && getBoolean(
-            configProvider,
-            PROFILING_DATADOG_PROFILER_WALL_JVMTI,
-            PROFILING_DATADOG_PROFILER_WALL_JVMTI_DEFAULT);
+    return getBoolean(
+        configProvider,
+        PROFILING_DATADOG_PROFILER_WALL_JVMTI,
+        PROFILING_DATADOG_PROFILER_WALL_JVMTI_DEFAULT);
   }
 
   private static String normalizeKey(String key) {


### PR DESCRIPTION
# What Does This Do
It does fix the incorrect check for the experimental JVMTI wallclock sampler enablement in #7641


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
