### PR TITLE
Fix dependency collection for new Spring Boot nested jars

### DIFF
--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/DependencyResolverSpecification.groovy
@@ -159,6 +159,48 @@ class DependencyResolverSpecification extends DepSpecification {
     dep.source == 'opentracing-util-0.33.0.jar'
   }
 
+  void 'spring boot dependency new style'() throws IOException {
+    when:
+    String zipPath = Classloader.classLoader.getResource('datadog/telemetry/dependencies/spring-boot-app.jar').path
+    URI uri = new URI("jar:nested:$zipPath/!BOOT-INF/lib/opentracing-util-0.33.0.jar!/")
+
+    Dependency dep = DependencyResolver.resolve(uri).get(0)
+
+    then:
+    dep != null
+    dep.name == 'io.opentracing:opentracing-util'
+    dep.version == '0.33.0'
+    dep.hash == null
+    dep.source == 'opentracing-util-0.33.0.jar'
+  }
+
+  void 'spring boot dependency new style empty path'() throws IOException {
+    when:
+    URI uri = new URI("jar:nested:")
+    List<Dependency> deps = DependencyResolver.resolve(uri)
+
+    then:
+    deps.isEmpty()
+  }
+
+  void 'spring boot dependency old style empty path'() throws IOException {
+    when:
+    URI uri = new URI("jar:file:")
+    List<Dependency> deps = DependencyResolver.resolve(uri)
+
+    then:
+    deps.isEmpty()
+  }
+
+  void 'jar unknown'() throws IOException {
+    when:
+    URI uri = new URI("jar:unknown")
+    List<Dependency> deps = DependencyResolver.resolve(uri)
+
+    then:
+    deps.isEmpty()
+  }
+
   void 'spring boot dependency without maven metadata'() throws IOException {
     given:
     def innerJarData = new ByteArrayOutputStream()

--- a/telemetry/src/test/groovy/datadog/telemetry/dependency/JarReaderSpecification.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/dependency/JarReaderSpecification.groovy
@@ -52,29 +52,9 @@ class JarReaderSpecification extends DepSpecification {
   void 'read nested jar'() {
     given:
     String outerPath = getJar("spring-boot-app.jar").getAbsolutePath()
-    String jarPath = "$outerPath!/BOOT-INF/lib/opentracing-util-0.33.0.jar"
 
     when:
-    def result = JarReader.readNestedJarFile(jarPath)
-
-    then:
-    result.jarName == "opentracing-util-0.33.0.jar"
-    result.pomProperties.size() == 1
-    def properties = result.pomProperties['META-INF/maven/io.opentracing/opentracing-util/pom.properties']
-    properties.groupId == "io.opentracing"
-    properties.artifactId == "opentracing-util"
-    properties.version == "0.33.0"
-    result.manifest != null
-    result.manifest.getValue("Automatic-Module-Name") == "io.opentracing.util"
-  }
-
-  void 'read nested jar with ending separator'() {
-    given:
-    String outerPath = getJar("spring-boot-app.jar").getAbsolutePath()
-    String jarPath = "$outerPath!/BOOT-INF/lib/opentracing-util-0.33.0.jar!/"
-
-    when:
-    def result = JarReader.readNestedJarFile(jarPath)
+    def result = JarReader.readNestedJarFile(outerPath, "BOOT-INF/lib/opentracing-util-0.33.0.jar")
 
     then:
     result.jarName == "opentracing-util-0.33.0.jar"
@@ -99,11 +79,8 @@ class JarReaderSpecification extends DepSpecification {
   }
 
   void 'non-existent outer jar for nested jar'() {
-    given:
-    String jarPath = "non-existent.jar!/BOOT-INF/lib/opentracing-util-0.33.0.jar!/"
-
     when:
-    JarReader.readNestedJarFile(jarPath)
+    JarReader.readNestedJarFile("non-existent.jar", "BOOT-INF/lib/opentracing-util-0.33.0.jar")
 
     then:
     thrown(IOException)
@@ -112,34 +89,27 @@ class JarReaderSpecification extends DepSpecification {
   void 'non-existent inner jar for nested jar'() {
     given:
     String outerPath = getJar("spring-boot-app.jar").getAbsolutePath()
-    String jarPath = "$outerPath!/BOOT-INF/lib/non-existent.jar"
 
     when:
-    JarReader.readNestedJarFile(jarPath)
+    JarReader.readNestedJarFile(outerPath, "BOOT-INF/lib/non-existent.jar")
 
     then:
     thrown(IOException)
   }
 
   void 'doubly nested jar path'() {
-    given:
-    String jarPath = "non-existent.jar!/BOOT-INF/lib/opentracing-util-0.33.0.jar!/third"
-
     when:
-    JarReader.readNestedJarFile(jarPath)
+    JarReader.readNestedJarFile("non-existent.jar", "BOOT-INF/lib/opentracing-util-0.33.0.jar/third")
 
     then:
     thrown(IOException)
   }
 
-  void 'lack of nested jar path'() {
-    given:
-    String jarPath = "non-existent.jar"
-
+  void 'empty nested jar path'() {
     when:
-    JarReader.readNestedJarFile(jarPath)
+    JarReader.readNestedJarFile("non-existent.jar", "")
 
     then:
-    thrown(IllegalArgumentException)
+    thrown(IOException)
   }
 }


### PR DESCRIPTION
# What Does This Do

Add support for new Spring Boot loader jars (using `jar:nested:` URLs) on dependency collection.

# Motivation

# Additional Notes
Some more info at https://docs.spring.io/spring-boot/specification/executable-jar/jarfile-class.html
It seems we could optimize access to these nested jars.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [APPSEC-55773](https://datadoghq.atlassian.net/browse/APPSEC-55773)


[APPSEC-55773]: https://datadoghq.atlassian.net/browse/APPSEC-55773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ