### PR TITLE
Reset iast request context on root span published

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastGlobalContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastGlobalContext.java
@@ -3,6 +3,7 @@ package com.datadog.iast;
 import com.datadog.iast.taint.TaintedMap;
 import com.datadog.iast.taint.TaintedObjects;
 import datadog.trace.api.iast.IastContext;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,6 +22,9 @@ public class IastGlobalContext implements IastContext {
   public TaintedObjects getTaintedObjects() {
     return taintedObjects;
   }
+
+  @Override
+  public void close() throws IOException {}
 
   public static class Provider extends IastContext.Provider {
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastOptOutContext.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/IastOptOutContext.java
@@ -2,18 +2,23 @@ package com.datadog.iast;
 
 import com.datadog.iast.taint.TaintedObjects;
 import datadog.trace.api.iast.IastContext;
+import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
 
 public class IastOptOutContext implements IastContext {
 
+  @Nonnull
   @SuppressWarnings("unchecked")
   @NotNull
   @Override
   public TaintedObjects getTaintedObjects() {
     return TaintedObjects.NoOp.INSTANCE;
   }
+
+  @Override
+  public void close() throws IOException {}
 
   public static class Provider extends IastContext.Provider {
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastSystemTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/IastSystemTest.groovy
@@ -73,6 +73,7 @@ class IastSystemTest extends DDSpecification {
 
     then:
     1 * iastContext.getTaintedObjects()
+    1 * iastContext.setTaintedObjects(_)
     1 * iastContext.getMetricCollector()
     1 * traceSegment.setTagTop('_dd.iast.enabled', 1)
     1 * iastContext.getxContentTypeOptions() >> 'nosniff'

--- a/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastAgentTestRunner.groovy
+++ b/dd-java-agent/agent-iast/src/testFixtures/groovy/com/datadog/iast/test/IastAgentTestRunner.groovy
@@ -6,7 +6,6 @@ import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableVisitor
 import datadog.trace.api.gateway.CallbackProvider
 import datadog.trace.api.gateway.Events
-import datadog.trace.api.gateway.Flow
 import datadog.trace.api.gateway.RequestContextSlot
 import datadog.trace.api.iast.IastContext
 import datadog.trace.api.iast.SourceTypes
@@ -15,7 +14,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.TagContext
 import datadog.trace.core.DDSpan
 
-import java.util.function.Supplier
 
 class IastAgentTestRunner extends AgentTestRunner implements IastRequestContextPreparationTrait {
   public static final EMPTY_SOURCE = new Source(SourceTypes.NONE, '', '')
@@ -40,18 +38,10 @@ class IastAgentTestRunner extends AgentTestRunner implements IastRequestContextP
     IastContext.Provider.get().taintedObjects
   }
 
-  protected TaintedObjectCollection getLocalTaintedObjectCollection() {
-    new TaintedObjectCollection(localTaintedObjects)
-  }
-
-  protected TaintedObjectCollection getTaintedObjectCollection(DDSpan span) {
-    final IastContext ctx = span.getRequestContext().getData(RequestContextSlot.IAST)
-    return new TaintedObjectCollection(ctx.getTaintedObjects())
-  }
-
   protected DDSpan runUnderIastTrace(Closure cl) {
     CallbackProvider iastCbp = TEST_TRACER.getCallbackProvider(RequestContextSlot.IAST)
-    Supplier<Flow<Object>> reqStartCb = iastCbp.getCallback(Events.EVENTS.requestStarted())
+    def reqStartCb = iastCbp.getCallback(Events.EVENTS.requestStarted())
+    def reqEndCb = iastCbp.getCallback(Events.EVENTS.requestEnded())
 
     def iastCtx = reqStartCb.get().result
     def ddctx = new TagContext().withRequestContextDataIast(iastCtx)
@@ -59,6 +49,7 @@ class IastAgentTestRunner extends AgentTestRunner implements IastRequestContextP
     try {
       AgentTracer.activateSpan(span).withCloseable cl
     } finally {
+      reqEndCb.apply(span.requestContext, span)
       span.finish()
     }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -2231,9 +2231,15 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
 
   class IastIGCallbacks {
     static class Context implements IastContext {
+      @Nonnull
       @Override
       <TO> TO getTaintedObjects() {
         throw new UnsupportedOperationException()
+      }
+
+      @Override
+      void close() throws IOException {
+        // ignore
       }
     }
 

--- a/internal-api/src/main/java/datadog/trace/api/iast/IastContext.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastContext.java
@@ -4,11 +4,12 @@ import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.gateway.RequestContextSlot;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import java.io.Closeable;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Encapsulation for the IAST context, */
-public interface IastContext {
+public interface IastContext extends Closeable {
 
   /**
    * Get the tainted objects dictionary linked to the context, since we have no visibility over the


### PR DESCRIPTION
# What Does This Do
Resets all IAST request context data structures when the root span of a trace is published.

# Motivation
We observed an akka-http service with a very high number of IAST contexts in the heap probably related to pending traces, once a trace has been published we should not hold down to any references.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55869]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55869]: https://datadoghq.atlassian.net/browse/APPSEC-55869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ