### PR TITLE
Fix test name uniqueness

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -422,7 +422,8 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     def ig = new InstrumentationGateway()
     def ss = ig.getSubscriptionService(RequestContextSlot.APPSEC)
     def cbpAppSec = ig.getCallbackProvider(RequestContextSlot.APPSEC)
-    def callbacks = new IGCallBacks(reqData)
+    def data = reqData ? new Object() : null
+    def callbacks = new IGCallBacks(data)
     if (reqStarted) {
       ss.registerCallback(EVENTS.requestStarted(), callbacks)
     }
@@ -434,7 +435,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
     }
     Map<String, String> headers = ["foo": "bar", "some": "thing", "another": "value"]
     def reqCtxt = Mock(RequestContext) {
-      getData(RequestContextSlot.APPSEC) >> reqData
+      getData(RequestContextSlot.APPSEC) >> data
     }
     def mSpan = Mock(AgentSpan) {
       getRequestContext() >> reqCtxt
@@ -461,13 +462,13 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
     where:
     // spotless:off
-    reqStarted | reqData      | reqHeader | reqHeaderDone | reqStartedCount | reqHeaderCount | reqHeaderDoneCount
-    false      | null         | false     | false         | 0               | 0              | 0
-    false      | new Object() | false     | false         | 0               | 0              | 0
-    true       | null         | false     | false         | 1               | 0              | 0
-    true       | new Object() | false     | false         | 1               | 0              | 0
-    true       | new Object() | true      | false         | 1               | 3              | 0
-    true       | new Object() | true      | true          | 1               | 3              | 1
+    reqStarted | reqData | reqHeader | reqHeaderDone | reqStartedCount | reqHeaderCount | reqHeaderDoneCount
+    false      | false   | false     | false         | 0               | 0              | 0
+    false      | true    | false     | false         | 0               | 0              | 0
+    true       | false   | false     | false         | 1               | 0              | 0
+    true       | true    | false     | false         | 1               | 0              | 0
+    true       | true    | true      | false         | 1               | 3              | 0
+    true       | true    | true      | true          | 1               | 3              | 1
     // spotless:on
   }
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/IteratorsTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/util/IteratorsTest.groovy
@@ -60,7 +60,7 @@ class IteratorsTest extends Specification {
     ['hello', 'World', '!'] | ['hello', 'World', '!']
   }
 
-  void 'joined iterator'() {
+  void 'joined iterator #iterationIndex'() {
     when:
     final iterator = Iterators.join(iterators as Iterator<?>[])
 

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -184,5 +184,10 @@ class BaseCallSiteTest extends DDSpecification {
     String type
     String method
     String descriptor
+
+    @Override
+    String toString() {
+      return descriptor
+    }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/metrics/SerializingMetricWriterTest.groovy
@@ -14,7 +14,7 @@ import static java.util.concurrent.TimeUnit.SECONDS
 
 class SerializingMetricWriterTest extends DDSpecification {
 
-  def "should produce correct message" () {
+  def "should produce correct message #iterationIndex" () {
     setup:
     long startTime = MILLISECONDS.toNanos(System.currentTimeMillis())
     long duration = SECONDS.toNanos(10)

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RuleBasedSamplingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/sampling/RuleBasedSamplingTest.groovy
@@ -328,9 +328,9 @@ class RuleBasedSamplingTest extends DDCoreSpecification {
     "*"         | "anything..."             | true
     "*"         | null                      | false
     "*"         | new StringBuilder("foo")  | true
-    "*"         | new Object() {}           | true
-    "**"        | new Object() {}           | true
-    "?"         | new Object() {}           | false
+    "*"         | object()                  | true
+    "**"        | object()                  | true
+    "?"         | object()                  | false
     "*"         | "foo"                     | true
     "**"        | "foo"                     | true
     "**"        | true                      | true
@@ -484,5 +484,14 @@ class RuleBasedSamplingTest extends DDCoreSpecification {
 
   static bigDecimal(str) {
     return new BigDecimal(str)
+  }
+
+  static object() {
+    return new Object() {
+        @Override
+        String toString() {
+          return 'object'
+        }
+      }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/common/writer/SerializationTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/common/writer/SerializationTest.groovy
@@ -5,19 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import datadog.trace.test.util.DDSpecification
 import org.msgpack.core.MessagePack
 import org.msgpack.jackson.dataformat.MessagePackFactory
-import spock.lang.Shared
 
 import static java.util.Collections.singletonMap
 
 class SerializationTest extends DDSpecification {
-  @Shared
-  def jsonMapper = new ObjectMapper()
-  @Shared
-  def mpMapper = new ObjectMapper(new MessagePackFactory())
-
-
   def "test json mapper serialization"() {
     setup:
+    def mapper = new ObjectMapper()
     def map = ["key1": "val1"]
     def serializedMap = mapper.writeValueAsBytes(map)
     def serializedList = "[${new String(serializedMap)}]".getBytes()
@@ -28,13 +22,13 @@ class SerializationTest extends DDSpecification {
     then:
     result == [map]
     new String(serializedList) == '[{"key1":"val1"}]'
-
-    where:
-    mapper = jsonMapper
   }
 
   def "test msgpack mapper serialization"() {
     setup:
+    def mapper = new ObjectMapper(new MessagePackFactory())
+    // GStrings get odd results in the serializer.
+    def input = (1..1).collect { singletonMap("key$it".toString(), "val$it".toString()) }
     def serializedMaps = input.collect {
       mapper.writeValueAsBytes(it)
     }
@@ -51,11 +45,5 @@ class SerializationTest extends DDSpecification {
 
     then:
     result == input
-
-    where:
-    mapper = mpMapper
-
-    // GStrings get odd results in the serializer.
-    input = (1..1).collect { singletonMap("key$it".toString(), "val$it".toString()) }
   }
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/histogram/HistogramsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/histogram/HistogramsTest.groovy
@@ -36,7 +36,7 @@ class HistogramsTest extends DDSpecification {
   @Shared
   Double[] quantiles = [0.5D, 0.75D, 0.9D, 0.95D, 0.99D]
 
-  def "test quantiles have 1% relative error"() {
+  def "test quantiles have 1% relative error #iterationIndex"() {
     setup:
     def histogram
 

--- a/internal-api/src/test/groovy/datadog/trace/api/FunctionsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/FunctionsTest.groovy
@@ -11,7 +11,7 @@ import java.util.function.Function
 
 class FunctionsTest extends DDSpecification {
 
-  def "test common string functions"() {
+  def "test common string functions #iterationIndex"() {
     when:
     CharSequence output = fn.apply(input)
     then:
@@ -46,14 +46,14 @@ class FunctionsTest extends DDSpecification {
     "value" | "value.test"
   }
 
-  def "test join strings"() {
+  def "test join strings #iterationIndex"() {
     when:
     CharSequence output = fn.apply(left, right)
     then:
     String.valueOf(output) == expected
     where:
     fn                                                | left | right | expected
-    Functions.PrefixJoin.of("~", Function.identity()) | "x" | "y" | "x~y"
+    Functions.PrefixJoin.of("~", Function.identity()) | "x"  | "y"   | "x~y"
     Functions.PrefixJoin.of("~")                      | "x"  | "y"   | "x~y"
     Functions.SuffixJoin.of("~", Function.identity()) | "x"  | "y"   | "x~y"
     Functions.SuffixJoin.of("~")                      | "x"  | "y"   | "x~y"

--- a/internal-api/src/test/groovy/datadog/trace/api/cache/QualifiedClassNameCacheTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/cache/QualifiedClassNameCacheTest.groovy
@@ -7,7 +7,7 @@ import java.util.function.Function
 
 class QualifiedClassNameCacheTest extends DDSpecification {
 
-  def "test cached string operations"() {
+  def "test cached string operations #iterationIndex"() {
     when:
     QualifiedClassNameCache cache = new QualifiedClassNameCache(new Function<Class<?>, String>() {
         @Override

--- a/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/iast/telemetry/IastMetricTest.groovy
@@ -9,7 +9,7 @@ import static datadog.trace.api.iast.telemetry.IastMetric.TRACE_METRIC_PREFIX
 
 class IastMetricTest extends Specification {
 
-  void 'test iast metrics attributes'() {
+  void 'test iast metrics attributes #metric.name()'() {
     given:
     final verbosity = Config.get().getIastTelemetryVerbosity()
 
@@ -29,7 +29,7 @@ class IastMetricTest extends Specification {
     metric << (IastMetric.values() as List<IastMetric>)
   }
 
-  void 'test unwrapping of tags'() {
+  void 'test unwrapping of tags #iterationIndex'() {
     when:
     final result = metricTag.unwrap(tag)
 
@@ -46,7 +46,7 @@ class IastMetricTest extends Specification {
     IastMetric.Tag.SOURCE_TYPE        | SourceTypes.REQUEST_PARAMETER_VALUE | null
   }
 
-  void 'test metric tags'() {
+  void 'test metric tags #metric.name()'() {
     when:
     final telemetryTags = []
     final spanTags = []

--- a/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/metric/MetricPeriodicActionTest.groovy
@@ -12,7 +12,7 @@ import spock.lang.Specification
 
 class MetricPeriodicActionTest extends Specification {
 
-  void 'test that common metrics are joined before being sent to telemetry'() {
+  void 'test that common metrics are joined before being sent to telemetry #iterationIndex'() {
     given:
     final service = Mock(TelemetryService)
     final MetricCollector<MetricCollector.Metric> metricCollector = Mock(MetricCollector)
@@ -43,7 +43,7 @@ class MetricPeriodicActionTest extends Specification {
     [col(counter: 2L, tags: ['a:b', 'c:d']), col(counter: 6L, tags: ['a:b', 'c:d'])] | [tel(points: [[_, 2L], [_, 6L]], tags: ['a:b', 'c:d'])]
   }
 
-  void 'test that common distribution series are joined before being sent to telemetry'() {
+  void 'test that common distribution series are joined before being sent to telemetry #iterationIndex'() {
     given:
     final service = Mock(TelemetryService)
     final MetricCollector<MetricCollector.Metric> metricCollector = Mock(MetricCollector)


### PR DESCRIPTION
# What Does This Do

This PR fixes test name uniqueness.

# Motivation

This will help with CI monitoring to keep track of test execution.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
