### PR TITLE
[🍒 7783] Fix Jacoco coverage exclusion

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemModuleImpl.java
@@ -191,11 +191,11 @@ public class BuildSystemModuleImpl extends AbstractTestModule implements BuildSy
             CiVisibilityConfig.CIVISIBILITY_SIGNAL_SERVER_PORT),
         String.valueOf(signalServerAddress != null ? signalServerAddress.getPort() : 0));
 
-    List<String> coverageEnabledPackages = sessionSettings.getCoverageEnabledPackages();
+    List<String> coverageIncludedPackages = sessionSettings.getCoverageIncludedPackages();
     propagatedSystemProperties.put(
         Strings.propertyNameToSystemPropertyName(
             CiVisibilityConfig.CIVISIBILITY_CODE_COVERAGE_INCLUDES),
-        String.join(":", coverageEnabledPackages));
+        String.join(":", coverageIncludedPackages));
 
     if (jacocoAgent != null && !config.isCiVisibilityCoverageLinesDisabled()) {
       // If the module is using Jacoco,

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/BuildSystemSessionImpl.java
@@ -40,9 +40,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 public class BuildSystemSessionImpl<T extends CoverageCalculator> extends AbstractTestSession
@@ -92,7 +90,10 @@ public class BuildSystemSessionImpl<T extends CoverageCalculator> extends Abstra
     this.repoIndexProvider = repoIndexProvider;
     this.coverageCalculatorFactory = coverageCalculatorFactory;
     this.coverageCalculator = coverageCalculatorFactory.sessionCoverage(span.getSpanId());
-    this.settings = new BuildSessionSettings(getCoverageEnabledPackages(config, repoIndexProvider));
+    this.settings =
+        new BuildSessionSettings(
+            getCoverageIncludedPackages(config, repoIndexProvider),
+            config.getCiVisibilityCodeCoverageExcludes());
 
     signalServer.registerSignalHandler(
         SignalType.MODULE_EXECUTION_RESULT, moduleSignalRouter::onModuleSignalReceived);
@@ -107,48 +108,19 @@ public class BuildSystemSessionImpl<T extends CoverageCalculator> extends Abstra
     setTag(Tags.TEST_COMMAND, startCommand);
   }
 
-  private static List<String> getCoverageEnabledPackages(
+  private static List<String> getCoverageIncludedPackages(
       Config config, RepoIndexProvider repoIndexProvider) {
     if (!config.isCiVisibilityCodeCoverageEnabled()) {
       return Collections.emptyList();
     }
 
     List<String> includedPackages = config.getCiVisibilityCodeCoverageIncludes();
-    List<String> packages;
     if (includedPackages != null && !includedPackages.isEmpty()) {
-      packages = includedPackages;
+      return new ArrayList<>(includedPackages);
     } else {
       RepoIndex repoIndex = repoIndexProvider.getIndex();
-      packages = new ArrayList<>(repoIndex.getRootPackages());
+      return new ArrayList<>(repoIndex.getRootPackages());
     }
-
-    List<String> excludedPackages = config.getCiVisibilityCodeCoverageExcludes();
-    if (excludedPackages != null && !excludedPackages.isEmpty()) {
-      removeMatchingPackages(packages, excludedPackages);
-    }
-    return packages;
-  }
-
-  private static void removeMatchingPackages(List<String> packages, List<String> excludedPackages) {
-    List<String> excludedPrefixes =
-        excludedPackages.stream()
-            .map(BuildSystemSessionImpl::trimTrailingAsterisk)
-            .collect(Collectors.toList());
-    Iterator<String> packagesIterator = packages.iterator();
-    while (packagesIterator.hasNext()) {
-      String p = packagesIterator.next();
-
-      for (String excludedPrefix : excludedPrefixes) {
-        if (p.startsWith(excludedPrefix)) {
-          packagesIterator.remove();
-          break;
-        }
-      }
-    }
-  }
-
-  private static String trimTrailingAsterisk(String s) {
-    return s.endsWith("*") ? s.substring(0, s.length() - 1) : s;
   }
 
   private SignalResponse onRepoIndexRequestReceived(RepoIndexRequest request) {

--- a/dd-java-agent/instrumentation/gradle-3.0/src/main/groovy/datadog/trace/instrumentation/gradle/legacy/GradleProjectConfigurator.groovy
+++ b/dd-java-agent/instrumentation/gradle-3.0/src/main/groovy/datadog/trace/instrumentation/gradle/legacy/GradleProjectConfigurator.groovy
@@ -203,13 +203,19 @@ class GradleProjectConfigurator {
       }
     }
 
-    def coverageEnabledPackages = sessionSettings.getCoverageEnabledPackages()
+    def coverageIncludedPackages = sessionSettings.getCoverageIncludedPackages()
+    def coverageExcludedPackages = sessionSettings.getCoverageExcludedPackages()
     forEveryTestTask project, { task ->
       task.jacoco.excludeClassLoaders += [DatadogClassLoader.name]
 
-      for (String coverageEnabledPackage : coverageEnabledPackages) {
-        if (Strings.isNotBlank(coverageEnabledPackage)) {
-          task.jacoco.includes += coverageEnabledPackage
+      for (String includedPackage : coverageIncludedPackages) {
+        if (Strings.isNotBlank(includedPackage)) {
+          task.jacoco.includes += includedPackage
+        }
+      }
+      for (String excludedPackage : coverageExcludedPackages) {
+        if (Strings.isNotBlank(excludedPackage)) {
+          task.jacoco.excludes += excludedPackage
         }
       }
     }

--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/java/datadog/trace/instrumentation/gradle/CiVisibilityPluginExtension.java
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/java/datadog/trace/instrumentation/gradle/CiVisibilityPluginExtension.java
@@ -170,16 +170,28 @@ public abstract class CiVisibilityPluginExtension {
           new ArrayList<>(ciVisibilityService.getExcludeClassLoaders()));
     }
 
-    List<String> taskIncludePackages = jacocoTaskExtension.getIncludes();
-    if (taskIncludePackages == null) {
-      taskIncludePackages = new ArrayList<>();
-      jacocoTaskExtension.setIncludes(taskIncludePackages);
-    }
-    for (String coverageEnabledPackage : ciVisibilityService.getCoverageEnabledPackages()) {
-      if (coverageEnabledPackage != null && !coverageEnabledPackage.isEmpty()) {
-        taskIncludePackages.add(coverageEnabledPackage);
+    jacocoTaskExtension.setIncludes(
+        merge(
+            jacocoTaskExtension.getIncludes(), ciVisibilityService.getCoverageIncludedPackages()));
+    jacocoTaskExtension.setExcludes(
+        merge(
+            jacocoTaskExtension.getExcludes(), ciVisibilityService.getCoverageExcludedPackages()));
+  }
+
+  @SafeVarargs
+  private static List<String> merge(List<String>... packageLists) {
+    List<String> merged = new ArrayList<>();
+    for (List<String> packageList : packageLists) {
+      if (packageList == null) {
+        continue;
+      }
+      for (String pkg : packageList) {
+        if (pkg != null && !pkg.isEmpty()) {
+          merged.add(pkg);
+        }
       }
     }
+    return merged;
   }
 
   private void applyTracerSettings(

--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/java/datadog/trace/instrumentation/gradle/CiVisibilityService.java
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/java/datadog/trace/instrumentation/gradle/CiVisibilityService.java
@@ -56,9 +56,14 @@ public abstract class CiVisibilityService
     return config.getCiVisibilityJacocoGradleSourceSets();
   }
 
-  public List<String> getCoverageEnabledPackages() {
+  public List<String> getCoverageIncludedPackages() {
     BuildSessionSettings sessionSettings = buildEventsHandler.getSessionSettings(SESSION_KEY);
-    return sessionSettings.getCoverageEnabledPackages();
+    return sessionSettings.getCoverageIncludedPackages();
+  }
+
+  public List<String> getCoverageExcludedPackages() {
+    BuildSessionSettings sessionSettings = buildEventsHandler.getSessionSettings(SESSION_KEY);
+    return sessionSettings.getCoverageExcludedPackages();
   }
 
   @SuppressForbidden

--- a/dd-java-agent/instrumentation/jacoco/src/main/java/datadog/trace/instrumentation/jacoco/ProbeInserterInstrumentation.java
+++ b/dd-java-agent/instrumentation/jacoco/src/main/java/datadog/trace/instrumentation/jacoco/ProbeInserterInstrumentation.java
@@ -139,9 +139,23 @@ public class ProbeInserterInstrumentation extends InstrumenterModule.CiVisibilit
       classNameField.setAccessible(true);
       String className = (String) classNameField.get(arrayStrategy);
 
-      String[] excludedClassnames = Config.get().getCiVisibilityCodeCoverageExcludedPackages();
-      for (String excludedClassname : excludedClassnames) {
-        if (className.startsWith(excludedClassname)) {
+      String[] excludedPackages = Config.get().getCiVisibilityCodeCoverageExcludedPackages();
+      for (String excludedPackage : excludedPackages) {
+        if (className.startsWith(excludedPackage)) {
+          return;
+        }
+      }
+
+      String[] includedPackages = Config.get().getCiVisibilityCodeCoverageIncludedPackages();
+      if (includedPackages.length > 0) {
+        boolean included = false;
+        for (String includedPackage : includedPackages) {
+          if (className.startsWith(includedPackage)) {
+            included = true;
+            break;
+          }
+        }
+        if (!included) {
           return;
         }
       }

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenProjectConfigurator.java
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/main/java/datadog/trace/instrumentation/maven3/MavenProjectConfigurator.java
@@ -312,7 +312,9 @@ class MavenProjectConfigurator {
     jacocoPlugin.addExecution(prepareAgentExecution);
 
     configureJacocoInstrumentedPackages(
-        prepareAgentExecution, sessionSettings.getCoverageEnabledPackages());
+        prepareAgentExecution,
+        sessionSettings.getCoverageIncludedPackages(),
+        sessionSettings.getCoverageExcludedPackages());
   }
 
   private static Plugin getJacocoPlugin(MavenProject project) {
@@ -345,20 +347,32 @@ class MavenProjectConfigurator {
   }
 
   private static void configureJacocoInstrumentedPackages(
-      PluginExecution execution, List<String> instrumentedPackages) {
-    Xpp3Dom includes = new Xpp3Dom("includes");
-    for (String instrumentedPackage : instrumentedPackages) {
-      if (Strings.isNotBlank(instrumentedPackage)) {
-        Xpp3Dom include = new Xpp3Dom("include");
-        include.setValue(instrumentedPackage);
-        includes.addChild(include);
+      PluginExecution execution, List<String> includedPackages, List<String> excludedPackages) {
+    Xpp3Dom configuration = new Xpp3Dom("configuration");
+    execution.setConfiguration(configuration);
+
+    if (!includedPackages.isEmpty()) {
+      Xpp3Dom includes = new Xpp3Dom("includes");
+      for (String instrumentedPackage : includedPackages) {
+        if (Strings.isNotBlank(instrumentedPackage)) {
+          Xpp3Dom include = new Xpp3Dom("include");
+          include.setValue(instrumentedPackage);
+          includes.addChild(include);
+        }
       }
+      configuration.addChild(includes);
     }
 
-    if (includes.getChildCount() > 0) {
-      Xpp3Dom configuration = new Xpp3Dom("configuration");
-      configuration.addChild(includes);
-      execution.setConfiguration(configuration);
+    if (!excludedPackages.isEmpty()) {
+      Xpp3Dom excludes = new Xpp3Dom("excludes");
+      for (String excludedPackage : excludedPackages) {
+        if (Strings.isNotBlank(excludedPackage)) {
+          Xpp3Dom exclude = new Xpp3Dom("exclude");
+          exclude.setValue(excludedPackage);
+          excludes.addChild(exclude);
+        }
+      }
+      configuration.addChild(excludes);
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/domain/BuildSessionSettings.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/domain/BuildSessionSettings.java
@@ -4,13 +4,20 @@ import java.util.List;
 
 public class BuildSessionSettings {
 
-  private final List<String> coverageEnabledPackages;
+  private final List<String> coverageIncludedPackages;
+  private final List<String> coverageExcludedPackages;
 
-  public BuildSessionSettings(List<String> coverageEnabledPackages) {
-    this.coverageEnabledPackages = coverageEnabledPackages;
+  public BuildSessionSettings(
+      List<String> coverageIncludedPackages, List<String> coverageExcludedPackages) {
+    this.coverageIncludedPackages = coverageIncludedPackages;
+    this.coverageExcludedPackages = coverageExcludedPackages;
   }
 
-  public List<String> getCoverageEnabledPackages() {
-    return coverageEnabledPackages;
+  public List<String> getCoverageIncludedPackages() {
+    return coverageIncludedPackages;
+  }
+
+  public List<String> getCoverageExcludedPackages() {
+    return coverageExcludedPackages;
   }
 }


### PR DESCRIPTION
Cherry pick #7783

# What Does This Do

Changes the logic for computing the list of packages included/excluded from Jacoco code coverage.

The old version of the logic checked the list of included packages and filtered out everything that was in the list of excluded packages, and then passed the resulting list of includes to Jacoco plugin.

The new version does two things:
1. passes the list of included/excluded packages to Jacoco plugin as is
2. in the instrumentation that is built on-top of the Jacoco plugin it checks excludes/includes before deciding whether a custom DD coverage probe needs to be inserted.

# Motivation

Motivation for 1 is simplification.
Motivation for 2 is to decouple ITR code coverage logic from Jacoco coverage logic: a traced project may have pre-configured Jacoco which already have its includes/excludes configured by the user - and these settings may include packages that we're not interested in covering (ITR computes the list of covered packages automatically based on repo index).

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1130]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1130]: https://datadoghq.atlassian.net/browse/SDTEST-1130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ