### PR TITLE
Add a built-in trace interceptor for keeping traces depending of their latency

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -69,8 +69,8 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_HOST = false;
   static final String DEFAULT_DB_DBM_PROPAGATION_MODE_MODE = "disabled";
-  // Default value is set to -1, it disables the latency trace interceptor
-  static final int DEFAULT_TRACE_LATENCY_INTERCEPTOR_VALUE = -1;
+  // Default value is set to 0, it disables the latency trace interceptor
+  static final int DEFAULT_TRACE_KEEP_LATENCY_THRESHOLD_MS = 0;
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
   static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 30; // in seconds
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -69,6 +69,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_HOST = false;
   static final String DEFAULT_DB_DBM_PROPAGATION_MODE_MODE = "disabled";
+  static final int DEFAULT_TRACE_LATENCY_INTERCEPTOR_VALUE = -1;
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
   static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 30; // in seconds
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -69,6 +69,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX = false;
   static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_HOST = false;
   static final String DEFAULT_DB_DBM_PROPAGATION_MODE_MODE = "disabled";
+  // Default value is set to -1, it disables the latency trace interceptor
   static final int DEFAULT_TRACE_LATENCY_INTERCEPTOR_VALUE = -1;
   static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
   static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 30; // in seconds

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -74,7 +74,7 @@ public final class TracerConfig {
 
   public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
   // trace latency interceptor value should be in ms
-  public static final String TRACE_LATENCY_INTERCEPTOR_VALUE = "trace.latency.interceptor.value";
+  public static final String TRACE_KEEP_LATENCY_THRESHOLD_MS = "trace.keep.latency.threshold.ms";
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
   public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";
   public static final String SCOPE_ITERATION_KEEP_ALIVE = "trace.scope.iteration.keep.alive";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -73,6 +73,7 @@ public final class TracerConfig {
   public static final String TRACE_HTTP_CLIENT_ERROR_STATUSES = "trace.http.client.error.statuses";
 
   public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
+  // trace latency interceptor value should be in ms
   public static final String TRACE_LATENCY_INTERCEPTOR_VALUE = "trace.latency.interceptor.value";
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
   public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -74,7 +74,8 @@ public final class TracerConfig {
 
   public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
   // trace latency interceptor value should be in ms
-  public static final String TRACE_KEEP_LATENCY_THRESHOLD_MS = "trace.experimental.keep.latency.threshold.ms";
+  public static final String TRACE_KEEP_LATENCY_THRESHOLD_MS =
+      "trace.experimental.keep.latency.threshold.ms";
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
   public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";
   public static final String SCOPE_ITERATION_KEEP_ALIVE = "trace.scope.iteration.keep.alive";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -74,7 +74,7 @@ public final class TracerConfig {
 
   public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
   // trace latency interceptor value should be in ms
-  public static final String TRACE_KEEP_LATENCY_THRESHOLD_MS = "trace.keep.latency.threshold.ms";
+  public static final String TRACE_KEEP_LATENCY_THRESHOLD_MS = "trace.experimental.keep.latency.threshold.ms";
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
   public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";
   public static final String SCOPE_ITERATION_KEEP_ALIVE = "trace.scope.iteration.keep.alive";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -73,7 +73,7 @@ public final class TracerConfig {
   public static final String TRACE_HTTP_CLIENT_ERROR_STATUSES = "trace.http.client.error.statuses";
 
   public static final String SPLIT_BY_TAGS = "trace.split-by-tags";
-
+  public static final String TRACE_LATENCY_INTERCEPTOR_VALUE = "trace.latency.interceptor.value";
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
   public static final String SCOPE_STRICT_MODE = "trace.scope.strict.mode";
   public static final String SCOPE_ITERATION_KEEP_ALIVE = "trace.scope.iteration.keep.alive";

--- a/dd-trace-api/src/main/java/datadog/trace/api/interceptor/AbstractTraceInterceptor.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/interceptor/AbstractTraceInterceptor.java
@@ -22,6 +22,9 @@ public abstract class AbstractTraceInterceptor implements TraceInterceptor {
     DD_INTAKE(2),
     GIT_METADATA(3),
 
+    // trace custom sampling
+    ROOT_SPAN_LATENCY(Integer.MAX_VALUE - 2),
+
     // trace data collection
     CI_VISIBILITY_TELEMETRY(Integer.MAX_VALUE - 1),
     SERVICE_NAME_COLLECTING(Integer.MAX_VALUE);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -88,6 +88,7 @@ import datadog.trace.core.propagation.PropagationTags;
 import datadog.trace.core.scopemanager.ContinuableScopeManager;
 import datadog.trace.core.taginterceptor.RuleFlags;
 import datadog.trace.core.taginterceptor.TagInterceptor;
+import datadog.trace.core.traceinterceptor.LatencyTraceInterceptor;
 import datadog.trace.lambda.LambdaHandler;
 import datadog.trace.relocate.api.RatelimitedLogger;
 import datadog.trace.util.AgentTaskScheduler;
@@ -743,6 +744,10 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
     if (config.isTraceGitMetadataEnabled()) {
       addTraceInterceptor(GitMetadataTraceInterceptor.INSTANCE);
+    }
+
+    if (config.isTraceLatencyInterceptorEnabled()) {
+      addTraceInterceptor(LatencyTraceInterceptor.INSTANCE);
     }
 
     this.instrumentationGateway = instrumentationGateway;

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -746,7 +746,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
       addTraceInterceptor(GitMetadataTraceInterceptor.INSTANCE);
     }
 
-    if (config.isTraceLatencyInterceptorEnabled()) {
+    if (config.isTraceKeepLatencyThresholdEnabled()) {
       addTraceInterceptor(LatencyTraceInterceptor.INSTANCE);
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/traceinterceptor/LatencyTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/traceinterceptor/LatencyTraceInterceptor.java
@@ -1,0 +1,36 @@
+package datadog.trace.core.traceinterceptor;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DDTags;
+import datadog.trace.api.interceptor.AbstractTraceInterceptor;
+import datadog.trace.api.interceptor.MutableSpan;
+import datadog.trace.api.interceptor.TraceInterceptor;
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LatencyTraceInterceptor extends AbstractTraceInterceptor {
+  private static final Logger log = LoggerFactory.getLogger(LatencyTraceInterceptor.class);
+  // duration configured in ms, need to be converted in nano seconds
+  private static final int LATENCY = Config.get().getTraceLatencyInterceptorValue() * 1000000;
+
+  public static final TraceInterceptor INSTANCE =
+      new LatencyTraceInterceptor(Priority.ROOT_SPAN_LATENCY);
+
+  protected LatencyTraceInterceptor(Priority priority) {
+    super(priority);
+  }
+
+  @Override
+  public Collection<? extends MutableSpan> onTraceComplete(
+      Collection<? extends MutableSpan> latencyTrace) {
+    if (latencyTrace.isEmpty()) {
+      return latencyTrace;
+    }
+    MutableSpan rootSpan = latencyTrace.iterator().next().getLocalRootSpan();
+    if (rootSpan != null && rootSpan.getDurationNano() > LATENCY) {
+      rootSpan.setTag(DDTags.MANUAL_KEEP, true);
+    }
+    return latencyTrace;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/traceinterceptor/LatencyTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/traceinterceptor/LatencyTraceInterceptor.java
@@ -14,10 +14,11 @@ import org.slf4j.LoggerFactory;
 // This value should be in milliseconds and this interceptor will retain any local trace who has a
 // root
 // span duration greater than this value.
-// The activation of this interceptor is ignored if partial flush is enabled.
+// The activation of this interceptor is ignored if partial flush is enabled in order to avoid
+// incomplete local trace (incomplete chunk of trace).
 // Note that since we're changing the sampling priority at the end of local trace, there is no
 // guarantee to get complete traces,
-// since the original sampling priority for this trace may have been already propagated.
+// since the original sampling priority for this trace may have already been propagated.
 
 public class LatencyTraceInterceptor extends AbstractTraceInterceptor {
   private static final Logger log = LoggerFactory.getLogger(LatencyTraceInterceptor.class);

--- a/dd-trace-core/src/main/java/datadog/trace/core/traceinterceptor/LatencyTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/traceinterceptor/LatencyTraceInterceptor.java
@@ -9,6 +9,16 @@ import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// This trace latency interceptor is disabled by default.
+// We can activate it by setting the value of dd.trace.latency.interceptor.value to a positive value
+// This value should be in milliseconds and this interceptor will retain any local trace who has a
+// root
+// span duration greater than this value.
+// The activation of this interceptor is ignored if partial flush is enabled.
+// Note that since we're changing the sampling priority at the end of local trace, there is no
+// guarantee to get complete traces,
+// since the original sampling priority for this trace may have been already propagated.
+
 public class LatencyTraceInterceptor extends AbstractTraceInterceptor {
   private static final Logger log = LoggerFactory.getLogger(LatencyTraceInterceptor.class);
   // duration configured in ms, need to be converted in nano seconds

--- a/dd-trace-core/src/main/java/datadog/trace/core/traceinterceptor/LatencyTraceInterceptor.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/traceinterceptor/LatencyTraceInterceptor.java
@@ -9,21 +9,19 @@ import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// This trace latency interceptor is disabled by default.
-// We can activate it by setting the value of dd.trace.latency.interceptor.value to a positive value
-// This value should be in milliseconds and this interceptor will retain any local trace who has a
-// root
-// span duration greater than this value.
-// The activation of this interceptor is ignored if partial flush is enabled in order to avoid
-// incomplete local trace (incomplete chunk of trace).
-// Note that since we're changing the sampling priority at the end of local trace, there is no
-// guarantee to get complete traces,
-// since the original sampling priority for this trace may have already been propagated.
-
+/**
+ * This trace latency interceptor is disabled by default. We can activate it by setting the value of
+ * dd.trace.latency.interceptor.value to a positive value This value should be in milliseconds and
+ * this interceptor will retain any local trace who has a root span duration greater than this
+ * value. The activation of this interceptor is ignored if partial flush is enabled in order to
+ * avoid incomplete local trace (incomplete chunk of trace). Note that since we're changing the
+ * sampling priority at the end of local trace, there is no guarantee to get complete traces, since
+ * the original sampling priority for this trace may have already been propagated.
+ */
 public class LatencyTraceInterceptor extends AbstractTraceInterceptor {
   private static final Logger log = LoggerFactory.getLogger(LatencyTraceInterceptor.class);
   // duration configured in ms, need to be converted in nano seconds
-  private static final int LATENCY = Config.get().getTraceLatencyInterceptorValue() * 1000000;
+  private static final long LATENCY = Config.get().getTraceKeepLatencyThreshold() * 1000000L;
 
   public static final TraceInterceptor INSTANCE =
       new LatencyTraceInterceptor(Priority.ROOT_SPAN_LATENCY);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
@@ -15,7 +15,7 @@ class LatencyTraceInterceptorTest  extends DDCoreSpecification {
     setup:
 
     injectSysConfig("trace.partial.flush.enabled", partialFlushEnabled)
-    injectSysConfig("trace.latency.interceptor.value", latencyThreshold)
+    injectSysConfig("trace.keep.latency.threshold.ms", latencyThreshold)
 
     when:
     def writer = new ListWriter()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
@@ -1,0 +1,46 @@
+package datadog.trace.core.traceinterceptor
+
+import datadog.trace.api.DDTags
+import datadog.trace.common.writer.ListWriter
+
+import datadog.trace.core.test.DDCoreSpecification
+
+import spock.lang.Timeout
+
+@Timeout(10)
+class LatencyTraceInterceptorTest  extends DDCoreSpecification {
+
+
+  def "test set sampling priority according to latency"() {
+    setup:
+    def writer = new ListWriter()
+    def props = new Properties()
+    props.setProperty("trace.partial.flush.enabled", partialFlushEnabled)
+    props.setProperty("trace.latency.interceptor.value", latencyThreshold)
+
+    def tracer = tracerBuilder().withProperties(props).writer(writer).build()
+
+    def spanSetup = tracer.buildSpan("test","my_operation_name").withTag(tagname, true).start()
+    sleep(duration)
+    spanSetup.finish()
+
+    expect:
+    def trace = writer.firstTrace()
+    trace.size() == 1
+    def span = trace[0]
+
+    span.context().getSamplingPriority() == expected
+
+    tracer.close()
+    where:
+    partialFlushEnabled | latencyThreshold | tagname                      | duration    | expected
+    "true"              |       "102"     | DDTags.MANUAL_KEEP            |   100       |  2
+    "true"              |       "102"    | DDTags.MANUAL_DROP             |   100       |  -1
+    "true"              |       "102"     | DDTags.MANUAL_KEEP            |   105       |  2
+    "true"              |       "102"     | DDTags.MANUAL_DROP            |   105       |  -1
+    // "false"             |       "102"     | DDTags.MANUAL_KEEP            |   100       |  2
+    // "false"             |       "102"     | DDTags.MANUAL_DROP            |   100       |  -1
+    // "false"             |       "102"     | DDTags.MANUAL_KEEP            |   105       |  2
+    // "false"             |       "102"     | DDTags.MANUAL_DROP            |   105       |  2
+  }
+}

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
@@ -45,6 +45,4 @@ class LatencyTraceInterceptorTest  extends DDCoreSpecification {
     "false"             |       "200"      | DDTags.MANUAL_KEEP            |   300          |   2
     "false"             |       "200"      | DDTags.MANUAL_DROP            |   300          |   2
   }
-
-
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
@@ -13,34 +13,38 @@ class LatencyTraceInterceptorTest  extends DDCoreSpecification {
 
   def "test set sampling priority according to latency"() {
     setup:
+
+    injectSysConfig("trace.partial.flush.enabled", partialFlushEnabled)
+    injectSysConfig("trace.latency.interceptor.value", latencyThreshold)
+
+    when:
     def writer = new ListWriter()
-    def props = new Properties()
-    props.setProperty("trace.partial.flush.enabled", partialFlushEnabled)
-    props.setProperty("trace.latency.interceptor.value", latencyThreshold)
+    def tracer = tracerBuilder().writer(writer).build()
 
-    def tracer = tracerBuilder().withProperties(props).writer(writer).build()
-
-    def spanSetup = tracer.buildSpan("test","my_operation_name").withTag(tagname, true).start()
-    sleep(duration)
+    def spanSetup = tracer.buildSpan("test","my_operation_name").withTag(priorityTag, true).start()
+    sleep(minDuration)
     spanSetup.finish()
 
-    expect:
+    then:
     def trace = writer.firstTrace()
     trace.size() == 1
     def span = trace[0]
-
     span.context().getSamplingPriority() == expected
 
+    cleanup:
     tracer.close()
+
     where:
-    partialFlushEnabled | latencyThreshold | tagname                      | duration    | expected
-    "true"              |       "102"     | DDTags.MANUAL_KEEP            |   100       |  2
-    "true"              |       "102"    | DDTags.MANUAL_DROP             |   100       |  -1
-    "true"              |       "102"     | DDTags.MANUAL_KEEP            |   105       |  2
-    "true"              |       "102"     | DDTags.MANUAL_DROP            |   105       |  -1
-    // "false"             |       "102"     | DDTags.MANUAL_KEEP            |   100       |  2
-    // "false"             |       "102"     | DDTags.MANUAL_DROP            |   100       |  -1
-    // "false"             |       "102"     | DDTags.MANUAL_KEEP            |   105       |  2
-    // "false"             |       "102"     | DDTags.MANUAL_DROP            |   105       |  2
+    partialFlushEnabled | latencyThreshold | priorityTag                   | minDuration    | expected
+    "true"              |       "200"      | DDTags.MANUAL_KEEP            |   10           |   2
+    "true"              |       "200"      | DDTags.MANUAL_DROP            |   10           |  -1
+    "true"              |       "200"      | DDTags.MANUAL_KEEP            |   300          |   2
+    "true"              |       "200"      | DDTags.MANUAL_DROP            |   300          |  -1
+    "false"             |       "200"      | DDTags.MANUAL_KEEP            |   10           |   2
+    "false"             |       "200"      | DDTags.MANUAL_DROP            |   10           |  -1
+    "false"             |       "200"      | DDTags.MANUAL_KEEP            |   300          |   2
+    "false"             |       "200"      | DDTags.MANUAL_DROP            |   300          |   2
   }
+
+
 }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/traceinterceptor/LatencyTraceInterceptorTest.groovy
@@ -15,7 +15,7 @@ class LatencyTraceInterceptorTest  extends DDCoreSpecification {
     setup:
 
     injectSysConfig("trace.partial.flush.enabled", partialFlushEnabled)
-    injectSysConfig("trace.keep.latency.threshold.ms", latencyThreshold)
+    injectSysConfig("trace.experimental.keep.latency.threshold.ms", latencyThreshold)
 
     when:
     def writer = new ListWriter()

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -176,6 +176,8 @@ public class Config {
   private final boolean scopeStrictMode;
   private final int scopeIterationKeepAlive;
   private final int partialFlushMinSpans;
+  private final int traceLatencyInterceptorValue;
+  private final boolean traceLatencyInterceptorEnabled;
   private final boolean traceStrictWritesEnabled;
   private final boolean logExtractHeaderNames;
   private final Set<PropagationStyle> propagationStylesToExtract;
@@ -859,6 +861,12 @@ public class Config {
         !partialFlushEnabled
             ? 0
             : configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
+
+    traceLatencyInterceptorValue =
+        configProvider.getInteger(
+            TRACE_LATENCY_INTERCEPTOR_VALUE, DEFAULT_TRACE_LATENCY_INTERCEPTOR_VALUE);
+
+    traceLatencyInterceptorEnabled = !partialFlushEnabled && (traceLatencyInterceptorValue >= 0);
 
     traceStrictWritesEnabled = configProvider.getBoolean(TRACE_STRICT_WRITES_ENABLED, false);
 
@@ -2073,6 +2081,14 @@ public class Config {
 
   public int getPartialFlushMinSpans() {
     return partialFlushMinSpans;
+  }
+
+  public int getTraceLatencyInterceptorValue() {
+    return traceLatencyInterceptorValue;
+  }
+
+  public boolean isTraceLatencyInterceptorEnabled() {
+    return traceLatencyInterceptorEnabled;
   }
 
   public boolean isTraceStrictWritesEnabled() {
@@ -4158,6 +4174,10 @@ public class Config {
         + scopeIterationKeepAlive
         + ", partialFlushMinSpans="
         + partialFlushMinSpans
+        + ", traceLatencyInterceptorEnabled="
+        + traceLatencyInterceptorEnabled
+        + ", traceLatencyInterceptorValue="
+        + traceLatencyInterceptorValue
         + ", traceStrictWritesEnabled="
         + traceStrictWritesEnabled
         + ", tracePropagationStylesToExtract="

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -176,8 +176,8 @@ public class Config {
   private final boolean scopeStrictMode;
   private final int scopeIterationKeepAlive;
   private final int partialFlushMinSpans;
-  private final int traceLatencyInterceptorValue;
-  private final boolean traceLatencyInterceptorEnabled;
+  private final int traceKeepLatencyThreshold;
+  private final boolean traceKeepLatencyThresholdEnabled;
   private final boolean traceStrictWritesEnabled;
   private final boolean logExtractHeaderNames;
   private final Set<PropagationStyle> propagationStylesToExtract;
@@ -862,11 +862,11 @@ public class Config {
             ? 0
             : configProvider.getInteger(PARTIAL_FLUSH_MIN_SPANS, DEFAULT_PARTIAL_FLUSH_MIN_SPANS);
 
-    traceLatencyInterceptorValue =
+    traceKeepLatencyThreshold =
         configProvider.getInteger(
-            TRACE_LATENCY_INTERCEPTOR_VALUE, DEFAULT_TRACE_LATENCY_INTERCEPTOR_VALUE);
+            TRACE_KEEP_LATENCY_THRESHOLD_MS, DEFAULT_TRACE_KEEP_LATENCY_THRESHOLD_MS);
 
-    traceLatencyInterceptorEnabled = !partialFlushEnabled && (traceLatencyInterceptorValue >= 0);
+    traceKeepLatencyThresholdEnabled = !partialFlushEnabled && (traceKeepLatencyThreshold > 0);
 
     traceStrictWritesEnabled = configProvider.getBoolean(TRACE_STRICT_WRITES_ENABLED, false);
 
@@ -2083,12 +2083,12 @@ public class Config {
     return partialFlushMinSpans;
   }
 
-  public int getTraceLatencyInterceptorValue() {
-    return traceLatencyInterceptorValue;
+  public int getTraceKeepLatencyThreshold() {
+    return traceKeepLatencyThreshold;
   }
 
-  public boolean isTraceLatencyInterceptorEnabled() {
-    return traceLatencyInterceptorEnabled;
+  public boolean isTraceKeepLatencyThresholdEnabled() {
+    return traceKeepLatencyThresholdEnabled;
   }
 
   public boolean isTraceStrictWritesEnabled() {
@@ -4174,10 +4174,10 @@ public class Config {
         + scopeIterationKeepAlive
         + ", partialFlushMinSpans="
         + partialFlushMinSpans
-        + ", traceLatencyInterceptorEnabled="
-        + traceLatencyInterceptorEnabled
-        + ", traceLatencyInterceptorValue="
-        + traceLatencyInterceptorValue
+        + ", traceKeepLatencyThresholdEnabled="
+        + traceKeepLatencyThresholdEnabled
+        + ", traceKeepLatencyThreshold="
+        + traceKeepLatencyThreshold
         + ", traceStrictWritesEnabled="
         + traceStrictWritesEnabled
         + ", tracePropagationStylesToExtract="


### PR DESCRIPTION
# What Does This Do
Add the possibility to enable a latency trace interceptor 

This latency trace interceptor is disabled by default.
We can activate it by setting the value of `dd.trace.experimental.keep.latency.threshold.ms`  or `DD_TRACE_EXPERIMENTAL_KEEP_LATENCY_THRESHOLD_MS` to a positive value
This value should be **in milliseconds** and this interceptor will retain any local trace who has a root span duration greater than this value.
The activation of this interceptor is ignored if partial flush is enabled in order to avoid incomplete local trace (incomplete chunk of trace).
Note that since we're changing the sampling priority at the end of local trace, there is no guarantee to get complete traces,
since the original sampling priority for this trace may have already been propagated.

**### Usage:**
dd.trace.experimental.keep.latency.threshold.ms
Environment Variable: DD_TRACE_EXPERIMENTAL_KEEP_LATENCY_THRESHOLD_MS
Default: 0
This value should be in milliseconds, any local traces who has a root span duration greater than this value will get a sampling value of[ MANUAL_KEEP](https://docs.datadoghq.com/tracing/trace_pipeline/ingestion_mechanisms/?tab=java#force-keep-and-drop). Note that partial flush needs to be disabled for this to be active: `dd.trace.partial.flush.enabled=false` or `DD_TRACE_PARTIAL_FLUSH_ENABLED=false`


# Motivation
[APMS-14002](https://datadoghq.atlassian.net/browse/APMS-14002)

# Additional Notes

# Contributor Checklist

- [X] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [X] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [X] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [X] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-14002]: https://datadoghq.atlassian.net/browse/APMS-14002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ