### PR TITLE
paranoid exception handling when setting profiling thread context

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -329,7 +329,7 @@ public final class DatadogProfiler {
     debugLogging(rootSpanId);
     try {
       profiler.setContext(spanId, rootSpanId);
-    } catch (IllegalStateException e) {
+    } catch (Throwable e) {
       log.debug("Failed to clear context", e);
     }
   }
@@ -338,14 +338,18 @@ public final class DatadogProfiler {
     debugLogging(0L);
     try {
       profiler.setContext(0L, 0L);
-    } catch (IllegalStateException e) {
+    } catch (Throwable e) {
       log.debug("Failed to set context", e);
     }
   }
 
   public boolean setContextValue(int offset, int encoding) {
     if (contextSetter != null && offset >= 0) {
-      return contextSetter.setContextValue(offset, encoding);
+      try {
+        return contextSetter.setContextValue(offset, encoding);
+      } catch (Throwable e) {
+        log.debug("Failed to set context", e);
+      }
     }
     return false;
   }
@@ -353,7 +357,11 @@ public final class DatadogProfiler {
   public boolean setContextValue(int offset, CharSequence value) {
     if (contextSetter != null && offset >= 0) {
       int encoding = encode(value);
-      return contextSetter.setContextValue(offset, encoding);
+      try {
+        return contextSetter.setContextValue(offset, encoding);
+      } catch (Throwable e) {
+        log.debug("Failed to set context", e);
+      }
     }
     return false;
   }
@@ -374,7 +382,11 @@ public final class DatadogProfiler {
 
   public boolean clearContextValue(int offset) {
     if (contextSetter != null && offset >= 0) {
-      return contextSetter.clearContextValue(offset);
+      try {
+        return contextSetter.clearContextValue(offset);
+      } catch (Throwable t) {
+        log.debug("Failed to clear context", t);
+      }
     }
     return false;
   }


### PR DESCRIPTION
# What Does This Do

This handles scenarios where the profiling context may not be able to store the thread context because the user has increased the value of pid_max during the process lifetime.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-10861]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-10861]: https://datadoghq.atlassian.net/browse/PROF-10861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ