### PR TITLE
Add config provider alias priority test

### DIFF
--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/ConfigProviderTest.groovy
@@ -22,4 +22,27 @@ class ConfigProviderTest extends DDSpecification {
     config["/a"] == "prop"
     config["/b"] == "env"
   }
+
+
+  def "test config alias priority"() {
+    setup:
+    injectEnvConfig("CONFIG_NAME", configNameValue)
+    injectEnvConfig("CONFIG_ALIAS1", configAlias1Value)
+    injectEnvConfig("CONFIG_ALIAS2", configAlias2Value)
+
+    when:
+    def config = configProvider.getString("CONFIG_NAME", null, "CONFIG_ALIAS1", "CONFIG_ALIAS2")
+
+    then:
+    config == expected
+
+    where:
+    configNameValue | configAlias1Value | configAlias2Value | expected
+    "default"       | null              | null              | "default"
+    null            | "alias1"          | null              | "alias1"
+    null            | null              | "alias2"          | "alias2"
+    "default"       | "alias1"          | null              | "default"
+    "default"       | null              | "alias2"          | "default"
+    null            | "alias1"          | "alias2"          | "alias1"
+  }
 }


### PR DESCRIPTION
# What Does This Do

Add missing tests useful to #7694

# Motivation

Config aliases were untested and should not be tested for every feature that use it but rather in config tests. 

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
