### PR TITLE
Fix /info endpoint in smoke tests

### DIFF
--- a/dd-smoke-tests/asm-standalone-billing/src/test/groovy/datadog/smoketest/asmstandalonebilling/AsmStandaloneBillingSmokeTest.groovy
+++ b/dd-smoke-tests/asm-standalone-billing/src/test/groovy/datadog/smoketest/asmstandalonebilling/AsmStandaloneBillingSmokeTest.groovy
@@ -60,7 +60,8 @@ class AsmStandaloneBillingSmokeTest extends AbstractAsmStandaloneBillingSmokeTes
 
     then: 'Check if Datadog-Client-Computed-Stats header is present and set to true, Disabling the metrics computation agent-side'
     waitForTraceCount(1)
-    def computedStatsHeader = server.lastRequest.headers.get('Datadog-Client-Computed-Stats')
+    lastTraceRequestHeaders != null
+    def computedStatsHeader = lastTraceRequestHeaders.get('Datadog-Client-Computed-Stats')
     assert computedStatsHeader != null && computedStatsHeader == 'true'
 
     then:'metrics should be disabled'

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -38,6 +38,9 @@ abstract class AbstractSmokeTest extends ProcessManager {
   private Throwable traceDecodingFailure = null
 
   @Shared
+  protected TestHttpServer.Headers lastTraceRequestHeaders = null
+
+  @Shared
   @AutoCleanup
   protected TestHttpServer server = httpServer {
     handlers {
@@ -48,7 +51,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
           "endpoints": [
             "/v0.4/traces",
             "/v0.5/traces",
-            "/telemetry/proxy/",
+            "/telemetry/proxy/"
           ],
           "client_drop_p0s": true,
           "span_meta_structs": true,
@@ -82,6 +85,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
           }
         }
         traceCount.addAndGet(count)
+        lastTraceRequestHeaders = request.headers
         println("Received v0.4 traces: " + countString)
         response.status(200).send()
       }
@@ -104,7 +108,11 @@ abstract class AbstractSmokeTest extends ProcessManager {
           }
         }
         traceCount.addAndGet(count)
+        lastTraceRequestHeaders = request.headers
         println("Received v0.5 traces: " + countString)
+        response.status(200).send()
+      }
+      prefix("/v0.6/stats") {
         response.status(200).send()
       }
       prefix("/v0.7/config") {


### PR DESCRIPTION
# What Does This Do

https://github.com/datadog/dd-trace-java/pull/7257 introduced the `/info` endpoint for the mock agent in smoke-tests, but it was malformed, leading to logged exceptions:

```
[dd.trace 2024-11-11 16:38:35:249 +0100] [main] DEBUG datadog.communication.ddagent.DDAgentFeaturesDiscovery - Error parsing trace agent /info response
com.squareup.moshi.JsonEncodingException: Use JsonReader.setLenient(true) to accept malformed JSON at path $.endpoints[3]
        at com.squareup.moshi.JsonReader.syntaxError(JsonReader.java:243)
        at com.squareup.moshi.JsonUtf8Reader.checkLenient(JsonUtf8Reader.java:1152)
        at com.squareup.moshi.JsonUtf8Reader.doPeek(JsonUtf8Reader.java:349)
        at com.squareup.moshi.JsonUtf8Reader.hasNext(JsonUtf8Reader.java:197)
        at com.squareup.moshi.CollectionJsonAdapter.fromJson(CollectionJsonAdapter.java:80)
        at com.squareup.moshi.CollectionJsonAdapter$2.fromJson(CollectionJsonAdapter.java:55)
        at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
        at com.squareup.moshi.StandardJsonAdapters$ObjectJsonAdapter.fromJson(StandardJsonAdapters.java:344)
        at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
        at com.squareup.moshi.MapJsonAdapter.fromJson(MapJsonAdapter.java:73)
        at com.squareup.moshi.MapJsonAdapter.fromJson(MapJsonAdapter.java:30)
        at com.squareup.moshi.internal.NullSafeJsonAdapter.fromJson(NullSafeJsonAdapter.java:41)
        at com.squareup.moshi.JsonAdapter.fromJson(JsonAdapter.java:51)
        at datadog.communication.ddagent.DDAgentFeaturesDiscovery.processInfoResponse(DDAgentFeaturesDiscovery.java:212)
[...]
```

Also modified `AsmStandaloneBillingSmokeTest.groovy` to stop relying on `TestHttpServer.last`, which is flaky/failing if a non-tracing request to the agent gets sent in the middle.

Added metrics endpoint to keep everything closer to prod.

# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
