### PR TITLE
Update CI reports to prod

### DIFF
--- a/.circleci/upload_ciapp.sh
+++ b/.circleci/upload_ciapp.sh
@@ -1,26 +1,39 @@
 #!/usr/bin/env bash
 SERVICE_NAME="dd-trace-java"
+PIPELINE_STAGE=$1
+TEST_JVM=$2
 
 # JAVA_???_HOME are set in the base image for each used JDK https://github.com/DataDog/dd-trace-java-docker-build/blob/master/Dockerfile#L86
-java_home="JAVA_$2_HOME"
-java_bin="${!java_home}/bin/java"
-if [ ! -x $java_bin ]; then
-    java_bin=$(which java)
+JAVA_HOME="JAVA_${TEST_JVM}_HOME"
+JAVA_BIN="${!JAVA_HOME}/bin/java"
+if [ ! -x "$JAVA_BIN" ]; then
+    JAVA_BIN=$(which java)
 fi
 
-java_props=$($java_bin -XshowSettings:properties -version 2>&1)
-java_prop () {
-    echo "$(echo "$java_props" | grep $1 | head -n1 | cut -d'=' -f2 | xargs)"
+# Extract Java properties from the JVM used to run the tests
+JAVA_PROPS=$($JAVA_BIN -XshowSettings:properties -version 2>&1)
+java_prop() {
+    local PROP_NAME=$1
+    echo "$JAVA_PROPS" | grep "$PROP_NAME" | head -n1 | cut -d'=' -f2 | xargs
 }
 
-# based on tracer implementation: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java#L55-L77
-datadog-ci junit upload --service $SERVICE_NAME \
-    --logs \
-    --tags "test.traits:{\"marker\":[\"$1\"]}" \
-    --tags "runtime.name:$(java_prop java.runtime.name)" \
-    --tags "runtime.vendor:$(java_prop java.vendor)" \
-    --tags "runtime.version:$(java_prop java.version)" \
-    --tags "os.architecture:$(java_prop os.arch)" \
-    --tags "os.platform:$(java_prop os.name)" \
-    --tags "os.version:$(java_prop os.version)" \
-./results
+# Upload test results to CI Visibility
+junit_upload() {
+    # based on tracer implementation: https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/TestDecorator.java#L55-L77
+    DD_API_KEY=$1 \
+        datadog-ci junit upload --service $SERVICE_NAME \
+        --logs \
+        --tags "test.traits:{\"marker\":[\"$PIPELINE_STAGE\"]}" \
+        --tags "runtime.name:$(java_prop java.runtime.name)" \
+        --tags "runtime.vendor:$(java_prop java.vendor)" \
+        --tags "runtime.version:$(java_prop java.version)" \
+        --tags "os.architecture:$(java_prop os.arch)" \
+        --tags "os.platform:$(java_prop os.name)" \
+        --tags "os.version:$(java_prop os.version)" \
+        ./results
+}
+
+# Upload test results to production environment like all other CI jobs
+junit_upload "$DATADOG_API_KEY_PROD"
+# And also upload to staging environment to benefit from the new features not yet released
+junit_upload "$DATADOG_API_KEY_DDSTAGING"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -54,6 +54,7 @@ _Recovery:_ Manually trigger the action again on the relevant tag.
 _Trigger:_ When creating a minor or major version tag.
 
 _Actions:_
+
 * Close the milestone related to the tag,
 * Create a new milestone by incrementing minor version.
 
@@ -76,6 +77,7 @@ _Notes:_ _Download releases_ are special GitHub releases with fixed URL and tags
 _Trigger:_ When a release is published. Releases of type `prereleased` should skip this.
 
 _Action:_
+
 * Find all issues related to the release by checking the related milestone,
 * Add a comment to let know the issue was addressed by the newly published release,
 * Close all those issues.
@@ -105,10 +107,13 @@ _Recovery:_ Manually trigger the action again.
 
 _Trigger:_ When pushing commits to `master` or any pull request targeting `master`.
 
-_Action:_ 
+_Action:_
+
 * Run [DataDog Static Analysis](https://docs.datadoghq.com/static_analysis/) and upload result to DataDog Code Analysis,
-* Run [GitHub CodeQL](https://codeql.github.com/) action, upload result to GitHub security tab and DataDog Code Analysis -- do not apply to pull request, only when pushing to `master`,
-* Run [Trivy security scanner](https://github.com/aquasecurity/trivy) on built artifacts and upload result to GitHub security tab.
+* Run [GitHub CodeQL](https://codeql.github.com/) action, upload result to GitHub security tab -- do not apply to pull request, only when pushing to `master`,
+* Run [Trivy security scanner](https://github.com/aquasecurity/trivy) on built artifacts and upload result to GitHub security tab and Datadog Code Analysis.
+
+_Notes:_ Results are sent on both production and staging environments.
 
 ### comment-on-submodule-update [🔗](comment-on-submodule-update.yaml)
 

--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -16,13 +16,25 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # 4.1.6
         with:
           submodules: 'recursive'
-      - name: Check code meets quality standards
+      - name: Check code meets quality standards (production)
         id: datadog-static-analysis
         uses: DataDog/datadog-static-analyzer-github-action@c74aff158c8cc1c3e285660713bcaa5f9c6d696e # v1
         with:
-          dd_app_key: ${{ secrets.DD_APP_KEY }}
-          dd_api_key: ${{ secrets.DD_API_KEY }}
-          dd_site: datad0g.com
+          dd_app_key: ${{ secrets.DATADOG_APP_KEY_PROD }}
+          dd_api_key: ${{ secrets.DATADOG_API_KEY_PROD }}
+          dd_site: "datadoghq.com"
+          dd_service: "dd-trace-java"
+          dd_env: "ci"
+          cpu_count: 2
+          enable_performance_statistics: false
+      # Also run the static analysis on the staging environment to benefit from the new features not yet released
+      - name: Check code meets quality standards (staging)
+        id: datadog-static-analysis-staging
+        uses: DataDog/datadog-static-analyzer-github-action@c74aff158c8cc1c3e285660713bcaa5f9c6d696e # v1
+        with:
+          dd_app_key: ${{ secrets.DATADOG_APP_KEY_STAGING }}
+          dd_api_key: ${{ secrets.DATADOG_API_KEY_STAGING }}
+          dd_site: "datad0g.com"
           dd_service: "dd-trace-java"
           dd_env: "ci"
           cpu_count: 2
@@ -77,11 +89,19 @@ jobs:
       # For now, CodeQL SARIF results are not supported by Datadog CI
       # - name: Upload results to Datadog CI Static Analysis
       #   run: |
-      #     wget --no-verbose https://github.com/DataDog/datadog-ci/releases/download/v2.42.0/datadog-ci_linux-x64 -O datadog-ci
+      #     wget --no-verbose https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64 -O datadog-ci
       #     chmod +x datadog-ci
       #     ./datadog-ci sarif upload /home/runner/work/dd-trace-java/results/java.sarif --service dd-trace-java --env ci
       #   env:
-      #     DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      #     DD_API_KEY: ${{ secrets.DATADOG_APP_KEY_PROD }}
+      #     DD_SITE: datadoghq.com
+
+      # For now, CodeQL SARIF results are not supported by Datadog CI
+      # - name: Upload results to Datadog Staging CI Static Analysis
+      #   run: |
+      #     ./datadog-ci sarif upload /home/runner/work/dd-trace-java/results/java.sarif --service dd-trace-java --env ci
+      #   env:
+      #     DD_API_KEY: ${{ secrets.DATADOG_API_KEY_STAGING }}
       #     DD_SITE: datad0g.com
 
   trivy:
@@ -152,9 +172,16 @@ jobs:
 
       - name: Upload results to Datadog CI Static Analysis
         run: |
-          wget --no-verbose https://github.com/DataDog/datadog-ci/releases/download/v2.42.0/datadog-ci_linux-x64 -O datadog-ci
+          wget --no-verbose https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64 -O datadog-ci
           chmod +x datadog-ci
           ./datadog-ci sarif upload trivy-results.sarif --service dd-trace-java --env ci
         env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_PROD }}
+          DD_SITE: datadoghq.com
+
+      - name: Upload results to Datadog Staging CI Static Analysis
+        run: |
+          ./datadog-ci sarif upload trivy-results.sarif --service dd-trace-java --env ci
+        env:
+          DD_API_KEY: ${{ secrets.DATADOG_API_KEY_STAGING }}
           DD_SITE: datad0g.com


### PR DESCRIPTION
# What Does This Do

This PR sends tests and static analysis result reports to Datadog production environment.

# Motivation

This was previously set up for staging, but all the repositories moved to production.
In order to have a complete view of the different projects and CI, this uploads the results to the production environment.

# Additional Notes

We will still send data to the staging environment to benefit from staging features.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
