### PR TITLE
Fix flaky log probe tests

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -71,8 +71,11 @@ public class LogProbeTest {
     LogProbe logProbe = createLog(null).evaluateAt(MethodLocation.valueOf(methodLocation)).build();
     CapturedContext entryContext = new CapturedContext();
     CapturedContext exitContext = new CapturedContext();
-    prepareContext(entryContext, logProbe, MethodLocation.ENTRY);
-    prepareContext(exitContext, logProbe, MethodLocation.EXIT);
+    LogProbe.LogStatus logEntryStatus =
+        prepareContext(entryContext, logProbe, MethodLocation.ENTRY);
+    logEntryStatus.setSampled(true); // force sampled to avoid rate limiting executing tests!
+    LogProbe.LogStatus logExitStatus = prepareContext(exitContext, logProbe, MethodLocation.EXIT);
+    logExitStatus.setSampled(true); // force sampled to avoid rate limiting executing tests!
     Snapshot snapshot = new Snapshot(Thread.currentThread(), logProbe, 10);
     assertTrue(logProbe.fillSnapshot(entryContext, exitContext, null, snapshot));
   }


### PR DESCRIPTION
# What Does This Do
rate limiting when evaluating probe can be triggered because of the previous test speed. need o force the sampling anyway make the test passes as expected

# Motivation
test flakiness

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
