### PR TITLE
Update Graal build-time instrumentation config for TracePropagationStyle

### DIFF
--- a/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/native-image/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -81,6 +81,7 @@ public final class NativeImageGeneratorRunnerInstrumentation
               + "datadog.trace.api.MethodFilterConfigParser:build_time,"
               + "datadog.trace.api.WithGlobalTracer:build_time,"
               + "datadog.trace.api.PropagationStyle:build_time,"
+              + "datadog.trace.api.TracePropagationStyle:build_time,"
               + "datadog.trace.api.telemetry.OtelEnvMetricCollector:build_time,"
               + "datadog.trace.api.profiling.ProfilingEnablement:build_time,"
               + "datadog.trace.bootstrap.config.provider.ConfigConverter:build_time,"


### PR DESCRIPTION
# What Does This Do
This adds the `TracePropagationStyle` enum to the build-time initialized list provided to GraalVM Native Image, similar to its deprecated predecessor `PropagationStyle`.

# Motivation
While modifying system tests to use JDK-22-based Graal, the following error was seen during container generation:

```
Error: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: An object of type 'datadog.trace.api.TracePropagationStyle' was found in the image heap. This type, however, is marked for initialization at image run time for the following reason: classes are initialized at run time by default.
#21 15.26 This is not allowed for correctness reasons: All objects that are stored in the image heap must be initialized at build time.
#21 15.26 
#21 15.26 You now have two options to resolve this:
#21 15.26 
#21 15.26 1) If it is intended that objects of type 'datadog.trace.api.TracePropagationStyle' are persisted in the image heap, add 
#21 15.26 
#21 15.26     '--initialize-at-build-time=datadog.trace.api.TracePropagationStyle'
#21 15.26 
#21 15.26 to the native-image arguments. Note that initializing new types can store additional objects to the heap. It is advised to check the static fields of 'datadog.trace.api.TracePropagationStyle' to see if they are safe for build-time initialization,  and that they do not contain any sensitive data that should not become part of the image.
#21 15.26 
#21 15.26 2) If these objects should not be stored in the image heap, you can use 
#21 15.26 
#21 15.26     '--trace-object-instantiation=datadog.trace.api.TracePropagationStyle'
#21 15.26 
#21 15.26 to find classes that instantiate these objects. Once you found such a class, you can mark it explicitly for run time initialization with 
#21 15.26 
#21 15.26     '--initialize-at-run-time=<culprit>'
#21 15.26 
#21 15.26 to prevent the instantiation of the object.
#21 15.26 
#21 15.26 If you are seeing this message after upgrading to a new GraalVM release, this means that some objects ended up in the image heap without their type being marked with --initialize-at-build-time.
#21 15.26 To fix this, include '--initialize-at-build-time=datadog.trace.api.TracePropagationStyle' in your configuration. If the classes do not originate from your code, it is advised to update all library or framework dependencies to the latest version before addressing this error.
#21 15.26 
```

# Additional Notes

# Contributor Checklist

- [x] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [x] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-11012]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-11012]: https://datadoghq.atlassian.net/browse/PROF-11012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ