### PR TITLE
[🍒 7784] Fix automatic coverage includes calculation for headless test sessions

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1773,7 +1773,7 @@ public class Config {
    * my.package.*,my.other.package.*}) to list of package prefixes suitable for use with ASM ({@code
    * my/package/,my/other/package/})
    */
-  private static String[] convertJacocoExclusionFormatToPackagePrefixes(List<String> packages) {
+  public static String[] convertJacocoExclusionFormatToPackagePrefixes(List<String> packages) {
     return packages.stream()
         .map(s -> (s.endsWith("*") ? s.substring(0, s.length() - 1) : s).replace('.', '/'))
         .toArray(String[]::new);


### PR DESCRIPTION
Cherry pick #7784

# What Does This Do

Fixes automatic configuration of code coverage-enabled packages for headless sessions.

# Motivation

"Headless" sessions are those where the build system is not instrumented.
At the moment we support instrumenting Maven and Gradle, so when a Maven or a Gradle build is traced, the tracer is injected into the parent build system process. The list of coverage-enabled packages is computed in the parent process and is then propagated to children.

For headless sessions, where there is no instrumented parent process, the list of packages needs to be computed inside the child process (JVM that runs the tests).

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1130]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1130]: https://datadoghq.atlassian.net/browse/SDTEST-1130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ