### PR TITLE
Add unit test for unix domain socket support

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
@@ -72,6 +72,15 @@ public class BatchUploaderTest {
   }
 
   @Test
+  void testUnixDomainSocket() {
+    when(config.getAgentUnixDomainSocket()).thenReturn("/tmp/ddagent/agent.sock");
+    uploader = new BatchUploader(config, "http://localhost:8126");
+    assertEquals(
+        "datadog.common.socket.UnixDomainSocketFactory",
+        uploader.getClient().socketFactory().getClass().getTypeName());
+  }
+
+  @Test
   void testOkHttpClientForcesCleartextConnspecWhenNotUsingTLS() {
     uploader = new BatchUploader(config, "http://example.com");
 

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -2465,4 +2465,18 @@ class ConfigTest extends DDSpecification {
     "auto"         | true            | PROFILING_START_DELAY_DEFAULT  | PROFILING_START_FORCE_FIRST_DEFAULT
     // spotless:on
   }
+
+  def "url for debugger with unix domain socket"() {
+    when:
+    def prop = new Properties()
+    prop.setProperty(AGENT_HOST, "myhost")
+    prop.setProperty(TRACE_AGENT_PORT, "1234")
+    prop.setProperty(TRACE_AGENT_URL, "unix:///path/to/socket")
+
+    Config config = Config.get(prop)
+
+    then:
+    config.finalDebuggerSnapshotUrl == "http://localhost:8126/debugger/v1/input"
+    config.finalDebuggerSymDBUrl == "http://localhost:8126/symdb/v1/input"
+  }
 }


### PR DESCRIPTION
# What Does This Do
add unit test for avoid regression like #7166 

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
