### PR TITLE
Update the CodeOriginProbe fingerprint to not rely on a stack walk

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.debugger;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.util.TimeoutChecker;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -72,7 +73,9 @@ public class DebuggerContext {
   }
 
   public interface CodeOriginRecorder {
-    String captureCodeOrigin(String signature);
+    String captureCodeOrigin(boolean entry);
+
+    String captureCodeOrigin(Method method, boolean entry);
   }
 
   private static volatile ProbeResolver probeResolver;
@@ -351,11 +354,23 @@ public class DebuggerContext {
     }
   }
 
-  public static String captureCodeOrigin(String signature) {
+  public static String captureCodeOrigin(boolean entry) {
     try {
       CodeOriginRecorder recorder = codeOriginRecorder;
       if (recorder != null) {
-        return recorder.captureCodeOrigin(signature);
+        return recorder.captureCodeOrigin(entry);
+      }
+    } catch (Exception ex) {
+      LOGGER.debug("Error in captureCodeOrigin: ", ex);
+    }
+    return null;
+  }
+
+  public static String captureCodeOrigin(Method method, boolean entry) {
+    try {
+      CodeOriginRecorder recorder = codeOriginRecorder;
+      if (recorder != null) {
+        return recorder.captureCodeOrigin(method, entry);
       }
     } catch (Exception ex) {
       LOGGER.debug("Error in captureCodeOrigin: ", ex);

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/spanorigin/CodeOriginInfo.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/spanorigin/CodeOriginInfo.java
@@ -1,29 +1,23 @@
 package datadog.trace.bootstrap.debugger.spanorigin;
 
 import static datadog.trace.bootstrap.debugger.DebuggerContext.captureCodeOrigin;
-import static java.util.Arrays.stream;
 
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import java.lang.reflect.Method;
-import java.util.stream.Collectors;
 
 public class CodeOriginInfo {
   public static void entry(Method method) {
     if (InstrumenterConfig.get().isCodeOriginEnabled()) {
-      String signature =
-          stream(method.getParameterTypes())
-              .map(Class::getTypeName)
-              .collect(Collectors.joining(", ", "(", ")"));
-      captureCodeOrigin(signature);
+      captureCodeOrigin(method, true);
     }
   }
 
   public static void exit(AgentSpan span) {
     if (InstrumenterConfig.get().isCodeOriginEnabled()) {
-      String probeId = captureCodeOrigin(null);
+      String probeId = captureCodeOrigin(false);
       if (span != null) {
-        span.getLocalRootSpan().setTag(probeId, span);
+        span.getLocalRootSpan().setTag(probeId, span.getSpanId());
       }
     }
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/codeorigin/DefaultCodeOriginRecorder.java
@@ -15,6 +15,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.stacktrace.StackWalkerFactory;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,61 +28,73 @@ import org.slf4j.LoggerFactory;
 public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
   private static final Logger LOG = LoggerFactory.getLogger(DefaultCodeOriginRecorder.class);
 
-  private final Config config;
-
   private final ConfigurationUpdater configurationUpdater;
 
   private final Map<String, CodeOriginProbe> fingerprints = new HashMap<>();
 
   private final Map<String, CodeOriginProbe> probes = new ConcurrentHashMap<>();
 
-  private final AgentTaskScheduler taskScheduler = AgentTaskScheduler.INSTANCE;
+  private final int maxUserFrames;
 
   public DefaultCodeOriginRecorder(Config config, ConfigurationUpdater configurationUpdater) {
-    this.config = config;
     this.configurationUpdater = configurationUpdater;
+    maxUserFrames = config.getDebuggerCodeOriginMaxUserFrames();
   }
 
   @Override
-  public String captureCodeOrigin(String signature) {
+  public String captureCodeOrigin(boolean entry) {
     StackTraceElement element = findPlaceInStack();
     String fingerprint = Fingerprinter.fingerprint(element);
-    if (fingerprint == null) {
-      LOG.debug("Unable to fingerprint stack trace");
-      return null;
-    }
     CodeOriginProbe probe;
 
-    AgentSpan span = AgentTracer.activeSpan();
-    if (!isAlreadyInstrumented(fingerprint)) {
-      Where where =
-          Where.of(
-              element.getClassName(),
-              element.getMethodName(),
-              signature,
-              String.valueOf(element.getLineNumber()));
-
-      probe =
-          new CodeOriginProbe(
-              new ProbeId(UUID.randomUUID().toString(), 0),
-              where.getSignature(),
-              where,
-              config.getDebuggerCodeOriginMaxUserFrames());
-      addFingerprint(fingerprint, probe);
-
-      installProbe(probe);
-      if (span != null) {
-        //  committing here manually so that first run probe encounters decorate the span until the
-        // instrumentation gets installed
-        probe.commit(
-            CapturedContext.EMPTY_CONTEXT, CapturedContext.EMPTY_CONTEXT, Collections.emptyList());
-      }
-
-    } else {
+    if (isAlreadyInstrumented(fingerprint)) {
       probe = fingerprints.get(fingerprint);
+    } else {
+      probe =
+          createProbe(
+              fingerprint,
+              entry,
+              Where.of(
+                  element.getClassName(),
+                  element.getMethodName(),
+                  null,
+                  String.valueOf(element.getLineNumber())));
     }
 
     return probe.getId();
+  }
+
+  @Override
+  public String captureCodeOrigin(Method method, boolean entry) {
+    CodeOriginProbe probe;
+
+    String fingerPrint = method.toString();
+    if (isAlreadyInstrumented(fingerPrint)) {
+      probe = fingerprints.get(fingerPrint);
+    } else {
+      probe = createProbe(fingerPrint, entry, Where.of(method));
+    }
+
+    return probe.getId();
+  }
+
+  private CodeOriginProbe createProbe(String fingerPrint, boolean entry, Where where) {
+    CodeOriginProbe probe;
+    AgentSpan span = AgentTracer.activeSpan();
+
+    probe =
+        new CodeOriginProbe(
+            new ProbeId(UUID.randomUUID().toString(), 0), entry, where, maxUserFrames);
+    addFingerprint(fingerPrint, probe);
+
+    installProbe(probe);
+    // committing here manually so that first run probe encounters decorate the span until the
+    // instrumentation gets installed
+    if (span != null) {
+      probe.commit(
+          CapturedContext.EMPTY_CONTEXT, CapturedContext.EMPTY_CONTEXT, Collections.emptyList());
+    }
+    return probe;
   }
 
   private StackTraceElement findPlaceInStack() {
@@ -104,7 +117,8 @@ public class DefaultCodeOriginRecorder implements CodeOriginRecorder {
   public String installProbe(CodeOriginProbe probe) {
     CodeOriginProbe installed = probes.putIfAbsent(probe.getId(), probe);
     if (installed == null) {
-      taskScheduler.execute(() -> configurationUpdater.accept(CODE_ORIGIN, getProbes()));
+      AgentTaskScheduler.INSTANCE.execute(
+          () -> configurationUpdater.accept(CODE_ORIGIN, getProbes()));
       return probe.getId();
     }
     return installed.getId();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/Where.java
@@ -1,5 +1,7 @@
 package com.datadog.debugger.probe;
 
+import static java.util.Arrays.stream;
+
 import com.datadog.debugger.agent.Generated;
 import com.datadog.debugger.instrumentation.Types;
 import com.datadog.debugger.util.ClassFileLines;
@@ -7,12 +9,14 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -46,8 +50,17 @@ public class Where {
     return new Where(typeName, methodName, signature, lines, null);
   }
 
+  public static Where of(Method method) {
+    return of(
+        method.getDeclaringClass().getName(),
+        method.getName(),
+        stream(method.getParameterTypes())
+            .map(Class::getTypeName)
+            .collect(Collectors.joining(", ", "(", ")")));
+  }
+
   protected static SourceLine[] sourceLines(String[] defs) {
-    if (defs == null) {
+    if (defs == null || defs.length == 0) {
       return null;
     }
     SourceLine[] lines = new SourceLine[defs.length];
@@ -72,7 +85,7 @@ public class Where {
             null);
       }
     }
-    throw new IllegalArgumentException("Invalid where to convert from line to method " + lineWhere);
+    return lineWhere;
   }
 
   public String getTypeName() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -119,7 +119,7 @@ public class CodeOriginTest extends CapturingTestBase {
     final String CLASS_NAME = "com.datadog.debugger.CodeOrigin04";
     installProbes(
         new CodeOriginProbe(
-            CODE_ORIGIN_ID1, null, Where.of(CLASS_NAME, "exit", "()", "39"), MAX_FRAMES));
+            CODE_ORIGIN_ID1, true, Where.of(CLASS_NAME, "exit", "()", "39"), MAX_FRAMES));
 
     Class<?> testClass = compileAndLoadClass("com.datadog.debugger.CodeOrigin04");
     countFrames(testClass, 10);
@@ -139,27 +139,54 @@ public class CodeOriginTest extends CapturingTestBase {
   }
 
   @Test
-  public void testCaptureCodeOriginWithSignature() {
+  public void testCaptureCodeOriginEntry() {
     installProbes();
-    CodeOriginProbe probe = codeOriginRecorder.getProbe(codeOriginRecorder.captureCodeOrigin("()"));
+    CodeOriginProbe probe = codeOriginRecorder.getProbe(codeOriginRecorder.captureCodeOrigin(true));
     assertNotNull(probe);
     assertTrue(probe.entrySpanProbe());
   }
 
   @Test
-  public void testCaptureCodeOriginWithNullSignature() {
+  public void testCaptureCodeOriginExit() {
     installProbes();
-    CodeOriginProbe probe = codeOriginRecorder.getProbe(codeOriginRecorder.captureCodeOrigin(null));
+    CodeOriginProbe probe =
+        codeOriginRecorder.getProbe(codeOriginRecorder.captureCodeOrigin(false));
     assertNotNull(probe);
     assertFalse(probe.entrySpanProbe());
+  }
+
+  @Test
+  public void testCaptureCodeOriginWithExplicitInfo()
+      throws IOException, URISyntaxException, NoSuchMethodException {
+    final String CLASS_NAME = "com.datadog.debugger.CodeOrigin04";
+    final Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    installProbes();
+    CodeOriginProbe probe =
+        codeOriginRecorder.getProbe(
+            codeOriginRecorder.captureCodeOrigin(testClass.getMethod("main", int.class), true));
+    assertNotNull(probe, "The probe should have been created.");
+    assertTrue(probe.entrySpanProbe(), "Should be an entry probe.");
+  }
+
+  @Test
+  public void testDuplicateInstrumentations()
+      throws IOException, URISyntaxException, NoSuchMethodException {
+    final String CLASS_NAME = "com.datadog.debugger.CodeOrigin04";
+    final Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    installProbes();
+    String probe1 =
+        codeOriginRecorder.captureCodeOrigin(testClass.getMethod("main", int.class), true);
+    String probe2 =
+        codeOriginRecorder.captureCodeOrigin(testClass.getMethod("main", int.class), true);
+    assertEquals(probe1, probe2);
   }
 
   @NotNull
   private List<LogProbe> codeOriginProbes(String type) {
     CodeOriginProbe entry =
-        new CodeOriginProbe(CODE_ORIGIN_ID1, "()", Where.of(type, "entry", "()", "53"), MAX_FRAMES);
+        new CodeOriginProbe(CODE_ORIGIN_ID1, true, Where.of(type, "entry", "()", "53"), MAX_FRAMES);
     CodeOriginProbe exit =
-        new CodeOriginProbe(CODE_ORIGIN_ID2, null, Where.of(type, "exit", "()", "60"), MAX_FRAMES);
+        new CodeOriginProbe(CODE_ORIGIN_ID2, false, Where.of(type, "exit", "()", "60"), MAX_FRAMES);
     return new ArrayList<>(asList(entry, exit));
   }
 


### PR DESCRIPTION
# What Does This Do

Currently the fingerprinting used to prevent repeat instrumentations uses the stack trace to track existing probe definitions.  This PR cleans that up to use a cheaper fingerprint that doesn't rely on walking the stack each time.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3147]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3147]: https://datadoghq.atlassian.net/browse/DEBUG-3147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ