### PR TITLE
Verify validity of extracted `SpanID` for compound header extraction span links

### DIFF
--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/baseTest/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -101,7 +101,7 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
     def type = id & 1 ? "p" : "f"
     String url = address.resolve("/injected-id/${type}ing/$id")
     def traceId = totalInvocations + id
-    def request = new Request.Builder().url(url).get().header("x-datadog-trace-id", traceId.toString()).build()
+    def request = new Request.Builder().url(url).get().addHeader("x-datadog-trace-id", traceId.toString()).addHeader("x-datadog-parent-id", "1").build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()
     assert responseBodyStr == "${type}ong $id -> $traceId"

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -99,7 +99,7 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
     def type = id & 1 ? "p" : "f"
     String url = address.resolve("/injected-id/${type}ing/$id")
     def traceId = totalInvocations + id
-    def request = new Request.Builder().url(url).get().header("x-datadog-trace-id", traceId.toString()).header("x-datadog-span-id", "1").build()
+    def request = new Request.Builder().url(url).get().addHeader("x-datadog-trace-id", traceId.toString()).addHeader("x-datadog-span-id", "1").build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()
     assert responseBodyStr == "${type}ong $id -> $traceId"

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -99,7 +99,7 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
     def type = id & 1 ? "p" : "f"
     String url = address.resolve("/injected-id/${type}ing/$id")
     def traceId = totalInvocations + id
-    def request = new Request.Builder().url(url).get().header("x-datadog-trace-id", traceId.toString()).build()
+    def request = new Request.Builder().url(url).get().header("x-datadog-trace-id", traceId.toString()).header("x-datadog-span-id", "1").build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()
     assert responseBodyStr == "${type}ong $id -> $traceId"

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -99,7 +99,7 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<AkkaHttp
     def type = id & 1 ? "p" : "f"
     String url = address.resolve("/injected-id/${type}ing/$id")
     def traceId = totalInvocations + id
-    def request = new Request.Builder().url(url).get().addHeader("x-datadog-trace-id", traceId.toString()).addHeader("x-datadog-span-id", "1").build()
+    def request = new Request.Builder().url(url).get().addHeader("x-datadog-trace-id", traceId.toString()).addHeader("x-datadog-parent-id", "1").build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()
     assert responseBodyStr == "${type}ong $id -> $traceId"

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpServerInstrumentationTest.groovy
@@ -56,7 +56,7 @@ abstract class PekkoHttpServerInstrumentationTest extends HttpServerTest<PekkoHt
     def type = id & 1 ? "p" : "f"
     String url = address.resolve("/injected-id/${type}ing/$id")
     def traceId = totalInvocations + id
-    def request = new Request.Builder().url(url).get().header("x-datadog-trace-id", traceId.toString()).header("x-datadog-span-id", "1").build()
+    def request = new Request.Builder().url(url).get().addHeader("x-datadog-trace-id", traceId.toString()).addHeader("x-datadog-span-id", "1").build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()
     assert responseBodyStr == "${type}ong $id -> $traceId"

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpServerInstrumentationTest.groovy
@@ -56,7 +56,7 @@ abstract class PekkoHttpServerInstrumentationTest extends HttpServerTest<PekkoHt
     def type = id & 1 ? "p" : "f"
     String url = address.resolve("/injected-id/${type}ing/$id")
     def traceId = totalInvocations + id
-    def request = new Request.Builder().url(url).get().header("x-datadog-trace-id", traceId.toString()).build()
+    def request = new Request.Builder().url(url).get().header("x-datadog-trace-id", traceId.toString()).header("x-datadog-span-id", "1").build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()
     assert responseBodyStr == "${type}ong $id -> $traceId"

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpServerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpServerInstrumentationTest.groovy
@@ -56,7 +56,7 @@ abstract class PekkoHttpServerInstrumentationTest extends HttpServerTest<PekkoHt
     def type = id & 1 ? "p" : "f"
     String url = address.resolve("/injected-id/${type}ing/$id")
     def traceId = totalInvocations + id
-    def request = new Request.Builder().url(url).get().addHeader("x-datadog-trace-id", traceId.toString()).addHeader("x-datadog-span-id", "1").build()
+    def request = new Request.Builder().url(url).get().addHeader("x-datadog-trace-id", traceId.toString()).addHeader("x-datadog-parent-id", "1").build()
     def response = client.newCall(request).execute()
     def responseBodyStr = response.body().string()
     assert responseBodyStr == "${type}ong $id -> $traceId"

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ContextInterpreter.java
@@ -246,7 +246,7 @@ public abstract class ContextInterpreter implements AgentPropagation.KeyClassifi
 
   protected TagContext build() {
     if (valid) {
-      if (fullContext && !DDTraceId.ZERO.equals(traceId)) {
+      if (fullContext && !DDTraceId.ZERO.equals(traceId) && DDSpanId.ZERO != spanId) {
         if (propagationTags == null) {
           propagationTags = propagationTagsFactory.empty();
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -239,7 +239,7 @@ public class HttpCodec {
               if (comingFromTraceContext) {
                 applyTraceContextToFirstContext(context, extractedContext, extractionCache);
               }
-            } else {
+            } else if (extractedContext.getSpanId() != 0) { // Check that SpanID of secondary extracted context is valid
               // Terminate extracted context and add it as span link
               context.addTerminatedContextLink(
                   DDSpanLink.from(

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -239,7 +239,8 @@ public class HttpCodec {
               if (comingFromTraceContext) {
                 applyTraceContextToFirstContext(context, extractedContext, extractionCache);
               }
-            } else if (extractedContext.getSpanId() != 0) { // Check that SpanID of secondary extracted context is valid
+            } else if (extractedContext.getSpanId()
+                != 0) { // Check that SpanID of secondary extracted context is valid
               // Terminate extracted context and add it as span link
               context.addTerminatedContextLink(
                   DDSpanLink.from(

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -239,8 +239,7 @@ public class HttpCodec {
               if (comingFromTraceContext) {
                 applyTraceContextToFirstContext(context, extractedContext, extractionCache);
               }
-            } else if (extractedContext.getSpanId()
-                != 0) { // Check that SpanID of secondary extracted context is valid
+            } else {
               // Terminate extracted context and add it as span link
               context.addTerminatedContextLink(
                   DDSpanLink.from(

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -355,7 +355,7 @@ class DatadogHttpExtractorTest extends DDSpecification {
     "-1"                  | "1"                   | null             | null
     "1"                   | "-1"                  | null             | null
     "0"                   | "1"                   | null             | null
-    "1"                   | "0"                   | DD64bTraceId.ONE | DDSpanId.ZERO
+    "1"                   | "0"                   | null             | null
     "$TRACE_ID_MAX"       | "1"                   | DD64bTraceId.MAX | 1
     "${TRACE_ID_MAX + 1}" | "1"                   | null             | null
     "1"                   | "$TRACE_ID_MAX"       | DD64bTraceId.ONE | DDSpanId.MAX

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/DatadogHttpExtractorTest.groovy
@@ -360,6 +360,7 @@ class DatadogHttpExtractorTest extends DDSpecification {
     "${TRACE_ID_MAX + 1}" | "1"                   | null             | null
     "1"                   | "$TRACE_ID_MAX"       | DD64bTraceId.ONE | DDSpanId.MAX
     "1"                   | "${TRACE_ID_MAX + 1}" | null             | null
+    "1"                   | "1"                   | DD64bTraceId.ONE | 1
   }
 
   def "extract http headers with end to end"() {

--- a/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
@@ -37,7 +37,7 @@ class LambdaHandlerTest extends DDCoreSpecification {
           response
             .status(200)
             .addHeader("x-datadog-trace-id", "1234")
-            .addHeader("x-datadog-span-id", "1")
+            .addHeader("x-datadog-parent-id", "1")
             .addHeader("x-datadog-sampling-priority", "2")
             .send()
         }
@@ -71,7 +71,7 @@ class LambdaHandlerTest extends DDCoreSpecification {
           response
             .status(200)
             .addHeader("x-datadog-trace-id", "5744042798732701615")
-            .addHeader("x-datadog-span-id", "1")
+            .addHeader("x-datadog-parent-id", "1")
             .addHeader("x-datadog-sampling-priority", "2")
             .addHeader("x-datadog-tags", "_dd.p.tid=1914fe7789eb32be")
             .send()

--- a/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/lambda/LambdaHandlerTest.groovy
@@ -37,6 +37,7 @@ class LambdaHandlerTest extends DDCoreSpecification {
           response
             .status(200)
             .addHeader("x-datadog-trace-id", "1234")
+            .addHeader("x-datadog-span-id", "1")
             .addHeader("x-datadog-sampling-priority", "2")
             .send()
         }
@@ -70,6 +71,7 @@ class LambdaHandlerTest extends DDCoreSpecification {
           response
             .status(200)
             .addHeader("x-datadog-trace-id", "5744042798732701615")
+            .addHeader("x-datadog-span-id", "1")
             .addHeader("x-datadog-sampling-priority", "2")
             .addHeader("x-datadog-tags", "_dd.p.tid=1914fe7789eb32be")
             .send()


### PR DESCRIPTION
# What Does This Do
Adds a check to ensure that Span Links are only created in compound header extraction when the `SpanID` is valid. 
# Motivation
This system-tests [PR](https://github.com/DataDog/system-tests/pull/3499/files#diff-2f9154dbb913f2bbd44191a5bcaeea03cb0ed080ab29fe2ca76e1fcef1b26044R123-R144) introduces a test to ensure that all libraries only create span links in distributed tracing header extraction when the `SpanID` is valid. This PR aims to implement this check in dd-trace-java and pass the test referenced.
# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
