### PR TITLE
Remove internal `dd.trace.scope.inherit.async.propagation` feature flag

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/TypeConverterTest.groovy
@@ -45,7 +45,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, false, true)
+    def scopeManager = new ContinuableScopeManager(0, false)
     def context = createTestSpanContext()
     def span1 = new DDSpan("test", 0, context, null)
     def span2 = new DDSpan("test", 0, context, null)

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/TypeConverterTest.groovy
@@ -50,7 +50,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, false, true)
+    def scopeManager = new ContinuableScopeManager(0, false)
     def context = createTestSpanContext()
     def span1 = new DDSpan("test", 0, context, null)
     def span2 = new DDSpan("test", 0, context, null)

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/TypeConverterTest.groovy
@@ -50,7 +50,7 @@ class TypeConverterTest extends AgentTestRunner {
   }
 
   def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, false, true)
+    def scopeManager = new ContinuableScopeManager(0, false)
     def context = createTestSpanContext()
     def span1 = new DDSpan("test", 0, context, null)
     def span2 = new DDSpan("test", 0, context, null)

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -76,8 +76,6 @@ public final class TracerConfig {
 
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
   public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";
-  public static final String SCOPE_INHERIT_ASYNC_PROPAGATION =
-      "trace.scope.inherit.async.propagation";
   public static final String SCOPE_ITERATION_KEEP_ALIVE = "trace.scope.iteration.keep.alive";
   public static final String PARTIAL_FLUSH_ENABLED = "trace.partial.flush.enabled";
   public static final String PARTIAL_FLUSH_MIN_SPANS = "trace.partial.flush.min.spans";

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -635,7 +635,6 @@ public class CoreTracer implements AgentTracer.TracerAPI {
           new ContinuableScopeManager(
               config.getScopeDepthLimit(),
               config.isScopeStrictMode(),
-              config.isScopeInheritAsyncPropagation(),
               profilingContextIntegration,
               healthMetrics);
     } else {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -48,7 +48,6 @@ public final class ContinuableScopeManager implements AgentScopeManager {
   final boolean strictMode;
   private final ScopeStackThreadLocal tlsScopeStack;
   private final int depthLimit;
-  private final boolean inheritAsyncPropagation;
   final HealthMetrics healthMetrics;
   private final ProfilingContextIntegration profilingContextIntegration;
 
@@ -57,17 +56,9 @@ public final class ContinuableScopeManager implements AgentScopeManager {
    *
    * @param depthLimit The maximum scope depth limit, <code>0</code> for unlimited.
    * @param strictMode Whether check if the closed spans are the active ones or not.
-   * @param inheritAsyncPropagation Whether the next span should inherit the active span
-   *     asyncPropagation flag.
    */
-  public ContinuableScopeManager(
-      final int depthLimit, final boolean strictMode, final boolean inheritAsyncPropagation) {
-    this(
-        depthLimit,
-        strictMode,
-        inheritAsyncPropagation,
-        ProfilingContextIntegration.NoOp.INSTANCE,
-        HealthMetrics.NO_OP);
+  public ContinuableScopeManager(final int depthLimit, final boolean strictMode) {
+    this(depthLimit, strictMode, ProfilingContextIntegration.NoOp.INSTANCE, HealthMetrics.NO_OP);
   }
 
   /**
@@ -75,18 +66,14 @@ public final class ContinuableScopeManager implements AgentScopeManager {
    *
    * @param depthLimit The maximum scope depth limit, <code>0</code> for unlimited.
    * @param strictMode Whether check if the closed spans are the active ones or not.
-   * @param inheritAsyncPropagation Whether the next span should inherit the active span
-   *     asyncPropagation flag.
    */
   public ContinuableScopeManager(
       final int depthLimit,
       final boolean strictMode,
-      final boolean inheritAsyncPropagation,
       final ProfilingContextIntegration profilingContextIntegration,
       final HealthMetrics healthMetrics) {
     this.depthLimit = depthLimit == 0 ? Integer.MAX_VALUE : depthLimit;
     this.strictMode = strictMode;
-    this.inheritAsyncPropagation = inheritAsyncPropagation;
     this.scopeListeners = new CopyOnWriteArrayList<>();
     this.extendedScopeListeners = new CopyOnWriteArrayList<>();
     this.healthMetrics = healthMetrics;
@@ -141,9 +128,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
     boolean asyncPropagation =
         overrideAsyncPropagation
             ? isAsyncPropagating
-            : inheritAsyncPropagation && top != null
-                ? top.isAsyncPropagating()
-                : DEFAULT_ASYNC_PROPAGATING;
+            : top != null ? top.isAsyncPropagating() : DEFAULT_ASYNC_PROPAGATING;
 
     final ContinuableScope scope =
         new ContinuableScope(this, span, source, asyncPropagation, createScopeState(span));
@@ -219,10 +204,7 @@ public final class ContinuableScopeManager implements AgentScopeManager {
 
     final ContinuableScope top = scopeStack.top;
 
-    boolean asyncPropagation =
-        inheritAsyncPropagation && top != null
-            ? top.isAsyncPropagating()
-            : DEFAULT_ASYNC_PROPAGATING;
+    boolean asyncPropagation = top != null ? top.isAsyncPropagating() : DEFAULT_ASYNC_PROPAGATING;
 
     final ContinuableScope scope =
         new ContinuableScope(

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceBufferTest.groovy
@@ -31,7 +31,7 @@ class PendingTraceBufferTest extends DDSpecification {
 
   def tracer = Mock(CoreTracer)
   def traceConfig = Mock(CoreTracer.ConfigSnapshot)
-  def scopeManager = new ContinuableScopeManager(10, true, true)
+  def scopeManager = new ContinuableScopeManager(10, true)
   def factory = new PendingTrace.Factory(tracer, bufferSpy, SystemTimeSource.INSTANCE, false, HealthMetrics.NO_OP)
   List<TraceScope.Continuation> continuations = []
 

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/TypeConverterTest.groovy
@@ -52,7 +52,7 @@ class TypeConverterTest extends DDSpecification {
   }
 
   def "should avoid extra allocation for a scope wrapper"() {
-    def scopeManager = new ContinuableScopeManager(0, false, true)
+    def scopeManager = new ContinuableScopeManager(0, false)
     def context = createTestSpanContext()
     def span1 = new DDSpan("test", 0, context, null)
     def span2 = new DDSpan("test", 0, context, null)

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -174,7 +174,6 @@ public class Config {
   private final Set<String> splitByTags;
   private final int scopeDepthLimit;
   private final boolean scopeStrictMode;
-  private final boolean scopeInheritAsyncPropagation;
   private final int scopeIterationKeepAlive;
   private final int partialFlushMinSpans;
   private final boolean traceStrictWritesEnabled;
@@ -853,8 +852,6 @@ public class Config {
     scopeDepthLimit = configProvider.getInteger(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
 
     scopeStrictMode = configProvider.getBoolean(SCOPE_STRICT_MODE, false);
-
-    scopeInheritAsyncPropagation = configProvider.getBoolean(SCOPE_INHERIT_ASYNC_PROPAGATION, true);
 
     scopeIterationKeepAlive =
         configProvider.getInteger(SCOPE_ITERATION_KEEP_ALIVE, DEFAULT_SCOPE_ITERATION_KEEP_ALIVE);
@@ -2071,10 +2068,6 @@ public class Config {
 
   public boolean isScopeStrictMode() {
     return scopeStrictMode;
-  }
-
-  public boolean isScopeInheritAsyncPropagation() {
-    return scopeInheritAsyncPropagation;
   }
 
   public int getScopeIterationKeepAlive() {
@@ -4168,8 +4161,6 @@ public class Config {
         + scopeDepthLimit
         + ", scopeStrictMode="
         + scopeStrictMode
-        + ", scopeInheritAsyncPropagation="
-        + scopeInheritAsyncPropagation
         + ", scopeIterationKeepAlive="
         + scopeIterationKeepAlive
         + ", partialFlushMinSpans="


### PR DESCRIPTION
# What Does This Do

Removes the internal `dd.trace.scope.inherit.async.propagation` feature flag, which has always defaulted to `true`

# Motivation

This flag was added in #1850 (v0.64.0) in case we needed to revert the fixed behaviour, but we have never needed to do that. Removing it simplifies some of the code and helps with future refactoring.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
