### PR TITLE
Enable grizzly by default

### DIFF
--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -29,11 +29,6 @@ public class GrizzlyHttpHandlerInstrumentation extends InstrumenterModule.Tracin
   }
 
   @Override
-  public boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public String instrumentedType() {
     return "org.glassfish.grizzly.http.server.HttpHandler";
   }

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyTest.groovy
@@ -31,13 +31,6 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.USER_B
 
 class GrizzlyTest extends HttpServerTest<HttpServer> {
 
-  @Override
-  void configurePreAgent() {
-    super.configurePreAgent()
-
-    injectSysConfig("dd.integration.grizzly.enabled", "true")
-  }
-
   static GrizzlyTest testInstance
 
   static void markHandlerRan(boolean value) {

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/AsyncHttpClientInstrumentation.java
@@ -28,11 +28,6 @@ public final class AsyncHttpClientInstrumentation extends InstrumenterModule.Tra
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public String instrumentedType() {
     return "com.ning.http.client.AsyncHttpClient";
   }

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
@@ -22,13 +22,6 @@ abstract class GrizzlyAsyncHttpClientTest extends HttpClientTest {
   def client = new AsyncHttpClient()
 
   @Override
-  void configurePreAgent() {
-    super.configurePreAgent()
-
-    injectSysConfig("dd.integration.grizzly-client.enabled", "true")
-  }
-
-  @Override
   int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
 
     RequestBuilder requestBuilder = new RequestBuilder(method)

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/build.gradle
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/build.gradle
@@ -33,7 +33,3 @@ dependencies {
   latestDepTestImplementation group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '2.+'
   latestDepTestImplementation group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.+'
 }
-
-tasks.withType(Test) {
-  jvmArgs += ['-Ddd.integration.grizzly-filterchain.enabled=true']
-}

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/DefaultFilterChainInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/DefaultFilterChainInstrumentation.java
@@ -36,11 +36,6 @@ public class DefaultFilterChainInstrumentation extends InstrumenterModule.Tracin
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         isMethod()

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpCodecFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpCodecFilterInstrumentation.java
@@ -22,11 +22,6 @@ public final class HttpCodecFilterInstrumentation extends InstrumenterModule.Tra
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".GrizzlyDecorator",

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpServerFilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/HttpServerFilterInstrumentation.java
@@ -22,11 +22,6 @@ public class HttpServerFilterInstrumentation extends InstrumenterModule.Tracing
   }
 
   @Override
-  protected boolean defaultEnabled() {
-    return false;
-  }
-
-  @Override
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".GrizzlyDecorator",

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyIOStrategyTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/test/groovy/GrizzlyIOStrategyTest.groovy
@@ -7,13 +7,6 @@ import org.glassfish.grizzly.strategies.SimpleDynamicNIOStrategy
 abstract class GrizzlyIOStrategyTest extends GrizzlyTest {
 
   @Override
-  void configurePreAgent() {
-    super.configurePreAgent()
-
-    injectSysConfig("dd.integration.grizzly-http.enabled", "true")
-  }
-
-  @Override
   HttpServer server() {
     def server = super.server() as GrizzlyServer
     server.server.getListener("grizzly").getTransport().setIOStrategy(strategy())

--- a/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
+++ b/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleForkedTest.groovy
@@ -27,10 +27,7 @@ class MuleForkedTest extends WithHttpServer<MuleTestContainer> {
   @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
-
-    injectSysConfig("integration.grizzly-filterchain.enabled", "true")
     injectSysConfig("integration.mule.enabled", "true")
-    injectSysConfig("integration.grizzly-client.enabled", "true")
   }
 
   @AutoCleanup

--- a/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleHttpServerForkedTest.groovy
+++ b/dd-java-agent/instrumentation/mule-4/src/test/groovy/mule4/MuleHttpServerForkedTest.groovy
@@ -29,8 +29,6 @@ class MuleHttpServerForkedTest extends HttpServerTest<MuleTestContainer> {
   @Override
   protected void configurePreAgent() {
     super.configurePreAgent()
-
-    injectSysConfig("integration.grizzly-filterchain.enabled", "true")
     injectSysConfig("integration.mule.enabled", "true")
   }
 

--- a/dd-smoke-tests/jersey-2/src/test/groovy/datadog/smoketest/Jersey2SmokeTest.groovy
+++ b/dd-smoke-tests/jersey-2/src/test/groovy/datadog/smoketest/Jersey2SmokeTest.groovy
@@ -17,7 +17,6 @@ class Jersey2SmokeTest extends AbstractJerseySmokeTest {
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
     command.addAll(iastJvmOpts())
-    command.add(withSystemProperty('integration.grizzly.enabled', true))
     if (Platform.isJavaVersionAtLeast(17)) {
       command.addAll((String[]) ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'])
     }

--- a/dd-smoke-tests/jersey-3/src/test/groovy/datadog/smoketest/Jersey3SmokeTest.groovy
+++ b/dd-smoke-tests/jersey-3/src/test/groovy/datadog/smoketest/Jersey3SmokeTest.groovy
@@ -16,7 +16,6 @@ class Jersey3SmokeTest extends AbstractJerseySmokeTest {
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
     command.addAll(iastJvmOpts())
-    command.add(withSystemProperty('integration.grizzly.enabled', true))
     //command.add("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000")
     //command.add("-Xdebug")
     command.addAll((String[]) ['-jar', jarPath, httpPort])

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/DDSpecification.groovy
@@ -117,11 +117,7 @@ abstract class DDSpecification extends Specification {
   }
 
   private static Map<Object, Object> systemPropertiesExceptAllowed() {
-    def allowlist = [
-      'dd.appsec.enabled',
-      'dd.iast.enabled',
-      'dd.integration.grizzly-filterchain.enabled',
-    ]
+    def allowlist = ['dd.appsec.enabled', 'dd.iast.enabled',]
     System.getProperties()
       .findAll { key, value -> !allowlist.contains(key as String) }
   }


### PR DESCRIPTION
# What Does This Do

Enables grizzly server and client integrations by default.

They can be disabled respectively with
* `-Ddd.integration.grizzly-filterchain.enabled=false`
* `-Ddd.integration.grizzly-client.enabled=false`

# Motivation


# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
