### PR TITLE
Protect currentContext access for reactor inner operators

### DIFF
--- a/dd-java-agent/instrumentation/reactive-streams/src/main/java/datadog/trace/instrumentation/reactivestreams/PublisherInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactive-streams/src/main/java/datadog/trace/instrumentation/reactivestreams/PublisherInstrumentation.java
@@ -94,7 +94,7 @@ public class PublisherInstrumentation extends InstrumenterModule.Tracing
       final AgentSpan span =
           InstrumentationContext.get(Publisher.class, AgentSpan.class).remove(self);
       final AgentSpan activeSpan = activeSpan();
-      if (span == null && activeSpan == null) {
+      if (s == null || (span == null && activeSpan == null)) {
         return null;
       }
       final AgentSpan current =

--- a/dd-java-agent/instrumentation/reactive-streams/src/main/java/datadog/trace/instrumentation/reactivestreams/SubscriberInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactive-streams/src/main/java/datadog/trace/instrumentation/reactivestreams/SubscriberInstrumentation.java
@@ -14,7 +14,6 @@ import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
@@ -65,8 +64,7 @@ public class SubscriberInstrumentation extends InstrumenterModule.Tracing
    */
   public static class SubscriberDownStreamAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static AgentScope before(
-        @Advice.Origin final Method m, @Advice.This final Subscriber self) {
+    public static AgentScope before(@Advice.This final Subscriber self) {
       if (activeSpan() != null) {
         return null;
       }

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
@@ -441,6 +441,15 @@ class ReactorCoreTest extends AgentTestRunner {
     })
   }
 
+  def "test currentContext() calls on inner operator is not throwing a NPE on the advice"() {
+    when:
+    def mono = Flux.range(1, 100).windowUntil {it % 10 == 0}.count()
+    then:
+    // we are not interested into asserting a trace structure but only that the instrumentation error count is 0
+    assert mono.block() == 10
+  }
+
+
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def assemblePublisherUnderTrace(def publisherSupplier) {
     def span = startSpan("publisher-parent")

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/CoreSubscriberInstrumentation.java
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/main/java/datadog/trace/instrumentation/reactor/core/CoreSubscriberInstrumentation.java
@@ -44,7 +44,14 @@ public class CoreSubscriberInstrumentation extends InstrumenterModule.Tracing
   public static class PropagateSpanInScopeAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope before(@Advice.This final CoreSubscriber<?> self) {
-      final Context context = self.currentContext();
+      Context context = null;
+      try {
+        context = self.currentContext();
+      } catch (Throwable ignored) {
+      }
+      if (context == null) {
+        return null;
+      }
       if (context.hasKey("dd.span")) {
         Object maybeSpan = context.get("dd.span");
         if (maybeSpan instanceof WithAgentSpan) {

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -490,6 +490,14 @@ class ReactorCoreTest extends AgentTestRunner {
     span.finish()
   }
 
+  def "test currentContext() calls on inner operator is not throwing a NPE on the advice"() {
+    when:
+    def mono = Flux.range(1, 100).windowUntil {it % 10 == 0}.count()
+    then:
+    // we are not interested into asserting a trace structure but only that the instrumentation error count is 0
+    assert mono.block() == 11
+  }
+
   @Trace(operationName = "addOne", resourceName = "addOne")
   def static addOneFunc(int i) {
     return i + 1


### PR DESCRIPTION
# What Does This Do

`CoreSubscriber` instrumentation access to the subscriber context via the `currentContext` method.
While this is not expected to throw, it may happen that inner operators like `reactor.core.publisher.FluxWindowPredicate$WindowFlux` might throw a NPE because it's implementation is defined as 

```
interface InnerOperator<I, O> extends InnerConsumer<I>, InnerProducer<O> {
    default Context currentContext() {
        return this.actual().currentContext();
    }
}
```
and `actual()` returns null

I also put a test to ensure that we do not have unhandled exception in that instrumentation. As well I protected other potential unsafe access context and cleaned up a leftover

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
