### PR TITLE
Fix integration tests - remove libgcc test reference

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,7 +216,7 @@ package-oci:
 onboarding_tests_installer:
   parallel:
     matrix:
-      - ONBOARDING_FILTER_WEBLOG: [test-app-java, test-app-java-container, test-app-java-container-jdk15, test-app-java-alpine-libgcc]
+      - ONBOARDING_FILTER_WEBLOG: [test-app-java, test-app-java-container, test-app-java-container-jdk15, test-app-java-alpine]
         SCENARIO: [ SIMPLE_INSTALLER_AUTO_INJECTION, SIMPLE_AUTO_INJECTION_PROFILING ]
       - ONBOARDING_FILTER_WEBLOG: [test-app-java-buildpack]
         SCENARIO: [ SIMPLE_INSTALLER_AUTO_INJECTION ]


### PR DESCRIPTION
libgcc scenario got removed as the injector does not require libgcc anymore https://github.com/DataDog/system-tests/pull/3174

I missed that the tracer reference it. Here's a [broken pipeline ](https://github.com/DataDog/dd-trace-java/pull/7661)
<img width="820" alt="image" src="https://github.com/user-attachments/assets/5637c625-696a-4c75-9945-846716503e85">

