### PR TITLE
Fix stack overflow in spock making junit ignore test failures

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -249,9 +249,14 @@ public abstract class InstrumenterModule implements Instrumenter {
 
     @Override
     public boolean isApplicable(Set<TargetSystem> enabledSystems) {
-      return enabledSystems.contains(TargetSystem.IAST)
-          || (isOptOutEnabled()
-              && InstrumenterConfig.get().getAppSecActivation() == ProductActivation.FULLY_ENABLED);
+      if (enabledSystems.contains(TargetSystem.IAST)) {
+        return true;
+      }
+      final InstrumenterConfig cfg = InstrumenterConfig.get();
+      if (!isOptOutEnabled() || cfg.isIastFullyDisabled()) {
+        return false;
+      }
+      return cfg.getAppSecActivation() == ProductActivation.FULLY_ENABLED;
     }
 
     /**

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
@@ -57,7 +57,7 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     if (param.class == String) {
       1 * iastModule.onStringBuilderAppend(target, (String) param)
     } else {
-      1 * iastModule.onStringBuilderAppend(target, param.toString())
+      1 * iastModule.onStringBuilderAppend(target, { it -> it.toString() == param.toString() } )
     }
     _ * TEST_PROFILING_CONTEXT_INTEGRATION._
     0 * _

--- a/dd-java-agent/instrumentation/owasp-esapi-2/src/test/groovy/datadog/trace/instrumentation/owasp/esapi/EncoderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/owasp-esapi-2/src/test/groovy/datadog/trace/instrumentation/owasp/esapi/EncoderCallSiteTest.groovy
@@ -25,7 +25,7 @@ class EncoderCallSiteTest extends AgentTestRunner {
     testSuite.&"$method".call(args)
 
     then:
-    1 * module.taintObjectIfTainted(_, _, false, mark)
+    1 * module.taintStringIfTainted(_, _, false, mark)
     0 * module._
 
     where:

--- a/dd-java-agent/instrumentation/tomcat-appsec-7/src/test/groovy/datadog/trace/instrumentation/tomcat7/ErrorReportValueInstrumentationForkedTest.groovy
+++ b/dd-java-agent/instrumentation/tomcat-appsec-7/src/test/groovy/datadog/trace/instrumentation/tomcat7/ErrorReportValueInstrumentationForkedTest.groovy
@@ -7,7 +7,7 @@ import org.apache.catalina.connector.Request
 import org.apache.catalina.connector.Response
 import org.apache.catalina.valves.ErrorReportValve
 
-class ErrorReportValueInstrumentationTest extends AgentTestRunner {
+class ErrorReportValueInstrumentationForkedTest extends AgentTestRunner {
 
   void 'test vulnerability detection'() {
     given:
@@ -37,7 +37,7 @@ class ErrorReportValueInstrumentationTest extends AgentTestRunner {
   }
 }
 
-class AppSecErrorReportValueInstrumentationTest extends ErrorReportValueInstrumentationTest {
+class AppSecErrorReportValueInstrumentationForkedTest extends ErrorReportValueInstrumentationForkedTest {
 
   @Override
   protected void configurePreAgent() {
@@ -51,7 +51,7 @@ class AppSecErrorReportValueInstrumentationTest extends ErrorReportValueInstrume
   }
 }
 
-class IastErrorReportValueInstrumentationTest extends ErrorReportValueInstrumentationTest {
+class IastErrorReportValueInstrumentationForkedTest extends ErrorReportValueInstrumentationForkedTest {
 
   @Override
   protected void configurePreAgent() {
@@ -65,7 +65,7 @@ class IastErrorReportValueInstrumentationTest extends ErrorReportValueInstrument
   }
 }
 
-class IastDisabledErrorReportValueInstrumentationTest extends ErrorReportValueInstrumentationTest {
+class IastDisabledErrorReportValueInstrumentationForkedTest extends ErrorReportValueInstrumentationForkedTest {
 
   @Override
   protected void configurePreAgent() {

--- a/dd-java-agent/testing/src/test/groovy/TooManyInvocationsErrorListenerTest.groovy
+++ b/dd-java-agent/testing/src/test/groovy/TooManyInvocationsErrorListenerTest.groovy
@@ -1,0 +1,38 @@
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.agent.test.SpockRunner
+import org.junit.runner.Description
+import org.junit.runner.notification.Failure
+import org.spockframework.mock.IMockInteraction
+import org.spockframework.mock.IMockMethod
+import org.spockframework.mock.IMockObject
+import org.spockframework.mock.IResponseGenerator
+import org.spockframework.mock.TooManyInvocationsError
+import org.spockframework.mock.runtime.MockInvocation
+
+class TooManyInvocationsErrorListenerTest extends AgentTestRunner {
+
+  @SuppressWarnings('GroovyAccessibility')
+  void 'test that listener modifies failure'() {
+    setup:
+    final error = new TooManyInvocationsError(Stub(IMockInteraction), [])
+    error.acceptedInvocations.add(new MockInvocation(Stub(IMockObject),
+      Stub(IMockMethod),
+      [error],
+      Stub(IResponseGenerator)))
+    final failure = new Failure(new Description(TooManyInvocationsErrorListenerTest, 'test'), error)
+
+    when:
+    failure.getMessage()
+
+    then:
+    thrown(StackOverflowError)
+
+    when:
+    final listener = new SpockRunner.TooManyInvocationsErrorListener()
+    listener.testFailure(failure)
+    failure.getMessage()
+
+    then:
+    noExceptionThrown()
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -108,6 +108,7 @@ public class InstrumenterConfig {
   private final boolean ciVisibilityEnabled;
   private final ProductActivation appSecActivation;
   private final ProductActivation iastActivation;
+  private final boolean iastFullyDisabled;
   private final boolean usmEnabled;
   private final boolean telemetryEnabled;
 
@@ -194,6 +195,8 @@ public class InstrumenterConfig {
       iastActivation =
           ProductActivation.fromString(
               configProvider.getStringNotEmpty(IAST_ENABLED, DEFAULT_IAST_ENABLED));
+      final Boolean iastEnabled = configProvider.getBoolean(IAST_ENABLED);
+      iastFullyDisabled = iastEnabled != null && !iastEnabled;
       usmEnabled = configProvider.getBoolean(USM_ENABLED, DEFAULT_USM_ENABLED);
       telemetryEnabled = configProvider.getBoolean(TELEMETRY_ENABLED, DEFAULT_TELEMETRY_ENABLED);
     } else {
@@ -201,6 +204,7 @@ public class InstrumenterConfig {
       ciVisibilityEnabled = false;
       appSecActivation = ProductActivation.FULLY_DISABLED;
       iastActivation = ProductActivation.FULLY_DISABLED;
+      iastFullyDisabled = true;
       telemetryEnabled = false;
       usmEnabled = false;
     }
@@ -319,6 +323,10 @@ public class InstrumenterConfig {
 
   public ProductActivation getIastActivation() {
     return iastActivation;
+  }
+
+  public boolean isIastFullyDisabled() {
+    return iastFullyDisabled;
   }
 
   public boolean isUsmEnabled() {


### PR DESCRIPTION
# What Does This Do
Fixes tests failures when a `org.spockframework.mock.TooManyInvocationsError` triggers a `java.lang.StackOverflowError` while composing the failure message.

# Motivation
When a mocked class captures the assertion error (e.g. TooManyInvocationsError), spock will throw an StackOverflowError while building the accepted invocations failure message, it causes the test to be ignored and won't be reported as a failure. As an example:

Before (warning message and test ignored):
```
Sep 24, 2024 11:35:27 AM org.junit.platform.launcher.core.CompositeTestExecutionListener lambda$notifyEach$19
WARNING: TestExecutionListener [org.junit.platform.runner.JUnitPlatformRunnerListener] threw exception for method: executionFinished(TestIdentifier [uniqueId = [engine:spock]/[spec:datadog.trace.instrumentation.java.lang.StringCallSiteTest]/[feature:$spock_feature_2_0], parentId = [engine:spock]/[spec:datadog.trace.instrumentation.java.lang.StringCallSiteTest], displayName = 'test string concat call site', legacyReportingName = 'test string concat call site', source = MethodSource [className = 'datadog.trace.instrumentation.java.lang.StringCallSiteTest', methodName = 'test string concat call site', methodParameterTypes = ''], tags = [], type = TEST], TestExecutionResult [status = FAILED, throwable = org.spockframework.mock.TooManyInvocationsError@35dc849b])
java.lang.StackOverflowError
	at java.util.AbstractList.listIterator(AbstractList.java:299)
```

After (test reported as a failure):
```
datadog.trace.instrumentation.java.lang.StringCallSiteTest > StringCallSiteTest.test string concat call site FAILED
    org.spockframework.mock.TooManyInvocationsError at MockInteraction.java:70
2 tests completed, 1 failed

Too many invocations for:

0 * _   (2 invocations)

Matching invocations (ordered by last occurrence):

1 * stringModule.onUnexpectedException('afetConcat threw', java.lang.AssertionError: 'org.spockframework.mock.TooManyInvocationsError' hidden due to 'java.lang.StackOverflowError')   <-- this triggered the error
1 * stringModule.onStringConcat('ERROR ', 'World!', 'ERROR World!')
```

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-54984]
<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-54984]: https://datadoghq.atlassian.net/browse/APPSEC-54984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ