### PR TITLE
Add missing test for JarReader with trailing separator

### DIFF
--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/JarReaderSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/JarReaderSpecification.groovy
@@ -68,6 +68,25 @@ class JarReaderSpecification extends DepSpecification {
     result.manifest.getValue("Automatic-Module-Name") == "io.opentracing.util"
   }
 
+  void 'read nested jar with ending separator'() {
+    given:
+    String outerPath = getJar("spring-boot-app.jar").getAbsolutePath()
+    String jarPath = "$outerPath!/BOOT-INF/lib/opentracing-util-0.33.0.jar!/"
+
+    when:
+    def result = JarReader.readNestedJarFile(jarPath)
+
+    then:
+    result.jarName == "opentracing-util-0.33.0.jar"
+    result.pomProperties.size() == 1
+    def properties = result.pomProperties['META-INF/maven/io.opentracing/opentracing-util/pom.properties']
+    properties.groupId == "io.opentracing"
+    properties.artifactId == "opentracing-util"
+    properties.version == "0.33.0"
+    result.manifest != null
+    result.manifest.getValue("Automatic-Module-Name") == "io.opentracing.util"
+  }
+
   void 'non-existent simple jar'() {
     given:
     String jarPath = "non-existent.jar"


### PR DESCRIPTION
# What Does This Do

Add missing test case for `JarReader` for nested jar path with trailing `!/`.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55773](https://datadoghq.atlassian.net/browse/APPSEC-55773) (related)

[APPSEC-55773]: https://datadoghq.atlassian.net/browse/APPSEC-55773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ