### PR TITLE
Ensure vulnerabilities are reported with taintable values

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Source.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/Source.java
@@ -52,6 +52,18 @@ public final class Source implements Taintable.Source {
     return asString(value);
   }
 
+  /** This will expose the internal reference so be careful */
+  @Nullable
+  public Object getRawValue() {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Reference<?>) {
+      return ((Reference<?>) value).get();
+    }
+    return value;
+  }
+
   @SuppressFBWarnings(
       value = "DM_STRING_CTOR",
       justification = "New string instance requires constructor")


### PR DESCRIPTION
# What Does This Do
Makes sure that all sink modules are able to deal with `datadog.trace.api.iast.Taintable` references when reporting a vulnerability.

# Motivation
Taintable references were never expected to reach sinks, as they are just propagation utilities to improve performance, we have detected that in some cases they might reach sinks hiding vulnerabilities.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
