### PR TITLE
Hide static checker notes when notes is enabled

### DIFF
--- a/dd-java-agent/instrumentation-annotation-processor/src/main/java/datadog/apt/LogUtils.java
+++ b/dd-java-agent/instrumentation-annotation-processor/src/main/java/datadog/apt/LogUtils.java
@@ -10,24 +10,25 @@ public final class LogUtils {
 
   private static final boolean NOTE = false;
 
-  public static final void log(
-      ProcessingEnvironment processingEnv, String formatStr, Object... args) {
+  public static void log(ProcessingEnvironment processingEnv, String formatStr, Object... args) {
     String msg = String.format(formatStr, args);
 
-    processingEnv.getMessager().printMessage(Kind.NOTE, msg);
+    if (NOTE) {
+      processingEnv.getMessager().printMessage(Kind.NOTE, msg);
+    }
   }
 
-  public static final void warning(
+  public static void warning(
       ProcessingEnvironment processingEnv, Element element, String formatStr, Object... args) {
     message(processingEnv, element, Kind.WARNING, formatStr, args);
   }
 
-  public static final void error(
+  public static void error(
       ProcessingEnvironment processingEnv, Element element, String formatStr, Object... args) {
     message(processingEnv, element, Kind.ERROR, formatStr, args);
   }
 
-  public static final void message(
+  public static void message(
       ProcessingEnvironment processingEnv,
       Element element,
       Kind kind,


### PR DESCRIPTION
# What Does This Do

This PR only shows the annotation processor notes when notes is enabled.

# Motivation

This aims to reduce the noise of the tool running to only the detected issues.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
