### PR TITLE
Fixed remote config update operation

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/CurrentAppSecConfig.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/config/CurrentAppSecConfig.java
@@ -88,7 +88,6 @@ public class CurrentAppSecConfig {
 
     Map<String, Object> mso = new HashMap<>();
     if (dirtyStatus.rules) {
-      mso.put("metadata", ddConfig.getRawConfig().getOrDefault("metadata", Collections.emptyMap()));
       mso.put("rules", ddConfig.getRawConfig().getOrDefault("rules", Collections.emptyList()));
       mso.put(
           "processors",
@@ -115,6 +114,10 @@ public class CurrentAppSecConfig {
     }
 
     mso.put("version", ddConfig.getVersion() == null ? "2.1" : ddConfig.getVersion());
+
+    if (dirtyStatus.isAnyDirty()) {
+      mso.put("metadata", ddConfig.getRawConfig().getOrDefault("metadata", Collections.emptyMap()));
+    }
 
     if (log.isDebugEnabled()) {
       log.debug(
@@ -220,11 +223,9 @@ public class CurrentAppSecConfig {
   }
 
   private List<Map<String, Object>> getMergedCustomRules() {
-    List<Map<String, Object>> customRules =
-        this.userConfigs.stream()
-            .map(uc -> uc.customRules)
-            .reduce(Collections.emptyList(), CurrentAppSecConfig::mergeMapsByIdKeepLatest);
-    return customRules;
+    return this.userConfigs.stream()
+        .map(uc -> uc.customRules)
+        .reduce(Collections.emptyList(), CurrentAppSecConfig::mergeMapsByIdKeepLatest);
   }
 
   private List<Map<String, Object>> getMergedExclusions() {


### PR DESCRIPTION
# What Does This Do
Remote config merge set metadata in all cases.

# Motivation
After updating remote config, tracer doesn't report `_dd.appsec.event_rules.version` because of missing metadata.

# Additional Notes
Issue found with test from [PR-3256](https://github.com/DataDog/system-tests/pull/3256)

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
