### PR TITLE
Fix telemetry logs default flag

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -211,7 +211,7 @@ public final class ConfigDefaults {
       24 * 60 * 60; // 24 hours in seconds
   static final int DEFAULT_TELEMETRY_METRICS_INTERVAL = 10; // in seconds
   static final boolean DEFAULT_TELEMETRY_DEPENDENCY_COLLECTION_ENABLED = true;
-  static final boolean DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED = false;
+  static final boolean DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED = true;
   static final int DEFAULT_TELEMETRY_DEPENDENCY_RESOLUTION_QUEUE_SIZE = 100000;
 
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = true;


### PR DESCRIPTION
# What Does This Do

* Set `DEFAULT_TELEMETRY_LOG_COLLECTION_ENABLED` to `true`.
* This was supposed to be done in v1.40.0, per https://github.com/DataDog/dd-trace-java/pull/7631, but the default value was not correctly set. This effectively enabled the telemetry logger by default, but not sending the logs to the backend.
* This is a telemetry logs regression in v1.40.0 for services that had it enabled by default until then (those using IAST, CI Visibility, Dynamic Instrumentation, or Java 8).

# Motivation


# Additional Notes
* This is now tested on system-tests, but requires https://github.com/DataDog/system-tests/pull/3301 which will be effective only after merging this PR.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~
