### PR TITLE
Fix mixed local vars for suspend funs in Kotlin

### DIFF
--- a/dd-java-agent/agent-debugger/build.gradle
+++ b/dd-java-agent/agent-debugger/build.gradle
@@ -52,7 +52,8 @@ dependencies {
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.3.5.RELEASE'
   testImplementation group: 'org.freemarker', name: 'freemarker', version: '2.3.30'
   testImplementation group: 'org.jooq', name: 'joor-java-8', version: '0.9.13'
-  testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: "1.5.21"
+  testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: "1.9.25"
+  testImplementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: "1.0.0"
   testImplementation project(':dd-trace-core')
   testImplementation project(':dd-java-agent:agent-builder')
   testImplementation project(':remote-config:remote-config-core')

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -590,8 +590,9 @@ public class CapturedSnapshotTest {
     URL resource = CapturedSnapshotTest.class.getResource("/" + CLASS_NAME + ".kt");
     assertNotNull(resource);
     List<File> filesToDelete = new ArrayList<>();
-    Class<?> testClass = KotlinHelper.compileAndLoad(CLASS_NAME, resource.getFile(), filesToDelete);
     try {
+      Class<?> testClass =
+          KotlinHelper.compileAndLoad(CLASS_NAME, resource.getFile(), filesToDelete);
       Object companion = Reflect.onClass(testClass).get("Companion");
       int result = Reflect.on(companion).call("main", "").get();
       assertEquals(48, result);
@@ -602,6 +603,29 @@ public class CapturedSnapshotTest {
       Assertions.assertEquals(CLASS_NAME, snapshot.getProbe().getLocation().getType());
       Assertions.assertEquals("f1", snapshot.getProbe().getLocation().getMethod());
       assertCaptureArgs(snapshot.getCaptures().getLines().get(4), "value", "int", "31");
+    } finally {
+      filesToDelete.forEach(File::delete);
+    }
+  }
+
+  @Test
+  public void suspendKotlin() {
+    final String CLASS_NAME = "CapturedSnapshot302";
+    TestSnapshotListener listener =
+        installProbes(CLASS_NAME, createSourceFileProbe(PROBE_ID, CLASS_NAME + ".kt", 9));
+    URL resource = CapturedSnapshotTest.class.getResource("/" + CLASS_NAME + ".kt");
+    assertNotNull(resource);
+    List<File> filesToDelete = new ArrayList<>();
+    try {
+      Class<?> testClass =
+          KotlinHelper.compileAndLoad(CLASS_NAME, resource.getFile(), filesToDelete);
+      Object companion = Reflect.onClass(testClass).get("Companion");
+      int result = Reflect.on(companion).call("main", "").get();
+      assertEquals(0, result);
+      Snapshot snapshot = assertOneSnapshot(listener);
+      assertCaptureFields(snapshot.getCaptures().getLines().get(9), "intField", "int", "42");
+      assertCaptureFields(
+          snapshot.getCaptures().getLines().get(9), "strField", String.class.getTypeName(), "foo");
     } finally {
       filesToDelete.forEach(File::delete);
     }

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot302.kt
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot302.kt
@@ -1,0 +1,49 @@
+import kotlinx.coroutines.*
+
+class CapturedSnapshot302 {
+  var intField = 42
+  var strField = "foo"
+  val list: MutableList<Int> = mutableListOf()
+
+  suspend fun process(arg: String): Int {
+    println(intField)
+    try {
+      list.add(1)
+      val content = download(arg)
+      list.add(2)
+      subprocess() {
+        println(arg)
+        println(list)
+        delay(1L)
+        intField = 43
+        strField = "bar"
+      }
+      println(strField)
+      println(content)
+    } catch (e: Exception) {
+      println(list)
+      println(e)
+    }
+    return arg.length
+  }
+
+  suspend fun download(arg: String): String {
+    delay(10L)
+    return arg
+  }
+
+  suspend fun subprocess(f: suspend () -> Unit): Unit {
+    println(intField)
+    f()
+    println(strField)
+  }
+
+
+
+  companion object {
+    fun main(arg: String): Int = runBlocking {
+      val c = CapturedSnapshot302()
+      c.process(arg)
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do
Recent Kotlin compiler generates multiple range for same local vars and mess up our algorithm for adjustment.
Fix this by made a list of unique local vars

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2948]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2948]: https://datadoghq.atlassian.net/browse/DEBUG-2948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ