### PR TITLE
Optionally run a one-time on-initialization JMX fetch action

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/JmxFetchConfig.java
@@ -12,6 +12,7 @@ public final class JmxFetchConfig {
   public static final String JMX_FETCH_START_DELAY = "jmxfetch.start-delay";
   public static final String JMX_FETCH_CONFIG_DIR = "jmxfetch.config.dir";
   public static final String JMX_FETCH_CONFIG = "jmxfetch.config";
+  public static final String JMX_FETCH_INIT_ACTION = "jmxfetch.init-action";
   @Deprecated public static final String JMX_FETCH_METRICS_CONFIGS = "jmxfetch.metrics-configs";
   public static final String JMX_FETCH_CHECK_PERIOD = "jmxfetch.check-period";
   public static final String JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -206,6 +206,7 @@ public class Config {
   private final Integer jmxFetchStatsdPort;
   private final boolean jmxFetchMultipleRuntimeServicesEnabled;
   private final int jmxFetchMultipleRuntimeServicesLimit;
+  private final String jmxFetchInitAction;
 
   // These values are default-ed to those of jmx fetch values as needed
   private final boolean healthMetricsEnabled;
@@ -976,6 +977,7 @@ public class Config {
     jmxFetchInitialRefreshBeansPeriod =
         configProvider.getInteger(JMX_FETCH_INITIAL_REFRESH_BEANS_PERIOD);
     jmxFetchRefreshBeansPeriod = configProvider.getInteger(JMX_FETCH_REFRESH_BEANS_PERIOD);
+    jmxFetchInitAction = configProvider.getString(JMX_FETCH_INIT_ACTION);
 
     jmxFetchStatsdPort = configProvider.getInteger(JMX_FETCH_STATSD_PORT, DOGSTATSD_PORT);
     jmxFetchStatsdHost =
@@ -2158,6 +2160,11 @@ public class Config {
   public int getJmxFetchMultipleRuntimeServicesLimit() {
     return jmxFetchMultipleRuntimeServicesLimit;
   }
+
+  public String getJmxFetchInitAction() {
+    return jmxFetchInitAction;
+  }
+
 
   public boolean isHealthMetricsEnabled() {
     return healthMetricsEnabled;
@@ -4130,6 +4137,9 @@ public class Config {
         + jmxFetchMultipleRuntimeServicesEnabled
         + ", jmxFetchMultipleRuntimeServicesLimit="
         + jmxFetchMultipleRuntimeServicesLimit
+        + ", jmxFetchInitAction='"
+        + jmxFetchInitAction
+        + '\''
         + ", healthMetricsEnabled="
         + healthMetricsEnabled
         + ", healthMetricsStatsdHost='"


### PR DESCRIPTION
# What Does This Do

Adds a feature to jmxfetch to run a one-time on-initialization action (e.g.: `list_everything`) within jmxfetch at the start of the collection thread.

# Motivation

This can be helpful for enumerating available JMX beans within the JVM when it is difficult to do otherwise.

# Additional Notes

## Usage examples

System property:

```
-Ddd.jmxfetch.init-action=list_with_metrics
```

Environment variable:

```
DD_JMXFETCH_INIT_ACTION=list_everything
```

This will use the ConsoleReporter in jmxfetch, which logs the output at `info` level. By default, if there's no explicit jmxfetch log configuration, this will set the ConsoleReporter log level to `info` to ensure it is visible without additional configuration.

This requires an updated jmxfetch with AppConfig's @Builder configured with toBuilder=true (see https://github.com/deejgregor/jmxfetch/commit/299680e7206fbce7a4665d1edd97cd4ac93dc172).

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
