### PR TITLE
Add Micronaut 4 support for code origin for spans

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -105,6 +105,9 @@ public class Agent {
     DEBUGGER(propertyNameToSystemPropertyName(DebuggerConfig.DEBUGGER_ENABLED), false),
     EXCEPTION_DEBUGGING(
         propertyNameToSystemPropertyName(DebuggerConfig.EXCEPTION_REPLAY_ENABLED), false),
+    SPAN_ORIGIN(
+        propertyNameToSystemPropertyName(TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED),
+        false),
     DATA_JOBS(propertyNameToSystemPropertyName(GeneralConfig.DATA_JOBS_ENABLED), false),
     AGENTLESS_LOG_SUBMISSION(
         propertyNameToSystemPropertyName(GeneralConfig.AGENTLESS_LOG_SUBMISSION_ENABLED), false);
@@ -152,6 +155,7 @@ public class Agent {
   private static boolean telemetryEnabled = true;
   private static boolean debuggerEnabled = false;
   private static boolean exceptionDebuggingEnabled = false;
+  private static boolean spanOriginEnabled = false;
   private static boolean agentlessLogSubmissionEnabled = false;
 
   /**
@@ -263,6 +267,7 @@ public class Agent {
     telemetryEnabled = isFeatureEnabled(AgentFeature.TELEMETRY);
     debuggerEnabled = isFeatureEnabled(AgentFeature.DEBUGGER);
     exceptionDebuggingEnabled = isFeatureEnabled(AgentFeature.EXCEPTION_DEBUGGING);
+    spanOriginEnabled = isFeatureEnabled(AgentFeature.SPAN_ORIGIN);
     agentlessLogSubmissionEnabled = isFeatureEnabled(AgentFeature.AGENTLESS_LOG_SUBMISSION);
 
     if (profilingEnabled) {
@@ -1073,7 +1078,7 @@ public class Agent {
   }
 
   private static void maybeStartDebugger(Instrumentation inst, Class<?> scoClass, Object sco) {
-    if (!debuggerEnabled && !exceptionDebuggingEnabled) {
+    if (!debuggerEnabled && !exceptionDebuggingEnabled && !spanOriginEnabled) {
       return;
     }
     if (!remoteConfigEnabled) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerAgent.java
@@ -100,6 +100,7 @@ public class DebuggerAgent {
       DebuggerContext.initExceptionDebugger(defaultExceptionDebugger);
     }
     if (config.isDebuggerCodeOriginEnabled()) {
+      LOGGER.info("Starting Code Origin for spans");
       DebuggerContext.initCodeOrigin(new DefaultCodeOriginRecorder(config, configurationUpdater));
     }
     if (config.isDebuggerInstrumentTheWorld()) {

--- a/dd-java-agent/instrumentation/micronaut/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/build.gradle
@@ -4,6 +4,15 @@
 
 apply from: "$rootDir/gradle/java.gradle"
 
+muzzle {
+  pass {
+    name = "micronaut-common"
+    group = "io.micronaut"
+    module = "micronaut-http-server-netty"
+    versions = "[2,)"
+  }
+}
+
 dependencies {
   compileOnly group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '2.0.0'
   implementation project(':dd-java-agent:instrumentation:span-origin')

--- a/dd-java-agent/instrumentation/micronaut/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/build.gradle
@@ -6,4 +6,5 @@ apply from: "$rootDir/gradle/java.gradle"
 
 dependencies {
   compileOnly group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '2.0.0'
+  implementation project(':dd-java-agent:instrumentation:span-origin')
 }

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
@@ -30,7 +30,6 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   main_java17CompileOnly group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '4.0.0'
-  implementation project(':dd-java-agent:instrumentation:span-origin')
 
   // Added to ensure cross compatibility:
   testImplementation project(':dd-java-agent:instrumentation:micronaut:http-server-netty-2.0')

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
@@ -30,11 +30,13 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   main_java17CompileOnly group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '4.0.0'
+  implementation project(':dd-java-agent:instrumentation:micronaut')
 
   // Added to ensure cross compatibility:
   testImplementation project(':dd-java-agent:instrumentation:micronaut:http-server-netty-2.0')
   testImplementation project(':dd-java-agent:instrumentation:micronaut:http-server-netty-3.0')
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
+  testImplementation project(':dd-java-agent:agent-debugger')
   testImplementation group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '4.0.0', {
     exclude group: 'org.slf4j', module: 'slf4j-api'
     exclude group: 'ch.qos.logback', module: 'logback-classic'

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/build.gradle
@@ -30,6 +30,7 @@ addTestSuiteForDir('latestDepTest', 'test')
 
 dependencies {
   main_java17CompileOnly group: 'io.micronaut', name: 'micronaut-http-server-netty', version: '4.0.0'
+  implementation project(':dd-java-agent:instrumentation:span-origin')
 
   // Added to ensure cross compatibility:
   testImplementation project(':dd-java-agent:instrumentation:micronaut:http-server-netty-2.0')

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/src/main/java/datadog/trace/instrumentation/micronaut/v4_0/MicronautCodeOriginInstrumentation.java
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/src/main/java/datadog/trace/instrumentation/micronaut/v4_0/MicronautCodeOriginInstrumentation.java
@@ -1,0 +1,31 @@
+package datadog.trace.instrumentation.micronaut.v4_0;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.instrumentation.codeorigin.CodeOriginInstrumentation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@AutoService(InstrumenterModule.class)
+public class MicronautCodeOriginInstrumentation extends CodeOriginInstrumentation {
+
+  public static final String IO_MICRONAUT_HTTP_ANNOTATION = "io.micronaut.http.annotation.";
+
+  public MicronautCodeOriginInstrumentation() {
+    super("micronaut-span-origin");
+  }
+
+  @Override
+  protected Set<String> getAnnotations() {
+    return new HashSet<>(
+        Arrays.asList(
+            IO_MICRONAUT_HTTP_ANNOTATION + "Get",
+            IO_MICRONAUT_HTTP_ANNOTATION + "Post",
+            IO_MICRONAUT_HTTP_ANNOTATION + "Put",
+            IO_MICRONAUT_HTTP_ANNOTATION + "Delete",
+            IO_MICRONAUT_HTTP_ANNOTATION + "Patch",
+            IO_MICRONAUT_HTTP_ANNOTATION + "Head",
+            IO_MICRONAUT_HTTP_ANNOTATION + "Options"));
+  }
+}

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/src/test/groovy/MicronautTest.groovy
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/src/test/groovy/MicronautTest.groovy
@@ -1,12 +1,8 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
-import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
-import datadog.trace.api.DDTags
-import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.debugger.DebuggerContext
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.micronaut.v4_0.MicronautDecorator
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
@@ -20,7 +16,6 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FO
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_TYPE
 import static datadog.trace.api.config.TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED
 
 class MicronautTest extends HttpServerTest<Object> {

--- a/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/src/test/groovy/MicronautTest.groovy
+++ b/dd-java-agent/instrumentation/micronaut/http-server-netty-4.0/src/test/groovy/MicronautTest.groovy
@@ -1,11 +1,18 @@
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.base.HttpServer
 import datadog.trace.agent.test.base.HttpServerTest
+import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
+import datadog.trace.api.DDTags
+import datadog.trace.api.config.TraceInstrumentationConfig
+import datadog.trace.bootstrap.debugger.DebuggerContext
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.micronaut.v4_0.MicronautDecorator
 import datadog.trace.instrumentation.netty41.server.NettyHttpServerDecorator
 import test.MicronautServer
+
+import java.lang.reflect.Method
 
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
@@ -13,8 +20,35 @@ import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FO
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.PATH_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_ENCODED_BOTH
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
+import static datadog.trace.api.DDTags.DD_CODE_ORIGIN_TYPE
+import static datadog.trace.api.config.TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED
 
 class MicronautTest extends HttpServerTest<Object> {
+
+  def codeOriginRecorder
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    injectSysConfig(CODE_ORIGIN_FOR_SPANS_ENABLED, "true")
+    codeOriginRecorder = new DebuggerContext.CodeOriginRecorder() {
+        def invoked = false
+        @Override
+        String captureCodeOrigin(boolean entry) {
+          invoked = true
+          return "done"
+        }
+
+        @Override
+        String captureCodeOrigin(Method method, boolean entry) {
+          invoked = true
+          return "done"
+        }
+      }
+    DebuggerContext.initCodeOrigin(codeOriginRecorder)
+  }
+
+
 
   @Override
   HttpServer server() {
@@ -67,6 +101,9 @@ class MicronautTest extends HttpServerTest<Object> {
 
   @Override
   void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
+    if (endpoint != NOT_FOUND) {
+      assert codeOriginRecorder.invoked
+    }
     trace.span {
       serviceName expectedServiceName()
       operationName "micronaut-controller"

--- a/dd-java-agent/instrumentation/micronaut/src/main/java/datadog/trace/instrumentation/micronaut/MicronautCodeOriginInstrumentation.java
+++ b/dd-java-agent/instrumentation/micronaut/src/main/java/datadog/trace/instrumentation/micronaut/MicronautCodeOriginInstrumentation.java
@@ -17,6 +17,11 @@ public class MicronautCodeOriginInstrumentation extends CodeOriginInstrumentatio
   }
 
   @Override
+  public String muzzleDirective() {
+    return "micronaut-common";
+  }
+
+  @Override
   protected Set<String> getAnnotations() {
     return new HashSet<>(
         Arrays.asList(

--- a/dd-java-agent/instrumentation/micronaut/src/main/java/datadog/trace/instrumentation/micronaut/MicronautCodeOriginInstrumentation.java
+++ b/dd-java-agent/instrumentation/micronaut/src/main/java/datadog/trace/instrumentation/micronaut/MicronautCodeOriginInstrumentation.java
@@ -1,4 +1,4 @@
-package datadog.trace.instrumentation.micronaut.v4_0;
+package datadog.trace.instrumentation.micronaut;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.InstrumenterModule;
@@ -13,7 +13,7 @@ public class MicronautCodeOriginInstrumentation extends CodeOriginInstrumentatio
   public static final String IO_MICRONAUT_HTTP_ANNOTATION = "io.micronaut.http.annotation.";
 
   public MicronautCodeOriginInstrumentation() {
-    super("micronaut-span-origin");
+    super("micronaut", "micronaut-span-origin");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/CodeOriginInstrumentation.java
+++ b/dd-java-agent/instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/CodeOriginInstrumentation.java
@@ -17,8 +17,8 @@ public abstract class CodeOriginInstrumentation extends Tracing implements ForTy
   private final OneOf<NamedElement> matcher;
 
   @SuppressForbidden
-  public CodeOriginInstrumentation(String instrumentationName) {
-    super(instrumentationName);
+  public CodeOriginInstrumentation(String instrumentationName, String... additionalNames) {
+    super(instrumentationName, additionalNames);
     this.matcher = NameMatchers.namedOneOf(getAnnotations());
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/StatusLogger.java
@@ -114,6 +114,8 @@ public final class StatusLogger extends JsonAdapter<Config>
     writer.value(config.isDebuggerEnabled());
     writer.name("debugger_exception_enabled");
     writer.value(config.isDebuggerExceptionEnabled());
+    writer.name("debugger_span_origin_enabled");
+    writer.value(config.isDebuggerCodeOriginEnabled());
     writer.name("appsec_enabled");
     writer.value(config.getAppSecActivation().toString());
     writer.name("appsec_rules_file_path");

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -4326,6 +4326,8 @@ public class Config {
         + debuggerSymbolIncludes
         + ", debuggerExceptionEnabled="
         + debuggerExceptionEnabled
+        + ", debuggerCodeOriginEnabled="
+        + debuggerCodeOriginEnabled
         + ", awsPropagationEnabled="
         + awsPropagationEnabled
         + ", sqsPropagationEnabled="


### PR DESCRIPTION
# What Does This Do
Make Code Origin for spans feature independent from dynamic instrumentation so it could be enabled while DI is not Add in Status Logger the code origin feature status

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3162]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3162]: https://datadoghq.atlassian.net/browse/DEBUG-3162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ