### PR TITLE
Fix Where signature

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/CodeOriginProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/CodeOriginProbeManager.java
@@ -65,7 +65,7 @@ public class CodeOriginProbeManager {
     AgentSpan span = AgentTracer.activeSpan();
     if (!isAlreadyInstrumented(fingerprint)) {
       Where where =
-          Where.convertLineToMethod(
+          Where.of(
               element.getClassName(),
               element.getMethodName(),
               signature,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -83,7 +83,7 @@ public class ExceptionProbeManager {
         continue;
       }
       Where where =
-          Where.convertLineToMethod(
+          Where.of(
               stackTraceElement.getClassName(),
               stackTraceElement.getMethodName(),
               null,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Types.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Types.java
@@ -25,6 +25,7 @@ import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.el.ReflectiveFieldValueResolver;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
@@ -337,6 +339,13 @@ public final class Types {
     }
     buf.append(descriptor);
     return buf.toString();
+  }
+
+  public static String descriptorToSignature(String desc) {
+    Type[] argumentTypes = Type.getArgumentTypes(desc);
+    return Arrays.stream(argumentTypes)
+        .map(Type::getClassName)
+        .collect(Collectors.joining(", ", "(", ")"));
   }
 
   /**

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
@@ -42,8 +42,7 @@ public class Where {
     this(typeName, methodName, signature, sourceLines(lines), sourceFile);
   }
 
-  public static Where convertLineToMethod(
-      String typeName, String methodName, String signature, String... lines) {
+  public static Where of(String typeName, String methodName, String signature, String... lines) {
     return new Where(typeName, methodName, signature, lines, null);
   }
 
@@ -65,7 +64,8 @@ public class Where {
       if (methodsByLine != null && !methodsByLine.isEmpty()) {
         // pick the first method, as we can have multiple methods (lambdas) on the same line
         MethodNode method = methodsByLine.get(0);
-        return new Where(lineWhere.typeName, method.name, method.desc, (SourceLine[]) null, null);
+        String javaSignature = Types.descriptorToSignature(method.desc);
+        return new Where(lineWhere.typeName, method.name, javaSignature, (SourceLine[]) null, null);
       }
     }
     throw new IllegalArgumentException("Invalid where to convert from line to method " + lineWhere);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -2359,7 +2359,7 @@ public class CapturedSnapshotTest {
   public void allProbesSameMethod() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     final String METRIC_NAME = "count";
-    Where where = Where.convertLineToMethod(CLASS_NAME, "main", null);
+    Where where = Where.of(CLASS_NAME, "main", null);
     Configuration configuration =
         Configuration.builder()
             .add(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerProbeInstrumentationTest.java
@@ -98,8 +98,7 @@ public class DebuggerProbeInstrumentationTest extends ProbeInstrumentationTest {
   public void testWithCodeOrigin() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
 
-    Where where =
-        Where.convertLineToMethod(CLASS_NAME, "process", "int (java.lang.String)", (String[]) null);
+    Where where = Where.of(CLASS_NAME, "process", "int (java.lang.String)", (String[]) null);
     installProbes(
         DebuggerProbe.builder()
             .probeId(DEBUG_PROBE_ID)

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -390,7 +390,7 @@ public class DebuggerTransformerTest {
         .when(mock)
         .instrument(any(), anyList(), anyList());
     when(mock.getProbeId()).thenReturn(new ProbeId(id, 0));
-    Where where = Where.convertLineToMethod(ArrayList.class.getName(), "add", "(Object)");
+    Where where = Where.of(ArrayList.class.getName(), "add", "(Object)");
     when(mock.getWhere()).thenReturn(where);
     return (T) mock;
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/TypesTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/TypesTest.java
@@ -90,6 +90,15 @@ class TypesTest {
         IllegalArgumentException.class, () -> Types.descriptorFromSignature("int (a, ,b)"));
   }
 
+  @Test
+  void descriptorToSignature() {
+    String desc = "(I[JLjava/util/Map;Ljava/util/Map$Entry;[[Ljava/lang/String;)Ljava/lang/String;";
+    String expectedSignature =
+        "(int, long[], java.util.Map, java.util.Map$Entry, java.lang.String[][])";
+    String signature = Types.descriptorToSignature(desc);
+    assertEquals(expectedSignature, signature);
+  }
+
   @ParameterizedTest
   @MethodSource("provideGetArrayType")
   void testGetArrayType(Class<?> clazz, int opcode) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.probe;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -9,6 +11,7 @@ import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.tree.MethodNode;
@@ -80,6 +83,19 @@ public class WhereTest {
     Assertions.assertEquals(new Where.SourceLine(12), lines[0]);
     Assertions.assertEquals(new Where.SourceLine(40, 42), lines[1]);
     Assertions.assertEquals(linesJson, adapter.toJson(lines));
+  }
+
+  @Test
+  public void convertLineToMethod() {
+    Where wherePut = Where.of("java.util.Map", "put", "(Object, Object)", "42");
+    ClassFileLines classFileLines = mock(ClassFileLines.class);
+    MethodNode methodNode = createMethodNode("put", "(Ljava/lang/Object;Ljava/lang/Object;)V");
+    when(classFileLines.getMethodsByLine(42)).thenReturn(Collections.singletonList(methodNode));
+    Where whereMapPut = Where.convertLineToMethod(wherePut, classFileLines);
+    assertEquals("java.util.Map", whereMapPut.getTypeName());
+    assertEquals("put", whereMapPut.getMethodName());
+    assertEquals("(java.lang.Object, java.lang.Object)", whereMapPut.getSignature());
+    assertNull(whereMapPut.getLines());
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
in `Where::convertLineToMethod` method we are converting a Where with a line to a new Where as a method + signature matching the line However the signature was the JVM descriptor and therefore does not match with the way we are using it for matching instrumentation that expect a java signature


# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
