### PR TITLE
Fold setAsyncPropagation into preceding activateSpan

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestImpl.java
@@ -98,8 +98,7 @@ public class TestImpl implements DDTest {
 
     span = spanBuilder.start();
 
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    activateSpan(span, true);
 
     span.setSpanType(InternalSpanTypes.TEST);
     span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_TEST);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
@@ -121,8 +121,7 @@ public class TestSuiteImpl implements DDTestSuite {
     testDecorator.afterStart(span);
 
     if (!parallelized) {
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      activateSpan(span, true);
     }
 
     metricCollector.add(CiVisibilityCountMetric.EVENT_CREATED, 1, instrumentation, EventType.SUITE);

--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/java/LinearTask.java
@@ -32,9 +32,7 @@ public class LinearTask extends RecursiveTask<Integer> {
     } else {
       int next = parent + 1;
       AgentSpan span = startSpan(Integer.toString(next));
-      try (AgentScope scope = activateSpan(span)) {
-        // shouldn't be necessary with a decent API
-        scope.setAsyncPropagation(true);
+      try (AgentScope scope = activateSpan(span, true)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();
       } finally {

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/main/java/datadog/trace/instrumentation/akkahttp/DatadogWrapperHelper.java
@@ -15,9 +15,7 @@ public class DatadogWrapperHelper {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request, request, extractedContext);
 
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
-    return scope;
+    return activateSpan(span, true);
   }
 
   public static void finishSpan(final AgentSpan span, final HttpResponse response) {

--- a/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
+++ b/dd-java-agent/instrumentation/finatra-2.9/src/main/java/datadog/trace/instrumentation/finatra/FinatraInstrumentation.java
@@ -76,9 +76,7 @@ public class FinatraInstrumentation extends InstrumenterModule.Tracing
       DECORATE.afterStart(span);
       span.setResourceName(DECORATE.className(clazz));
 
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/grizzly-2/src/main/java/datadog/trace/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -78,8 +78,7 @@ public class GrizzlyHttpHandlerInstrumentation extends InstrumenterModule.Tracin
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request, request, parentContext);
 
-      scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      scope = activateSpan(span, true);
 
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);
       request.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/FilterAdvice.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/FilterAdvice.java
@@ -7,27 +7,22 @@ import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecora
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import net.bytebuddy.asm.Advice;
-import org.glassfish.grizzly.filterchain.BaseFilter;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
 
 public class FilterAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static AgentScope onEnter(
-      @Advice.This BaseFilter it, @Advice.Argument(0) final FilterChainContext ctx) {
-    if (ctx.getAttributes().getAttribute(DD_SPAN_ATTRIBUTE) == null || activeSpan() != null) {
+  public static AgentScope onEnter(@Advice.Argument(0) final FilterChainContext ctx) {
+    Object span = ctx.getAttributes().getAttribute(DD_SPAN_ATTRIBUTE);
+    if (span == null || activeSpan() != null) {
       return null;
     }
-    AgentScope scope =
-        activateSpan((AgentSpan) ctx.getAttributes().getAttribute(DD_SPAN_ATTRIBUTE));
-    scope.setAsyncPropagation(true);
-    return scope;
+    return activateSpan((AgentSpan) span, true);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-  public static void onExit(@Advice.This BaseFilter it, @Advice.Enter final AgentScope scope) {
+  public static void onExit(@Advice.Enter final AgentScope scope) {
     if (scope != null) {
-      scope.setAsyncPropagation(false);
       scope.close();
     }
   }

--- a/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-http-2.3.20/src/main/java/datadog/trace/instrumentation/grizzlyhttp232/GrizzlyDecorator.java
@@ -115,8 +115,7 @@ public class GrizzlyDecorator
     HttpResponsePacket httpResponse = httpRequest.getResponse();
     AgentSpan.Context.Extracted context = DECORATE.extract(httpRequest);
     AgentSpan span = DECORATE.startSpan(httpRequest, context);
-    AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    AgentScope scope = activateSpan(span, true);
     DECORATE.afterStart(span);
     ctx.getAttributes().setAttribute(DD_SPAN_ATTRIBUTE, span);
     ctx.getAttributes().setAttribute(DD_RESPONSE_ATTRIBUTE, httpResponse);

--- a/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/ignite-2.0/src/main/java/datadog/trace/instrumentation/ignite/v2/cache/IgniteCacheAsyncInstrumentation.java
@@ -91,11 +91,9 @@ public class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheInstrume
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
       DECORATE.onOperation(span, that.getName(), methodName);
 
-      final AgentScope scope = activateSpan(span);
       // Enable async propagation, so the newly spawned task will be associated back with this
       // original trace.
-      scope.setAsyncPropagation(true);
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -149,11 +147,9 @@ public class IgniteCacheAsyncInstrumentation extends AbstractIgniteCacheInstrume
           span, InstrumentationContext.get(IgniteCache.class, Ignite.class).get(that));
       DECORATE.onOperation(span, that.getName(), methodName, key);
 
-      final AgentScope scope = activateSpan(span);
       // Enable async propagation, so the newly spawned task will be associated back with this
       // original trace.
-      scope.setAsyncPropagation(true);
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/DefaultRequestContextInstrumentation.java
@@ -47,8 +47,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
           // can only be aborted inside the filter method
         }
 
-        final AgentScope scope = activateSpan(span);
-        scope.setAsyncPropagation(true);
+        final AgentScope scope = activateSpan(span, true);
 
         DECORATE.afterStart(span);
         DECORATE.onJakartaRsSpan(span, parent, filterClass, method);

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsInstrumentation.java
@@ -123,8 +123,7 @@ public final class JakartaRsAnnotationsInstrumentation extends InstrumenterModul
       DECORATE.onJakartaRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);
 
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      final AgentScope scope = activateSpan(span, true);
 
       if (contextStore != null && asyncResponse != null) {
         contextStore.put(asyncResponse, span);

--- a/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/jakarta-rs-annotations-3/src/main/java/datadog/trace/instrumentation/jakarta3/RequestFilterHelper.java
@@ -28,8 +28,7 @@ public class RequestFilterHelper {
         parent = activeSpan();
         span = startSpan(JAKARTA_RS_REQUEST_ABORT);
 
-        final AgentScope scope = activateSpan(span);
-        scope.setAsyncPropagation(true);
+        final AgentScope scope = activateSpan(span, true);
 
         DECORATE.afterStart(span);
         DECORATE.onJakartaRsSpan(span, parent, resourceClass, method);

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolExecution.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolExecution.java
@@ -26,8 +26,7 @@ public class RecursiveThreadPoolExecution implements Runnable {
       return;
     }
     AgentSpan span = startSpan(String.valueOf(depth));
-    try (AgentScope scope = activateSpan(span)) {
-      scope.setAsyncPropagation(true);
+    try (AgentScope scope = activateSpan(span, true)) {
       executor.execute(new RecursiveThreadPoolExecution(executor, maxDepth, depth + 1));
     } finally {
       span.finish();

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolMixedSubmissionAndExecution.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolMixedSubmissionAndExecution.java
@@ -27,8 +27,7 @@ public class RecursiveThreadPoolMixedSubmissionAndExecution implements Runnable 
       return;
     }
     AgentSpan span = startSpan(String.valueOf(depth));
-    try (AgentScope scope = activateSpan(span)) {
-      scope.setAsyncPropagation(true);
+    try (AgentScope scope = activateSpan(span, true)) {
       if (depth % 2 == 0) {
         executor.submit(
             new RecursiveThreadPoolMixedSubmissionAndExecution(executor, maxDepth, depth + 1));

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolSubmission.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/executor/recursive/RecursiveThreadPoolSubmission.java
@@ -26,8 +26,7 @@ public class RecursiveThreadPoolSubmission implements Runnable {
       return;
     }
     AgentSpan span = startSpan(String.valueOf(depth));
-    try (AgentScope scope = activateSpan(span)) {
-      scope.setAsyncPropagation(true);
+    try (AgentScope scope = activateSpan(span, true)) {
       executor.submit(new RecursiveThreadPoolSubmission(executor, maxDepth, depth + 1));
     } finally {
       span.finish();

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/java/forkjoin/LinearTask.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/java/forkjoin/LinearTask.java
@@ -34,9 +34,7 @@ public class LinearTask extends RecursiveTask<Integer> {
     } else {
       int next = parent + 1;
       AgentSpan span = startSpan(Integer.toString(next));
-      try (AgentScope scope = activateSpan(span)) {
-        // shouldn't be necessary with a decent API
-        scope.setAsyncPropagation(true);
+      try (AgentScope scope = activateSpan(span, true)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();
       } finally {

--- a/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsInstrumentation.java
@@ -100,9 +100,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);
 
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/DefaultRequestContextInstrumentation.java
@@ -47,8 +47,7 @@ public class DefaultRequestContextInstrumentation extends AbstractRequestContext
           // can only be aborted inside the filter method
         }
 
-        final AgentScope scope = activateSpan(span);
-        scope.setAsyncPropagation(true);
+        final AgentScope scope = activateSpan(span, true);
 
         DECORATE.afterStart(span);
         DECORATE.onJaxRsSpan(span, parent, filterClass, method);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsInstrumentation.java
@@ -131,8 +131,7 @@ public final class JaxRsAnnotationsInstrumentation extends InstrumenterModule.Tr
       DECORATE.onJaxRsSpan(span, parent, target.getClass(), method);
       DECORATE.afterStart(span);
 
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      final AgentScope scope = activateSpan(span, true);
 
       if (contextStore != null && asyncResponse != null) {
         contextStore.put(asyncResponse, span);

--- a/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations-2/src/main/java/datadog/trace/instrumentation/jaxrs2/RequestFilterHelper.java
@@ -27,8 +27,7 @@ public class RequestFilterHelper {
         parent = activeSpan();
         span = startSpan(JAX_RS_REQUEST_ABORT);
 
-        final AgentScope scope = activateSpan(span);
-        scope.setAsyncPropagation(true);
+        final AgentScope scope = activateSpan(span, true);
 
         DECORATE.afterStart(span);
         DECORATE.onJaxRsSpan(span, parent, resourceClass, method);

--- a/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/dd-java-agent/instrumentation/jdbc/src/main/java/datadog/trace/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -67,9 +67,7 @@ public final class DataSourceInstrumentation extends InstrumenterModule.Tracing
 
       span.setResourceName(DECORATE.spanNameForMethod(ds.getClass(), "getConnection"));
 
-      final AgentScope agentScope = activateSpan(span);
-      agentScope.setAsyncPropagation(true);
-      return agentScope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-11/src/main/java11/datadog/trace/instrumentation/jetty11/JettyServerAdvice.java
@@ -27,8 +27,7 @@ public class JettyServerAdvice {
 
       final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(req);
       span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      final AgentScope scope = activateSpan(span, true);
       span.setMeasured(true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);

--- a/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyServerAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-12/src/main/java17/datadog/trace/instrumentation/jetty12/JettyServerAdvice.java
@@ -29,8 +29,7 @@ public class JettyServerAdvice {
 
       final AgentSpan.Context.Extracted extractedContext = JettyDecorator.DECORATE.extract(req);
       final AgentSpan span = JettyDecorator.DECORATE.startSpan(req, extractedContext);
-      try (final AgentScope scope = activateSpan(span)) {
-        scope.setAsyncPropagation(true);
+      try (final AgentScope scope = activateSpan(span, true)) {
         span.setMeasured(true);
         JettyDecorator.DECORATE.afterStart(span);
         JettyDecorator.DECORATE.onRequest(span, req, req, extractedContext);

--- a/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.0/src/main/java/datadog/trace/instrumentation/jetty70/JettyServerInstrumentation.java
@@ -155,8 +155,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(req);
       span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      final AgentScope scope = activateSpan(span, true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-7.6/src/main/java/datadog/trace/instrumentation/jetty76/JettyServerInstrumentation.java
@@ -156,8 +156,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(req);
       span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      final AgentScope scope = activateSpan(span, true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java/datadog/trace/instrumentation/jetty9/JettyServerInstrumentation.java
@@ -169,8 +169,7 @@ public final class JettyServerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(req);
       span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      final AgentScope scope = activateSpan(span, true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, req, req, extractedContext);
 

--- a/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
+++ b/dd-java-agent/instrumentation/jetty-9/src/main/java_jetty10/datadog/trace/instrumentation/jetty10/HandleAdvice.java
@@ -29,8 +29,7 @@ public class HandleAdvice {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, req, req, extractedContext);
 
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    final AgentScope scope = activateSpan(span, true);
     req.setAttribute(DD_SPAN_ATTRIBUTE, span);
     req.setAttribute(CorrelationIdentifier.getTraceIdKey(), GlobalTracer.get().getTraceId());
     req.setAttribute(CorrelationIdentifier.getSpanIdKey(), GlobalTracer.get().getSpanId());

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaProducerCallback.java
@@ -39,8 +39,7 @@ public class KafkaProducerCallback implements Callback {
     span.finish();
     if (callback != null) {
       if (parent != null) {
-        try (final AgentScope scope = activateSpan(parent)) {
-          scope.setAsyncPropagation(true);
+        try (final AgentScope scope = activateSpan(parent, true)) {
           callback.onCompletion(metadata, exception);
         }
       } else {

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaProducerCallback.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaProducerCallback.java
@@ -38,8 +38,7 @@ public class KafkaProducerCallback implements Callback {
     span.finish();
     if (callback != null) {
       if (parent != null) {
-        try (final AgentScope scope = activateSpan(parent)) {
-          scope.setAsyncPropagation(true);
+        try (final AgentScope scope = activateSpan(parent, true)) {
           callback.onCompletion(metadata, exception);
         }
       } else {

--- a/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-20/src/main/java/datadog/trace/instrumentation/liberty20/LibertyServerInstrumentation.java
@@ -103,8 +103,7 @@ public final class LibertyServerInstrumentation extends InstrumenterModule.Traci
       final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(request);
       request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
       final AgentSpan span = DECORATE.startSpan(request, extractedContext);
-      scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      scope = activateSpan(span, true);
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request, request, extractedContext);

--- a/dd-java-agent/instrumentation/liberty-23/src/main/java/datadog/trace/instrumentation/liberty23/LibertyServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/liberty-23/src/main/java/datadog/trace/instrumentation/liberty23/LibertyServerInstrumentation.java
@@ -105,8 +105,7 @@ public final class LibertyServerInstrumentation extends InstrumenterModule.Traci
       final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(request);
       request.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
       final AgentSpan span = DECORATE.startSpan(request, extractedContext);
-      scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      scope = activateSpan(span, true);
 
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request, request, extractedContext);

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/client/HttpClientResponseTracingHandler.java
@@ -48,8 +48,7 @@ public class HttpClientResponseTracingHandler extends SimpleChannelUpstreamHandl
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(parent, true)) {
       ctx.sendUpstream(msg);
     }
   }
@@ -77,8 +76,7 @@ public class HttpClientResponseTracingHandler extends SimpleChannelUpstreamHandl
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(parent, true)) {
       super.exceptionCaught(ctx, e);
     }
   }

--- a/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/server/HttpServerRequestTracingHandler.java
@@ -35,8 +35,7 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
       if (span == null) {
         ctx.sendUpstream(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span)) {
-          scope.setAsyncPropagation(true);
+        try (final AgentScope scope = activateSpan(span, true)) {
           ctx.sendUpstream(msg); // superclass does not throw
         }
       }
@@ -51,11 +50,9 @@ public class HttpServerRequestTracingHandler extends SimpleChannelUpstreamHandle
     channelTraceContext.reset();
     channelTraceContext.setRequestHeaders(headers);
 
-    try (final AgentScope scope = activateSpan(span)) {
+    try (final AgentScope scope = activateSpan(span, true)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, ctx.getChannel(), request, context);
-
-      scope.setAsyncPropagation(true);
 
       channelTraceContext.setServerSpan(span);
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/client/HttpClientResponseTracingHandler.java
@@ -37,8 +37,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(parent, true)) {
       ctx.fireChannelRead(msg);
     }
   }
@@ -59,8 +58,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     }
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(parent, true)) {
       super.exceptionCaught(ctx, cause);
     }
   }
@@ -78,8 +76,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     }
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(parent, true)) {
       super.channelInactive(ctx);
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.0/src/main/java/datadog/trace/instrumentation/netty40/server/HttpServerRequestTracingHandler.java
@@ -31,8 +31,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       if (span == null) {
         ctx.fireChannelRead(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span)) {
-          scope.setAsyncPropagation(true);
+        try (final AgentScope scope = activateSpan(span, true)) {
           ctx.fireChannelRead(msg); // superclass does not throw
         }
       }
@@ -44,11 +43,9 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     final Context.Extracted extractedContext = DECORATE.extract(headers);
     final AgentSpan span = DECORATE.startSpan(headers, extractedContext);
 
-    try (final AgentScope scope = activateSpan(span)) {
+    try (final AgentScope scope = activateSpan(span, true)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, channel, request, extractedContext);
-
-      scope.setAsyncPropagation(true);
 
       channel.attr(ANALYZED_RESPONSE_KEY).set(null);
       channel.attr(BLOCKED_RESPONSE_KEY).set(null);

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/client/HttpClientResponseTracingHandler.java
@@ -46,8 +46,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
     }
 
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(parent, true)) {
       ctx.fireChannelRead(msg);
     }
   }
@@ -68,8 +67,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     }
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(parent, true)) {
       super.exceptionCaught(ctx, cause);
     }
   }
@@ -87,8 +85,7 @@ public class HttpClientResponseTracingHandler extends ChannelInboundHandlerAdapt
       }
     }
     // We want the callback in the scope of the parent, not the client span
-    try (final AgentScope scope = activateSpan(parent)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(parent, true)) {
       super.channelInactive(ctx);
     }
   }

--- a/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
+++ b/dd-java-agent/instrumentation/netty-4.1/src/main/java/datadog/trace/instrumentation/netty41/server/HttpServerRequestTracingHandler.java
@@ -30,8 +30,7 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
       if (span == null) {
         ctx.fireChannelRead(msg); // superclass does not throw
       } else {
-        try (final AgentScope scope = activateSpan(span)) {
-          scope.setAsyncPropagation(true);
+        try (final AgentScope scope = activateSpan(span, true)) {
           ctx.fireChannelRead(msg); // superclass does not throw
         }
       }
@@ -43,11 +42,9 @@ public class HttpServerRequestTracingHandler extends ChannelInboundHandlerAdapte
     final Context.Extracted extractedContext = DECORATE.extract(headers);
     final AgentSpan span = DECORATE.startSpan(headers, extractedContext);
 
-    try (final AgentScope scope = activateSpan(span)) {
+    try (final AgentScope scope = activateSpan(span, true)) {
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, channel, request, extractedContext);
-
-      scope.setAsyncPropagation(true);
 
       channel.attr(ANALYZED_RESPONSE_KEY).set(null);
       channel.attr(BLOCKED_RESPONSE_KEY).set(null);

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/main/java/datadog/trace/instrumentation/opentelemetry/annotations/WithSpanAdvice.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-annotations-1.20/src/main/java/datadog/trace/instrumentation/opentelemetry/annotations/WithSpanAdvice.java
@@ -14,9 +14,7 @@ public class WithSpanAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static AgentScope onEnter(@Advice.Origin final Method method) {
     AgentSpan span = DECORATE.startMethodSpan(method);
-    AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
-    return scope;
+    return activateSpan(span, true);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogWrapperHelper.java
@@ -15,9 +15,7 @@ public class DatadogWrapperHelper {
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, request, request, extractedContext);
 
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
-    return scope;
+    return activateSpan(span, true);
   }
 
   public static void finishSpan(final AgentSpan span, final HttpResponse response) {

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/PlayAdvice.java
@@ -32,8 +32,7 @@ public class PlayAdvice {
       span.setMeasured(true);
     }
 
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    final AgentScope scope = activateSpan(span, true);
     DECORATE.afterStart(span);
     return scope;
   }

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/PlayAdvice.java
@@ -38,8 +38,7 @@ public class PlayAdvice {
       span.setMeasured(true);
     }
 
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    final AgentScope scope = activateSpan(span, true);
     DECORATE.afterStart(span);
 
     req = RequestHelper.withTag(req, "_dd_HasPlayRequestSpan", "true");

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayAdvice.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/PlayAdvice.java
@@ -38,8 +38,7 @@ public class PlayAdvice {
       // Do not extract the context.
       span = startSpan(PLAY_REQUEST);
     }
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    final AgentScope scope = activateSpan(span, true);
     span.setMeasured(true);
     DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ActionWrapper.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/ActionWrapper.java
@@ -22,8 +22,7 @@ public class ActionWrapper<T> implements Action<T> {
 
   @Override
   public void execute(final T t) throws Exception {
-    try (final AgentScope scope = activateSpan(span)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(span, true)) {
       delegate.execute(t);
     }
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/BlockWrapper.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/BlockWrapper.java
@@ -23,8 +23,7 @@ public class BlockWrapper implements Block {
 
   @Override
   public void execute() throws Exception {
-    try (final AgentScope scope = activateSpan(span)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(span, true)) {
       delegate.execute();
     }
   }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/TracingHandler.java
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/main/java/datadog/trace/instrumentation/ratpack/TracingHandler.java
@@ -42,8 +42,7 @@ public final class TracingHandler implements Handler {
 
     boolean setFinalizer = false;
 
-    try (final AgentScope scope = activateSpan(ratpackSpan)) {
-      scope.setAsyncPropagation(true);
+    try (final AgentScope scope = activateSpan(ratpackSpan, true)) {
 
       ctx.getResponse()
           .beforeSend(

--- a/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedSubscriber.java
+++ b/dd-java-agent/instrumentation/rxjava-1/src/main/java/datadog/trace/instrumentation/rxjava/TracedSubscriber.java
@@ -28,8 +28,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onStart() {
     final AgentSpan span = spanRef.get();
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span)) {
-        scope.setAsyncPropagation(true);
+      try (final AgentScope scope = activateSpan(span, true)) {
         delegate.onStart();
       }
     } else {
@@ -41,8 +40,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onNext(final T value) {
     final AgentSpan span = spanRef.get();
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span)) {
-        scope.setAsyncPropagation(true);
+      try (final AgentScope scope = activateSpan(span, true)) {
         delegate.onNext(value);
       } catch (final Throwable e) {
         onError(e);
@@ -57,8 +55,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
     final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
       boolean errored = false;
-      try (final AgentScope scope = activateSpan(span)) {
-        scope.setAsyncPropagation(true);
+      try (final AgentScope scope = activateSpan(span, true)) {
         delegate.onCompleted();
       } catch (final Throwable e) {
         // Repopulate the spanRef for onError
@@ -81,8 +78,7 @@ public class TracedSubscriber<T> extends Subscriber<T> {
   public void onError(final Throwable e) {
     final AgentSpan span = spanRef.getAndSet(null);
     if (span != null) {
-      try (final AgentScope scope = activateSpan(span)) {
-        scope.setAsyncPropagation(true);
+      try (final AgentScope scope = activateSpan(span, true)) {
         decorator.onError(span, e);
         delegate.onError(e);
       } catch (final Throwable e2) {

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/java/LinearTask.java
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/java/LinearTask.java
@@ -32,9 +32,7 @@ public class LinearTask extends RecursiveTask<Integer> {
     } else {
       int next = parent + 1;
       AgentSpan span = startSpan(Integer.toString(next));
-      try (AgentScope scope = activateSpan(span)) {
-        // shouldn't be necessary with a decent API
-        scope.setAsyncPropagation(true);
+      try (AgentScope scope = activateSpan(span, true)) {
         LinearTask child = new LinearTask(next, depth);
         return child.fork().join();
       } finally {

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -50,8 +50,7 @@ public class Servlet2Advice {
 
     final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(httpServletRequest);
     final AgentSpan span = DECORATE.startSpan(httpServletRequest, extractedContext);
-    scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    scope = activateSpan(span, true);
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, httpServletRequest, httpServletRequest, extractedContext);
 

--- a/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/main/java/datadog/trace/instrumentation/servlet3/Servlet3Advice.java
@@ -67,8 +67,7 @@ public class Servlet3Advice {
 
     final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(httpServletRequest);
     final AgentSpan span = DECORATE.startSpan(httpServletRequest, extractedContext);
-    scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    scope = activateSpan(span, true);
 
     DECORATE.afterStart(span);
     DECORATE.onRequest(span, httpServletRequest, httpServletRequest, extractedContext);

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -129,9 +129,7 @@ public final class RequestDispatcherInstrumentation extends InstrumenterModule.T
       requestSpan = request.getAttribute(DD_SPAN_ATTRIBUTE);
       request.setAttribute(DD_SPAN_ATTRIBUTE, span);
 
-      final AgentScope agentScope = activateSpan(span);
-      agentScope.setAsyncPropagation(true);
-      return agentScope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -74,9 +74,7 @@ public final class FilterInstrumentation extends InstrumenterModule.Tracing
       // Here we use "this" instead of "the method target" to distinguish abstract filter instances.
       span.setResourceName(DECORATE.spanNameForMethod(filter.getClass(), "doFilter"));
 
-      final AgentScope agentScope = activateSpan(span);
-      agentScope.setAsyncPropagation(true);
-      return agentScope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -84,9 +84,7 @@ public final class HttpServletInstrumentation extends InstrumenterModule.Tracing
       // Here we use the Method instead of "this.class.name" to distinguish calls to "super".
       span.setResourceName(DECORATE.spanNameForMethod(method));
 
-      final AgentScope agentScope = activateSpan(span);
-      agentScope.setAsyncPropagation(true);
-      return agentScope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -72,9 +72,7 @@ public final class HttpServletResponseInstrumentation extends InstrumenterModule
 
       span.setResourceName(DECORATE.spanNameForMethod(HttpServletResponse.class, method));
 
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
+++ b/dd-java-agent/instrumentation/spray-1.3/src/main/scala/datadog/trace/instrumentation/spray/SprayHttpServerRunSealedRouteAdvice.java
@@ -26,12 +26,11 @@ public class SprayHttpServerRunSealedRouteAdvice {
       extractedContext = null;
       span = startSpan(DECORATE.spanName());
     }
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    final AgentScope scope = activateSpan(span, true);
 
     DECORATE.afterStart(span);
 
-    ctx = SprayHelper.wrapRequestContext(ctx, scope.span(), extractedContext);
+    ctx = SprayHelper.wrapRequestContext(ctx, span, extractedContext);
     return scope;
   }
 

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/RepositoryInterceptor.java
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/main/java/datadog/trace/instrumentation/springdata/RepositoryInterceptor.java
@@ -35,8 +35,7 @@ final class RepositoryInterceptor implements MethodInterceptor {
     DECORATOR.afterStart(span);
     DECORATOR.onOperation(span, invokedMethod, repositoryInterface);
 
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
+    final AgentScope scope = activateSpan(span, true);
 
     Object result = null;
     try {

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -45,8 +45,7 @@ public class SpannedMethodInvocation implements MethodInvocation {
 
   private Object invokeWithSpan(CharSequence spanName) throws Throwable {
     AgentSpan span = startSpan(spanName);
-    try (AgentScope scope = activateSpan(span)) {
-      scope.setAsyncPropagation(true);
+    try (AgentScope scope = activateSpan(span, true)) {
       return delegate.proceed();
     } finally {
       span.finish();

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
@@ -26,9 +26,8 @@ public class SpringSchedulingRunnableWrapper implements Runnable {
         LEGACY_TRACING ? startSpan(SCHEDULED_CALL) : startSpan(SCHEDULED_CALL, null);
     DECORATE.afterStart(span);
 
-    try (final AgentScope scope = activateSpan(span)) {
+    try (final AgentScope scope = activateSpan(span, true)) {
       DECORATE.onRun(span, runnable);
-      scope.setAsyncPropagation(true);
 
       try {
         runnable.run();

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/main/java/datadog/trace/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
@@ -44,8 +44,7 @@ public class HandlerAdapterAdvice {
       span.setSpanName(operationName);
       span.setTag("handler.type", handlerType);
 
-      scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      scope = activateSpan(span, true);
     }
 
     final AgentSpan parentSpan = exchange.getAttribute(AdviceUtils.PARENT_SPAN_ATTRIBUTE);

--- a/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -81,9 +81,7 @@ public final class HandlerAdapterInstrumentation extends InstrumenterModule.Trac
       DECORATE.afterStart(span);
       DECORATE.onHandle(span, handler);
 
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
-      return scope;
+      return activateSpan(span, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
+++ b/dd-java-agent/instrumentation/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/ControllerAdvice.java
@@ -34,9 +34,7 @@ public class ControllerAdvice {
     SpringWebHttpServerDecorator.DECORATE.afterStart(span);
     SpringWebHttpServerDecorator.DECORATE.onHandle(span, handler);
 
-    final AgentScope scope = activateSpan(span);
-    scope.setAsyncPropagation(true);
-    return scope;
+    return activateSpan(span, true);
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
@@ -125,8 +125,7 @@ public final class TomcatServerInstrumentation extends InstrumenterModule.Tracin
       req.setAttribute(DD_EXTRACTED_CONTEXT_ATTRIBUTE, extractedContext);
 
       final AgentSpan span = DECORATE.startSpan(req, extractedContext);
-      final AgentScope scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      final AgentScope scope = activateSpan(span, true);
       // This span is finished when Request.recycle() is called by RequestInstrumentation.
       DECORATE.afterStart(span);
 

--- a/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/dd-java-agent/instrumentation/twilio/src/main/java/datadog/trace/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -106,11 +106,9 @@ public class TwilioAsyncInstrumentation extends InstrumenterModule.Tracing
       DECORATE.afterStart(span);
       DECORATE.onServiceExecution(span, that, methodName);
 
-      final AgentScope scope = activateSpan(span);
       // Enable async propagation, so the newly spawned task will be associated back with this
       // original trace.
-      scope.setAsyncPropagation(true);
-      return scope;
+      return activateSpan(span, true);
     }
 
     /** Method exit instrumentation. */

--- a/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/undertow/undertow-2.0/src/main/java/datadog/trace/instrumentation/undertow/HandlerInstrumentation.java
@@ -93,8 +93,7 @@ public final class HandlerInstrumentation extends InstrumenterModule.Tracing
 
       final AgentSpan.Context.Extracted extractedContext = DECORATE.extract(exchange);
       final AgentSpan span = DECORATE.startSpan(exchange, extractedContext).setMeasured(true);
-      scope = activateSpan(span);
-      scope.setAsyncPropagation(true);
+      scope = activateSpan(span, true);
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, exchange, exchange, extractedContext);
 

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RouteHandlerWrapper.java
@@ -56,8 +56,7 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
       updateRoutingContextWithRoute(routingContext);
     }
     try (final AgentScope scope =
-        span != null ? activateSpan(span) : AgentTracer.NoopAgentScope.INSTANCE) {
-      scope.setAsyncPropagation(true);
+        span != null ? activateSpan(span, true) : AgentTracer.NoopAgentScope.INSTANCE) {
       try {
         actual.handle(routingContext);
       } catch (final Throwable t) {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RouteHandlerWrapper.java
@@ -50,8 +50,7 @@ public class RouteHandlerWrapper implements Handler<RoutingContext> {
     }
 
     try (final AgentScope scope =
-        span != null ? activateSpan(span) : AgentTracer.NoopAgentScope.INSTANCE) {
-      scope.setAsyncPropagation(true);
+        span != null ? activateSpan(span, true) : AgentTracer.NoopAgentScope.INSTANCE) {
       try {
         actual.handle(routingContext);
       } catch (final Throwable t) {


### PR DESCRIPTION
# Motivation

Helps reduce the number of `setAsyncPropagation` calls into those that just want to temporarily disable async propagation. 

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
