### PR TITLE
Add IAST propagation to String valueOf

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
@@ -761,7 +761,7 @@ public class StringModuleImpl implements StringModule {
       if (!taintable.$DD$isTainted()) {
         return;
       }
-      final Taintable.Source source = taintable.$$DD$getSource();
+      final Source source = (Source) taintable.$$DD$getSource();
       final Range[] ranges =
           Ranges.forCharSequence(
               result, new Source(source.getOrigin(), source.getName(), source.getValue()));

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
@@ -778,7 +778,17 @@ public class StringModuleImpl implements StringModule {
         return;
       }
 
-      taintedObjects.taint(result, rangesParam);
+      // Special objects like InputStream...
+      if (rangesParam[0].getLength() == Integer.MAX_VALUE) {
+        final Source source = rangesParam[0].getSource();
+        final Range[] ranges =
+            Ranges.forCharSequence(
+                result, new Source(source.getOrigin(), source.getName(), source.getValue()));
+
+        taintedObjects.taint(result, ranges);
+      } else {
+        taintedObjects.taint(result, rangesParam);
+      }
     }
   }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
@@ -8,6 +8,7 @@ import static com.datadog.iast.taint.Tainteds.getTainted;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
 import com.datadog.iast.model.Range;
+import com.datadog.iast.model.Source;
 import com.datadog.iast.taint.Ranges;
 import com.datadog.iast.taint.TaintedObject;
 import com.datadog.iast.taint.TaintedObjects;
@@ -15,6 +16,7 @@ import com.datadog.iast.util.RangeBuilder;
 import com.datadog.iast.util.Ranged;
 import com.datadog.iast.util.StringUtils;
 import datadog.trace.api.iast.IastContext;
+import datadog.trace.api.iast.Taintable;
 import datadog.trace.api.iast.propagation.StringModule;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -753,17 +755,31 @@ public class StringModuleImpl implements StringModule {
       return;
     }
     final TaintedObjects taintedObjects = ctx.getTaintedObjects();
-    final TaintedObject taintedParam = taintedObjects.get(param);
-    if (taintedParam == null) {
-      return;
-    }
 
-    final Range[] rangesParam = taintedParam.getRanges();
-    if (rangesParam.length == 0) {
-      return;
-    }
+    if (param instanceof Taintable) {
+      final Taintable taintable = (Taintable) param;
+      if (!taintable.$DD$isTainted()) {
+        return;
+      }
+      final Taintable.Source source = taintable.$$DD$getSource();
+      final Range[] ranges =
+          Ranges.forCharSequence(
+              result, new Source(source.getOrigin(), source.getName(), source.getValue()));
 
-    taintedObjects.taint(result, rangesParam);
+      taintedObjects.taint(result, ranges);
+    } else {
+      final TaintedObject taintedParam = taintedObjects.get(param);
+      if (taintedParam == null) {
+        return;
+      }
+
+      final Range[] rangesParam = taintedParam.getRanges();
+      if (rangesParam.length == 0) {
+        return;
+      }
+
+      taintedObjects.taint(result, rangesParam);
+    }
   }
 
   /**

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/propagation/StringModuleImpl.java
@@ -742,6 +742,30 @@ public class StringModuleImpl implements StringModule {
         numReplacements);
   }
 
+  @Override
+  @SuppressFBWarnings("ES_COMPARING_PARAMETER_STRING_WITH_EQ")
+  public void onStringValueOf(Object param, @Nonnull String result) {
+    if (param == null || !canBeTainted(result)) {
+      return;
+    }
+    final IastContext ctx = IastContext.Provider.get();
+    if (ctx == null) {
+      return;
+    }
+    final TaintedObjects taintedObjects = ctx.getTaintedObjects();
+    final TaintedObject taintedParam = taintedObjects.get(param);
+    if (taintedParam == null) {
+      return;
+    }
+
+    final Range[] rangesParam = taintedParam.getRanges();
+    if (rangesParam.length == 0) {
+      return;
+    }
+
+    taintedObjects.taint(result, rangesParam);
+  }
+
   /**
    * Adds the tainted ranges belonging to the current parameter added via placeholder taking care of
    * an optional tainted placeholder.

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
@@ -1337,7 +1337,7 @@ class StringModuleTest extends IastModuleImplTestBase {
 
     then:
     1 * tracer.activeSpan() >> span
-    taintFormat(result, taintedObject.getRanges()) == "==>" + param.toString() + "<=="
+    taintFormat(result, taintedObject.getRanges()) == "==>my_input<=="
   }
 
   void 'test valueOf with special objects and make sure IastRequestContext is called'() {
@@ -1411,7 +1411,7 @@ class StringModuleTest extends IastModuleImplTestBase {
 
     @Override
     String toString() {
-      return Taintable.name
+      return "my_input"
     }
   }
 }

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/propagation/StringModuleTest.groovy
@@ -1332,7 +1332,7 @@ class StringModuleTest extends IastModuleImplTestBase {
     if (taintable) {
       param = taintable(taintedObjects, source)
     } else {
-      param = new ObjectInputStream()
+      param = new ByteArrayInputStream(''.bytes)
       taintObject(taintedObjects, param, source)
     }
     def result = String.valueOf(param)

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -303,7 +303,6 @@ public class StringCallSite {
 
   @CallSite.After("java.lang.String java.lang.String.valueOf(java.lang.Object)")
   public static String afterValueOf(
-      //      @CallSite.This final String self,
       @CallSite.Argument(0) final Object obj, @CallSite.Return final String result) {
     final StringModule module = InstrumentationBridge.STRING;
     if (module != null) {

--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringCallSite.java
@@ -300,4 +300,19 @@ public class StringCallSite {
     }
     return result;
   }
+
+  @CallSite.After("java.lang.String java.lang.String.valueOf(java.lang.Object)")
+  public static String afterValueOf(
+      //      @CallSite.This final String self,
+      @CallSite.Argument(0) final Object obj, @CallSite.Return final String result) {
+    final StringModule module = InstrumentationBridge.STRING;
+    if (module != null) {
+      try {
+        module.onStringValueOf(obj, result);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterValueOf threw", e);
+      }
+    }
+    return result;
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringCallSiteTest.groovy
@@ -265,4 +265,24 @@ class StringCallSiteTest extends AgentTestRunner {
     "test" | 't'     | 'T'     | "TesT"
     "test" | 'e'     | 'E'     | "tEst"
   }
+
+  def 'test string valueOf call site'() {
+    setup:
+    final stringModule = Mock(StringModule)
+    InstrumentationBridge.registerIastModule(stringModule)
+
+    when:
+    final result = TestStringSuite.valueOf(input)
+
+    then:
+    result == expected
+    1 * stringModule.onStringValueOf(input, expected)
+    0 * _
+
+    where:
+    input                     | expected
+    "test"                    | "test"
+    new StringBuilder("test") | "test"
+    new StringBuffer("test")  | "test"
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringSuite.java
@@ -239,4 +239,11 @@ public class TestStringSuite {
     LOGGER.debug("After replace first {}", result);
     return result;
   }
+
+  public static String valueOf(final Object param) {
+    LOGGER.debug("Before valueOf {}", param);
+    String result = String.valueOf(param);
+    LOGGER.debug("After valueOf {}", result);
+    return result;
+  }
 }

--- a/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/propagation/StringModule.java
@@ -61,4 +61,6 @@ public interface StringModule extends IastModule {
 
   String onStringReplace(
       @Nonnull String self, String regex, String replacement, int numReplacements);
+
+  void onStringValueOf(Object param, @Nullable String result);
 }


### PR DESCRIPTION
# What Does This Do
This adds the instrumentation to propagate the taint values through the following method of `String`:
- `valueOf(Object)`

# Motivation
Increase IAST propagation of String methods.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55357]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55357]: https://datadoghq.atlassian.net/browse/APPSEC-55357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ