### PR TITLE
Reenable kafka client tests

### DIFF
--- a/dd-java-agent/instrumentation/kafka-clients-3.8/build.gradle
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/build.gradle
@@ -78,4 +78,8 @@ configurations.testRuntimeClasspath {
   resolutionStrategy.force 'org.assertj:assertj-core:2.9.1'
 }
 
-
+project.afterEvaluate {
+  tasks.withType(Test).configureEach {
+    usesService(testcontainersLimit)
+  }
+}

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/test/groovy/KafkaClientCustomPropagationConfigTest.groovy
@@ -1,7 +1,6 @@
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import datadog.trace.test.util.Flaky
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.header.Headers
@@ -26,7 +25,6 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
 import static datadog.trace.instrumentation.kafka_clients38.KafkaDecorator.KAFKA_PRODUCE
 
-@Flaky
 class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
   static final SHARED_TOPIC = ["topic1", "topic2", "topic3", "topic4"]
   static final MESSAGE = "Testing without headers for certain topics"
@@ -55,7 +53,7 @@ class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
     injectSysConfig("dd.kafka.e2e.duration.enabled", "true")
     injectSysConfig("dd.trace.experimental.kafka.enabled","true")
   }
-  @Flaky
+
   def "test kafka client header propagation with topic filters"() {
     setup:
     injectSysConfig(TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS, value as String)
@@ -163,7 +161,6 @@ class KafkaClientCustomPropagationConfigTest extends AgentTestRunner {
     [value, expected1, expected2, expected3, expected4]<< dataTable()
   }
 
-  @Flaky
   def "test consumer with topic filters"() {
     setup:
     injectSysConfig(TraceInstrumentationConfig.KAFKA_CLIENT_PROPAGATION_DISABLED_TOPICS, value as String)

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/test/groovy/KafkaClientTestBase.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/test/groovy/KafkaClientTestBase.groovy
@@ -7,7 +7,6 @@ import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.common.writer.ListWriter
 import datadog.trace.core.DDSpan
 import datadog.trace.core.datastreams.StatsGroup
-import datadog.trace.test.util.Flaky
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
@@ -41,7 +40,6 @@ import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 
-@Flaky
 abstract class KafkaClientTestBase extends VersionedNamingTestBase {
   static final SHARED_TOPIC = "shared.topic"
   static final String MESSAGE = "Testing without headers for certain topics"
@@ -152,7 +150,7 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
   protected boolean isDataStreamsEnabled() {
     return true
   }
-  @Flaky
+
   def "test kafka produce and consume"() {
     setup:
     // Create and start a Kafka container using Testcontainers
@@ -295,7 +293,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     kafkaContainer.stop()
   }
 
-  @Flaky
   def "test producing message too large"() {
     setup:
     // set a low max request size, so that we can crash it
@@ -318,7 +315,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     producer.close()
   }
 
-  @Flaky
   def "test spring kafka template produce and consume"() {
     setup:
     KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest")).withEmbeddedZookeeper().withEnv("KAFKA_CREATE_TOPICS", SHARED_TOPIC)
@@ -462,7 +458,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
     kafkaContainer.stop()
   }
 
-  @Flaky
   def "test pass through tombstone"() {
     setup:
     KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest")).withEmbeddedZookeeper().withEnv("KAFKA_CREATE_TOPICS", SHARED_TOPIC)
@@ -534,7 +529,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
   }
 
-  @Flaky
   def "test records(TopicPartition) kafka consume"() {
     setup:
     KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest")).withEmbeddedZookeeper().withEnv("KAFKA_CREATE_TOPICS", SHARED_TOPIC)
@@ -595,7 +589,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
   }
 
-  @Flaky
   def "test records(TopicPartition).subList kafka consume"() {
     setup:
 
@@ -658,7 +651,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
   }
 
-  @Flaky
   def "test records(TopicPartition).forEach kafka consume"() {
     setup:
     KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest")).withEmbeddedZookeeper().withEnv("KAFKA_CREATE_TOPICS", SHARED_TOPIC)
@@ -720,7 +712,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
   }
 
-  @Flaky
   def "test iteration backwards over ConsumerRecords"() {
     setup:
     KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest")).withEmbeddedZookeeper().withEnv("KAFKA_CREATE_TOPICS", SHARED_TOPIC)
@@ -835,7 +826,6 @@ abstract class KafkaClientTestBase extends VersionedNamingTestBase {
 
   }
 
-  @Flaky
   def "test kafka client header propagation manual config"() {
     setup:
     KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest")).withEmbeddedZookeeper().withEnv("KAFKA_CREATE_TOPICS", SHARED_TOPIC)


### PR DESCRIPTION
# What Does This Do
This PR reenables the kafka-client tests that were disabled due to CI issues in [the new kafka integration](https://github.com/DataDog/dd-trace-java/pull/7626)
# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
