### PR TITLE
Send upper 64 bits of trace ID from Lambda Handler to Extension on end-invocation

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
@@ -137,7 +137,7 @@ class LambdaHandlerTest extends DDCoreSpecification {
     }
     LambdaHandler.setExtensionBaseUrl(server.address.toString())
     DDSpan span = Mock(DDSpan) {
-      getTraceId() >> DDTraceId.from("1234")
+      getTraceId() >> DDTraceId.fromHex("1234567890abcdef0000000000001234")
       getSpanId() >> DDSpanId.from("5678")
       getSamplingPriority() >> 2
     }
@@ -150,15 +150,16 @@ class LambdaHandlerTest extends DDCoreSpecification {
     server.lastRequest.headers.get("x-datadog-trace-id") == tIdHeaderValue
     server.lastRequest.headers.get("x-datadog-span-id") == sIdHeaderValue
     server.lastRequest.headers.get("x-datadog-sampling-priority") == sPIdHeaderValue
+    server.lastRequest.headers.get("x-datadog-tags") == tUpper64HeaderValue
     result == expected
 
     cleanup:
     server.close()
 
     where:
-    expected | eHeaderValue | tIdHeaderValue | sIdHeaderValue | sPIdHeaderValue | lambdaResult | boolValue
-    true     | "true"       | "1234"         | "5678"         | "2"             | {}           | true
-    true     | null         | "1234"         | "5678"         | "2"             | "12345"      | false
+    expected | eHeaderValue | tIdHeaderValue | tUpper64HeaderValue           | sIdHeaderValue | sPIdHeaderValue | lambdaResult | boolValue
+    true     | "true"       | "4660"         | "_dd.p.tid=1234567890abcdef"   | "5678"         | "2"             | {}           | true
+    true     | null         | "4660"         | "_dd.p.tid=1234567890abcdef"   | "5678"         | "2"             | "12345"      | false
   }
 
   def "test end invocation failure"() {


### PR DESCRIPTION
# What Does This Do

@duncanista pointed out that the Datadog Lambda Extension needs the tracer to send the full 128 bit trace ID back to it when the tracer calls end-invocation. This change quickly implements that. A more complete implementation using `tracer.propagate().extract` will be added to the list of fast-follow items.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
