### PR TITLE
Fix JUnit test case name uniqueness when uploading results

### DIFF
--- a/.circleci/collect_results.sh
+++ b/.circleci/collect_results.sh
@@ -7,20 +7,30 @@ set -e
 #Enable '**' support
 shopt -s globstar
 
-TEST_RESULTS_DIR=./results
-mkdir -p $TEST_RESULTS_DIR >/dev/null 2>&1
-
+TEST_RESULTS_DIR=results
+WORKSPACE_DIR=workspace
 mkdir -p $TEST_RESULTS_DIR
+mkdir -p $WORKSPACE_DIR
 
-mkdir -p workspace
-mapfile -t test_result_dirs < <(find workspace -name test-results -type d)
+mapfile -t TEST_RESULT_DIRS < <(find $WORKSPACE_DIR -name test-results -type d)
 
-if [[ ${#test_result_dirs[@]} -eq 0 ]]; then
+if [[ ${#TEST_RESULT_DIRS[@]} -eq 0 ]]; then
   echo "No test results found"
   exit 0
 fi
 
-echo "saving test results"
-find "${test_result_dirs[@]}" -name \*.xml -exec sh -c '
-  file=$(echo "$0" | rev | cut -d "/" -f 1,2,5 | rev | tr "/" "_")
-  cp "$0" "$1/$file"' {} $TEST_RESULTS_DIR \;
+echo "Saving test results:"
+while IFS= read -r -d '' RESULT_XML_FILE
+do
+  echo -n "- $RESULT_XML_FILE"
+  AGGREGATED_FILE_NAME=$(echo "$RESULT_XML_FILE" | rev | cut -d "/" -f 1,2,5 | rev | tr "/" "_")
+  echo -n " as $AGGREGATED_FILE_NAME"
+  cp "$RESULT_XML_FILE" "$TEST_RESULTS_DIR/$AGGREGATED_FILE_NAME"
+  # Replace Java Object hashCode by marker in testcase XML nodes to get stable test names
+  sed -i '/<testcase/ s/@[0-9a-f]\{5,\}/@HASHCODE/g' "$TEST_RESULTS_DIR/$AGGREGATED_FILE_NAME"
+  if cmp -s "$RESULT_XML_FILE" "$TEST_RESULTS_DIR/$AGGREGATED_FILE_NAME"; then
+    echo ""
+  else
+    echo " (hashCode replaced)"
+  fi
+done <   <(find "${TEST_RESULT_DIRS[@]}" -name \*.xml -print0)


### PR DESCRIPTION
# What Does This Do

This PR will alter JUnit test reports that are uploaded to CI Visibility to remove Java object hashCode from the test case name, replacing them by `HASHCODE`.

# Motivation

This will help with CI monitoring to keep track of test execution.

# Additional Notes

In addition, the script will now dump the collected result files, their mapping, and warn about hashCode presence.

Output example:
```
Saving test results:
- ./internal-api/build/test-results/forkedTest/TEST-datadog.trace.api.WithGlobalTracerForkedTest.xml as internal-api_forkedTest_TEST-datadog.trace.api.WithGlobalTracerForkedTest.xml
- ./internal-api/build/test-results/forkedTest/TEST-datadog.trace.api.naming.NamingV0ForkedTest.xml as internal-api_forkedTest_TEST-datadog.trace.api.naming.NamingV0ForkedTest.xml
- ./internal-api/build/test-results/test/TEST-datadog.trace.api.cache.QualifiedClassNameCacheTest.xml as internal-api_test_TEST-datadog.trace.api.cache.QualifiedClassNameCacheTest.xml (hashCode replaced)
- ...
```

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
