### PR TITLE
Improve isolation of embedded JFFI dependency

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -105,8 +105,25 @@ public final class DatadogClassLoader extends SecureClassLoader {
         }
       }
       return cl.loadInstrumentationClass(name, agentCodeSource);
+    } else if (name.startsWith("com.kenai.jffi")) {
+      // prefer our embedded JFFI to other versions exposed by the parent class-loader
+      return loadLocalClass(name, resolve);
     } else {
       return super.loadClass(name, resolve);
+    }
+  }
+
+  /** Same as {@link #loadClass(String, boolean)} but it doesn't delegate to the parent. */
+  private Class<?> loadLocalClass(String name, boolean resolve) throws ClassNotFoundException {
+    synchronized (getClassLoadingLock(name)) {
+      Class<?> c = findLoadedClass(name);
+      if (null == c) {
+        c = findClass(name);
+      }
+      if (resolve) {
+        resolveClass(c);
+      }
+      return c;
     }
   }
 

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -53,6 +53,9 @@ ext.generalShadowJarConfig = {
   relocate 'net.jpountz', 'datadog.jpountz'
   // rewrite dependencies calling Logger.getLogger
   relocate 'java.util.logging.Logger', 'datadog.trace.bootstrap.PatchLogger'
+  // patch JFFI loading mechanism to maintain isolation
+  exclude '**/com/kenai/jffi/Init.class'
+  relocate('com.kenai.jffi.Init', 'com.kenai.jffi.PatchInit')
 
   final String projectName = "${project.name}"
 

--- a/utils/socket-utils/src/main/java/com/kenai/jffi/PatchInit.java
+++ b/utils/socket-utils/src/main/java/com/kenai/jffi/PatchInit.java
@@ -1,0 +1,27 @@
+package com.kenai.jffi;
+
+import com.kenai.jffi.internal.StubLoader;
+
+/** Replacement Init class that loads StubLoader from the same (isolating) class-loader. */
+final class PatchInit {
+  private static volatile boolean loaded;
+
+  private PatchInit() {}
+
+  static void load() {
+    if (loaded) {
+      return;
+    }
+    try {
+      if (StubLoader.isLoaded()) {
+        loaded = true;
+      } else {
+        throw StubLoader.getFailureCause();
+      }
+    } catch (UnsatisfiedLinkError e) {
+      throw e;
+    } catch (Throwable e) {
+      throw (UnsatisfiedLinkError) new UnsatisfiedLinkError(e.getLocalizedMessage()).initCause(e);
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

Isolates our embedded JFFI dependency from other versions that might be on the boot or system class-paths.

# Motivation

Avoids some obscure linkage exceptions that can happen when multiple versions of JFFI are on the class-path.

# Additional Notes

This PR contains two changes:
* Removing parent delegation when looking up `com.kenai.jffi` classes from our isolatiing `DatadogClassLoader`
* Replacing [`com.kenai.jffi.Init`](https://github.com/jnr/jffi/blob/master/src/main/java/com/kenai/jffi/Init.java#L59) with a much simpler `PatchInit` class that loads from the same isolating class-loader

Note we cannot fully shade JFFI (or the related JNR dependency) because it has a native component which would also need to be updated and recompiled for every platform.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-13480]

[APMS-13480]: https://datadoghq.atlassian.net/browse/APMS-13480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ