### PR TITLE
Fix duplicate PR check comments

### DIFF
--- a/.github/workflows/check-pull-requests.yaml
+++ b/.github/workflows/check-pull-requests.yaml
@@ -1,7 +1,7 @@
 name: Check pull requests
 on:
   pull_request:
-    types: [opened, reopened, edited, labeled, unlabeled]
+    types: [opened, edited, labeled, unlabeled]
     branches:
     - master
     - release/v*
@@ -40,14 +40,36 @@ jobs:
             }
             // Add comment to the pull request
             if (labelsCheckFailed || titleCheckFailed) {
-              await github.rest.issues.createComment({
-                issue_number: context.payload.pull_request.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: 'Hi! 👋 Thanks for your pull request! 🎉\n\n' +
+              // Define comment body
+              const commentMarker = '<!-- dd-trace-java-check-pull-requests-workflow -->'
+              const commentBody = 'Hi! 👋 Thanks for your pull request! 🎉\n\n' +
                   'To help us review it, please make sure to:\n\n' +
                   (labelsCheckFailed ? '* Add at least one type, and one component or instrumentation label to the pull request\n' : '') +
                   (titleCheckFailed ? '* Remove the tag from the pull request title\n' : '') +
-                  '\nIf you need help, please check our [contributing guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md).'
+                  '\nIf you need help, please check our [contributing guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md).' +
+                  '\n\n' + commentMarker
+              // Look for previous comment
+              const comments = await github.rest.issues.listComments({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo
               })
+              const previousComment = comments.data.find(comment => comment.body.includes(commentMarker))
+              if (previousComment) {
+                // Update previous comment
+                await github.rest.issues.updateComment({
+                  comment_id: previousComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                })
+              } else {
+                // Create new comment
+                await github.rest.issues.createComment({
+                  issue_number: context.payload.pull_request.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                })
+              }
             }


### PR DESCRIPTION
# What Does This Do

This PR will avoid duplicating PR check messages by updating the original one.

# Motivation

GitHub workflow trigger event are somewhat messy to keep track of.
So the last run will update the message accordingly.

# Additional Notes

The workflow is disabled until the fix PR is merged.
Originally reported by @amarziali 

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
