### PR TITLE
Add support for `TRACE_HTTP_SERVER_ERROR_STATUSES`

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -65,7 +65,8 @@ public final class TracerConfig {
       "trace.http.server.path-resource-name-mapping";
   public static final String TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING =
       "trace.http.client.path-resource-name-mapping";
-  public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";
+  // Use TRACE_HTTP_SERVER_ERROR_STATUSES instead
+  @Deprecated public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";
   public static final String TRACE_HTTP_SERVER_ERROR_STATUSES = "trace.http.server.error.statuses";
   public static final String HTTP_CLIENT_ERROR_STATUSES = "http.client.error.statuses";
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -66,6 +66,7 @@ public final class TracerConfig {
   public static final String TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING =
       "trace.http.client.path-resource-name-mapping";
   public static final String HTTP_SERVER_ERROR_STATUSES = "http.server.error.statuses";
+  public static final String TRACE_HTTP_SERVER_ERROR_STATUSES = "trace.http.server.error.statuses";
   public static final String HTTP_CLIENT_ERROR_STATUSES = "http.client.error.statuses";
 
   public static final String SPLIT_BY_TAGS = "trace.split-by-tags";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -779,7 +779,7 @@ public class Config {
 
     httpServerErrorStatuses =
         configProvider.getIntegerRange(
-            HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES);
+            TRACE_HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES, HTTP_SERVER_ERROR_STATUSES);
 
     httpClientErrorStatuses =
         configProvider.getIntegerRange(

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -779,7 +779,9 @@ public class Config {
 
     httpServerErrorStatuses =
         configProvider.getIntegerRange(
-            TRACE_HTTP_SERVER_ERROR_STATUSES, DEFAULT_HTTP_SERVER_ERROR_STATUSES, HTTP_SERVER_ERROR_STATUSES);
+            TRACE_HTTP_SERVER_ERROR_STATUSES,
+            DEFAULT_HTTP_SERVER_ERROR_STATUSES,
+            HTTP_SERVER_ERROR_STATUSES);
 
     httpClientErrorStatuses =
         configProvider.getIntegerRange(

--- a/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -309,8 +309,8 @@ public final class ConfigProvider {
     return merged;
   }
 
-  public BitSet getIntegerRange(final String key, final BitSet defaultValue) {
-    final String value = getString(key);
+  public BitSet getIntegerRange(final String key, final BitSet defaultValue, String... aliases) {
+    final String value = getString(key, null, aliases);
     try {
       if (value != null) {
         return ConfigConverter.parseIntegerRangeSet(value, key);


### PR DESCRIPTION
# What Does This Do
Add support to handle `TRACE_HTTP_SERVER_ERROR_STATUSES` tag as well as the original `HTTP_CLIENT_ERROR_STATUSES` tag in efforts to be more consistent with the tags from other languages.
# Motivation
Our goal is to make the implementation of configuration variables consistent for all languages as part of the config consistency effort listed in the following [RFC](https://docs.google.com/document/d/1kI-gTAKghfcwI7YzKhqRv2ExUstcHqADIWA4-TZ387o/edit).
# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-479](https://datadoghq.atlassian.net/browse/APMAPI-479)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-477]: https://datadoghq.atlassian.net/browse/APMAPI-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APMAPI-479]: https://datadoghq.atlassian.net/browse/APMAPI-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ