### PR TITLE
Adding crash tracking to integration tests

### DIFF
--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/PortUtils.java
@@ -115,7 +115,17 @@ public class PortUtils {
       }
 
       if (!process.isAlive()) {
-        throw new RuntimeException("Process died before port " + port + " was opened");
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+          throw new RuntimeException(
+              "Process exited abnormally exitCode="
+                  + exitCode
+                  + " before port="
+                  + port
+                  + " was opened");
+        } else {
+          throw new RuntimeException("Process finished before port=" + port + " was opened");
+        }
       }
 
       if (isPortOpen(port)) {

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -164,13 +164,18 @@ abstract class AbstractSmokeTest extends ProcessManager {
     "-Ddd.version=${VERSION}"
   ]
 
+  def testCrashTracking() {
+    return true
+  }
 
   def javaProperties() {
+    def tmpDir = "/tmp"
+
     def ret = [
       "${getMaxMemoryArgumentForFork()}",
       "${getMinMemoryArgumentForFork()}",
       "-javaagent:${shadowJarPath}",
-      isIBM ? "-Xdump:directory=/tmp" : "-XX:ErrorFile=/tmp/hs_err_pid%p.log",
+      isIBM ? "-Xdump:directory=${tmpDir}" : "-XX:ErrorFile=${tmpDir}/hs_err_pid%p.log",
       "-Ddd.trace.agent.port=${server.address.port}",
       "-Ddd.env=${ENV}",
       "-Ddd.version=${VERSION}",
@@ -190,7 +195,18 @@ abstract class AbstractSmokeTest extends ProcessManager {
     if (testTelemetry()) {
       ret += "-Ddd.telemetry.heartbeat.interval=5"
     }
+    // DQH - Nov 2024 - skipping for J9 which doesn't have full crash tracking support
+    if (testCrashTracking() && !Platform.isJ9()) {
+      def extension = getScriptExtension()
+      ret += "-XX:OnError=\"${tmpDir}/dd_crash_uploader.${extension} %p\""
+      // Unlike crash tracking smoke test, keep the default delay; otherwise, otherwise other tests will fail
+      // ret += "-Ddd.dogstatsd.start-delay=0"
+    }
     ret as String[]
+  }
+
+  static String getScriptExtension() {
+    return Platform.isWindows() ? "bat" : "sh"
   }
 
   def inferServiceName() {

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -196,6 +196,18 @@ abstract class ProcessManager extends Specification {
       outputThreads.captureOutput(p, new File(logFilePaths[idx]))
     }
     testedProcess = numberOfProcesses == 1 ? testedProcesses[0] : null
+
+
+    (0..<numberOfProcesses).each { idx ->
+      def curProc = testedProcesses[idx]
+
+      if ( !curProc.isAlive() && curProc.exitValue() != 0 ) {
+        def exitCode = curProc.exitValue()
+        def logFile = logFilePaths[idx]
+
+        throw new RuntimeException("Process exited abormally - exitCode:${exitCode}; logFile=${logFile}")
+      }
+    }
   }
 
   String javaPath() {


### PR DESCRIPTION
# What Does This Do
Adds crash tracking into integration tests

# Motivation
Now that single step installer is using crash tracking, want to expand crash tracking coverage in CI

# Additional Notes
For now, crash tracking is selectively enabled for a subset of integration tests.

The intention is that future pull requests will broadened the coverage.
Right now, the means of argument construction is incompatible with the tests that pass arguments via JAVA_TOOL_OPTIONS.
IAST tests have also been excluded
