### PR TITLE
Consult the environment variable when setting the max users frames in code origin probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -100,7 +100,7 @@ public class DebuggerAgent {
       DebuggerContext.initExceptionDebugger(defaultExceptionDebugger);
     }
     if (config.isDebuggerCodeOriginEnabled()) {
-      DebuggerContext.initCodeOrigin(new DefaultCodeOriginRecorder(configurationUpdater));
+      DebuggerContext.initCodeOrigin(new DefaultCodeOriginRecorder(config, configurationUpdater));
     }
     if (config.isDebuggerInstrumentTheWorld()) {
       setupInstrumentTheWorldTransformer(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
@@ -6,6 +6,7 @@ import com.datadog.debugger.agent.ConfigurationUpdater;
 import com.datadog.debugger.exception.Fingerprinter;
 import com.datadog.debugger.probe.CodeOriginProbe;
 import com.datadog.debugger.probe.Where;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.DebuggerContext.CodeOriginRecorder;
@@ -34,8 +35,9 @@ public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
 
   private final AgentTaskScheduler taskScheduler = AgentTaskScheduler.INSTANCE;
 
-  public DefaultCodeOriginRecorder(ConfigurationUpdater configurationUpdater) {
+  public DefaultCodeOriginRecorder(Config config, ConfigurationUpdater configurationUpdater) {
     this.configurationUpdater = configurationUpdater;
+    CodeOriginProbe.MAX_FRAMES = config.getDebuggerCodeOriginMaxUserFrames();
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCodeOriginRecorder.class);
 
+  private final Config config;
+
   private final ConfigurationUpdater configurationUpdater;
 
   private final Map<String, CodeOriginProbe> fingerprints = new HashMap<>();
@@ -36,8 +38,8 @@ public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
   private final AgentTaskScheduler taskScheduler = AgentTaskScheduler.INSTANCE;
 
   public DefaultCodeOriginRecorder(Config config, ConfigurationUpdater configurationUpdater) {
+    this.config = config;
     this.configurationUpdater = configurationUpdater;
-    CodeOriginProbe.MAX_FRAMES = config.getDebuggerCodeOriginMaxUserFrames();
   }
 
   @Override
@@ -61,7 +63,10 @@ public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
 
       probe =
           new CodeOriginProbe(
-              new ProbeId(UUID.randomUUID().toString(), 0), where.getSignature(), where);
+              new ProbeId(UUID.randomUUID().toString(), 0),
+              where.getSignature(),
+              where,
+              config.getDebuggerCodeOriginMaxUserFrames());
       addFingerprint(fingerprint, probe);
 
       installProbe(probe);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 public class CodeOriginProbe extends LogProbe implements ForceMethodInstrumentation {
   private static final Logger LOGGER = LoggerFactory.getLogger(CodeOriginProbe.class);
 
+  public static int MAX_FRAMES = 8;
+
   private final String signature;
 
   private final boolean entrySpanProbe;
@@ -133,6 +135,7 @@ public class CodeOriginProbe extends LogProbe implements ForceMethodInstrumentat
         stream ->
             stream
                 .filter(element -> !DebuggerContext.isClassNameExcluded(element.getClassName()))
+                .limit(MAX_FRAMES)
                 .collect(Collectors.toList()));
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/CodeOriginProbe.java
@@ -26,16 +26,17 @@ import org.slf4j.LoggerFactory;
 public class CodeOriginProbe extends LogProbe implements ForceMethodInstrumentation {
   private static final Logger LOGGER = LoggerFactory.getLogger(CodeOriginProbe.class);
 
-  public static int MAX_FRAMES = 8;
+  public final int maxFrames;
 
   private final String signature;
 
   private final boolean entrySpanProbe;
 
-  public CodeOriginProbe(ProbeId probeId, String signature, Where where) {
+  public CodeOriginProbe(ProbeId probeId, String signature, Where where, int maxFrames) {
     super(LANGUAGE, probeId, null, where, MethodLocation.EXIT, null, null, true, null, null, null);
     this.signature = signature;
     this.entrySpanProbe = signature != null;
+    this.maxFrames = maxFrames;
   }
 
   @Override
@@ -135,7 +136,7 @@ public class CodeOriginProbe extends LogProbe implements ForceMethodInstrumentat
         stream ->
             stream
                 .filter(element -> !DebuggerContext.isClassNameExcluded(element.getClassName()))
-                .limit(MAX_FRAMES)
+                .limit(maxFrames)
                 .collect(Collectors.toList()));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
@@ -358,6 +358,7 @@ public class CapturingTestBase {
     when(config.getFinalDebuggerSnapshotUrl())
         .thenReturn("http://localhost:8126/debugger/v1/input");
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
+    when(config.getDebuggerCodeOriginMaxUserFrames()).thenReturn(20);
     instrumentationListener = new MockInstrumentationListener();
     probeStatusSink = mock(ProbeStatusSink.class);
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -49,6 +49,8 @@ public class CodeOriginTest extends CapturingTestBase {
   private static final ProbeId CODE_ORIGIN_ID1 = new ProbeId("code origin 1", 0);
   private static final ProbeId CODE_ORIGIN_ID2 = new ProbeId("code origin 2", 0);
 
+  private static final int MAX_FRAMES = 20;
+
   private DefaultCodeOriginRecorder codeOriginRecorder;
 
   private TestTraceInterceptor traceInterceptor;
@@ -116,16 +118,12 @@ public class CodeOriginTest extends CapturingTestBase {
   public void stackDepth() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CodeOrigin04";
     installProbes(
-        new CodeOriginProbe(CODE_ORIGIN_ID1, null, Where.of(CLASS_NAME, "exit", "()", "39")));
+        new CodeOriginProbe(
+            CODE_ORIGIN_ID1, null, Where.of(CLASS_NAME, "exit", "()", "39"), MAX_FRAMES));
 
     Class<?> testClass = compileAndLoadClass("com.datadog.debugger.CodeOrigin04");
-    CodeOriginProbe.MAX_FRAMES = 20;
     countFrames(testClass, 10);
     countFrames(testClass, 100);
-    CodeOriginProbe.MAX_FRAMES = 8;
-    countFrames(testClass, 10);
-    countFrames(testClass, 1);
-    countFrames(testClass, 0);
   }
 
   private void countFrames(Class<?> testClass, int loops) {
@@ -137,7 +135,7 @@ public class CodeOriginTest extends CapturingTestBase {
             .flatMap(s -> s.getTags().keySet().stream())
             .filter(key -> key.contains("frames") && key.endsWith("method"))
             .count();
-    assertTrue(count <= CodeOriginProbe.MAX_FRAMES);
+    assertTrue(count <= MAX_FRAMES);
   }
 
   @Test
@@ -159,9 +157,9 @@ public class CodeOriginTest extends CapturingTestBase {
   @NotNull
   private List<LogProbe> codeOriginProbes(String type) {
     CodeOriginProbe entry =
-        new CodeOriginProbe(CODE_ORIGIN_ID1, "()", Where.of(type, "entry", "()", "53"));
+        new CodeOriginProbe(CODE_ORIGIN_ID1, "()", Where.of(type, "entry", "()", "53"), MAX_FRAMES);
     CodeOriginProbe exit =
-        new CodeOriginProbe(CODE_ORIGIN_ID2, null, Where.of(type, "exit", "()", "60"));
+        new CodeOriginProbe(CODE_ORIGIN_ID2, null, Where.of(type, "exit", "()", "60"), MAX_FRAMES);
     return new ArrayList<>(asList(entry, exit));
   }
 

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin04.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin04.java
@@ -1,0 +1,42 @@
+package com.datadog.debugger;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
+
+public class CodeOrigin04 {
+  private int intField = 42;
+
+  private static TracerAPI tracerAPI = AgentTracer.get();
+
+  public static int main(int level) throws ReflectiveOperationException {
+    doExit(level);
+
+    return level;
+  }
+
+  private static void doExit(int level) {
+    if (level > 0) {
+      doExit(level - 1);
+    } else {
+      AgentSpan span;
+      AgentScope scope;
+      span = newSpan("exit");
+      scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+      exit();
+      span.finish();
+      scope.close();
+    }
+  }
+
+  private static AgentSpan newSpan(String name) {
+    return tracerAPI.buildSpan("code origin tests", name).start();
+  }
+
+  private static void exit() {
+    int x = 47 / 3;
+  }
+
+}

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -49,6 +49,7 @@ public final class ConfigDefaults {
   static final String DEFAULT_SITE = "datadoghq.com";
 
   static final boolean DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED = false;
+  static final int DEFAULT_CODE_ORIGIN_MAX_USER_FRAMES = 8;
   static final boolean DEFAULT_TRACE_SPAN_ORIGIN_ENRICHED = false;
   static final boolean DEFAULT_TRACE_ENABLED = true;
   public static final boolean DEFAULT_TRACE_OTEL_ENABLED = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -10,6 +10,7 @@ package datadog.trace.api.config;
  */
 public final class TraceInstrumentationConfig {
   public static final String CODE_ORIGIN_FOR_SPANS_ENABLED = "code.origin.for.spans.enabled";
+  public static final String CODE_ORIGIN_MAX_USER_FRAMES = "code.origin.max.user.frames";
   public static final String TRACE_ENABLED = "trace.enabled";
   public static final String TRACE_OTEL_ENABLED = "trace.otel.enabled";
   public static final String INTEGRATIONS_ENABLED = "integrations.enabled";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -403,6 +403,7 @@ public class Config {
   private final int debuggerExceptionMaxCapturedFrames;
   private final int debuggerExceptionCaptureInterval;
   private final boolean debuggerCodeOriginEnabled;
+  private final int debuggerCodeOriginMaxUserFrames;
 
   private final Set<String> debuggerThirdPartyIncludes;
   private final Set<String> debuggerThirdPartyExcludes;
@@ -1533,6 +1534,8 @@ public class Config {
     debuggerCodeOriginEnabled =
         configProvider.getBoolean(
             CODE_ORIGIN_FOR_SPANS_ENABLED, DEFAULT_CODE_ORIGIN_FOR_SPANS_ENABLED);
+    debuggerCodeOriginMaxUserFrames =
+        configProvider.getInteger(CODE_ORIGIN_MAX_USER_FRAMES, DEFAULT_CODE_ORIGIN_MAX_USER_FRAMES);
     debuggerMaxExceptionPerSecond =
         configProvider.getInteger(
             DEBUGGER_MAX_EXCEPTION_PER_SECOND, DEFAULT_DEBUGGER_MAX_EXCEPTION_PER_SECOND);
@@ -2968,6 +2971,10 @@ public class Config {
 
   public boolean isDebuggerCodeOriginEnabled() {
     return debuggerCodeOriginEnabled;
+  }
+
+  public int getDebuggerCodeOriginMaxUserFrames() {
+    return debuggerCodeOriginMaxUserFrames;
   }
 
   public Set<String> getThirdPartyIncludes() {


### PR DESCRIPTION
# What Does This Do

Update the code origin code to check for an environment variable when configuring the maximum number of user frames to include in a code origin probe's output.

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2727]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2727]: https://datadoghq.atlassian.net/browse/DEBUG-2727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ