### PR TITLE
Fix crashtracking log parser

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/parsers/HotspotCrashLogParserTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/parsers/HotspotCrashLogParserTest.java
@@ -1,0 +1,23 @@
+package com.datadog.crashtracking.parsers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class HotspotCrashLogParserTest {
+  @ParameterizedTest
+  @CsvSource({
+    // From sample-crash-for-telemetry - 2 digits time offset
+    "Tue Oct 17 20:25:14 2023 +08,      2023-10-17T20:25:14+08:00",
+    // From sample-crash-for-telemetry-2 - UTC time zone name
+    "Fri Sep 20 13:19:06 2024 UTC,      2024-09-20T13:19:06Z",
+    // Test single digit day
+    "Tue Oct  1 05:05:47 2024 +00:00,   2024-10-01T05:05:47Z",
+    // Test CEST time zone name
+    "Tue Oct  1 14:37:58 2024 CEST,     2024-10-01T14:37:58+02:00"
+  })
+  public void testDateTimeParser(String logDateTime, String expectedISODateTime) {
+    assertEquals(expectedISODateTime, HotspotCrashLogParser.dateTimeToISO(logDateTime));
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR fixes the date time parser from the crashtracking log parser to support:

* Single digit day of month
* Both offset and timezone date times

It also adds some unit tests that cover this change to quickly test for new values. 

# Motivation

The Summary section uses time format with space padding for days of the month while our parser uses zero padded number (`dd`, [reference](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/time/format/DateTimeFormatter.html#:~:text=Number%3A%20If%20the%20count%20of%20letters%20is%20one%2C%20then%20the%20value%20is%20output%20using%20the%20minimum%20number%20of%20digits%20and%20without%20padding.%20Otherwise%2C%20the%20count%20of%20digits%20is%20used%20as%20the%20width%20of%20the%20output%20field%2C%20with%20the%20value%20zero%2Dpadded%20as%20necessary.)).

The Summary section time can also be offset based (`Z`, `+08`, `+08:00`) or time zone based (`CEST`, `UTC`, `GMT`).

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
