### PR TITLE
Fix issue with call sites in super calls to constructor

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/AdviceGeneratorImpl.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/AdviceGeneratorImpl.java
@@ -286,31 +286,26 @@ public class AdviceGeneratorImpl implements AdviceGenerator {
       body.addStatement(dupMethod);
     } else {
       final MethodCallExpr dupMethod = new MethodCallExpr().setScope(new NameExpr("handler"));
-      if (advice.isConstructor() && advice instanceof AfterSpecification) {
-        dupMethod.setName("dupConstructor");
+      if (advice.includeThis()) {
+        dupMethod.setName("dupInvoke");
+        dupMethod.addArgument(new NameExpr("owner"));
         dupMethod.addArgument(new NameExpr("descriptor"));
       } else {
-        if (advice.includeThis()) {
-          dupMethod.setName("dupInvoke");
-          dupMethod.addArgument(new NameExpr("owner"));
-          dupMethod.addArgument(new NameExpr("descriptor"));
-        } else {
-          dupMethod.setName("dupParameters");
-          dupMethod.addArgument(new NameExpr("descriptor"));
-        }
-        String mode = "COPY";
-        if (allArgsSpec != null) {
-          if (advice instanceof AfterSpecification) {
-            mode = "PREPEND_ARRAY";
-          } else {
-            mode = "APPEND_ARRAY";
-          }
-        }
-        dupMethod.addArgument(
-            new FieldAccessExpr()
-                .setScope(new TypeExpr(new ClassOrInterfaceType().setName(STACK_DUP_MODE_CLASS)))
-                .setName(mode));
+        dupMethod.setName("dupParameters");
+        dupMethod.addArgument(new NameExpr("descriptor"));
       }
+      String mode = "COPY";
+      if (allArgsSpec != null) {
+        if (advice instanceof AfterSpecification) {
+          mode = advice.isConstructor() ? "PREPEND_ARRAY_CTOR" : "PREPEND_ARRAY";
+        } else {
+          mode = "APPEND_ARRAY";
+        }
+      }
+      dupMethod.addArgument(
+          new FieldAccessExpr()
+              .setScope(new TypeExpr(new ClassOrInterfaceType().setName(STACK_DUP_MODE_CLASS)))
+              .setName(mode));
       body.addStatement(dupMethod);
     }
   }

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/AdviceGeneratorTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/AdviceGeneratorTest.groovy
@@ -140,7 +140,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
       advices(0) {
         pointcut('java/net/URL', '<init>', '(Ljava/lang/String;)V')
         statements(
-          'handler.dupConstructor(descriptor);',
+          'handler.dupParameters(descriptor, StackDupMode.PREPEND_ARRAY_CTOR);',
           'handler.method(opcode, owner, name, descriptor, isInterface);',
           'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$AfterAdviceCtor", "after", "([Ljava/lang/Object;Ljava/net/URL;)Ljava/net/URL;");',
         )
@@ -441,7 +441,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
       advices(0) {
         pointcut('java/lang/StringBuilder', '<init>', '(Ljava/lang/String;)V')
         statements(
-          'handler.dupConstructor(descriptor);',
+          'handler.dupParameters(descriptor, StackDupMode.PREPEND_ARRAY_CTOR);',
           'handler.method(opcode, owner, name, descriptor, isInterface);',
           'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$SuperTypeReturnAdvice", "after", "([Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");',
           'handler.instruction(Opcodes.CHECKCAST, "java/lang/StringBuilder");'

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/AdviceGeneratorTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/AdviceGeneratorTest.groovy
@@ -47,7 +47,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
         pointcut('java/security/MessageDigest', 'getInstance', '(Ljava/lang/String;)Ljava/security/MessageDigest;')
         statements(
           'handler.dupParameters(descriptor, StackDupMode.COPY);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$BeforeAdvice", "before", "(Ljava/lang/String;)V", false);',
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$BeforeAdvice", "before", "(Ljava/lang/String;)V");',
           'handler.method(opcode, owner, name, descriptor, isInterface);'
         )
       }
@@ -78,7 +78,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
       advices(0) {
         pointcut('java/lang/String', 'replaceAll', '(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;')
         statements(
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$AroundAdvice", "around", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;", false);'
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$AroundAdvice", "around", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");'
         )
       }
     }
@@ -110,7 +110,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
         statements(
           'handler.dupInvoke(owner, descriptor, StackDupMode.COPY);',
           'handler.method(opcode, owner, name, descriptor, isInterface);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$AfterAdvice", "after", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;", false);',
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$AfterAdvice", "after", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");',
         )
       }
     }
@@ -140,9 +140,9 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
       advices(0) {
         pointcut('java/net/URL', '<init>', '(Ljava/lang/String;)V')
         statements(
-          'handler.dupParameters(descriptor, StackDupMode.PREPEND_ARRAY_CTOR);',
+          'handler.dupConstructor(descriptor);',
           'handler.method(opcode, owner, name, descriptor, isInterface);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$AfterAdviceCtor", "after", "([Ljava/lang/Object;Ljava/net/URL;)Ljava/net/URL;", false);',
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$AfterAdviceCtor", "after", "([Ljava/lang/Object;Ljava/net/URL;)Ljava/net/URL;");',
         )
       }
     }
@@ -208,7 +208,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
         statements(
           'handler.dupParameters(descriptor, StackDupMode.PREPEND_ARRAY);',
           'handler.invokeDynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$InvokeDynamicAfterAdvice", "after", "([Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/String;", false);'
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$InvokeDynamicAfterAdvice", "after", "([Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/String;");'
         )
       }
     }
@@ -297,7 +297,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
           'handler.dupParameters(descriptor, StackDupMode.PREPEND_ARRAY);',
           'handler.invokeDynamic(name, descriptor, bootstrapMethodHandle, bootstrapMethodArguments);',
           'handler.loadConstantArray(bootstrapMethodArguments);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$InvokeDynamicWithConstantsAdvice", "after", "([Ljava/lang/Object;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;", false);'
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$InvokeDynamicWithConstantsAdvice", "after", "([Ljava/lang/Object;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;");'
         )
       }
     }
@@ -393,7 +393,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
         statements(
           'int[] parameterIndices = new int[] { 0 };',
           'handler.dupParameters(descriptor, parameterIndices, owner);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$PartialArgumentsBeforeAdvice", "before", "(Ljava/lang/String;)V", false);',
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$PartialArgumentsBeforeAdvice", "before", "(Ljava/lang/String;)V");',
           'handler.method(opcode, owner, name, descriptor, isInterface);',
         )
       }
@@ -402,7 +402,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
         statements(
           'int[] parameterIndices = new int[] { 1 };',
           'handler.dupParameters(descriptor, parameterIndices, null);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$PartialArgumentsBeforeAdvice", "before", "([Ljava/lang/Object;)V", false);',
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$PartialArgumentsBeforeAdvice", "before", "([Ljava/lang/Object;)V");',
           'handler.method(opcode, owner, name, descriptor, isInterface);',
         )
       }
@@ -411,7 +411,7 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
         statements(
           'int[] parameterIndices = new int[] { 0 };',
           'handler.dupInvoke(owner, descriptor, parameterIndices);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$PartialArgumentsBeforeAdvice", "before", "(Ljava/lang/String;I)V", false);',
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$PartialArgumentsBeforeAdvice", "before", "(Ljava/lang/String;I)V");',
           'handler.method(opcode, owner, name, descriptor, isInterface);',
         )
       }
@@ -441,9 +441,9 @@ final class AdviceGeneratorTest extends BaseCsiPluginTest {
       advices(0) {
         pointcut('java/lang/StringBuilder', '<init>', '(Ljava/lang/String;)V')
         statements(
-          'handler.dupParameters(descriptor, StackDupMode.PREPEND_ARRAY_CTOR);',
+          'handler.dupConstructor(descriptor);',
           'handler.method(opcode, owner, name, descriptor, isInterface);',
-          'handler.method(Opcodes.INVOKESTATIC, "datadog/trace/plugin/csi/impl/AdviceGeneratorTest$SuperTypeReturnAdvice", "after", "([Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;", false);',
+          'handler.advice("datadog/trace/plugin/csi/impl/AdviceGeneratorTest$SuperTypeReturnAdvice", "after", "([Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");',
           'handler.instruction(Opcodes.CHECKCAST, "java/lang/StringBuilder");'
         )
       }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
@@ -150,7 +150,8 @@ public abstract class CallSiteUtils {
         dup(mv, parameters);
         break;
       case PREPEND_ARRAY:
-      case PREPEND_ARRAY_CTOR:
+      case PREPEND_ARRAY_ON_NEW_CTOR:
+      case PREPEND_ARRAY_ON_SUPER_CTOR:
       case APPEND_ARRAY:
         dupN(mv, parameters, mode);
         break;
@@ -279,9 +280,19 @@ public abstract class CallSiteUtils {
         loadArray(mv, arraySize, parameters);
         mv.visitInsn(POP);
         break;
-      case PREPEND_ARRAY_CTOR:
-        // move the array before the NEW and DUP opcodes
+      case PREPEND_ARRAY_ON_NEW_CTOR:
+        // move the array before the uninitialized entry created by NEW and DUP
+        // stack start = [uninitialized, uninitialized, arg_0, ..., arg_n]
+        // stack   end = [array, uninitialized, uninitialized, arg_0, ..., arg_n]
         mv.visitInsn(DUP_X2);
+        loadArray(mv, arraySize, parameters);
+        mv.visitInsn(POP);
+        break;
+      case PREPEND_ARRAY_ON_SUPER_CTOR:
+        // move the array before the uninitialized entry
+        // stack start = [uninitialized, arg_0, ..., arg_n]
+        // stack   end = [array, uninitialized, arg_0, ..., arg_n]
+        mv.visitInsn(DUP_X1);
         loadArray(mv, arraySize, parameters);
         mv.visitInsn(POP);
         break;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/csi/CallSiteUtils.java
@@ -150,8 +150,8 @@ public abstract class CallSiteUtils {
         dup(mv, parameters);
         break;
       case PREPEND_ARRAY:
-      case PREPEND_ARRAY_ON_NEW_CTOR:
-      case PREPEND_ARRAY_ON_SUPER_CTOR:
+      case PREPEND_ARRAY_CTOR:
+      case PREPEND_ARRAY_SUPER_CTOR:
       case APPEND_ARRAY:
         dupN(mv, parameters, mode);
         break;
@@ -280,7 +280,7 @@ public abstract class CallSiteUtils {
         loadArray(mv, arraySize, parameters);
         mv.visitInsn(POP);
         break;
-      case PREPEND_ARRAY_ON_NEW_CTOR:
+      case PREPEND_ARRAY_CTOR:
         // move the array before the uninitialized entry created by NEW and DUP
         // stack start = [uninitialized, uninitialized, arg_0, ..., arg_n]
         // stack   end = [array, uninitialized, uninitialized, arg_0, ..., arg_n]
@@ -288,7 +288,7 @@ public abstract class CallSiteUtils {
         loadArray(mv, arraySize, parameters);
         mv.visitInsn(POP);
         break;
-      case PREPEND_ARRAY_ON_SUPER_CTOR:
+      case PREPEND_ARRAY_SUPER_CTOR:
         // move the array before the uninitialized entry
         // stack start = [uninitialized, arg_0, ..., arg_n]
         // stack   end = [array, uninitialized, arg_0, ..., arg_n]

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
@@ -37,9 +37,6 @@ public interface CallSiteAdvice {
         Handle bootstrapMethodHandle,
         Object... bootstrapMethodArguments);
 
-    /** Duplicates all the ctor parameters in the stack just before the method is invoked. */
-    void dupConstructor(String methodDescriptor);
-
     /** Duplicates all the method parameters in the stack just before the method is invoked. */
     void dupParameters(String methodDescriptor, StackDupMode mode);
 
@@ -69,9 +66,9 @@ public interface CallSiteAdvice {
     /** Copies the parameters in an array and prepends it */
     PREPEND_ARRAY,
     /** Copies the parameters in an array and adds it between NEW and DUP opcodes */
-    PREPEND_ARRAY_ON_NEW_CTOR,
+    PREPEND_ARRAY_CTOR,
     /** Copies the parameters in an array and adds it before the uninitialized instance in a ctor */
-    PREPEND_ARRAY_ON_SUPER_CTOR,
+    PREPEND_ARRAY_SUPER_CTOR,
     /** Copies the parameters in an array and appends it */
     APPEND_ARRAY
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/csi/CallSiteAdvice.java
@@ -27,12 +27,18 @@ public interface CallSiteAdvice {
     /** Performs a method invocation (static, special, virtual, interface...) */
     void method(int opcode, String owner, String name, String descriptor, boolean isInterface);
 
+    /** Performs an advice invocation (always static) */
+    void advice(String owner, String name, String descriptor);
+
     /** Performs a dynamic method invocation */
     void invokeDynamic(
         String name,
         String descriptor,
         Handle bootstrapMethodHandle,
         Object... bootstrapMethodArguments);
+
+    /** Duplicates all the ctor parameters in the stack just before the method is invoked. */
+    void dupConstructor(String methodDescriptor);
 
     /** Duplicates all the method parameters in the stack just before the method is invoked. */
     void dupParameters(String methodDescriptor, StackDupMode mode);
@@ -62,11 +68,10 @@ public interface CallSiteAdvice {
     COPY,
     /** Copies the parameters in an array and prepends it */
     PREPEND_ARRAY,
-    /**
-     * Copies the parameters in an array, prepends it and swaps the array with the uninitialized
-     * instance in a ctor
-     */
-    PREPEND_ARRAY_CTOR,
+    /** Copies the parameters in an array and adds it between NEW and DUP opcodes */
+    PREPEND_ARRAY_ON_NEW_CTOR,
+    /** Copies the parameters in an array and adds it before the uninitialized instance in a ctor */
+    PREPEND_ARRAY_ON_SUPER_CTOR,
     /** Copies the parameters in an array and appends it */
     APPEND_ARRAY
   }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -15,6 +15,8 @@ import net.bytebuddy.jar.asm.Type
 import net.bytebuddy.matcher.ElementMatcher
 import net.bytebuddy.utility.JavaModule
 import net.bytebuddy.utility.nullability.MaybeNull
+
+import java.lang.reflect.Constructor
 import java.security.MessageDigest
 
 
@@ -81,6 +83,10 @@ class BaseCallSiteTest extends DDSpecification {
     return buildPointcut(String.getDeclaredMethod('concat', String))
   }
 
+  protected static Pointcut stringReaderPointcut() {
+    return buildPointcut(StringReader.getDeclaredConstructor(String))
+  }
+
   protected static Pointcut messageDigestGetInstancePointcut() {
     return buildPointcut(MessageDigest.getDeclaredMethod('getInstance', String))
   }
@@ -98,6 +104,10 @@ class BaseCallSiteTest extends DDSpecification {
 
   protected static Pointcut buildPointcut(final Method executable) {
     return buildPointcut(Type.getType(executable.getDeclaringClass()).internalName, executable.name, Type.getType(executable).descriptor)
+  }
+
+  protected static Pointcut buildPointcut(final Constructor<?> executable) {
+    return buildPointcut(Type.getType(executable.getDeclaringClass()).internalName, "<init>", Type.getType(executable).descriptor)
   }
 
   protected static Pointcut buildPointcut(final String type, final String method, final String descriptor) {
@@ -155,6 +165,13 @@ class BaseCallSiteTest extends DDSpecification {
     final classLoader = new ByteArrayClassLoader(loader, [(type.className): data])
     final Class<?> clazz = classLoader.loadClass(type.className)
     return clazz.getConstructor().newInstance()
+  }
+
+  protected static Class<?> loadClass(final Type type,
+  final byte[] data,
+  final ClassLoader loader = Thread.currentThread().contextClassLoader) {
+    final classLoader = new ByteArrayClassLoader(loader, [(type.className): data])
+    return classLoader.loadClass(type.className)
   }
 
   protected static byte[] transformType(final Type source,

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteInstrumentationTest.groovy
@@ -8,6 +8,8 @@ import net.bytebuddy.jar.asm.Type
 
 import java.util.concurrent.atomic.AtomicInteger
 
+import static datadog.trace.agent.tooling.csi.CallSiteAdvice.StackDupMode.PREPEND_ARRAY_CTOR
+
 class CallSiteInstrumentationTest extends BaseCallSiteTest {
 
   def 'test instrumentation adds type advice'() {
@@ -73,7 +75,7 @@ class CallSiteInstrumentationTest extends BaseCallSiteTest {
     final InvokeAdvice advice = new InvokeAdvice() {
         @Override
         void apply(CallSiteAdvice.MethodHandler handler, int opcode, String owner, String name, String descriptor, boolean isInterface) {
-          handler.dupConstructor(descriptor)
+          handler.dupParameters(descriptor, PREPEND_ARRAY_CTOR)
           handler.method(opcode, owner, name, descriptor, isInterface)
           handler.advice(
             Type.getType(SuperInCtorExampleAdvice).internalName,

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteUtilsTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteUtilsTest.groovy
@@ -207,7 +207,7 @@ class CallSiteUtilsTest extends DDSpecification {
     final visitor = mockMethodVisitor(stack)
 
     when:
-    CallSiteUtils.dup(visitor, expected*.type as Type[], PREPEND_ARRAY_ON_NEW_CTOR)
+    CallSiteUtils.dup(visitor, expected*.type as Type[], PREPEND_ARRAY_CTOR)
 
     then: 'the first element of the stack should be an array with the parameters'
     final arrayFromStack = stack.remove(0)
@@ -246,7 +246,7 @@ class CallSiteUtilsTest extends DDSpecification {
     final visitor = mockMethodVisitor(stack)
 
     when:
-    CallSiteUtils.dup(visitor, expected*.type as Type[], PREPEND_ARRAY_ON_SUPER_CTOR)
+    CallSiteUtils.dup(visitor, expected*.type as Type[], PREPEND_ARRAY_SUPER_CTOR)
 
     then: 'the first element of the stack should be an array with the parameters'
     final arrayFromStack = stack.remove(0)

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteUtilsTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/CallSiteUtilsTest.groovy
@@ -207,7 +207,7 @@ class CallSiteUtilsTest extends DDSpecification {
     final visitor = mockMethodVisitor(stack)
 
     when:
-    CallSiteUtils.dup(visitor, expected*.type as Type[], PREPEND_ARRAY_CTOR)
+    CallSiteUtils.dup(visitor, expected*.type as Type[], PREPEND_ARRAY_ON_NEW_CTOR)
 
     then: 'the first element of the stack should be an array with the parameters'
     final arrayFromStack = stack.remove(0)
@@ -238,6 +238,44 @@ class CallSiteUtilsTest extends DDSpecification {
       forChar((char) '?'),
       forBoolean(true)
     ] | items.subList(2, items.size())
+  }
+
+  void 'test stack dup with array before super ctor of #items'() {
+    setup:
+    final stack = buildStack(items)
+    final visitor = mockMethodVisitor(stack)
+
+    when:
+    CallSiteUtils.dup(visitor, expected*.type as Type[], PREPEND_ARRAY_ON_SUPER_CTOR)
+
+    then: 'the first element of the stack should be an array with the parameters'
+    final arrayFromStack = stack.remove(0)
+    arrayFromStack.type.descriptor == '[Ljava/lang/Object;'
+    final array = (arrayFromStack.value as Object[]).toList() as List<StackObject>
+    [array, expected].transpose().each { arrayItem, expectedItem ->
+      assert arrayItem.value == expectedItem.value // some of the items might be boxed so be careful
+    }
+
+    then: 'the rest of the stack should contain the original values'
+    final result = fromStack(stack)
+    result == items
+
+    where:
+    items                                                                      | expected
+    [forObject('uninitialized'), forInt(1)]                                    | items.subList(1, items.size())
+    [forObject('uninitialized'), forInt(1), forInt(2)]                         | items.subList(1, items.size())
+    [forObject('uninitialized'), forLong(1L)]                                  | items.subList(1, items.size())
+    [forObject('uninitialized'), forLong(1L), forLong(2L)]                     | items.subList(1, items.size())
+    [forObject('uninitialized'), forInt(1), forLong(2L)]                       | items.subList(1, items.size())
+    [forObject('uninitialized'), forInt(1), forInt(2), forLong(3L)]            | items.subList(1, items.size())
+    [forObject('uninitialized'), forInt(1), forInt(2), forInt(3), forLong(4L)] | items.subList(1, items.size())
+    [
+      forObject('uninitialized'),
+      forObject('PI = '),
+      forDouble(3.14D),
+      forChar((char) '?'),
+      forBoolean(true)
+    ]                                                                          | items.subList(1, items.size())
   }
 
   private MethodVisitor mockMethodVisitor(final List<StackObject> stack) {

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/SuperInCtorExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/SuperInCtorExample.java
@@ -1,0 +1,10 @@
+package datadog.trace.agent.tooling.csi;
+
+import java.io.StringReader;
+
+public class SuperInCtorExample extends StringReader {
+
+  public SuperInCtorExample(String s) {
+    super(s + new StringReader(s + "Test" + new StringBuilder("another test")));
+  }
+}

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/StringReaderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/StringReaderCallSiteTest.groovy
@@ -31,7 +31,7 @@ class StringReaderCallSiteTest extends BaseIoCallSiteTest {
 
     then:
     // new StringReader
-    1 * iastModule.taintObjectIfTainted(
+    3 * iastModule.taintObjectIfTainted(
       { it -> !(it instanceof TestCustomStringReader) },
       { String it ->
         it.startsWith("New") }

--- a/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/StringReaderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-io/src/test/groovy/datadog/trace/instrumentation/java/io/StringReaderCallSiteTest.groovy
@@ -2,11 +2,12 @@ package datadog.trace.instrumentation.java.io
 
 import datadog.trace.api.iast.InstrumentationBridge
 import datadog.trace.api.iast.propagation.PropagationModule
+import foo.bar.TestCustomStringReader
 import foo.bar.TestStringReaderSuite
 
-class StringReaderCallSiteTest extends  BaseIoCallSiteTest{
+class StringReaderCallSiteTest extends BaseIoCallSiteTest {
 
-  void 'test StringReader.<init>'(){
+  void 'test StringReader.<init>'() {
     given:
     PropagationModule iastModule = Mock(PropagationModule)
     InstrumentationBridge.registerIastModule(iastModule)
@@ -17,5 +18,28 @@ class StringReaderCallSiteTest extends  BaseIoCallSiteTest{
 
     then:
     1 * iastModule.taintObjectIfTainted(_ as StringReader, input)
+  }
+
+  void 'test super call to StringReader.<init>'() {
+    given:
+    PropagationModule iastModule = Mock(PropagationModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+    final input = 'Test input'
+
+    when:
+    new TestCustomStringReader(input)
+
+    then:
+    // new StringReader
+    1 * iastModule.taintObjectIfTainted(
+      { it -> !(it instanceof TestCustomStringReader) },
+      { String it ->
+        it.startsWith("New") }
+      )
+
+    // super(...)
+    1 * iastModule.taintObjectIfTainted(
+      { it instanceof TestCustomStringReader },
+      { String it -> it.startsWith("Super") })
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomStringReader.java
+++ b/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomStringReader.java
@@ -5,6 +5,10 @@ import java.io.StringReader;
 public class TestCustomStringReader extends StringReader {
 
   public TestCustomStringReader(String s) {
-    super("Super" + s + (new StringReader("New" + s)));
+    super(
+        "Super "
+            + s
+            + (new StringReader(
+                "New_1" + new StringReader("New_2" + new StringReader("New_3" + s)))));
   }
 }

--- a/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomStringReader.java
+++ b/dd-java-agent/instrumentation/java-io/src/test/java/foo/bar/TestCustomStringReader.java
@@ -1,0 +1,10 @@
+package foo.bar;
+
+import java.io.StringReader;
+
+public class TestCustomStringReader extends StringReader {
+
+  public TestCustomStringReader(String s) {
+    super("Super" + s + (new StringReader("New" + s)));
+  }
+}

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -2,6 +2,7 @@ package datadog.smoketest.springboot.controller;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonParser;
+import datadog.communication.util.IOUtils;
 import datadog.smoketest.springboot.TestBean;
 import ddtest.client.sources.Hasher;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -413,6 +414,11 @@ public class IastWebController {
     return "OK";
   }
 
+  @GetMapping("/test_custom_string_reader")
+  public String testCustomStringReader(@RequestParam("param") String param) throws IOException {
+    return String.join("", IOUtils.readLines(new CustomStringReader(param)));
+  }
+
   private void withProcess(final Operation<Process> op) {
     Process process = null;
     try {
@@ -428,5 +434,12 @@ public class IastWebController {
 
   private interface Operation<E> {
     E run() throws Throwable;
+  }
+
+  public static class CustomStringReader extends StringReader {
+
+    public CustomStringReader(String s) {
+      super("Super " + s + (new StringReader("New " + s)));
+    }
   }
 }

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/IastWebController.java
@@ -439,7 +439,11 @@ public class IastWebController {
   public static class CustomStringReader extends StringReader {
 
     public CustomStringReader(String s) {
-      super("Super " + s + (new StringReader("New " + s)));
+      super(
+          "Super "
+              + s
+              + (new StringReader(
+                  "New_1" + new StringReader("New_2" + new StringReader("New_3" + s)))));
     }
   }
 }

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -1184,5 +1184,16 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
     hasVulnerability { vul -> vul.type == 'UNTRUSTED_DESERIALIZATION' }
   }
 
+  void 'test custom string reader'() {
+    setup:
+    final url = "http://localhost:${httpPort}/test_custom_string_reader?param=Test"
+    final request = new Request.Builder().url(url).get().build()
+
+    when:
+    final response = client.newCall(request).execute()
+
+    then:
+    response.body().string().contains("Test")
+  }
 
 }


### PR DESCRIPTION
# What Does This Do
Fixes an issue in IAST with call-sites instrumenting constructor super calls. The Java compiler generates different bytecode when the `<init>` method is called from a `new` instruction or via `super`:

* **new**

```java
public class TestStringReaderSuite {
    public static void init(String input) {
        new StringReader(input);
    }
}
```
```
NEW java/io/StringReader
DUP
ALOAD 0
INVOKESPECIAL java/io/StringReader.<init> (Ljava/lang/String;)V
```

* **super**
```java
public class TestStringReaderIssue extends StringReader {
    public TestStringReaderIssue(String s) {
        super(s);
    }
}
```
```
ALOAD 0
ALOAD 1
INVOKESPECIAL java/io/StringReader.<init> (Ljava/lang/String;)V
```

This PR ensures that the `CallSiteTransformer` is able to deal with both cases successfully.

# Motivation
One customer reported an issue when enabling IAST:

```
karta.servlet.ServletException: Handler processing failed: java.lang.VerifyError: Operand stack underflow
Exception Details:
  Location:
    x.y.z.StringReader.<init>(Ljava/lang/String;)V @12: dup_x2
  Reason:
    Attempt to pop empty stack.
  Current Frame:
    bci: @12
    flags: { flagThisUninit }
    locals: { uninitializedThis, 'java/lang/String' }
    stack: { uninitializedThis, '[Ljava/lang/Object;' }
  Bytecode:
    0000000: 2a2b 04bd 001b 5a5f 1000 5f53 5b59 0332
    0000010: c000 1d5f 57b7 0001 b800 232a 2bb5 0007
    0000020: b1
```

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55918]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55918]: https://datadoghq.atlassian.net/browse/APPSEC-55918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ