### PR TITLE
Add outer exceptions support for Exception Replay

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -14,6 +14,9 @@ import datadog.trace.bootstrap.debugger.DebuggerContext.ClassNameFilter;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.util.AgentTaskScheduler;
 import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,32 +78,42 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
       LOGGER.debug("Unable to fingerprint exception", t);
       return;
     }
-    Throwable innerMostException = ExceptionHelper.getInnerMostThrowable(t);
+    Deque<Throwable> chainedExceptions = new ArrayDeque<>();
+    Throwable innerMostException = ExceptionHelper.getInnerMostThrowable(t, chainedExceptions);
     if (innerMostException == null) {
       LOGGER.debug("Unable to find root cause of exception");
       return;
     }
+    List<Throwable> chainedExceptionsList = new ArrayList<>(chainedExceptions);
     if (exceptionProbeManager.isAlreadyInstrumented(fingerprint)) {
       ThrowableState state = exceptionProbeManager.getStateByThrowable(innerMostException);
       if (state == null) {
         LOGGER.debug("Unable to find state for throwable: {}", innerMostException.toString());
         return;
       }
-      processSnapshotsAndSetTags(t, span, state, innerMostException, fingerprint);
+      processSnapshotsAndSetTags(t, span, state, chainedExceptionsList, fingerprint);
       exceptionProbeManager.updateLastCapture(fingerprint);
     } else {
-      ExceptionProbeManager.CreationResult creationResult =
-          exceptionProbeManager.createProbesForException(innerMostException.getStackTrace());
-      if (creationResult.probesCreated > 0) {
-        AgentTaskScheduler.INSTANCE.execute(() -> applyExceptionConfiguration(fingerprint));
-      } else {
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug(
-              "No probe created, nativeFrames={}, thirdPartyFrames={} for exception: {}",
-              creationResult.nativeFrames,
-              creationResult.thirdPartyFrames,
-              ExceptionHelper.foldExceptionStackTrace(innerMostException));
+      // climb up the exception chain to find the first exception that has instrumented frames
+      Throwable throwable;
+      int chainedExceptionIdx = 0;
+      while ((throwable = chainedExceptions.pollFirst()) != null) {
+        ExceptionProbeManager.CreationResult creationResult =
+            exceptionProbeManager.createProbesForException(
+                throwable.getStackTrace(), chainedExceptionIdx);
+        if (creationResult.probesCreated > 0) {
+          AgentTaskScheduler.INSTANCE.execute(() -> applyExceptionConfiguration(fingerprint));
+          break;
+        } else {
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                "No probe created, nativeFrames={}, thirdPartyFrames={} for exception: {}",
+                creationResult.nativeFrames,
+                creationResult.thirdPartyFrames,
+                ExceptionHelper.foldExceptionStackTrace(throwable));
+          }
         }
+        chainedExceptionIdx++;
       }
     }
   }
@@ -114,7 +127,7 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
       Throwable t,
       AgentSpan span,
       ThrowableState state,
-      Throwable innerMostException,
+      List<Throwable> chainedExceptions,
       String fingerprint) {
     if (span.getTag(DD_DEBUG_ERROR_EXCEPTION_ID) != null) {
       LOGGER.debug("Clear previous frame tags");
@@ -127,12 +140,13 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
                 }
               });
     }
-    int[] mapping = createThrowableMapping(innerMostException, t);
-    StackTraceElement[] innerTrace = innerMostException.getStackTrace();
     boolean snapshotAssigned = false;
     List<Snapshot> snapshots = state.getSnapshots();
     for (int i = 0; i < snapshots.size(); i++) {
       Snapshot snapshot = snapshots.get(i);
+      Throwable currentEx = chainedExceptions.get(snapshot.getChainedExceptionIdx());
+      int[] mapping = createThrowableMapping(currentEx, t);
+      StackTraceElement[] innerTrace = currentEx.getStackTrace();
       int currentIdx = innerTrace.length - snapshot.getStack().size();
       if (!sanityCheckSnapshotAssignment(snapshot, innerTrace, currentIdx)) {
         continue;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -79,7 +79,8 @@ public class ExceptionProbeManager {
     }
   }
 
-  public CreationResult createProbesForException(StackTraceElement[] stackTraceElements) {
+  public CreationResult createProbesForException(
+      StackTraceElement[] stackTraceElements, int chainedExceptionIdx) {
     int instrumentedFrames = 0;
     int nativeFrames = 0;
     int thirdPartyFrames = 0;
@@ -102,7 +103,7 @@ public class ExceptionProbeManager {
               stackTraceElement.getMethodName(),
               null,
               String.valueOf(stackTraceElement.getLineNumber()));
-      ExceptionProbe probe = createMethodProbe(this, where);
+      ExceptionProbe probe = createMethodProbe(this, where, chainedExceptionIdx);
       probes.putIfAbsent(probe.getId(), probe);
       instrumentedFrames++;
     }
@@ -114,10 +115,16 @@ public class ExceptionProbeManager {
   }
 
   private static ExceptionProbe createMethodProbe(
-      ExceptionProbeManager exceptionProbeManager, Where where) {
+      ExceptionProbeManager exceptionProbeManager, Where where, int chainedExceptionIdx) {
     String probeId = UUID.randomUUID().toString();
     return new ExceptionProbe(
-        new ProbeId(probeId, 0), where, null, null, null, exceptionProbeManager);
+        new ProbeId(probeId, 0),
+        where,
+        null,
+        null,
+        null,
+        exceptionProbeManager,
+        chainedExceptionIdx);
   }
 
   public boolean isAlreadyInstrumented(String fingerprint) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ExceptionProbe.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentation {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionProbe.class);
   private final transient ExceptionProbeManager exceptionProbeManager;
+  private final transient int chainedExceptionIdx;
 
   public ExceptionProbe(
       ProbeId probeId,
@@ -28,7 +29,8 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
       ProbeCondition probeCondition,
       Capture capture,
       Sampling sampling,
-      ExceptionProbeManager exceptionProbeManager) {
+      ExceptionProbeManager exceptionProbeManager,
+      int chainedExceptionIdx) {
     super(
         LANGUAGE,
         probeId,
@@ -42,6 +44,7 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
         capture,
         sampling);
     this.exceptionProbeManager = exceptionProbeManager;
+    this.chainedExceptionIdx = chainedExceptionIdx;
   }
 
   @Override
@@ -116,6 +119,7 @@ public class ExceptionProbe extends LogProbe implements ForceMethodInstrumentati
       // inside the stateByThrowable map
       clearExceptionRefs(snapshot);
       // add snapshot for later to wait for triggering point (ExceptionDebugger::handleException)
+      snapshot.setChainedExceptionIdx(chainedExceptionIdx);
       exceptionProbeManager.addSnapshot(snapshot);
       LOGGER.debug(
           "committing exception probe id={}, snapshot id={}, exception id={}",

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Snapshot.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Snapshot.java
@@ -33,6 +33,7 @@ public class Snapshot {
   private transient String message;
   private final transient int maxDepth;
   private String exceptionId;
+  private transient int chainedExceptionIdx;
 
   public Snapshot(java.lang.Thread thread, ProbeImplementation probeImplementation, int maxDepth) {
     this.version = VERSION;
@@ -89,6 +90,10 @@ public class Snapshot {
 
   public void setExceptionId(String exceptionId) {
     this.exceptionId = exceptionId;
+  }
+
+  public void setChainedExceptionIdx(int chainedExceptionIdx) {
+    this.chainedExceptionIdx = chainedExceptionIdx;
   }
 
   public void addLine(CapturedContext context, int line) {
@@ -176,6 +181,10 @@ public class Snapshot {
 
   public String getExceptionId() {
     return exceptionId;
+  }
+
+  public int getChainedExceptionIdx() {
+    return chainedExceptionIdx;
   }
 
   public void recordStackTrace(int offset) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.List;
 import org.slf4j.Logger;
 
@@ -60,9 +61,19 @@ public class ExceptionHelper {
   }
 
   public static Throwable getInnerMostThrowable(Throwable t) {
+    return getInnerMostThrowable(t, null);
+  }
+
+  public static Throwable getInnerMostThrowable(Throwable t, Deque<Throwable> chainedExceptions) {
+    if (chainedExceptions != null) {
+      chainedExceptions.addFirst(t);
+    }
     int i = 100;
     while (t.getCause() != null && i > 0) {
       t = t.getCause();
+      if (chainedExceptions != null) {
+        chainedExceptions.addFirst(t);
+      }
       i--;
     }
     if (i == 0) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ExceptionHelper.java
@@ -68,6 +68,7 @@ public class ExceptionHelper {
     if (chainedExceptions != null) {
       chainedExceptions.addFirst(t);
     }
+    // putting an arbitrary limit to avoid infinite loops with cycling causes
     int i = 100;
     while (t.getCause() != null && i > 0) {
       t = t.getCause();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/DefaultExceptionDebuggerTest.java
@@ -3,10 +3,11 @@ package com.datadog.debugger.exception;
 import static com.datadog.debugger.exception.DefaultExceptionDebugger.SNAPSHOT_ID_TAG_FMT;
 import static com.datadog.debugger.util.TestHelper.assertWithTimeout;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,9 +37,12 @@ import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BinaryOperator;
@@ -58,7 +62,9 @@ public class DefaultExceptionDebuggerTest {
   @BeforeEach
   public void setUp() {
     configurationUpdater = mock(ConfigurationUpdater.class);
-    classNameFiltering = new ClassNameFiltering(emptySet());
+    classNameFiltering =
+        new ClassNameFiltering(
+            new HashSet<>(singletonList("com.datadog.debugger.exception.ThirdPartyCode")));
     exceptionDebugger =
         new DefaultExceptionDebugger(
             configurationUpdater, classNameFiltering, Duration.ofHours(1), 100);
@@ -221,6 +227,51 @@ public class DefaultExceptionDebuggerTest {
   }
 
   @Test
+  public void innermostExceptionFullThirdParty() {
+    RuntimeException exception = ThirdPartyCode.createThirdPartyException();
+    AgentSpan span = mock(AgentSpan.class);
+    doAnswer(this::recordTags).when(span).setTag(anyString(), anyString());
+    exceptionDebugger.handleException(exception, span);
+    // no probes created as all frames are filtered out (third-party code
+    assertTrue(exceptionDebugger.getExceptionProbeManager().getProbes().isEmpty());
+  }
+
+  @Test
+  public void nestedExceptionFullThirdParty() {
+    RuntimeException thirdPartyException = ThirdPartyCode.createThirdPartyException();
+    RuntimeException exception = createTest2Exception(thirdPartyException);
+    String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
+    AgentSpan span = mock(AgentSpan.class);
+    doAnswer(this::recordTags).when(span).setTag(anyString(), anyString());
+    exceptionDebugger.handleException(exception, span);
+    assertWithTimeout(
+        () -> exceptionDebugger.getExceptionProbeManager().isAlreadyInstrumented(fingerprint),
+        Duration.ofSeconds(30));
+    generateSnapshots(exception);
+    exception.printStackTrace();
+    exceptionDebugger.handleException(exception, span);
+    ExceptionProbeManager.ThrowableState state =
+        exceptionDebugger
+            .getExceptionProbeManager()
+            .getStateByThrowable(ExceptionHelper.getInnerMostThrowable(exception));
+    assertEquals(
+        state.getExceptionId(), spanTags.get(DefaultExceptionDebugger.DD_DEBUG_ERROR_EXCEPTION_ID));
+    Map<String, Snapshot> snapshotMap =
+        listener.snapshots.stream().collect(toMap(Snapshot::getId, Function.identity()));
+    List<String> lines = parseStackTrace(exception);
+    int expectedFrameIndex =
+        findFrameIndex(
+            lines,
+            "com.datadog.debugger.exception.DefaultExceptionDebuggerTest.createTest2Exception");
+    assertSnapshot(
+        spanTags,
+        snapshotMap,
+        expectedFrameIndex,
+        "com.datadog.debugger.exception.DefaultExceptionDebuggerTest",
+        "createTest2Exception");
+  }
+
+  @Test
   public void filteringOutErrors() {
     ExceptionProbeManager manager = mock(ExceptionProbeManager.class);
     exceptionDebugger =
@@ -278,58 +329,68 @@ public class DefaultExceptionDebuggerTest {
   }
 
   private void generateSnapshots(RuntimeException exception) {
-    BinaryOperator<ExceptionProbe> dropMerger = (oldValue, newValue) -> oldValue;
-    Map<String, ExceptionProbe> probesByLocation =
-        exceptionDebugger.getExceptionProbeManager().getProbes().stream()
-            .collect(
-                toMap(
-                    probe ->
-                        probe.getWhere().getTypeName()
-                            + "::"
-                            + probe.getWhere().getMethodName()
-                            + ":"
-                            + probe.getWhere().getLines()[0],
-                    Function.identity(),
-                    dropMerger));
-    Throwable innerMost = ExceptionHelper.getInnerMostThrowable(exception);
-    int framesToRemove = -1;
-    for (StackTraceElement element : innerMost.getStackTrace()) {
-      framesToRemove++;
-      ExceptionProbe exceptionProbe =
-          probesByLocation.get(
-              element.getClassName()
-                  + "::"
-                  + element.getMethodName()
-                  + ":"
-                  + element.getLineNumber());
-      if (exceptionProbe == null) {
-        continue;
+    Map<String, ExceptionProbe> probesByLocation = buildProbesByLocation();
+    Deque<Throwable> chainedExceptions = new ArrayDeque<>();
+    ExceptionHelper.getInnerMostThrowable(exception, chainedExceptions);
+    for (Throwable throwable : chainedExceptions) {
+      int framesToRemove = -1;
+      for (StackTraceElement element : throwable.getStackTrace()) {
+        framesToRemove++;
+        String probeLocation =
+            element.getClassName() + "::" + element.getMethodName() + ":" + element.getLineNumber();
+        ExceptionProbe exceptionProbe = probesByLocation.get(probeLocation);
+        if (exceptionProbe == null) {
+          continue;
+        }
+        evalAndCommitProbe(exception, exceptionProbe);
+        rewriteSnapshotStacktrace(exception, throwable, framesToRemove);
       }
-      exceptionProbe.buildLocation(null);
-      CapturedContext capturedContext = new CapturedContext();
-      capturedContext.addThrowable(exception);
-      capturedContext.evaluate(
-          exceptionProbe.getProbeId().getEncodedId(),
-          exceptionProbe,
-          "",
-          System.currentTimeMillis(),
-          MethodLocation.EXIT);
-      exceptionProbe.commit(CapturedContext.EMPTY_CAPTURING_CONTEXT, capturedContext, emptyList());
-      //  rewrite snapshot stacktrace
-      ExceptionProbeManager.ThrowableState state =
-          exceptionDebugger
-              .getExceptionProbeManager()
-              .getStateByThrowable(ExceptionHelper.getInnerMostThrowable(exception));
-      Snapshot lastSnapshot = state.getSnapshots().get(state.getSnapshots().size() - 1);
-      lastSnapshot.getStack().clear();
-      lastSnapshot
-          .getStack()
-          .addAll(
-              Arrays.stream(innerMost.getStackTrace())
-                  .skip(framesToRemove)
-                  .map(CapturedStackFrame::from)
-                  .collect(toList()));
     }
+  }
+
+  private void rewriteSnapshotStacktrace(
+      RuntimeException exception, Throwable throwable, int framesToRemove) {
+    ExceptionProbeManager.ThrowableState state =
+        exceptionDebugger
+            .getExceptionProbeManager()
+            .getStateByThrowable(ExceptionHelper.getInnerMostThrowable(exception));
+    Snapshot lastSnapshot = state.getSnapshots().get(state.getSnapshots().size() - 1);
+    lastSnapshot.getStack().clear();
+    lastSnapshot
+        .getStack()
+        .addAll(
+            Arrays.stream(throwable.getStackTrace())
+                .skip(framesToRemove)
+                .map(CapturedStackFrame::from)
+                .collect(toList()));
+  }
+
+  private void evalAndCommitProbe(RuntimeException exception, ExceptionProbe exceptionProbe) {
+    exceptionProbe.buildLocation(null);
+    CapturedContext capturedContext = new CapturedContext();
+    capturedContext.addThrowable(exception);
+    capturedContext.evaluate(
+        exceptionProbe.getProbeId().getEncodedId(),
+        exceptionProbe,
+        "",
+        System.currentTimeMillis(),
+        MethodLocation.EXIT);
+    exceptionProbe.commit(CapturedContext.EMPTY_CAPTURING_CONTEXT, capturedContext, emptyList());
+  }
+
+  private Map<String, ExceptionProbe> buildProbesByLocation() {
+    BinaryOperator<ExceptionProbe> dropMerger = (oldValue, newValue) -> oldValue;
+    return exceptionDebugger.getExceptionProbeManager().getProbes().stream()
+        .collect(
+            toMap(
+                probe ->
+                    probe.getWhere().getTypeName()
+                        + "::"
+                        + probe.getWhere().getMethodName()
+                        + ":"
+                        + probe.getWhere().getLines()[0],
+                Function.identity(),
+                dropMerger));
   }
 
   private RuntimeException createNestException() {
@@ -354,5 +415,26 @@ public class DefaultExceptionDebuggerTest {
     when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
     when(config.getDebuggerUploadBatchSize()).thenReturn(100);
     return config;
+  }
+}
+
+// Hacky way to generate an exception with a stacktrace that does not contain the test class
+// we are starting a thread and create an exception in that thread and return it
+class ThirdPartyCode extends Thread {
+  volatile RuntimeException ex;
+
+  public void run() {
+    ex = new RuntimeException("third party code");
+  }
+
+  public static RuntimeException createThirdPartyException() {
+    ThirdPartyCode thirdPartyCode = new ThirdPartyCode();
+    thirdPartyCode.start();
+    try {
+      thirdPartyCode.join();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    return thirdPartyCode.ex;
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -26,7 +26,7 @@ class ExceptionProbeManagerTest {
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     RuntimeException exception = new RuntimeException("test");
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
-    exceptionProbeManager.createProbesForException(exception.getStackTrace());
+    exceptionProbeManager.createProbesForException(exception.getStackTrace(), 0);
     assertFalse(exceptionProbeManager.getProbes().isEmpty());
   }
 
@@ -47,7 +47,7 @@ class ExceptionProbeManagerTest {
 
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     assertEquals("4974b2b4853e6152d8f218fb79a42a761a45335447e22e53d75f5325e742655", fingerprint);
-    exceptionProbeManager.createProbesForException(exception.getStackTrace());
+    exceptionProbeManager.createProbesForException(exception.getStackTrace(), 0);
     assertEquals(1, exceptionProbeManager.getProbes().size());
     ExceptionProbe exceptionProbe = exceptionProbeManager.getProbes().iterator().next();
     assertEquals(
@@ -71,7 +71,7 @@ class ExceptionProbeManagerTest {
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     assertEquals("7a1e5e1bcc64ee26801d1471245eff6b6e8d7c61d0ea36fe85f3f75d79e42c", fingerprint);
-    exceptionProbeManager.createProbesForException(exception.getStackTrace());
+    exceptionProbeManager.createProbesForException(exception.getStackTrace(), 0);
     assertEquals(0, exceptionProbeManager.getProbes().size());
   }
 
@@ -106,7 +106,7 @@ class ExceptionProbeManagerTest {
                 .collect(Collectors.toSet()));
     ExceptionProbeManager exceptionProbeManager =
         new ExceptionProbeManager(classNameFiltering, Duration.ofHours(1), Clock.systemUTC(), 3);
-    exceptionProbeManager.createProbesForException(deepException.getStackTrace());
+    exceptionProbeManager.createProbesForException(deepException.getStackTrace(), 0);
     assertEquals(3, exceptionProbeManager.getProbes().size());
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/util/ExceptionHelperTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 import datadog.trace.relocate.api.RatelimitedLogger;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -72,7 +74,8 @@ public class ExceptionHelperTest {
     String strStackTrace = ExceptionHelper.foldExceptionStackTrace(new Exception());
     assertTrue(
         strStackTrace.startsWith(
-            "java.lang.Exception at com.datadog.debugger.util.ExceptionHelperTest.foldExceptionStackTrace(ExceptionHelperTest.java:72) at "));
+            "java.lang.Exception at com.datadog.debugger.util.ExceptionHelperTest.foldExceptionStackTrace(ExceptionHelperTest.java:74) at "),
+        strStackTrace);
     assertFalse(strStackTrace.contains("\n"));
     assertFalse(strStackTrace.contains("\t"));
     assertFalse(strStackTrace.contains("\r"));
@@ -86,6 +89,13 @@ public class ExceptionHelperTest {
     Exception nested = new RuntimeException("test3", new RuntimeException("test2", ex));
     innerMost = ExceptionHelper.getInnerMostThrowable(nested);
     assertEquals(ex, innerMost);
+    Deque<Throwable> exceptions = new ArrayDeque<>();
+    innerMost = ExceptionHelper.getInnerMostThrowable(nested, exceptions);
+    assertEquals(ex, innerMost);
+    assertEquals(3, exceptions.size());
+    assertEquals(nested, exceptions.pollLast());
+    assertEquals(nested.getCause(), exceptions.pollLast());
+    assertEquals(nested.getCause().getCause(), exceptions.pollLast());
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
In some cases, the innermost exception could contain only third-party frames and no instrumentation is performed while the exception could be re-throw up in the stack where the call originated. This could help to root cause the inner exception.
Now in that case we are climbing up the chained of exceptions to find user frames to instrument.
when finding the innermost exception, we are reporting the list of all outer exceptions beginning by the innermost. The chained index is also kept in the probe and injected into the snapshot to be able to remap the frame index correctly and report it to the span as tag.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3107]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3107]: https://datadoghq.atlassian.net/browse/DEBUG-3107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ