### PR TITLE
Improve crashtracking support for older Bash version

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/resources/com/datadog/crashtracking/notify_oome.sh
+++ b/dd-java-agent/agent-crashtracking/src/main/resources/com/datadog/crashtracking/notify_oome.sh
@@ -22,20 +22,25 @@ fi
 # The expected contents are:
 # - agent: Path to the agent jar
 # - tags: Comma-separated list of tags to be sent with the OOME event; key:value pairs are supported
-declare -A config
 while IFS="=" read -r key value; do
-    config["$key"]="$value"
+    declare "config_$key"="$value"
 done < "$configFile"
 
+# Exiting early if configuration is missing
+if [ -z "${config_agent}" ] || [ -z "${config_tags}" ]; then
+    echo "Error: Missing configuration"
+    exit 1
+fi
+
 # Debug: Print the loaded values (Optional)
-echo "Agent Jar: ${config[agent]}"
-echo "Tags: ${config[tags]}"
+echo "Agent Jar: ${config_agent}"
+echo "Tags: ${config_tags}"
 echo "PID: $PID"
 
 # Execute the Java command with the loaded values
-java -Ddd.dogstatsd.start-delay=0 -jar "${config[agent]}" sendOomeEvent "${config[tags]}"
+java -Ddd.dogstatsd.start-delay=0 -jar "${config_agent}" sendOomeEvent "${config_tags}"
 RC=$?
-rm -f ${configFile} # Remove the configuration file
+rm -f "${configFile}" # Remove the configuration file
 
 if [ $RC -eq 0 ]; then
     echo "OOME Event generated successfully"

--- a/dd-java-agent/agent-crashtracking/src/main/resources/com/datadog/crashtracking/upload_crash.sh
+++ b/dd-java-agent/agent-crashtracking/src/main/resources/com/datadog/crashtracking/upload_crash.sh
@@ -30,24 +30,29 @@ fi
 # The expected contents are:
 # - agent: Path to the agent jar
 # - hs_err: Path to the hs_err log file
-declare -A config
 while IFS="=" read -r key value; do
-    config["$key"]="$value"
+    declare "config_$key"="$value"
 done < "$configFile"
 
+# Exiting early if configuration is missing
+if [ -z "${config_agent}" ] || [ -z "${config_hs_err}" ]; then
+    echo "Error: Missing configuration"
+    exit 1
+fi
+
 # Debug: Print the loaded values (Optional)
-echo "Agent Jar: ${config[agent]}"
-echo "Error Log: ${config[hs_err]}"
+echo "Agent Jar: ${config_agent}"
+echo "Error Log: ${config_hs_err}"
 echo "PID: $PID"
 
 # Execute the Java command with the loaded values
-java -jar "${config[agent]}" uploadCrash "${config[hs_err]}"
+java -jar "${config_agent}" uploadCrash "${config_hs_err}"
 RC=$?
-rm -f ${configFile} # Remove the configuration file
+rm -f "${configFile}" # Remove the configuration file
 
 if [ $RC -eq 0 ]; then
-    echo "Error file ${config[hs_err]} was uploaded successfully"
+    echo "Error file ${config_hs_err} was uploaded successfully"
 else
-    echo "Error: Failed to upload error file ${config[hs_err]}"
+    echo "Error: Failed to upload error file ${config_hs_err}"
     exit $RC
 fi


### PR DESCRIPTION
# What Does This Do

This PR fixes case when Bash associative array are not supported as associative arrays require Bash 4.
I replaced them with dynamic variable names.

# Motivation

It was reported by @dougqh encountering issues with its dev environment.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
