### PR TITLE
K8s Lib Injection tests run on a matrix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -220,8 +220,9 @@ onboarding_tests_installer:
         SCENARIO: [ SIMPLE_INSTALLER_AUTO_INJECTION, SIMPLE_AUTO_INJECTION_PROFILING ]
 
 onboarding_tests_k8s_injection:
-  variables:
-    WEBLOG_VARIANT: dd-lib-java-init-test-app
+  parallel:
+    matrix:
+      - WEBLOG_VARIANT: [dd-lib-java-init-test-app]
 
 create_key:
   stage: generate-signing-key


### PR DESCRIPTION
# What Does This Do
This PR run the K8s Lib injection tests on a matrix.
# Motivation
This change is necessary because we are going to change the "one pipeline" and these changes could break dd-trace-js pipeline. We need to merge this PR before merging the "one pipeline".
it is the first PR to do this adaptation step by step.

# Additional Notes
Coming PRs to apply the change:

- system-tests PR changing the K8s lib injection tests: https://github.com/DataDog/system-tests/pull/3689
- one pipeline PR: https://github.com/DataDog/libdatadog-build/pull/59/files
- Final PR on dd-trace-java: https://github.com/DataDog/dd-trace-java/pull/8103/files

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
