### PR TITLE
Remove SSI guardrails entries for hbase and hive

### DIFF
--- a/metadata/denied-environment-variables.tsv
+++ b/metadata/denied-environment-variables.tsv
@@ -1,4 +1,2 @@
 # Identifier    EnvironmentVariable     Description
-apache_hbase    HBASE_HOME              Skip Apache HBase
-apache_hive     HIVE_HOME               Skip Apache Hive
 apache_solr9    SOLR_PORT               Skip Apache Solr 9

--- a/metadata/requirements.json
+++ b/metadata/requirements.json
@@ -338,30 +338,6 @@
       "envars": null
     },
     {
-      "id": "apache_hbase",
-      "description": "Skip Apache HBase",
-      "os": null,
-      "cmds": [
-        "**/java"
-      ],
-      "args": [],
-      "envars": {
-        "HBASE_HOME": null
-      }
-    },
-    {
-      "id": "apache_hive",
-      "description": "Skip Apache Hive",
-      "os": null,
-      "cmds": [
-        "**/java"
-      ],
-      "args": [],
-      "envars": {
-        "HIVE_HOME": null
-      }
-    },
-    {
       "id": "apache_solr9",
       "description": "Skip Apache Solr 9",
       "os": null,


### PR DESCRIPTION
# What Does This Do

This PR removes SSI guardrails entries for HBase and Hive.

# Motivation

Hadoop, Hbase and Hive will be blocked using the shell script blocking rules from the injector repository.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMLP-177] [APMLP-178]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-177]: https://datadoghq.atlassian.net/browse/APMLP-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ