### PR TITLE
Remove Strings.join API in favor of JDK String.join

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/git/tree/GitClient.java
@@ -484,7 +484,7 @@ public class GitClient {
     return executeCommand(
         Command.PACK_OBJECTS,
         () -> {
-          byte[] input = Strings.join("\n", objectHashes).getBytes(Charset.defaultCharset());
+          byte[] input = String.join("\n", objectHashes).getBytes(Charset.defaultCharset());
 
           Path tempDirectory = createTempDirectory();
           String basename = Strings.random(8);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/ShellCommandExecutor.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/ShellCommandExecutor.java
@@ -5,7 +5,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.context.TraceScope;
 import datadog.trace.util.AgentThreadFactory;
 import datadog.trace.util.AgentThreadFactory.AgentThread;
-import datadog.trace.util.Strings;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -124,7 +123,7 @@ public class ShellCommandExecutor {
           throw new ShellCommandFailedException(
               exitValue,
               "Command '"
-                  + Strings.join(" ", command)
+                  + String.join(" ", command)
                   + "' failed with exit code "
                   + exitValue
                   + ": "
@@ -147,7 +146,7 @@ public class ShellCommandExecutor {
         terminate(p);
         throw new TimeoutException(
             "Timeout while waiting for '"
-                + Strings.join(" ", command)
+                + String.join(" ", command)
                 + "'; "
                 + IOUtils.readFully(errorStreamConsumer.read(), Charset.defaultCharset()));
       }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -2,7 +2,6 @@ package datadog.trace.agent.tooling;
 
 import static datadog.trace.bootstrap.AgentClassLoading.INJECTING_HELPERS;
 
-import datadog.trace.util.Strings;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.security.CodeSource;
@@ -101,7 +100,7 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
       if (classLoader == null) {
         throw new UnsupportedOperationException(
             "Cannot inject helper classes onto boot-class-path; move "
-                + Strings.join(",", helperClassNames)
+                + String.join(",", helperClassNames)
                 + " to agent-bootstrap");
       }
 
@@ -112,7 +111,7 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
                 "Injecting helper classes - instrumentation.class={} instrumentation.target.classloader={} instrumentation.helper_classes=[{}]",
                 requestingName,
                 classLoader,
-                Strings.join(",", helperClassNames));
+                String.join(",", helperClassNames));
           }
 
           final Map<String, byte[]> classnameToBytes = getHelperMap();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterState.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterState.java
@@ -2,7 +2,6 @@ package datadog.trace.agent.tooling;
 
 import datadog.trace.api.cache.DDCache;
 import datadog.trace.api.cache.DDCaches;
-import datadog.trace.util.Strings;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLongArray;
 import org.slf4j.Logger;
@@ -130,7 +129,7 @@ public final class InstrumenterState {
   public static String describe(int instrumentationId) {
     if (instrumentationId >= 0 && instrumentationId < instrumentationNames.length) {
       return "instrumentation.names=["
-          + Strings.join(",", instrumentationNames[instrumentationId])
+          + String.join(",", instrumentationNames[instrumentationId])
           + "] instrumentation.class="
           + instrumentationClasses[instrumentationId];
     } else {

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -23,7 +23,6 @@ import datadog.trace.api.gateway.SubscriptionService;
 import datadog.trace.api.telemetry.ProductChange;
 import datadog.trace.api.telemetry.ProductChangeCollector;
 import datadog.trace.bootstrap.ActiveSubsystems;
-import datadog.trace.util.Strings;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -104,7 +103,7 @@ public class AppSecSystem {
 
     STARTED.set(true);
 
-    String startedAppSecModules = Strings.join(", ", STARTED_MODULES_INFO.values());
+    String startedAppSecModules = String.join(", ", STARTED_MODULES_INFO.values());
     if (appSecEnabledConfig == ProductActivation.FULLY_ENABLED) {
       log.info("AppSec is {} with {}", appSecEnabledConfig, startedAppSecModules);
     } else {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/main/java/datadog/trace/instrumentation/elasticsearch2/TransportActionListener.java
@@ -4,7 +4,6 @@ import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransport
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -32,12 +31,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
+        span.setTag("elasticsearch.request.indices", String.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
+      span.setTag("elasticsearch.request.search.types", String.join(",", req.types()));
     }
     if (request instanceof DocumentRequest) {
       final DocumentRequest req = (DocumentRequest) request;

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/main/java/datadog/trace/instrumentation/elasticsearch5_3/TransportActionListener.java
@@ -4,7 +4,6 @@ import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransport
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -34,12 +33,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
+        span.setTag("elasticsearch.request.indices", String.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
+      span.setTag("elasticsearch.request.search.types", String.join(",", req.types()));
     }
     if (request instanceof DocWriteRequest) {
       final DocWriteRequest req = (DocWriteRequest) request;

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/main/java/datadog/trace/instrumentation/elasticsearch5/TransportActionListener.java
@@ -4,7 +4,6 @@ import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransport
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
-import datadog.trace.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -37,12 +36,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
+        span.setTag("elasticsearch.request.indices", String.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
+      span.setTag("elasticsearch.request.search.types", String.join(",", req.types()));
     }
     if (request instanceof DocumentRequest) {
       final DocumentRequest req = (DocumentRequest) request;

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/main/java/datadog/trace/instrumentation/elasticsearch6/TransportActionListener.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.elasticsearch6;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -37,12 +36,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
+        span.setTag("elasticsearch.request.indices", String.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
+      span.setTag("elasticsearch.request.search.types", String.join(",", req.types()));
     }
     if (request instanceof DocWriteRequest) {
       final DocWriteRequest req = (DocWriteRequest) request;

--- a/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-7.3/src/main/java/datadog/trace/instrumentation/elasticsearch7_3/TransportActionListener.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.elasticsearch7_3;
 import static datadog.trace.instrumentation.elasticsearch.ElasticsearchTransportClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -34,12 +33,12 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("elasticsearch.request.indices", Strings.join(",", req.indices()));
+        span.setTag("elasticsearch.request.indices", String.join(",", req.indices()));
       }
     }
     if (request instanceof SearchRequest) {
       final SearchRequest req = (SearchRequest) request;
-      span.setTag("elasticsearch.request.search.types", Strings.join(",", req.types()));
+      span.setTag("elasticsearch.request.search.types", String.join(",", req.types()));
     }
     if (request instanceof DocWriteRequest) {
       final DocWriteRequest req = (DocWriteRequest) request;

--- a/dd-java-agent/instrumentation/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectDecorator.java
+++ b/dd-java-agent/instrumentation/hazelcast-3.6/src/main/java/datadog/trace/instrumentation/hazelcast36/DistributedObjectDecorator.java
@@ -15,7 +15,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
-import datadog.trace.util.Strings;
 import java.util.function.Function;
 
 /** Decorate Hazelcast distributed object span's with relevant contextual information. */
@@ -84,7 +83,7 @@ public class DistributedObjectDecorator extends ClientDecorator {
         QUALIFIED_NAME_CACHE.computeIfAbsent(
             Pair.of(object.getServiceName(), object.getName()), COMPUTE_QUALIFIED_NAME);
 
-    span.setResourceName(UTF8BytesString.create(Strings.join(".", objectName, methodName)));
+    span.setResourceName(UTF8BytesString.create(String.join(".", objectName, methodName)));
 
     span.setTag(HAZELCAST_SERVICE, object.getServiceName());
     span.setTag(HAZELCAST_OPERATION, methodName);

--- a/dd-java-agent/instrumentation/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationDecorator.java
+++ b/dd-java-agent/instrumentation/hazelcast-3.9/src/main/java/datadog/trace/instrumentation/hazelcast39/ClientInvocationDecorator.java
@@ -13,7 +13,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
-import datadog.trace.util.Strings;
 
 /** Decorate Hazelcast client invocations with relevant contextual information. */
 public class ClientInvocationDecorator extends ClientDecorator {
@@ -51,7 +50,7 @@ public class ClientInvocationDecorator extends ClientDecorator {
       long correlationId) {
 
     if (objectName != null) {
-      span.setResourceName(UTF8BytesString.create(Strings.join(" ", operationName, objectName)));
+      span.setResourceName(UTF8BytesString.create(String.join(" ", operationName, objectName)));
       span.setTag(HAZELCAST_NAME, objectName);
     } else {
       span.setResourceName(UTF8BytesString.create(operationName));

--- a/dd-java-agent/instrumentation/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/HazelcastDecorator.java
+++ b/dd-java-agent/instrumentation/hazelcast-4.0/src/main/java/datadog/trace/instrumentation/hazelcast4/HazelcastDecorator.java
@@ -12,7 +12,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ClientDecorator;
-import datadog.trace.util.Strings;
 
 /** Decorate Hazelcast distributed object span's with relevant contextual information. */
 public class HazelcastDecorator extends ClientDecorator {
@@ -51,7 +50,7 @@ public class HazelcastDecorator extends ClientDecorator {
 
     if (objectName != null) {
       span.setResourceName(
-          UTF8BytesString.create(Strings.join(" ", operationName, objectName.toString())));
+          UTF8BytesString.create(String.join(" ", operationName, objectName.toString())));
       span.setTag(HAZELCAST_NAME, objectName.toString());
     } else {
       span.setResourceName(UTF8BytesString.create(operationName));

--- a/dd-java-agent/instrumentation/opensearch/transport/src/main/java/datadog/trace/instrumentation/opensearch/TransportActionListener.java
+++ b/dd-java-agent/instrumentation/opensearch/transport/src/main/java/datadog/trace/instrumentation/opensearch/TransportActionListener.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.opensearch;
 import static datadog.trace.instrumentation.opensearch.OpensearchTransportClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
-import datadog.trace.util.Strings;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
@@ -32,7 +31,7 @@ public class TransportActionListener<T extends ActionResponse> implements Action
     if (request instanceof IndicesRequest) {
       final IndicesRequest req = (IndicesRequest) request;
       if (req.indices() != null) {
-        span.setTag("opensearch.request.indices", Strings.join(",", req.indices()));
+        span.setTag("opensearch.request.indices", String.join(",", req.indices()));
       }
     }
     if (request instanceof DocWriteRequest) {

--- a/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.0.0/src/main/java/datadog/trace/instrumentation/redisson/RedissonInstrumentation.java
@@ -14,7 +14,6 @@ import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.util.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
@@ -100,7 +99,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       for (CommandData<?, ?> commandData : command.getCommands()) {
         commandResourceNames.add(commandData.getCommand().getName());
       }
-      DECORATE.onStatement(span, Strings.join(";", commandResourceNames));
+      DECORATE.onStatement(span, String.join(";", commandResourceNames));
       command.getPromise().addListener(new SpanFinishListener(AgentTracer.captureSpan(span)));
       return activateSpan(span);
     }

--- a/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-2.3.0/src/main/java/datadog/trace/instrumentation/redisson23/RedissonInstrumentation.java
@@ -13,7 +13,6 @@ import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.util.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import net.bytebuddy.asm.Advice;
@@ -101,7 +100,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       for (CommandData<?, ?> commandData : command.getCommands()) {
         commandResourceNames.add(commandData.getCommand().getName());
       }
-      RedissonClientDecorator.DECORATE.onStatement(span, Strings.join(";", commandResourceNames));
+      RedissonClientDecorator.DECORATE.onStatement(span, String.join(";", commandResourceNames));
       ((RFuture<?>) command.getPromise())
           .addListener(new SpanFinishListener(AgentTracer.captureSpan(span)));
       return activateSpan(span);

--- a/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
+++ b/dd-java-agent/instrumentation/redisson/redisson-3.10.3/src/main/java/datadog/trace/instrumentation/redisson30/RedissonInstrumentation.java
@@ -13,7 +13,6 @@ import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import datadog.trace.util.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -111,7 +110,7 @@ public final class RedissonInstrumentation extends InstrumenterModule.Tracing
       for (CommandData<?, ?> commandData : command.getCommands()) {
         commandResourceNames.add(commandData.getCommand().getName());
       }
-      RedissonClientDecorator.DECORATE.onStatement(span, Strings.join(";", commandResourceNames));
+      RedissonClientDecorator.DECORATE.onStatement(span, String.join(";", commandResourceNames));
       promise.whenComplete(new SpanFinishListener(AgentTracer.captureSpan(span)));
       return activateSpan(span);
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/flare/TracerFlareService.java
@@ -13,7 +13,6 @@ import datadog.trace.logging.GlobalLogLevelSwitcher;
 import datadog.trace.logging.LogLevel;
 import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.AgentTaskScheduler.Scheduled;
-import datadog.trace.util.Strings;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -239,8 +238,7 @@ final class TracerFlareService {
   private void addRuntime(ZipOutputStream zip) throws IOException {
     try {
       RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
-      TracerFlare.addText(
-          zip, "jvm_args.txt", Strings.join(" ", runtimeMXBean.getInputArguments()));
+      TracerFlare.addText(zip, "jvm_args.txt", String.join(" ", runtimeMXBean.getInputArguments()));
       TracerFlare.addText(zip, "classpath.txt", runtimeMXBean.getClassPath());
       TracerFlare.addText(zip, "library_path.txt", runtimeMXBean.getLibraryPath());
       if (runtimeMXBean.isBootClassPathSupported()) {

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/CloudNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/CloudNamingV1.java
@@ -2,7 +2,6 @@ package datadog.trace.api.naming.v1;
 
 import datadog.trace.api.naming.NamingSchema;
 import datadog.trace.api.naming.SpanNaming;
-import datadog.trace.util.Strings;
 import java.util.Locale;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,7 +33,7 @@ public class CloudNamingV1 implements NamingSchema.ForCloud {
         return SpanNaming.instance().namingSchema().messaging().outboundOperation("sns");
       default:
         final String lowercaseService = cloudService.toLowerCase(Locale.ROOT);
-        return Strings.join(".", provider, lowercaseService, "request"); // aws.s3.request
+        return String.join(".", provider, lowercaseService, "request"); // aws.s3.request
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/util/Strings.java
+++ b/internal-api/src/main/java/datadog/trace/util/Strings.java
@@ -118,46 +118,6 @@ public final class Strings {
     return lastDot < 0 ? "" : className.substring(0, lastDot);
   }
 
-  public static String join(CharSequence joiner, Iterable<? extends CharSequence> strings) {
-    if (strings == null) {
-      return "";
-    }
-
-    Iterator<? extends CharSequence> it = strings.iterator();
-    // no elements
-    if (!it.hasNext()) {
-      return "";
-    }
-
-    // first element
-    CharSequence first = it.next();
-    if (!it.hasNext()) {
-      return first.toString();
-    }
-
-    // remaining elements with joiner
-    StringBuilder sb = new StringBuilder(first);
-    while (it.hasNext()) {
-      sb.append(joiner).append(it.next());
-    }
-    return sb.toString();
-  }
-
-  public static String join(CharSequence joiner, CharSequence... strings) {
-    int len = strings.length;
-    if (len > 0) {
-      if (len == 1) {
-        return strings[0].toString();
-      }
-      StringBuilder sb = new StringBuilder(strings[0]);
-      for (int i = 1; i < len; ++i) {
-        sb.append(joiner).append(strings[i]);
-      }
-      return sb.toString();
-    }
-    return "";
-  }
-
   // reimplementation of string functions without regex
   public static String replace(String str, String delimiter, String replacement) {
     StringBuilder sb = new StringBuilder(str);

--- a/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/util/StringsTest.groovy
@@ -12,9 +12,11 @@ class StringsTest extends DDSpecification {
     s == expected
     where:
     // spotless:off
-    className       | expected
-    "foo.bar.Class" | "foo/bar/Class.class"
-    "Class"         | "Class.class"
+    className             | expected
+    "foo.bar.Class"       | "foo/bar/Class.class"
+    "foo/bar/Class.class" | "foo/bar/Class.class"
+    "Class"               | "Class.class"
+    "Class.class"         | "Class.class"
     // spotless:on
   }
 
@@ -27,7 +29,22 @@ class StringsTest extends DDSpecification {
     // spotless:off
     resourceName          | expected
     "foo/bar/Class.class" | "foo.bar.Class"
+    "foo.bar.Class"       | "foo.bar.Class"
     "Class.class"         | "Class"
+    "Class"               | "Class"
+    // spotless:on
+  }
+
+  def "test internal name from class name"() {
+    when:
+    String s = Strings.getInternalName(resourceName)
+    then:
+    s == expected
+    where:
+    // spotless:off
+    resourceName    | expected
+    "foo.bar.Class" | "foo/bar/Class"
+    "Class"         | "Class"
     // spotless:on
   }
 
@@ -47,37 +64,6 @@ class StringsTest extends DDSpecification {
   def "test envvar from property"() {
     expect:
     "FOO_BAR_QUX" == Strings.toEnvVar("foo.bar-qux")
-  }
-
-  def "test join strings"() {
-    when:
-    String s = Strings.join(joiner, strings)
-    then:
-    s == expected
-    where:
-    // spotless:off
-    joiner | strings         | expected
-    ","    | ["a", "b", "c"] | "a,b,c"
-    ","    | ["a", "b"]      | "a,b"
-    ","    | ["a"]           | "a"
-    ","    | []              | ""
-    // spotless:on
-  }
-
-  def "test join strings varargs"() {
-    when:
-    // apparently groovy doesn't like this but it runs as if it's java
-    String s = Strings.join(joiner, strings.toArray(new CharSequence[0]))
-    then:
-    s == expected
-    where:
-    // spotless:off
-    joiner | strings         | expected
-    ","    | ["a", "b", "c"] | "a,b,c"
-    ","    | ["a", "b"]      | "a,b"
-    ","    | ["a"]           | "a"
-    ","    | []              | ""
-    // spotless:on
   }
 
   def "test replace strings"() {


### PR DESCRIPTION
# What Does This Do

This PR cleans up custom `Strings.join` to use the JDK `String.join` instead.

# Motivation

This API should date from pre 1.0 which was Java 7 compatible while `String.join` was introduced in Java 8.
The JDK method pass our custom `Strings.join` tests too.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
