### PR TITLE
Refactored requires post-processing flag

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -33,7 +33,6 @@ import datadog.trace.api.http.StoredBodySupplier;
 import datadog.trace.api.internal.TraceSegment;
 import datadog.trace.api.telemetry.RuleType;
 import datadog.trace.api.telemetry.WafMetricCollector;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.util.stacktrace.StackTraceEvent;
@@ -618,16 +617,8 @@ public class GatewayBridge {
       }
     }
 
-    ctx.close(requiresPostProcessing(spanInfo));
+    ctx.close(spanInfo.isRequiresPostProcessing());
     return NoopFlow.INSTANCE;
-  }
-
-  private boolean requiresPostProcessing(final IGSpanInfo spanInfo) {
-    if (!(spanInfo instanceof AgentSpan)) {
-      return true; // be conservative
-    }
-    final AgentSpan span = (AgentSpan) spanInfo;
-    return span.isRequiresPostProcessing();
   }
 
   private Flow<Void> onRequestHeadersDone(RequestContext ctx_) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
@@ -13,7 +13,6 @@ import datadog.trace.common.writer.ddagent.Prioritization;
 import datadog.trace.common.writer.ddagent.PrioritizationStrategy;
 import datadog.trace.core.CoreSpan;
 import datadog.trace.core.DDSpan;
-import datadog.trace.core.DDSpanContext;
 import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.postprocessor.SpanPostProcessor;
 import java.util.ArrayList;
@@ -266,8 +265,7 @@ public class TraceProcessingWorker implements AutoCloseable {
       // Filter spans that need post-processing
       List<DDSpan> spansToPostProcess = null;
       for (DDSpan span : trace) {
-        DDSpanContext context = span.context();
-        if (context != null && context.isRequiresPostProcessing()) {
+        if (span.isRequiresPostProcessing()) {
           if (spansToPostProcess == null) {
             spansToPostProcess = new ArrayList<>();
           }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -841,6 +841,11 @@ public class DDSpan
     return context.isRequiresPostProcessing();
   }
 
+  @Override
+  public void setRequiresPostProcessing(boolean requiresPostProcessing) {
+    context.setRequiresPostProcessing(requiresPostProcessing);
+  }
+
   // to be accessible in Spock spies, which the field wouldn't otherwise be
   public long getStartTimeNano() {
     return startTimeNano;

--- a/internal-api/src/main/java/datadog/trace/api/gateway/IGSpanInfo.java
+++ b/internal-api/src/main/java/datadog/trace/api/gateway/IGSpanInfo.java
@@ -16,4 +16,8 @@ public interface IGSpanInfo {
   void setRequestBlockingAction(Flow.Action.RequestBlockingAction rba);
 
   Flow.Action.RequestBlockingAction getRequestBlockingAction();
+
+  boolean isRequiresPostProcessing();
+
+  void setRequiresPostProcessing(boolean requiresPostProcessing);
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -141,8 +141,6 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo, ImplicitContextKeyed
 
   void addLink(AgentSpanLink link);
 
-  boolean isRequiresPostProcessing();
-
   @Override
   default ScopedContext storeInto(ScopedContext context) {
     return context.with(ScopedContextKey.SPAN_KEY, this);

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -865,6 +865,9 @@ public class AgentTracer {
     public boolean isRequiresPostProcessing() {
       return false;
     }
+
+    @Override
+    public void setRequiresPostProcessing(boolean requiresPostProcessing) {}
   }
 
   public static final class NoopAgentScope implements AgentScope {


### PR DESCRIPTION
# What Does This Do
Refactored `requiresPostProcessing` flag. Now we are able to set post-processing flag from `AppSec` module

# Motivation
This is preparation work for new API Security Sampling

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
