### PR TITLE
Fix message for snapshots with evaluation errors

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -572,22 +572,28 @@ public class LogProbe extends ProbeDefinition {
       shouldCommit = true;
     }
     if (entryStatus.shouldReportError()) {
-      if (entryContext.getCapturedThrowable() != null) {
-        // report also uncaught exception
-        snapshot.setEntry(entryContext);
-      }
-      snapshot.addEvaluationErrors(entryStatus.getErrors());
+      fillEvaluationErrors(entryContext, snapshot, entryStatus);
       shouldCommit = true;
     }
     if (exitStatus.shouldReportError()) {
-      if (exitContext.getCapturedThrowable() != null) {
-        // report also uncaught exception
-        snapshot.setExit(exitContext);
-      }
-      snapshot.addEvaluationErrors(exitStatus.getErrors());
+      fillEvaluationErrors(exitContext, snapshot, exitStatus);
       shouldCommit = true;
     }
     return shouldCommit;
+  }
+
+  private static void fillEvaluationErrors(
+      CapturedContext context, Snapshot snapshot, LogStatus status) {
+    if (context.getCapturedThrowable() != null) {
+      // report also uncaught exception
+      snapshot.setEntry(context);
+    }
+    snapshot.addEvaluationErrors(status.getErrors());
+    if (status.getMessage() != null) {
+      snapshot.setMessage(status.getMessage());
+    } else if (!status.getErrors().isEmpty()) {
+      snapshot.setMessage(status.getErrors().get(0).getMessage());
+    }
   }
 
   private LogStatus convertStatus(CapturedContext.Status status) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -572,21 +573,24 @@ public class LogProbe extends ProbeDefinition {
       shouldCommit = true;
     }
     if (entryStatus.shouldReportError()) {
-      fillEvaluationErrors(entryContext, snapshot, entryStatus);
+      populateErrors(entryContext, snapshot, entryStatus, snapshot::setEntry);
       shouldCommit = true;
     }
     if (exitStatus.shouldReportError()) {
-      fillEvaluationErrors(exitContext, snapshot, exitStatus);
+      populateErrors(exitContext, snapshot, exitStatus, snapshot::setExit);
       shouldCommit = true;
     }
     return shouldCommit;
   }
 
-  private static void fillEvaluationErrors(
-      CapturedContext context, Snapshot snapshot, LogStatus status) {
+  private static void populateErrors(
+      CapturedContext context,
+      Snapshot snapshot,
+      LogStatus status,
+      Consumer<CapturedContext> contextSetter) {
     if (context.getCapturedThrowable() != null) {
       // report also uncaught exception
-      snapshot.setEntry(context);
+      contextSetter.accept(context);
     }
     snapshot.addEvaluationErrors(status.getErrors());
     if (status.getMessage() != null) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -1147,11 +1147,12 @@ public class CapturedSnapshotTest {
     TestSnapshotListener listener = installProbes(CLASS_NAME, logProbes);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.onClass(testClass).call("main", "1").get();
-    assertEquals(1, listener.snapshots.size());
-    List<EvaluationError> evaluationErrors = listener.snapshots.get(0).getEvaluationErrors();
-    Assertions.assertEquals(1, evaluationErrors.size());
-    Assertions.assertEquals("nullTyped.fld.fld", evaluationErrors.get(0).getExpr());
-    Assertions.assertEquals("Cannot dereference field: fld", evaluationErrors.get(0).getMessage());
+    Snapshot snapshot = assertOneSnapshot(listener);
+    List<EvaluationError> evaluationErrors = snapshot.getEvaluationErrors();
+    assertEquals(1, evaluationErrors.size());
+    assertEquals("nullTyped.fld.fld", evaluationErrors.get(0).getExpr());
+    assertEquals("Cannot dereference field: fld", evaluationErrors.get(0).getMessage());
+    assertEquals("Cannot dereference field: fld", snapshot.getMessage());
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
set the message in snapshot with the content of the first evaluation errors

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2704]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2704]: https://datadoghq.atlassian.net/browse/DEBUG-2704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ