### PR TITLE
Add CPU count tag to Test Visibility events

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/decorator/TestDecoratorImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/decorator/TestDecoratorImpl.java
@@ -15,6 +15,7 @@ public class TestDecoratorImpl implements TestDecorator {
   private final String component;
   private final String sessionName;
   private final Map<String, String> ciTags;
+  private final int cpuCount;
 
   public TestDecoratorImpl(
       String component, String sessionName, String testCommand, Map<String, String> ciTags) {
@@ -27,6 +28,7 @@ public class TestDecoratorImpl implements TestDecorator {
       this.sessionName =
           Strings.isNotBlank(ciJobName) ? ciJobName + "-" + testCommand : testCommand;
     }
+    cpuCount = Runtime.getRuntime().availableProcessors();
   }
 
   protected String testType() {
@@ -46,6 +48,7 @@ public class TestDecoratorImpl implements TestDecorator {
   public AgentSpan afterStart(final AgentSpan span) {
     span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
     span.setTag(DDTags.ORIGIN_KEY, CIAPP_TEST_ORIGIN);
+    span.setTag(DDTags.HOST_VCPU_COUNT, cpuCount);
     span.setTag(Tags.TEST_TYPE, testType());
     span.setTag(Tags.COMPONENT, component());
     span.setTag(Tags.TEST_SESSION_NAME, sessionName);

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/decorator/TestDecoratorImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/decorator/TestDecoratorImplTest.groovy
@@ -23,6 +23,7 @@ class TestDecoratorImplTest extends Specification {
     1 * span.setTag(Tags.TEST_TYPE, decorator.testType())
     1 * span.setSamplingPriority(PrioritySampling.SAMPLER_KEEP)
     1 * span.setTag(DDTags.ORIGIN_KEY, decorator.origin())
+    1 * span.setTag(DDTags.HOST_VCPU_COUNT, Runtime.runtime.availableProcessors())
     1 * span.setTag("ci-tag-1", "value")
     1 * span.setTag("ci-tag-2", "another value")
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -75,6 +75,7 @@ public class DDTags {
   public static final String PEER_SERVICE_REMAPPED_FROM = "_dd.peer.service.remapped_from";
   public static final String INTERNAL_GIT_REPOSITORY_URL = "_dd.git.repository_url";
   public static final String INTERNAL_GIT_COMMIT_SHA = "_dd.git.commit.sha";
+  public static final String HOST_VCPU_COUNT = "_dd.host.vcpu_count";
 
   public static final String PROFILING_ENABLED = "_dd.profiling.enabled";
   public static final String DSM_ENABLED = "_dd.dsm.enabled";


### PR DESCRIPTION
# What Does This Do

Adds new `_dd.host.vcpu_count` tag with the count of available CPUs to all Test Visibility events: tests, suites, modules, sessions.

# Motivation

This is needed by Datadog backend for evaluating CI costs.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-867]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-867]: https://datadoghq.atlassian.net/browse/SDTEST-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ