### PR TITLE
Add backport script

### DIFF
--- a/tooling/backport-pr-to-patch-release.sh
+++ b/tooling/backport-pr-to-patch-release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+
+PATCH_RELEASE_NAME=$1
+PATCH_RELEASE_BRANCH=release/$PATCH_RELEASE_NAME
+PR_NUMBER=$2
+
+#
+# Check arguments.
+#
+# Check if no arguments are provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <patch-release-name> <pr-number>"
+    echo "<patch-release-name>: v1.2.x or release/v1.2.x"
+    echo "<pr-number>: PR number to backport"
+    exit 1
+fi
+# Check patch release name is provided
+if [ -z "$PATCH_RELEASE_NAME" ]; then
+    echo "Patch release name is not provided: $0 <patch-release-name> <pr-number>"
+    exit 1
+fi
+# Check patch release name starts with "release/"
+if [[ ! "$PATCH_RELEASE_NAME" =~ ^release/.* ]]; then
+    PATCH_RELEASE_NAME="release/$PATCH_RELEASE_NAME"
+fi
+# Check PR number is provided
+if [ -z "$PR_NUMBER" ]; then
+    echo "PR number is not provided"
+    exit 1
+fi
+
+#
+# Check requirements.
+#
+# Get current git branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+# Check gh is installed
+echo "- Checking gh is installed"
+gh --version 1>/dev/null 2>&1 || { echo "gh is not installed"; exit 1; }
+# Check jq is installed
+echo "- Checking jq is installed"
+jq --version 1>/dev/null 2>&1 || { echo "jq is not installed"; exit 1; }
+# Check there is no local changes
+echo "- Checking there is no local changes"
+git diff --exit-code || { echo "There are local changes"; exit 1; }
+# Check remote branch exists
+echo "- Checking remote release branch exists"
+git fetch --quiet
+git show-ref --verify --quiet "refs/remotes/origin/$PATCH_RELEASE_BRANCH" 1>/dev/null 2>&1 || { echo "Branch $PATCH_RELEASE_BRANCH does not exist"; exit 1; }
+# Check PR exists
+echo "- Checking PR exists"
+PR_COMMIT=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
+if [ -z "$PR_COMMIT" ]; then
+    echo "PR $PR_NUMBER does not exist"
+    exit 1
+fi
+PR_TITLE=$(gh pr view "$PR_NUMBER" --json title --jq '.title')
+PR_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(",")')
+
+#
+# Backport PR to patch release branch.
+#
+# Checkout release branch
+git checkout "$PATCH_RELEASE_BRANCH"
+# Ensure the branch is up-to-date
+git pull
+# Create a new branch for the backport
+BRANCH_NAME="$USER/backport-pr-$PR_NUMBER"
+git checkout -b "$BRANCH_NAME"
+# Cherry-pick PR commit
+git cherry-pick "$PR_COMMIT"
+# Push the branch
+git push -u origin "$BRANCH_NAME" --no-verify
+# Create a PR
+gh pr create --base "$PATCH_RELEASE_BRANCH" \
+    --head "$BRANCH_NAME" \
+    --title "[🍒 $PR_NUMBER] $PR_TITLE" \
+    --body "Backport #$PR_NUMBER to $PATCH_RELEASE_BRANCH" \
+    --label "$PR_LABELS"
+
+#
+# Clean up.
+#
+# Restore current branch
+echo "- Restoring original state"
+git checkout "$CURRENT_BRANCH"


### PR DESCRIPTION
# What Does This Do

This PR introduces a script to backport pull request to patch release branch.

The script takes care of:

* The patch release branch exists
* The PR to backport exists
* The tools needed (`gh` and `jq`) are installed
* There is no local change to your git working copy

It will then:
* Starts a branch from the release branch
*  Find the PR commit, title, and tags
* Cherry pick the PR merge commit
* Push the backport branch and create a new PR with copied tittle and tags.

And it finally restore your original git branch.

# Motivation

This should fasten backporting PRs and issuing patch release.

# Additional Notes

Here is a demo:
```shell
$ tooling/backport-pr-to-patch-release.sh v1.40.x 7697
- Checking gh is installed
- Checking jq is installed
- Checking there is no local changes
- Checking remote release branch exists
- Checking PR exists
Switched to branch 'release/v1.40.x'
Your branch is up to date with 'origin/release/v1.40.x'.
Switched to a new branch 'bruce.bujon/backport-pr-7697'
[bruce.bujon/backport-pr-7697 2cc5379e34] fix(crashtracking): Fix crash tracking log parser
 Date: Tue Oct 1 13:47:28 2024 +0200
 2 files changed, 48 insertions(+), 22 deletions(-)
 create mode 100644 dd-java-agent/agent-crashtracking/src/test/java/com/datadog/crashtracking/parsers/HotspotCrashLogParserTest.java
Enumerating objects: 32, done.
Counting objects: 100% (32/32), done.
Delta compression using up to 10 threads
Compressing objects: 100% (13/13), done.
Writing objects: 100% (19/19), 2.62 KiB | 2.62 MiB/s, done.
Total 19 (delta 4), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote:
remote: Create a pull request for 'bruce.bujon/backport-pr-7697' on GitHub by visiting:
remote:      https://github.com/DataDog/dd-trace-java/pull/new/bruce.bujon/backport-pr-7697
remote:
To github.com:DataDog/dd-trace-java.git
 * [new branch]            bruce.bujon/backport-pr-7697 -> bruce.bujon/backport-pr-7697
branch 'bruce.bujon/backport-pr-7697' set up to track 'origin/bruce.bujon/backport-pr-7697'.
Warning: 1 uncommitted change

Creating pull request for bruce.bujon/backport-pr-7697 into release/v1.40.x in DataDog/dd-trace-java

https://github.com/DataDog/dd-trace-java/pull/7703
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
```


# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
