### PR TITLE
Add avoid double instrumenting lambda non-streaming handlers.

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -221,6 +221,7 @@
 2 javax.xml.*
 # note we do not ignore kotlinx because we instrument coroutines code
 2 kotlin.*
+1 lambdainternal.EventHandlerLoader$PojoHandlerAsStreamHandler
 2 net.sf.cglib.*
 2 org.apache.bcel.*
 2 org.apache.html.*


### PR DESCRIPTION
# What Does This Do

Adds `lambdainternal.EventHandlerLoader$PojoHandlerAsStreamHandler` to the list of ignored classes.

# Motivation

It seems that, under the hood, aws lambda wraps non-streaming handlers in an internal streaming handler class. This allows them to execute these two different kinds of lambda functions in a single unified way.

However, since this internally wrapping handler is also matching our advice matchers, it gets instrumented as well. Mostly, that is not an issue, except for the fact that it means we're unable to capture the return value of the original handler function.

In the non-streaming case, since the internal streaming handler class is wrapping the customer's handler function, the streaming instrumentation gets executed first. This means that, for the `OnMethodExit` we cannot grab the handler's return value since all streaming handlers return void. Therefore, the returned object is not passed to the extension and not captured.

Adding this lambda internal streaming handler class to the list of ignores ensures that the `OnMethodExit` is called specifically when the customer's handler code returns.

# Additional Notes

I deployed this code in a testing layer to aws lambda and confirmed that we are now able to see the response payload in the non-streaming case.

<img width="533" alt="Screenshot 2024-12-10 at 11 35 05 AM" src="https://github.com/user-attachments/assets/b2e1bf32-918f-4699-9047-8a27438ac931">

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->

https://datadoghq.atlassian.net/browse/SLES-1920