### PR TITLE
Add JMXFetch to SSI Guardrails denylist

### DIFF
--- a/metadata/denied-arguments.tsv
+++ b/metadata/denied-arguments.tsv
@@ -26,6 +26,9 @@ apache_solr8_start              -Dsolr.solr.home=*                              
 apache_solr8_stop               *solr/server/start.jar                              Skip Apache Solr 8 stop using path to jar
 apache_solr8_tools              org.apache.solr.util.SolrCLI                        Skip Apache Solr 8 CLI tools
 
+# DataDog JMXFetch
+datadog_jmxfetch                org.datadog.jmxfetch.App                            Skip DataDog JMXFetch
+
 # Elastic Search 7+
 elasticsearch7                  -Des.path.home=*                                    Skip Elastic Search 7+ commands
 

--- a/metadata/requirements-block.json
+++ b/metadata/requirements-block.json
@@ -197,5 +197,46 @@
             "arch": "x64",
             "libc": "glibc:2.17"
         }
+    },
+    {
+        "name": "should block JMXFetch instance from DataDog Agent",
+        "filepath": "/opt/java/openjdk/bin/java",
+        "args": [
+            "java",
+            "-Djdk.attach.allowAttachSelf=true",
+            "-XX:+UseContainerSupport",
+            "-XX:MaxRAMPercentage=25.0000",
+            "-classpath",
+            "/opt/datadog-agent/bin/agent/dist/jmx/jmxfetch.jar",
+            "org.datadog.jmxfetch.App",
+            "--ipc_host",
+            "localhost",
+            "--ipc_port",
+            "5001",
+            "--check_period",
+            "15000",
+            "--thread_pool_size",
+            "3",
+            "--collection_timeout",
+            "60",
+            "--reconnection_timeout",
+            "60",
+            "--reconnection_thread_pool_size",
+            "3",
+            "--log_level",
+            "INFO",
+            "--reporter",
+            "statsd:unix:///var/run/datadog/statsd.sock",
+            "--statsd_queue_size",
+            "4096",
+            "--jmxfetch_telemetry",
+            "collect"
+        ],
+        "envars": [],
+        "host": {
+            "os": "linux",
+            "arch": "x64",
+            "libc": "glibc:2.17"
+        }
     }
 ]

--- a/metadata/requirements.json
+++ b/metadata/requirements.json
@@ -304,6 +304,23 @@
       "envars": null
     },
     {
+      "id": "datadog_jmxfetch",
+      "description": "Skip DataDog JMXFetch",
+      "os": null,
+      "cmds": [
+        "**/java"
+      ],
+      "args": [
+        {
+          "args": [
+            "org.datadog.jmxfetch.App"
+          ],
+          "position": null
+        }
+      ],
+      "envars": null
+    },
+    {
       "id": "elasticsearch7",
       "description": "Skip Elastic Search 7+ commands",
       "os": null,


### PR DESCRIPTION
# What Does This Do

This PR excludes DataDog JMXFetch from the processes being automatically instrumented. 

# Motivation

There is no use instrumenting JMXFetch and it will add noise while troubleshooting (using flare).

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMLP-325]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-325]: https://datadoghq.atlassian.net/browse/APMLP-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ