### PR TITLE
Fix `Where` conversion for CodeOrigin probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
@@ -68,7 +68,7 @@ public class Where {
             lineWhere.typeName,
             method.name,
             Types.descriptorToSignature(method.desc),
-            new SourceLine[0],
+            (SourceLine[]) null,
             null);
       }
     }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
@@ -334,6 +334,11 @@ public class CapturingTestBase {
   }
 
   public static LogProbe.Builder createProbeBuilder(
+      ProbeId id, String typeName, String methodName, String signature) {
+    return createProbeBuilder(id, typeName, methodName, signature, (String[]) null);
+  }
+
+  public static LogProbe.Builder createProbeBuilder(
       ProbeId id, String typeName, String methodName, String signature, String... lines) {
     return LogProbe.builder()
         .language(LANGUAGE)

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/WhereTest.java
@@ -1,6 +1,7 @@
 package com.datadog.debugger.probe;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -94,7 +95,7 @@ public class WhereTest {
     assertEquals("java.util.Map", whereMapPut.getTypeName());
     assertEquals("put", whereMapPut.getMethodName());
     assertEquals("(java.lang.Object, java.lang.Object)", whereMapPut.getSignature());
-    assertEquals(0, whereMapPut.getLines().length);
+    assertNull(whereMapPut.getLines());
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
Conversion must create a Where instance with no SourceLine (null)

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
