### PR TITLE
Fix `update-gradle-dependencies` for missing `\`

### DIFF
--- a/.github/workflows/update-gradle-dependencies.yaml
+++ b/.github/workflows/update-gradle-dependencies.yaml
@@ -77,5 +77,5 @@ jobs:
             --base master \
             --head $BRANCH_NAME \
             --label "tag: dependencies" \
-            --label "tag: no release notes"
+            --label "tag: no release notes" \
             --body-file -


### PR DESCRIPTION
# What Does This Do

Fixes `update-gradle-dependencies.yaml` to add the missing `\`

# Motivation

The `update-gradle-dependencies` workflow failed last week due to it failing to create the PR so no updates were made.
A change was made in [#7760](https://github.com/DataDog/dd-trace-java/pull/7760) to make sure that code fixes get added to the PR, but this caused the workflow to fail with the following error:

```
must provide `--title` and `--body` (or `--fill` or `fill-first` or `--fillverbose`) when not running interactively
```

See: https://github.com/DataDog/dd-trace-java/actions/runs/11423279997/job/31782287313

# Additional Notes

A bit tricky to run these workflows without impacting the repository, so I copied this down and ran it locally to a different repository and it appeared to work.

Additionally, we could also just use `$'...'` bash strings to accept `\n` in the `--body` flag itself, but piping from `stdin` seems okay.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] ~~Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~~

Jira ticket: [AIDM-365](https://datadoghq.atlassian.net/browse/AIDM-365)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIDM-365]: https://datadoghq.atlassian.net/browse/AIDM-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ