### PR TITLE
Add File and Path as string primitive

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -26,24 +26,24 @@ public class WellKnownClasses {
 
   static {
     TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Class", WellKnownClasses::classToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.String", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Boolean", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Integer", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Long", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Double", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Character", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Byte", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Float", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Short", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.math.BigDecimal", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.math.BigInteger", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.Duration", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.Instant", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalTime", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalDate", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalDateTime", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.util.UUID", WellKnownClasses::genericToString);
-    TO_STRING_FINAL_SAFE_CLASSES.put("java.net.URI", WellKnownClasses::genericToString);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.String", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Boolean", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Integer", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Long", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Double", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Character", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Byte", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Float", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.lang.Short", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.math.BigDecimal", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.math.BigInteger", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.Duration", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.Instant", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalTime", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalDate", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.time.LocalDateTime", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.util.UUID", String::valueOf);
+    TO_STRING_FINAL_SAFE_CLASSES.put("java.net.URI", String::valueOf);
   }
 
   private static final Map<String, Function<Object, String>> SAFE_TO_STRING_FUNCTIONS =
@@ -51,12 +51,13 @@ public class WellKnownClasses {
 
   static {
     SAFE_TO_STRING_FUNCTIONS.putAll(TO_STRING_FINAL_SAFE_CLASSES);
-    SAFE_TO_STRING_FUNCTIONS.put(
-        "java.util.concurrent.atomic.AtomicBoolean", WellKnownClasses::genericToString);
-    SAFE_TO_STRING_FUNCTIONS.put(
-        "java.util.concurrent.atomic.AtomicInteger", WellKnownClasses::genericToString);
-    SAFE_TO_STRING_FUNCTIONS.put(
-        "java.util.concurrent.atomic.AtomicLong", WellKnownClasses::genericToString);
+    SAFE_TO_STRING_FUNCTIONS.put("java.util.concurrent.atomic.AtomicBoolean", String::valueOf);
+    SAFE_TO_STRING_FUNCTIONS.put("java.util.concurrent.atomic.AtomicInteger", String::valueOf);
+    SAFE_TO_STRING_FUNCTIONS.put("java.util.concurrent.atomic.AtomicLong", String::valueOf);
+    SAFE_TO_STRING_FUNCTIONS.put("java.io.File", String::valueOf);
+    // implementations of java.io.file.Path interfaces
+    SAFE_TO_STRING_FUNCTIONS.put("sun.nio.fs.UnixPath", String::valueOf);
+    SAFE_TO_STRING_FUNCTIONS.put("sun.nio.fs.WindowsPath", String::valueOf);
   }
 
   private static final Set<String> EQUALS_SAFE_CLASSES = new HashSet<>();
@@ -81,6 +82,9 @@ public class WellKnownClasses {
     EQUALS_SAFE_CLASSES.add("java.time.LocalDateTime");
     EQUALS_SAFE_CLASSES.add("java.util.UUID");
     EQUALS_SAFE_CLASSES.add("java.net.URI");
+    EQUALS_SAFE_CLASSES.add("java.io.File");
+    EQUALS_SAFE_CLASSES.add("sun.nio.fs.UnixPath");
+    EQUALS_SAFE_CLASSES.add("sun.nio.fs.WindowsPath");
   }
 
   private static final Set<String> STRING_PRIMITIVES =
@@ -93,7 +97,10 @@ public class WellKnownClasses {
               "java.time.LocalTime",
               "java.time.LocalDate",
               "java.time.LocalDateTime",
-              "java.util.UUID"));
+              "java.util.UUID",
+              "java.io.File",
+              "sun.nio.fs.UnixPath",
+              "sun.nio.fs.WindowsPath"));
 
   private static final Map<Class<?>, Map<String, Function<Object, CapturedContext.CapturedValue>>>
       SPECIAL_TYPE_ACCESS = new HashMap<>();
@@ -234,10 +241,6 @@ public class WellKnownClasses {
 
   private static String classToString(Object o) {
     return ((Class<?>) o).getTypeName();
-  }
-
-  private static String genericToString(Object o) {
-    return String.valueOf(o);
   }
 
   public static boolean isEqualsSafe(Class<?> clazz) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -40,12 +40,14 @@ import datadog.trace.bootstrap.debugger.ProbeImplementation;
 import datadog.trace.bootstrap.debugger.ProbeLocation;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import datadog.trace.test.util.Flaky;
+import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -308,6 +310,8 @@ public class SnapshotSerializationTest {
     OptionalLong maybeLong = OptionalLong.of(84);
     Exception ex = new IllegalArgumentException("invalid arg");
     StackTraceElement element = new StackTraceElement("Foo", "bar", "foo.java", 42);
+    File file = new File("/tmp/foo");
+    Path path = file.toPath();
   }
 
   @Test
@@ -384,6 +388,10 @@ public class SnapshotSerializationTest {
     assertPrimitiveValue(elementFields, "methodName", String.class.getTypeName(), "bar");
     assertPrimitiveValue(elementFields, "fileName", String.class.getTypeName(), "foo.java");
     assertPrimitiveValue(elementFields, "lineNumber", Integer.class.getTypeName(), "42");
+    // file
+    assertPrimitiveValue(objLocalFields, "file", File.class.getTypeName(), "/tmp/foo");
+    // path
+    assertPrimitiveValue(objLocalFields, "path", "sun.nio.fs.UnixPath", "/tmp/foo");
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
Since jdk 17 it's not possible to do deep reflection. The content of File or Path instances are difficult to see content with deep reflection, though the meaningful value is the toString representation We are adding File and Path instances serialized as string primitive and evaluated in EL as String as well

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2853]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2853]: https://datadoghq.atlassian.net/browse/DEBUG-2853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ