### PR TITLE
Replace JAVA_TOOL_OPTIONS by jvm.options OpenLiberty server configuration file

### DIFF
--- a/dd-smoke-tests/springboot-openliberty-20/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty-20/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeTest.groovy
@@ -7,7 +7,10 @@ import okhttp3.Request
 import spock.lang.Requires
 import spock.lang.Shared
 
-import java.util.stream.Collectors
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 
 // This test currently fails on IBM JVMs
 @Requires({ !Platform.isJ9() })
@@ -21,31 +24,57 @@ class SpringBootOpenLibertySmokeTest extends AbstractServerSmokeTest {
 
   @Override
   ProcessBuilder createProcessBuilder() {
-    List<String> command = new ArrayList<>()
-    command.add(javaPath())
+    // Make a copy of the OpenLiberty runnable JAR before injecting JVM configuration
+    def applicationJar = copyApplicationJar().toAbsolutePath().toString()
 
-    command.addAll((String[]) ["-jar", openLibertyShadowJar, "--server.port=${httpPort}"])
+    List<String> command = [
+      javaPath(),
+      "-jar",
+      applicationJar,
+      "--server.port=${httpPort}" as String
+    ]
 
-    List<String> envParams = new ArrayList<>()
-    envParams.addAll(defaultJavaProperties)
-    envParams.addAll(
-      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter",
+    List<String> jvmOptions = new ArrayList<>()
+    jvmOptions.addAll(defaultJavaProperties)
+    jvmOptions.addAll(
+      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter" as String,
       "-Ddd.jmxfetch.enabled=false",
       "-Ddd.appsec.enabled=true",
       "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
       "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
-      "-Ddd.iast.enabled=true", "-Ddd.iast.request-sampling=100",
+      "-Ddd.iast.enabled=true",
+      "-Ddd.iast.request-sampling=100",
       "-Ddd.integration.spring-boot.enabled=true"
       )
-
-
-    String javaToolOptions = envParams.stream().collect(Collectors.joining(" "))
-
+    injectOpenLibertyJvmOptions(applicationJar, jvmOptions)
 
     ProcessBuilder processBuilder = new ProcessBuilder(command)
-    processBuilder.environment().put("JAVA_TOOL_OPTIONS", javaToolOptions)
+    processBuilder.environment().put('WLP_JAR_EXTRACT_ROOT', 'application')
     processBuilder.directory(new File(buildDirectory))
     return processBuilder
+  }
+
+  Path copyApplicationJar() {
+    def applicationJar = Paths.get(openLibertyShadowJar)
+    def randomId = System.nanoTime()
+    def uniqueName = applicationJar.fileName.toString()
+    uniqueName = uniqueName.substring(0, uniqueName.length() - 4) + "-${randomId}.jar"
+    def specificationJar = applicationJar.parent.parent.resolve(uniqueName)
+    Files.copy(applicationJar, specificationJar)
+    return specificationJar
+  }
+
+  void injectOpenLibertyJvmOptions(String applicationJar, List<String> options) {
+    def appUri = URI.create("jar:file:$applicationJar")
+    try (def fs = FileSystems.newFileSystem(appUri, [:])) {
+      def jvmOptionFile = fs.getPath( 'wlp', 'usr', 'servers', 'defaultServer', 'jvm.options')
+      try (def writer = Files.newBufferedWriter(jvmOptionFile)) {
+        options.each {
+          writer.write(it)
+          writer.newLine()
+        }
+      }
+    }
   }
 
   @Override

--- a/dd-smoke-tests/springboot-openliberty-20/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeVulnerabilityTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty-20/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeVulnerabilityTest.groovy
@@ -1,6 +1,5 @@
 package datadog.smoketest
 
-
 import datadog.trace.api.Platform
 import datadog.trace.test.agent.decoder.DecodedSpan
 import okhttp3.Request
@@ -8,45 +7,71 @@ import spock.lang.Requires
 import spock.lang.Shared
 import spock.util.concurrent.PollingConditions
 
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.function.Function
-import java.util.stream.Collectors
 
 // This test currently fails on IBM JVMs
 @Requires({ !Platform.isJ9() })
 class SpringBootOpenLibertySmokeVulnerabilityTest extends AbstractServerSmokeTest {
 
   @Shared
-  int totalInvocations = 100
-
-  @Shared
   String openLibertyShadowJar = System.getProperty("datadog.smoketest.openliberty.jar.path")
 
   @Override
   ProcessBuilder createProcessBuilder() {
-    List<String> command = new ArrayList<>()
-    command.add(javaPath())
+    // Make a copy of the OpenLiberty runnable JAR before injecting JVM configuration
+    def applicationJar = copyApplicationJar().toAbsolutePath().toString()
 
-    command.addAll((String[]) ["-jar", openLibertyShadowJar, "--server.port=${httpPort}"])
+    List<String> command = [
+      javaPath(),
+      "-jar",
+      applicationJar,
+      "--server.port=${httpPort}" as String
+    ]
 
-    List<String> envParams = new ArrayList<>()
-    envParams.addAll(defaultJavaProperties)
-    envParams.addAll(
-      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter",
+    List<String> jvmOptions = new ArrayList<>()
+    jvmOptions.addAll(defaultJavaProperties)
+    jvmOptions.addAll(
+      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter" as String,
       "-Ddd.jmxfetch.enabled=false",
       "-Ddd.appsec.enabled=true",
       "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
       "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
-      "-Ddd.iast.enabled=true", "-Ddd.iast.request-sampling=100"
+      "-Ddd.iast.enabled=true",
+      "-Ddd.iast.request-sampling=100"
       )
-
-
-    String javaToolOptions = envParams.stream().collect(Collectors.joining(" "))
-
+    injectOpenLibertyJvmOptions(applicationJar, jvmOptions)
 
     ProcessBuilder processBuilder = new ProcessBuilder(command)
-    processBuilder.environment().put("JAVA_TOOL_OPTIONS", javaToolOptions)
+    processBuilder.environment().put('WLP_JAR_EXTRACT_ROOT', 'application')
     processBuilder.directory(new File(buildDirectory))
     return processBuilder
+  }
+
+  Path copyApplicationJar() {
+    def applicationJar = Paths.get(openLibertyShadowJar)
+    def randomId = System.nanoTime()
+    def uniqueName = applicationJar.fileName.toString()
+    uniqueName = uniqueName.substring(0, uniqueName.length() - 4) + "-${randomId}.jar"
+    def specificationJar = applicationJar.parent.parent.resolve(uniqueName)
+    Files.copy(applicationJar, specificationJar)
+    return specificationJar
+  }
+
+  void injectOpenLibertyJvmOptions(String applicationJar, List<String> options) {
+    def appUri = URI.create("jar:file:$applicationJar")
+    try (def fs = FileSystems.newFileSystem(appUri, [:])) {
+      def jvmOptionFile = fs.getPath( 'wlp', 'usr', 'servers', 'defaultServer', 'jvm.options')
+      try (def writer = Files.newBufferedWriter(jvmOptionFile)) {
+        options.each {
+          writer.write(it)
+          writer.newLine()
+        }
+      }
+    }
   }
 
   @Override

--- a/dd-smoke-tests/springboot-openliberty-23/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeVulnerabilityTest.groovy
+++ b/dd-smoke-tests/springboot-openliberty-23/src/test/groovy/datadog/smoketest/SpringBootOpenLibertySmokeVulnerabilityTest.groovy
@@ -8,45 +8,70 @@ import spock.lang.Requires
 import spock.lang.Shared
 import spock.util.concurrent.PollingConditions
 
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.function.Function
-import java.util.stream.Collectors
 
 // This test currently fails on IBM JVMs
 @Requires({ !Platform.isJ9() })
 class SpringBootOpenLibertySmokeVulnerabilityTest extends AbstractServerSmokeTest {
 
   @Shared
-  int totalInvocations = 100
-
-  @Shared
   String openLibertyShadowJar = System.getProperty("datadog.smoketest.openliberty.jar.path")
 
   @Override
   ProcessBuilder createProcessBuilder() {
-    List<String> command = new ArrayList<>()
-    command.add(javaPath())
+    // Make a copy of the OpenLiberty runnable JAR before injecting JVM configuration
+    def applicationJar = copyApplicationJar().toAbsolutePath().toString()
 
-    command.addAll((String[]) ["-jar", openLibertyShadowJar, "--server.port=${httpPort}"])
+    List<String> command = [
+      javaPath(),
+      "-jar",
+      applicationJar,
+      "--server.port=${httpPort}" as String
+    ]
 
-    List<String> envParams = new ArrayList<>()
-    envParams.addAll(defaultJavaProperties)
-    envParams.addAll(
-      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter",
+    List<String> jvmOptions = new ArrayList<>()
+    jvmOptions.addAll(defaultJavaProperties)
+    jvmOptions.addAll(
+      "-Ddd.writer.type=MultiWriter:TraceStructureWriter:${output.getAbsolutePath()},DDAgentWriter" as String,
       "-Ddd.jmxfetch.enabled=false",
       "-Ddd.appsec.enabled=true",
       "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=debug",
       "-Dorg.slf4j.simpleLogger.defaultLogLevel=debug",
       "-Ddd.iast.enabled=true", "-Ddd.iast.request-sampling=100"
       )
-
-
-    String javaToolOptions = envParams.stream().collect(Collectors.joining(" "))
-
+    injectOpenLibertyJvmOptions(applicationJar, jvmOptions)
 
     ProcessBuilder processBuilder = new ProcessBuilder(command)
-    processBuilder.environment().put("JAVA_TOOL_OPTIONS", javaToolOptions)
+    processBuilder.environment().put('WLP_JAR_EXTRACT_ROOT', 'application')
     processBuilder.directory(new File(buildDirectory))
     return processBuilder
+  }
+
+  Path copyApplicationJar() {
+    def applicationJar = Paths.get(openLibertyShadowJar)
+    def randomId = System.nanoTime()
+    def uniqueName = applicationJar.fileName.toString()
+    uniqueName = uniqueName.substring(0, uniqueName.length() - 4) + "-${randomId}.jar"
+    def specificationJar = applicationJar.parent.parent.resolve(uniqueName)
+    Files.copy(applicationJar, specificationJar)
+    return specificationJar
+  }
+
+  void injectOpenLibertyJvmOptions(String applicationJar, List<String> options) {
+    def appUri = URI.create("jar:file:$applicationJar")
+    try (def fs = FileSystems.newFileSystem(appUri, [:])) {
+      def jvmOptionFile = fs.getPath( 'wlp', 'usr', 'servers', 'defaultServer', 'jvm.options')
+      try (def writer = Files.newBufferedWriter(jvmOptionFile)) {
+        options.each {
+          writer.write(it)
+          writer.newLine()
+        }
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

This PR replaces usage of the `JAVA_TOOL_OPTIONS` environment variable by the `jvm.options` server configuration file from OpenLiberty.

# Motivation

The `JAVA_TOOL_OPTIONS` is limited to 1024 characters on some Java versions and it starts reaching the limit.
I also tried `JVM_ARGS` environment variable but it was not picked by our deployment method (runnable jar).

# Additional Notes

As multiple specifications can use the same runnable jar at the same time (when running tests in parallel), the jar is copied before injecting configuration.
This is a fix required to enable crash-tracking more widely in our system tests #7855 

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
