### PR TITLE
Improve crash tracking install logging

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/OOMENotifierScriptInitializer.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/OOMENotifierScriptInitializer.java
@@ -124,7 +124,11 @@ public final class OOMENotifierScriptInitializer {
           Files.walkFileTree(dir, new ScriptCleanupVisitor());
         }
       } catch (IOException e) {
-        LOG.warn("Failed cleaning up process specific files in {}", dir, e);
+        if (LOG.isDebugEnabled()) {
+          LOG.info("Failed cleaning up process specific files in {}", dir, e);
+        } else {
+          LOG.info("Failed cleaning up process specific files in {}: {}", dir, e.toString());
+        }
       }
     }
 


### PR DESCRIPTION
# What Does This Do

This PR avoids logging stack trace when failing to clean up previous crash tracking configuration files.

# Motivation

Avoid showing exception message to the customers for clean up operations

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
