### PR TITLE
Refactor tests of StringBuffer substring

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
@@ -190,6 +190,23 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     where:
     param         | beginIndex | expected
     sb('012345')  | 1          | '12345'
+  }
+
+  def 'test string buffer substring call site'() {
+    setup:
+    final iastModule = Mock(StringModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    final result = TestStringBufferSuite.substring(param, beginIndex)
+
+    then:
+    result == expected
+    1 * iastModule.onStringSubSequence(param, beginIndex, param.length(), expected)
+    0 * _
+
+    where:
+    param         | beginIndex | expected
     sbf('012345') | 1          | '12345'
   }
 
@@ -209,6 +226,23 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     where:
     param         | beginIndex | endIndex | expected
     sb('012345')  | 1          | 5        | '1234'
+  }
+
+  def 'test string buffer substring with endIndex call site'() {
+    setup:
+    final iastModule = Mock(StringModule)
+    InstrumentationBridge.registerIastModule(iastModule)
+
+    when:
+    final result = TestStringBufferSuite.substring(param, beginIndex, endIndex)
+
+    then:
+    result == expected
+    1 * iastModule.onStringSubSequence(param, beginIndex, endIndex, expected)
+    0 * _
+
+    where:
+    param         | beginIndex | endIndex | expected
     sbf('012345') | 1          | 5        | '1234'
   }
 

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBufferSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBufferSuite.java
@@ -51,4 +51,18 @@ public class TestStringBufferSuite implements TestAbstractStringBuilderSuite<Str
     LOGGER.debug("After string buffer toString {}", result);
     return result;
   }
+
+  public static String substring(StringBuffer self, int beginIndex, int endIndex) {
+    LOGGER.debug("Before string buffer substring {} from {} to {}", self, beginIndex, endIndex);
+    final String result = self.substring(beginIndex, endIndex);
+    LOGGER.debug("After string buffer substring {}", result);
+    return result;
+  }
+
+  public static String substring(StringBuffer self, int beginIndex) {
+    LOGGER.debug("Before string buffer substring {} from {}", self, beginIndex);
+    final String result = self.substring(beginIndex);
+    LOGGER.debug("After string buffer substring {}", result);
+    return result;
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBuilderSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBuilderSuite.java
@@ -90,18 +90,4 @@ public class TestStringBuilderSuite implements TestAbstractStringBuilderSuite<St
     LOGGER.debug("After string builder substring {}", result);
     return result;
   }
-
-  public static String substring(StringBuffer self, int beginIndex, int endIndex) {
-    LOGGER.debug("Before string buffer substring {} from {} to {}", self, beginIndex, endIndex);
-    final String result = self.substring(beginIndex, endIndex);
-    LOGGER.debug("After string buffer substring {}", result);
-    return result;
-  }
-
-  public static String substring(StringBuffer self, int beginIndex) {
-    LOGGER.debug("Before string buffer substring {} from {}", self, beginIndex);
-    final String result = self.substring(beginIndex);
-    LOGGER.debug("After string buffer substring {}", result);
-    return result;
-  }
 }


### PR DESCRIPTION
# What Does This Do
This refactors the test suite of the `StringBuffer` to his proper file. Previously was inside the `StringBuilder` test suite

# Motivation

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55369]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55369]: https://datadoghq.atlassian.net/browse/APPSEC-55369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ