### PR TITLE
Logback to span events - experimental, for review/discussion

### DIFF
--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LogbackLoggerInstrumentation.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LogbackLoggerInstrumentation.java
@@ -18,6 +18,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.util.Map;
@@ -34,6 +35,13 @@ public class LogbackLoggerInstrumentation extends InstrumenterModule.Tracing
   @Override
   public String instrumentedType() {
     return "ch.qos.logback.classic.Logger";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+        packageName + ".LoggingHelper",
+    };
   }
 
   @Override
@@ -56,12 +64,33 @@ public class LogbackLoggerInstrumentation extends InstrumenterModule.Tracing
   public static class CallAppendersAdvice {
     @Advice.OnMethodEnter
     public static void onEnter(@Advice.Argument(0) ILoggingEvent event) {
-      AgentSpan span = activeSpan();
+      int callDepth = CallDepthThreadLocalMap.incrementCallDepth(LoggingHelper.class);
+      if (callDepth == 0) {
+        AgentSpan span = activeSpan();
 
-      if (span != null && traceConfig(span).isLogsInjectionEnabled()) {
-        InstrumentationContext.get(ILoggingEvent.class, AgentSpan.Context.class)
-            .put(event, span.context());
+        if (span != null && traceConfig(span).isLogsInjectionEnabled()) {
+          InstrumentationContext.get(ILoggingEvent.class, AgentSpan.Context.class)
+              .put(event, span.context());
+
+          /*
+           * TODO: This needs to be configurable, such as:
+           * - enabled
+           * - level of logs to add to span events
+           * - level to set span status to error
+           * - record exceptions as tags
+           *
+           * References:
+           * - https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/logback/logback-appender-1.0/library/README.md
+           * - https://pkg.go.dev/github.com/uptrace/opentelemetry-go-extra/otelzap#readme-options
+           */
+          LoggingHelper.createSpanEvent(event, span);
+        }
       }
+    }
+
+    @Advice.OnMethodExit
+    public static void onExit() {
+      CallDepthThreadLocalMap.decrementCallDepth(LoggingHelper.class);
     }
   }
 }

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingHelper.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingHelper.java
@@ -1,4 +1,48 @@
 package datadog.trace.instrumentation.logback;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.SpanAttributes;
+import datadog.trace.bootstrap.instrumentation.api.SpanEvent;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.concurrent.TimeUnit;
+
 public class LoggingHelper {
+  public static void createSpanEvent(ILoggingEvent event, AgentSpan span) {
+    SpanAttributes.Builder builder = SpanAttributes.builder()
+        .put("logger", event.getLoggerName())
+        .put("level", event.getLevel().toString())
+        .put("thread", event.getThreadName())
+        .put("message", event.getFormattedMessage());
+
+    if (Level.ERROR.equals(event.getLevel())) {
+      span.setError(true);
+    }
+
+    Throwable throwable = null;
+    IThrowableProxy throwableProxy = event.getThrowableProxy();
+    if (throwableProxy instanceof ThrowableProxy) {
+      // the returned Throwable might still be null
+      throwable = ((ThrowableProxy)throwableProxy).getThrowable();
+    }
+    if (throwable != null) {
+      final StringWriter errorString = new StringWriter();
+      throwable.printStackTrace(new PrintWriter(errorString));
+
+      builder.put("exception.message", throwable.getMessage());
+      builder.put("exception.type", throwable.getClass().getName());
+      builder.put("exception.stacktrace", errorString.toString());
+
+      span.setTag("error.message", throwable.getMessage());
+      span.setTag("error.type", throwable.getClass().getName());
+      span.setTag("error.stack", errorString.toString());
+    }
+
+    span.addEvent(new SpanEvent("LogEvent", builder.build(), event.getTimeStamp(), TimeUnit.MILLISECONDS));
+  }
 }

--- a/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingHelper.java
+++ b/dd-java-agent/instrumentation/logback-1/src/main/java/datadog/trace/instrumentation/logback/LoggingHelper.java
@@ -1,0 +1,4 @@
+package datadog.trace.instrumentation.logback;
+
+public class LoggingHelper {
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -24,11 +24,14 @@ import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanEvent;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
 import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
+import datadog.trace.bootstrap.instrumentation.api.SpanEvent;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Collections;
@@ -115,6 +118,8 @@ public class DDSpan
 
   private final List<AgentSpanLink> links;
 
+  private final List<AgentSpanEvent> events;
+
   /**
    * Spans should be constructed using the builder, not by calling the constructor directly.
    *
@@ -142,6 +147,8 @@ public class DDSpan
     }
 
     this.links = links == null ? new CopyOnWriteArrayList<>() : new CopyOnWriteArrayList<>(links);
+
+    this.events = new CopyOnWriteArrayList<>();
   }
 
   public boolean isFinished() {
@@ -715,7 +722,7 @@ public class DDSpan
 
   @Override
   public void processTagsAndBaggage(final MetadataConsumer consumer) {
-    context.processTagsAndBaggage(consumer, longRunningVersion, links);
+    context.processTagsAndBaggage(consumer, longRunningVersion, links, events);
   }
 
   @Override
@@ -804,7 +811,9 @@ public class DDSpan
         + ", forceKeep="
         + forceKeep
         + ", links="
-        + links;
+        + links
+        + ", events="
+        + SpanEvent.toTag(events);
   }
 
   @Override
@@ -833,6 +842,12 @@ public class DDSpan
   public void addLink(AgentSpanLink link) {
     if (link != null) {
       this.links.add(link);
+    }
+  }
+
+  public void addEvent(AgentSpanEvent event) {
+    if (event != null) {
+      this.events.add(event);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -1,5 +1,6 @@
 package datadog.trace.core;
 
+import static datadog.trace.api.DDTags.SPAN_EVENTS;
 import static datadog.trace.api.DDTags.SPAN_LINKS;
 import static datadog.trace.api.cache.RadixTreeCache.HTTP_STATUSES;
 import static datadog.trace.bootstrap.instrumentation.api.ErrorPriorities.UNSET;
@@ -17,6 +18,7 @@ import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpanEvent;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilerContext;
@@ -845,13 +847,19 @@ public class DDSpanContext
   }
 
   public void processTagsAndBaggage(
-      final MetadataConsumer consumer, int longRunningVersion, List<AgentSpanLink> links) {
+      final MetadataConsumer consumer, int longRunningVersion, List<AgentSpanLink> links,
+      List<AgentSpanEvent> events) {
     synchronized (unsafeTags) {
       // Tags
       Map<String, Object> tags = TagsPostProcessorFactory.instance().processTags(unsafeTags, this);
       String linksTag = DDSpanLink.toTag(links);
       if (linksTag != null) {
         tags.put(SPAN_LINKS, linksTag);
+      }
+      // Events
+      String eventsTag = DDSpanEvent.toTag(events);
+      if (eventsTag != null) {
+        tags.put(SPAN_EVENTS, eventsTag);
       }
       // Baggage
       Map<String, String> baggageItemsWithPropagationTags;

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanEvent.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanEvent.java
@@ -1,0 +1,16 @@
+package datadog.trace.core;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.SpanEvent;
+
+import java.util.concurrent.*;
+
+public class DDSpanEvent extends SpanEvent {
+  public DDSpanEvent(String name, AgentSpan.Attributes attributes) {
+    super(name, attributes);
+  }
+
+  public DDSpanEvent(String name, AgentSpan.Attributes attributes, long timestamp, TimeUnit unit) {
+    super(name, attributes, timestamp, unit);
+  }
+}

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -59,6 +59,10 @@ excludedClassesCoverage += [
   // Caused by empty 'default' interface method
   "datadog.trace.bootstrap.instrumentation.api.AgentSpan",
   "datadog.trace.bootstrap.instrumentation.api.AgentSpan.Context",
+  "datadog.trace.bootstrap.instrumentation.api.AgentSpanEvent",
+  "datadog.trace.bootstrap.instrumentation.api.SpanEvent",
+  "datadog.trace.bootstrap.instrumentation.api.AgentSpanLink",
+  "datadog.trace.bootstrap.instrumentation.api.SpanLink",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopAgentPropagation",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer",
   "datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopContext",

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -141,6 +141,8 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo, ImplicitContextKeyed
 
   void addLink(AgentSpanLink link);
 
+  void addEvent(AgentSpanEvent event);
+
   boolean isRequiresPostProcessing();
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpanEvent.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpanEvent.java
@@ -1,0 +1,12 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+/**
+ * This interface describes a span event.
+ */
+public interface AgentSpanEvent {
+  long timestamp();
+
+  String name();
+
+  String attributes();
+}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -852,6 +852,9 @@ public class AgentTracer {
     public void addLink(AgentSpanLink link) {}
 
     @Override
+    public void addEvent(AgentSpanEvent event) {}
+
+    @Override
     public AgentSpan setMetaStruct(String field, Object value) {
       return this;
     }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanEvent.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanEvent.java
@@ -1,0 +1,138 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import datadog.trace.api.time.SystemTimeSource;
+import datadog.trace.api.time.TimeSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class SpanEvent implements AgentSpanEvent {
+
+  // TODO TimeSource instance is not retrieved from CoreTracer
+  private static TimeSource timeSource = SystemTimeSource.INSTANCE;
+
+  private final String name;
+  private final String attributes;
+  /** Event timestamp in nanoseconds. */
+  private final long timestamp;
+
+  public SpanEvent(String name, AgentSpan.Attributes attributes) {
+    this.name = name;
+    this.attributes = AttributesJsonParser.toJson(attributes);
+    this.timestamp = SpanEvent.timeSource.getCurrentTimeNanos();
+  }
+
+  public SpanEvent(String name, AgentSpan.Attributes attributes, long timestamp, TimeUnit unit) {
+    this.name = name;
+    this.attributes = AttributesJsonParser.toJson(attributes);
+    this.timestamp = unit.toNanos(timestamp);
+  }
+
+  @NonNull
+  public static String toTag(List<AgentSpanEvent> events) {
+    StringBuilder builder = new StringBuilder("[");
+    for (AgentSpanEvent event : events) {
+      if (builder.length() > 1) {
+        builder.append(',');
+      }
+      builder.append(toJson(event));
+    }
+    return builder.append(']').toString();
+  }
+
+  public static String toJson(AgentSpanEvent event) {
+    StringBuilder builder =
+        new StringBuilder(
+            "{\"time_unix_nano\":" + event.timestamp() + ",\"name\":\"" + event.name() + "\"");
+    if (!event.attributes().isEmpty()) {
+      builder.append(",\"attributes\":").append(event.attributes());
+    }
+    return builder.append('}').toString();
+  }
+
+  @Override
+  public long timestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public String attributes() {
+    return attributes;
+  }
+
+  /** Helper class for JSON-encoding {@link SpanEvent} {@link #attributes}. */
+  public static class AttributesJsonParser {
+    public static String toJson(AgentSpan.Attributes attributes) {
+      if (attributes == null || attributes.isEmpty()) {
+        return "";
+      }
+      StringBuilder jsonBuilder = new StringBuilder();
+      jsonBuilder.append('{');
+
+      Set<Map.Entry<String, String>> entrySet = attributes.asMap().entrySet();
+
+      for (Map.Entry<String, String> entry : entrySet) {
+        if (jsonBuilder.length() > 1) {
+          jsonBuilder.append(',');
+        }
+        // XXX not any more
+        // AttributeKey type has method `getKey()` that "stringifies" the key
+        String key = entry.getKey();
+        Object value = entry.getValue();
+        // Escape key and append it
+        jsonBuilder.append('"').append(escapeJson(key)).append("\":");
+        // Append value to jsonBuilder
+        appendValue(value, jsonBuilder);
+      }
+      jsonBuilder.append('}');
+      return jsonBuilder.toString();
+    }
+
+    /**
+     * Recursively adds the value of an {@link SpanAttributes} to the active StringBuilder in JSON
+     * format, depending on the value's type.
+     *
+     * @param value       The value to append
+     * @param jsonBuilder The active {@link StringBuilder}
+     */
+    private static void appendValue(Object value, StringBuilder jsonBuilder) {
+      // Append value based on its type
+      if (value instanceof String) {
+        jsonBuilder.append('"').append(escapeJson((String) value)).append('"');
+      } else if (value instanceof List) {
+        jsonBuilder.append('[');
+        List<?> valArray = (List<?>) value;
+        for (int i = 0; i < valArray.size(); i++) {
+          if (i > 0) {
+            jsonBuilder.append(',');
+          }
+          appendValue(valArray.get(i), jsonBuilder);
+        }
+        jsonBuilder.append(']');
+      } else if (value instanceof Number || value instanceof Boolean) {
+        jsonBuilder.append(value);
+      } else {
+        jsonBuilder.append("null"); // null for unsupported types
+      }
+    }
+
+    private static String escapeJson(String value) {
+      return value
+          .replace("\\", "\\\\")
+          .replace("\"", "\\\"")
+          .replace("\b", "\\b")
+          .replace("\f", "\\f")
+          .replace("\n", "\\n")
+          .replace("\r", "\\r")
+          .replace("\t", "\\t");
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

1. [Add span event support to AgentSpan, based on OtelSpanEvent](https://github.com/DataDog/dd-trace-java/commit/2d0c27ef576acb2a9895c8973e8bc99aeedaad17)
2. [Experimental: add logback logs as span logs](https://github.com/DataDog/dd-trace-java/commit/318cfe4286b6160b1ca3997d531de3232c065ddf)

# Motivation

Provide visibility to application logs as span events.

# Additional Notes

This is incomplete, and at this point is a proof-of-concept for discussion on approach.

# Possible future work, depending on approach

- [ ] Refactor OtelSpanEvent to use SpanEvent
- [ ] Configurability ([see here](https://github.com/DataDog/dd-trace-java/compare/master...deejgregor:dd-trace-java:logback-to-span-events?expand=1#diff-6ff8f40627cec503fd44d806ff994b3ab3f7d9815d2c5f99832f2bb201c010ffR75-R85))
- [ ] Tests

# Related possible issues

- [ ] Look at possible JSON encoding issues -- [name not encoded here](https://github.com/DataDog/dd-trace-java/blob/9e8d0dcb45855f9d0102f8c01572b19321030d7f/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpanEvent.java#L174)
- [ ] Limit number of span events added
- [ ] Don't let the JSON encoded events exceed the tag limit -- [noticed this limit documented in DDSpanLink](https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java#L26); oh, the encoder there uses it, as well
- [ ] In general, look at patterns in DDSpanLink and see if they can be used here

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
