### PR TITLE
Fix NullPointerException in RASP metrics

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -118,7 +118,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
   // set after additive is set
   private volatile PowerwafMetrics wafMetrics;
   private volatile PowerwafMetrics raspMetrics;
-  private AtomicInteger raspMetricsCounter;
+  private final AtomicInteger raspMetricsCounter = new AtomicInteger(0);
   private volatile boolean blocked;
   private volatile int timeouts;
 
@@ -182,7 +182,6 @@ public class AppSecRequestContext implements DataBundle, Closeable {
       }
       if (isRasp && raspMetrics == null) {
         this.raspMetrics = ctx.createMetrics();
-        this.raspMetricsCounter = new AtomicInteger(0);
       }
     }
 

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFStatsReporter.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFStatsReporter.java
@@ -35,7 +35,10 @@ public class PowerWAFStatsReporter implements TraceSegmentPostProcessor {
       segment.setTagTop(RASP_TOTAL_DURATION_US_TAG, raspMetrics.getTotalRunTimeNs() / 1000L);
       segment.setTagTop(
           RASP_TOTAL_DDWAF_RUN_DURATION_US_TAG, raspMetrics.getTotalDdwafRunTimeNs() / 1000L);
-      segment.setTagTop(RASP_RULE_EVAL, ctx.getRaspMetricsCounter().get());
+      final int raspCount = ctx.getRaspMetricsCounter().get();
+      if (raspCount > 0) {
+        segment.setTagTop(RASP_RULE_EVAL, raspCount);
+      }
     }
 
     String rulesVersion = this.rulesVersion;


### PR DESCRIPTION
# What Does This Do
Avoid NullPointerException when incrementing RASP call count after request end.

# Motivation

Fixing this exception:

```
WARN com.datadog.appsec.event.EventDispatcher - AppSec callback exception"
java.lang.NullPointerException: Cannot invoke ""java.util.concurrent.atomic.AtomicInteger.incrementAndGet()"" because the return value of ""com.datadog.appsec.gateway.AppSecRequestContext.getRaspMetricsCounter()"" is null"
at com.datadog.appsec.powerwaf.PowerWAFModule$PowerWAFDataCallback.doRunPowerwaf(PowerWAFModule.java:611)"
at com.datadog.appsec.powerwaf.PowerWAFModule$PowerWAFDataCallback.onDataAvailable(PowerWAFModule.java:439)"
at com.datadog.appsec.event.EventDispatcher.publishDataEvent(EventDispatcher.java:148)"
at com.datadog.appsec.event.ReplaceableEventProducerService.publishDataEvent(ReplaceableEventProducerService.java:29)"
at com.datadog.appsec.gateway.GatewayBridge.onDatabaseSqlQuery(GatewayBridge.java:184)"
at datadog.trace.api.gateway.InstrumentationGateway$14.apply(InstrumentationGateway.java:389)"
at datadog.trace.api.gateway.InstrumentationGateway$14.apply(InstrumentationGateway.java:384)"
at datadog.trace.bootstrap.instrumentation.decorator.DatabaseClientDecorator.onRawStatement(DatabaseClientDecorator.java:130)"
at datadog.trace.instrumentation.jdbc.JDBCDecorator.onStatement(JDBCDecorator.java:216)"
at com.zaxxer.hikari.pool.HikariProxyStatement.executeQuery(HikariProxyStatement.java)"
at org.springframework.jdbc.core.JdbcTemplate$1QueryStatementCallback.doInStatement(JdbcTemplate.java:452)"
```

This should not be triggered anyway once we prevent WAF calls for Exploit Prevention (RASP) after request end, but we should guard against the NPE just in case.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [APPSEC-54970](https://datadoghq.atlassian.net/browse/APPSEC-54970)