### PR TITLE
Increase IAST propagation to StringBuilder subSequence

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringBuilderCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringBuilderCallSite.java
@@ -139,4 +139,21 @@ public class StringBuilderCallSite {
     }
     return result;
   }
+
+  @CallSite.After("java.lang.CharSequence java.lang.StringBuilder.subSequence(int, int)")
+  public static CharSequence afterSubSequence(
+      @CallSite.This final CharSequence self,
+      @CallSite.Argument final int beginIndex,
+      @CallSite.Argument final int endIndex,
+      @CallSite.Return final CharSequence result) {
+    final StringModule module = InstrumentationBridge.STRING;
+    if (module != null) {
+      try {
+        module.onStringSubSequence(self, beginIndex, endIndex, result);
+      } catch (final Throwable e) {
+        module.onUnexpectedException("afterSubSequence threw", e);
+      }
+    }
+    return result;
+  }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
@@ -210,13 +210,13 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     sbf('012345') | 1          | '12345'
   }
 
-  def 'test string builder substring with endIndex call site'() {
+  def 'test string builder/buffer #method with endIndex call site'() {
     setup:
     final iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    final result = TestStringBuilderSuite.substring(param, beginIndex, endIndex)
+    final result = suite."$method"(param, beginIndex, endIndex)
 
     then:
     result == expected
@@ -224,17 +224,18 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     0 * _
 
     where:
-    param         | beginIndex | endIndex | expected
-    sb('012345')  | 1          | 5        | '1234'
+    suite                        | method        | param         | beginIndex | endIndex | expected
+    new TestStringBuilderSuite() | "substring"   | sb('012345')  | 1          | 5        | '1234'
+    new TestStringBufferSuite()  | "substring"   | sbf('012345') | 1          | 5        | '1234'
   }
 
-  def 'test string buffer substring with endIndex call site'() {
+  def 'test string builder/buffer #method with endIndex call site'() {
     setup:
     final iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    final result = TestStringBufferSuite.substring(param, beginIndex, endIndex)
+    final result = suite."$method"(param, beginIndex, endIndex)
 
     then:
     result == expected
@@ -242,8 +243,8 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     0 * _
 
     where:
-    param         | beginIndex | endIndex | expected
-    sbf('012345') | 1          | 5        | '1234'
+    suite                        | method        | param         | beginIndex | endIndex | expected
+    new TestStringBuilderSuite() | "subSequence" | sb('012345')  | 1          | 5        | '1234'
   }
 
   private static class BrokenToString {

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
@@ -174,13 +174,13 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     ex.stackTrace.find { it.className == StringBuilderCallSite.name } == null
   }
 
-  def 'test string builder substring call site'() {
+  def 'test string #type substring call site'() {
     setup:
     final iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    final result = TestStringBuilderSuite.substring(param, beginIndex)
+    final result = suite.substring(param, beginIndex)
 
     then:
     result == expected
@@ -188,35 +188,18 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     0 * _
 
     where:
-    param         | beginIndex | expected
-    sb('012345')  | 1          | '12345'
+    type      | suite                        | param         | beginIndex | expected
+    "builder" | new TestStringBuilderSuite() | sb('012345')  | 1          | '12345'
+    "buffer"  | new TestStringBufferSuite()  | sbf('012345') | 1          | '12345'
   }
 
-  def 'test string buffer substring call site'() {
+  def 'test string #type substring with endIndex call site'() {
     setup:
     final iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    final result = TestStringBufferSuite.substring(param, beginIndex)
-
-    then:
-    result == expected
-    1 * iastModule.onStringSubSequence(param, beginIndex, param.length(), expected)
-    0 * _
-
-    where:
-    param         | beginIndex | expected
-    sbf('012345') | 1          | '12345'
-  }
-
-  def 'test string builder/buffer #method with endIndex call site'() {
-    setup:
-    final iastModule = Mock(StringModule)
-    InstrumentationBridge.registerIastModule(iastModule)
-
-    when:
-    final result = suite."$method"(param, beginIndex, endIndex)
+    final result = suite.substring(param, beginIndex, endIndex)
 
     then:
     result == expected
@@ -224,18 +207,18 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     0 * _
 
     where:
-    suite                        | method        | param         | beginIndex | endIndex | expected
-    new TestStringBuilderSuite() | "substring"   | sb('012345')  | 1          | 5        | '1234'
-    new TestStringBufferSuite()  | "substring"   | sbf('012345') | 1          | 5        | '1234'
+    type      | suite                        | param         | beginIndex | endIndex | expected
+    "builder" | new TestStringBuilderSuite() | sb('012345')  | 1          | 5        | '1234'
+    "buffer"  | new TestStringBufferSuite()  | sbf('012345') | 1          | 5        | '1234'
   }
 
-  def 'test string builder/buffer #method with endIndex call site'() {
+  def 'test string #type subSequence with endIndex call site'() {
     setup:
     final iastModule = Mock(StringModule)
     InstrumentationBridge.registerIastModule(iastModule)
 
     when:
-    final result = suite."$method"(param, beginIndex, endIndex)
+    final result = suite.subSequence(param, beginIndex, endIndex)
 
     then:
     result == expected
@@ -243,8 +226,8 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     0 * _
 
     where:
-    suite                        | method        | param         | beginIndex | endIndex | expected
-    new TestStringBuilderSuite() | "subSequence" | sb('012345')  | 1          | 5        | '1234'
+    type      | suite                        | param         | beginIndex | endIndex | expected
+    "builder" | new TestStringBuilderSuite() | sb('012345')  | 1          | 5        | '1234'
   }
 
   private static class BrokenToString {

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestAbstractStringBuilderSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestAbstractStringBuilderSuite.java
@@ -12,5 +12,11 @@ public interface TestAbstractStringBuilderSuite<E> {
 
   void append(final E target, final Object param);
 
+  String substring(final E self, final int beginIndex, final int endIndex);
+
+  String substring(final E self, final int beginIndex);
+
+  CharSequence subSequence(final E self, final int beginIndex, final int endIndex);
+
   String toString(final E target);
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBufferSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBufferSuite.java
@@ -52,17 +52,28 @@ public class TestStringBufferSuite implements TestAbstractStringBuilderSuite<Str
     return result;
   }
 
-  public static String substring(StringBuffer self, int beginIndex, int endIndex) {
+  @Override
+  public String substring(final StringBuffer self, final int beginIndex, final int endIndex) {
     LOGGER.debug("Before string buffer substring {} from {} to {}", self, beginIndex, endIndex);
     final String result = self.substring(beginIndex, endIndex);
     LOGGER.debug("After string buffer substring {}", result);
     return result;
   }
 
-  public static String substring(StringBuffer self, int beginIndex) {
+  @Override
+  public String substring(final StringBuffer self, final int beginIndex) {
     LOGGER.debug("Before string buffer substring {} from {}", self, beginIndex);
     final String result = self.substring(beginIndex);
     LOGGER.debug("After string buffer substring {}", result);
+    return result;
+  }
+
+  @Override
+  public CharSequence subSequence(
+      final StringBuffer self, final int beginIndex, final int endIndex) {
+    LOGGER.debug("Before string builder subSequence {} from {} to {}", self, beginIndex, endIndex);
+    final CharSequence result = self.subSequence(beginIndex, endIndex);
+    LOGGER.debug("After string builder subSequence {}", result);
     return result;
   }
 }

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBuilderSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBuilderSuite.java
@@ -77,21 +77,25 @@ public class TestStringBuilderSuite implements TestAbstractStringBuilderSuite<St
     return result;
   }
 
-  public static String substring(StringBuilder self, int beginIndex, int endIndex) {
+  @Override
+  public String substring(final StringBuilder self, final int beginIndex, final int endIndex) {
     LOGGER.debug("Before string builder substring {} from {} to {}", self, beginIndex, endIndex);
     final String result = self.substring(beginIndex, endIndex);
     LOGGER.debug("After string builder substring {}", result);
     return result;
   }
 
-  public static String substring(StringBuilder self, int beginIndex) {
+  @Override
+  public String substring(final StringBuilder self, final int beginIndex) {
     LOGGER.debug("Before string builder substring {} from {}", self, beginIndex);
     final String result = self.substring(beginIndex);
     LOGGER.debug("After string builder substring {}", result);
     return result;
   }
 
-  public static CharSequence subSequence(StringBuilder self, int beginIndex, int endIndex) {
+  @Override
+  public CharSequence subSequence(
+      final StringBuilder self, final int beginIndex, final int endIndex) {
     LOGGER.debug("Before string builder subSequence {} from {} to {}", self, beginIndex, endIndex);
     final CharSequence result = self.subSequence(beginIndex, endIndex);
     LOGGER.debug("After string builder subSequence {}", result);

--- a/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBuilderSuite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/test/java/foo/bar/TestStringBuilderSuite.java
@@ -90,4 +90,11 @@ public class TestStringBuilderSuite implements TestAbstractStringBuilderSuite<St
     LOGGER.debug("After string builder substring {}", result);
     return result;
   }
+
+  public static CharSequence subSequence(StringBuilder self, int beginIndex, int endIndex) {
+    LOGGER.debug("Before string builder subSequence {} from {} to {}", self, beginIndex, endIndex);
+    final CharSequence result = self.subSequence(beginIndex, endIndex);
+    LOGGER.debug("After string builder subSequence {}", result);
+    return result;
+  }
 }


### PR DESCRIPTION
# What Does This Do
This adds the instrumentation to propagate the taint values through the following methods of `StringBuilder`:
- `subSequence(int, int)`

# Motivation
Increase propagation of `StringBuilder` methods.

# Additional Notes
In this PR it has been made one refactor in the tests to make them clear.

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55360]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55360]: https://datadoghq.atlassian.net/browse/APPSEC-55360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ