### PR TITLE
Support lettuce 6.5

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-5/build.gradle
+++ b/dd-java-agent/instrumentation/lettuce-5/build.gradle
@@ -5,7 +5,6 @@ muzzle {
     module = "lettuce-core"
     versions = "[5.0.0.RELEASE,)"
     assertInverse = true
-    skipVersions = ["6.5.0.RELEASE"]
   }
 }
 
@@ -23,7 +22,7 @@ dependencies {
   testImplementation project(':dd-java-agent:instrumentation:reactive-streams')
 
 
-  latestDepTestImplementation group: 'io.lettuce', name: 'lettuce-core', version: '5.+'
+  latestDepTestImplementation group: 'io.lettuce', name: 'lettuce-core', version: '+'
 
   tasks.withType(Test).configureEach {
     usesService(testcontainersLimit)

--- a/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceInstrumentationUtil.java
+++ b/dd-java-agent/instrumentation/lettuce-5/src/main/java/datadog/trace/instrumentation/lettuce5/LettuceInstrumentationUtil.java
@@ -70,7 +70,7 @@ public class LettuceInstrumentationUtil {
 
       // get the redis command name (i.e. GET, SET, HMSET, etc)
       if (command.getType() != null) {
-        commandName = command.getType().name().trim();
+        commandName = command.getType().toString().trim();
       }
     }
     return commandName;


### PR DESCRIPTION
# What Does This Do

Add support for lettuce 6.5 and extend testing.

Avoid using `name` while using `toString` (generally works ok on previous versions since commandKeyword are enums and toString is not overridden)

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
