### PR TITLE
Fix crash tracking setup in smoke test

### DIFF
--- a/dd-smoke-tests/jersey-2/src/test/groovy/datadog/smoketest/Jersey2SmokeTest.groovy
+++ b/dd-smoke-tests/jersey-2/src/test/groovy/datadog/smoketest/Jersey2SmokeTest.groovy
@@ -21,7 +21,7 @@ class Jersey2SmokeTest extends AbstractJerseySmokeTest {
     if (Platform.isJavaVersionAtLeast(17)) {
       command.addAll((String[]) ['--add-opens', 'java.base/java.lang=ALL-UNNAMED'])
     }
-    command.addAll((String[]) ['-jar', jarPath, httpPort])
+    command.addAll(['-jar', jarPath, Integer.toString(httpPort)])
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))
     return processBuilder

--- a/dd-smoke-tests/jersey-3/src/test/groovy/datadog/smoketest/Jersey3SmokeTest.groovy
+++ b/dd-smoke-tests/jersey-3/src/test/groovy/datadog/smoketest/Jersey3SmokeTest.groovy
@@ -19,7 +19,7 @@ class Jersey3SmokeTest extends AbstractJerseySmokeTest {
     command.add(withSystemProperty('integration.grizzly.enabled', true))
     //command.add("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000")
     //command.add("-Xdebug")
-    command.addAll((String[]) ['-jar', jarPath, httpPort])
+    command.addAll(['-jar', jarPath, Integer.toString(httpPort)])
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))
     return processBuilder

--- a/dd-smoke-tests/play-2.4/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.4/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
@@ -49,7 +49,7 @@ class PlayNettySmokeTest extends AbstractServerSmokeTest {
       new ProcessBuilder("${playDirectory}/bin/${command}")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
-      defaultJavaProperties.join(" ")
+      defaultJavaProperties.collect({ it.replace(' ', '\\ ')}).join(" ")
       + " -Dconfig.file=${playDirectory}/conf/application.conf"
       + " -Dhttp.port=${httpPort}"
       + " -Dhttp.address=127.0.0.1"

--- a/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.5/src/test/groovy/datadog/smoketest/PlayNettySmokeTest.groovy
@@ -47,7 +47,7 @@ class PlayNettySmokeTest extends AbstractServerSmokeTest {
       new ProcessBuilder("${playDirectory}/bin/${command}")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
-      defaultJavaProperties.join(" ")
+      defaultJavaProperties.collect({ it.replace(' ', '\\ ')}).join(" ")
       + " -Dconfig.file=${playDirectory}/conf/application.conf"
       + " -Dhttp.port=${httpPort}"
       + " -Dhttp.address=127.0.0.1"

--- a/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.6/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
@@ -47,7 +47,7 @@ abstract class PlaySmokeTest extends AbstractServerSmokeTest {
       new ProcessBuilder("${playDirectory}/bin/${command}")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
-      defaultJavaProperties.join(" ")
+      defaultJavaProperties.collect({ it.replace(' ', '\\ ')}).join(" ")
       + " -Dconfig.file=${playDirectory}/conf/application.conf"
       + " -Dhttp.port=${httpPort}"
       + " -Dhttp.address=127.0.0.1"

--- a/dd-smoke-tests/play-2.7/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.7/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
@@ -47,7 +47,7 @@ abstract class PlaySmokeTest extends AbstractServerSmokeTest {
       new ProcessBuilder("${playDirectory}/bin/${command}")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
-      defaultJavaProperties.join(" ")
+      defaultJavaProperties.collect({ it.replace(' ', '\\ ')}).join(" ")
       + " -Dconfig.file=${playDirectory}/conf/application.conf"
       + " -Dhttp.port=${httpPort}"
       + " -Dhttp.address=127.0.0.1"

--- a/dd-smoke-tests/play-2.8-otel/src/test/groovy/datadog/smoketest/Play28OTelSmokeTest.groovy
+++ b/dd-smoke-tests/play-2.8-otel/src/test/groovy/datadog/smoketest/Play28OTelSmokeTest.groovy
@@ -47,7 +47,7 @@ abstract class Play28OTelSmokeTest extends AbstractServerSmokeTest {
       new ProcessBuilder("${playDirectory}/bin/${command}")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
-      defaultJavaProperties.join(" ")
+      defaultJavaProperties.collect({ it.replace(' ', '\\ ')}).join(" ")
       + " -Dconfig.file=${playDirectory}/conf/application.conf"
       + " -Dhttp.port=${httpPort}"
       + " -Dhttp.address=127.0.0.1"

--- a/dd-smoke-tests/play-2.8-split-routes/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.8-split-routes/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
@@ -47,7 +47,7 @@ abstract class PlaySmokeTest extends AbstractServerSmokeTest {
       new ProcessBuilder("${playDirectory}/bin/${command}")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
-      defaultJavaProperties.join(" ")
+      defaultJavaProperties.collect({ it.replace(' ', '\\ ')}).join(" ")
       + " -Dconfig.file=${playDirectory}/conf/application.conf"
       + " -Dhttp.port=${httpPort}"
       + " -Dhttp.address=127.0.0.1"

--- a/dd-smoke-tests/play-2.8/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
+++ b/dd-smoke-tests/play-2.8/src/test/groovy/datadog/smoketest/PlaySmokeTest.groovy
@@ -47,7 +47,7 @@ abstract class PlaySmokeTest extends AbstractServerSmokeTest {
       new ProcessBuilder("${playDirectory}/bin/${command}")
     processBuilder.directory(playDirectory)
     processBuilder.environment().put("JAVA_OPTS",
-      defaultJavaProperties.join(" ")
+      defaultJavaProperties.collect({ it.replace(' ', '\\ ')}).join(" ")
       + " -Dconfig.file=${playDirectory}/conf/application.conf"
       + " -Dhttp.port=${httpPort}"
       + " -Dhttp.address=127.0.0.1"

--- a/dd-smoke-tests/resteasy/src/test/groovy/smoketest/ResteasySmokeTest.groovy
+++ b/dd-smoke-tests/resteasy/src/test/groovy/smoketest/ResteasySmokeTest.groovy
@@ -2,6 +2,7 @@ package smoketest
 
 import datadog.smoketest.AbstractIastServerSmokeTest
 import datadog.trace.api.Platform
+import datadog.trace.api.config.IastConfig
 import okhttp3.Request
 import spock.lang.IgnoreIf
 
@@ -18,14 +19,14 @@ class ResteasySmokeTest extends AbstractIastServerSmokeTest {
     command.add(javaPath())
     command.addAll(defaultJavaProperties)
     command.addAll([
-      withSystemProperty(datadog.trace.api.config.IastConfig.IAST_ENABLED, true),
-      withSystemProperty(datadog.trace.api.config.IastConfig.IAST_DETECTION_MODE, 'FULL'),
-      withSystemProperty(datadog.trace.api.config.IastConfig.IAST_DEBUG_ENABLED, true)
+      withSystemProperty(IastConfig.IAST_ENABLED, true),
+      withSystemProperty(IastConfig.IAST_DETECTION_MODE, 'FULL'),
+      withSystemProperty(IastConfig.IAST_DEBUG_ENABLED, true)
     ])
     if (Platform.isJavaVersionAtLeast(17)) {
-      command.addAll((String[]) ["--add-opens", "java.base/java.lang=ALL-UNNAMED"])
+      command.addAll(["--add-opens", "java.base/java.lang=ALL-UNNAMED"])
     }
-    command.addAll((String[]) ["-jar", jarPath, httpPort])
+    command.addAll(["-jar", jarPath, Integer.toString(httpPort)])
     ProcessBuilder processBuilder = new ProcessBuilder(command)
     processBuilder.directory(new File(buildDirectory))
   }

--- a/dd-smoke-tests/springboot-tomcat/src/test/groovy/datadog/smoketest/SpringBootTomcatSmokeTest.groovy
+++ b/dd-smoke-tests/springboot-tomcat/src/test/groovy/datadog/smoketest/SpringBootTomcatSmokeTest.groovy
@@ -24,7 +24,7 @@ class SpringBootTomcatSmokeTest extends AbstractServerSmokeTest {
       def permissions = new HashSet<>(Files.getPosixFilePermissions(catalinaPath))
       permissions.add(PosixFilePermission.OWNER_EXECUTE)
       Files.setPosixFilePermissions(catalinaPath, permissions)
-    } catch (Exception e) {
+    } catch (Exception ignored) {
       // not posix ... continue
     }
     Files.copy(springBootShadowWar, tomcatDirectory.resolve("webapps/smoke.war"), StandardCopyOption.REPLACE_EXISTING)
@@ -40,9 +40,12 @@ class SpringBootTomcatSmokeTest extends AbstractServerSmokeTest {
     ProcessBuilder processBuilder =
       new ProcessBuilder("bin/catalina.sh", "run")
     processBuilder.directory(tomcatDirectory.toFile())
-    defaultJavaProperties += "-Ddd.writer.type=TraceStructureWriter:${output.getAbsolutePath()}:includeService:includeResource"
-    defaultJavaProperties += "-Ddd.integration.spring-boot.enabled=true"
-    processBuilder.environment().put("CATALINA_OPTS", defaultJavaProperties.join(" "))
+    List<String> catalinaOpts = [
+      *defaultJavaProperties,
+      "-Ddd.writer.type=TraceStructureWriter:${output.getAbsolutePath()}:includeService:includeResource",
+      "-Ddd.integration.spring-boot.enabled=true"
+    ]
+    processBuilder.environment().put("CATALINA_OPTS", catalinaOpts.collect({ it.replace(' ', '\\ ')}).join(" "))
     return processBuilder
   }
 

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -198,7 +198,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
     // DQH - Nov 2024 - skipping for J9 which doesn't have full crash tracking support
     if (testCrashTracking() && !Platform.isJ9()) {
       def extension = getScriptExtension()
-      ret += "-XX:OnError=\"${tmpDir}/dd_crash_uploader.${extension} %p\""
+      ret += "-XX:OnError=${tmpDir}/dd_crash_uploader.${extension} %p"
       // Unlike crash tracking smoke test, keep the default delay; otherwise, otherwise other tests will fail
       // ret += "-Ddd.dogstatsd.start-delay=0"
     }

--- a/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/WildflySmokeTest.groovy
+++ b/dd-smoke-tests/wildfly/src/test/groovy/datadog/smoketest/WildflySmokeTest.groovy
@@ -20,10 +20,13 @@ class WildflySmokeTest extends AbstractServerSmokeTest {
     ProcessBuilder processBuilder =
       new ProcessBuilder("${wildflyDirectory}/bin/standalone.sh")
     processBuilder.directory(wildflyDirectory)
-    processBuilder.environment().put("JAVA_OPTS",
-      defaultJavaProperties.join(" ")
-      + " -Djboss.http.port=${httpPort} -Djboss.https.port=${httpsPort}"
-      + " -Djboss.management.http.port=${managementPort}")
+    List<String> javaOpts = [
+      *defaultJavaProperties,
+      "-Djboss.http.port=${httpPort}",
+      "-Djboss.https.port=${httpsPort}",
+      "-Djboss.management.http.port=${managementPort}"
+    ]
+    processBuilder.environment().put("JAVA_OPTS", javaOpts.collect({ it.replace(' ', '\\ ')}).join(' '))
     return processBuilder
   }
 


### PR DESCRIPTION
# What Does This Do

While crash tracking was enabled in #7855 invalid escaping was put in place, leading the install the crash tracking uploader script at a wrong location.

This PR removes the escaping which was not needed for the Java Process API nor OpenLiberty `jvm.options` file and make sure escaping is set up for environment variables like tomcat `CATALINA_OPT` and Netty / Wildfly `JAVA_OPTS`.

# Motivation

Trying to escape the space ` ` lead to installing the crash tracking uploader script in `<current_dir>/"/tmp/dd_crash_uploader.sh`.

# Additional Notes

This PR is a follow up of #7855 

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
