### PR TITLE
Improve system tests execution

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -994,9 +994,11 @@ jobs:
       - run:
           name: Collect artifacts
           command: tar -cvzf logs_java_parametric_dev.tar.gz -C system-tests logs_parametric
+          when: always
 
       - store_artifacts:
           path: logs_java_parametric_dev.tar.gz
+          when: always
 
 
 build_test_jobs: &build_test_jobs

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -971,19 +971,20 @@ jobs:
             cd system-tests
             set +e
             RUN_ATTEMPTS=1
-            while [ $RUN_ATTEMPTS -le 3 ]; do
+            MAX_ATTEMPTS=1 # Disable retries as the runner is supposed to be stable. Revert to 3 if needed.
+            while [ $RUN_ATTEMPTS -le $MAX_ATTEMPTS ]; do
               echo "Running parametric test attempt $RUN_ATTEMPTS"
-              timeout 20m ./run.sh PARAMETRIC -L java --log-cli-level=DEBUG --durations=30 -vv
+              timeout 20m ./run.sh PARAMETRIC --library java --durations=30 -vv
               status=$?
-              #timneout returns 124 if it times out
-              #if the return code is not 124, then we exit with the status
+              # timeout returns 124 if it times out
+              # if the return code is not 124, then we exit with the status
               if [ $status -ne 124 ]; then
                 exit $status
                 break
               fi
               RUN_ATTEMPTS=$((RUN_ATTEMPTS+1))
-              if [ $RUN_ATTEMPTS -eq 4 ]; then
-                #Max attempts reached, exit with 124
+              if [ $RUN_ATTEMPTS -gt $MAX_ATTEMPTS ]; then
+                # Max attempts reached, exit with 124
                 exit 124
               fi
             done


### PR DESCRIPTION
# What Does This Do

* Make sure to always upload parametric tests logs and results as 
* Disabled (left but documented for later re-activation if needed) retries as the execution is supposed to be stable following #7756

# Motivation

Always uploading logs will help with parametric tests investigations

# Additional Notes

@cbeauchesne recommended to disable retries.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
