### PR TITLE
Fix NullPointerException Extracting Class symbols

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -1161,7 +1161,10 @@ public class CapturedContextInstrumentor extends Instrumentor {
       Limits limits,
       List<FieldNode> results,
       int fieldCount) {
-    String superClassName = Strings.getClassName(classNode.superName);
+    String superClassName =
+        classNode.superName != null
+            ? Strings.getClassName(classNode.superName)
+            : Object.class.getTypeName();
     while (!superClassName.equals(Object.class.getTypeName())) {
       Class<?> clazz;
       try {
@@ -1215,7 +1218,10 @@ public class CapturedContextInstrumentor extends Instrumentor {
       Limits limits,
       List<FieldNode> results,
       int fieldCount) {
-    String superClassName = Strings.getClassName(classNode.superName);
+    String superClassName =
+        classNode.superName != null
+            ? Strings.getClassName(classNode.superName)
+            : Object.class.getTypeName();
     while (!superClassName.equals(Object.class.getTypeName())) {
       Class<?> clazz;
       try {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolExtractor.java
@@ -51,7 +51,7 @@ public class SymbolExtractor {
               .addModifiers(extractClassModifiers(classNode.access))
               .addInterfaces(extractInterfaces(classNode))
               .addAnnotations(extractAnnotations(classNode.visibleAnnotations))
-              .superClass(Strings.getClassName(classNode.superName))
+              .superClass(extractSuperClass(classNode))
               .build();
       Scope classScope =
           Scope.builder(ScopeType.CLASS, sourceFile, classStartLine, classEndLine)
@@ -70,6 +70,13 @@ public class SymbolExtractor {
               "Extracting scopes for class[{}] in jar[{}] failed: ", classNode.name, jarName, ex);
       return null;
     }
+  }
+
+  private static String extractSuperClass(ClassNode classNode) {
+    if (classNode.superName == null) {
+      return Object.class.getTypeName();
+    }
+    return Strings.getClassName(classNode.superName);
   }
 
   private static Collection<String> extractInterfaces(ClassNode classNode) {


### PR DESCRIPTION
# What Does This Do
In rare cases, class super name is null (normally only for java.lag.Object). Handle nicely this case.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3111]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
