### PR TITLE
Add support for session tracking in jetty

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/AppSecRequestContext.java
@@ -125,6 +125,8 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   // keep a reference to the last published usr.id
   private volatile String userId;
+  // keep a reference to the last published usr.session_id
+  private volatile String sessionId;
 
   private static final AtomicIntegerFieldUpdater<AppSecRequestContext> TIMEOUTS_UPDATER =
       AtomicIntegerFieldUpdater.newUpdater(AppSecRequestContext.class, "timeouts");
@@ -431,6 +433,14 @@ public class AppSecRequestContext implements DataBundle, Closeable {
 
   public void setUserId(String userId) {
     this.userId = userId;
+  }
+
+  public void setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+  }
+
+  public String getSessionId() {
+    return sessionId;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/armeria-jetty/src/test/jetty11/groovy/ArmeriaJetty11ServerTest.groovy
+++ b/dd-java-agent/instrumentation/armeria-jetty/src/test/jetty11/groovy/ArmeriaJetty11ServerTest.groovy
@@ -114,4 +114,9 @@ class ArmeriaJetty11ServerTest extends HttpServerTest<ArmeriaServer> {
   boolean testEncodedPath() {
     return false
   }
+
+  @Override
+  boolean testSessionId() {
+    true
+  }
 }

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java/datadog/trace/instrumentation/jetty11/RequestInstrumentation.java
@@ -27,5 +27,8 @@ public final class RequestInstrumentation extends InstrumenterModule.Tracing
             .and(takesArgument(0, named("org.eclipse.jetty.server.handler.ContextHandler$Context")))
             .and(takesArgument(1, String.class)),
         packageName + ".SetContextPathAdvice");
+    transformer.applyAdvice(
+        named("setRequestedSessionId").and(takesArgument(0, String.class)),
+        packageName + ".SetRequestedSessionIdAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/SetRequestedSessionIdAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/SetRequestedSessionIdAdvice.java
@@ -1,0 +1,22 @@
+package datadog.trace.instrumentation.jetty11;
+
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Because we are processing the initial request before the requestedSessionId is set, we must
+ * update it when it is actually set.
+ */
+@RequiresRequestContext(RequestContextSlot.APPSEC)
+public class SetRequestedSessionIdAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void setRequestedSessionId(
+      @ActiveRequestContext RequestContext reqCtx,
+      @Advice.Argument(0) final String requestedSessionId) {
+    JettyBlockingHelper.maybeBlockOnSession(reqCtx, requestedSessionId);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/SetRequestedSessionIdAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/SetRequestedSessionIdAdvice.java
@@ -1,10 +1,16 @@
 package datadog.trace.instrumentation.jetty11;
 
+import static datadog.trace.api.gateway.Events.EVENTS;
+
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
-import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
 import net.bytebuddy.asm.Advice;
 
 /**
@@ -17,6 +23,21 @@ public class SetRequestedSessionIdAdvice {
   public static void setRequestedSessionId(
       @ActiveRequestContext RequestContext reqCtx,
       @Advice.Argument(0) final String requestedSessionId) {
-    JettyBlockingHelper.maybeBlockOnSession(reqCtx, requestedSessionId);
+    if (requestedSessionId != null && reqCtx != null) {
+      final CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      if (cbp == null) {
+        return;
+      }
+      final BiFunction<RequestContext, String, Flow<Void>> addrCallback =
+          cbp.getCallback(EVENTS.requestSession());
+      if (addrCallback == null) {
+        return;
+      }
+      final Flow<Void> flow = addrCallback.apply(reqCtx, requestedSessionId);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        throw new BlockingException("Blocked request (for sessionId)");
+      }
+    }
   }
 }

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
@@ -84,6 +84,11 @@ abstract class Jetty11Test extends HttpServerTest<Server> {
   boolean hasExtraErrorInformation() {
     true
   }
+
+  @Override
+  boolean testSessionId() {
+    true
+  }
 }
 
 class Jetty11V0ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV0 {

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
@@ -91,7 +91,7 @@ abstract class Jetty11Test extends HttpServerTest<Server> {
   }
 }
 
-class  Jetty11V0ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV0 {
+class Jetty11V0ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV0 {
 }
 
 class Jetty11V1ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV1 {

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/Jetty11Test.groovy
@@ -91,7 +91,7 @@ abstract class Jetty11Test extends HttpServerTest<Server> {
   }
 }
 
-class Jetty11V0ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV0 {
+class  Jetty11V0ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV0 {
 }
 
 class Jetty11V1ForkedTest extends Jetty11Test implements TestingGenericHttpNamingConventions.ServerV1 {

--- a/dd-java-agent/instrumentation/jetty-11/src/test/groovy/JettyAsyncHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/test/groovy/JettyAsyncHandlerTest.groovy
@@ -15,6 +15,11 @@ class JettyAsyncHandlerTest extends Jetty11Test implements TestingGenericHttpNam
     new ContinuationTestHandler(super.handler())
   }
 
+  @Override
+  boolean testSessionId() {
+    false // continuation test handler not working with sessions
+  }
+
   static class ContinuationTestHandler implements Handler {
     @Delegate
     private final Handler delegate

--- a/dd-java-agent/instrumentation/jetty-11/src/testFixtures/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/testFixtures/groovy/JettyServer.groovy
@@ -20,8 +20,7 @@ class JettyServer implements HttpServer {
   final server = new Server(0) // select random open port
 
   JettyServer(Handler handler) {
-    sessionHandler.handler = handler
-    server.handler = sessionHandler
+    server.handler = handler
     server.addBean(errorHandler)
   }
 
@@ -49,6 +48,7 @@ class JettyServer implements HttpServer {
 
   static AbstractHandler servletHandler(Class<? extends Servlet> servlet) {
     ServletContextHandler handler = new ServletContextHandler(null, "/context-path")
+    final sessionHandler = new SessionHandler()
     handler.sessionHandler = sessionHandler
     handler.errorHandler = errorHandler
     handler.servletHandler.addFilterWithMapping(EnableMultipartFilter, '/*', FilterMapping.ALL)
@@ -75,6 +75,4 @@ class JettyServer implements HttpServer {
       }
     }
   }
-
-  static sessionHandler = new SessionHandler()
 }

--- a/dd-java-agent/instrumentation/jetty-11/src/testFixtures/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty-11/src/testFixtures/groovy/JettyServer.groovy
@@ -11,6 +11,7 @@ import org.eclipse.jetty.server.Handler
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
 import org.eclipse.jetty.server.handler.ErrorHandler
+import org.eclipse.jetty.server.session.SessionHandler
 import org.eclipse.jetty.servlet.FilterMapping
 import org.eclipse.jetty.servlet.ServletContextHandler
 
@@ -19,7 +20,8 @@ class JettyServer implements HttpServer {
   final server = new Server(0) // select random open port
 
   JettyServer(Handler handler) {
-    server.handler = handler
+    sessionHandler.handler = handler
+    server.handler = sessionHandler
     server.addBean(errorHandler)
   }
 
@@ -47,6 +49,7 @@ class JettyServer implements HttpServer {
 
   static AbstractHandler servletHandler(Class<? extends Servlet> servlet) {
     ServletContextHandler handler = new ServletContextHandler(null, "/context-path")
+    handler.sessionHandler = sessionHandler
     handler.errorHandler = errorHandler
     handler.servletHandler.addFilterWithMapping(EnableMultipartFilter, '/*', FilterMapping.ALL)
     handler.servletHandler.addServletWithMapping(servlet, '/*')
@@ -72,4 +75,6 @@ class JettyServer implements HttpServer {
       }
     }
   }
+
+  static sessionHandler = new SessionHandler()
 }

--- a/dd-java-agent/instrumentation/jetty-12/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-12/build.gradle
@@ -39,6 +39,9 @@ dependencies {
   main_java17CompileOnly ("org.eclipse.jetty:jetty-server:12.0.0") {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
+  main_java17CompileOnly ("org.eclipse.jetty:jetty-session:12.0.0") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
   main_java17Implementation project(':dd-java-agent:instrumentation:jetty-common')
   implementation project(':dd-java-agent:instrumentation:jetty-common')
 
@@ -60,6 +63,9 @@ dependencies {
   testRuntimeOnly(project(':dd-java-agent:instrumentation:jetty-util'))
 
   latestDepTestImplementation ("org.eclipse.jetty:jetty-server:12.+") {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+  }
+  latestDepTestImplementation ("org.eclipse.jetty:jetty-session:12.+") {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
 

--- a/dd-java-agent/instrumentation/jetty-12/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-12/build.gradle
@@ -32,9 +32,14 @@ addTestSuiteExtendingForDir('ee10LatestDepTest', 'latestDepTest', 'test/ee10')
   }
 }
 
+forbiddenApisMain_java17 {
+  failOnMissingClasses = false
+}
+
 compileTestGroovy {
   javaLauncher = getJavaLauncherFor(17)
 }
+
 dependencies {
   main_java17CompileOnly ("org.eclipse.jetty:jetty-server:12.0.0") {
     exclude group: 'org.slf4j', module: 'slf4j-api'

--- a/dd-java-agent/instrumentation/jetty-12/build.gradle
+++ b/dd-java-agent/instrumentation/jetty-12/build.gradle
@@ -7,6 +7,13 @@ muzzle {
     group = "org.eclipse.jetty"
     module = 'jetty-server'
     versions = "[12,]"
+    additionalDependencies = ['org.eclipse.jetty:jetty-session:12.0.0']
+  }
+  pass {
+    name = 'jetty-session'
+    group = "org.eclipse.jetty"
+    module = 'jetty-session'
+    versions = "[12,]"
   }
 }
 

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java/datadog/trace/instrumentation/jetty12/AbstractSessionManagerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java/datadog/trace/instrumentation/jetty12/AbstractSessionManagerInstrumentation.java
@@ -10,7 +10,7 @@ import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 
 @AutoService(InstrumenterModule.class)
-public final class AbstractSessionManagerInstrumentation extends InstrumenterModule.Tracing
+public final class AbstractSessionManagerInstrumentation extends InstrumenterModule.AppSec
     implements Instrumenter.ForSingleType {
 
   public AbstractSessionManagerInstrumentation() {

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java/datadog/trace/instrumentation/jetty12/AbstractSessionManagerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java/datadog/trace/instrumentation/jetty12/AbstractSessionManagerInstrumentation.java
@@ -1,0 +1,34 @@
+package datadog.trace.instrumentation.jetty12;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isProtected;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+
+@AutoService(InstrumenterModule.class)
+public final class AbstractSessionManagerInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForSingleType {
+
+  public AbstractSessionManagerInstrumentation() {
+    super("jetty");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "org.eclipse.jetty.session.AbstractSessionManager";
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("resolveRequestedSessionId")
+            .and(isProtected())
+            .and(takesArguments(1))
+            .and(takesArgument(0, named("org.eclipse.jetty.server.Request"))),
+        packageName + ".ResolveRequestedSessionIdAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java/datadog/trace/instrumentation/jetty12/AbstractSessionManagerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java/datadog/trace/instrumentation/jetty12/AbstractSessionManagerInstrumentation.java
@@ -18,6 +18,11 @@ public final class AbstractSessionManagerInstrumentation extends InstrumenterMod
   }
 
   @Override
+  public String muzzleDirective() {
+    return "jetty-session";
+  }
+
+  @Override
   public String instrumentedType() {
     return "org.eclipse.jetty.session.AbstractSessionManager";
   }

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/ResolveRequestedSessionIdAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/ResolveRequestedSessionIdAdvice.java
@@ -1,0 +1,46 @@
+package datadog.trace.instrumentation.jetty12;
+
+import static datadog.trace.api.gateway.Events.EVENTS;
+import static org.eclipse.jetty.session.AbstractSessionManager.RequestedSession;
+
+import datadog.appsec.api.blocking.BlockingException;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Because we are processing the initial request before the requestedSession is set, we must update
+ * it when it is actually set.
+ */
+@RequiresRequestContext(RequestContextSlot.APPSEC)
+public class ResolveRequestedSessionIdAdvice {
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void resolveRequestedSessionId(
+      @ActiveRequestContext RequestContext reqCtx,
+      @Advice.Return final RequestedSession requestedSession) {
+    final String requestedSessionId =
+        requestedSession == null ? null : requestedSession.sessionId();
+    if (requestedSessionId != null && reqCtx != null) {
+      final CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      if (cbp == null) {
+        return;
+      }
+      final BiFunction<RequestContext, String, Flow<Void>> addrCallback =
+          cbp.getCallback(EVENTS.requestSession());
+      if (addrCallback == null) {
+        return;
+      }
+      final Flow<Void> flow = addrCallback.apply(reqCtx, requestedSessionId);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        throw new BlockingException("Blocked request (for sessionId)");
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-12/src/test/ee8/groovy/Jetty12Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-12/src/test/ee8/groovy/Jetty12Test.groovy
@@ -48,6 +48,11 @@ abstract class Jetty12Test extends HttpServerTest<Server> implements TestingGene
   boolean hasExtraErrorInformation() {
     true
   }
+
+  @Override
+  boolean testSessionId() {
+    true
+  }
 }
 
 class Jetty12SyncTest extends Jetty12Test {

--- a/dd-java-agent/instrumentation/jetty-12/src/test/ee8/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty-12/src/test/ee8/groovy/JettyServer.groovy
@@ -1,3 +1,5 @@
+import org.eclipse.jetty.session.DefaultSessionIdManager
+
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN
 
@@ -5,8 +7,11 @@ import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
 import org.eclipse.jetty.ee8.nested.ErrorHandler
 import org.eclipse.jetty.ee8.servlet.ServletContextHandler
+import org.eclipse.jetty.ee8.nested.SessionHandler as EE8SessionHandler
 import org.eclipse.jetty.server.Handler
 import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.session.SessionHandler
+
 
 import javax.servlet.Servlet
 import javax.servlet.ServletException
@@ -17,8 +22,11 @@ class JettyServer implements HttpServer {
   final server = new Server(0) // select random open port
 
   JettyServer(Handler handler) {
-    server.handler = handler
+    final sessionHandler = new SessionHandler()
+    sessionHandler.handler = handler
+    server.handler = sessionHandler
     server.addBean(errorHandler)
+    server.addBean(sessionHandler.sessionIdManager, true)
   }
 
   @Override
@@ -46,6 +54,7 @@ class JettyServer implements HttpServer {
   static Handler servletHandler(Class<? extends Servlet> servlet) {
     // defaults to jakarta servlet
     ServletContextHandler handler = new ServletContextHandler(null, "/context-path")
+    handler.sessionHandler = new EE8SessionHandler()
     handler.errorHandler = errorHandler
     HttpServerTest.ServerEndpoint.values()
       .findAll { !(it in [NOT_FOUND, UNKNOWN]) }

--- a/dd-java-agent/instrumentation/jetty-12/src/test/ee8/groovy/JettyServer.groovy
+++ b/dd-java-agent/instrumentation/jetty-12/src/test/ee8/groovy/JettyServer.groovy
@@ -1,5 +1,3 @@
-import org.eclipse.jetty.session.DefaultSessionIdManager
-
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.UNKNOWN
 

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/RequestInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty70;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
@@ -10,14 +11,18 @@ import static datadog.trace.instrumentation.jetty70.JettyDecorator.DD_SERVLET_PA
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
 import net.bytebuddy.asm.Advice;
 import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
@@ -100,7 +105,23 @@ public final class RequestInstrumentation extends InstrumenterModule.Tracing
     public static void updateContextPath(
         @ActiveRequestContext RequestContext reqCtx,
         @Advice.Argument(0) final String requestedSessionId) {
-      JettyBlockingHelper.maybeBlockOnSession(reqCtx, requestedSessionId);
+      if (requestedSessionId != null && reqCtx != null) {
+        final CallbackProvider cbp =
+            AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        if (cbp == null) {
+          return;
+        }
+        final BiFunction<RequestContext, String, Flow<Void>> addrCallback =
+            cbp.getCallback(EVENTS.requestSession());
+        if (addrCallback == null) {
+          return;
+        }
+        final Flow<Void> flow = addrCallback.apply(reqCtx, requestedSessionId);
+        Flow.Action action = flow.getAction();
+        if (action instanceof Flow.Action.RequestBlockingAction) {
+          throw new BlockingException("Blocked request (for sessionId)");
+        }
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/RequestInstrumentation.java
@@ -10,9 +10,14 @@ import static datadog.trace.instrumentation.jetty70.JettyDecorator.DD_SERVLET_PA
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
 import net.bytebuddy.asm.Advice;
 import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Request;
@@ -38,6 +43,9 @@ public final class RequestInstrumentation extends InstrumenterModule.Tracing
     transformer.applyAdvice(
         named("setServletPath").and(takesArgument(0, String.class)),
         RequestInstrumentation.class.getName() + "$SetServletPathAdvice");
+    transformer.applyAdvice(
+        named("setRequestedSessionId").and(takesArgument(0, String.class)),
+        RequestInstrumentation.class.getName() + "$SetRequestedSessionId");
   }
 
   /**
@@ -79,6 +87,20 @@ public final class RequestInstrumentation extends InstrumenterModule.Tracing
 
     private void muzzleCheck(HttpConnection connection) {
       connection.getGenerator();
+    }
+  }
+
+  /**
+   * Because we are processing the initial request before the requestedSessionId is set, we must
+   * update it when it is actually set.
+   */
+  @RequiresRequestContext(RequestContextSlot.APPSEC)
+  public static class SetRequestedSessionId {
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void updateContextPath(
+        @ActiveRequestContext RequestContext reqCtx,
+        @Advice.Argument(0) final String requestedSessionId) {
+      JettyBlockingHelper.maybeBlockOnSession(reqCtx, requestedSessionId);
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/test/groovy/Jetty70Test.groovy
@@ -6,6 +6,7 @@ import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
 import org.eclipse.jetty.server.handler.ErrorHandler
+import org.eclipse.jetty.server.session.SessionHandler
 
 import javax.servlet.ServletException
 import javax.servlet.http.HttpServletRequest
@@ -21,7 +22,9 @@ abstract class Jetty70Test extends HttpServerTest<Server> {
     final server = new Server(0) // select random open port
 
     JettyServer() {
-      server.setHandler(handler())
+      final sessionHandler = new SessionHandler()
+      sessionHandler.handler = handler()
+      server.setHandler(sessionHandler)
       server.addBean(errorHandler)
     }
 
@@ -120,6 +123,11 @@ abstract class Jetty70Test extends HttpServerTest<Server> {
 
   @Override
   boolean testBlockingOnResponse() {
+    true
+  }
+
+  @Override
+  boolean testSessionId() {
     true
   }
 

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/RequestInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty76;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
@@ -10,14 +11,18 @@ import static datadog.trace.instrumentation.jetty76.JettyDecorator.DD_SERVLET_PA
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
 import net.bytebuddy.asm.Advice;
 import org.eclipse.jetty.server.AbstractHttpConnection;
 import org.eclipse.jetty.server.Request;
@@ -100,7 +105,23 @@ public final class RequestInstrumentation extends InstrumenterModule.Tracing
     public static void updateContextPath(
         @ActiveRequestContext RequestContext reqCtx,
         @Advice.Argument(0) final String requestedSessionId) {
-      JettyBlockingHelper.maybeBlockOnSession(reqCtx, requestedSessionId);
+      if (requestedSessionId != null && reqCtx != null) {
+        final CallbackProvider cbp =
+            AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        if (cbp == null) {
+          return;
+        }
+        final BiFunction<RequestContext, String, Flow<Void>> addrCallback =
+            cbp.getCallback(EVENTS.requestSession());
+        if (addrCallback == null) {
+          return;
+        }
+        final Flow<Void> flow = addrCallback.apply(reqCtx, requestedSessionId);
+        Flow.Action action = flow.getAction();
+        if (action instanceof Flow.Action.RequestBlockingAction) {
+          throw new BlockingException("Blocked request (for sessionId)");
+        }
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/test/groovy/Jetty76Test.groovy
@@ -6,6 +6,7 @@ import org.eclipse.jetty.server.Request
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
 import org.eclipse.jetty.server.handler.ErrorHandler
+import org.eclipse.jetty.server.session.SessionHandler
 
 import javax.servlet.ServletException
 import javax.servlet.http.HttpServletRequest
@@ -21,7 +22,9 @@ abstract class Jetty76Test extends HttpServerTest<Server> {
     final server = new Server(0) // select random open port
 
     JettyServer() {
-      server.setHandler(handler())
+      final sessionHandler = new SessionHandler()
+      sessionHandler.handler = handler()
+      server.setHandler(sessionHandler)
       server.addBean(errorHandler)
     }
 
@@ -121,6 +124,11 @@ abstract class Jetty76Test extends HttpServerTest<Server> {
 
   @Override
   boolean testBlockingOnResponse() {
+    true
+  }
+
+  @Override
+  boolean testSessionId() {
     true
   }
 

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty10/RequestInstrumentation.java
@@ -33,5 +33,8 @@ public final class RequestInstrumentation extends InstrumenterModule.Tracing
     transformer.applyAdvice(
         named("setServletPath").and(takesArgument(0, String.class)),
         packageName + ".SetServletPathAdvice");
+    transformer.applyAdvice(
+        named("setRequestedSessionId").and(takesArgument(0, String.class)),
+        packageName + ".SetRequestedSessionIdAdvice");
   }
 }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/RequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/RequestInstrumentation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.jetty9;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_CONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.SERVLET_PATH;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_DISPATCH_SPAN_ATTRIBUTE;
@@ -10,14 +11,18 @@ import static datadog.trace.instrumentation.jetty9.JettyDecorator.DD_SERVLET_PAT
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
 import javax.servlet.http.HttpServletRequest;
 import net.bytebuddy.asm.Advice;
 import org.eclipse.jetty.http.HttpFields;
@@ -110,7 +115,23 @@ public final class RequestInstrumentation extends InstrumenterModule.Tracing
     public static void updateContextPath(
         @ActiveRequestContext RequestContext reqCtx,
         @Advice.Argument(0) final String requestedSessionId) {
-      JettyBlockingHelper.maybeBlockOnSession(reqCtx, requestedSessionId);
+      if (requestedSessionId != null && reqCtx != null) {
+        final CallbackProvider cbp =
+            AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+        if (cbp == null) {
+          return;
+        }
+        final BiFunction<RequestContext, String, Flow<Void>> addrCallback =
+            cbp.getCallback(EVENTS.requestSession());
+        if (addrCallback == null) {
+          return;
+        }
+        final Flow<Void> flow = addrCallback.apply(reqCtx, requestedSessionId);
+        Flow.Action action = flow.getAction();
+        if (action instanceof Flow.Action.RequestBlockingAction) {
+          throw new BlockingException("Blocked request (for sessionId)");
+        }
+      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SetRequestedSessionIdAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SetRequestedSessionIdAdvice.java
@@ -1,10 +1,16 @@
 package datadog.trace.instrumentation.jetty10;
 
+import static datadog.trace.api.gateway.Events.EVENTS;
+
+import datadog.appsec.api.blocking.BlockingException;
 import datadog.trace.advice.ActiveRequestContext;
 import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.CallbackProvider;
+import datadog.trace.api.gateway.Flow;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
-import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.util.function.BiFunction;
 import net.bytebuddy.asm.Advice;
 
 /**
@@ -17,6 +23,21 @@ public class SetRequestedSessionIdAdvice {
   public static void setRequestedSessionId(
       @ActiveRequestContext RequestContext reqCtx,
       @Advice.Argument(0) final String requestedSessionId) {
-    JettyBlockingHelper.maybeBlockOnSession(reqCtx, requestedSessionId);
+    if (requestedSessionId != null && reqCtx != null) {
+      final CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
+      if (cbp == null) {
+        return;
+      }
+      final BiFunction<RequestContext, String, Flow<Void>> addrCallback =
+          cbp.getCallback(EVENTS.requestSession());
+      if (addrCallback == null) {
+        return;
+      }
+      final Flow<Void> flow = addrCallback.apply(reqCtx, requestedSessionId);
+      Flow.Action action = flow.getAction();
+      if (action instanceof Flow.Action.RequestBlockingAction) {
+        throw new BlockingException("Blocked request (for sessionId)");
+      }
+    }
   }
 }

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SetRequestedSessionIdAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/SetRequestedSessionIdAdvice.java
@@ -1,0 +1,22 @@
+package datadog.trace.instrumentation.jetty10;
+
+import datadog.trace.advice.ActiveRequestContext;
+import datadog.trace.advice.RequiresRequestContext;
+import datadog.trace.api.gateway.RequestContext;
+import datadog.trace.api.gateway.RequestContextSlot;
+import datadog.trace.instrumentation.jetty.JettyBlockingHelper;
+import net.bytebuddy.asm.Advice;
+
+/**
+ * Because we are processing the initial request before the requestedSessionId is set, we must
+ * update it when it is actually set.
+ */
+@RequiresRequestContext(RequestContextSlot.APPSEC)
+public class SetRequestedSessionIdAdvice {
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static void setRequestedSessionId(
+      @ActiveRequestContext RequestContext reqCtx,
+      @Advice.Argument(0) final String requestedSessionId) {
+    JettyBlockingHelper.maybeBlockOnSession(reqCtx, requestedSessionId);
+  }
+}

--- a/dd-java-agent/instrumentation/jetty-9/src/test/groovy/datadog/trace/instrumentation/jetty9/Jetty9Test.groovy
+++ b/dd-java-agent/instrumentation/jetty-9/src/test/groovy/datadog/trace/instrumentation/jetty9/Jetty9Test.groovy
@@ -5,12 +5,15 @@ import datadog.trace.agent.test.base.HttpServerTest
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.AbstractHandler
+import org.eclipse.jetty.server.session.SessionHandler
 
 abstract class Jetty9Test extends HttpServerTest<Server> {
 
   @Override
   HttpServer server() {
-    new JettyServer(handler())
+    final sessionHandler = new SessionHandler()
+    sessionHandler.handler = handler()
+    new JettyServer(sessionHandler)
   }
 
   AbstractHandler handler() {
@@ -75,6 +78,11 @@ abstract class Jetty9Test extends HttpServerTest<Server> {
 
   @Override
   boolean testBodyMultipart() {
+    true
+  }
+
+  @Override
+  boolean testSessionId() {
     true
   }
 }

--- a/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty/JettyBlockingHelper.java
+++ b/dd-java-agent/instrumentation/jetty-common/src/main/java/datadog/trace/instrumentation/jetty/JettyBlockingHelper.java
@@ -1,20 +1,15 @@
 package datadog.trace.instrumentation.jetty;
 
-import static datadog.trace.api.gateway.Events.EVENTS;
 import static java.lang.invoke.MethodHandles.collectArguments;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodType.methodType;
 
 import datadog.appsec.api.blocking.BlockingContentType;
 import datadog.appsec.api.blocking.BlockingException;
-import datadog.trace.api.gateway.CallbackProvider;
 import datadog.trace.api.gateway.Flow;
-import datadog.trace.api.gateway.RequestContext;
-import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.bootstrap.blocking.BlockingActionHelper;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -24,7 +19,6 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.function.BiFunction;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -246,26 +240,6 @@ public class JettyBlockingHelper {
       Request request, Response response, Flow.Action.RequestBlockingAction rba, AgentSpan span) {
     if (!block(request, response, rba, span)) {
       throw new BlockingException("Throwing after being unable to commit blocking response");
-    }
-  }
-
-  public static void maybeBlockOnSession(
-      final RequestContext reqCtx, final String requestedSessionId) {
-    if (requestedSessionId != null && reqCtx != null) {
-      final CallbackProvider cbp = AgentTracer.get().getCallbackProvider(RequestContextSlot.APPSEC);
-      if (cbp == null) {
-        return;
-      }
-      final BiFunction<RequestContext, String, Flow<Void>> addrCallback =
-          cbp.getCallback(EVENTS.requestSession());
-      if (addrCallback == null) {
-        return;
-      }
-      final Flow<Void> flow = addrCallback.apply(reqCtx, requestedSessionId);
-      Flow.Action action = flow.getAction();
-      if (action instanceof Flow.Action.RequestBlockingAction) {
-        throw new BlockingException("Blocked request (for sessionId)");
-      }
     }
   }
 }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/TestServlet2.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/test/groovy/TestServlet2.groovy
@@ -58,9 +58,9 @@ class TestServlet2 {
           case EXCEPTION:
             throw new Exception(endpoint.body)
           case SESSION_ID:
-            def session = req.getSession(true)
+            req.getSession(true)
             resp.status = endpoint.status
-            resp.writer.print(session.id)
+            resp.writer.print(req.requestedSessionId)
             break
         }
       }

--- a/dd-java-agent/instrumentation/servlet/request-3/src/testFixtures/groovy/datadog/trace/instrumentation/servlet3/TestServlet3.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/testFixtures/groovy/datadog/trace/instrumentation/servlet3/TestServlet3.groovy
@@ -119,9 +119,9 @@ class TestServlet3 {
           case CUSTOM_EXCEPTION:
             throw new InputMismatchException(endpoint.body)
           case SESSION_ID:
-            def session = req.getSession(true)
+            req.getSession(true)
             resp.status = endpoint.status
-            resp.writer.print(session.id)
+            resp.writer.print(req.requestedSessionId)
             break
         }
       }
@@ -204,9 +204,9 @@ class TestServlet3 {
               context.complete()
               break
             case SESSION_ID:
-              def session = req.getSession(true)
+              req.getSession(true)
               resp.status = endpoint.status
-              resp.writer.print(session.id)
+              resp.writer.print(req.requestedSessionId)
               context.complete()
               break
           }
@@ -263,9 +263,9 @@ class TestServlet3 {
               resp.writer.print('should not be reached')
               break
             case SESSION_ID:
-              def session = req.getSession(true)
+              req.getSession(true)
               resp.status = endpoint.status
-              resp.writer.print(session.id)
+              resp.writer.print(req.requestedSessionId)
               break
           }
         }

--- a/dd-java-agent/instrumentation/servlet/request-5/src/testFixtures/groovy/datadog/trace/instrumentation/servlet5/TestServlet5.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-5/src/testFixtures/groovy/datadog/trace/instrumentation/servlet5/TestServlet5.groovy
@@ -98,9 +98,9 @@ class TestServlet5 extends HttpServlet {
         case CUSTOM_EXCEPTION:
           throw new InputMismatchException(endpoint.body)
         case SESSION_ID:
-          def session = req.getSession(true)
+          req.getSession(true)
           resp.status = endpoint.status
-          resp.writer.print(session.id)
+          resp.writer.print(req.requestedSessionId)
           break
         default:
           resp.status = NOT_FOUND.status


### PR DESCRIPTION
# What Does This Do
Adds support for session tracking in all versions of jetty.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55559]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55559]: https://datadoghq.atlassian.net/browse/APPSEC-55559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ