### PR TITLE
Fix NoClassDefFoundError: Could not initialize class DDSpanLink$EncoderHolder in Graal native-image

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
+++ b/dd-java-agent/agent-bootstrap/src/main/resources/META-INF/native-image/com.datadoghq/dd-java-agent/reflect-config.json
@@ -38,24 +38,42 @@
   {
     "name" : "datadog.trace.agent.common.sampling.SpanSamplingRules$RuleAdapter",
     "methods": [
-      {"name": "fromJson"}
+      {"name": "fromJson"},
+      {"name": "toJson"}
     ]
+  },
+  {
+    "name" : "datadog.trace.agent.common.sampling.SpanSamplingRules$JsonRule",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "datadog.trace.agent.common.sampling.TraceSamplingRules$RuleAdapter",
     "methods": [
-      {"name": "fromJson"}
+      {"name": "fromJson"},
+      {"name": "toJson"}
     ]
+  },
+  {
+    "name" : "datadog.trace.agent.common.sampling.TraceSamplingRules$JsonRule",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
   },
   {
     "name" : "datadog.trace.agent.core.TracingConfigPoller$TracingSamplingRulesAdapter",
     "methods": [
-      {"name": "fromJson"}
+      {"name": "fromJson"},
+      {"name": "toJson"}
     ]
   },
   {
     "name" : "datadog.trace.agent.core.DDSpanLink$SpanLinkAdapter",
     "methods": [
+      {"name": "fromSpanLinkJson"},
       {"name": "toSpanLinkJson"}
     ]
   },


### PR DESCRIPTION
# What Does This Do

Both fromJson and toJson methods need to be registered even if only one is used, do the same for other JSON entries to be consistent.

# Motivation

When an incoming request has both Datadog and W3C headers we add a span link to the local trace. For traced native-images this will result in `NoClassDefFoundError: Could not initialize class DDSpanLink$EncoderHolder` caused by the missing `fromSpanLinkJson` reference, even though it's not used in practice.

# Additional Notes

Also declare some JsonRule types need reflective access for a related issue using DD_TRACE_SAMPLING_RULES

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-928]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-928]: https://datadoghq.atlassian.net/browse/APMAPI-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ