### PR TITLE
Limit the collections that the iast visitor can handle

### DIFF
--- a/dd-java-agent/agent-iast/build.gradle
+++ b/dd-java-agent/agent-iast/build.gradle
@@ -56,6 +56,7 @@ dependencies {
   testImplementation libs.bytebuddy
   testImplementation('org.skyscreamer:jsonassert:1.5.1')
   testImplementation('org.codehaus.groovy:groovy-yaml:3.0.17')
+  testImplementation libs.guava
 
   testImplementation group: 'io.grpc', name: 'grpc-core', version: grpcVersion
   testImplementation group: 'io.grpc', name: 'grpc-protobuf', version: grpcVersion

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/ObjectVisitor.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/util/ObjectVisitor.java
@@ -9,8 +9,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -23,6 +25,12 @@ import org.slf4j.LoggerFactory;
 public class ObjectVisitor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ObjectVisitor.class);
+  private static final List<String> ALLOWED_COLLECTION_PKGS =
+      Arrays.asList(
+          "java.util",
+          "com.google.protobuf",
+          "org.apache.commons.collections",
+          "com.google.common.collect");
 
   private static final int MAX_VISITED_OBJECTS = 1000;
   private static final int MAX_DEPTH = 10;
@@ -122,6 +130,9 @@ public class ObjectVisitor {
   }
 
   private State visitMap(final int depth, final String path, final Map<?, ?> map) {
+    if (!isAllowedCollection(map)) {
+      return CONTINUE;
+    }
     final int mapDepth = depth + 1;
     for (final Map.Entry<?, ?> entry : map.entrySet()) {
       final Object key = entry.getKey();
@@ -145,6 +156,9 @@ public class ObjectVisitor {
   }
 
   private State visitIterable(final int depth, final String path, final Iterable<?> iterable) {
+    if (!isAllowedCollection(iterable)) {
+      return CONTINUE;
+    }
     final int iterableDepth = depth + 1;
     int index = 0;
     for (final Object item : iterable) {
@@ -186,6 +200,19 @@ public class ObjectVisitor {
       klass = klass.getSuperclass();
     }
     return ObjectVisitor.State.CONTINUE;
+  }
+
+  private static boolean isAllowedCollection(final Object value) {
+    if (value == null) {
+      return false;
+    }
+    final String packageName = value.getClass().getPackage().getName();
+    for (final String allowed : ALLOWED_COLLECTION_PKGS) {
+      if (packageName.startsWith(allowed)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public static boolean inspectClass(final Class<?> cls) {

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/GrpcRequestMessageHandlerTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/GrpcRequestMessageHandlerTest.groovy
@@ -66,7 +66,6 @@ class GrpcRequestMessageHandlerTest extends IastModuleImplTestBase {
     given:
     final visitor = Mock(ObjectVisitor.Visitor) {
       visit(_ as String, _ as Object) >> {
-        println 'feo'
         return CONTINUE
       }
     }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/ObjectVisitorTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/ObjectVisitorTest.groovy
@@ -1,5 +1,6 @@
 package com.datadog.iast.util
 
+import com.google.common.collect.Iterables
 import foo.bar.VisitableClass
 import spock.lang.Specification
 
@@ -39,12 +40,7 @@ class ObjectVisitorTest extends Specification {
     given:
     final visitor = Mock(ObjectVisitor.Visitor)
     final wrapped = ['1', '2', '3']
-    final target = new Iterable() {
-        @Override
-        Iterator iterator() {
-          return wrapped.iterator()
-        }
-      }
+    final target = Iterables.unmodifiableIterable(wrapped)
 
     when:
     ObjectVisitor.visit(target, visitor)
@@ -71,6 +67,29 @@ class ObjectVisitorTest extends Specification {
     target.each { key, value ->
       1 * visitor.visit("root[$key]", value) >> CONTINUE
     }
+    0 * _
+  }
+
+  void 'test visiting ignored collection'() {
+    given:
+    final visitor = Mock(ObjectVisitor.Visitor)
+    final target = new AbstractList<String>() {
+        @Override
+        String get(int index) {
+          assert index == 0
+          return 'value'
+        }
+
+        @Override
+        int size() {
+          return 1
+        }
+      }
+
+    when:
+    ObjectVisitor.visit(target, visitor)
+
+    then:
     0 * _
   }
 


### PR DESCRIPTION
# What Does This Do
Limits the types of collections that IAST object visitor can handle to:

- Java collections
- Apache commons collections
- Guava collections
- Protobuf collections

# Motivation
When an hibernate persistent collection is added to the session scope, we will try to visit the different elements in order to detect trust boundary violation vulnerabilities and we might trigger issues further down the line due to lazy loading in ORMs.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SCRS-1113]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SCRS-1113]: https://datadoghq.atlassian.net/browse/SCRS-1113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ