### PR TITLE
Check logs for errors at smoke tests cleanup

### DIFF
--- a/dd-smoke-tests/armeria-grpc/src/test/groovy/datadog/smoketest/ArmeriaSmokeTest.groovy
+++ b/dd-smoke-tests/armeria-grpc/src/test/groovy/datadog/smoketest/ArmeriaSmokeTest.groovy
@@ -57,8 +57,6 @@ class ArmeriaSmokeTest extends AbstractServerSmokeTest {
     })
     waitForTraceCount(totalInvocations) >= totalInvocations
     validateLogInjection() == totalInvocations
-    checkLogPostExit()
-    !logHasErrors
   }
 
   void doAndValidateRequest(int id) {

--- a/dd-smoke-tests/asm-standalone-billing/src/test/groovy/datadog/smoketest/asmstandalonebilling/AsmStandaloneBillingSmokeTest.groovy
+++ b/dd-smoke-tests/asm-standalone-billing/src/test/groovy/datadog/smoketest/asmstandalonebilling/AsmStandaloneBillingSmokeTest.groovy
@@ -64,10 +64,8 @@ class AsmStandaloneBillingSmokeTest extends AbstractAsmStandaloneBillingSmokeTes
     def computedStatsHeader = lastTraceRequestHeaders.get('Datadog-Client-Computed-Stats')
     assert computedStatsHeader != null && computedStatsHeader == 'true'
 
-    then:'metrics should be disabled'
-    checkLogPostExit { log ->
-      return log.contains('datadog.trace.agent.common.metrics.MetricsAggregatorFactory - tracer metrics disabled')
-    }
+    then: 'metrics should be disabled'
+    isLogPresent { it.contains('datadog.trace.agent.common.metrics.MetricsAggregatorFactory - tracer metrics disabled') }
   }
 
   void 'test _dd.p.appsec propagation for appsec event'() {

--- a/dd-smoke-tests/custom-systemloader/src/test/groovy/datadog/smoketest/CustomSystemLoaderSmokeTest.groovy
+++ b/dd-smoke-tests/custom-systemloader/src/test/groovy/datadog/smoketest/CustomSystemLoaderSmokeTest.groovy
@@ -30,20 +30,21 @@ class CustomSystemLoaderSmokeTest extends AbstractSmokeTest {
   def "resource types loaded by custom system class-loader are transformed"() {
     when:
     testedProcess.waitFor(TIMEOUT_SECS, SECONDS)
+
+    then:
+    testedProcess.exitValue() == 0
     int loadedResources = 0
     int transformedResources = 0
-    checkLogPostExit {
+    assertNoErrorLogs { String it ->
       if (it =~ /Loading sample.app.Resource[$]Test[1-3] from TestLoader/) {
         loadedResources++
       }
       if (it =~ /Transformed.*class=sample.app.Resource[$]Test[1-3].*classloader=datadog.smoketest.systemloader.TestLoader/) {
         transformedResources++
       }
+      false
     }
-    then:
-    testedProcess.exitValue() == 0
     loadedResources == 3
     transformedResources == 3
-    !logHasErrors
   }
 }

--- a/dd-smoke-tests/custom-systemloader/src/test/groovy/datadog/smoketest/CustomSystemLoaderSmokeTest.groovy
+++ b/dd-smoke-tests/custom-systemloader/src/test/groovy/datadog/smoketest/CustomSystemLoaderSmokeTest.groovy
@@ -35,14 +35,13 @@ class CustomSystemLoaderSmokeTest extends AbstractSmokeTest {
     testedProcess.exitValue() == 0
     int loadedResources = 0
     int transformedResources = 0
-    assertNoErrorLogs { String it ->
+    forEachLogLine { String it ->
       if (it =~ /Loading sample.app.Resource[$]Test[1-3] from TestLoader/) {
         loadedResources++
       }
       if (it =~ /Transformed.*class=sample.app.Resource[$]Test[1-3].*classloader=datadog.smoketest.systemloader.TestLoader/) {
         transformedResources++
       }
-      false
     }
     loadedResources == 3
     transformedResources == 3

--- a/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/SsrfController.java
+++ b/dd-smoke-tests/iast-util/src/main/java/datadog/smoketest/springboot/controller/SsrfController.java
@@ -80,7 +80,10 @@ public class SsrfController {
     } catch (final Exception e) {
     }
     client.getDispatcher().getExecutorService().shutdown();
-    client.getConnectionPool().evictAll();
+    com.squareup.okhttp.ConnectionPool pool = client.getConnectionPool();
+    if (pool != null) {
+      pool.evictAll();
+    }
     return "ok";
   }
 

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastServerSmokeTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastServerSmokeTest.groovy
@@ -54,10 +54,7 @@ abstract class AbstractIastServerSmokeTest extends AbstractServerSmokeTest {
     try {
       processTestLogLines(closure)
     } catch (TimeoutException toe) {
-      checkLogPostExit(closure)
-      if (!found) {
-        throw new AssertionError("No matching tainted found. Tainteds found: ${new JsonBuilder(tainteds).toPrettyString()}")
-      }
+      assert found, "No matching tainted found. Tainteds found: ${new JsonBuilder(tainteds).toPrettyString()}"
     }
   }
 
@@ -81,12 +78,11 @@ abstract class AbstractIastServerSmokeTest extends AbstractServerSmokeTest {
       return false
     }
     try {
-      processTestLogLines(closure)
-    } catch (TimeoutException toe) {
-      checkLogPostExit(closure)
-      if (!found) {
-        throw new AssertionError("No matching vulnerability found. Vulnerabilities found: ${new JsonBuilder(vulnerabilities).toPrettyString()}")
+      processTestLogLines {
+        closure(it)
       }
+    } catch (TimeoutException toe) {
+      assert found, "No matching vulnerability found. Vulnerabilities found: ${new JsonBuilder(vulnerabilities).toPrettyString()}"
     }
   }
 

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastServerSmokeTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastServerSmokeTest.groovy
@@ -78,9 +78,7 @@ abstract class AbstractIastServerSmokeTest extends AbstractServerSmokeTest {
       return false
     }
     try {
-      processTestLogLines {
-        closure(it)
-      }
+      processTestLogLines(closure)
     } catch (TimeoutException toe) {
       assert found, "No matching vulnerability found. Vulnerabilities found: ${new JsonBuilder(vulnerabilities).toPrettyString()}"
     }

--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastSpringBootTest.groovy
@@ -41,18 +41,6 @@ abstract class AbstractIastSpringBootTest extends AbstractIastServerSmokeTest {
 
   @Override
   boolean isErrorLog(String log) {
-    // XXX: Flaky profiler exception:
-    // java.lang.Error: not finished chunk 2024-12-18T21:17:11.612Z
-    //        at jdk.jfr.internal.PlatformRecording.appendChunk(PlatformRecording.java:515)
-    //        at jdk.jfr.internal.PlatformRecorder.finishChunk(PlatformRecorder.java:396)
-    //        at jdk.jfr.internal.PlatformRecorder.rotateDisk(PlatformRecorder.java:349)
-    //        at jdk.jfr.internal.PlatformRecorder.fillWithRecordedData(PlatformRecorder.java:511)
-    //        at jdk.jfr.FlightRecorder.takeSnapshot(FlightRecorder.java:116)
-    //        at com.datadog.profiling.controller.openjdk.OpenJdkOngoingRecording.snapshot(OpenJdkOngoingRecording.java:155)
-    if (log.contains('ERROR com.datadog.profiling.controller.ProfilingSystem - Fatal exception in profiling thread, trying to continue')) {
-      return false
-    }
-
     if (log.contains('no such algorithm: DES for provider SUN')) {
       return false
     }

--- a/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
+++ b/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
@@ -23,6 +23,17 @@ class Java9ModulesSmokeTest extends AbstractSmokeTest {
     processBuilder.directory(new File(buildDirectory))
   }
 
+  @Override
+  boolean isErrorLog(String log) {
+    // XXX: This test will make the tracer to fail at bootstrap:
+    //      Caused by: java.lang.NoClassDefFoundError: java/lang/management/ManagementFactory
+    //        at datadog.trace.api.Platform$GC.current(Platform.java:32)
+    if (log.contains('ERROR datadog.trace.bootstrap.AgentBootstrap')) {
+      return false
+    }
+    return super.isErrorLog(log)
+  }
+
   def "Module application runs correctly"() {
     expect:
     assert testedProcess.waitFor(TIMEOUT_SECS, SECONDS)

--- a/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
+++ b/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
@@ -23,6 +23,12 @@ class Java9ModulesSmokeTest extends AbstractSmokeTest {
     processBuilder.directory(new File(buildDirectory))
   }
 
+  @Override
+  boolean isErrorLog(String line) {
+    // FIXME: Too many bootstrap errors.
+    return false
+  }
+
   def "Module application runs correctly"() {
     expect:
     assert testedProcess.waitFor(TIMEOUT_SECS, SECONDS)

--- a/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
+++ b/dd-smoke-tests/java9-modules/src/test/groovy/datadog/smoketest/Java9ModulesSmokeTest.groovy
@@ -23,17 +23,6 @@ class Java9ModulesSmokeTest extends AbstractSmokeTest {
     processBuilder.directory(new File(buildDirectory))
   }
 
-  @Override
-  boolean isErrorLog(String log) {
-    // XXX: This test will make the tracer to fail at bootstrap:
-    //      Caused by: java.lang.NoClassDefFoundError: java/lang/management/ManagementFactory
-    //        at datadog.trace.api.Platform$GC.current(Platform.java:32)
-    if (log.contains('ERROR datadog.trace.bootstrap.AgentBootstrap')) {
-      return false
-    }
-    return super.isErrorLog(log)
-  }
-
   def "Module application runs correctly"() {
     expect:
     assert testedProcess.waitFor(TIMEOUT_SECS, SECONDS)

--- a/dd-smoke-tests/jboss-modules/src/test/groovy/datadog/smoketest/AbstractModulesSmokeTest.groovy
+++ b/dd-smoke-tests/jboss-modules/src/test/groovy/datadog/smoketest/AbstractModulesSmokeTest.groovy
@@ -28,27 +28,20 @@ abstract class AbstractModulesSmokeTest extends AbstractSmokeTest {
     return processBuilder
   }
 
+  @Override
+  boolean isErrorLog(String log) {
+    super.isErrorLog(log) || log.contains("Cannot resolve type description") || log.contains("Instrumentation muzzled")
+  }
+
   def "example application runs without errors"() {
     when:
     testedProcess.waitFor()
-    boolean instrumentedMessageClient = false
-    checkLogPostExit {
-      // check for additional OSGi class-loader issues
-      if (it.contains("Cannot resolve type description") ||
-        it.contains("Instrumentation muzzled")) {
-        println it
-        logHasErrors = true
-      }
-      if (it.contains("Transformed - instrumentation.target.class=datadog.smoketest.jbossmodules.client.MessageClient")) {
-        println it
-        instrumentedMessageClient = true
-      }
-    }
 
-    then:
+    then: 'MessageClient is transformed'
     testedProcess.exitValue() == 0
-    instrumentedMessageClient
-    !logHasErrors
+    processTestLogLines {
+      it.contains("Transformed - instrumentation.target.class=datadog.smoketest.jbossmodules.client.MessageClient")
+    }
   }
 
   @Override

--- a/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
+++ b/dd-smoke-tests/log-injection/src/test/groovy/datadog/smoketest/LogInjectionSmokeTest.groovy
@@ -105,6 +105,21 @@ abstract class LogInjectionSmokeTest extends AbstractSmokeTest {
   }
 
   @Override
+  boolean isErrorLog(String log) {
+    // Exclude some errors that we consistently get because of the logging setups used here:
+    if (log.contains('no applicable action for [immediateFlush]')) {
+      return false
+    }
+    if (log.contains('JSONLayout contains an invalid element or attribute')) {
+      return false
+    }
+    if (log.contains('JSONLayout has no parameter that matches element')) {
+      return false
+    }
+    return super.isErrorLog(log)
+  }
+
+  @Override
   def logLevel() {
     return "debug"
   }

--- a/dd-smoke-tests/osgi/src/test/groovy/datadog/smoketest/AbstractOSGiSmokeTest.groovy
+++ b/dd-smoke-tests/osgi/src/test/groovy/datadog/smoketest/AbstractOSGiSmokeTest.groovy
@@ -37,27 +37,20 @@ abstract class AbstractOSGiSmokeTest extends AbstractSmokeTest {
 
   abstract List<String> frameworkArguments()
 
+  @Override
+  boolean isErrorLog(String log) {
+    super.isErrorLog(log) || log.contains("Cannot resolve type description") || log.contains("Instrumentation muzzled")
+  }
+
   def "example application runs without errors"() {
     when:
     testedProcess.waitFor()
-    boolean instrumentedMessageClient = false
-    checkLogPostExit {
-      // check for additional OSGi class-loader issues
-      if (it.contains("Cannot resolve type description") ||
-        it.contains("Instrumentation muzzled")) {
-        println it
-        logHasErrors = true
-      }
-      if (it.contains("Transformed - instrumentation.target.class=datadog.smoketest.osgi.client.MessageClient")) {
-        println it
-        instrumentedMessageClient = true
-      }
-    }
 
     then:
     testedProcess.exitValue() == 0
-    instrumentedMessageClient
-    !logHasErrors
+    processTestLogLines {
+      it.contains("Transformed - instrumentation.target.class=datadog.smoketest.osgi.client.MessageClient")
+    }
   }
 
   @Override

--- a/dd-smoke-tests/quarkus-native/src/test/groovy/datadog/smoketest/QuarkusNativeSmokeTest.groovy
+++ b/dd-smoke-tests/quarkus-native/src/test/groovy/datadog/smoketest/QuarkusNativeSmokeTest.groovy
@@ -55,8 +55,6 @@ abstract class QuarkusNativeSmokeTest extends AbstractServerSmokeTest {
     })
     waitForTraceCount(totalInvocations) == totalInvocations
     validateLogInjection(resourceName()) == totalInvocations
-    checkLogPostExit()
-    !logHasErrors
   }
 
   void doAndValidateRequest(int id) {

--- a/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSmokeTest.groovy
+++ b/dd-smoke-tests/quarkus/src/test/groovy/datadog/smoketest/QuarkusSmokeTest.groovy
@@ -57,8 +57,6 @@ abstract class QuarkusSmokeTest extends AbstractServerSmokeTest {
     })
     waitForTraceCount(totalInvocations) == totalInvocations
     validateLogInjection(resourceName()) == totalInvocations
-    checkLogPostExit()
-    !logHasErrors
   }
 
   void doAndValidateRequest(int id) {

--- a/dd-smoke-tests/spring-boot-3.0-native/src/test/groovy/SpringBootNativeInstrumentationTest.groovy
+++ b/dd-smoke-tests/spring-boot-3.0-native/src/test/groovy/SpringBootNativeInstrumentationTest.groovy
@@ -60,6 +60,12 @@ class SpringBootNativeInstrumentationTest extends AbstractServerSmokeTest {
     false
   }
 
+  @Override
+  boolean isErrorLog(String log) {
+    // Check that there are no ClassNotFound errors printed from bad reflect-config.json
+    super.isErrorLog(log) || log.contains("ClassNotFoundException")
+  }
+
   def "check native instrumentation"() {
     setup:
     String url = "http://localhost:${httpPort}/hello"
@@ -81,18 +87,6 @@ class SpringBootNativeInstrumentationTest extends AbstractServerSmokeTest {
       LockSupport.parkNanos(1_000_000)
     }
     countJfrs() > 0
-
-    when:
-    checkLogPostExit {
-      // Check that there are no ClassNotFound errors printed from bad reflect-config.json
-      if (it.contains("ClassNotFoundException")) {
-        println "Found ClassNotFoundException in log: ${it}"
-        logHasErrors = true
-      }
-    }
-
-    then:
-    !logHasErrors
   }
 
   int countJfrs() {

--- a/dd-smoke-tests/spring-boot-rabbit/src/test/groovy/datadog/smoketest/SpringBootRabbitIntegrationTest.groovy
+++ b/dd-smoke-tests/spring-boot-rabbit/src/test/groovy/datadog/smoketest/SpringBootRabbitIntegrationTest.groovy
@@ -89,6 +89,14 @@ class SpringBootRabbitIntegrationTest extends AbstractServerSmokeTest {
     return expected
   }
 
+  @Override
+  boolean isErrorLog(String log) {
+    if (log.contains('org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer - Failed to check/redeclare auto-delete queue(s).')) {
+      return false
+    }
+    return super.isErrorLog(log)
+  }
+
   def "check message #message roundtrip"() {
     setup:
     String url = "http://localhost:${httpPort}/roundtrip/${message}"

--- a/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/springboot/src/test/groovy/datadog/smoketest/IastSpringBootSmokeTest.groovy
@@ -40,13 +40,17 @@ class IastSpringBootSmokeTest extends AbstractIastSpringBootTest {
 
     then:
     response.successful
-    hasVulnerabilityInLogs {
-      vul ->
-      vul.type == 'HARDCODED_SECRET'
-      && vul.location.method == 'hardcodedSecret'
-      && vul.location.path == 'datadog.smoketest.springboot.controller.HardcodedSecretController'
-      && vul.location.line == 11
-      && vul.evidence.value == 'age-secret-key'
+    isLogPresent {
+      String log ->
+      def vulns = parseVulnerabilitiesLog(log)
+      vulns.any {
+        vul ->
+        vul.type == 'HARDCODED_SECRET'
+        && vul.location.method == 'hardcodedSecret'
+        && vul.location.path == 'datadog.smoketest.springboot.controller.HardcodedSecretController'
+        && vul.location.line == 11
+        && vul.evidence.value == 'age-secret-key'
+      }
     }
   }
 

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/AbstractSmokeTest.groovy
@@ -243,6 +243,7 @@ abstract class AbstractSmokeTest extends ProcessManager {
 
   def cleanupSpec() {
     stopServer()
+    assertNoErrorLogs()
   }
 
   def startServer() {

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -262,7 +262,7 @@ abstract class ProcessManager extends Specification {
    *
    * @param errorFilter Returns true if certain log line must be considered an error.
    */
-  void assertNoErrorLogs(final Closure<Boolean> errorFilter = { String it -> isErrorLog(it) }) {
+  void assertNoErrorLogs(final Closure<Boolean> errorFilter = this.&isErrorLog) {
     final List<String> errorLogs = new ArrayList<>()
     forEachLogLine { String line ->
       if (errorFilter(line)) {

--- a/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
+++ b/dd-smoke-tests/src/main/groovy/datadog/smoketest/ProcessManager.groovy
@@ -250,6 +250,11 @@ abstract class ProcessManager extends Specification {
    * These will be checked on suite shutdown, or explicitly by calling {@link #assertNoErrorLogs()}.
    */
   boolean isErrorLog(String line) {
+    // FIXME: Flaky profiler exception. See PROF-11068.
+    if (line.contains('ERROR com.datadog.profiling.controller.ProfilingSystem - Fatal exception in profiling thread, trying to continue')) {
+      return false
+    }
+
     return line.contains("ERROR") || line.contains("ASSERTION FAILED")
     || line.contains("Failed to handle exception in instrumentation")
   }


### PR DESCRIPTION
# What Does This Do

* Add `boolean isErrorLog(String line)` defining what is considered an error log for a given smoke test. Most smoke tests can just rely on the default. This PR includes several examples on how to extend it, both to add additional errors, or to exclude some errors.
* Add `void assertNoErrorLogs(final Closure<Boolean> errorFilter)`, which can be used to assert there are no error logs. Most tests should not use directly, and when they do, they should do it only after the test process has finished (otherwise, the test may be flaky).
* Call `assertNoErrorLogs` on `cleanupSpec` for every smoke test. Most suites were not checking error logs.
* Use `processTestLogLines` when we need to wait for a log line that is supposed to be printed. This should be less flaky than `assertNoErrorLogs` in the case where the test process has not ended.
* Remove `checkLogPostExit`, which was superseded by the above methods.

# Motivation

We have various flaky tests on smoke tests, and sometimes non-flaky failures that are hard to diagnose, that show up in errors all just as:

```
Condition not satisfied:

!logHasErrors
||
|true
false
```

This means there was an error printed to logs, but to find which one we need to download `reports.tar` and dig into the logs.

After this PR, they look like this:

```
Condition not satisfied:

errorLogs.isEmpty()
|         |
|         false
[16:39:08,836 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@5:21 - no applicable action for [immediateFlush], current pattern is [[configuration][appender][immediateFlush]], 16:39:08,984 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@15:21 - no applicable action for [immediateFlush], current pattern is [[configuration][appender][immediateFlush]]]

Test application log contains 2 errors:
1: 16:39:08,836 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@5:21 - no applicable action for [immediateFlush], current pattern is [[configuration][appender][immediateFlush]]
2: 16:39:08,984 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@15:21 - no applicable action for [immediateFlush], current pattern is [[configuration][appender][immediateFlush]]


	at datadog.smoketest.ProcessManager.assertNoErrorLogs(ProcessManager.groovy:294)
	at datadog.smoketest.ProcessManager.assertNoErrorLogs(ProcessManager.groovy:259)
	at datadog.smoketest.AbstractSmokeTest.cleanupSpec(AbstractSmokeTest.groovy:246)
```

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
