### PR TITLE
Support using OpenTelemetry Event API inside `@WithSpan` annotated method

### DIFF
--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/OpenTelemetryInstrumentation.java
@@ -73,12 +73,12 @@ public class OpenTelemetryInstrumentation extends InstrumenterModule.Tracing
       "datadog.opentelemetry.shim.trace.OtelSpanBuilder",
       "datadog.opentelemetry.shim.trace.OtelSpanBuilder$1",
       "datadog.opentelemetry.shim.trace.OtelSpanContext",
+      "datadog.opentelemetry.shim.trace.OtelSpanEvent",
       "datadog.opentelemetry.shim.trace.OtelSpanEvent$AttributesJsonParser",
       "datadog.opentelemetry.shim.trace.OtelSpanLink",
       "datadog.opentelemetry.shim.trace.OtelTracer",
       "datadog.opentelemetry.shim.trace.OtelTracerBuilder",
       "datadog.opentelemetry.shim.trace.OtelTracerProvider",
-      "datadog.opentelemetry.shim.trace.OtelSpanEvent",
     };
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextInstrumentation.java
@@ -67,6 +67,8 @@ public class OpenTelemetryContextInstrumentation extends InstrumenterModule.Trac
       "datadog.opentelemetry.shim.trace.OtelSpanBuilder",
       "datadog.opentelemetry.shim.trace.OtelSpanBuilder$1",
       "datadog.opentelemetry.shim.trace.OtelSpanContext",
+      "datadog.opentelemetry.shim.trace.OtelSpanEvent",
+      "datadog.opentelemetry.shim.trace.OtelSpanEvent$AttributesJsonParser",
       "datadog.opentelemetry.shim.trace.OtelSpanLink",
       "datadog.opentelemetry.shim.trace.OtelTracer",
       "datadog.opentelemetry.shim.trace.OtelTracerBuilder",

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextStorageInstrumentation.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/main/java/datadog/trace/instrumentation/opentelemetry14/context/OpenTelemetryContextStorageInstrumentation.java
@@ -68,6 +68,8 @@ public class OpenTelemetryContextStorageInstrumentation extends InstrumenterModu
       "datadog.opentelemetry.shim.trace.OtelSpanBuilder",
       "datadog.opentelemetry.shim.trace.OtelSpanBuilder$1",
       "datadog.opentelemetry.shim.trace.OtelSpanContext",
+      "datadog.opentelemetry.shim.trace.OtelSpanEvent",
+      "datadog.opentelemetry.shim.trace.OtelSpanEvent$AttributesJsonParser",
       "datadog.opentelemetry.shim.trace.OtelSpanLink",
       "datadog.opentelemetry.shim.trace.OtelTracer",
       "datadog.opentelemetry.shim.trace.OtelTracerBuilder",

--- a/dd-smoke-tests/opentelemetry/build.gradle
+++ b/dd-smoke-tests/opentelemetry/build.gradle
@@ -11,6 +11,7 @@ application {
 
 dependencies {
   implementation group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.4.0'
+  implementation group: 'io.opentelemetry.instrumentation', name: 'opentelemetry-instrumentation-annotations', version: '1.20.0'
   testImplementation project(':dd-smoke-tests')
 }
 

--- a/dd-smoke-tests/opentelemetry/src/main/java/datadog/smoketest/opentelemetry/Application.java
+++ b/dd-smoke-tests/opentelemetry/src/main/java/datadog/smoketest/opentelemetry/Application.java
@@ -3,15 +3,26 @@ package datadog.smoketest.opentelemetry;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 
 /**
  * This application is a minimalistic application to create a trace with Open Telemetry Tracer API.
  */
 public class Application {
+
+  @WithSpan
+  static void annotatedSpan() {
+    Span.current().addEvent("annotated-span-event");
+  }
+
   public static void main(String[] args) throws InterruptedException {
+    // Start trace without touching GlobalOpenTelemetry
+    annotatedSpan();
+
     // Get an Open Telemetry tracer
     Tracer tracer = GlobalOpenTelemetry.getTracerProvider().tracerBuilder("smoketests").build();
-    // Create a trace with few spans
+
+    // Start some manual traces
     for (int i = 0; i < 10; i++) {
       Span span = tracer.spanBuilder("span-" + i).startSpan();
       Thread.sleep(20);

--- a/dd-smoke-tests/opentelemetry/src/test/groovy/datadog/smoketest/OpenTelemetrySmokeTest.groovy
+++ b/dd-smoke-tests/opentelemetry/src/test/groovy/datadog/smoketest/OpenTelemetrySmokeTest.groovy
@@ -1,13 +1,17 @@
 package datadog.smoketest
 
+import static java.util.concurrent.TimeUnit.SECONDS
+
 class OpenTelemetrySmokeTest extends AbstractSmokeTest {
+  public static final int TIMEOUT_SECS = 30
+
   @Override
   ProcessBuilder createProcessBuilder() {
     def jarPath = System.getProperty("datadog.smoketest.shadowJar.path")
     def command = new ArrayList<String>()
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
-    command.add("-Ddd.integration.opentelemetry.experimental.enabled=true")
+    command.add("-Ddd.trace.otel.enabled=true")
     command.addAll(["-jar", jarPath])
 
     ProcessBuilder processBuilder = new ProcessBuilder(command)
@@ -16,6 +20,8 @@ class OpenTelemetrySmokeTest extends AbstractSmokeTest {
 
   def 'receive trace'() {
     expect:
-    waitForTraceCount(1)
+    waitForTraceCount(11) // 1 annotated, 10 manual
+    assert testedProcess.waitFor(TIMEOUT_SECS, SECONDS)
+    assert testedProcess.exitValue() == 0
   }
 }


### PR DESCRIPTION
# What Does This Do

Adds `OtelSpanEvent` to the helpers injected when interacting with the OpenTelemetry Context API.

# Motivation

This helper is needed to support Event API calls made inside contexts produced by `@WithSpan` before the main `OpenTelemetry` API is touched.

# Additional Notes

One workaround is to add a static reference to `GlobalOpenTelemetry` in your application:
```
  static {
    GlobalOpenTelemetry.get();
  }
```
which will trigger injection of `OtelSpanEvent` via `OpenTelemetryInstrumentation`

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
