### PR TITLE
Do not force-disable TLAB allocation events on JDK 8

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
+++ b/dd-java-agent/agent-profiling/profiling-controller-openjdk/src/main/java/com/datadog/profiling/controller/openjdk/OpenJdkController.java
@@ -265,6 +265,8 @@ public final class OpenJdkController implements Controller {
 
     // Register periodic events
     AvailableProcessorCoresEvent.register();
+
+    log.debug("JFR Recording Settings: {}", recordingSettings);
   }
 
   private static String getJfrRepositoryBase(ConfigProvider configProvider) {

--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfilerConfig.java
@@ -172,19 +172,23 @@ public class DatadogProfilerConfig {
   }
 
   public static boolean isAllocationProfilingEnabled(ConfigProvider configProvider) {
-    boolean dflt = isJmethodIDSafe();
-    boolean enableDdprofAlloc =
-        getBoolean(
-            configProvider,
-            PROFILING_ALLOCATION_ENABLED,
-            dflt,
-            PROFILING_DATADOG_PROFILER_ALLOC_ENABLED);
+    // JVMTI Allocation Sampler is available since Java 11
+    if (Platform.isJavaVersionAtLeast(11)) {
+      boolean dflt = isJmethodIDSafe();
+      boolean enableDdprofAlloc =
+          getBoolean(
+              configProvider,
+              PROFILING_ALLOCATION_ENABLED,
+              dflt,
+              PROFILING_DATADOG_PROFILER_ALLOC_ENABLED);
 
-    if (!dflt && enableDdprofAlloc) {
-      log.warn(
-          "Allocation profiling was enabled although it is not considered stable on this JVM version.");
+      if (!dflt && enableDdprofAlloc) {
+        log.warn(
+            "Allocation profiling was enabled although it is not considered stable on this JVM version.");
+      }
+      return enableDdprofAlloc;
     }
-    return enableDdprofAlloc;
+    return false;
   }
 
   public static boolean isAllocationProfilingEnabled() {


### PR DESCRIPTION
# What Does This Do
Adjusts the DatadogProfiler configuration code not to force-disable TLAB allocation events on JDK 8

# Motivation
Currently it is not possible to run DD Java profiler and have allocation profiling at the same time, even with manually enabled TLAB allocation events. The reason is that Java profiler incorrectly assumes that it can provide the allocation profiling feature and proactively disables the TLAB allocation events, which can be particularly expensive, depending on the application.

The change is to make Java profiler aware of the fact that on Java 8 it can not provide the allocation profiling feature.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-10847]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
