### PR TITLE
Fix test name uniqueness

### DIFF
--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/HealthMetricsTest.groovy
@@ -175,7 +175,7 @@ class HealthMetricsTest extends DDSpecification {
     0 * _
   }
 
-  def "test onSend"() {
+  def "test onSend #iterationIndex"() {
     setup:
     def latch = new CountDownLatch(3 + (response.exception() ? 1 : 0) + (response.status() ? 1 : 0))
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)
@@ -212,7 +212,7 @@ class HealthMetricsTest extends DDSpecification {
     sendSize = ThreadLocalRandom.current().nextInt(1, 100)
   }
 
-  def "test onFailedSend"() {
+  def "test onFailedSend #iterationIndex"() {
     setup:
     def latch = new CountDownLatch(3 + (response.exception() ? 1 : 0) + (response.status() ? 1 : 0))
     def healthMetrics = new TracerHealthMetrics(new Latched(statsD, latch), 100, TimeUnit.MILLISECONDS)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/monitor/TimingTest.groovy
@@ -43,7 +43,7 @@ class TimingTest extends DDSpecification {
     0 * _
   }
 
-  def "reset timer"() {
+  def "reset timer #iterationIndex"() {
     setup:
     StatsDClient statsd = Mock(StatsDClient)
     MonitoringImpl monitoring = new MonitoringImpl(statsd, 100, MILLISECONDS)
@@ -75,7 +75,7 @@ class TimingTest extends DDSpecification {
     Monitoring.DISABLED.newThreadLocalTimer("foo") instanceof NoOpRecording
   }
 
-  def "no ops are safe to use"() {
+  def "no ops are safe to use #iterationIndex"() {
     expect:
     try {
       recording.start().stop()


### PR DESCRIPTION
# What Does This Do

This PR fixes test name uniqueness.

# Motivation

This will help with CI monitoring to keep track of test execution.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
