### PR TITLE
feat(ci): Add pull request checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,6 +20,14 @@ _Action:_ Append the new release to the Cloud Foundry repository.
 
 _Recovery:_ Manually edit and push the `index.yml` file from [the cloudfoundry branch](https://github.com/DataDog/dd-trace-java/tree/cloudfoundry).
 
+### check-pull-requests [🔗](check-pull-requests.yaml)
+
+_Trigger:_ When creating or updating a pull request.
+
+_Action:_ Check the pull request complies with [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md).
+
+_Recovery:_ Manually verify the guideline compliance.
+
 ### create-next-milestone [🔗](create-next-milestone.yaml)
 
 _Trigger:_ When closing a milestone.

--- a/.github/workflows/check-pull-requests.yaml
+++ b/.github/workflows/check-pull-requests.yaml
@@ -1,0 +1,53 @@
+name: Check pull requests
+on:
+  pull_request:
+    types: [opened, reopened, edited, labeled, unlabeled]
+    branches:
+    - master
+    - release/v*
+jobs:
+  check_pull_requests:
+    name: Check pull requests
+    permissions:
+      issues: write # Required to create a comment on the pull request
+      pull-requests: write # Required to create a comment on the pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull requests
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Skip draft pull requests
+            if (context.payload.pull_request.draft) {
+              return
+            }
+            // Check at least one type and (component or instrumentation) label is set
+            const labels = context.payload.pull_request.labels.map(label => label.name)
+            const ignoreReleaseNotes = labels.filter(label => label == 'tag: no release notes').length > 0
+            const hasTypeLabel = labels.filter(label => label.startsWith('type:')).length > 0
+            const hasComponentLabel = labels.filter(label => label.startsWith('comp:')).length > 0
+            const hasInstrumentationLabel = labels.filter(label => label.startsWith('instr:')).length > 0
+            const labelsCheckFailed = !ignoreReleaseNotes && (!hasTypeLabel || (!hasComponentLabel && !hasInstrumentationLabel));
+            if (labelsCheckFailed) {
+              core.setFailed('Please add at least one type, and one component or instrumentation label to the pull request.')
+            }
+            // Check title does not contain tag
+            const title = context.payload.pull_request.title
+            const titleCheckFailed = title.match(/\[.*\]/)
+            if (titleCheckFailed) {
+              core.setFailed('Please remove the tag from the pull request title.')
+            }
+            // Add comment to the pull request
+            if (labelsCheckFailed || titleCheckFailed) {
+              await github.rest.issues.createComment({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'Hi! 👋 Thanks for your pull request! 🎉\n\n' +
+                  'To help us review it, please make sure to:\n\n' +
+                  (labelsCheckFailed ? '* Add at least one type, and one component or instrumentation label to the pull request\n' : '') +
+                  (titleCheckFailed ? '* Remove the tag from the pull request title\n' : '') +
+                  '\nIf you need help, please check our [contributing guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md).'
+              })
+            }

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-draft.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-draft.json
@@ -1,0 +1,8 @@
+{
+    "pull_request": {
+        "number": 7884,
+        "draft": true,
+        "labels": [],
+        "title": "Adding some new features"
+    }
+}

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-missing-label.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-missing-label.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "number": 7884,
+        "draft": false,
+        "labels": [
+            {
+                "name": "comp: api"
+            }
+        ],
+        "title": "Adding some new features"
+    }
+}

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-no-release-notes.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-no-release-notes.json
@@ -1,0 +1,12 @@
+{
+    "pull_request": {
+        "number": 7884,
+        "draft": false,
+        "labels": [
+            {
+                "name": "tag: no release notes"
+            }
+        ],
+        "title": "Adding some new features"
+    }
+}

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-title-tag.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-title-tag.json
@@ -1,0 +1,15 @@
+{
+    "pull_request": {
+        "number": 7884,
+        "draft": false,
+        "labels": [
+            {
+                "name": "comp: api"
+            },
+            {
+                "name": "type: enhancement"
+            }
+        ],
+        "title": "[API] Adding some new features"
+    }
+}

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request.json
@@ -1,0 +1,15 @@
+{
+    "pull_request": {
+        "number": 7884,
+        "draft": false,
+        "labels": [
+            {
+                "name": "comp: api"
+            },
+            {
+                "name": "type: enhancement"
+            }
+        ],
+        "title": "Adding some new features"
+    }
+}

--- a/.github/workflows/tests/check-pull-requests/test-pull-request.sh
+++ b/.github/workflows/tests/check-pull-requests/test-pull-request.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+source "$(dirname "$0")/../env.sh"
+testworkflow pull_request && \
+testworkflow pull_request draft && \
+testworkflow pull_request no-release-notes && \
+! testworkflow pull_request missing-label && \
+! testworkflow pull_request title-tag

--- a/.github/workflows/tests/env.sh
+++ b/.github/workflows/tests/env.sh
@@ -2,17 +2,23 @@
 
 function testworkflow() {
     local EVENT_TYPE=$1
+    local SCENARIO=$2
     # Get workflow name
     local TEST_PATH
     TEST_PATH=$(dirname "$(readlink -f "${BASH_SOURCE[1]}")")
     local WORKFLOW_NAME
     WORKFLOW_NAME=$(basename "$TEST_PATH")
     local WORKFLOW_FILE=.github/workflows/${WORKFLOW_NAME}.yaml
-    local PAYLOAD_FILE=${TEST_PATH}/payload-${EVENT_TYPE//_/-}.json
+    local PAYLOAD_FILE
+    PAYLOAD_FILE=${TEST_PATH}/payload-${EVENT_TYPE//_/-}
+    if [ "$SCENARIO" != "" ]; then
+        PAYLOAD_FILE=${PAYLOAD_FILE}-${SCENARIO}
+    fi
+    PAYLOAD_FILE=${PAYLOAD_FILE}.json
     # Move to project root directory
     local FILE_PATH
     FILE_PATH=$(dirname "$0")
-    cd "$FILE_PATH/../../../../" || exit 1
+    pushd "$FILE_PATH/../../../../" || exit 1
     # Check if workflow file and payload file exist
     if [ ! -f "$WORKFLOW_FILE" ]; then
         echo "Workflow file not found: $WORKFLOW_FILE"
@@ -29,4 +35,10 @@ function testworkflow() {
         --container-architecture linux/amd64 \
         --secret GITHUB_TOKEN="$(gh auth token)" \
         --verbose
+    # Capture the exit code
+    local EXIT_CODE=$?
+    # Move back to initial directory
+    popd || exit 1
+    # Return the test exit code
+    return $EXIT_CODE
 }


### PR DESCRIPTION
# What Does This Do

This PR introduces a workflow to check that PRs labels and title match the contributing guidelines.
The check won’t be blocking but the action will add a comment for awareness.

# Motivation

This will reduce the load of reviewers / releasers and get contributors more involved.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
