### PR TITLE
Add compression support for SymDB paylods

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/ProbeStatusSink.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.sink;
 
+import static com.datadog.debugger.uploader.BatchUploader.APPLICATION_JSON;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
 import com.datadog.debugger.agent.ProbeStatus;
@@ -104,7 +105,8 @@ public class ProbeStatusSink {
     for (byte[] batch : batches) {
       if (useMultiPart) {
         diagnosticUploader.uploadAsMultipart(
-            tags, new BatchUploader.MultiPartContent(batch, "event", "event.json"));
+            tags,
+            new BatchUploader.MultiPartContent(batch, "event", "event.json", APPLICATION_JSON));
       } else {
         diagnosticUploader.upload(batch, tags);
       }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SymbolSink.java
@@ -243,9 +243,11 @@ public class SymbolSink {
   }
 
   private void updateStats(List<Scope> scopesToSerialize, String json) {
+    int totalClasses = 0;
     for (Scope scope : scopesToSerialize) {
-      stats.updateStats(scope.getScopes() != null ? scope.getScopes().size() : 0, json.length());
+      totalClasses += scope.getScopes() != null ? scope.getScopes().size() : 0;
     }
+    stats.updateStats(totalClasses, json.length());
     LOGGER.debug("SymbolSink stats: {}", stats);
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/uploader/BatchUploader.java
@@ -38,11 +38,13 @@ public class BatchUploader {
     private final byte[] content;
     private final String partName;
     private final String fileName;
+    private final MediaType mediaType;
 
-    public MultiPartContent(byte[] content, String partName, String fileName) {
+    public MultiPartContent(byte[] content, String partName, String fileName, MediaType mediaType) {
       this.content = content;
       this.partName = partName;
       this.fileName = fileName;
+      this.mediaType = mediaType;
     }
 
     public byte[] getContent() {
@@ -55,6 +57,10 @@ public class BatchUploader {
 
     public String getFileName() {
       return fileName;
+    }
+
+    public MediaType getMediaType() {
+      return mediaType;
     }
   }
 
@@ -69,13 +75,14 @@ public class BatchUploader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BatchUploader.class);
   private static final int MINUTES_BETWEEN_ERROR_LOG = 5;
-  private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
   private static final String HEADER_DD_CONTAINER_ID = "Datadog-Container-ID";
   private static final String HEADER_DD_ENTITY_ID = "Datadog-Entity-ID";
   static final String HEADER_DD_API_KEY = "DD-API-KEY";
   static final int MAX_RUNNING_REQUESTS = 10;
   public static final int MAX_ENQUEUED_REQUESTS = 20;
   static final int TERMINATION_TIMEOUT = 5;
+  public static final MediaType APPLICATION_JSON = MediaType.get("application/json");
+  public static final MediaType APPLICATION_GZIP = MediaType.get("application/gzip");
 
   private final String containerId;
   private final String entityId;
@@ -182,7 +189,7 @@ public class BatchUploader {
   }
 
   private int addPart(MultipartBody.Builder builder, MultiPartContent part) {
-    RequestBody fileBody = RequestBody.create(APPLICATION_JSON, part.content);
+    RequestBody fileBody = RequestBody.create(part.mediaType, part.content);
     builder.addFormDataPart(part.partName, part.fileName, fileBody);
     return part.content.length;
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/sink/SymbolSinkTest.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 class SymbolSinkTest {
@@ -24,6 +23,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
+    when(config.isDebuggerSymbolCompressed()).thenReturn(false);
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, MAX_SYMDB_UPLOAD_SIZE);
     symbolSink.addScope(Scope.builder(ScopeType.JAR, null, 0, 0).build());
     symbolSink.flush();
@@ -47,6 +47,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
+    when(config.isDebuggerSymbolCompressed()).thenReturn(false);
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, MAX_SYMDB_UPLOAD_SIZE);
     symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar1.jar", 0, 0).build());
     symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar2.jar", 0, 0).build());
@@ -63,6 +64,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
+    when(config.isDebuggerSymbolCompressed()).thenReturn(false);
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, MAX_SYMDB_UPLOAD_SIZE);
     for (int i = 0; i < SymbolSink.CAPACITY; i++) {
       symbolSink.addScope(Scope.builder(ScopeType.JAR, "jar1.jar", 0, 0).build());
@@ -86,6 +88,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
+    when(config.isDebuggerSymbolCompressed()).thenReturn(false);
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 1024);
     final int NUM_JAR_SCOPES = 10;
     for (int i = 0; i < NUM_JAR_SCOPES; i++) {
@@ -108,6 +111,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
+    when(config.isDebuggerSymbolCompressed()).thenReturn(false);
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 2048);
     final int NUM_JAR_SCOPES = 21;
     for (int i = 0; i < NUM_JAR_SCOPES; i++) {
@@ -132,6 +136,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
+    when(config.isDebuggerSymbolCompressed()).thenReturn(false);
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 1024);
     final int NUM_CLASS_SCOPES = 10;
     List<Scope> classScopes = new ArrayList<>();
@@ -173,6 +178,7 @@ class SymbolSinkTest {
     SymbolUploaderMock symbolUploaderMock = new SymbolUploaderMock();
     Config config = mock(Config.class);
     when(config.getServiceName()).thenReturn("service1");
+    when(config.isDebuggerSymbolCompressed()).thenReturn(false);
     SymbolSink symbolSink = new SymbolSink(config, symbolUploaderMock, 1);
     final int NUM_CLASS_SCOPES = 10;
     List<Scope> classScopes = new ArrayList<>();
@@ -196,7 +202,6 @@ class SymbolSinkTest {
     assertTrue(symbolUploaderMock.multiPartContents.isEmpty());
   }
 
-  @NotNull
   private static String assertMultipartContent(SymbolUploaderMock symbolUploaderMock, int index) {
     BatchUploader.MultiPartContent eventContent = symbolUploaderMock.multiPartContents.get(index);
     assertEquals("event", eventContent.getPartName());

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.verification.VerificationMode;
 
 /** Unit tests for the snapshot uploader. */
 @ExtendWith(MockitoExtension.class)

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.verification.VerificationMode;
 
 /** Unit tests for the snapshot uploader. */
 @ExtendWith(MockitoExtension.class)
@@ -120,7 +123,7 @@ public class BatchUploaderTest {
 
     // Shutting down uploader ensures all callbacks are called on http client
     uploader.shutdown();
-    verify(ratelimitedLogger)
+    verify(ratelimitedLogger, atLeastOnce())
         .warn(
             eq("Failed to upload batch to {}"),
             ArgumentMatchers.argThat(arg -> arg.toString().startsWith(url.toString())),

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/uploader/BatchUploaderTest.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.uploader;
 
+import static com.datadog.debugger.uploader.BatchUploader.APPLICATION_JSON;
 import static com.datadog.debugger.uploader.BatchUploader.HEADER_DD_API_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -277,7 +278,8 @@ public class BatchUploaderTest {
   public void testUploadMultiPart() throws InterruptedException {
     server.enqueue(RESPONSE_200);
     uploader.uploadAsMultipart(
-        "", new BatchUploader.MultiPartContent(SNAPSHOT_BUFFER, "file", "file.json"));
+        "",
+        new BatchUploader.MultiPartContent(SNAPSHOT_BUFFER, "file", "file.json", APPLICATION_JSON));
     RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
     assertNotNull(recordedRequest);
     String strBody = recordedRequest.getBody().readUtf8();

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -178,6 +178,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DEBUGGER_SYMBOL_ENABLED = false;
   static final boolean DEFAULT_DEBUGGER_SYMBOL_FORCE_UPLOAD = false;
   static final int DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD = 100; // nb of classes
+  static final boolean DEFAULT_DEBUGGER_SYMBOL_COMPRESSED = true;
   static final boolean DEFAULT_DEBUGGER_EXCEPTION_ENABLED = false;
   static final int DEFAULT_DEBUGGER_MAX_EXCEPTION_PER_SECOND = 100;
   static final boolean DEFAULT_DEBUGGER_EXCEPTION_ONLY_LOCAL_ROOT = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -32,6 +32,7 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_SYMBOL_FORCE_UPLOAD = "internal.force.symbol.database.upload";
   public static final String DEBUGGER_SYMBOL_INCLUDES = "symbol.database.includes";
   public static final String DEBUGGER_SYMBOL_FLUSH_THRESHOLD = "symbol.database.flush.threshold";
+  public static final String DEBUGGER_SYMBOL_COMPRESSED = "symbol.database.compressed";
   public static final String DEBUGGER_EXCEPTION_ENABLED = "exception.debugging.enabled";
   public static final String EXCEPTION_REPLAY_ENABLED = "exception.replay.enabled";
   public static final String DEBUGGER_MAX_EXCEPTION_PER_SECOND =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -394,6 +394,7 @@ public class Config {
   private final boolean debuggerSymbolForceUpload;
   private final String debuggerSymbolIncludes;
   private final int debuggerSymbolFlushThreshold;
+  private final boolean debuggerSymbolCompressed;
   private final boolean debuggerExceptionEnabled;
   private final int debuggerMaxExceptionPerSecond;
   @Deprecated private final boolean debuggerExceptionOnlyLocalRoot;
@@ -1513,6 +1514,8 @@ public class Config {
     debuggerSymbolFlushThreshold =
         configProvider.getInteger(
             DEBUGGER_SYMBOL_FLUSH_THRESHOLD, DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD);
+    debuggerSymbolCompressed =
+        configProvider.getBoolean(DEBUGGER_SYMBOL_COMPRESSED, DEFAULT_DEBUGGER_SYMBOL_COMPRESSED);
     debuggerExceptionEnabled =
         configProvider.getBoolean(
             DEBUGGER_EXCEPTION_ENABLED,
@@ -2909,12 +2912,12 @@ public class Config {
     return debuggerSymbolForceUpload;
   }
 
-  public String getDebuggerSymbolIncludes() {
-    return debuggerSymbolIncludes;
-  }
-
   public int getDebuggerSymbolFlushThreshold() {
     return debuggerSymbolFlushThreshold;
+  }
+
+  public boolean isDebuggerSymbolCompressed() {
+    return debuggerSymbolCompressed;
   }
 
   public boolean isDebuggerExceptionEnabled() {


### PR DESCRIPTION
# What Does This Do
Add support of SymDB payload compresion using gzip. an option is still available to disable compression.
The usual factor of compression is 40:1 which is very effective for json payload and therefore reaching the 50MB limitation is very unlikely.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3074]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3074]: https://datadoghq.atlassian.net/browse/DEBUG-3074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ