### PR TITLE
Widen catch blocks to make agent discovery more tolerant

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
+++ b/communication/src/main/java/datadog/communication/ddagent/DDAgentFeaturesDiscovery.java
@@ -9,7 +9,6 @@ import datadog.communication.monitor.Monitoring;
 import datadog.communication.monitor.Recording;
 import datadog.trace.api.telemetry.LogCollector;
 import datadog.trace.util.Strings;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
@@ -200,7 +199,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
           state = response.header(DATADOG_AGENT_STATE);
           return candidate;
         }
-      } catch (IOException e) {
+      } catch (Throwable e) {
         errorQueryingEndpoint(candidate, e);
       }
     }
@@ -310,7 +309,7 @@ public class DDAgentFeaturesDiscovery implements DroppingPolicy {
       }
       int statsdPort = ((Number) statsdPortObj).intValue();
       DDAgentStatsDClientManager.setDefaultStatsDPort(statsdPort);
-    } catch (Exception ex) {
+    } catch (Throwable ex) {
       log.debug("statsd_port missing from trace agent /info response", ex);
     }
   }


### PR DESCRIPTION
# What Does This Do

Widen catch blocks to make agent discovery more tolerant of underlying errors, like `UnsatisfiedLinkError`

# Motivation

Otherwise if an underlying transport throws an non I/O related error, such as JFFI throwing `UnsatisfiedLinkError` when it fails to load native components, then the exception will bubble up and installation of the tracer will be cancelled.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-13480]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-13480]: https://datadoghq.atlassian.net/browse/APMS-13480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ