### PR TITLE
[🍒 7793] Throw exception when using repo index to resolve source path for classes with identical names

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/ConcurrentCoverageStore.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/ConcurrentCoverageStore.java
@@ -4,6 +4,7 @@ import datadog.trace.api.DDTraceId;
 import datadog.trace.api.civisibility.coverage.CoverageProbes;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.coverage.TestReport;
+import datadog.trace.civisibility.source.SourceResolutionException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,13 +37,18 @@ public abstract class ConcurrentCoverageStore<T extends CoverageProbes> implemen
 
   @Override
   public boolean report(DDTraceId testSessionId, Long testSuiteId, long testSpanId) {
-    report = report(testSessionId, testSuiteId, testSpanId, probes.values());
-    return report != null && report.isNotEmpty();
+    try {
+      report = report(testSessionId, testSuiteId, testSpanId, probes.values());
+      return report != null && report.isNotEmpty();
+    } catch (SourceResolutionException e) {
+      return false;
+    }
   }
 
   @Nullable
   protected abstract TestReport report(
-      DDTraceId testSessionId, Long testSuiteId, long testSpanId, Collection<T> probes);
+      DDTraceId testSessionId, Long testSuiteId, long testSpanId, Collection<T> probes)
+      throws SourceResolutionException;
 
   @Nullable
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/file/FileCoverageStore.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/file/FileCoverageStore.java
@@ -11,6 +11,7 @@ import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.tag.CoverageErrorType;
 import datadog.trace.civisibility.coverage.ConcurrentCoverageStore;
 import datadog.trace.civisibility.source.SourcePathResolver;
+import datadog.trace.civisibility.source.SourceResolutionException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,7 +47,8 @@ public class FileCoverageStore extends ConcurrentCoverageStore<FileProbes> {
   @Nullable
   @Override
   protected TestReport report(
-      DDTraceId testSessionId, Long testSuiteId, long testSpanId, Collection<FileProbes> probes) {
+      DDTraceId testSessionId, Long testSuiteId, long testSpanId, Collection<FileProbes> probes)
+      throws SourceResolutionException {
     try {
       Set<Class<?>> combinedClasses = Collections.newSetFromMap(new IdentityHashMap<>());
       Collection<String> combinedNonCodeResources = new HashSet<>();

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/LineCoverageStore.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/coverage/line/LineCoverageStore.java
@@ -11,6 +11,7 @@ import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.tag.CoverageErrorType;
 import datadog.trace.civisibility.coverage.ConcurrentCoverageStore;
 import datadog.trace.civisibility.source.SourcePathResolver;
+import datadog.trace.civisibility.source.SourceResolutionException;
 import datadog.trace.civisibility.source.Utils;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -52,7 +53,8 @@ public class LineCoverageStore extends ConcurrentCoverageStore<LineProbes> {
   @Nullable
   @Override
   protected TestReport report(
-      DDTraceId testSessionId, Long testSuiteId, long testSpanId, Collection<LineProbes> probes) {
+      DDTraceId testSessionId, Long testSuiteId, long testSpanId, Collection<LineProbes> probes)
+      throws SourceResolutionException {
     try {
       Map<Class<?>, ExecutionDataAdapter> combinedExecutionData = new IdentityHashMap<>();
       Collection<String> combinedNonCodeResources = new HashSet<>();

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -32,6 +32,7 @@ import datadog.trace.civisibility.codeowners.Codeowners;
 import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.source.MethodLinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
+import datadog.trace.civisibility.source.SourceResolutionException;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.function.Consumer;
@@ -147,8 +148,14 @@ public class TestImpl implements DDTest {
       return;
     }
 
-    String sourcePath = sourcePathResolver.getSourcePath(testClass);
-    if (sourcePath == null || sourcePath.isEmpty()) {
+    String sourcePath;
+    try {
+      sourcePath = sourcePathResolver.getSourcePath(testClass);
+      if (sourcePath == null || sourcePath.isEmpty()) {
+        return;
+      }
+    } catch (SourceResolutionException e) {
+      log.debug("Could not populate source path for {}", testClass, e);
       return;
     }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/BestEffortSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/BestEffortSourcePathResolver.java
@@ -13,7 +13,7 @@ public class BestEffortSourcePathResolver implements SourcePathResolver {
 
   @Nullable
   @Override
-  public String getSourcePath(@Nonnull Class<?> c) {
+  public String getSourcePath(@Nonnull Class<?> c) throws SourceResolutionException {
     for (SourcePathResolver delegate : delegates) {
       String sourcePath = delegate.getSourcePath(c);
       if (sourcePath != null) {
@@ -25,7 +25,7 @@ public class BestEffortSourcePathResolver implements SourcePathResolver {
 
   @Nullable
   @Override
-  public String getResourcePath(@Nullable String relativePath) {
+  public String getResourcePath(@Nullable String relativePath) throws SourceResolutionException {
     for (SourcePathResolver delegate : delegates) {
       String resourcePath = delegate.getResourcePath(relativePath);
       if (resourcePath != null) {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/SourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/SourcePathResolver.java
@@ -9,12 +9,12 @@ public interface SourcePathResolver {
    *     root. {@code null} is returned if the path could not be resolved
    */
   @Nullable
-  String getSourcePath(@Nonnull Class<?> c);
+  String getSourcePath(@Nonnull Class<?> c) throws SourceResolutionException;
 
   /**
    * @param relativePath Path to a resource in current run's repository, relative to a resource root
    * @return Path relative to repository root
    */
   @Nullable
-  String getResourcePath(@Nullable String relativePath);
+  String getResourcePath(@Nullable String relativePath) throws SourceResolutionException;
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/SourceResolutionException.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/SourceResolutionException.java
@@ -1,0 +1,8 @@
+package datadog.trace.civisibility.source;
+
+public class SourceResolutionException extends Exception {
+
+  public SourceResolutionException(String message) {
+    super(message);
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexBuilder.java
@@ -13,8 +13,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
@@ -94,6 +96,8 @@ public class RepoIndexBuilder implements RepoIndexProvider {
     private final PackageResolver packageResolver;
     private final ResourceResolver resourceResolver;
     private final ClassNameTrie.Builder trieBuilder;
+    private final Map<String, String> trieKeyToPath;
+    private final Collection<String> duplicateTrieKeys;
     private final Map<RepoIndex.SourceRoot, Integer> sourceRoots;
     private final PackageTree packageTree;
     private final RepoIndexingStats indexingStats;
@@ -109,6 +113,8 @@ public class RepoIndexBuilder implements RepoIndexProvider {
       this.resourceResolver = resourceResolver;
       this.repoRoot = repoRoot;
       trieBuilder = new ClassNameTrie.Builder();
+      trieKeyToPath = new HashMap<>();
+      duplicateTrieKeys = new HashSet<>();
       sourceRoots = new HashMap<>();
       packageTree = new PackageTree(config);
       indexingStats = new RepoIndexingStats();
@@ -161,6 +167,12 @@ public class RepoIndexBuilder implements RepoIndexProvider {
           if (!relativePath.isEmpty()) {
             String key = Utils.toTrieKey(relativePath);
             trieBuilder.put(key, sourceRootIdx);
+
+            String existingPath = trieKeyToPath.put(key, file.toString());
+            if (existingPath != null) {
+              log.warn("Duplicate repo index key: {} - {}", existingPath, file);
+              duplicateTrieKeys.add(key);
+            }
           }
         }
       } catch (Exception e) {
@@ -221,7 +233,8 @@ public class RepoIndexBuilder implements RepoIndexProvider {
         roots[e.getValue()] = e.getKey();
       }
 
-      return new RepoIndex(trieBuilder.buildTrie(), Arrays.asList(roots), packageTree.asList());
+      return new RepoIndex(
+          trieBuilder.buildTrie(), duplicateTrieKeys, Arrays.asList(roots), packageTree.asList());
     }
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolver.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolver.java
@@ -1,6 +1,7 @@
 package datadog.trace.civisibility.source.index;
 
 import datadog.trace.civisibility.source.SourcePathResolver;
+import datadog.trace.civisibility.source.SourceResolutionException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -14,13 +15,13 @@ public class RepoIndexSourcePathResolver implements SourcePathResolver {
 
   @Nullable
   @Override
-  public String getSourcePath(@Nonnull Class<?> c) {
+  public String getSourcePath(@Nonnull Class<?> c) throws SourceResolutionException {
     return indexProvider.getIndex().getSourcePath(c);
   }
 
   @Nullable
   @Override
-  public String getResourcePath(@Nullable String relativePath) {
+  public String getResourcePath(@Nullable String relativePath) throws SourceResolutionException {
     return indexProvider.getIndex().getSourcePath(relativePath);
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolverTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/source/index/RepoIndexSourcePathResolverTest.groovy
@@ -4,6 +4,7 @@ import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import datadog.trace.api.Config
 import datadog.trace.api.civisibility.domain.Language
+import datadog.trace.civisibility.source.SourceResolutionException
 import groovy.transform.PackageScope
 import spock.lang.Specification
 
@@ -147,6 +148,20 @@ class RepoIndexSourcePathResolverTest extends Specification {
     sourcePathResolver.getSourcePath(RepoIndexSourcePathResolverTest) == expectedSourcePathOne
     sourcePathResolver.getSourcePath(InnerClass) == expectedSourcePathOne
     sourcePathResolver.getSourcePath(RepoIndexSourcePathResolver) == expectedSourcePathTwo
+  }
+
+  def "test trying to resolve a duplicate key throws exception"() {
+    setup:
+    givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src/java")
+    givenSourceFile(RepoIndexSourcePathResolverTest, repoRoot + "/src/scala")
+
+    def sourcePathResolver = new RepoIndexSourcePathResolver(new RepoIndexBuilder(config, repoRoot, packageResolver, resourceResolver, fileSystem))
+
+    when:
+    sourcePathResolver.getSourcePath(RepoIndexSourcePathResolverTest)
+
+    then:
+    thrown SourceResolutionException
   }
 
   private String givenSourceFile(Class c, String sourceRoot, Language language = Language.GROOVY) {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -41,8 +41,8 @@ public final class CiVisibilityConfig {
       "civisibility.test.skipping.enabled";
   public static final String CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED =
       "civisibility.ciprovider.integration.enabled";
-  public static final String CIVISIBILITY_REPO_INDEX_SHARING_ENABLED =
-      "civisibility.repo.index.sharing.enabled";
+  public static final String CIVISIBILITY_REPO_INDEX_DUPLICATE_KEY_CHECK_ENABLED =
+      "civisibility.repo.index.duplicate.key.check.enabled";
   public static final String CIVISIBILITY_EXECUTION_SETTINGS_CACHE_SIZE =
       "civisibility.execution.settings.cache.size";
   public static final String CIVISIBILITY_JVM_INFO_CACHE_SIZE = "civisibility.jvm.info.cache.size";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -338,7 +338,7 @@ public class Config {
   private final boolean ciVisibilityItrEnabled;
   private final boolean ciVisibilityTestSkippingEnabled;
   private final boolean ciVisibilityCiProviderIntegrationEnabled;
-  private final boolean ciVisibilityRepoIndexSharingEnabled;
+  private final boolean ciVisibilityRepoIndexDuplicateKeyCheckEnabled;
   private final int ciVisibilityExecutionSettingsCacheSize;
   private final int ciVisibilityJvmInfoCacheSize;
   private final int ciVisibilityCoverageRootPackagesLimit;
@@ -1406,8 +1406,8 @@ public class Config {
         configProvider.getBoolean(CIVISIBILITY_TEST_SKIPPING_ENABLED, true);
     ciVisibilityCiProviderIntegrationEnabled =
         configProvider.getBoolean(CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED, true);
-    ciVisibilityRepoIndexSharingEnabled =
-        configProvider.getBoolean(CIVISIBILITY_REPO_INDEX_SHARING_ENABLED, true);
+    ciVisibilityRepoIndexDuplicateKeyCheckEnabled =
+        configProvider.getBoolean(CIVISIBILITY_REPO_INDEX_DUPLICATE_KEY_CHECK_ENABLED, true);
     ciVisibilityExecutionSettingsCacheSize =
         configProvider.getInteger(CIVISIBILITY_EXECUTION_SETTINGS_CACHE_SIZE, 16);
     ciVisibilityJvmInfoCacheSize = configProvider.getInteger(CIVISIBILITY_JVM_INFO_CACHE_SIZE, 8);
@@ -2721,8 +2721,8 @@ public class Config {
     return ciVisibilityCiProviderIntegrationEnabled;
   }
 
-  public boolean isCiVisibilityRepoIndexSharingEnabled() {
-    return ciVisibilityRepoIndexSharingEnabled;
+  public boolean isCiVisibilityRepoIndexDuplicateKeyCheckEnabled() {
+    return ciVisibilityRepoIndexDuplicateKeyCheckEnabled;
   }
 
   public int getCiVisibilityExecutionSettingsCacheSize() {


### PR DESCRIPTION
Cherry-pick #7793

# What Does This Do

Updates repo indexing logic: the logic now stores the list of classes whose path relative to source root is the same (e.g. `src/java/main/my/package/MyClass.java` and `src/java9/main/my/package/MyClass.java`).

When a source path lookup is performed with the repo index, if the class if one of those "duplicates", an exception will be thrown to indicate that we cannot reliably detect the source path for this class.

# Motivation

The motivation is to skip code coverage report creation and submission for test cases that cover such classes.
The idea is that since we cannot reliably detect all the source paths, we do not want ITR to skip these test cases, which is why we will not be submitting code coverage reports for them.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1130]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1130]: https://datadoghq.atlassian.net/browse/SDTEST-1130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
