### PR TITLE
Fixed closing WAF context

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -205,8 +205,8 @@ public class AppSecRequestContext implements DataBundle, Closeable {
         if (additive != null) {
           try {
             additive.close();
-            additiveClosed = true;
           } finally {
+            additiveClosed = true;
             additive = null;
           }
         }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -116,6 +116,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   // should be guarded by this
   private volatile Additive additive;
+  private volatile boolean additiveClosed;
   // set after additive is set
   private volatile PowerwafMetrics wafMetrics;
   private volatile PowerwafMetrics raspMetrics;
@@ -204,6 +205,7 @@ public class AppSecRequestContext implements DataBundle, Closeable {
         if (additive != null) {
           try {
             additive.close();
+            additiveClosed = true;
           } finally {
             additive = null;
           }
@@ -549,5 +551,9 @@ public class AppSecRequestContext implements DataBundle, Closeable {
       throttled = rateLimiter.isThrottled();
     }
     return throttled;
+  }
+
+  public boolean isAdditiveClosed() {
+    return additiveClosed;
   }
 }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -204,9 +204,9 @@ public class AppSecRequestContext implements DataBundle, Closeable {
       synchronized (this) {
         if (additive != null) {
           try {
+            additiveClosed = true;
             additive.close();
           } finally {
-            additiveClosed = true;
             additive = null;
           }
         }

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -410,6 +410,11 @@ public class PowerWAFModule implements AppSecModule {
         return;
       }
 
+      if (reqCtx.isAdditiveClosed()) {
+        log.debug("Skipped; the WAF context is closed");
+        return;
+      }
+
       StandardizedLogging.executingWAF(log);
       long start = 0L;
       if (log.isDebugEnabled()) {
@@ -430,7 +435,9 @@ public class PowerWAFModule implements AppSecModule {
         }
         return;
       } catch (AbstractPowerwafException e) {
-        log.error("Error calling WAF", e);
+        if (!reqCtx.isAdditiveClosed()) {
+          log.error("Error calling WAF", e);
+        }
         return;
       } finally {
         if (log.isDebugEnabled()) {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -211,6 +211,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
@@ -244,6 +245,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     2 * ctx.closeAdditive()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
@@ -285,6 +287,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
@@ -309,6 +312,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
@@ -365,6 +369,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
@@ -383,6 +388,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive = it[0].openAdditive()
     }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     0 * _
   }
@@ -441,6 +447,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> { pwafAdditive.close() }
     1 * ctx.setBlocked()
     1 * ctx.isThrottled(null)
@@ -461,6 +468,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive = it[0].openAdditive()
     }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     0 * _
   }
@@ -522,6 +530,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     // we get two events: one for origin rule, and one for the custom one
     1 * ctx.reportEvents(hasSize(2))
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.setBlocked()
     1 * ctx.isThrottled(null)
@@ -598,6 +607,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
@@ -621,6 +631,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive
     }
     1 * ctx.getWafMetrics() >> metrics
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
     1 * ctx.setBlocked()
@@ -686,6 +697,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive
     }
     1 * ctx.getWafMetrics() >> metrics
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
     1 * ctx.setBlocked()
@@ -712,6 +724,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       pwafAdditive = it[0].openAdditive()
     }
     1 * ctx.getWafMetrics() >> null
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.reportEvents(_)
     1 * ctx.setBlocked()
@@ -768,6 +781,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.reportEvents(*_)
     1 * ctx.setBlocked()
     1 * ctx.isThrottled(null)
+    1 * ctx.isAdditiveClosed() >> false
     0 * ctx._(*_)
     flow.blocking == true
   }
@@ -1032,6 +1046,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * flow.setAction({ it.blocking })
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
@@ -1086,6 +1101,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> { pwafAdditive.close() }
     _ * ctx.increaseTimeouts()
     0 * _
@@ -1108,6 +1124,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     1 * reconf.reloadSubscriptions()
     _ * ctx.increaseTimeouts()
@@ -1132,6 +1149,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
     1 * ctx.getWafMetrics()
     1 * flow.setAction({ it.blocking })
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
@@ -1155,6 +1173,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * reconf.reloadSubscriptions()
     1 * ctx.getOrCreateAdditive(_, true, false) >> { pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     _ * ctx.increaseTimeouts()
     0 * _
@@ -1184,6 +1203,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     // no attack
     1 * ctx.getOrCreateAdditive(_, true, false) >> { pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     _ * ctx.increaseTimeouts()
     0 * _
@@ -1207,6 +1227,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     _ * ctx.increaseTimeouts()
     0 * _
@@ -1234,6 +1255,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * flow.setAction({ it.blocking })
     2 * tracer.activeSpan()
     1 * ctx.reportEvents(_ as Collection<AppSecEvent>)
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive() >> {pwafAdditive.close()}
     _ * ctx.increaseTimeouts()
     1 * ctx.isThrottled(null)
@@ -1256,6 +1278,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getOrCreateAdditive(_, true, false) >> {
       pwafAdditive = it[0].openAdditive() }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     _ * ctx.increaseTimeouts()
     0 * _
@@ -1371,6 +1394,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * ctx.getWafMetrics()
     1 * flow.isBlocking()
     1 * ctx.isThrottled(null)
+    1 * ctx.isAdditiveClosed() >> false
     0 * _
 
     when:
@@ -1386,6 +1410,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
       it[0].iterator().next().ruleMatches[0].parameters[0].value == 'user-to-block-1'
     }
     1 * ctx.getWafMetrics()
+    1 * ctx.isAdditiveClosed() >> false
     1 * ctx.closeAdditive()
     1 * ctx.isThrottled(null)
     1 * flow.isBlocking()
@@ -1485,6 +1510,7 @@ class PowerWAFModuleSpecification extends DDSpecification {
     1 * flow.setAction({ Flow.Action.RequestBlockingAction rba ->
       rba.statusCode == 402 && rba.blockingContentType == BlockingContentType.AUTO
     })
+    1 * ctx.isAdditiveClosed() >> false
   }
 
   void 'http endpoint fingerprint support'() {

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -1581,6 +1581,26 @@ class PowerWAFModuleSpecification extends DDSpecification {
     addresses.contains(KnownAddresses.REQUEST_BODY_OBJECT)
   }
 
+  void 'waf not used if the context is closed'() {
+    ChangeableFlow flow = Mock()
+
+    when:
+    setupWithStubConfigService('rules_with_data_config.json')
+    dataListener = pwafModule.dataSubscriptions.first()
+
+    def bundle = MapDataBundle.of(
+            KnownAddresses.USER_ID,
+            'legit-user'
+    )
+    ctx.closeAdditive()
+    dataListener.onDataAvailable(flow, ctx, bundle, gwCtx)
+
+    then:
+    1 * ctx.closeAdditive()
+    1 * ctx.isAdditiveClosed() >> true
+    0 * _
+  }
+
   private Map<String, Object> getDefaultConfig() {
     def service = new StubAppSecConfigService()
     service.init()

--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/powerwaf/PowerWAFModuleSpecification.groovy
@@ -1589,9 +1589,9 @@ class PowerWAFModuleSpecification extends DDSpecification {
     dataListener = pwafModule.dataSubscriptions.first()
 
     def bundle = MapDataBundle.of(
-            KnownAddresses.USER_ID,
-            'legit-user'
-    )
+      KnownAddresses.USER_ID,
+      'legit-user'
+      )
     ctx.closeAdditive()
     dataListener.onDataAvailable(flow, ctx, bundle, gwCtx)
 

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/AsyncConfig.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/AsyncConfig.java
@@ -1,0 +1,22 @@
+package datadog.smoketest.appsec.springboot;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+  @Bean(name = "taskExecutor")
+  public Executor taskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(5);
+    executor.setMaxPoolSize(10);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("Async-");
+    executor.initialize();
+    return executor;
+  }
+}

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/MyAsyncService.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/MyAsyncService.java
@@ -1,0 +1,20 @@
+package datadog.smoketest.appsec.springboot;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MyAsyncService {
+
+  @Async("taskExecutor")
+  public void performAsyncTask(String id) {
+    try {
+      Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
+      conn.createStatement().execute("SELECT 1 FROM DUAL WHERE '1' = '" + id + "'");
+    } catch (Exception e) {
+      // ignore
+    }
+  }
+}

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -7,6 +7,9 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+
+import datadog.smoketest.appsec.springboot.MyAsyncService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +23,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class WebController {
+
+  @Autowired
+  private MyAsyncService myAsyncService;
+
   @RequestMapping("/greeting")
   public String greeting() {
     return "Sup AppSec Dawg";
@@ -43,6 +50,12 @@ public class WebController {
   public String sqliQuery(@RequestParam("id") String id) throws Exception {
     Connection conn = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
     conn.createStatement().execute("SELECT 1 FROM DUAL WHERE '1' = '" + id + "'");
+    return "EXECUTED";
+  }
+
+  @GetMapping("parallel/sqli/query")
+  public String sqliQueryParallel(@RequestParam("id") String id) {
+    myAsyncService.performAsyncTask(id);
     return "EXECUTED";
   }
 

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -1,6 +1,6 @@
 package datadog.smoketest.appsec.springboot.controller;
 
-import datadog.smoketest.appsec.springboot.MyAsyncService;
+import datadog.smoketest.appsec.springboot.service.AsyncService;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class WebController {
 
-  @Autowired private MyAsyncService myAsyncService;
+  @Autowired private AsyncService myAsyncService;
 
   @RequestMapping("/greeting")
   public String greeting() {

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/controller/WebController.java
@@ -1,5 +1,6 @@
 package datadog.smoketest.appsec.springboot.controller;
 
+import datadog.smoketest.appsec.springboot.MyAsyncService;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -7,8 +8,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
-
-import datadog.smoketest.appsec.springboot.MyAsyncService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,8 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class WebController {
 
-  @Autowired
-  private MyAsyncService myAsyncService;
+  @Autowired private MyAsyncService myAsyncService;
 
   @RequestMapping("/greeting")
   public String greeting() {

--- a/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/service/AsyncService.java
+++ b/dd-smoke-tests/appsec/springboot/src/main/java/datadog/smoketest/appsec/springboot/service/AsyncService.java
@@ -1,4 +1,4 @@
-package datadog.smoketest.appsec.springboot;
+package datadog.smoketest.appsec.springboot.service;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -6,7 +6,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
-public class MyAsyncService {
+public class AsyncService {
 
   @Async("taskExecutor")
   public void performAsyncTask(String id) {

--- a/gradle/spotbugFilters/exclude.xml
+++ b/gradle/spotbugFilters/exclude.xml
@@ -6,6 +6,7 @@
       <Package name="io.sqreen.testapp.sampleapp" />
       <Package name="datadog.trace.bootstrap.instrumentation.decorator.http.utils" />
       <Package name="datadog.smoketest.appsec.springboot.controller" />
+      <Package name="datadog.smoketest.appsec.springboot.service" />
       <!-- these are auto-generated -->
       <Package name="com.datadog.appsec.report.raw.contexts._definitions" />
       <Package name="com.datadog.appsec.report.raw.contexts.actor" />


### PR DESCRIPTION
# What Does This Do
Added extra checks to prevent occurring exceptions, in case the WAF context was closed earlier during the race condition.

# Motivation
Reported exception from customers' service
```
io.sqreen.powerwaf.exception.UnclassifiedPowerwafException: Error calling WAF
io.sqreen.powerwaf.exception.UnclassifiedPowerwafException
  at (redacted: 2 frames)
  at com.datadog.appsec.powerwaf.PowerWAFModule.runPowerwafTransient(PowerWAFModule.java:634)
  at com.datadog.appsec.powerwaf.PowerWAFModule.access$700(PowerWAFModule.java:74)
  at com.datadog.appsec.powerwaf.PowerWAFModule$PowerWAFDataCallback.doRunPowerwaf(PowerWAFModule.java:617)
  at com.datadog.appsec.powerwaf.PowerWAFModule$PowerWAFDataCallback.onDataAvailable(PowerWAFModule.java:439)
  at com.datadog.appsec.event.EventDispatcher.publishDataEvent(EventDispatcher.java:148)
  at com.datadog.appsec.event.ReplaceableEventProducerService.publishDataEvent(ReplaceableEventProducerService.java:29)
  at com.datadog.appsec.gateway.GatewayBridge.onDatabaseSqlQuery(GatewayBridge.java:184)
  at datadog.trace.api.gateway.InstrumentationGateway$14.apply(InstrumentationGateway.java:389)
  at datadog.trace.api.gateway.InstrumentationGateway$14.apply(InstrumentationGateway.java:384)
  at datadog.trace.bootstrap.instrumentation.decorator.DatabaseClientDecorator.onRawStatement(DatabaseClientDecorator.java:130)
  at datadog.trace.instrumentation.jdbc.JDBCDecorator.onStatement(JDBCDecorator.java:216)
  at (redacted: 13 frames)
  at datadog.trace.instrumentation.springscheduling.SpannedMethodInvocation.invokeWithSpan(SpannedMethodInvocation.java:50)
  at datadog.trace.instrumentation.springscheduling.SpannedMethodInvocation.invokeWithContinuation(SpannedMethodInvocation.java:42)
  at datadog.trace.instrumentation.springscheduling.SpannedMethodInvocation.proceed(SpannedMethodInvocation.java:36)
  at (redacted)
  at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  at java.base/java.lang.Thread.run(Thread.java:833)
```

# Additional Notes
Occasional exceptions were observed when the root span and SQL query span executed concurrently. This created a risk of a race condition, where the WAF context could be prematurely closed and finalized before all parallel spans completed. Upon further investigation, the following issues were identified:
1. An attempt to use the WAF context after the root span had already closed (since the WAF context was tied to the root span).
2. Due to the premature closure of the WAF context, a new context was re-created but never released.

<img width="656" alt="image" src="https://github.com/user-attachments/assets/2c7da342-e864-44b8-a19a-5c135400b250">


# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
