### PR TITLE
 Fix relying on configId for remote config log level tracer flare change

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlarePoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlarePoller.java
@@ -86,9 +86,7 @@ public final class TracerFlarePoller {
 
     @Override
     public void remove(ConfigKey configKey, PollingRateHinter hinter) {
-      String configId = configKey.getConfigId();
-      if (configAction.get(configId).equals(FLARE_LOG_LEVEL)) {
-        configAction.remove(configId);
+      if (configAction.remove(configKey.getConfigId(), FLARE_LOG_LEVEL)) {
         cleanupAfterFlare();
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlarePoller.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlarePoller.java
@@ -14,17 +14,20 @@ import datadog.trace.api.DynamicConfig;
 import datadog.trace.core.CoreTracer;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import okio.Okio;
 
 public final class TracerFlarePoller {
-  private static final String FLARE_LOG_LEVEL_PREFIX = "flare-log-level.";
-
+  private static final String FLARE_LOG_LEVEL = "flare-log-level";
   private final DynamicConfig<?> dynamicConfig;
 
   private Runnable stopPreparer;
   private Runnable stopSubmitter;
 
   private TracerFlareService tracerFlareService;
+
+  private final Map<String, String> configAction = new HashMap<>();
 
   public TracerFlarePoller(DynamicConfig<?> dynamicConfig) {
     this.dynamicConfig = dynamicConfig;
@@ -68,23 +71,24 @@ public final class TracerFlarePoller {
     @Override
     public void accept(ConfigKey configKey, byte[] content, PollingRateHinter hinter)
         throws IOException {
-      if (configKey.getConfigId().startsWith(FLARE_LOG_LEVEL_PREFIX)) {
-        AgentConfigLayer agentConfigLayer =
-            AGENT_CONFIG_LAYER_ADAPTER.fromJson(
-                Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
-        if (null != agentConfigLayer
-            && null != agentConfigLayer.config
-            && null != agentConfigLayer.config.logLevel) {
-          prepareForFlare(agentConfigLayer.config.logLevel);
-        } else {
-          cleanupAfterFlare();
-        }
+      AgentConfigLayer agentConfigLayer =
+          AGENT_CONFIG_LAYER_ADAPTER.fromJson(
+              Okio.buffer(Okio.source(new ByteArrayInputStream(content))));
+      if (null != agentConfigLayer
+          && null != agentConfigLayer.config
+          && null != agentConfigLayer.config.logLevel) {
+        configAction.put(configKey.getConfigId(), FLARE_LOG_LEVEL);
+        prepareForFlare(agentConfigLayer.config.logLevel);
+      } else {
+        cleanupAfterFlare();
       }
     }
 
     @Override
     public void remove(ConfigKey configKey, PollingRateHinter hinter) {
-      if (configKey.getConfigId().startsWith(FLARE_LOG_LEVEL_PREFIX)) {
+      String configId = configKey.getConfigId();
+      if (configAction.get(configId).equals(FLARE_LOG_LEVEL)) {
+        configAction.remove(configId);
         cleanupAfterFlare();
       }
     }


### PR DESCRIPTION
# What Does This Do

For changing the log level of the logs in the tracer flare , we were relying on configID starting with "flare-log-level.".
But we shouldn't: The configId could change in the future, so in order to be future-proof, the tracer should rely on the content of the config instead.
In addition, since for resetting the log level to its original value, we stop sending the configuration, we need to keep the action associated with this configId.

# Contributor Checklist

- [ ✅ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ✅  ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ n/a] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)

Jira ticket: [APMAPI-124](https://datadoghq.atlassian.net/browse/APMAPI-124 )



[APMAPI-124]: https://datadoghq.atlassian.net/browse/APMAPI-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ