### PR TITLE
Cache entry span code origin information to avoid unnecessary repeated stack walks.

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/InstrumentationResult.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/InstrumentationResult.java
@@ -18,8 +18,10 @@ public class InstrumentationResult {
 
   private final Status status;
   private final Map<ProbeId, List<DiagnosticMessage>> diagnostics;
-  private String typeName;
-  private String methodName;
+  private final String sourceFileName;
+  private final String typeName;
+  private final String methodName;
+  private final int methodStart;
 
   public static class Factory {
     public static InstrumentationResult blocked(String className) {
@@ -41,8 +43,10 @@ public class InstrumentationResult {
     this(
         status,
         diagnostics,
+        methodInfo.getClassNode().sourceFile,
         methodInfo.getClassNode().name.replace('/', '.'),
-        methodInfo.getMethodNode().name);
+        methodInfo.getMethodNode().name,
+        methodInfo.getMethodStart());
   }
 
   public InstrumentationResult(
@@ -54,6 +58,23 @@ public class InstrumentationResult {
     this.diagnostics = diagnostics;
     this.typeName = className;
     this.methodName = methodName;
+    this.methodStart = -1;
+    this.sourceFileName = null;
+  }
+
+  public InstrumentationResult(
+      Status status,
+      Map<ProbeId, List<DiagnosticMessage>> diagnostics,
+      String sourceFileName,
+      String className,
+      String methodName,
+      int methodStart) {
+    this.status = status;
+    this.diagnostics = diagnostics;
+    this.sourceFileName = sourceFileName;
+    this.typeName = className;
+    this.methodName = methodName;
+    this.methodStart = methodStart;
   }
 
   public boolean isError() {
@@ -78,6 +99,14 @@ public class InstrumentationResult {
 
   public String getMethodName() {
     return methodName;
+  }
+
+  public int getMethodStart() {
+    return methodStart;
+  }
+
+  public String getSourceFileName() {
+    return sourceFileName;
   }
 
   @Generated

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MethodInfo.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MethodInfo.java
@@ -37,4 +37,8 @@ public class MethodInfo {
   public ClassFileLines getClassFileLines() {
     return classFileLines;
   }
+
+  public int getMethodStart() {
+    return classFileLines != null ? classFileLines.getMethodStart(methodNode) : -1;
+  }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileLines.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileLines.java
@@ -13,6 +13,7 @@ import org.objectweb.asm.tree.MethodNode;
 
 public class ClassFileLines {
   private final Map<Integer, List<MethodNode>> methodByLine = new HashMap<>();
+  private final Map<MethodNode, Integer> methodStarts = new HashMap<>();
   private final TreeMap<Integer, LabelNode> lineLabels = new TreeMap<>();
 
   public ClassFileLines(ClassNode classNode) {
@@ -21,6 +22,7 @@ public class ClassFileLines {
       while (currentNode != null) {
         if (currentNode.getType() == AbstractInsnNode.LINE) {
           LineNumberNode lineNode = (LineNumberNode) currentNode;
+          methodStarts.putIfAbsent(methodNode, lineNode.line);
           // on the same line, we can have multiple methods (lambdas, inner classes, etc)
           List<MethodNode> methodNodes =
               methodByLine.computeIfAbsent(lineNode.line, k -> new ArrayList<>());
@@ -38,6 +40,10 @@ public class ClassFileLines {
         currentNode = currentNode.getNext();
       }
     }
+  }
+
+  public int getMethodStart(MethodNode node) {
+    return methodStarts.getOrDefault(node, -1);
   }
 
   public List<MethodNode> getMethodsByLine(int line) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileLines.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/ClassFileLines.java
@@ -13,7 +13,7 @@ import org.objectweb.asm.tree.MethodNode;
 
 public class ClassFileLines {
   private final Map<Integer, List<MethodNode>> methodByLine = new HashMap<>();
-  private final Map<MethodNode, Integer> methodStarts = new HashMap<>();
+  private final Map<String, Integer> methodStarts = new HashMap<>();
   private final TreeMap<Integer, LabelNode> lineLabels = new TreeMap<>();
 
   public ClassFileLines(ClassNode classNode) {
@@ -22,7 +22,7 @@ public class ClassFileLines {
       while (currentNode != null) {
         if (currentNode.getType() == AbstractInsnNode.LINE) {
           LineNumberNode lineNode = (LineNumberNode) currentNode;
-          methodStarts.putIfAbsent(methodNode, lineNode.line);
+          methodStarts.putIfAbsent(methodNode.name + methodNode.desc, lineNode.line);
           // on the same line, we can have multiple methods (lambdas, inner classes, etc)
           List<MethodNode> methodNodes =
               methodByLine.computeIfAbsent(lineNode.line, k -> new ArrayList<>());
@@ -43,7 +43,7 @@ public class ClassFileLines {
   }
 
   public int getMethodStart(MethodNode node) {
-    return methodStarts.getOrDefault(node, -1);
+    return methodStarts.getOrDefault(node.name + node.desc, -1);
   }
 
   public List<MethodNode> getMethodsByLine(int line) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -271,10 +271,11 @@ public class CodeOriginTest extends CapturingTestBase {
 
     MutableSpan rootSpan = span.getLocalRootSpan();
     assertEquals(rootSpan.getTag(DD_CODE_ORIGIN_TYPE), "entry", keys);
-    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 1, "file")));
-    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 1, "line")));
-    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 1, "method")));
-    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 1, "type")));
+    Object file = rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "file"));
+    assertNotNull(file, rootSpan.getTags().toString());
+    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
+    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "method")));
+    assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "type")));
   }
 
   private static Set<String> ldKeys(MutableSpan span) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/origin/CodeOriginTest.java
@@ -8,6 +8,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -234,6 +235,7 @@ public class CodeOriginTest extends CapturingTestBase {
     assertKeyPresent(span, DD_CODE_ORIGIN_TYPE);
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "file"));
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "line"));
+    assertNotEquals(-1, span.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "method"));
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "signature"));
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "type"));
@@ -263,6 +265,7 @@ public class CodeOriginTest extends CapturingTestBase {
     assertKeyPresent(span, DD_CODE_ORIGIN_TYPE);
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "file"));
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "line"));
+    assertNotEquals(-1, span.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "method"));
     assertKeyPresent(span, format(DD_CODE_ORIGIN_FRAME, 0, "type"));
     if (includeSnapshot) {
@@ -274,6 +277,7 @@ public class CodeOriginTest extends CapturingTestBase {
     Object file = rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "file"));
     assertNotNull(file, rootSpan.getTags().toString());
     assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
+    assertNotEquals(-1, rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "line")));
     assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "method")));
     assertNotNull(rootSpan.getTag(format(DD_CODE_ORIGIN_FRAME, 0, "type")));
   }


### PR DESCRIPTION
# What Does This Do
This PR uses the class parsing during instrumentation to extract out more accurate entry span information
caches that information to reuse it on commit()

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3159]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3159]: https://datadoghq.atlassian.net/browse/DEBUG-3159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ