### PR TITLE
[WIP] Add file attribute to JUnit reports

### DIFF
--- a/dd-java-agent/instrumentation/jdbc/build.gradle
+++ b/dd-java-agent/instrumentation/jdbc/build.gradle
@@ -20,6 +20,10 @@ addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepJava11Test', 'latestDepTest', 'test')
 
 dependencies {
+  // junit extension
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.x.x'
+  testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.x.x'
+
   compileOnly group: 'com.zaxxer', name: 'HikariCP', version: '2.4.0'
   testImplementation(testFixtures(project(':dd-java-agent:agent-iast')))
 

--- a/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTestBase.groovy
+++ b/dd-java-agent/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTestBase.groovy
@@ -6,8 +6,10 @@ import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.InstrumentationTags
 import datadog.trace.bootstrap.instrumentation.api.Tags
+import datadog.trace.test.util.TestSourceFileExtension
 import org.apache.derby.jdbc.EmbeddedDataSource
 import org.h2.jdbcx.JdbcDataSource
+import org.junit.jupiter.api.extension.ExtendWith
 import spock.lang.Shared
 import test.TestConnection
 import test.WrappedConnection
@@ -24,6 +26,7 @@ import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 
+@ExtendWith(TestSourceFileExtension)
 abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
 
   @Shared
@@ -752,7 +755,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
     for (int i = 0; i < numQueries; ++i) {
       res[i] == 3
     }
-    assertTraces(5) {
+    assertTraces(6) {
       trace(1) {
         span {
           operationName this.operation(dbType)
@@ -849,6 +852,7 @@ abstract class JDBCInstrumentationTest extends VersionedNamingTestBase {
   protected abstract boolean dbmTraceInjected()
 }
 
+@ExtendWith(TestSourceFileExtension)
 class JDBCInstrumentationV0Test extends JDBCInstrumentationTest {
 
   @Override
@@ -872,6 +876,7 @@ class JDBCInstrumentationV0Test extends JDBCInstrumentationTest {
   }
 }
 
+TestSourceFileExtension
 class JDBCInstrumentationV1ForkedTest extends JDBCInstrumentationTest {
 
   @Override
@@ -895,6 +900,7 @@ class JDBCInstrumentationV1ForkedTest extends JDBCInstrumentationTest {
   }
 }
 
+@ExtendWith(TestSourceFileExtension)
 class JDBCInstrumentationDBMTraceInjectedForkedTest extends JDBCInstrumentationTest {
 
   @Override

--- a/utils/test-utils/src/main/groovy/datadog/trace/test/util/TestSourceFileExtension.groovy
+++ b/utils/test-utils/src/main/groovy/datadog/trace/test/util/TestSourceFileExtension.groovy
@@ -1,0 +1,50 @@
+package datadog.trace.test.util
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestWatcher
+
+class TestSourceFileExtension implements TestWatcher {
+  TestSourceFileExtension() {
+    System.out.println("TestSourceFileExtension initialized!")
+  }
+
+  @Override
+  void testSuccessful(ExtensionContext context) {
+    System.out.println("test was successful!")
+    getTestData(context)
+  }
+
+  @Override
+  void testFailed(ExtensionContext context, Throwable cause) {
+    System.out.println("test failed!")
+    getTestData(context)
+  }
+
+  @Override
+  void testAborted(ExtensionContext context, Throwable cause) {
+    System.out.println("test aborted!")
+    getTestData(context)
+  }
+
+  @Override
+  void testDisabled(ExtensionContext context, Optional<String> reason) {
+    System.out.println("test disabled!")
+    getTestData(context)
+  }
+
+  private static void getTestData(ExtensionContext context) {
+    String testClassName = context.getTestClass().get().getSimpleName()
+    String testMethodName = context.getTestMethod().get().getName()
+    String className = context.getClass()
+    String requiredTestClassName = context.getRequiredTestClass().getName()
+    String requiredTestMethodName = context.getRequiredTestMethod().getName()
+
+    System.out.println("--------------------------")
+    System.out.println("testClassName: " + testClassName)
+    System.out.println("testMethodName: " + testMethodName)
+    System.out.println("className: " + className)
+    System.out.println("requiredTestClassName: " + requiredTestClassName)
+    System.out.println("requiredTestMethodName: " + requiredTestMethodName)
+    System.out.println("--------------------------")
+  }
+}


### PR DESCRIPTION
# What Does This Do
This PR adds a script that appends a `file` attribute to each XML file that is uploaded to CI.

# Motivation
The motivation behind this PR is to eventually add the codeowners tag to our tests. This PR would be step 2 under "Using the Github Integration" in [this doc](https://docs.datadoghq.com/tests/setup/junit_xml/?tab=linux#adding-code-owners).

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

[LANGPLAT-80]


<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-80]: https://datadoghq.atlassian.net/browse/LANGPLAT-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ