### PR TITLE
Rename the code origin tags

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
@@ -1,8 +1,8 @@
 package com.datadog.debugger.probe;
 
 import static com.datadog.debugger.codeorigin.DebuggerConfiguration.isDebuggerEnabled;
-import static datadog.trace.api.DDTags.DD_STACK_CODE_ORIGIN_FRAME;
-import static datadog.trace.api.DDTags.DD_STACK_CODE_ORIGIN_TYPE;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_TYPE;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -98,19 +98,19 @@ public class CodeOriginProbe extends LogProbe implements ForceMethodInstrumentat
         entrySpanProbe ? asList(span, span.getLocalRootSpan()) : singletonList(span);
 
     for (AgentSpan s : agentSpans) {
-      s.setTag(DD_STACK_CODE_ORIGIN_TYPE, entrySpanProbe ? "entry" : "exit");
+      s.setTag(DD_CODE_ORIGIN_TYPE, entrySpanProbe ? "entry" : "exit");
 
       for (int i = 0; i < entries.size(); i++) {
         StackTraceElement info = entries.get(i);
-        s.setTag(format(DD_STACK_CODE_ORIGIN_FRAME, i, "file"), info.getFileName());
-        s.setTag(format(DD_STACK_CODE_ORIGIN_FRAME, i, "method"), info.getMethodName());
-        s.setTag(format(DD_STACK_CODE_ORIGIN_FRAME, i, "line"), info.getLineNumber());
-        s.setTag(format(DD_STACK_CODE_ORIGIN_FRAME, i, "type"), info.getClassName());
+        s.setTag(format(DD_CODE_ORIGIN_FRAME, i, "file"), info.getFileName());
+        s.setTag(format(DD_CODE_ORIGIN_FRAME, i, "method"), info.getMethodName());
+        s.setTag(format(DD_CODE_ORIGIN_FRAME, i, "line"), info.getLineNumber());
+        s.setTag(format(DD_CODE_ORIGIN_FRAME, i, "type"), info.getClassName());
         if (i == 0 && signature != null) {
-          s.setTag(format(DD_STACK_CODE_ORIGIN_FRAME, i, "signature"), signature);
+          s.setTag(format(DD_CODE_ORIGIN_FRAME, i, "signature"), signature);
         }
         if (i == 0 && snapshotId != null) {
-          s.setTag(format(DD_STACK_CODE_ORIGIN_FRAME, i, "snapshot_id"), snapshotId);
+          s.setTag(format(DD_CODE_ORIGIN_FRAME, i, "snapshot_id"), snapshotId);
         }
       }
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -2,8 +2,9 @@ package com.datadog.debugger.origin;
 
 import static com.datadog.debugger.agent.ConfigurationAcceptor.Source.REMOTE_CONFIG;
 import static com.datadog.debugger.util.TestHelper.setFieldInConfig;
-import static datadog.trace.api.DDTags.DD_STACK_CODE_ORIGIN_FRAME;
-import static datadog.trace.api.DDTags.DD_STACK_CODE_ORIGIN_TYPE;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_FRAME;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_PREFIX;
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_TYPE;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -191,16 +192,16 @@ public class CodeOriginTest {
   private static void checkEntrySpanTags(MutableSpan span, boolean includeSnapshot) {
     String keys = format("Existing keys for %s: %s", span.getOperationName(), ldKeys(span));
 
-    assertEquals(span.getTag(DD_STACK_CODE_ORIGIN_TYPE), "entry", keys);
-    assertKeyPresent(span, DD_STACK_CODE_ORIGIN_TYPE);
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "file"));
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "line"));
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "method"));
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "signature"));
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "type"));
+    assertEquals(span.getTag(DD_CODE_ORIGIN_TYPE), "entry", keys);
+    assertKeyPresent(span, DD_CODE_ORIGIN_TYPE);
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "file"));
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "line"));
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "method"));
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "signature"));
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "type"));
 
     if (includeSnapshot) {
-      assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "snapshot_id"));
+      assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "snapshot_id"));
     }
   }
 
@@ -224,26 +225,26 @@ public class CodeOriginTest {
     String keys =
         format("Existing keys for %s: %s", span.getOperationName(), new TreeSet<>(ldKeys(span)));
 
-    assertKeyPresent(span, DD_STACK_CODE_ORIGIN_TYPE);
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "file"));
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "line"));
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "method"));
-    assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "type"));
+    assertKeyPresent(span, DD_CODE_ORIGIN_TYPE);
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "file"));
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "line"));
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "method"));
+    assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "type"));
     if (includeSnapshot) {
-      assertKeyPresent(span, format(DD_STACK_CODE_ORIGIN_FRAME, 0, "snapshot_id"));
+      assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "snapshot_id"));
     }
 
     MutableSpan rootSpan = span.getLocalRootSpan();
-    assertEquals(rootSpan.getTag(DD_STACK_CODE_ORIGIN_TYPE), "entry", keys);
-    assertNotNull(rootSpan.getTag(format(DD_STACK_CODE_ORIGIN_FRAME, 1, "file")));
-    assertNotNull(rootSpan.getTag(format(DD_STACK_CODE_ORIGIN_FRAME, 1, "line")));
-    assertNotNull(rootSpan.getTag(format(DD_STACK_CODE_ORIGIN_FRAME, 1, "method")));
-    assertNotNull(rootSpan.getTag(format(DD_STACK_CODE_ORIGIN_FRAME, 1, "type")));
+    assertEquals(rootSpan.getTag(DD_CODE_ORIGIN_TYPE), "entry", keys);
+    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 1, "file")));
+    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 1, "line")));
+    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 1, "method")));
+    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 1, "type")));
   }
 
   private static Set<String> ldKeys(MutableSpan span) {
     return span.getTags().keySet().stream()
-        .filter(key -> key.startsWith("_dd.ld") || key.startsWith("_dd.stack"))
+        .filter(key -> key.startsWith(DD_CODE_ORIGIN_PREFIX))
         .collect(Collectors.toCollection(TreeSet::new));
   }
 

--- a/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/DDTags.java
@@ -2,13 +2,11 @@ package datadog.trace.api;
 
 public class DDTags {
 
-  private static final String DD_LD_PREFIX = "_dd.ld.";
-  public static final String DD_STACK_CODE_ORIGIN_PREFIX = DD_LD_PREFIX + "code_origin.";
+  public static final String DD_CODE_ORIGIN_PREFIX = "_dd.code_origin.";
 
-  public static final String DD_STACK_CODE_ORIGIN_TYPE = DD_STACK_CODE_ORIGIN_PREFIX + "type";
-  // _dd.ld.code_origin.frames.%d.file|line|method|type|snapshot_id
-  public static final String DD_STACK_CODE_ORIGIN_FRAME =
-      DD_STACK_CODE_ORIGIN_PREFIX + "frames.%d.%s";
+  public static final String DD_CODE_ORIGIN_TYPE = DD_CODE_ORIGIN_PREFIX + "type";
+  // _dd.code_origin.frames.%d.file|line|method|type|snapshot_id
+  public static final String DD_CODE_ORIGIN_FRAME = DD_CODE_ORIGIN_PREFIX + "frames.%d.%s";
 
   public static final String SPAN_TYPE = "span.type";
   public static final String SERVICE_NAME = "service.name";


### PR DESCRIPTION
# What Does This Do
Moves the code origin tags under their own namespace `_dd.code_origin`

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2951]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2951]: https://datadoghq.atlassian.net/browse/DEBUG-2951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ