### PR TITLE
Fix PR label check

### DIFF
--- a/.github/workflows/check-pull-requests.yaml
+++ b/.github/workflows/check-pull-requests.yaml
@@ -27,7 +27,7 @@ jobs:
             const ignoreReleaseNotes = labels.filter(label => label == 'tag: no release notes').length > 0
             const hasTypeLabel = labels.filter(label => label.startsWith('type:')).length > 0
             const hasComponentLabel = labels.filter(label => label.startsWith('comp:')).length > 0
-            const hasInstrumentationLabel = labels.filter(label => label.startsWith('instr:')).length > 0
+            const hasInstrumentationLabel = labels.filter(label => label.startsWith('inst:')).length > 0
             const labelsCheckFailed = !ignoreReleaseNotes && (!hasTypeLabel || (!hasComponentLabel && !hasInstrumentationLabel));
             if (labelsCheckFailed) {
               core.setFailed('Please add at least one type, and one component or instrumentation label to the pull request.')

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-instrumentation.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-instrumentation.json
@@ -1,0 +1,15 @@
+{
+    "pull_request": {
+        "number": 7884,
+        "draft": false,
+        "labels": [
+            {
+                "name": "inst: java"
+            },
+            {
+                "name": "type: bug"
+            }
+        ],
+        "title": "Adding some new features"
+    }
+}

--- a/.github/workflows/tests/check-pull-requests/test-pull-request.sh
+++ b/.github/workflows/tests/check-pull-requests/test-pull-request.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source "$(dirname "$0")/../env.sh"
 testworkflow pull_request && \
+testworkflow pull_request instrumentation && \
 testworkflow pull_request draft && \
 testworkflow pull_request no-release-notes && \
 ! testworkflow pull_request missing-label && \


### PR DESCRIPTION
# What Does This Do

This PR fixes instrumentation label detection during PR check.

# Motivation

Prevent wrong negative from the PR checker.

# Additional Notes

Reported by @amarziali 

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
