### PR TITLE
Dynamically evaluate service name for message consumers

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sqs/SqsDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
+import java.util.function.Supplier;
 
 public class SqsDecorator extends MessagingClientDecorator {
   static final CharSequence COMPONENT_NAME = UTF8BytesString.create("java-aws-sdk");
@@ -25,7 +26,7 @@ public class SqsDecorator extends MessagingClientDecorator {
       Config.get().isTimeInQueueEnabled(!SQS_LEGACY_TRACING, "sqs");
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
   public static final SqsDecorator CONSUMER_DECORATE =
       new SqsDecorator(
@@ -42,10 +43,10 @@ public class SqsDecorator extends MessagingClientDecorator {
           MESSAGE_BROKER,
           SpanNaming.instance().namingSchema().messaging().timeInQueueService("sqs"));
 
-  protected SqsDecorator(String spanKind, CharSequence spanType, String serviceName) {
+  protected SqsDecorator(String spanKind, CharSequence spanType, Supplier<String> serviceName) {
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceName;
   }
 
   @Override
@@ -60,7 +61,7 @@ public class SqsDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-1.0/src/test/groovy/SqsClientTest.groovy
@@ -407,7 +407,7 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
       }
       trace(1) {
         span {
-          serviceName SpanNaming.instance().namingSchema().messaging().inboundService("jms", Config.get().isJmsLegacyTracingEnabled()) ?: Config.get().getServiceName()
+          serviceName SpanNaming.instance().namingSchema().messaging().inboundService("jms", Config.get().isJmsLegacyTracingEnabled()).get() ?: Config.get().getServiceName()
           operationName SpanNaming.instance().namingSchema().messaging().inboundOperation("jms")
           resourceName "Consumed from Queue somequeue"
           spanType DDSpanTypes.MESSAGE_CONSUMER

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.api.naming.SpanNaming;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
+import java.util.function.Supplier;
 
 public class SqsDecorator extends MessagingClientDecorator {
   static final CharSequence COMPONENT_NAME = UTF8BytesString.create("java-aws-sdk");
@@ -26,7 +27,7 @@ public class SqsDecorator extends MessagingClientDecorator {
       Config.get().isTimeInQueueEnabled(!SQS_LEGACY_TRACING, "sqs");
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
   public static final SqsDecorator CONSUMER_DECORATE =
       new SqsDecorator(
@@ -43,10 +44,11 @@ public class SqsDecorator extends MessagingClientDecorator {
           MESSAGE_BROKER,
           SpanNaming.instance().namingSchema().messaging().timeInQueueService("sqs"));
 
-  protected SqsDecorator(String spanKind, CharSequence spanType, String serviceName) {
+  protected SqsDecorator(
+      String spanKind, CharSequence spanType, Supplier<String> serviceNameSupplier) {
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceNameSupplier;
   }
 
   @Override
@@ -61,7 +63,7 @@ public class SqsDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java-sqs-2.0/src/test/groovy/SqsClientTest.groovy
@@ -419,7 +419,7 @@ abstract class SqsClientTest extends VersionedNamingTestBase {
       }
       trace(1) {
         span {
-          serviceName SpanNaming.instance().namingSchema().messaging().inboundService("jms", Config.get().isJmsLegacyTracingEnabled()) ?: Config.get().getServiceName()
+          serviceName SpanNaming.instance().namingSchema().messaging().inboundService("jms", Config.get().isJmsLegacyTracingEnabled()).get() ?: Config.get().getServiceName()
           operationName SpanNaming.instance().namingSchema().messaging().inboundOperation("jms")
           resourceName "Consumed from Queue somequeue"
           spanType DDSpanTypes.MESSAGE_CONSUMER

--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/PubSubDecorator.java
@@ -22,6 +22,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
 import java.util.LinkedHashMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -91,12 +92,13 @@ public class PubSubDecorator extends MessagingClientDecorator {
               .inboundService(PUBSUB, Config.get().isGooglePubSubLegacyTracingEnabled()));
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
-  protected PubSubDecorator(String spanKind, CharSequence spanType, String serviceName) {
+  protected PubSubDecorator(
+      String spanKind, CharSequence spanType, Supplier<String> serviceNameSupplier) {
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceNameSupplier;
   }
 
   @Override
@@ -111,7 +113,7 @@ public class PubSubDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jakarta-jms/src/main/java/datadog/trace/instrumentation/jakarta/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jakarta-jms/src/main/java/datadog/trace/instrumentation/jakarta/jms/JMSDecorator.java
@@ -22,6 +22,7 @@ import jakarta.jms.TemporaryTopic;
 import jakarta.jms.Topic;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,7 @@ public final class JMSDecorator extends MessagingClientDecorator {
 
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
   public static final JMSDecorator PRODUCER_DECORATE =
       new JMSDecorator(
@@ -89,7 +90,10 @@ public final class JMSDecorator extends MessagingClientDecorator {
           SpanNaming.instance().namingSchema().messaging().timeInQueueService(JMS.toString()));
 
   public JMSDecorator(
-      String resourcePrefix, String spanKind, CharSequence spanType, String serviceName) {
+      String resourcePrefix,
+      String spanKind,
+      CharSequence spanType,
+      Supplier<String> serviceNameSupplier) {
     this.resourcePrefix = resourcePrefix;
 
     this.queueTempResourceName = UTF8BytesString.create(resourcePrefix + "Temporary Queue");
@@ -100,7 +104,7 @@ public final class JMSDecorator extends MessagingClientDecorator {
 
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceNameSupplier;
   }
 
   @Override
@@ -115,7 +119,7 @@ public final class JMSDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
+++ b/dd-java-agent/instrumentation/jms/src/main/java/datadog/trace/instrumentation/jms/JMSDecorator.java
@@ -15,6 +15,7 @@ import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -60,7 +61,7 @@ public final class JMSDecorator extends MessagingClientDecorator {
 
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
   public static final JMSDecorator PRODUCER_DECORATE =
       new JMSDecorator(
@@ -90,7 +91,10 @@ public final class JMSDecorator extends MessagingClientDecorator {
           SpanNaming.instance().namingSchema().messaging().timeInQueueService(JMS.toString()));
 
   public JMSDecorator(
-      String resourcePrefix, String spanKind, CharSequence spanType, String serviceName) {
+      String resourcePrefix,
+      String spanKind,
+      CharSequence spanType,
+      Supplier<String> serviceNameSupplier) {
     this.resourcePrefix = resourcePrefix;
 
     this.queueTempResourceName = UTF8BytesString.create(resourcePrefix + "Temporary Queue");
@@ -101,7 +105,7 @@ public final class JMSDecorator extends MessagingClientDecorator {
 
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceNameSupplier;
   }
 
   public static void logJMSException(JMSException ex) {
@@ -122,7 +126,7 @@ public final class JMSDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/KafkaDecorator.java
@@ -18,6 +18,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -41,7 +42,7 @@ public class KafkaDecorator extends MessagingClientDecorator {
   public static final String KAFKA_PRODUCED_KEY = "x_datadog_kafka_produced";
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
   private static final DDCache<CharSequence, CharSequence> PRODUCER_RESOURCE_NAME_CACHE =
       DDCaches.newFixedSizeCache(32);
@@ -78,10 +79,11 @@ public class KafkaDecorator extends MessagingClientDecorator {
           InternalSpanTypes.MESSAGE_BROKER,
           SpanNaming.instance().namingSchema().messaging().timeInQueueService(KAFKA));
 
-  protected KafkaDecorator(String spanKind, CharSequence spanType, String serviceName) {
+  protected KafkaDecorator(
+      String spanKind, CharSequence spanType, Supplier<String> serviceNameSupplier) {
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceNameSupplier;
   }
 
   @Override
@@ -96,7 +98,7 @@ public class KafkaDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/KafkaDecorator.java
@@ -18,6 +18,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -41,7 +42,7 @@ public class KafkaDecorator extends MessagingClientDecorator {
   public static final String KAFKA_PRODUCED_KEY = "x_datadog_kafka_produced";
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
   private static final DDCache<CharSequence, CharSequence> PRODUCER_RESOURCE_NAME_CACHE =
       DDCaches.newFixedSizeCache(32);
@@ -78,10 +79,11 @@ public class KafkaDecorator extends MessagingClientDecorator {
           InternalSpanTypes.MESSAGE_BROKER,
           SpanNaming.instance().namingSchema().messaging().timeInQueueService(KAFKA));
 
-  protected KafkaDecorator(String spanKind, CharSequence spanType, String serviceName) {
+  protected KafkaDecorator(
+      String spanKind, CharSequence spanType, Supplier<String> serviceNameSupplier) {
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceNameSupplier;
   }
 
   @Override
@@ -96,7 +98,7 @@ public class KafkaDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -14,6 +14,7 @@ import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorator;
+import java.util.function.Supplier;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.StampedRecord;
@@ -33,7 +34,7 @@ public class KafkaStreamsDecorator extends MessagingClientDecorator {
 
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
   private static final DDCache<CharSequence, CharSequence> RESOURCE_NAME_CACHE =
       DDCaches.newFixedSizeCache(32);
@@ -54,10 +55,11 @@ public class KafkaStreamsDecorator extends MessagingClientDecorator {
           InternalSpanTypes.MESSAGE_BROKER,
           SpanNaming.instance().namingSchema().messaging().timeInQueueService(KAFKA));
 
-  protected KafkaStreamsDecorator(String spanKind, CharSequence spanType, String serviceName) {
+  protected KafkaStreamsDecorator(
+      String spanKind, CharSequence spanType, Supplier<String> serviceNameSupplier) {
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceNameSupplier;
   }
 
   @Override
@@ -67,7 +69,7 @@ public class KafkaStreamsDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/main/java/datadog/trace/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -30,6 +30,7 @@ import datadog.trace.bootstrap.instrumentation.decorator.MessagingClientDecorato
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 public class RabbitDecorator extends MessagingClientDecorator {
 
@@ -84,12 +85,13 @@ public class RabbitDecorator extends MessagingClientDecorator {
 
   private final String spanKind;
   private final CharSequence spanType;
-  private final String serviceName;
+  private final Supplier<String> serviceNameSupplier;
 
-  public RabbitDecorator(String spanKind, CharSequence spanType, String serviceName) {
+  public RabbitDecorator(
+      String spanKind, CharSequence spanType, Supplier<String> serviceNameSupplier) {
     this.spanKind = spanKind;
     this.spanType = spanType;
-    this.serviceName = serviceName;
+    this.serviceNameSupplier = serviceNameSupplier;
   }
 
   @Override
@@ -99,7 +101,7 @@ public class RabbitDecorator extends MessagingClientDecorator {
 
   @Override
   protected String service() {
-    return serviceName;
+    return serviceNameSupplier.get();
   }
 
   @Override

--- a/dd-trace-core/src/jmh/java/datadog/trace/api/naming/MessagingNamingBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/api/naming/MessagingNamingBenchmark.java
@@ -1,0 +1,96 @@
+package datadog.trace.api.naming;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.core.BlackholeWriter;
+import datadog.trace.core.CoreTracer;
+import datadog.trace.core.TraceCounters;
+import java.util.WeakHashMap;
+import java.util.function.Supplier;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmark (pinThreadServiceName) Mode Cnt Score Error Units
+ * MessagingNamingBenchmark.complexSupplierServiceName false avgt 3 0.710 ± 0.040 us/op
+ * MessagingNamingBenchmark.complexSupplierServiceName true avgt 3 0.718 ± 0.105 us/op
+ * MessagingNamingBenchmark.constantServiceName false avgt 3 0.668 ± 0.024 us/op
+ * MessagingNamingBenchmark.constantSupplierServiceName false avgt 3 0.666 ± 0.044 us/op
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 15, timeUnit = SECONDS)
+@Measurement(iterations = 3, time = 30, timeUnit = SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(value = 1)
+public class MessagingNamingBenchmark {
+
+  CoreTracer tracer;
+
+  WeakHashMap<ClassLoader, String> weakCache;
+
+  private static final Supplier<String> constantSupplier = () -> "constant";
+
+  private final Supplier<String> complexSupplier =
+      () -> {
+        String ret = weakCache.get(Thread.currentThread().getContextClassLoader());
+        if (ret == null) {
+          ret = Config.get().getServiceName();
+        }
+        return ret;
+      };
+
+  @Param({"false", "true"})
+  boolean pinThreadServiceName;
+
+  @Setup(Level.Iteration)
+  public void init(Blackhole blackhole) {
+    tracer =
+        CoreTracer.builder()
+            .writer(new BlackholeWriter(blackhole, new TraceCounters(), 0))
+            .strictTraceWrites(false)
+            .build();
+    weakCache = new WeakHashMap<>();
+    if (pinThreadServiceName) {
+      weakCache.put(Thread.currentThread().getContextClassLoader(), constantSupplier.get());
+    }
+  }
+
+  @Benchmark
+  public void constantServiceName(Blackhole blackhole) {
+    final AgentSpan span = tracer.startSpan("", "");
+    span.setServiceName("constant");
+    span.finish();
+    blackhole.consume(span);
+  }
+
+  @Benchmark
+  public void constantSupplierServiceName(Blackhole blackhole) {
+    final AgentSpan span = tracer.startSpan("", "");
+    span.setServiceName(constantSupplier.get());
+    span.finish();
+    blackhole.consume(span);
+  }
+
+  @Benchmark
+  public void complexSupplierServiceName(Blackhole blackhole) {
+    final AgentSpan span = tracer.startSpan("", "");
+    span.setServiceName(complexSupplier.get());
+    span.finish();
+    blackhole.consume(span);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/NamingSchema.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.naming;
 
 import java.util.Map;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -176,9 +177,9 @@ public interface NamingSchema {
      *
      * @param messagingSystem the messaging system (e.g. jms, kafka, amqp,..)
      * @param useLegacyTracing if true legacy tracing service naming will be applied if compatible
-     * @return the service name
+     * @return the supplier for the service name
      */
-    String inboundService(@Nonnull String messagingSystem, boolean useLegacyTracing);
+    Supplier<String> inboundService(@Nonnull String messagingSystem, boolean useLegacyTracing);
 
     /**
      * Calculate the operation name for a messaging producer span.
@@ -196,16 +197,16 @@ public interface NamingSchema {
      * @param useLegacyTracing if true legacy tracing service naming will be applied if compatible
      * @return the service name
      */
-    String outboundService(@Nonnull String messagingSystem, boolean useLegacyTracing);
+    Supplier<String> outboundService(@Nonnull String messagingSystem, boolean useLegacyTracing);
 
     /**
      * Calculate the service name for a messaging time in queue synthetic span.
      *
      * @param messagingSystem the messaging system (e.g. jms, kafka, amqp,..)
-     * @return the service name
+     * @return the service name supplier
      */
     @Nonnull
-    String timeInQueueService(@Nonnull String messagingSystem);
+    Supplier<String> timeInQueueService(@Nonnull String messagingSystem);
 
     /**
      * Calculate the operation name for a messaging time in queue synthetic span.

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/MessagingNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/MessagingNamingV1.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
 public class MessagingNamingV1 implements NamingSchema.ForMessaging {
+  private static final Supplier<String> NULL_SUPPLIER = () -> null;
 
   private String normalizeForCloud(@Nonnull final String messagingSystem) {
     switch (messagingSystem) {
@@ -27,7 +28,7 @@ public class MessagingNamingV1 implements NamingSchema.ForMessaging {
   @Override
   public Supplier<String> outboundService(
       @Nonnull String messagingSystem, boolean useLegacyTracing) {
-    return () -> null;
+    return NULL_SUPPLIER;
   }
 
   @Nonnull
@@ -39,7 +40,7 @@ public class MessagingNamingV1 implements NamingSchema.ForMessaging {
   @Override
   public Supplier<String> inboundService(
       @Nonnull String messagingSystem, boolean useLegacyTracing) {
-    return () -> null;
+    return NULL_SUPPLIER;
   }
 
   @Override

--- a/internal-api/src/main/java/datadog/trace/api/naming/v1/MessagingNamingV1.java
+++ b/internal-api/src/main/java/datadog/trace/api/naming/v1/MessagingNamingV1.java
@@ -1,6 +1,7 @@
 package datadog.trace.api.naming.v1;
 
 import datadog.trace.api.naming.NamingSchema;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
 public class MessagingNamingV1 implements NamingSchema.ForMessaging {
@@ -24,8 +25,9 @@ public class MessagingNamingV1 implements NamingSchema.ForMessaging {
   }
 
   @Override
-  public String outboundService(@Nonnull String messagingSystem, boolean useLegacyTracing) {
-    return null;
+  public Supplier<String> outboundService(
+      @Nonnull String messagingSystem, boolean useLegacyTracing) {
+    return () -> null;
   }
 
   @Nonnull
@@ -35,14 +37,15 @@ public class MessagingNamingV1 implements NamingSchema.ForMessaging {
   }
 
   @Override
-  public String inboundService(@Nonnull String messagingSystem, boolean useLegacyTracing) {
-    return null;
+  public Supplier<String> inboundService(
+      @Nonnull String messagingSystem, boolean useLegacyTracing) {
+    return () -> null;
   }
 
   @Override
   @Nonnull
-  public String timeInQueueService(@Nonnull String messagingSystem) {
-    return messagingSystem + "-queue";
+  public Supplier<String> timeInQueueService(@Nonnull String messagingSystem) {
+    return () -> messagingSystem + "-queue";
   }
 
   @Nonnull

--- a/internal-api/src/test/groovy/datadog/trace/api/naming/NamingV0ForkedTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/naming/NamingV0ForkedTest.groovy
@@ -17,8 +17,8 @@ class NamingV0ForkedTest extends DDSpecification {
     then:
     assert SpanNaming.instance().version() == 0
     assert !schema.allowInferredServices()
-    assert schema.messaging().inboundService("anything", true) == null
-    assert schema.messaging().outboundService("anything", true) == null
+    assert schema.messaging().inboundService("anything", true) .get()== null
+    assert schema.messaging().outboundService("anything", true).get() == null
     assert schema.database().service("anything") == null
     assert schema.cache().service("anything") == null
     assert schema.cloud().serviceForRequest("any", "anything") == null


### PR DESCRIPTION
# What Does This Do

If a split-by-jee-deployment is used and the legacy tracing is disabled,  the service name for the message consumers spans will be initialized once with the first value it's obtained. 

This is not correct since in this case it has to be evaluated every time. This PR forces using a supplier for the service name and evaluates it every time when the decorator is setting the service name. In the general case, it will always returns a constant so it should not impact any performance.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
