### PR TITLE
[🍒 7866] Remove hadoop from the denylist

### DIFF
--- a/metadata/denied-environment-variables.tsv
+++ b/metadata/denied-environment-variables.tsv
@@ -1,5 +1,4 @@
 # Identifier    EnvironmentVariable     Description
 apache_hbase    HBASE_HOME              Skip Apache HBase
-apache_hadoop3  HADOOP_HOME             Skip Apache Hadoop 3
 apache_hive     HIVE_HOME               Skip Apache Hive
 apache_solr9    SOLR_PORT               Skip Apache Solr 9

--- a/metadata/requirements.json
+++ b/metadata/requirements.json
@@ -350,18 +350,6 @@
       }
     },
     {
-      "id": "apache_hadoop3",
-      "description": "Skip Apache Hadoop 3",
-      "os": null,
-      "cmds": [
-        "**/java"
-      ],
-      "args": [],
-      "envars": {
-        "HADOOP_HOME": null
-      }
-    },
-    {
       "id": "apache_hive",
       "description": "Skip Apache Hive",
       "os": null,


### PR DESCRIPTION
# What Does This Do
Cherry pick https://github.com/DataDog/dd-trace-java/pull/7866

# Motivation
DJM relies on the Hadoop instrumentation to integrate with Spark jobs. We didn't originally consider DJM to be in scope for SSI, hence the original addition. However as some customers are already using DJM with SSI we are removing it from the list.

# Additional Notes
DJM will add additional integration tests for the integration and SSI at a later date

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
