### PR TITLE
Update PR checks automation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,12 +6,11 @@
 
 # Contributor Checklist
 
-- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
-- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
-- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
-- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
+- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
+- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
+- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
   Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
-- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior
+- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior
 
 Jira ticket: [PROJ-IDENT]
 

--- a/.github/workflows/check-pull-requests.yaml
+++ b/.github/workflows/check-pull-requests.yaml
@@ -1,7 +1,7 @@
 name: Check pull requests
 on:
   pull_request:
-    types: [opened, edited, labeled, unlabeled]
+    types: [opened, edited, ready_for_review, labeled, unlabeled]
     branches:
     - master
     - release/v*
@@ -38,14 +38,22 @@ jobs:
             if (titleCheckFailed) {
               core.setFailed('Please remove the tag from the pull request title.')
             }
+            // Check body does 
+            const linkingKeywords = ['closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved']
+            const body = context.payload.pull_request.body
+            const bodyCheckFailed = linkingKeywords.some(keyword => body.search(new RegExp(`${keyword}\\s\\d+`, "im")) !== -1)
+            if (bodyCheckFailed) {
+              core.setFailed('Please remove the issue linking keyword from the pull request body.')
+            }
             // Add comment to the pull request
-            if (labelsCheckFailed || titleCheckFailed) {
+            if (labelsCheckFailed || titleCheckFailed || bodyCheckFailed) {
               // Define comment body
               const commentMarker = '<!-- dd-trace-java-check-pull-requests-workflow -->'
               const commentBody = 'Hi! 👋 Thanks for your pull request! 🎉\n\n' +
                   'To help us review it, please make sure to:\n\n' +
                   (labelsCheckFailed ? '* Add at least one type, and one component or instrumentation label to the pull request\n' : '') +
                   (titleCheckFailed ? '* Remove the tag from the pull request title\n' : '') +
+                  (bodyCheckFailed ? '* Remove the issue linking keyword\n' : '') +
                   '\nIf you need help, please check our [contributing guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md).' +
                   '\n\n' + commentMarker
               // Look for previous comment

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-draft.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-draft.json
@@ -3,6 +3,7 @@
         "number": 7884,
         "draft": true,
         "labels": [],
-        "title": "Adding some new features"
+        "title": "Adding some new features",
+        "body": "# What Does This Do\n\nThis PR introduces a workflow that checks PRs contributing guidelines."
     }
 }

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-instrumentation.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-instrumentation.json
@@ -10,6 +10,7 @@
                 "name": "type: bug"
             }
         ],
-        "title": "Adding some new features"
+        "title": "Adding some new features",
+        "body": "# What Does This Do\n\nThis PR introduces a workflow that checks PRs contributing guidelines."
     }
 }

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-linking-issue.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-linking-issue.json
@@ -10,7 +10,7 @@
                 "name": "type: enhancement"
             }
         ],
-        "title": "[API] Adding some new features",
-        "body": "# What Does This Do\n\nThis PR introduces a workflow that checks PRs contributing guidelines."
+        "title": "Adding some new features",
+        "body": "# What Does This Do\n\nThis PR introduces a workflow to check that PRs labels and title match the contributing guidelines.\nIt fixes #1234 amoung other issues."
     }
 }

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-missing-label.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-missing-label.json
@@ -7,6 +7,7 @@
                 "name": "comp: api"
             }
         ],
-        "title": "Adding some new features"
+        "title": "Adding some new features",
+        "body": "# What Does This Do\n\nThis PR introduces a workflow that checks PRs contributing guidelines."
     }
 }

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request-no-release-notes.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request-no-release-notes.json
@@ -7,6 +7,7 @@
                 "name": "tag: no release notes"
             }
         ],
-        "title": "Adding some new features"
+        "title": "Adding some new features",
+        "body": "# What Does This Do\n\nThis PR introduces a workflow that checks PRs contributing guidelines."
     }
 }

--- a/.github/workflows/tests/check-pull-requests/payload-pull-request.json
+++ b/.github/workflows/tests/check-pull-requests/payload-pull-request.json
@@ -10,6 +10,7 @@
                 "name": "type: enhancement"
             }
         ],
-        "title": "Adding some new features"
+        "title": "Adding some new features",
+        "body": "# What Does This Do\n\nThis PR introduces a workflow that checks PRs contributing guidelines."
     }
 }

--- a/.github/workflows/tests/check-pull-requests/test-pull-request.sh
+++ b/.github/workflows/tests/check-pull-requests/test-pull-request.sh
@@ -5,4 +5,5 @@ testworkflow pull_request instrumentation && \
 testworkflow pull_request draft && \
 testworkflow pull_request no-release-notes && \
 ! testworkflow pull_request missing-label && \
-! testworkflow pull_request title-tag
+! testworkflow pull_request title-tag && \
+! testworkflow pull_request linking-issue


### PR DESCRIPTION
# What Does This Do

This PR improves the PR checks automation and template:

* Fix missing ready_for_review event
* Add issue liking keyword detection
* Replace the checklist by a simple list as the workflow does most of the checks automatically
* Remove the squash your commits entry from the checklist as it is now enforced in GitHub repository settings

# Motivation

Automate more checks

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
