### PR TITLE
Add support for multiple commits PR backport

### DIFF
--- a/tooling/backport-pr-to-patch-release.sh
+++ b/tooling/backport-pr-to-patch-release.sh
@@ -50,8 +50,8 @@ git fetch --quiet
 git show-ref --verify --quiet "refs/remotes/origin/$PATCH_RELEASE_BRANCH" 1>/dev/null 2>&1 || { echo "Branch $PATCH_RELEASE_BRANCH does not exist"; exit 1; }
 # Check PR exists
 echo "- Checking PR exists"
-PR_COMMIT=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
-if [ -z "$PR_COMMIT" ]; then
+PR_COMMITS=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
+if [ -z "$PR_COMMITS" ]; then
     echo "PR $PR_NUMBER does not exist"
     exit 1
 fi
@@ -68,8 +68,10 @@ git pull
 # Create a new branch for the backport
 BRANCH_NAME="$USER/backport-pr-$PR_NUMBER"
 git checkout -b "$BRANCH_NAME"
-# Cherry-pick PR commit
-git cherry-pick "$PR_COMMIT"
+# Cherry-pick PR commits
+for PR_COMMIT in $PR_COMMITS; do
+    git cherry-pick -x "$PR_COMMIT"
+done
 # Push the branch
 git push -u origin "$BRANCH_NAME" --no-verify
 # Create a PR


### PR DESCRIPTION
# What Does This Do

This PR add support for PRs with multiple commits to be back-ported to patch release using the `tooling/backport-pr-patch-release.sh` script.

# Motivation

Only single commit PR worked.
So when PR are merged using the squash feature, the script failed to back-port them.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
