### PR TITLE
Fix parametric tests (timeouts, worker allocation)

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -973,7 +973,7 @@ jobs:
             RUN_ATTEMPTS=1
             while [ $RUN_ATTEMPTS -le 3 ]; do
               echo "Running parametric test attempt $RUN_ATTEMPTS"
-              timeout 20m ./run.sh PARAMETRIC -L java
+              timeout 20m ./run.sh PARAMETRIC -L java --log-cli-level=DEBUG --durations=30 -vv
               status=$?
               #timneout returns 124 if it times out
               #if the return code is not 124, then we exit with the status

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -962,7 +962,6 @@ jobs:
           name: Build runner
           command: |
             cd system-tests
-            export TEST_LIBRARY=java
             ./build.sh -i runner
 
       - run:
@@ -970,13 +969,11 @@ jobs:
           command: |
             set -e
             cd system-tests
-            export TEST_LIBRARY=java
-            export PYTEST_XDIST_AUTO_NUM_WORKERS=6
             set +e
             RUN_ATTEMPTS=1
             while [ $RUN_ATTEMPTS -le 3 ]; do
               echo "Running parametric test attempt $RUN_ATTEMPTS"
-              timeout 12m ./run.sh PARAMETRIC --log-cli-level=DEBUG --durations=30 -vv
+              timeout 20m ./run.sh PARAMETRIC -L java
               status=$?
               #timneout returns 124 if it times out
               #if the return code is not 124, then we exit with the status


### PR DESCRIPTION
# What Does This Do

1. removes `TEST_LIBRARY` for `build runner` step as it's not needed here.
    * Nothing positive to get from this change, appart a slightly cleaner yaml file
3. removes `TEST_LIBRARY` for run step, replacing it with the `-L` parameter, which is the clean way to have this
    * Nothing positive to get from this change, appart a slightly cleaner yaml file
4. removes `PYTEST_XDIST_AUTO_NUM_WORKERS` env var : by default, parametric test will use the optimal numbers of workers
    * it was previously set to 6, where the runner in circle CI has only 4 CPU. Having more workers than CPU is a known cause of instability, and in theory, should not make the run faster.  
5. increase the timeout from 12mn to 20mn  to see if it really hangs out forever, or if it happen to take 12mn + few seconds
    * this time out is here to catch the "hang forever" issue. If the value set is too close to the expected test time, there is "false positive" risk.

Before the fix, the test takes 10mn-ish, with a 12mn timeout that being hit numerous time

After, without any pytest options : 

* run 1 : [11'50](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41128/workflows/63b52f8b-72c1-4e39-87ae-1530b93db56f/jobs/1530239?invite=true#step-106-0_33)
* run 2 : [12'01](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41128/workflows/22464033-d31d-40c7-bdca-72246c9bb742/jobs/1530523?invite=true#step-106-0_33)
* run 3 : [11'55](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41128/workflows/22464033-d31d-40c7-bdca-72246c9bb742/jobs/1530536?invite=true#step-107-0_33)
* run 4 : [11'41](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41128/workflows/22464033-d31d-40c7-bdca-72246c9bb742/jobs/1530542?invite=true#step-107-0_33)
* run 5 : [11'49](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41128/workflows/22464033-d31d-40c7-bdca-72246c9bb742/jobs/1530543?invite=true#step-107-0_33)

--> 711s +/- 7.5s

After,  with `--log-cli-level=DEBUG --durations=30 -vv` options : 

* run 1 : [11'38](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41157/workflows/67fc9308-bd42-4bb5-ab02-a4c9b7f41f4d/jobs/1532061?invite=true#step-106-0_33)
* run 2 : [11'40](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41157/workflows/67fc9308-bd42-4bb5-ab02-a4c9b7f41f4d/jobs/1532223?invite=true#step-107-0_33)
* run 3 : [11'43](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41157/workflows/67fc9308-bd42-4bb5-ab02-a4c9b7f41f4d/jobs/1532243?invite=true#step-107-0_33)
* run 4 : [11'48](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41157/workflows/67fc9308-bd42-4bb5-ab02-a4c9b7f41f4d/jobs/1532244?invite=true#step-107-0_33)
* run 5 : [11'55](https://app.circleci.com/pipelines/github/DataDog/dd-trace-java/41157/workflows/67fc9308-bd42-4bb5-ab02-a4c9b7f41f4d/jobs/1532395?invite=true#step-107-0_33)

--> 704s +/- 6.8s

# Conclusion

None of those 10 runs shows any time instability, the overall average is 708s, with a standard deviation of 7.5s, we can call it "stable".

The previous instability was probably caused by the WORKERS count set to 6, where the circle CI runner has only 4 logical CPU. This speeds up a little bit the run, but is a known source of time instability.

The fact that a timeout was set to 12mn, where the run took 10mn was a probable cause of unsuccessfully re-runs.

The `--log-cli-level=DEBUG --durations=30 -vv` options does not change anything to the time stability, and can be kept. The timeout can also be kept as a safeguard, but with a value at least 150% the expected value.

Though, I encourage removing `--log-cli-level=DEBUG`, as it make the output very verbose on successful tests, which brings no value. I also recommend removing the retry logic : as the execution time is stable, it will only hide a real issue. 


# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
