### PR TITLE
Stable test names in Mongo instrumentation tests

### DIFF
--- a/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1-core-test/src/test/groovy/MongoCore31ClientTest.groovy
@@ -47,8 +47,9 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
     client = null
   }
 
-  def "test create collection"() {
+  def "test create collection with renameService=#renameService"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
 
@@ -63,12 +64,12 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
     }
 
     where:
-    collectionName = randomCollectionName()
     renameService << [false, true]
   }
 
   def "test create collection no description"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = new MongoClient("localhost", port).getDatabase(databaseName)
 
     when:
@@ -80,13 +81,11 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create","{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -99,13 +98,11 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -129,13 +126,11 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -164,13 +159,11 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -197,13 +190,11 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test error"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -221,13 +212,11 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
     thrown(IllegalArgumentException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test client failure"() {
     setup:
+    String collectionName = randomCollectionName()
     def options = MongoClientOptions.builder().serverSelectionTimeout(10).build()
     def client = new MongoClient(new ServerAddress("localhost", UNUSABLE_PORT), [], options)
 
@@ -239,9 +228,6 @@ abstract class MongoCore31ClientTest extends MongoBaseTest {
     thrown(MongoTimeoutException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.1/src/test/groovy/MongoJava31ClientTest.groovy
@@ -49,8 +49,9 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
     client = null
   }
 
-  def "test create collection"() {
+  def "test create collection with renameService=#renameService"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
 
@@ -65,12 +66,12 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
     }
 
     where:
-    collectionName = randomCollectionName()
     renameService << [false, true]
   }
 
   def "test create collection no description"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = new MongoClient("localhost", port).getDatabase(databaseName)
 
     when:
@@ -82,13 +83,11 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -101,13 +100,11 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -131,13 +128,11 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -166,13 +161,11 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -199,13 +192,11 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test error"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -223,13 +214,11 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
     thrown(IllegalArgumentException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test client failure"() {
     setup:
+    String collectionName = randomCollectionName()
     def options = MongoClientOptions.builder().serverSelectionTimeout(10).build()
     def client = new MongoClient(new ServerAddress("localhost", UNUSABLE_PORT), [], options)
 
@@ -241,9 +230,6 @@ abstract class MongoJava31ClientTest extends MongoBaseTest {
     thrown(MongoTimeoutException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.10-sync-test/src/test/groovy/MongoSyncClientTest.groovy
@@ -28,8 +28,9 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
     client = null
   }
 
-  def "test create collection"() {
+  def "test create collection with renameService=#renameService"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
 
@@ -45,12 +46,12 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
     }
 
     where:
-    collectionName = randomCollectionName()
     renameService << [false, true]
   }
 
   def "test create collection no description"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(databaseName)
 
     when:
@@ -62,13 +63,11 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -81,13 +80,11 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -113,13 +110,11 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -150,13 +145,11 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -185,13 +178,11 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test error"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -209,13 +200,11 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
     thrown(IllegalArgumentException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test client failure"() {
     setup:
+    String collectionName = randomCollectionName()
     def client = MongoClients.create("mongodb://localhost:$UNUSABLE_PORT/?serverselectiontimeoutms=10")
 
     when:
@@ -226,9 +215,6 @@ abstract class MongoSyncClientTest extends MongoBaseTest {
     thrown(MongoTimeoutException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.3-async-test/src/test/groovy/MongoAsyncClientTest.groovy
@@ -39,6 +39,7 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
 
   def "test create collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -50,13 +51,11 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test create collection no description"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(databaseName)
 
     when:
@@ -68,13 +67,11 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -88,13 +85,11 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -124,13 +119,11 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -168,13 +161,11 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -210,9 +201,6 @@ abstract class MongoAsyncClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   SingleResultCallback toCallback(Closure closure) {

--- a/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.4/src/test/groovy/MongoJava34ClientTest.groovy
@@ -47,8 +47,9 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
     client = null
   }
 
-  def "test create collection"() {
+  def "test create collection with renameService=#renameService"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
 
@@ -63,12 +64,12 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
     }
 
     where:
-    collectionName = randomCollectionName()
     renameService << [false, true]
   }
 
   def "test create collection no description"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = new MongoClient("localhost", port).getDatabase(databaseName)
 
     when:
@@ -80,13 +81,11 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create","{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -99,13 +98,11 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -129,13 +126,11 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -164,13 +159,11 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -197,13 +190,11 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test error"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -221,13 +212,11 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
     thrown(IllegalArgumentException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test client failure"() {
     setup:
+    String collectionName = randomCollectionName()
     def options = MongoClientOptions.builder().serverSelectionTimeout(10).build()
     def client = new MongoClient(new ServerAddress("localhost", UNUSABLE_PORT), [], options)
 
@@ -239,9 +228,6 @@ abstract class MongoJava34ClientTest extends MongoBaseTest {
     thrown(MongoTimeoutException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 }
 

--- a/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-3.7-core-test/src/test/groovy/MongoCore37ClientTest.groovy
@@ -28,8 +28,9 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
     client = null
   }
 
-  def "test create collection"() {
+  def "test create collection with renameService=#renameService"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
 
@@ -45,12 +46,12 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
     }
 
     where:
-    collectionName = randomCollectionName()
     renameService << [false, true]
   }
 
   def "test create collection no description"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(databaseName)
 
     when:
@@ -62,13 +63,11 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -81,13 +80,11 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-instance")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -113,13 +110,11 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-instance")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -150,13 +145,11 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-instance")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -185,13 +178,11 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\",\"query\":{}}", false, "some-instance")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test error"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -209,13 +200,11 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
     thrown(IllegalArgumentException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test client failure"() {
     setup:
+    String collectionName = randomCollectionName()
     def client = MongoClients.create("mongodb://localhost:$UNUSABLE_PORT/?serverselectiontimeoutms=10")
 
     when:
@@ -226,9 +215,6 @@ abstract class MongoCore37ClientTest extends MongoBaseTest {
     thrown(MongoTimeoutException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 }
 

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/Mongo4ClientTest.groovy
@@ -40,8 +40,9 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
     return ''
   }.call()
 
-  def "test create collection"() {
+  def "test create collection with renameService=#renameService"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
     injectSysConfig(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService")
 
@@ -57,12 +58,12 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
     }
 
     where:
-    collectionName = randomCollectionName()
     renameService << [false, true]
   }
 
   def "test create collection no description"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(databaseName)
 
     when:
@@ -74,13 +75,11 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -93,13 +92,11 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -125,13 +122,11 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -162,13 +157,11 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -197,13 +190,11 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test error"() {
     setup:
+    String collectionName = randomCollectionName()
     DDSpan setupSpan = null
     MongoCollection<Document> collection = runUnderTrace("setup") {
       setupSpan = activeSpan() as DDSpan
@@ -221,13 +212,11 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
     thrown(IllegalArgumentException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test client failure"() {
     setup:
+    String collectionName = randomCollectionName()
     def client = MongoClients.create("mongodb://localhost:$UNUSABLE_PORT/?serverselectiontimeoutms=10")
 
     when:
@@ -238,9 +227,6 @@ abstract class Mongo4ClientTest extends MongoBaseTest {
     thrown(MongoTimeoutException)
     // Unfortunately not caught by our instrumentation.
     assertTraces(0) {}
-
-    where:
-    collectionName = randomCollectionName()
   }
 }
 

--- a/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/mongo/driver-4.0/src/test/groovy/MongoReactiveClientTest.groovy
@@ -80,6 +80,7 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
 
   def "test create collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -91,13 +92,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test create collection with parent"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -113,13 +112,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 1, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, "some-description", span(0))
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test create collection no description"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(databaseName)
 
     when:
@@ -131,13 +128,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName)
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test create collection no description with parent"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = MongoClients.create("mongodb://localhost:$port").getDatabase(databaseName)
 
     when:
@@ -153,13 +148,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 1, "create", "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, databaseName, span(0))
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -173,13 +166,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test get collection with parent"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoDatabase db = client.getDatabase(databaseName)
 
     when:
@@ -197,13 +188,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 1, "count", "{\"count\":\"$collectionName\"$query}", false, "some-description", span(0))
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert"() {
     setup:
+    String collectionName = randomCollectionName()
     def collection = setupCollection(collectionName)
 
     when:
@@ -222,13 +211,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test insert with parent"() {
     setup:
+    String collectionName = randomCollectionName()
     def collection = setupCollection(collectionName)
 
     when:
@@ -249,13 +236,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\"$query}", false, "some-description", span(0))
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoCollection<Document> collection = setupCollection(collectionName)
     insertDocument(collection, new Document("password", "OLDPW"), null)
 
@@ -280,13 +265,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test update with parent"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoCollection<Document> collection = setupCollection(collectionName)
     insertDocument(collection, new Document("password", "OLDPW"), null)
 
@@ -313,13 +296,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\"$query}", false, "some-description", span(0))
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoCollection<Document> collection = setupCollection(collectionName)
     insertDocument(collection, new Document("password", "SECRET"), null)
 
@@ -342,13 +323,11 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 0, "count", "{\"count\":\"$collectionName\"$query}")
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def "test delete with parent"() {
     setup:
+    String collectionName = randomCollectionName()
     MongoCollection<Document> collection = setupCollection(collectionName)
     insertDocument(collection, new Document("password", "SECRET"), null)
 
@@ -373,9 +352,6 @@ abstract class MongoReactiveClientTest extends MongoBaseTest {
         mongoSpan(it, 2, "count", "{\"count\":\"$collectionName\"$query}", false, "some-description", span(0))
       }
     }
-
-    where:
-    collectionName = randomCollectionName()
   }
 
   def Subscriber<?> toSubscriber(Closure closure) {


### PR DESCRIPTION
# What Does This Do

# Motivation
Avoid unstable test names, such as `test create collection [collectionName: testCollection-806d900f-caae-483d-ad69-df899f2169bc, renameService: false, #0]`. These prevent flakiness detection.


# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
