### PR TITLE
Add _dd.dbm_trace_injected tag to SQL Server prepared statements

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/AbstractPreparedStatementInstrumentation.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jdbc;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.bootstrap.instrumentation.api.InstrumentationTags.DBM_TRACE_INJECTED;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DATABASE_QUERY;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.DECORATE;
 import static datadog.trace.instrumentation.jdbc.JDBCDecorator.INJECT_COMMENT;
@@ -84,6 +85,7 @@ public abstract class AbstractPreparedStatementInstrumentation extends Instrumen
           final long spanID = DECORATE.setContextInfo(connection, dbInfo);
           // we then force that pre-determined span ID for the span covering the actual query
           span = AgentTracer.get().buildSpan(DATABASE_QUERY).withSpanId(spanID).start();
+          span.setTag(DBM_TRACE_INJECTED, true);
         } else {
           span = startSpan(DATABASE_QUERY);
         }

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/StatementInstrumentation.java
@@ -93,7 +93,6 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
           final long spanID = DECORATE.setContextInfo(connection, dbInfo);
           // we then force that pre-determined span ID for the span covering the actual query
           span = AgentTracer.get().buildSpan(DATABASE_QUERY).withSpanId(spanID).start();
-          span.setTag(DBM_TRACE_INJECTED, true);
         } else {
           span = startSpan(DATABASE_QUERY);
         }
@@ -101,13 +100,15 @@ public final class StatementInstrumentation extends InstrumenterModule.Tracing
         DECORATE.afterStart(span);
         DECORATE.onConnection(span, dbInfo);
         final String copy = sql;
-        if (span != null && INJECT_COMMENT && !isSqlServer) {
+        if (span != null && INJECT_COMMENT) {
           String traceParent = null;
 
           if (injectTraceContext) {
             Integer priority = span.forceSamplingDecision();
             if (priority != null) {
-              traceParent = DECORATE.traceParent(span, priority);
+              if (!isSqlServer) {
+                traceParent = DECORATE.traceParent(span, priority);
+              }
               // set the dbm trace injected tag on the span
               span.setTag(DBM_TRACE_INJECTED, true);
             }

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/RemoteJDBCInstrumentationTest.groovy
@@ -346,7 +346,8 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
     then:
     resultSet.next()
     resultSet.getInt(1) == 3
-    if (driver == POSTGRESQL || driver == MYSQL || !dbmTraceInjected()) {
+    def addDbmTag = dbmTraceInjected()
+    if (driver == POSTGRESQL || driver == MYSQL || !addDbmTag) {
       assertTraces(1) {
         trace(2) {
           basicSpan(it, "parent")
@@ -401,6 +402,9 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
               "$Tags.DB_OPERATION" operation
               if (usingHikari) {
                 "$Tags.DB_POOL_NAME" String
+              }
+              if (addDbmTag) {
+                "$InstrumentationTags.DBM_TRACE_INJECTED" true
               }
               peerServiceFrom(Tags.DB_INSTANCE)
               defaultTags()
@@ -526,6 +530,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
               if (conPoolType == "hikari") {
                 "$Tags.DB_POOL_NAME" String
               }
+              "$InstrumentationTags.DBM_TRACE_INJECTED" true
               peerServiceFrom(Tags.DB_INSTANCE)
               defaultTags()
             }
@@ -645,6 +650,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
               if (conPoolType == "hikari") {
                 "$Tags.DB_POOL_NAME" String
               }
+              "$InstrumentationTags.DBM_TRACE_INJECTED" true
               defaultTags()
             }
           }
@@ -774,6 +780,7 @@ abstract class RemoteJDBCInstrumentationTest extends VersionedNamingTestBase {
               if (conPoolType == "hikari") {
                 "$Tags.DB_POOL_NAME" String
               }
+              "$InstrumentationTags.DBM_TRACE_INJECTED" true
               peerServiceFrom(Tags.DB_INSTANCE)
               defaultTags()
             }


### PR DESCRIPTION
# What Does This Do

Add `_dd.dbm_trace_injected` tag to `PreperedStatement` advisor for SQL Server.

# Motivation

Full mode APM/DBM support for prepared statements.

![image](https://github.com/user-attachments/assets/2dc0c118-ecfa-421c-b50b-5478ba83a24f)

![image](https://github.com/user-attachments/assets/a7bab4e6-22a7-4d5c-a506-18ae3e54ded5)


# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
