### PR TITLE
Fix NPE in logic that parses flaky tests list

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -211,12 +211,14 @@ public class ConfigurationApiImpl implements ConfigurationApi {
 
     LOGGER.debug("Received {} flaky tests in total", response.size());
 
+    Configurations requestConf = tracerEnvironment.getConfigurations();
+
     int flakyTestsCount = 0;
     Map<String, Collection<TestIdentifier>> testIdentifiers = new HashMap<>();
     for (DataDto<TestIdentifierJson> dataDto : response) {
       TestIdentifierJson testIdentifierJson = dataDto.getAttributes();
-      Configurations configurations = testIdentifierJson.getConfigurations();
-      String moduleName = configurations.getTestBundle();
+      Configurations conf = testIdentifierJson.getConfigurations();
+      String moduleName = (conf != null ? conf : requestConf).getTestBundle();
       testIdentifiers
           .computeIfAbsent(moduleName, k -> new HashSet<>())
           .add(testIdentifierJson.toTestIdentifier());

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -168,7 +168,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
     for (DataDto<TestIdentifierJson> dataDto : response.data) {
       TestIdentifierJson testIdentifierJson = dataDto.getAttributes();
       Configurations conf = testIdentifierJson.getConfigurations();
-      String moduleName = (conf != null ? conf : requestConf).getTestBundle();
+      String moduleName =
+          (conf != null && conf.getTestBundle() != null ? conf : requestConf).getTestBundle();
       testIdentifiersByModule
           .computeIfAbsent(moduleName, k -> new HashMap<>())
           .put(testIdentifierJson.toTestIdentifier(), testIdentifierJson.toTestMetadata());
@@ -218,7 +219,8 @@ public class ConfigurationApiImpl implements ConfigurationApi {
     for (DataDto<TestIdentifierJson> dataDto : response) {
       TestIdentifierJson testIdentifierJson = dataDto.getAttributes();
       Configurations conf = testIdentifierJson.getConfigurations();
-      String moduleName = (conf != null ? conf : requestConf).getTestBundle();
+      String moduleName =
+          (conf != null && conf.getTestBundle() != null ? conf : requestConf).getTestBundle();
       testIdentifiers
           .computeIfAbsent(moduleName, k -> new HashSet<>())
           .add(testIdentifierJson.toTestIdentifier());


### PR DESCRIPTION
# What Does This Do

Fixes NPE in logic that parses the list of flaky tests received from the backend.
The error only happens when a "partial build" is run for a single module.

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
