### PR TITLE
Split SymDB payload when too large

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.sink;
 
 import com.datadog.debugger.symbol.Scope;
+import com.datadog.debugger.symbol.ScopeType;
 import com.datadog.debugger.symbol.ServiceVersion;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.MoshiHelper;
@@ -9,6 +10,8 @@ import datadog.trace.api.Config;
 import datadog.trace.util.TagsHelper;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -29,24 +32,30 @@ public class SymbolSink {
           + "\"service\": \"%s\",%n"
           + "\"runtimeId\": \"%s\"%n"
           + "}";
+  static final int MAX_SYMDB_UPLOAD_SIZE = 50 * 1024 * 1024;
 
   private final String serviceName;
   private final String env;
   private final String version;
   private final BatchUploader symbolUploader;
+  private final int maxPayloadSize;
   private final BatchUploader.MultiPartContent event;
   private final BlockingQueue<Scope> scopes = new ArrayBlockingQueue<>(CAPACITY);
   private final Stats stats = new Stats();
 
   public SymbolSink(Config config) {
-    this(config, new BatchUploader(config, config.getFinalDebuggerSymDBUrl(), RETRY_POLICY));
+    this(
+        config,
+        new BatchUploader(config, config.getFinalDebuggerSymDBUrl(), RETRY_POLICY),
+        MAX_SYMDB_UPLOAD_SIZE);
   }
 
-  SymbolSink(Config config, BatchUploader symbolUploader) {
+  SymbolSink(Config config, BatchUploader symbolUploader, int maxPayloadSize) {
     this.serviceName = TagsHelper.sanitize(config.getServiceName());
     this.env = TagsHelper.sanitize(config.getEnv());
     this.version = TagsHelper.sanitize(config.getVersion());
     this.symbolUploader = symbolUploader;
+    this.maxPayloadSize = maxPayloadSize;
     byte[] eventContent =
         String.format(
                 EVENT_FORMAT, TagsHelper.sanitize(config.getServiceName()), config.getRuntimeId())
@@ -87,13 +96,92 @@ public class SymbolSink {
     String json =
         SERVICE_VERSION_ADAPTER.toJson(
             new ServiceVersion(serviceName, env, version, "JAVA", scopesToSerialize));
-    LOGGER.debug("Sending {} jar scopes size={}", scopesToSerialize.size(), json.length());
-    updateStats(scopesToSerialize, json);
-    symbolUploader.uploadAsMultipart(
-        "",
-        event,
-        new BatchUploader.MultiPartContent(
-            json.getBytes(StandardCharsets.UTF_8), "file", "file.json"));
+    if (json.length() > maxPayloadSize) {
+      LOGGER.debug(
+          "Upload split is required for {} scopes: {}/{}",
+          scopesToSerialize.size(),
+          json.length(),
+          maxPayloadSize);
+      splitAndSend(scopesToSerialize);
+    } else {
+      LOGGER.debug("Sending {} jar scopes size={}", scopesToSerialize.size(), json.length());
+      updateStats(scopesToSerialize, json);
+      LOGGER.debug("SymbolSink stats: {}", stats);
+      symbolUploader.uploadAsMultipart(
+          "",
+          event,
+          new BatchUploader.MultiPartContent(
+              json.getBytes(StandardCharsets.UTF_8), "file", "file.json"));
+    }
+  }
+
+  /*
+   * Try to split recursively the scopes to send in smaller chunks
+   * first try by splitting the jar scopes, then by splitting the class scopes
+   * stopped the recursion when the scopes are small enough to be sent or <2 classes in one scope
+   */
+  private void splitAndSend(List<Scope> scopesToSerialize) {
+    if (scopesToSerialize.size() > 1) {
+      // try to split by jar scopes: one scope per request
+      if (scopesToSerialize.size() < BatchUploader.MAX_ENQUEUED_REQUESTS) {
+        for (Scope scope : scopesToSerialize) {
+          String json =
+              SERVICE_VERSION_ADAPTER.toJson(
+                  new ServiceVersion(
+                      serviceName, env, version, "JAVA", Collections.singletonList(scope)));
+          if (json.length() > maxPayloadSize) {
+            // this jar scope is still too big, split it by classes
+            LOGGER.debug(
+                "Upload split is required for jar scope {}: {}/{}",
+                scope.getName(),
+                json.length(),
+                maxPayloadSize);
+            splitAndSend(Collections.singletonList(scope));
+            continue;
+          }
+          LOGGER.debug("Sending {} jar scope size={}", scope.getName(), json.length());
+          updateStats(Collections.singletonList(scope), json);
+          symbolUploader.uploadAsMultipart(
+              "",
+              event,
+              new BatchUploader.MultiPartContent(
+                  json.getBytes(StandardCharsets.UTF_8), "file", "file.json"));
+        }
+      } else {
+        LOGGER.warn(
+            "Too many jar scopes to send, {} jar scopes, max is {}",
+            scopesToSerialize.size(),
+            BatchUploader.MAX_ENQUEUED_REQUESTS);
+      }
+    } else {
+      Scope jarScope = scopesToSerialize.get(0);
+      if (jarScope.getScopes() == null) {
+        LOGGER.debug("No class scopes to send for jar scope {}", jarScope.getName());
+        return;
+      }
+      if (jarScope.getScopes().size() < 2) {
+        LOGGER.warn(
+            "Cannot split jar scope with less than 2 classes scope: {}", jarScope.getName());
+        return;
+      }
+      // split the jar scope in 2 jar scopes with half of the class scopes
+      int half = jarScope.getScopes().size() / 2;
+      List<Scope> firstHalf = jarScope.getScopes().subList(0, half);
+      List<Scope> secondHalf = jarScope.getScopes().subList(half, jarScope.getScopes().size());
+      LOGGER.debug(
+          "split jar scope {} in 2 jar scopes: {} and {}",
+          jarScope.getName(),
+          firstHalf.size(),
+          secondHalf.size());
+      splitAndSend(
+          Arrays.asList(
+              createJarScope(jarScope.getName(), firstHalf),
+              createJarScope(jarScope.getName(), secondHalf)));
+    }
+  }
+
+  private static Scope createJarScope(String jarName, List<Scope> classScopes) {
+    return Scope.builder(ScopeType.JAR, jarName, 0, 0).name(jarName).scopes(classScopes).build();
   }
 
   private void updateStats(List<Scope> scopesToSerialize, String json) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -74,7 +74,7 @@ public class BatchUploader {
   private static final String HEADER_DD_ENTITY_ID = "Datadog-Entity-ID";
   static final String HEADER_DD_API_KEY = "DD-API-KEY";
   static final int MAX_RUNNING_REQUESTS = 10;
-  static final int MAX_ENQUEUED_REQUESTS = 20;
+  public static final int MAX_ENQUEUED_REQUESTS = 20;
   static final int TERMINATION_TIMEOUT = 5;
 
   private final String containerId;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.sink;
 
+import static com.datadog.debugger.sink.SymbolSink.MAX_SYMDB_UPLOAD_SIZE;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -10,7 +12,9 @@ import com.datadog.debugger.uploader.BatchUploader;
 import datadog.trace.api.Config;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 class SymbolSinkTest {
@@ -20,7 +24,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
-    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock);
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, MAX_SYMDB_UPLOAD_SIZE);
     symbolSink.addScope(Scope.builder(ScopeType.JAR, null, 0, 0).build());
     symbolSink.flush();
     assertEquals(2, symbolUploaderMock.multiPartContents.size());
@@ -43,17 +47,13 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
-    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock);
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, MAX_SYMDB_UPLOAD_SIZE);
     symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar1.jar", 0, 0).build());
     symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar2.jar", 0, 0).build());
     symbolSink.flush();
     // only 1 request because we are batching the scopes
     assertEquals(2, symbolUploaderMock.multiPartContents.size());
-    BatchUploader.MultiPartContent eventContent = symbolUploaderMock.multiPartContents.get(0);
-    assertEquals("event", eventContent.getPartName());
-    BatchUploader.MultiPartContent symbolContent = symbolUploaderMock.multiPartContents.get(1);
-    assertEquals("file", symbolContent.getPartName());
-    String strContent = new String(symbolContent.getContent());
+    String strContent = assertMultipartContent(symbolUploaderMock, 0);
     assertTrue(strContent.contains("\"source_file\":\"jar1.jar\""));
     assertTrue(strContent.contains("\"source_file\":\"jar2.jar\""));
   }
@@ -63,7 +63,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
-    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock);
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, MAX_SYMDB_UPLOAD_SIZE);
     for (int i = 0; i < SymbolSink.CAPACITY; i++) {
       symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar1.jar", 0, 0).build());
     }
@@ -79,6 +79,107 @@ class SymbolSinkTest {
     assertTrue(
         new String(symbolUploaderMock.multiPartContents.get(3).getContent())
             .contains("\"source_file\":\"jar2.jar\""));
+  }
+
+  @Test
+  public void splitByJarScopes() {
+    SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
+    Config config = mock(Config.class);
+    when(config.getServiceName()).thenReturn("service1");
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 1024);
+    final int NUM_JAR_SCOPES = 10;
+    for (int i = 0; i < NUM_JAR_SCOPES; i++) {
+      symbolSink.addScope(
+          Scope.builder(ScopeType.JAR, "jar" + i + ".jar", 0, 0)
+              .scopes(singletonList(Scope.builder(ScopeType.CLASS, "class" + i, 0, 0).build()))
+              .build());
+    }
+    symbolSink.flush();
+    // split upload request per jar scope
+    assertEquals(NUM_JAR_SCOPES * 2, symbolUploaderMock.multiPartContents.size());
+    for (int i = 0; i < NUM_JAR_SCOPES * 2; i += 2) {
+      String strContent = assertMultipartContent(symbolUploaderMock, i);
+      assertTrue(strContent.contains("\"source_file\":\"jar" + (i / 2) + ".jar\""));
+    }
+  }
+
+  @Test
+  public void splitByClassScopes() {
+    SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
+    Config config = mock(Config.class);
+    when(config.getServiceName()).thenReturn("service1");
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 1024);
+    final int NUM_CLASS_SCOPES = 10;
+    List<Scope> classScopes = new ArrayList<>();
+    for (int i = 0; i < NUM_CLASS_SCOPES; i++) {
+      classScopes.add(
+          Scope.builder(ScopeType.CLASS, "class" + i, 0, 0)
+              .scopes(
+                  Collections.singletonList(
+                      Scope.builder(ScopeType.METHOD, "class" + i, 0, 0)
+                          .name("method" + i)
+                          .build()))
+              .build());
+    }
+    symbolSink.addScope(
+        Scope.builder(ScopeType.JAR, "jar1.jar", 0, 0)
+            .name("jar1.jar")
+            .scopes(classScopes)
+            .build());
+    symbolSink.flush();
+    // split upload request per jar scope
+    final int EXPECTED_REQUESTS = 4;
+    assertEquals(EXPECTED_REQUESTS * 2, symbolUploaderMock.multiPartContents.size());
+    List<List<String>> expectedSourceFiles =
+        Arrays.asList(
+            Arrays.asList("class0", "class1"),
+            Arrays.asList("class2", "class3", "class4"),
+            Arrays.asList("class5", "class6"),
+            Arrays.asList("class7", "class8", "class9"));
+    for (int i = 0; i < EXPECTED_REQUESTS * 2; i += 2) {
+      String strContent = assertMultipartContent(symbolUploaderMock, i);
+      for (String sourceFile : expectedSourceFiles.get(i / 2)) {
+        assertTrue(strContent.contains("\"source_file\":\"" + sourceFile + "\""));
+      }
+    }
+  }
+
+  @Test
+  public void splitByClassScopesImpossible() {
+    SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
+    Config config = mock(Config.class);
+    when(config.getServiceName()).thenReturn("service1");
+    SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 1);
+    final int NUM_CLASS_SCOPES = 10;
+    List<Scope> classScopes = new ArrayList<>();
+    for (int i = 0; i < NUM_CLASS_SCOPES; i++) {
+      classScopes.add(
+          Scope.builder(ScopeType.CLASS, "class" + i, 0, 0)
+              .scopes(
+                  Collections.singletonList(
+                      Scope.builder(ScopeType.METHOD, "class" + i, 0, 0)
+                          .name("method" + i)
+                          .build()))
+              .build());
+    }
+    symbolSink.addScope(
+        Scope.builder(ScopeType.JAR, "jar1.jar", 0, 0)
+            .name("jar1.jar")
+            .scopes(classScopes)
+            .build());
+    symbolSink.flush();
+    // no request to upload because we cannot split the jar scope
+    assertTrue(symbolUploaderMock.multiPartContents.isEmpty());
+  }
+
+  @NotNull
+  private static String assertMultipartContent(SymbolUploaderMock symbolUploaderMock, int index) {
+    BatchUploader.MultiPartContent eventContent = symbolUploaderMock.multiPartContents.get(index);
+    assertEquals("event", eventContent.getPartName());
+    BatchUploader.MultiPartContent symbolContent =
+        symbolUploaderMock.multiPartContents.get(index + 1);
+    assertEquals("file", symbolContent.getPartName());
+    return new String(symbolContent.getContent());
   }
 
   static class SymbolUploaderMock extends BatchUploader {


### PR DESCRIPTION
# What Does This Do
SymDB payload cannot be larger than 50MB otherwise datadog agent will generate an error. When serializing the upload request we are now verifying that we are below this limit, otherwise we are splitting the payload first by uploading by jar scope, but if a jar scope is still large we are splitting by class scopes. If down to one class the payload is still too large we are dropping the upload.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3068]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3068]: https://datadoghq.atlassian.net/browse/DEBUG-3068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ