### PR TITLE
Improves ServiceNameCollector

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
@@ -53,7 +53,7 @@ public class ServiceNameCollector {
       }
       return;
     }
-    services.put(serviceName, serviceName);
+    services.putIfAbsent(serviceName, serviceName);
   }
 
   /**

--- a/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
@@ -4,10 +4,9 @@ import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
 import datadog.trace.api.Config;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -18,9 +17,6 @@ public class ServiceNameCollector {
   private static final Logger log = LoggerFactory.getLogger(ServiceNameCollector.class);
 
   private static final int MAX_EXTRA_SERVICE = Config.get().getRemoteConfigMaxExtraServices();
-
-  private static final String SERVICE_NAME_LOWERCASE =
-      Config.get().getServiceName().toLowerCase(Locale.ROOT);
 
   // This is not final to allow mocking it on tests
   private static ServiceNameCollector INSTANCE = new ServiceNameCollector();
@@ -67,16 +63,10 @@ public class ServiceNameCollector {
     if (services.isEmpty()) {
       return null;
     }
-    final Set<String> uniques = new HashSet<>(services.size());
-    // avoids reiterating again to convert a set to a list
-    final ArrayList<String> ret = new ArrayList<>(services.size());
-    for (String current : services.keySet()) {
-      String lowerCase = current.toLowerCase(Locale.ROOT);
-      if (!SERVICE_NAME_LOWERCASE.equals(lowerCase) && uniques.add(lowerCase)) {
-        ret.add(current);
-      }
-    }
-    return ret.isEmpty() ? null : ret;
+    final Set<String> uniqueNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+    uniqueNames.addAll(services.keySet());
+    uniqueNames.remove(Config.get().getServiceName());
+    return uniqueNames.isEmpty() ? null : new ArrayList<>(uniqueNames);
   }
 
   public void clear() {

--- a/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/remoteconfig/ServiceNameCollector.java
@@ -4,8 +4,10 @@ import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
 import datadog.trace.api.Config;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -16,6 +18,9 @@ public class ServiceNameCollector {
   private static final Logger log = LoggerFactory.getLogger(ServiceNameCollector.class);
 
   private static final int MAX_EXTRA_SERVICE = Config.get().getRemoteConfigMaxExtraServices();
+
+  private static final String SERVICE_NAME_LOWERCASE =
+      Config.get().getServiceName().toLowerCase(Locale.ROOT);
 
   // This is not final to allow mocking it on tests
   private static ServiceNameCollector INSTANCE = new ServiceNameCollector();
@@ -48,14 +53,30 @@ public class ServiceNameCollector {
       }
       return;
     }
-    if (!Config.get().getServiceName().equalsIgnoreCase(serviceName)) {
-      services.put(serviceName.toLowerCase(Locale.ROOT), serviceName);
-    }
+    services.put(serviceName, serviceName);
   }
 
+  /**
+   * Get the list of unique services deduplicated by case. There is no locking on the addService map
+   * so, the method is not thread safe.
+   *
+   * @return
+   */
   @Nullable
   public List<String> getServices() {
-    return services.isEmpty() ? null : new ArrayList<>(services.values());
+    if (services.isEmpty()) {
+      return null;
+    }
+    final Set<String> uniques = new HashSet<>(services.size());
+    // avoids reiterating again to convert a set to a list
+    final ArrayList<String> ret = new ArrayList<>(services.size());
+    for (String current : services.keySet()) {
+      String lowerCase = current.toLowerCase(Locale.ROOT);
+      if (!SERVICE_NAME_LOWERCASE.equals(lowerCase) && uniques.add(lowerCase)) {
+        ret.add(current);
+      }
+    }
+    return ret.isEmpty() ? null : ret;
   }
 
   public void clear() {


### PR DESCRIPTION
# What Does This Do

ServiceNameCollector.add is called very frequently. This PR aims moving the expensive operations inside it (i.e. string case transformation, default service name deduplication) to the `getServices` method that's called way more infrequently 

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
