### PR TITLE
Add retry policy for uploading requests to agent

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -48,8 +48,6 @@ import org.slf4j.LoggerFactory;
 /** Debugger agent implementation */
 public class DebuggerAgent {
   private static final Logger LOGGER = LoggerFactory.getLogger(DebuggerAgent.class);
-  private static final BatchUploader.RetryPolicy SNAPSHOT_RETRY_POLICY =
-      new BatchUploader.RetryPolicy(3, 3);
   private static ConfigurationPoller configurationPoller;
   private static DebuggerSink sink;
   private static String agentVersion;
@@ -171,7 +169,8 @@ public class DebuggerAgent {
         new SnapshotSink(
             config,
             tags,
-            new BatchUploader(config, config.getFinalDebuggerSnapshotUrl(), SNAPSHOT_RETRY_POLICY));
+            new BatchUploader(
+                config, config.getFinalDebuggerSnapshotUrl(), SnapshotSink.RETRY_POLICY));
     SymbolSink symbolSink = new SymbolSink(config);
     return new DebuggerSink(
         config,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -48,6 +48,8 @@ import org.slf4j.LoggerFactory;
 /** Debugger agent implementation */
 public class DebuggerAgent {
   private static final Logger LOGGER = LoggerFactory.getLogger(DebuggerAgent.class);
+  private static final BatchUploader.RetryPolicy SNAPSHOT_RETRY_POLICY =
+      new BatchUploader.RetryPolicy(3, 3);
   private static ConfigurationPoller configurationPoller;
   private static DebuggerSink sink;
   private static String agentVersion;
@@ -167,7 +169,9 @@ public class DebuggerAgent {
     String tags = getDefaultTagsMergedWithGlobalTags(config);
     SnapshotSink snapshotSink =
         new SnapshotSink(
-            config, tags, new BatchUploader(config, config.getFinalDebuggerSnapshotUrl()));
+            config,
+            tags,
+            new BatchUploader(config, config.getFinalDebuggerSnapshotUrl(), SNAPSHOT_RETRY_POLICY));
     SymbolSink symbolSink = new SymbolSink(config);
     return new DebuggerSink(
         config,

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -152,7 +152,12 @@ public class DebuggerTransformer implements ClassFileTransformer {
             DebuggerMetrics.getInstance(config),
             new ProbeStatusSink(config, config.getFinalDebuggerSnapshotUrl(), false),
             new SnapshotSink(
-                config, "", new BatchUploader(config, config.getFinalDebuggerSnapshotUrl())),
+                config,
+                "",
+                new BatchUploader(
+                    config,
+                    config.getFinalDebuggerSnapshotUrl(),
+                    new BatchUploader.RetryPolicy(3, 3))),
             new SymbolSink(config)));
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -155,9 +155,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
                 config,
                 "",
                 new BatchUploader(
-                    config,
-                    config.getFinalDebuggerSnapshotUrl(),
-                    new BatchUploader.RetryPolicy(3, 3))),
+                    config, config.getFinalDebuggerSnapshotUrl(), SnapshotSink.RETRY_POLICY)),
             new SymbolSink(config)));
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -43,7 +43,10 @@ public class DebuggerSink {
         DebuggerMetrics.getInstance(config),
         probeStatusSink,
         new SnapshotSink(
-            config, null, new BatchUploader(config, config.getFinalDebuggerSnapshotUrl())),
+            config,
+            null,
+            new BatchUploader(
+                config, config.getFinalDebuggerSnapshotUrl(), new BatchUploader.RetryPolicy(3, 3))),
         new SymbolSink(config));
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -46,7 +46,7 @@ public class DebuggerSink {
             config,
             null,
             new BatchUploader(
-                config, config.getFinalDebuggerSnapshotUrl(), new BatchUploader.RetryPolicy(3, 3))),
+                config, config.getFinalDebuggerSnapshotUrl(), SnapshotSink.RETRY_POLICY)),
         new SymbolSink(config));
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -33,6 +33,8 @@ public class ProbeStatusSink {
   private static final JsonAdapter<ProbeStatus> PROBE_STATUS_ADAPTER =
       MoshiHelper.createMoshiProbeStatus().adapter(ProbeStatus.class);
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
+  private static final BatchUploader.RetryPolicy STATUS_RETRY_POLICY =
+      new BatchUploader.RetryPolicy(10, 10);
 
   private final BatchUploader diagnosticUploader;
   private final Builder messageBuilder;
@@ -46,7 +48,7 @@ public class ProbeStatusSink {
   private final boolean useMultiPart;
 
   public ProbeStatusSink(Config config, String diagnosticsEndpoint, boolean useMultiPart) {
-    this(config, new BatchUploader(config, diagnosticsEndpoint), useMultiPart);
+    this(config, new BatchUploader(config, diagnosticsEndpoint, STATUS_RETRY_POLICY), useMultiPart);
   }
 
   ProbeStatusSink(Config config, BatchUploader diagnosticUploader, boolean useMultiPart) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -33,8 +33,7 @@ public class ProbeStatusSink {
   private static final JsonAdapter<ProbeStatus> PROBE_STATUS_ADAPTER =
       MoshiHelper.createMoshiProbeStatus().adapter(ProbeStatus.class);
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
-  private static final BatchUploader.RetryPolicy STATUS_RETRY_POLICY =
-      new BatchUploader.RetryPolicy(10, 10);
+  public static final BatchUploader.RetryPolicy RETRY_POLICY = new BatchUploader.RetryPolicy(10);
 
   private final BatchUploader diagnosticUploader;
   private final Builder messageBuilder;
@@ -48,7 +47,7 @@ public class ProbeStatusSink {
   private final boolean useMultiPart;
 
   public ProbeStatusSink(Config config, String diagnosticsEndpoint, boolean useMultiPart) {
-    this(config, new BatchUploader(config, diagnosticsEndpoint, STATUS_RETRY_POLICY), useMultiPart);
+    this(config, new BatchUploader(config, diagnosticsEndpoint, RETRY_POLICY), useMultiPart);
   }
 
   ProbeStatusSink(Config config, BatchUploader diagnosticUploader, boolean useMultiPart) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
@@ -30,6 +30,7 @@ public class SnapshotSink {
   private static final int HIGH_RATE_25_PERCENT_CAPACITY = HIGH_RATE_CAPACITY / 4;
   private static final int HIGH_RATE_75_PERCENT_CAPACITY = HIGH_RATE_CAPACITY * 3 / 4;
   static final long HIGH_RATE_STEP_SIZE = 10;
+  public static final BatchUploader.RetryPolicy RETRY_POLICY = new BatchUploader.RetryPolicy(0);
 
   private final BlockingQueue<Snapshot> lowRateSnapshots =
       new ArrayBlockingQueue<>(LOW_RATE_CAPACITY);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -20,6 +20,8 @@ public class SymbolSink {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SymbolSink.class);
   static final int CAPACITY = 1024;
+  private static final BatchUploader.RetryPolicy SYMBOL_RETRY_POLICY =
+      new BatchUploader.RetryPolicy(10, 10);
   private static final JsonAdapter<ServiceVersion> SERVICE_VERSION_ADAPTER =
       MoshiHelper.createMoshiSymbol().adapter(ServiceVersion.class);
   private static final String EVENT_FORMAT =
@@ -38,7 +40,7 @@ public class SymbolSink {
   private final Stats stats = new Stats();
 
   public SymbolSink(Config config) {
-    this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl()));
+    this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl(), SYMBOL_RETRY_POLICY));
   }
 
   SymbolSink(Config config, BatchUploader symbolUploader) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -20,8 +20,7 @@ public class SymbolSink {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SymbolSink.class);
   static final int CAPACITY = 1024;
-  private static final BatchUploader.RetryPolicy SYMBOL_RETRY_POLICY =
-      new BatchUploader.RetryPolicy(10, 10);
+  public static final BatchUploader.RetryPolicy RETRY_POLICY = new BatchUploader.RetryPolicy(10);
   private static final JsonAdapter<ServiceVersion> SERVICE_VERSION_ADAPTER =
       MoshiHelper.createMoshiSymbol().adapter(ServiceVersion.class);
   private static final String EVENT_FORMAT =
@@ -40,7 +39,7 @@ public class SymbolSink {
   private final Stats stats = new Stats();
 
   public SymbolSink(Config config) {
-    this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl(), SYMBOL_RETRY_POLICY));
+    this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl(), RETRY_POLICY));
   }
 
   SymbolSink(Config config, BatchUploader symbolUploader) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -10,6 +10,8 @@ import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentThreadFactory;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.SynchronousQueue;
@@ -56,7 +58,18 @@ public class BatchUploader {
     }
   }
 
-  private static final Logger log = LoggerFactory.getLogger(BatchUploader.class);
+  public static class RetryPolicy {
+    public final ConcurrentMap<Call, Integer> failures = new ConcurrentHashMap<>();
+    public final int maxNetworkFailures;
+    public final int max500Failures;
+
+    public RetryPolicy(int maxNetworkFailures, int max500Failures) {
+      this.maxNetworkFailures = maxNetworkFailures;
+      this.max500Failures = max500Failures;
+    }
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BatchUploader.class);
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
   private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
   private static final String HEADER_DD_CONTAINER_ID = "Datadog-Container-ID";
@@ -76,18 +89,28 @@ public class BatchUploader {
   private final DebuggerMetrics debuggerMetrics;
   private final boolean instrumentTheWorld;
   private final RatelimitedLogger ratelimitedLogger;
+  private final RetryPolicy retryPolicy;
 
   private final Phaser inflightRequests = new Phaser(1);
 
-  public BatchUploader(Config config, String endpoint) {
-    this(config, endpoint, new RatelimitedLogger(log, MINUTES_BETWEEN_ERROR_LOG, TimeUnit.MINUTES));
+  public BatchUploader(Config config, String endpoint, RetryPolicy retryPolicy) {
+    this(
+        config,
+        endpoint,
+        new RatelimitedLogger(LOGGER, MINUTES_BETWEEN_ERROR_LOG, TimeUnit.MINUTES),
+        retryPolicy);
   }
 
-  BatchUploader(Config config, String endpoint, RatelimitedLogger ratelimitedLogger) {
+  BatchUploader(
+      Config config,
+      String endpoint,
+      RatelimitedLogger ratelimitedLogger,
+      RetryPolicy retryPolicy) {
     this(
         config,
         endpoint,
         ratelimitedLogger,
+        retryPolicy,
         ContainerInfo.get().containerId,
         ContainerInfo.getEntityId());
   }
@@ -97,6 +120,7 @@ public class BatchUploader {
       Config config,
       String endpoint,
       RatelimitedLogger ratelimitedLogger,
+      RetryPolicy retryPolicy,
       String containerId,
       String entityId) {
     instrumentTheWorld = config.isDebuggerInstrumentTheWorld();
@@ -104,10 +128,9 @@ public class BatchUploader {
       throw new IllegalArgumentException("Endpoint url is empty");
     }
     urlBase = HttpUrl.get(endpoint);
-    log.debug("Started BatchUploader with target url {}", urlBase);
+    LOGGER.debug("Started BatchUploader with target url {}", urlBase);
     apiKey = config.getApiKey();
     this.ratelimitedLogger = ratelimitedLogger;
-    responseCallback = new ResponseCallback(ratelimitedLogger, inflightRequests);
     // This is the same thing OkHttp Dispatcher is doing except thread naming and daemonization
     okHttpExecutorService =
         new ThreadPoolExecutor(
@@ -117,6 +140,7 @@ public class BatchUploader {
             TimeUnit.SECONDS,
             new SynchronousQueue<>(),
             new AgentThreadFactory(DEBUGGER_HTTP_DISPATCHER));
+    this.retryPolicy = retryPolicy;
     this.containerId = containerId;
     this.entityId = entityId;
     Duration requestTimeout = Duration.ofSeconds(config.getDebuggerUploadTimeout());
@@ -132,6 +156,8 @@ public class BatchUploader {
             null, /* proxyUsername */
             null, /* proxyPassword */
             requestTimeout.toMillis());
+    responseCallback =
+        new ResponseCallback(ratelimitedLogger, inflightRequests, client, retryPolicy);
     debuggerMetrics = DebuggerMetrics.getInstance(config);
   }
 
@@ -195,6 +221,10 @@ public class BatchUploader {
     return urlBase;
   }
 
+  RetryPolicy getRetryPolicy() {
+    return retryPolicy;
+  }
+
   private void makeUploadRequest(byte[] json, String tags) {
     int contentLength = json.length;
     // use RequestBody.create(MediaType, byte[]) to avoid changing Content-Type to
@@ -205,8 +235,8 @@ public class BatchUploader {
 
   private void buildAndSendRequest(RequestBody body, int contentLength, String tags) {
     debuggerMetrics.histogram("batch.uploader.request.size", contentLength);
-    if (log.isDebugEnabled()) {
-      log.debug("Uploading batch data size={} bytes", contentLength);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Uploading batch data size={} bytes", contentLength);
     }
     HttpUrl.Builder builder = urlBase.newBuilder();
     if (tags != null && !tags.isEmpty()) {
@@ -215,17 +245,17 @@ public class BatchUploader {
     Request.Builder requestBuilder = new Request.Builder().url(builder.build()).post(body);
     if (apiKey != null) {
       if (apiKey.isEmpty()) {
-        log.debug("API key is empty");
+        LOGGER.debug("API key is empty");
       }
       if (apiKey.length() != 32) {
-        log.debug(
+        LOGGER.debug(
             "API key length is incorrect (truncated?) expected=32 actual={} API key={}...",
             apiKey.length(),
             apiKey.substring(0, Math.min(apiKey.length(), 6)));
       }
       requestBuilder.addHeader(HEADER_DD_API_KEY, apiKey);
     } else {
-      log.debug("API key is null");
+      LOGGER.debug("API key is null");
     }
     if (containerId != null) {
       requestBuilder.addHeader(HEADER_DD_CONTAINER_ID, containerId);
@@ -234,16 +264,15 @@ public class BatchUploader {
       requestBuilder.addHeader(HEADER_DD_ENTITY_ID, entityId);
     }
     Request request = requestBuilder.build();
-    log.debug("Sending request: {} CT: {}", request, request.body().contentType());
-    client.newCall(request).enqueue(responseCallback);
-    inflightRequests.register();
+    LOGGER.debug("Sending request: {} CT: {}", request, request.body().contentType());
+    enqueueCall(client, request, responseCallback, retryPolicy, 0, inflightRequests);
   }
 
   public void shutdown() {
     try {
       inflightRequests.awaitAdvanceInterruptibly(inflightRequests.arrive(), 10, TimeUnit.SECONDS);
     } catch (TimeoutException | InterruptedException ignored) {
-      log.warn("Not all upload requests have been handled");
+      LOGGER.warn("Not all upload requests have been handled");
     }
     okHttpExecutorService.shutdownNow();
     try {
@@ -251,7 +280,7 @@ public class BatchUploader {
     } catch (final InterruptedException e) {
       // Note: this should only happen in main thread right before exiting, so eating up interrupted
       // state should be fine.
-      log.warn("Wait for executor shutdown interrupted");
+      LOGGER.warn("Wait for executor shutdown interrupted");
     }
     client.connectionPool().evictAll();
   }
@@ -260,28 +289,67 @@ public class BatchUploader {
     return client.dispatcher().queuedCallsCount() < MAX_ENQUEUED_REQUESTS;
   }
 
+  private static void enqueueCall(
+      OkHttpClient client,
+      Request request,
+      Callback responseCallback,
+      RetryPolicy retryPolicy,
+      int failureCount,
+      Phaser inflightRequests) {
+    Call call = client.newCall(request);
+    retryPolicy.failures.put(call, failureCount);
+    call.enqueue(responseCallback);
+    inflightRequests.register();
+  }
+
   private static final class ResponseCallback implements Callback {
 
     private final RatelimitedLogger ratelimitedLogger;
     private final Phaser inflightRequests;
+    private final OkHttpClient client;
+    private final RetryPolicy retryPolicy;
 
-    public ResponseCallback(final RatelimitedLogger ratelimitedLogger, Phaser inflightRequests) {
+    public ResponseCallback(
+        final RatelimitedLogger ratelimitedLogger,
+        Phaser inflightRequests,
+        OkHttpClient client,
+        RetryPolicy retryPolicy) {
       this.ratelimitedLogger = ratelimitedLogger;
       this.inflightRequests = inflightRequests;
+      this.client = client;
+      this.retryPolicy = retryPolicy;
     }
 
     @Override
-    public void onFailure(final Call call, final IOException e) {
+    public void onFailure(Call call, IOException e) {
       inflightRequests.arriveAndDeregister();
       ratelimitedLogger.warn("Failed to upload batch to {}", call.request().url(), e);
+      handleRetry(call, retryPolicy.maxNetworkFailures);
+    }
+
+    private void handleRetry(Call call, int maxFailures) {
+      Integer failure = retryPolicy.failures.remove(call);
+      if (failure != null) {
+        int failureCount = failure + 1;
+        if (failureCount <= maxFailures) {
+          LOGGER.debug("Retrying upload {}/{}", failureCount, maxFailures);
+          enqueueCall(client, call.request(), this, retryPolicy, failureCount, inflightRequests);
+        } else {
+          LOGGER.warn(
+              "Failed permanently to upload batch to {} after {} attempts",
+              call.request().url(),
+              maxFailures);
+        }
+      }
     }
 
     @Override
-    public void onResponse(final Call call, final Response response) {
+    public void onResponse(Call call, Response response) {
       try {
         inflightRequests.arriveAndDeregister();
         if (response.isSuccessful()) {
-          log.debug("Upload done");
+          LOGGER.debug("Upload done");
+          retryPolicy.failures.remove(call);
         } else {
           ResponseBody body = response.body();
           // Retrieve body content for detailed error messages
@@ -300,6 +368,11 @@ public class BatchUploader {
                 "Failed to upload batch: unexpected response code {} {}",
                 response.message(),
                 response.code());
+          }
+          if (response.code() >= 500) {
+            handleRetry(call, retryPolicy.max500Failures);
+          } else {
+            retryPolicy.failures.remove(call);
           }
         }
       } finally {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -483,7 +483,10 @@ public class DebuggerSinkTest {
     DebuggerMetrics debuggerMetrics = spy(DebuggerMetrics.getInstance(config));
     SnapshotSink snapshotSink =
         new SnapshotSink(
-            config, "", new BatchUploader(config, config.getFinalDebuggerSnapshotUrl()));
+            config,
+            "",
+            new BatchUploader(
+                config, config.getFinalDebuggerSnapshotUrl(), new BatchUploader.RetryPolicy(3, 3)));
     SymbolSink symbolSink = new SymbolSink(config);
     DebuggerSink sink =
         new DebuggerSink(config, "", debuggerMetrics, probeStatusSink, snapshotSink, symbolSink);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/DebuggerSinkTest.java
@@ -486,7 +486,7 @@ public class DebuggerSinkTest {
             config,
             "",
             new BatchUploader(
-                config, config.getFinalDebuggerSnapshotUrl(), new BatchUploader.RetryPolicy(3, 3)));
+                config, config.getFinalDebuggerSnapshotUrl(), SnapshotSink.RETRY_POLICY));
     SymbolSink symbolSink = new SymbolSink(config);
     DebuggerSink sink =
         new DebuggerSink(config, "", debuggerMetrics, probeStatusSink, snapshotSink, symbolSink);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -85,7 +85,7 @@ class SymbolSinkTest {
     final List<MultiPartContent> multiPartContents = new ArrayList<>();
 
     public SymbolUploaderMock() {
-      super(Config.get(), "http://localhost", new RetryPolicy(10, 10));
+      super(Config.get(), "http://localhost", SymbolSink.RETRY_POLICY);
     }
 
     @Override

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -85,7 +85,7 @@ class SymbolSinkTest {
     final List<MultiPartContent> multiPartContents = new ArrayList<>();
 
     public SymbolUploaderMock() {
-      super(Config.get(), "http://localhost");
+      super(Config.get(), "http://localhost", new RetryPolicy(10, 10));
     }
 
     @Override


### PR DESCRIPTION
# What Does This Do
Add a mechanism to retry on network failure or 500 response code. The retry policy store the call made to OkHttp to track number of retries made and the maximum retries allowed by failure categories: network or 500.
3 retries are allowed for snapshots, 10 for probe statuses & symdb

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
