### PR TITLE
Fix the temp location manager on J9

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
@@ -71,7 +71,7 @@ public final class TempLocationManager {
     private final Instant cutoff;
     private final Instant timeoutTarget;
 
-    private boolean terminated;
+    private boolean terminated = false;
 
     CleanupVisitor(boolean cleanSelf, long timeout, TimeUnit unit) {
       this.cleanSelf = cleanSelf;
@@ -107,7 +107,8 @@ public final class TempLocationManager {
       // the JFR repository directories are under <basedir>/pid_<pid>
       String pid = fileName.startsWith("pid_") ? fileName.substring(4) : null;
       boolean isSelfPid = pid != null && pid.equals(PidHelper.getPid());
-      shouldClean |= (cleanSelf && isSelfPid) || (!cleanSelf && !pidSet.contains(pid));
+      shouldClean |=
+          (cleanSelf && isSelfPid) || (!cleanSelf && !isSelfPid && !pidSet.contains(pid));
       if (shouldClean) {
         log.debug("Cleaning temporary location {}", dir);
       }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
@@ -107,8 +107,7 @@ public final class TempLocationManager {
       // the JFR repository directories are under <basedir>/pid_<pid>
       String pid = fileName.startsWith("pid_") ? fileName.substring(4) : null;
       boolean isSelfPid = pid != null && pid.equals(PidHelper.getPid());
-      shouldClean |=
-          (cleanSelf && isSelfPid) || (!cleanSelf && !isSelfPid && !pidSet.contains(pid));
+      shouldClean |= cleanSelf ? isSelfPid : !isSelfPid && !pidSet.contains(pid);
       if (shouldClean) {
         log.debug("Cleaning temporary location {}", dir);
       }


### PR DESCRIPTION
# What Does This Do
Fix up of #7971 

# Motivation
Due to a different mechanism to retrieve running JVM processes the cleanup is not correct on J9

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
