### PR TITLE
Exclude lettuce-6.5.0.RELEASE from muzzle check

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-5/build.gradle
+++ b/dd-java-agent/instrumentation/lettuce-5/build.gradle
@@ -5,6 +5,7 @@ muzzle {
     module = "lettuce-core"
     versions = "[5.0.0.RELEASE,)"
     assertInverse = true
+    skipVersions = ["6.5.0.RELEASE"]
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Excludes lettuce-6.5.0.RELEASE from muzzle check

# Motivation

Fix breaking muzzle check

# Additional Notes

https://github.com/redis/lettuce/releases/tag/6.5.0.RELEASE

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
