### PR TITLE
Fix AWS Payload Tagging prefix generation related to SdkPojo

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -495,7 +495,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     } else if (object instanceof SdkBytes) {
       SdkBytes bytes = (SdkBytes) object;
       payloadTagsData.add(new PayloadTagsData.PathAndValue(path.toArray(), bytes.asInputStream()));
-    } else {
+    } else if (object != null) {
       payloadTagsData.add(new PayloadTagsData.PathAndValue(path.toArray(), object));
     }
   }

--- a/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/payloadTaggingTest/groovy/PayloadTaggingTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sdk-2.2/src/payloadTaggingTest/groovy/PayloadTaggingTest.groovy
@@ -114,9 +114,8 @@ class PayloadTaggingRedactionForkedTest extends AbstractPayloadTaggingTest {
   @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
-    def redactTopLevelTags = "\$.*,\$.Owner.DisplayName"
-    injectSysConfig(TracerConfig.TRACE_CLOUD_REQUEST_PAYLOAD_TAGGING, redactTopLevelTags)
-    injectSysConfig(TracerConfig.TRACE_CLOUD_RESPONSE_PAYLOAD_TAGGING, redactTopLevelTags)
+    injectSysConfig(TracerConfig.TRACE_CLOUD_REQUEST_PAYLOAD_TAGGING, "all")
+    injectSysConfig(TracerConfig.TRACE_CLOUD_RESPONSE_PAYLOAD_TAGGING, "\$.*,\$.Owner.DisplayName")
   }
 
   def "test payload tag observability support for #service"() {
@@ -133,45 +132,46 @@ class PayloadTaggingRedactionForkedTest extends AbstractPayloadTaggingTest {
         span {
           spanType DDSpanTypes.HTTP_CLIENT
           childOf(span(0))
-          assert expectedReqTag == NA || span.tags.get("aws.request.body." + expectedReqTag) == "redacted"
+          assert expectedReqTag == NA || span.tags.get("aws.request.body." + expectedReqTag) == "tagvalue"
           assert expectedRespTag == NA || span.tags.get("aws.response.body." + expectedRespTag) == "redacted"
 
           assert !span.tags.containsKey("_dd.payload_tags_incomplete")
           assert !span.tags.containsKey("aws.request.body")
           assert !span.tags.containsKey("aws.response.body")
+          assert !span.tags.containsValue(null)
         }
       }
     }
 
     where:
-    service       | expectedReqTag                | expectedRespTag      | apiCall
-    "ApiGateway"  | "name"                        | "value"              | {
+    service       | expectedReqTag | expectedRespTag     | apiCall
+    "ApiGateway"  | "name"         | "value"             | {
       apiGatewayClient.createApiKey {
-        it.name("testapi")
+        it.name("tagvalue")
       }
     }
-    "EventBridge" | "Name"                        | "EventBusArn"        | {
+    "EventBridge" | "Name"         | "EventBusArn"       | {
       eventBridgeClient.createEventBus {
-        it.name("testbus")
+        it.name("tagvalue")
       }
     }
-    "Sns"         | "Name"                        | "TopicArn"           | {
+    "Sns"         | "Name"         | "TopicArn"          | {
       snsClient.createTopic {
-        it.name("testtopic")
+        it.name("tagvalue")
       }
     }
-    "Sqs"         | "QueueName"                   | "QueueUrl"           | {
+    "Sqs"         | "QueueName"    | "QueueUrl"          | {
       sqsClient.createQueue {
-        it.queueName("testqueue")
+        it.queueName("tagvalue")
       }
     }
-    "Kinesis"     | "StreamModeDetails"           | NA                   | {
+    "Kinesis"     | "StreamName"   | NA                  | {
       kinesisClient.createStream {
-        it.streamName("teststream")
+        it.streamName("tagvalue")
       }
     }
-    "Kinesis"     | NA                            | "ShardLimit"         | { kinesisClient.describeLimits() }
-    "S3"          | NA                            | "Owner.DisplayName"  | { s3Client.listBuckets() }
+    "Kinesis"     | NA             | "ShardLimit"        | { kinesisClient.describeLimits() }
+    "S3"          | NA             | "Owner.DisplayName" | { s3Client.listBuckets() }
   }
 }
 
@@ -346,11 +346,6 @@ class PayloadTaggingMaxTagsForkedTest extends AbstractPayloadTaggingTest {
 
     where:
     apiCall << [
-      {
-        snsClient.publish {
-          it.phoneNumber("+15555555555").message('message')
-        }
-      },
       {
         snsClient.createTopic {
           it.name("testtopic")


### PR DESCRIPTION
# What Does This Do

Fix AWS Payload Tagging prefix generation related to SdkPojo field traversal.

# Motivation

Fix the bug.

# Additional Notes

Original Feature PR: #7811

## Examples 

Activated with:

```bash
export DD_TRACE_CLOUD_REQUEST_PAYLOAD_TAGGING=all
export DD_TRACE_CLOUD_RESPONSE_PAYLOAD_TAGGING=all
```

### Default S3

<img width="832" alt="image" src="https://github.com/user-attachments/assets/80227efd-502b-431c-ac76-ed15c5f87ef0">

### Manually enabled Sso with custom redaction rules

Additional custom settings:

```bash
export DD_TRACE_CLOUD_PAYLOAD_TAGGING_SERVICES=S3,Sso
export DD_TRACE_CLOUD_REQUEST_PAYLOAD_TAGGING='$.accessToken'
export DD_TRACE_CLOUD_RESPONSE_PAYLOAD_TAGGING='$.roleCredentials.secretAccessKey,$.roleCredentials.sessionToken'
```

<img width="830" alt="image" src="https://github.com/user-attachments/assets/b758a7c3-7f58-46d3-a74a-bf21a78fb7c8">


# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
