### PR TITLE
Prevent spans from having login success and failure events simultaneously

### DIFF
--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java/datadog/trace/instrumentation/springsecurity5/AuthenticationManagerInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java/datadog/trace/instrumentation/springsecurity5/AuthenticationManagerInstrumentation.java
@@ -18,16 +18,16 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 
 @AutoService(InstrumenterModule.class)
-public class AuthenticationProviderInstrumentation extends InstrumenterModule.AppSec
+public class AuthenticationManagerInstrumentation extends InstrumenterModule.AppSec
     implements Instrumenter.ForTypeHierarchy {
 
-  public AuthenticationProviderInstrumentation() {
+  public AuthenticationManagerInstrumentation() {
     super("spring-security");
   }
 
   @Override
   public String hierarchyMarkerType() {
-    return "org.springframework.security.authentication.AuthenticationProvider";
+    return "org.springframework.security.authentication.AuthenticationManager";
   }
 
   @Override
@@ -50,10 +50,10 @@ public class AuthenticationProviderInstrumentation extends InstrumenterModule.Ap
             .and(takesArgument(0, named("org.springframework.security.core.Authentication")))
             .and(returns(named("org.springframework.security.core.Authentication")))
             .and(isPublic()),
-        getClass().getName() + "$AuthenticationProviderAdvice");
+        getClass().getName() + "$AuthenticationManagerAdvice");
   }
 
-  public static class AuthenticationProviderAdvice {
+  public static class AuthenticationManagerAdvice {
 
     @Advice.OnMethodExit(onThrowable = AuthenticationException.class, suppress = Throwable.class)
     public static void onExit(

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SecurityConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SecurityConfig.groovy
@@ -2,9 +2,13 @@ package datadog.trace.instrumentation.springsecurity5
 
 import custom.CustomAuthenticationFilter
 import custom.CustomAuthenticationProvider
+import custom.FailingAuthenticationProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.AuthenticationProvider
+import org.springframework.security.authentication.ProviderManager
+import org.springframework.security.config.annotation.ObjectPostProcessor
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer
@@ -49,6 +53,7 @@ class SecurityConfig {
     @Override
     void configure(HttpSecurity http) throws Exception {
       AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager)
+      http.authenticationProvider(new FailingAuthenticationProvider())
       http.authenticationProvider(new CustomAuthenticationProvider())
       http.addFilterBefore(new CustomAuthenticationFilter(authenticationManager), UsernamePasswordAuthenticationFilter)
     }

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/groovy/datadog/trace/instrumentation/springsecurity5/SpringBootBasedTest.groovy
@@ -235,6 +235,8 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     span.getTag("appsec.events.users.login.success")['enabled'] == 'true'
     span.getTag("appsec.events.users.login.success")['authorities'] == 'ROLE_USER'
     span.getTag("appsec.events.users.login.success")['accountNonLocked'] == 'true'
+
+    span.getTag("appsec.events.users.login.failure.track") == null
   }
 
   void 'test failed signup'() {

--- a/dd-java-agent/instrumentation/spring-security-5/src/test/java/custom/FailingAuthenticationProvider.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/test/java/custom/FailingAuthenticationProvider.java
@@ -1,0 +1,19 @@
+package custom;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class FailingAuthenticationProvider implements AuthenticationProvider {
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    throw new AuthenticationServiceException("I'm dumb");
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return true;
+  }
+}

--- a/dd-java-agent/instrumentation/spring-security-6/src/test/groovy/datadog/trace/instrumentation/springsecurity6/SecurityConfig.groovy
+++ b/dd-java-agent/instrumentation/spring-security-6/src/test/groovy/datadog/trace/instrumentation/springsecurity6/SecurityConfig.groovy
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.springsecurity6
 
 import custom.CustomAuthenticationFilter
 import custom.CustomAuthenticationProvider
+import custom.FailingAuthenticationProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AuthenticationManager
@@ -47,6 +48,7 @@ class SecurityConfig {
     @Override
     void configure(HttpSecurity http) throws Exception {
       AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager)
+      http.authenticationProvider(new FailingAuthenticationProvider())
       http.authenticationProvider(new CustomAuthenticationProvider())
       http.addFilterBefore(new CustomAuthenticationFilter(authenticationManager), UsernamePasswordAuthenticationFilter)
     }

--- a/dd-java-agent/instrumentation/spring-security-6/src/test/groovy/datadog/trace/instrumentation/springsecurity6/SpringBootBasedTest.groovy
+++ b/dd-java-agent/instrumentation/spring-security-6/src/test/groovy/datadog/trace/instrumentation/springsecurity6/SpringBootBasedTest.groovy
@@ -211,6 +211,8 @@ class SpringBootBasedTest extends AppSecHttpServerTest<ConfigurableApplicationCo
     span.getTag("appsec.events.users.login.success")['enabled'] == 'true'
     span.getTag("appsec.events.users.login.success")['authorities'] == 'ROLE_USER'
     span.getTag("appsec.events.users.login.success")['accountNonLocked'] == 'true'
+
+    span.getTag("appsec.events.users.login.failure.track") == null
   }
 
   void 'test failed signup'() {

--- a/dd-java-agent/instrumentation/spring-security-6/src/test/java/custom/FailingAuthenticationProvider.java
+++ b/dd-java-agent/instrumentation/spring-security-6/src/test/java/custom/FailingAuthenticationProvider.java
@@ -1,0 +1,19 @@
+package custom;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+public class FailingAuthenticationProvider implements AuthenticationProvider {
+
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    throw new AuthenticationServiceException("I'm dumb");
+  }
+
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return true;
+  }
+}


### PR DESCRIPTION
# What Does This Do
Changes spring-security instrumentation from `org.springframework.security.authentication.AuthenticationProvider` (multiple providers can coexist causing false triggers of failure) to `org.springframework.security.authentication.AuthenticationManager` that should be stable and generate only login success or failure but never both.

# Motivation
Having both login success and failure can cause problems specially in terms of ATO (account take over), this PR ensures that we don't get false positives in the events.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
