### PR TITLE
Mute some static analysis rules

### DIFF
--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -16,9 +16,24 @@ rulesets:
           - "**"
       forloop-variable-count:
         max-variables: 2
+      literals-first-in-comparison:
+        ignore:
+          - "**"
+      one-declaration-per-line:
+        ignore:
+          - "**"
+      redundant-initializer:
+        ignore:
+          - "**"
   - java-code-style:
     rules:
+      avoid-dollar-signs:
+        ignore:
+          - "**"
       boolean-get-method-name:
+        ignore:
+          - "**"
+      control-statement-braces:
         ignore:
           - "**"
       generics-naming:


### PR DESCRIPTION
# What Does This Do
Ignore a few static analysis rules:
* `one-declaration-per-line`, `control-statement-braces`: stylistic choices that are currently in use, any enforcement here should be done through a formatter, if any.
* `avoid-dollar-signs`: We use dollar signs in some class and method names, and there's no way around it (e.g. referencing Scala classes from Java, manipulating auto-generated classes).
* `literals-first-in-comparison`: not in line with our current practice at all, prefer nullability analysis (e.g. NullAway).
* `redundant-initializer`: No consensus, and low value.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [PROJ-IDENT]
