### PR TITLE
Ensure instrumentation class is logged if helper class fails to be injected

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -126,8 +126,11 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
           }
         } catch (final Exception e) {
           if (log.isErrorEnabled()) {
+            // requestingName is concatenated to ensure it is sent to telemetry
             log.error(
-                "Failed to inject helper classes - instrumentation.class={} instrumentation.target.classloader={} instrumentation.target.class={}",
+                "Failed to inject helper classes - instrumentation.class="
+                    + requestingName
+                    + " instrumentation.target.classloader={} instrumentation.target.class={}",
                 requestingName,
                 classLoader,
                 typeDescription,


### PR DESCRIPTION
# What Does This Do

# Motivation
Errors in telemetry:
```
Error : Failed to inject helper classes - instrumentation.class={} instrumentation.target.classloader={} instrumentation.target.class={}
```

Having at least the instrumentation class, which is not a sensitive parameter, will help us group errors in telemetry.

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
