### PR TITLE
Increase IAST propagation to StringBuffer append

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringBuilderCallSite.java
+++ b/dd-java-agent/instrumentation/java-lang/src/main/java/datadog/trace/instrumentation/java/lang/StringBuilderCallSite.java
@@ -41,6 +41,7 @@ public class StringBuilderCallSite {
   @CallSite.After("java.lang.StringBuilder java.lang.StringBuilder.append(java.lang.StringBuffer)")
   @CallSite.After("java.lang.StringBuffer java.lang.StringBuffer.append(java.lang.String)")
   @CallSite.After("java.lang.StringBuffer java.lang.StringBuffer.append(java.lang.CharSequence)")
+  @CallSite.After("java.lang.StringBuffer java.lang.StringBuffer.append(java.lang.StringBuffer)")
   @Nonnull
   public static CharSequence afterAppend(
       @CallSite.This @Nonnull final CharSequence self,
@@ -59,6 +60,8 @@ public class StringBuilderCallSite {
 
   @CallSite.After(
       "java.lang.StringBuilder java.lang.StringBuilder.append(java.lang.CharSequence, int, int)")
+  @CallSite.After(
+      "java.lang.StringBuffer java.lang.StringBuffer.append(java.lang.CharSequence, int, int)")
   @Nonnull
   public static CharSequence afterAppendWithSubstring(
       @CallSite.This @Nonnull final CharSequence self,

--- a/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
+++ b/dd-java-agent/instrumentation/java-lang/src/test/groovy/datadog/trace/instrumentation/java/lang/StringBuilderCallSiteTest.groovy
@@ -63,13 +63,13 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     0 * _
 
     where:
-    suite                        | target                      | param                       | expected
-    new TestStringBuilderSuite() | new StringBuilder('Hello ') | 23.5F                       | 'Hello 23.5'
-    new TestStringBuilderSuite() | new StringBuilder('Hello ') | new StringBuffer('World!')  | 'Hello World!'
-    new TestStringBuilderSuite() | new StringBuilder('Hello ') | 'World!'                    | 'Hello World!'
-    new TestStringBufferSuite()  | new StringBuffer('Hello ')  | 23.5F                       | 'Hello 23.5'
-    new TestStringBufferSuite()  | new StringBuffer('Hello ')  | new StringBuilder('World!') | 'Hello World!'
-    new TestStringBufferSuite()  | new StringBuffer('Hello ')  | 'World!'                    | 'Hello World!'
+    suite                        | target        | param         | expected
+    new TestStringBuilderSuite() | sb('Hello ')  | 23.5F         | 'Hello 23.5'
+    new TestStringBuilderSuite() | sb('Hello ')  | sbf('World!') | 'Hello World!'
+    new TestStringBuilderSuite() | sb('Hello ')  | 'World!'      | 'Hello World!'
+    new TestStringBufferSuite()  | sbf('Hello ') | 23.5F         | 'Hello 23.5'
+    new TestStringBufferSuite()  | sbf('Hello ') | sbf('World!') | 'Hello World!'
+    new TestStringBufferSuite()  | sbf('Hello ') | 'World!'      | 'Hello World!'
   }
 
   void 'test string builder append object throwing exceptions'() {
@@ -104,8 +104,9 @@ class StringBuilderCallSiteTest extends AgentTestRunner {
     0 * _
 
     where:
-    suite                        | target                      | param    | start | end | expected
-    new TestStringBuilderSuite() | new StringBuilder('Hello ') | 'World!' | 0     | 5   | 'Hello World'
+    suite                        | target        | param    | start | end | expected
+    new TestStringBuilderSuite() | sb('Hello ')  | 'World!' | 0     | 5   | 'Hello World'
+    new TestStringBufferSuite()  | sbf('Hello ') | 'World!' | 0     | 5   | 'Hello World'
   }
 
   void 'test string builder toString call site'() {


### PR DESCRIPTION
# What Does This Do
This adds the instrumentation to propagate the taint values through the following methods of `StringBuffer`:
- `append(CharSequence, int, int)`
- `append(StringBuffer)`

# Motivation
Increase propagation of `StringBuffer` methods.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55365]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55365]: https://datadoghq.atlassian.net/browse/APPSEC-55365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ