### PR TITLE
Set unexpected IAST exceptions to debug log level

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
+++ b/internal-api/src/main/java/datadog/trace/api/iast/IastModule.java
@@ -12,7 +12,7 @@ public interface IastModule {
   Logger LOG = LoggerFactory.getLogger(IastModule.class);
 
   default void onUnexpectedException(final String message, final Throwable error) {
-    LOG.warn(message, error);
+    LOG.debug(message, error);
   }
 
   @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
# What Does This Do
Set logs from `IastModule#onUnexpectedException` to debug level.

# Motivation
Unexpected exceptions in IAST, when caught by `IastModule#onUnexpectedException` should be safe for the application. Logging to warning level has sometimes become the source of problems for some customers (e.g. most recently, broken log format).

These exceptions should not happen, but when they do, they may happen frequently.

We will still received redacted exceptions through telemetry, so we'll continue to proactively fix them without bothering end users.

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- ~[ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior~

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
