### PR TITLE
Fix duplicated locals with arguments

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -476,6 +476,7 @@ public class CapturedContextInstrumentor extends Instrumentor {
       }
       checkHoistableLocalVar(localVar, localVarsByName, localVarsBySlot, hoistableVarByName);
     }
+    removeDuplicatesFromArgs(hoistableVarByName, localVarsBySlotArray);
     // hoist vars
     List<LocalVariableNode> results = new ArrayList<>();
     for (Map.Entry<String, List<LocalVariableNode>> entry : hoistableVarByName.entrySet()) {
@@ -510,6 +511,19 @@ public class CapturedContextInstrumentor extends Instrumentor {
       results.add(newVarNode);
     }
     return results;
+  }
+
+  private void removeDuplicatesFromArgs(
+      Map<String, List<LocalVariableNode>> hoistableVarByName,
+      LocalVariableNode[] localVarsBySlotArray) {
+    for (int idx = 0; idx < argOffset; idx++) {
+      LocalVariableNode localVar = localVarsBySlotArray[idx];
+      if (localVar == null) {
+        continue;
+      }
+      // we are removing local variables that are arguments
+      hoistableVarByName.remove(localVar.name);
+    }
   }
 
   private LabelNode findLatestLabel(InsnList instructions, Set<LabelNode> endLabels) {
@@ -762,8 +776,8 @@ public class CapturedContextInstrumentor extends Instrumentor {
     int slot = isStatic ? 0 : 1;
     for (Type argType : argTypes) {
       String currentArgName = null;
-      if (slot < localVarsBySlot.length) {
-        LocalVariableNode localVarNode = localVarsBySlot[slot];
+      if (slot < localVarsBySlotArray.length) {
+        LocalVariableNode localVarNode = localVarsBySlotArray[slot];
         currentArgName = localVarNode != null ? localVarNode.name : null;
       }
       if (currentArgName == null) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -45,7 +45,7 @@ public abstract class Instrumentor {
   protected final LabelNode methodEnterLabel;
   protected int localVarBaseOffset;
   protected int argOffset;
-  protected final LocalVariableNode[] localVarsBySlot;
+  protected final LocalVariableNode[] localVarsBySlotArray;
   protected LabelNode returnHandlerLabel;
   protected final List<CapturedContextInstrumentor.FinallyBlock> finallyBlocks = new ArrayList<>();
 
@@ -68,7 +68,7 @@ public abstract class Instrumentor {
     for (Type t : argTypes) {
       argOffset += t.getSize();
     }
-    localVarsBySlot = extractLocalVariables(argTypes);
+    localVarsBySlotArray = extractLocalVariables(argTypes);
   }
 
   public abstract InstrumentationResult.Status instrument();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumentor.java
@@ -697,8 +697,8 @@ public class MetricInstrumentor extends Instrumentor {
       int slot = instrumentor.isStatic ? 0 : 1;
       for (Type argType : argTypes) {
         String currentArgName = null;
-        if (instrumentor.localVarsBySlot.length > 0) {
-          LocalVariableNode localVarNode = instrumentor.localVarsBySlot[slot];
+        if (instrumentor.localVarsBySlotArray.length > 0) {
+          LocalVariableNode localVarNode = instrumentor.localVarsBySlotArray[slot];
           currentArgName = localVarNode != null ? localVarNode.name : null;
         }
         if (currentArgName == null) {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
@@ -4,6 +4,7 @@ import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadog.debugger.agent.JsonSnapshotSerializer;
@@ -99,6 +100,8 @@ public class TracerDebuggerIntegrationTest extends BaseIntegrationTest {
     Snapshot snapshot = request.getDebugger().getSnapshot();
     assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
     assertEquals(42, snapshot.getCaptures().getEntry().getArguments().get("argInt").getValue());
+    // no locals captured
+    assertNull(snapshot.getCaptures().getEntry().getLocals());
     assertTrue(Pattern.matches("[0-9a-f]+", request.getTraceId()));
     assertTrue(Pattern.matches("\\d+", request.getSpanId()));
   }


### PR DESCRIPTION
# What Does This Do
When hoisting local variables remove the locals that could be have the
 same name than arguments.
This could happen resulting of the instrumentation by the tracer that reshuffle the local variable table and then reassign dedicated slots to those arguments

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2901]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2601]: https://datadoghq.atlassian.net/browse/DEBUG-2601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEBUG-2901]: https://datadoghq.atlassian.net/browse/DEBUG-2901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ