### PR TITLE
Fix module name detection for headless sessions

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/CiVisibilityRepoServices.java
@@ -89,18 +89,18 @@ public class CiVisibilityRepoServices {
     }
   }
 
-  private static String getModuleName(Config config, Path path, CIInfo ciInfo) {
+  static String getModuleName(Config config, Path path, CIInfo ciInfo) {
     // if parent process is instrumented, it will provide build system's module name
     String parentModuleName = config.getCiVisibilityModuleName();
     if (parentModuleName != null) {
       return parentModuleName;
     }
     String repoRoot = ciInfo.getNormalizedCiWorkspace();
-    if (repoRoot != null
-        && path.startsWith(repoRoot)
-        // module name cannot be empty
-        && !path.toString().equals(repoRoot)) {
-      return Paths.get(repoRoot).relativize(path).toString();
+    if (repoRoot != null && path.startsWith(repoRoot)) {
+      String relativePath = Paths.get(repoRoot).relativize(path).toString();
+      if (!relativePath.isEmpty()) {
+        return relativePath;
+      }
     }
     return config.getServiceName();
   }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/CiVisibilityRepoServicesTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/CiVisibilityRepoServicesTest.groovy
@@ -1,0 +1,33 @@
+package datadog.trace.civisibility
+
+
+import datadog.trace.api.Config
+import datadog.trace.civisibility.ci.CIInfo
+import spock.lang.Specification
+
+import java.nio.file.Paths
+
+class CiVisibilityRepoServicesTest extends Specification {
+
+  def "test get parent module name: #parentModuleName, #repoSubFolder, #serviceName"() {
+    given:
+    def config = Stub(Config)
+    config.getCiVisibilityModuleName() >> parentModuleName
+    config.getServiceName() >> serviceName
+
+    def repoRoot = "/path/to/repo/root/"
+    def path = Paths.get(repoRoot + repoSubFolder)
+
+    def ciInfo = Stub(CIInfo)
+    ciInfo.getNormalizedCiWorkspace() >> repoRoot
+
+    expect:
+    CiVisibilityRepoServices.getModuleName(config, path, ciInfo) == moduleName
+
+    where:
+    parentModuleName | repoSubFolder  | serviceName    | moduleName
+    "parent-module"  | "child-module" | "service-name" | "parent-module"
+    null             | "child-module" | "service-name" | "child-module"
+    null             | ""             | "service-name" | "service-name"
+  }
+}


### PR DESCRIPTION
# What Does This Do

Fixes module name detection for headless test sessions (i.e. sessions for JVMs that are not part of an instrumented Maven/Gradle build).

When a JVM is a part of an instrumented Maven/Gradle build, the parent process provides module names to the children processes via system properties.
For headless sessions the module name is not provided, so there is a fallback that tries to derive module name from current path and repository root (e.g. if repo root is `/my/repo/root` and current path is `/my/repo/root/submodule`, then the module name is set to `submodule`).
This fallback logic works incorrectly when repo root is `/my/repo/root` and the current path is `/my/repo/root/`: in this case module name is empty, which is not allowed.

The fix detects these cases, and uses service name as the last fallback if module name cannot be derived from current path.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1110]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1110]: https://datadoghq.atlassian.net/browse/SDTEST-1110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ