### PR TITLE
Parallelize system-tests

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -816,6 +816,7 @@ jobs:
     parameters:
       weblog-variant:
         type: string
+    parallelism: 3
     steps:
       - setup_system_tests
 
@@ -833,32 +834,38 @@ jobs:
 
       - run:
           name: Run
-          command: |
-            cd system-tests
-            DD_API_KEY=$SYSTEM_TESTS_DD_API_KEY ./run.sh
-
-      - run:
-          name: Run APM E2E default tests
           # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
           no_output_timeout: 5m
           command: |
             cd system-tests
-            DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E
-
-      - run:
-          name: Run APM E2E Single Span tests
-          # Stop the job after 5m to avoid excessive overhead. Will need adjustment as more tests are added.
-          no_output_timeout: 5m
-          command: |
-            cd system-tests
-            DD_SITE=datadoghq.com DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY ./run.sh APM_TRACING_E2E_SINGLE_SPAN
+            echo "
+            DEFAULT
+            APM_TRACING_E2E
+            APM_TRACING_E2E_SINGLE_SPAN
+            " | circleci tests split > scenarios.list
+            for scenario in $(<scenarios.list); do
+              if [[ $scenario =~ .*_E2E.* ]]; then
+                export DD_SITE=datadoghq.com
+                export DD_API_KEY=$SYSTEM_TESTS_E2E_DD_API_KEY
+                export DD_APPLICATION_KEY=$SYSTEM_TESTS_E2E_DD_APP_KEY
+              else
+                export DD_API_KEY=$SYSTEM_TESTS_DD_API_KEY
+              fi
+              echo "Running scenario $scenario"
+              ./run.sh $scenario
+            done
 
       - run:
           name: Collect artifacts
-          command: tar -cvzf logs_java_<< parameters.weblog-variant >>_dev.tar.gz -C system-tests logs logs_apm_tracing_e2e logs_apm_tracing_e2e_single_span
+          command: |
+            mkdir -p artifacts
+            cd system-tests
+            for log_dir in logs*; do
+              tar -cvzf ../artifacts/${log_dir}_<< parameters.weblog-variant >>.tar.gz $log_dir
+            done
 
       - store_artifacts:
-          path: logs_java_<< parameters.weblog-variant >>_dev.tar.gz
+          path: artifacts
 
   integrations-system-tests:
     machine:


### PR DESCRIPTION
# What Does This Do
Parallelize system-tests at scenario level. We just use `circleci tests` for splitting, which will be quite naive, but might just do the job at the moment.

# Motivation
I'll be expanding the number of scenarios that are run, and running them linearly will increase the wall clock time for the full pipeline. Parallelization here is quite reasonable since there's just ~2min of the job that is redundant, and these are medium size runners anyway.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
