### PR TITLE
Twilio: allow service name flattening

### DIFF
--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioClientDecorator.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioClientDecorator.java
@@ -5,6 +5,7 @@ import com.twilio.rest.api.v2010.account.Call;
 import com.twilio.rest.api.v2010.account.Message;
 import datadog.trace.api.Functions;
 import datadog.trace.api.cache.QualifiedClassNameCache;
+import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
@@ -23,6 +24,11 @@ public class TwilioClientDecorator extends ClientDecorator {
   public static final CharSequence TWILIO_SDK = UTF8BytesString.create("twilio.sdk");
 
   private static final CharSequence COMPONENT_NAME = UTF8BytesString.create("twilio-sdk");
+
+  private static final String SERVICE_NAME =
+      SpanNaming.instance().namingSchema().allowInferredServices()
+          ? COMPONENT_NAME.toString()
+          : null;
 
   private static final QualifiedClassNameCache NAMES =
       new QualifiedClassNameCache(
@@ -54,7 +60,7 @@ public class TwilioClientDecorator extends ClientDecorator {
 
   @Override
   protected String service() {
-    return COMPONENT_NAME.toString();
+    return SERVICE_NAME;
   }
 
   /** Decorate trace based on service execution metadata. */


### PR DESCRIPTION
# What Does This Do

Allows using `DD_SERVICE` when the naming schema is `v1` or if `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true`

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-13987]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-13987]: https://datadoghq.atlassian.net/browse/APMS-13987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ