### PR TITLE
Standardize some of the profiler sampling frequencies

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
+++ b/dd-java-agent/agent-profiling/profiling-ddprof/src/main/java/com/datadog/profiling/ddprof/DatadogProfiler.java
@@ -36,6 +36,7 @@ import com.datadog.profiling.controller.OngoingRecording;
 import com.datadog.profiling.utils.ProfilingMode;
 import com.datadoghq.profiler.ContextSetter;
 import com.datadoghq.profiler.JavaProfiler;
+import datadog.trace.api.Platform;
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.api.profiling.RecordingData;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
@@ -258,8 +259,6 @@ public final class DatadogProfiler {
     }
     if (profilingModes.contains(CPU)) {
       // cpu profiling is enabled.
-      final int DEFAULT_J9_CPU_SAMPLING_FREQUENCY = 50;
-
       String schedulingEvent = getSchedulingEvent(configProvider);
       if (schedulingEvent != null && !schedulingEvent.isEmpty()) {
         // using a user-specified event, e.g. L1-dcache-load-misses
@@ -271,10 +270,11 @@ public final class DatadogProfiler {
       } else {
         // using cpu time schedule
         int interval = getCpuInterval();
-        interval =
-            interval == ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_INTERVAL_DEFAULT
-                ? DEFAULT_J9_CPU_SAMPLING_FREQUENCY
-                : interval;
+        if (Platform.isJ9())
+          interval =
+              interval == ProfilingConfig.PROFILING_DATADOG_PROFILER_CPU_INTERVAL_DEFAULT
+                  ? ProfilingConfig.PROFILING_DATADOG_PROFILER_J9_CPU_INTERVAL_DEFAULT
+                  : interval;
         cmd.append(",cpu=").append(interval).append('m');
       }
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/ProfilingConfig.java
@@ -108,6 +108,8 @@ public final class ProfilingConfig {
       "profiling.ddprof.wall.interval.ms";
   public static final int PROFILING_DATADOG_PROFILER_WALL_INTERVAL_DEFAULT = 50;
 
+  public static final int PROFILING_DATADOG_PROFILER_J9_CPU_INTERVAL_DEFAULT = 50;
+
   public static final String PROFILING_DATADOG_PROFILER_WALL_COLLAPSING =
       "profiling.ddprof.wall.collapsing";
   public static final boolean PROFILING_DATADOG_PROFILER_WALL_COLLAPSING_DEFAULT = true;


### PR DESCRIPTION
# What Does This Do
Modifies profiler launch config to CPU sample every 50ms (due to triggering safepoints). Updates default wallclock sampling frequency to be true to ddprof (50ms).

# Motivation
Following benchmarking and code review, we've identified that J9 CPU sampling overhead is adequately low at ≥50ms. Additionally, the wallclock default frequency should have been 50ms to maintain parity with ddprof.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-10875]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-10875]: https://datadoghq.atlassian.net/browse/PROF-10875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ