### PR TITLE
Avoid duplicate class symbol extraction

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
@@ -115,7 +115,6 @@ public class SymDBEnablement implements ProductListener {
                 Instant.ofEpochMilli(lastUploadTimestamp), ZoneId.systemDefault()));
         return;
       }
-      symbolAggregator.loadedClassesProcessStarted();
       try {
         symbolExtractionTransformer =
             new SymbolExtractionTransformer(symbolAggregator, classNameFilter);
@@ -125,8 +124,6 @@ public class SymDBEnablement implements ProductListener {
       } catch (Throwable ex) {
         // catch all Throwables because LinkageError is possible (duplicate class definition)
         LOGGER.debug("Error during symbol extraction: ", ex);
-      } finally {
-        symbolAggregator.loadedClassesProcessEnded();
       }
     } finally {
       starting.set(false);


### PR DESCRIPTION
# What Does This Do
We need to track all classes loaded and extracted into ClassNameTrie that is space efficient prefix tree. That way we prevent any duplicates reaching SymDB backend

# Motivation
Same classes can be loaded in different classloader, but symbol-wise they are the same. In some situation (like Groovy script) we can a lot
 of class loaded for same symbols which pollute SymDB backend.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3114]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3114]: https://datadoghq.atlassian.net/browse/DEBUG-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ