### PR TITLE
Fix flakiness in Gradle Launcher smoke test

### DIFF
--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleLauncherSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleLauncherSmokeTest.groovy
@@ -51,11 +51,12 @@ class GradleLauncherSmokeTest extends AbstractGradleTest {
 
   private String whenRunningGradleLauncherWithJavaTracerInjected(String gradleDaemonCmdLineParams) {
     def shellCommandExecutor = new ShellCommandExecutor(projectFolder.toFile(), GRADLE_BUILD_TIMEOUT_MILLIS, [
-      "GRADLE_OPTS"                      : "-javaagent:${AGENT_JAR}".toString(),
-      "DD_CIVISIBILITY_ENABLED"          : "true",
-      "DD_CIVISIBILITY_AGENTLESS_ENABLED": "true",
-      "DD_CIVISIBILITY_AGENTLESS_URL"    : "${mockBackend.intakeUrl}".toString(),
-      "DD_API_KEY"                       : "dummy"
+      "GRADLE_OPTS"                        : "-javaagent:${AGENT_JAR}".toString(),
+      "DD_CIVISIBILITY_ENABLED"            : "true",
+      "DD_CIVISIBILITY_AGENTLESS_ENABLED"  : "true",
+      "DD_CIVISIBILITY_AGENTLESS_URL"      : "${mockBackend.intakeUrl}".toString(),
+      "DD_CIVISIBILITY_GIT_UPLOAD_ENABLED" : "false",
+      "DD_API_KEY"                         : "dummy"
     ])
     String[] command = ["./gradlew", "--no-daemon", "--info"]
     if (gradleDaemonCmdLineParams) {


### PR DESCRIPTION
# What Does This Do

Disables Git data upload in Gradle Launcher smoke test: the mock backend that is used by the test does not implement endpoints that are called for Git data upload. 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
