### PR TITLE
Increase lambda extension request timeout

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaHandler.java
@@ -44,7 +44,7 @@ public class LambdaHandler {
   private static final String START_INVOCATION = "/lambda/start-invocation";
   private static final String END_INVOCATION = "/lambda/end-invocation";
 
-  private static final Long REQUEST_TIMEOUT_IN_S = 1L;
+  private static final Long REQUEST_TIMEOUT_IN_S = 3L;
   private static final int MAX_IDLE_CONNECTIONS = 5;
   private static final Long KEEP_ALIVE_DURATION = 300L;
 


### PR DESCRIPTION
# What Does This Do
Increases timeout for communicating with the Lambda extension.

# Motivation
Customers are occasionally getting
```
[dd.trace 2024-11-20 18:26:27:926 +0900] [main] ERROR datadog.trace.lambda.LambdaHandler - could not reach the extension, not injecting the context
java.io.InterruptedIOException: timeout
at datadog.okhttp3.RealCall.timeoutExit(RealCall.java:108)
at datadog.okhttp3.RealCall.execute(RealCall.java:97)
at datadog.trace.lambda.LambdaHandler.notifyEndInvocation(LambdaHandler.java:162)
at datadog.trace.agent.core.CoreTracer.notifyExtensionEnd(CoreTracer.java:956)
```
This should resolve this.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SLES-1952]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SLES-1952]: https://datadoghq.atlassian.net/browse/SLES-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ