### PR TITLE
[WIP] Handle multi-value tagging for server spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -626,7 +626,12 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE, REQUEST
     public boolean accept(String key, String value) {
       String mappedKey = headerTags.get(key.toLowerCase(Locale.ROOT));
       if (mappedKey != null) {
-        span.setTag(mappedKey, value);
+        Object existing_val = span.getTag(mappedKey);
+        if (existing_val == null) {
+          span.setTag(mappedKey, value);
+        } else {
+          span.setTag(mappedKey, existing_val.toString() + value);
+        }
       }
       return true;
     }


### PR DESCRIPTION
# What Does This Do
The goal of this PR is to handle multi-value tagging for server spans.

# Motivation
Currently, the HTTP protocol allows splitting the header into multiple lines per value; however, the Java tracer only allows users to extrace the first value of the HTTP header. This PR will now allow extracting multi-valued multi-line headers. This PR  would help allow extracting multi-valued multi-line HTTP headers in conjunction with #7943.

# Additional Notes
This PR is made in response to [this Jira ticket](https://datadoghq.atlassian.net/browse/AIDM-273).

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
