### PR TITLE
Avoid NPE on vertx end advice when parent span is not available

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/EndHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/EndHandlerWrapper.java
@@ -29,12 +29,14 @@ public class EndHandlerWrapper implements Handler<Void> {
         actual.handle(event);
       }
     } finally {
-      if (path != null) {
+      if (path != null && parentSpan != null) {
         HTTP_RESOURCE_DECORATOR.withRoute(
             parentSpan, routingContext.request().rawMethod(), path, true);
       }
-      DECORATE.onResponse(span, routingContext.response());
-      span.finish();
+      if (span != null) {
+        DECORATE.onResponse(span, routingContext.response());
+        span.finish();
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/EndHandlerWrapper.java
@@ -29,12 +29,14 @@ public class EndHandlerWrapper implements Handler<Void> {
         actual.handle(event);
       }
     } finally {
-      if (path != null) {
+      if (path != null && parentSpan != null) {
         HTTP_RESOURCE_DECORATOR.withRoute(
             parentSpan, routingContext.request().method().name(), path, true);
       }
-      DECORATE.onResponse(span, routingContext.response());
-      span.finish();
+      if (span != null) {
+        DECORATE.onResponse(span, routingContext.response());
+        span.finish();
+      }
     }
   }
 }


### PR DESCRIPTION
# What Does This Do

This PR avoid enriching with the route the parent span when it's not available.

It solves #7773 

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
