### PR TITLE
Run system-tests scenarios related to RASP

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -816,7 +816,7 @@ jobs:
     parameters:
       weblog-variant:
         type: string
-    parallelism: 3
+    parallelism: 4
     steps:
       - setup_system_tests
 
@@ -842,6 +842,11 @@ jobs:
             DEFAULT
             APM_TRACING_E2E
             APM_TRACING_E2E_SINGLE_SPAN
+            APPSEC_BLOCKING
+            APPSEC_REQUEST_BLOCKING
+            APPSEC_RASP
+            APPSEC_RUNTIME_ACTIVATION
+            REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
             " | circleci tests split > scenarios.list
             for scenario in $(<scenarios.list); do
               if [[ $scenario =~ .*_E2E.* ]]; then

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -838,16 +838,22 @@ jobs:
           no_output_timeout: 5m
           command: |
             cd system-tests
+            (
             echo "
             DEFAULT
             APM_TRACING_E2E
             APM_TRACING_E2E_SINGLE_SPAN
-            APPSEC_BLOCKING
-            APPSEC_REQUEST_BLOCKING
-            APPSEC_RASP
-            APPSEC_RUNTIME_ACTIVATION
-            REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
-            " | circleci tests split > scenarios.list
+            "
+            if ! [[ << parameters.weblog-variant >> =~ .*native ]]; then
+              echo "
+              APPSEC_BLOCKING
+              APPSEC_REQUEST_BLOCKING
+              APPSEC_RASP
+              APPSEC_RUNTIME_ACTIVATION
+              REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD
+              "
+            fi
+            ) | circleci tests split > scenarios.list
             for scenario in $(<scenarios.list); do
               if [[ $scenario =~ .*_E2E.* ]]; then
                 export DD_SITE=datadoghq.com

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -871,6 +871,7 @@ jobs:
           command: |
             mkdir -p artifacts
             cd system-tests
+            shopt -s nullglob
             for log_dir in logs*; do
               tar -cvzf ../artifacts/${log_dir}_<< parameters.weblog-variant >>.tar.gz $log_dir
             done


### PR DESCRIPTION
# What Does This Do
Add the following system-tests scenarios relevant to the upcoming GA release of Exploit Prevention (aka RASP):
* `APPSEC_RASP`
* `APPSEC_RUNTIME_ACTIVATION`
* `REMOTE_CONFIG_MOCKED_BACKEND_ASM_DD`

And the following related to blocking:
* `APPSEC_BLOCKING`
* `APPSEC_REQUEST_BLOCKING`.

# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [APPSEC-55833](https://datadoghq.atlassian.net/browse/APPSEC-55833)

[APPSEC-55833]: https://datadoghq.atlassian.net/browse/APPSEC-55833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ