### PR TITLE
add test to verify trace does not propagate when TPE is instantiated

### DIFF
--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/ContextLeakTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/ContextLeakTest.groovy
@@ -1,0 +1,37 @@
+package executor
+
+import datadog.trace.agent.test.AgentTestRunner
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.atomic.AtomicBoolean
+
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+
+class ContextLeakTest extends AgentTestRunner {
+
+  def "trace should not leak into TPE Worker task when '#name'"() {
+    setup:
+    AtomicBoolean parentSpanActive = new AtomicBoolean(false)
+    def tpe = Executors.newFixedThreadPool(1) as ThreadPoolExecutor
+
+    when: "tpe prestarted under an active trace"
+    runUnderTrace("span") {
+      interaction(tpe)
+    }
+    // submit a probe to check if the span is active or not
+    tpe.submit {
+      parentSpanActive.set(AgentTracer.activeSpan()?.operationName == "span")
+    }.get()
+
+    then: "the prestart time span did not leak into the worker"
+    !parentSpanActive.get()
+
+    where:
+    name                         | interaction
+    "prestart all core threads"  | { e -> assert e.prestartAllCoreThreads() > 0 : "threads already started" }
+    "prestart core thread"       | { e -> assert e.prestartCoreThread() : "thread already started" }
+    "lazy init worker"           | { e -> e.execute {} }
+  }
+}


### PR DESCRIPTION
# What Does This Do

I'm investigating a case where a trace appears to have leaked into an idle thread pool executor. This test doesn't reproduce the behaviour, but seems useful to prevent it from ever regressing.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
