### PR TITLE
Revert HTTP client sharing in CI Vis components

### DIFF
--- a/communication/src/main/java/datadog/communication/BackendApiFactory.java
+++ b/communication/src/main/java/datadog/communication/BackendApiFactory.java
@@ -3,11 +3,13 @@ package datadog.communication;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.communication.http.HttpRetryPolicy;
+import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
 import datadog.trace.util.throwable.FatalAgentMisconfigurationError;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,13 +36,10 @@ public class BackendApiFactory {
             "Agentless mode is enabled and api key is not set. Please set application key");
       }
       String traceId = config.getIdGenerationStrategy().generateTraceId().toString();
-      return new IntakeApi(
-          agentlessUrl,
-          apiKey,
-          traceId,
-          retryPolicyFactory,
-          sharedCommunicationObjects.okHttpClient,
-          true);
+      OkHttpClient httpClient =
+          OkHttpUtils.buildHttpClient(
+              agentlessUrl, config.getCiVisibilityBackendApiTimeoutMillis());
+      return new IntakeApi(agentlessUrl, apiKey, traceId, retryPolicyFactory, httpClient, true);
     }
 
     DDAgentFeaturesDiscovery featuresDiscovery =

--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -36,21 +36,11 @@ public class SharedCommunicationObjects {
       }
     }
     if (okHttpClient == null) {
-      String unixDomainSocket;
-      String namedPipe;
-      HttpUrl url;
-      if (!config.isCiVisibilityAgentlessEnabled()) {
-        unixDomainSocket = SocketUtils.discoverApmSocket(config);
-        namedPipe = config.getAgentNamedPipe();
-        url = agentUrl;
-      } else {
-        unixDomainSocket = null;
-        namedPipe = null;
-        url = null;
-      }
+      String unixDomainSocket = SocketUtils.discoverApmSocket(config);
+      String namedPipe = config.getAgentNamedPipe();
       okHttpClient =
           OkHttpUtils.buildHttpClient(
-              url, unixDomainSocket, namedPipe, getHttpClientTimeout(config));
+              agentUrl, unixDomainSocket, namedPipe, getHttpClientTimeout(config));
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -188,7 +188,6 @@ public class WriterFactory {
       }
       return DDIntakeApi.builder()
           .hostUrl(hostUrl)
-          .httpClient(commObjects.okHttpClient)
           .apiKey(config.getApiKey())
           .trackType(trackType)
           .build();


### PR DESCRIPTION
# What Does This Do

Partially reverts the changes done in https://github.com/DataDog/dd-trace-java/pull/7689
Shared HTTP client is replaced with dedicated HTTP clients for events intake, coverage intake, and backend API - the way it was before the changes.

# Motivation

Sharing HTTP client results in performance regression in the Java test environment.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-999]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-999]: https://datadoghq.atlassian.net/browse/SDTEST-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ