### PR TITLE
Exclude okio from vulnerability locations

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -185,6 +185,7 @@
 1 okhttp3.*
 2 okhttp3.Request
 2 okhttp3.Request$*
+2 okio.*
 1 ognl.*
 2 oracle.j2ee.*
 1 oracle.jdbc.*


### PR DESCRIPTION
# What Does This Do
Exclude `okio.*` from vunerability locations

# Motivation
Avoid `okio.*` as vulnerability location (e.g. weak hash being reported at okio itself when using `okio.ByteString#digest`. The vulnerabilities will still be reported, but with the caller code as location.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [APPSEC-55765](https://datadoghq.atlassian.net/browse/APPSEC-55765)

[APPSEC-55765]: https://datadoghq.atlassian.net/browse/APPSEC-55765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ