### PR TITLE
[SSI/Onboarding] Fix telemetry

### DIFF
--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/AgentBootstrap.java
@@ -97,8 +97,8 @@ public final class AgentBootstrap {
 
     BootstrapInitializationTelemetry initTelemetry =
         BootstrapInitializationTelemetry.createFromForwarderPath(forwarderPath);
-    initTelemetry.initMetaInfo("runtime_name", "java");
-    initTelemetry.initMetaInfo("language_name", "java");
+    initTelemetry.initMetaInfo("runtime_name", "jvm");
+    initTelemetry.initMetaInfo("language_name", "jvm");
 
     String javaVersion = SystemUtils.tryGetProperty("java.version");
     if (javaVersion != null) {

--- a/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
+++ b/dd-java-agent/src/main/java/datadog/trace/bootstrap/BootstrapInitializationTelemetry.java
@@ -202,7 +202,7 @@ public abstract class BootstrapInitializationTelemetry {
 
     @Override
     public void send(JsonBuffer buffer) throws IOException {
-      ProcessBuilder builder = new ProcessBuilder(forwarderPath);
+      ProcessBuilder builder = new ProcessBuilder(forwarderPath, "library_entrypoint");
 
       Process process = builder.start();
       try (OutputStream out = process.getOutputStream()) {


### PR DESCRIPTION
# What Does This Do

Fix the SSI telemetry by adding `library_entrypoint` as the first argument to the telemetry forwarder command.

[Specifications](https://docs.google.com/document/d/1kH8wnGDBWJcGw7s5J9dl2McG9H7-pvl0gA6NL0IJ3BQ/edit?tab=t.0) say
```
In addition tracers should add library_entrypoint  as the first argument to the execution, which is necessary for the lib injection script to follow the code path for receiving telemetry.
```

# Motivation

We noticed we weren't getting any telemetry

https://datadoghq.atlassian.net/browse/INPLAT-11

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
