### PR TITLE
Exclude dev.failsafe from IAST instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
+++ b/dd-java-agent/instrumentation/iast-instrumenter/src/main/resources/datadog/trace/instrumentation/iastinstrumenter/iast_exclusion.trie
@@ -118,6 +118,8 @@
 1 com.zaxxer.*
 1 commonj.work.*
 1 cryptix.*
+# Avoid weak random in dev.failsafe.internal.RetryPolicyExecutor
+1 dev.failsafe.*
 1 edu.emory.*
 1 edu.oswego.*
 1 freemarker.*


### PR DESCRIPTION
# What Does This Do
Exclude IAST instrumentation from `dev.failsafe.*`.

# Motivation
Avoids weak randomness false positive. Instrumentation fully exclude since there's little value in running for this library (retry operations).

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [APPSEC-55801](https://datadoghq.atlassian.net/browse/APPSEC-55801)

[APPSEC-55801]: https://datadoghq.atlassian.net/browse/APPSEC-55801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ