### PR TITLE
Add configurable Dependency service resolution period

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -89,6 +89,8 @@ public final class GeneralConfig {
   public static final String AGENTLESS_LOG_SUBMISSION_ENABLED = "agentless.log.submission.enabled";
   public static final String AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE =
       "agentless.log.submission.queue.size";
+  public static final String TELEMETRY_DEPENDENCY_RESOLUTION_PERIOD_MILLIS =
+      "telemetry.dependency.resolution.period.millis";
   public static final String AGENTLESS_LOG_SUBMISSION_LEVEL = "agentless.log.submission.level";
   public static final String AGENTLESS_LOG_SUBMISSION_URL = "agentless.log.submission.url";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -538,6 +538,8 @@ public class Config {
   private final int cloudPayloadTaggingMaxDepth;
   private final int cloudPayloadTaggingMaxTags;
 
+  private final long dependecyResolutionPeriodMillis;
+
   // Read order: System Properties -> Env Variables, [-> properties file], [-> default value]
   private Config() {
     this(ConfigProvider.createDefault());
@@ -1801,6 +1803,11 @@ public class Config {
         configProvider.getInteger(TracerConfig.TRACE_CLOUD_PAYLOAD_TAGGING_MAX_DEPTH, 10);
     this.cloudPayloadTaggingMaxTags =
         configProvider.getInteger(TracerConfig.TRACE_CLOUD_PAYLOAD_TAGGING_MAX_TAGS, 758);
+
+    this.dependecyResolutionPeriodMillis =
+        configProvider.getLong(
+            GeneralConfig.TELEMETRY_DEPENDENCY_RESOLUTION_PERIOD_MILLIS,
+            1000); // 1 second by default
 
     timelineEventsEnabled =
         configProvider.getBoolean(
@@ -3698,6 +3705,10 @@ public class Config {
       final boolean defaultEnabled, final String settingName, String settingSuffix) {
     return configProvider.isEnabled(
         Collections.singletonList(settingName), "", settingSuffix, defaultEnabled);
+  }
+
+  public long getDependecyResolutionPeriodMillis() {
+    return dependecyResolutionPeriodMillis;
   }
 
   public boolean isDBMTracePreparedStatements() {

--- a/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
+++ b/telemetry/src/main/java/datadog/telemetry/dependency/DependencyService.java
@@ -1,5 +1,6 @@
 package datadog.telemetry.dependency;
 
+import datadog.trace.api.Config;
 import datadog.trace.util.AgentTaskScheduler;
 import java.lang.instrument.Instrumentation;
 import java.net.URI;
@@ -31,7 +32,11 @@ public class DependencyService implements Runnable {
   public void schedulePeriodicResolution() {
     scheduledTask =
         AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
-            AgentTaskScheduler.RunnableTask.INSTANCE, this, 0, 1000L, TimeUnit.MILLISECONDS);
+            AgentTaskScheduler.RunnableTask.INSTANCE,
+            this,
+            0,
+            Config.get().getDependecyResolutionPeriodMillis(),
+            TimeUnit.MILLISECONDS);
   }
 
   public void resolveOneDependency() {


### PR DESCRIPTION
# What Does This Do

Add new APPSEC_DEPENDENCY_RESOLUTION_PERIOD_MILLIS env variable to be able to configure the dependency service resolution period

# Motivation

For testing environments the default 1 second period is excessive

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
