### PR TITLE
Collect git metadata for telemetry

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/git/UserSuppliedGitInfoBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/UserSuppliedGitInfoBuilder.java
@@ -13,6 +13,8 @@ import static datadog.trace.api.git.GitInfo.DD_GIT_REPOSITORY_URL;
 import static datadog.trace.api.git.GitInfo.DD_GIT_TAG;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.ConfigCollector;
+import datadog.trace.api.ConfigOrigin;
 import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import javax.annotation.Nullable;
@@ -49,6 +51,9 @@ public class UserSuppliedGitInfoBuilder implements GitInfoBuilder {
     if (gitCommitSha == null) {
       gitCommitSha = Config.get().getGlobalTags().get(Tags.GIT_COMMIT_SHA);
     }
+
+    ConfigCollector.get().put(DD_GIT_REPOSITORY_URL, gitRepositoryUrl, ConfigOrigin.ENV);
+    ConfigCollector.get().put(DD_GIT_COMMIT_SHA, gitCommitSha, ConfigOrigin.ENV);
 
     final String gitCommitMessage = System.getenv(DD_GIT_COMMIT_MESSAGE);
     final String gitCommitAuthorName = System.getenv(DD_GIT_COMMIT_AUTHOR_NAME);


### PR DESCRIPTION
# What Does This Do
Collect git metadata (git repository url and git commit sha) to be sent with app-started event by telemetry

# Motivation
Having git metadata at startup even without traces, and help onboard for SCI

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
