### PR TITLE
Ignore timeouts on closing elasticmq for sqs tests

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/LegacySqsClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/LegacySqsClientForkedTest.groovy
@@ -46,7 +46,11 @@ class LegacySqsClientForkedTest extends AgentTestRunner {
 
   def cleanupSpec() {
     if (server != null) {
-      server.stopAndWait()
+      try {
+        server.stopAndWait()
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt()
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -75,7 +75,11 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
 
   def cleanupSpec() {
     if (server != null) {
-      server.stopAndWait()
+      try {
+        server.stopAndWait()
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt()
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -44,7 +44,11 @@ class TimeInQueueForkedTest extends AgentTestRunner {
 
   def cleanupSpec() {
     if (server != null) {
-      server.stopAndWait()
+      try {
+        server.stopAndWait()
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt()
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/LegacySqsClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/LegacySqsClientForkedTest.groovy
@@ -48,7 +48,11 @@ class LegacySqsClientForkedTest extends AgentTestRunner {
 
   def cleanupSpec() {
     if (server != null) {
-      server.stopAndWait()
+      try {
+        server.stopAndWait()
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt()
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
@@ -57,7 +57,11 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
 
   def cleanupSpec() {
     if (server != null) {
-      server.stopAndWait()
+      try {
+        server.stopAndWait()
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt()
+      }
     }
   }
 

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -44,7 +44,11 @@ class TimeInQueueForkedTest extends AgentTestRunner {
 
   def cleanupSpec() {
     if (server != null) {
-      server.stopAndWait()
+      try {
+        server.stopAndWait()
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt()
+      }
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Ignore exceptions on closing the elasticmq sqs server used in tests

That should happen when the test class shuts down

```
java.util.concurrent.ExecutionException: Boxed Exception
	at scala.concurrent.impl.Promise$.scala$concurrent$impl$Promise$$resolve(Promise.scala:99)
	at scala.concurrent.impl.Promise$Transformation.handleFailure(Promise.scala:444)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:506)
	at org.apache.pekko.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:73)
	at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:110)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:94)
	at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:110)
	at org.apache.pekko.dispatch.TaskInvocation.run(AbstractDispatcher.scala:59)
	at org.apache.pekko.dispatch.ForkJoinExecutorConfigurator$PekkoForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:57)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: java.lang.InterruptedException
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1133)
	at scala.concurrent.impl.Promise$DefaultPromise.tryAwait0(Promise.scala:241)
	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:261)
	at scala.concurrent.Await$.$anonfun$result$1(package.scala:201)
	at org.apache.pekko.dispatch.MonitorableThreadFactory$PekkoForkJoinWorkerThread$$anon$3.block(ThreadPoolBuilder.scala:183)
	at java.util.concurrent.ForkJoinPool.compensatedBlock(ForkJoinPool.java:3740)
	at java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3723)
	at org.apache.pekko.dispatch.MonitorableThreadFactory$PekkoForkJoinWorkerThread.blockOn(ThreadPoolBuilder.scala:181)
	at org.apache.pekko.dispatch.BatchingExecutor$BlockableBatch.blockOn(BatchingExecutor.scala:126)
	at scala.concurrent.Await$.result(package.scala:124)
	at org.apache.pekko.actor.LightArrayRevolverScheduler.close(LightArrayRevolverScheduler.scala:178)
	at org.apache.pekko.actor.ActorSystemImpl.stopScheduler(ActorSystem.scala:1138)
	at org.apache.pekko.actor.ActorSystemImpl.$anonfun$_start$1(ActorSystem.scala:1043)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at org.apache.pekko.actor.ActorSystemImpl$$anon$2.run(ActorSystem.scala:1065)
	at org.apache.pekko.actor.ActorSystemImpl$TerminationCallbacks$$anonfun$addRec$1$1.applyOrElse(ActorSystem.scala:1297)
	at org.apache.pekko.actor.ActorSystemImpl$TerminationCallbacks$$anonfun$addRec$1$1.applyOrElse(ActorSystem.scala:1297)
	at scala.concurrent.Future.$anonfun$andThen$1(Future.scala:515)
	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:475)
	... 12 more
```

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
