### PR TITLE
Remove datadog-static-analysis workflow

### DIFF
--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -16,18 +16,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # 4.1.6
         with:
           submodules: 'recursive'
-      - name: Check code meets quality standards (production)
-        id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@c74aff158c8cc1c3e285660713bcaa5f9c6d696e # v1
-        with:
-          dd_app_key: ${{ secrets.DATADOG_APP_KEY_PROD }}
-          dd_api_key: ${{ secrets.DATADOG_API_KEY_PROD }}
-          dd_site: "datadoghq.com"
-          dd_service: "dd-trace-java"
-          dd_env: "ci"
-          cpu_count: 2
-          enable_performance_statistics: false
-      # Also run the static analysis on the staging environment to benefit from the new features not yet released
+      # Run the static analysis on the staging environment to benefit from the new features not yet released
       - name: Check code meets quality standards (staging)
         id: datadog-static-analysis-staging
         uses: DataDog/datadog-static-analyzer-github-action@c74aff158c8cc1c3e285660713bcaa5f9c6d696e # v1


### PR DESCRIPTION
# What Does This Do

Remove the run of datadog-static-analysis.

# Motivation

Already done automatically by datadog hosted scan, this duplicates the results.
