### PR TITLE
[🍒 7635] Add support of spring boot nested jar for SymDB

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/JarScanner.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/JarScanner.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 public class JarScanner {
   private static final Logger LOGGER = LoggerFactory.getLogger(JarScanner.class);
   private static final String JAR_FILE_PREFIX = "jar:file:";
+  private static final String JAR_NESTED_PREFIX = "jar:nested:";
   private static final String FILE_PREFIX = "file:";
   // Spring prefixes:
   // https://docs.spring.io/spring-boot/docs/current/reference/html/executable-jar.html
@@ -40,6 +41,11 @@ public class JarScanner {
       int idx = locationStr.indexOf("!/");
       if (idx != -1) {
         return getPathFromPrefixedFileName(locationStr, JAR_FILE_PREFIX, idx);
+      }
+    } else if (locationStr.startsWith(JAR_NESTED_PREFIX)) {
+      int idx = locationStr.indexOf("/!BOOT-INF/");
+      if (idx != -1) {
+        return getPathFromPrefixedFileName(locationStr, JAR_NESTED_PREFIX, idx);
       }
     } else if (locationStr.startsWith(FILE_PREFIX)) {
       return getPathFromPrefixedFileName(locationStr, FILE_PREFIX, locationStr.length());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/JarScannerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/JarScannerTest.java
@@ -1,11 +1,16 @@
 package com.datadog.debugger.symbol;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.security.cert.Certificate;
 import org.junit.jupiter.api.Test;
 
 class JarScannerTest {
@@ -30,5 +35,16 @@ class JarScannerTest {
     URLClassLoader urlClassLoader = new URLClassLoader(new URL[] {jarFileUrl}, null);
     Class<?> testClass = urlClassLoader.loadClass(CLASS_NAME);
     assertEquals(jarFileUrl.getFile(), JarScanner.extractJarPath(testClass).toString());
+  }
+
+  @Test
+  public void extractJarPathFromNestedJar() throws URISyntaxException {
+    URL jarFileUrl = getClass().getResource("/debugger-symbol.jar");
+    URL mockLocation = mock(URL.class);
+    when(mockLocation.toString())
+        .thenReturn("jar:nested:" + jarFileUrl.getFile() + "/!BOOT-INF/classes/!");
+    CodeSource codeSource = new CodeSource(mockLocation, (Certificate[]) null);
+    ProtectionDomain protectionDomain = new ProtectionDomain(codeSource, null);
+    assertEquals(jarFileUrl.getFile(), JarScanner.extractJarPath(protectionDomain).toString());
   }
 }


### PR DESCRIPTION
This is a cherry-pick of #7635 

# What Does This Do
Spring boot use a special jar organisation for nested ones. It uses a new jar protocol for URL: jar:nested:

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
