### PR TITLE
Fix suspend Kotlin methods instrumentation

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumentor.java
@@ -396,7 +396,11 @@ public class CapturedContextInstrumentor extends Instrumentor {
     if (methodNode.tryCatchBlocks.size() > 0) {
       throwableListVar = declareThrowableList(insnList);
     }
-    unscopedLocalVars = initAndHoistLocalVars(insnList);
+    unscopedLocalVars = Collections.emptyList();
+    if (Config.get().isDebuggerHoistLocalVarsEnabled() && language == JvmLanguage.JAVA) {
+      // for now, only hoist local vars for Java
+      unscopedLocalVars = initAndHoistLocalVars(insnList);
+    }
     insnList.add(contextInitLabel);
     if (definition instanceof SpanDecorationProbe
         && definition.getEvaluateAt() == MethodLocation.EXIT) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumentor.java
@@ -46,6 +46,7 @@ public abstract class Instrumentor {
   protected int localVarBaseOffset;
   protected int argOffset;
   protected final LocalVariableNode[] localVarsBySlotArray;
+  protected final JvmLanguage language;
   protected LabelNode returnHandlerLabel;
   protected final List<CapturedContextInstrumentor.FinallyBlock> finallyBlocks = new ArrayList<>();
 
@@ -69,6 +70,7 @@ public abstract class Instrumentor {
       argOffset += t.getSize();
     }
     localVarsBySlotArray = extractLocalVariables(argTypes);
+    this.language = JvmLanguage.of(classNode);
   }
 
   public abstract InstrumentationResult.Status instrument();
@@ -292,6 +294,33 @@ public abstract class Instrumentor {
       this.startLabel = startLabel;
       this.endLabel = endLabel;
       this.handlerLabel = handlerLabel;
+    }
+  }
+
+  protected enum JvmLanguage {
+    JAVA,
+    KOTLIN,
+    SCALA,
+    GROOVY,
+    UNKNOWN;
+
+    public static JvmLanguage of(ClassNode classNode) {
+      if (classNode.sourceFile == null) {
+        return UNKNOWN;
+      }
+      if (classNode.sourceFile.endsWith(".java")) {
+        return JAVA;
+      }
+      if (classNode.sourceFile.endsWith(".kt")) {
+        return KOTLIN;
+      }
+      if (classNode.sourceFile.endsWith(".scala")) {
+        return SCALA;
+      }
+      if (classNode.sourceFile.endsWith(".groovy")) {
+        return GROOVY;
+      }
+      return UNKNOWN;
     }
   }
 }

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -179,6 +179,7 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_DEBUGGER_VERIFY_BYTECODE = true;
   static final boolean DEFAULT_DEBUGGER_INSTRUMENT_THE_WORLD = false;
   static final int DEFAULT_DEBUGGER_CAPTURE_TIMEOUT = 100; // milliseconds
+  static final boolean DEFAULT_DEBUGGER_HOIST_LOCALVARS_ENABLED = true;
   static final boolean DEFAULT_DEBUGGER_SYMBOL_ENABLED = true;
   static final boolean DEFAULT_DEBUGGER_SYMBOL_FORCE_UPLOAD = false;
   static final int DEFAULT_DEBUGGER_SYMBOL_FLUSH_THRESHOLD = 100; // nb of classes

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/DebuggerConfig.java
@@ -28,6 +28,8 @@ public final class DebuggerConfig {
   public static final String DEBUGGER_REDACTION_EXCLUDED_IDENTIFIERS =
       "dynamic.instrumentation.redaction.excluded.identifiers";
   public static final String DEBUGGER_REDACTED_TYPES = "dynamic.instrumentation.redacted.types";
+  public static final String DEBUGGER_HOIST_LOCALVARS_ENABLED =
+      "dynamic.instrumentation.hoist.localvars.enabled";
   public static final String DEBUGGER_SYMBOL_ENABLED = "symbol.database.upload.enabled";
   public static final String DEBUGGER_SYMBOL_FORCE_UPLOAD = "internal.force.symbol.database.upload";
   public static final String DEBUGGER_SYMBOL_INCLUDES = "symbol.database.includes";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -394,6 +394,7 @@ public class Config {
   private final String debuggerRedactedIdentifiers;
   private final Set<String> debuggerRedactionExcludedIdentifiers;
   private final String debuggerRedactedTypes;
+  private final boolean debuggerHoistLocalVarsEnabled;
   private final boolean debuggerSymbolEnabled;
   private final boolean debuggerSymbolForceUpload;
   private final String debuggerSymbolIncludes;
@@ -1526,6 +1527,9 @@ public class Config {
     debuggerRedactionExcludedIdentifiers =
         tryMakeImmutableSet(configProvider.getList(DEBUGGER_REDACTION_EXCLUDED_IDENTIFIERS));
     debuggerRedactedTypes = configProvider.getString(DEBUGGER_REDACTED_TYPES, null);
+    debuggerHoistLocalVarsEnabled =
+        configProvider.getBoolean(
+            DEBUGGER_HOIST_LOCALVARS_ENABLED, DEFAULT_DEBUGGER_HOIST_LOCALVARS_ENABLED);
     debuggerSymbolEnabled =
         configProvider.getBoolean(DEBUGGER_SYMBOL_ENABLED, DEFAULT_DEBUGGER_SYMBOL_ENABLED);
     debuggerSymbolForceUpload =
@@ -3040,6 +3044,10 @@ public class Config {
 
   public String getDebuggerRedactedTypes() {
     return debuggerRedactedTypes;
+  }
+
+  public boolean isDebuggerHoistLocalVarsEnabled() {
+    return debuggerHoistLocalVarsEnabled;
   }
 
   public boolean isAwsPropagationEnabled() {


### PR DESCRIPTION
# What Does This Do
suspend methods in Kotlin generates a special bytecode for the method with a state machine and could return different objects. for each return branch we need to have a specific return handler to avoid having mismatch stack maps.
Add new config parameter to be able to disable local var hoisting that can be problematic in some situations.
Detects language and only enable hoisting for Java. 

# Motivation
support `suspend` Kotlin methods

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3229]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3229]: https://datadoghq.atlassian.net/browse/DEBUG-3229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ