### PR TITLE
Only decorate spans without code origin information 

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CodeOrigin05.java
@@ -1,0 +1,72 @@
+package com.datadog.debugger;
+
+import datadog.trace.bootstrap.debugger.spanorigin.CodeOriginInfo;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
+import datadog.trace.bootstrap.instrumentation.api.ScopeSource;
+import datadog.trace.core.DDSpan;
+
+public class CodeOrigin05 {
+  private int intField = 42;
+
+  private static TracerAPI tracerAPI = AgentTracer.get();
+
+  public static int main(String arg) throws ReflectiveOperationException {
+    AgentSpan span = newSpan("main");
+    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    if (arg.equals("debug_1")) {
+      ((DDSpan) span.getLocalRootSpan()).setTag("_dd.p.debug", "1");
+    } else if (arg.equals("debug_0")) {
+      ((DDSpan) span.getLocalRootSpan()).setTag("_dd.p.debug", "0");
+    }
+
+    fullTrace();
+
+    span.finish();
+    scope.close();
+
+    return 0;
+  }
+
+  private static void fullTrace() throws NoSuchMethodException {
+    AgentSpan span = newSpan("entry");
+    AgentScope scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    entry();
+    span.finish();
+    scope.close();
+
+    span = newSpan("exit");
+    scope = tracerAPI.activateSpan(span, ScopeSource.MANUAL);
+    exit();
+    span.finish();
+    scope.close();
+  }
+
+  private static AgentSpan newSpan(String name) {
+    return tracerAPI.buildSpan("code origin tests", name).start();
+  }
+
+  public static void entry() throws NoSuchMethodException {
+    // just to fill out the method body
+    boolean dummyCode = true;
+    if (!dummyCode) {
+      dummyCode = false;
+    }
+    doubleEntry();
+  }
+
+  private static void exit() {
+    int x = 47 / 3;
+  }
+
+  public static void doubleEntry() throws NoSuchMethodException {
+    // just to fill out the method body
+    boolean dummyCode = true;
+    if (!dummyCode) {
+      dummyCode = false;
+    }
+  }
+
+}


### PR DESCRIPTION
# What Does This Do

There are scenarios where multiple code origin probes might want to decorate the local root span, e.g., with information.  This PR ensures this only happens once.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3212]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3212]: https://datadoghq.atlassian.net/browse/DEBUG-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ