### PR TITLE
Allow multivalue multiline header extraction

### DIFF
--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/baseTest/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.0/src/baseTest/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -36,10 +36,10 @@ abstract class AkkaHttpClientInstrumentationTest extends HttpClientTest {
   abstract CompletionStage<HttpResponse> doRequest(HttpRequest request)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = HttpRequest.create(uri.toString())
       .withMethod(HttpMethods.lookup(method).get())
-      .addHeaders(headers.collect { RawHeader.create(it.key, it.value) })
+      .addHeaders(headers.collect { RawHeader.create(it[0], it[1]) })
 
     def response
     try {

--- a/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http/akka-http-10.6/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -25,10 +25,10 @@ abstract class AkkaHttpClientInstrumentationTest extends HttpClientTest {
   abstract CompletionStage<HttpResponse> doRequest(HttpRequest request)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = HttpRequest.create(uri.toString())
       .withMethod(HttpMethods.lookup(method).get())
-      .addHeaders(headers.collect { RawHeader.create(it.key, it.value) })
+      .addHeaders(headers.collect { RawHeader.create(it[0], it[1]) })
 
     def response
     try {

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
@@ -60,9 +60,16 @@ public class ApacheHttpAsyncClientDecorator
 
   @Override
   protected String getRequestHeader(HttpUriRequest request, String headerName) {
-    Header header = request.getFirstHeader(headerName);
-    if (header != null) {
-      return header.getValue();
+    Header[] headers = request.getHeaders(headerName);
+    if (headers.length > 0) {
+      StringBuilder result = new StringBuilder();
+      for (int i = 0; i < headers.length; i++) {
+        result.append(headers[i].getValue());
+        if (i + 1 < headers.length) {
+          result.append(",");
+        }
+      }
+      return result.toString();
     }
     return null;
   }
@@ -71,9 +78,16 @@ public class ApacheHttpAsyncClientDecorator
   protected String getResponseHeader(HttpContext context, String headerName) {
     final Object responseObject = context.getAttribute(HttpCoreContext.HTTP_RESPONSE);
     if (responseObject instanceof HttpResponse) {
-      Header header = ((HttpResponse) responseObject).getFirstHeader(headerName);
-      if (header != null) {
-        return header.getValue();
+      Header[] headers = ((HttpResponse) responseObject).getHeaders(headerName);
+      if (headers.length > 0) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < headers.length; i++) {
+          result.append(headers[i].getValue());
+          if (i + 1 < headers.length) {
+            result.append(",");
+          }
+        }
+        return result.toString();
       }
     }
     return null;

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/HostAndRequestAsHttpUriRequest.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/HostAndRequestAsHttpUriRequest.java
@@ -72,6 +72,11 @@ public class HostAndRequestAsHttpUriRequest extends AbstractHttpMessage implemen
     return actualRequest.getFirstHeader(name);
   }
 
+  @Override
+  public Header[] getHeaders(String name) {
+    return actualRequest.getHeaders(name);
+  }
+
   public HttpRequest getActualRequest() {
     return actualRequest;
   }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -31,11 +31,9 @@ class ApacheHttpAsyncClientCallbackTest extends HttpClientTest2 implements Testi
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = new HttpUriRequest(method, uri)
-    headers.entrySet().each {
-      request.addHeader(new BasicHeader(it.key, it.value))
-    }
+    headers.each { request.addHeader(new BasicHeader(it[0], it[1])) }
 
     def responseFuture = new CompletableFuture<>()
 

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import org.apache.http.HttpResponse
@@ -14,7 +14,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 @Timeout(5)
-class ApacheHttpAsyncClientCallbackTest extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+class ApacheHttpAsyncClientCallbackTest extends HttpClientTest2 implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import org.apache.http.client.config.RequestConfig
@@ -11,7 +11,7 @@ import spock.lang.Timeout
 import java.util.concurrent.Future
 
 @Timeout(5)
-class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0{
+class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest2 implements TestingGenericHttpNamingConventions.ClientV0{
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -28,11 +28,9 @@ class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest2 implements T
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = new HttpUriRequest(method, uri)
-    headers.entrySet().each {
-      request.addHeader(new BasicHeader(it.key, it.value))
-    }
+    headers.each { request.addHeader(new BasicHeader(it[0], it[1])) }
 
     // The point here is to test case when callback is null - fire-and-forget style
     // So to make sure request is done we start request, wait for future to finish

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -1,5 +1,5 @@
 import datadog.trace.agent.test.asserts.TraceAssert
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import org.apache.http.HttpHost
@@ -16,7 +16,7 @@ import spock.lang.Timeout
 import java.util.concurrent.CountDownLatch
 
 @Timeout(5)
-abstract class ApacheHttpAsyncClientTest extends HttpClientTest {
+abstract class ApacheHttpAsyncClientTest extends HttpClientTest2 {
 
   @Shared
   RequestConfig requestConfig = RequestConfig.custom()

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -41,11 +41,9 @@ abstract class ApacheHttpAsyncClientTest extends HttpClientTest2 {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = createRequest(method, uri)
-    headers.entrySet().each {
-      request.addHeader(new BasicHeader(it.key, it.value))
-    }
+    headers.each { request.addHeader(new BasicHeader(it[0], it[1])) }
 
     def latch = new CountDownLatch(callback == null ? 0 : 1)
 

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
@@ -46,18 +46,32 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriReques
 
   @Override
   protected String getRequestHeader(HttpUriRequest request, String headerName) {
-    Header header = request.getFirstHeader(headerName);
-    if (null != header) {
-      return header.getValue();
+    Header[] headers = request.getHeaders(headerName);
+    if (headers.length > 0) {
+      StringBuilder result = new StringBuilder();
+      for (int i = 0; i < headers.length; i++) {
+        result.append(headers[i].getValue());
+        if (i + 1 < headers.length) {
+          result.append(",");
+        }
+      }
+      return result.toString();
     }
     return null;
   }
 
   @Override
   protected String getResponseHeader(HttpResponse response, String headerName) {
-    Header header = response.getFirstHeader(headerName);
-    if (null != header) {
-      return header.getValue();
+    Header[] headers = response.getHeaders(headerName);
+    if (headers.length > 0) {
+      StringBuilder result = new StringBuilder();
+      for (int i = 0; i < headers.length; i++) {
+        result.append(headers[i].getValue());
+        if (i + 1 < headers.length) {
+          result.append(",");
+        }
+      }
+      return result.toString();
     }
     return null;
   }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HostAndRequestAsHttpUriRequest.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/main/java/datadog/trace/instrumentation/apachehttpclient/HostAndRequestAsHttpUriRequest.java
@@ -68,6 +68,11 @@ public class HostAndRequestAsHttpUriRequest extends AbstractHttpMessage implemen
     return actualRequest.getFirstHeader(name);
   }
 
+  @Override
+  public Header[] getHeaders(String name) {
+    return actualRequest.getHeaders(name);
+  }
+
   public HttpRequest getActualRequest() {
     return actualRequest;
   }

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator
 import org.apache.http.HttpResponse
@@ -11,7 +11,7 @@ import spock.lang.Shared
 import spock.lang.Timeout
 
 @Timeout(5)
-class ApacheHttpClientResponseHandlerTest extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+class ApacheHttpClientResponseHandlerTest extends HttpClientTest2 implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Shared
   def client = new DefaultHttpClient()

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -31,11 +31,9 @@ class ApacheHttpClientResponseHandlerTest extends HttpClientTest2 implements Tes
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = new HttpUriRequest(method, uri)
-    headers.entrySet().each {
-      request.addHeader(new BasicHeader(it.key, it.value))
-    }
+    headers.each { request.addHeader(new BasicHeader(it[0], it[1])) }
 
     def status = client.execute(request, handler)
 

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient.ApacheHttpClientDecorator
 import org.apache.http.HttpHost
@@ -13,7 +13,7 @@ import org.apache.http.protocol.BasicHttpContext
 import spock.lang.Shared
 import spock.lang.Timeout
 
-abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest2 implements TestingGenericHttpNamingConventions.ClientV0 {
   @Shared
   def client = new DefaultHttpClient()
 

--- a/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-4/src/test/groovy/ApacheHttpClientTest.groovy
@@ -29,11 +29,9 @@ abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTes
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = createRequest(method, uri)
-    headers.entrySet().each {
-      request.addHeader(new BasicHeader(it.key, it.value))
-    }
+    headers.each { request.addHeader(new BasicHeader(it[0], it[1])) }
 
     def response = executeRequest(request, uri)
     callback?.call()

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientDecorator.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpClientDecorator.java
@@ -54,18 +54,32 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
 
   @Override
   protected String getRequestHeader(HttpRequest request, String headerName) {
-    Header header = request.getFirstHeader(headerName);
-    if (null != header) {
-      return header.getValue();
+    Header[] headers = request.getHeaders(headerName);
+    if (headers.length > 0) {
+      StringBuilder result = new StringBuilder();
+      for (int i = 0; i < headers.length; i++) {
+        result.append(headers[i].getValue());
+        if (i + 1 < headers.length) {
+          result.append(",");
+        }
+      }
+      return result.toString();
     }
     return null;
   }
 
   @Override
   protected String getResponseHeader(HttpResponse response, String headerName) {
-    Header header = response.getFirstHeader(headerName);
-    if (null != header) {
-      return header.getValue();
+    Header[] headers = response.getHeaders(headerName);
+    if (headers.length > 0) {
+      StringBuilder result = new StringBuilder();
+      for (int i = 0; i < headers.length; i++) {
+        result.append(headers[i].getValue());
+        if (i + 1 < headers.length) {
+          result.append(",");
+        }
+      }
+      return result.toString();
     }
     return null;
   }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HostAndRequestAsHttpUriRequest.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/HostAndRequestAsHttpUriRequest.java
@@ -39,4 +39,9 @@ public class HostAndRequestAsHttpUriRequest extends BasicClassicHttpRequest {
   public Header getFirstHeader(String name) {
     return actualRequest.getFirstHeader(name);
   }
+
+  @Override
+  public Header[] getHeaders(String name) {
+    return actualRequest.getHeaders(name);
+  }
 }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
@@ -45,10 +45,10 @@ abstract class ApacheHttpAsyncClient5Test<T extends HttpRequest> extends HttpCli
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = SimpleHttpRequests.create(method, uri)
     request.setConfig(RequestConfig.custom().setConnectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS).build())
-    headers.each { request.addHeader(it.key, it.value) }
+    headers.each { request.addHeader(it[0], it[1]) }
 
     def future = client.execute(request, null)
     def response = future.get(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequests
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
 
 import static org.apache.hc.core5.reactor.IOReactorConfig.custom
 
-abstract class ApacheHttpAsyncClient5Test<T extends HttpRequest> extends HttpClientTest {
+abstract class ApacheHttpAsyncClient5Test<T extends HttpRequest> extends HttpClientTest2 {
 
   @Shared
   def ioReactorConfig = custom()

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -38,11 +38,9 @@ class ApacheHttpClientResponseHandlerTest extends HttpClientTest2 implements Tes
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = new BasicClassicHttpRequest(method, uri)
-    headers.entrySet().each {
-      request.addHeader(new BasicHeader(it.key, it.value))
-    }
+    headers.each { request.addHeader(new BasicHeader(it[0], it[1])) }
 
     CloseableHttpResponse response = null
     def status = client.execute(request, handler)

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator
 import org.apache.hc.client5.http.config.RequestConfig
@@ -15,7 +15,7 @@ import spock.lang.Timeout
 import java.util.concurrent.TimeUnit
 
 @Timeout(5)
-class ApacheHttpClientResponseHandlerTest extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+class ApacheHttpClientResponseHandlerTest extends HttpClientTest2 implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Shared
   def client = HttpClients.custom()

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator
 import org.apache.hc.client5.http.config.RequestConfig
@@ -16,7 +16,7 @@ import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
-abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest implements TestingGenericHttpNamingConventions.ClientV0 {
+abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest2 implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Shared
   def client = HttpClients.custom()

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
@@ -31,11 +31,9 @@ abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTes
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = createRequest(method, uri)
-    headers.entrySet().each {
-      request.addHeader(new BasicHeader(it.key, it.value))
-    }
+    headers.each { request.addHeader(new BasicHeader(it[0], it[1])) }
 
     CloseableHttpResponse response = null
     try {

--- a/dd-java-agent/instrumentation/commons-httpclient-2/src/test/groovy/CommonsHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/commons-httpclient-2/src/test/groovy/CommonsHttpClientTest.groovy
@@ -24,7 +24,7 @@ abstract class CommonsHttpClientTest extends HttpClientTest {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     HttpMethod httpMethod
 
     switch (method) {
@@ -53,7 +53,7 @@ abstract class CommonsHttpClientTest extends HttpClientTest {
         throw new RuntimeException("Unsupported method: " + method)
     }
 
-    headers.each { httpMethod.setRequestHeader(it.key, it.value) }
+    headers.each { httpMethod.setRequestHeader(it[0], it[1]) }
 
     try {
       client.executeMethod(httpMethod)

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -12,11 +12,11 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
   def requestFactory = new NetHttpTransport().createRequestFactory()
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     doRequest(method, uri, headers, callback, false)
   }
 
-  int doRequest(String method, URI uri, Map<String, String> headers, Closure callback, boolean throwExceptionOnError) {
+  int doRequest(String method, URI uri, List<List<String>> headers, Closure callback, boolean throwExceptionOnError) {
     GenericUrl genericUrl = new GenericUrl(uri)
 
     HttpRequest request = requestFactory.buildRequest(method, genericUrl, null)
@@ -26,8 +26,8 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
     // GenericData::putAll method converts all known http headers to List<String>
     // and lowercase all other headers
     def ci = request.getHeaders().getClassInfo()
-    request.getHeaders().putAll(headers.collectEntries { name, value ->
-      [(name): (ci.getFieldInfo(name) != null ? [value]: value.toLowerCase())]
+    request.getHeaders().putAll(headers.collectEntries { header ->
+      [(header[0]): (ci.getFieldInfo(header[0]) != null ? [header[1]]: header[1].toLowerCase())]
     })
 
     request.setThrowExceptionOnExecuteError(throwExceptionOnError)

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientDecorator.java
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/main/java/datadog/trace/instrumentation/grizzly/client/ClientDecorator.java
@@ -42,7 +42,7 @@ public class ClientDecorator extends HttpClientDecorator<Request, Response> {
 
   @Override
   protected String getRequestHeader(Request request, String headerName) {
-    return request.getHeaders().getFirstValue(headerName);
+    return request.getHeaders().getJoinedValue(headerName, ",");
   }
 
   @Override

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
@@ -7,7 +7,7 @@ import com.ning.http.client.Request
 import com.ning.http.client.RequestBuilder
 import com.ning.http.client.Response
 import com.ning.http.client.uri.Uri
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.instrumentation.grizzly.client.ClientDecorator
 import spock.lang.AutoCleanup
@@ -15,7 +15,7 @@ import spock.lang.Shared
 
 import java.util.concurrent.Executors
 
-abstract class GrizzlyAsyncHttpClientTest extends HttpClientTest {
+abstract class GrizzlyAsyncHttpClientTest extends HttpClientTest2 {
 
   @AutoCleanup
   @Shared

--- a/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-client-1.9/src/test/groovy/GrizzlyAsyncHttpClientTest.groovy
@@ -29,13 +29,11 @@ abstract class GrizzlyAsyncHttpClientTest extends HttpClientTest2 {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
 
     RequestBuilder requestBuilder = new RequestBuilder(method)
       .setUri(Uri.create(uri.toString()))
-    headers.entrySet().each {
-      requestBuilder.addHeader(it.key, it.value)
-    }
+    headers.each { requestBuilder.addHeader(it[0], it[1]) }
     Request request = requestBuilder.build()
 
     def handler = new AsyncHandlerMock(callback)

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionConnectFirstTest.groovy
@@ -7,11 +7,11 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 class HttpUrlConnectionConnectFirstTest extends HttpUrlConnectionTest implements TestingGenericHttpNamingConventions.ClientV0{
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     HttpURLConnection connection = uri.toURL().openConnection()
     try {
       connection.setRequestMethod(method)
-      headers.each { connection.setRequestProperty(it.key, it.value) }
+      headers.each { connection.setRequestProperty(it[0], it[1]) }
       connection.setRequestProperty("Connection", "close")
       connection.connectTimeout = CONNECT_TIMEOUT_MS
       connection.readTimeout = READ_TIMEOUT_MS

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -5,13 +5,13 @@ import spock.lang.Timeout
 class HttpUrlConnectionResponseCodeOnlyTest extends HttpUrlConnectionTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     HttpURLConnection connection = uri.toURL().openConnection()
     try {
       connection.setRequestMethod(method)
       connection.connectTimeout = CONNECT_TIMEOUT_MS
       connection.readTimeout = READ_TIMEOUT_MS
-      headers.each { connection.setRequestProperty(it.key, it.value) }
+      headers.each { connection.setRequestProperty(it[0], it[1]) }
       connection.setRequestProperty("Connection", "close")
       return connection.getResponseCode()
     } finally {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -19,11 +19,11 @@ abstract class HttpUrlConnectionTest extends HttpClientTest {
   static final STATUS = 200
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     HttpURLConnection connection = uri.toURL().openConnection()
     try {
       connection.setRequestMethod(method)
-      headers.each { connection.setRequestProperty(it.key, it.value) }
+      headers.each { connection.setRequestProperty(it[0], it[1]) }
       connection.setRequestProperty("Connection", "close")
       connection.useCaches = true
       connection.connectTimeout = CONNECT_TIMEOUT_MS

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -7,11 +7,11 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScop
 class HttpUrlConnectionUseCachesFalseTest extends HttpUrlConnectionTest implements TestingGenericHttpNamingConventions.ClientV0 {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     HttpURLConnection connection = uri.toURL().openConnection()
     try {
       connection.setRequestMethod(method)
-      headers.each { connection.setRequestProperty(it.key, it.value) }
+      headers.each { connection.setRequestProperty(it[0], it[1]) }
       connection.setRequestProperty("Connection", "close")
       connection.useCaches = false
       connection.connectTimeout = CONNECT_TIMEOUT_MS

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
@@ -27,9 +27,9 @@ abstract class SpringRestTemplateTest extends HttpClientTest {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def httpHeaders = new HttpHeaders()
-    headers.each { httpHeaders.put(it.key, [it.value]) }
+    headers.each { httpHeaders.put(it[0], [it[1]]) }
     def request = new HttpEntity<String>(httpHeaders)
     try {
       ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.resolve(method), request, String)

--- a/dd-java-agent/instrumentation/java-http-client/src/test/groovy/datadog/trace/instrumentation/httpclient/JavaHttpClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/java-http-client/src/test/groovy/datadog/trace/instrumentation/httpclient/JavaHttpClientAsyncTest.groovy
@@ -5,12 +5,12 @@ import java.net.http.HttpResponse
 
 class JavaHttpClientAsyncTest extends JavaHttpClientTest {
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = HttpRequest.newBuilder()
       .uri(uri)
       .method(method, HttpRequest.BodyPublishers.ofString(body))
     if (headers != null) {
-      headers.each { key, value -> request.header(key, value) }
+      headers.each { request.header(it[0], it[1]) }
     }
 
     def response = client.sendAsync(request.build(), HttpResponse.BodyHandlers.discarding())

--- a/dd-java-agent/instrumentation/java-http-client/src/test/groovy/datadog/trace/instrumentation/httpclient/JavaHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/java-http-client/src/test/groovy/datadog/trace/instrumentation/httpclient/JavaHttpClientTest.groovy
@@ -20,12 +20,12 @@ abstract class JavaHttpClientTest extends HttpClientTest {
   .build()
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = HttpRequest.newBuilder()
       .uri(uri)
       .method(method, HttpRequest.BodyPublishers.ofString(body))
     if (headers != null) {
-      headers.each { key, value -> request.header(key, value) }
+      headers.each { request.header(it[0], it[1]) }
     }
 
     def response = client.send(request.build(), HttpResponse.BodyHandlers.discarding())

--- a/dd-java-agent/instrumentation/jax-rs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
@@ -22,9 +22,9 @@ abstract class JaxRsClientV1Test extends HttpClientTest {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def resource = client.resource(uri).requestBuilder
-    headers.each { resource.header(it.key, it.value) }
+    headers.each { resource.header(it[0], it[1]) }
     def reqBody = BODY_METHODS.contains(method) ? body : null
     ClientResponse response = resource.method(method, ClientResponse, reqBody)
     callback?.call()

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -21,11 +21,11 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest  {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     Client client = builder().build()
     WebTarget service = client.target(uri)
     def builder = service.request(MediaType.TEXT_PLAIN)
-    headers.each { builder.header(it.key, it.value) }
+    headers.each { builder.header(it[0], it[1]) }
     AsyncInvoker request = builder.async()
 
     def latch = new CountDownLatch(1)

--- a/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
@@ -24,12 +24,12 @@ import java.util.concurrent.TimeUnit
 abstract class JaxRsClientTest extends HttpClientTest {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
 
     Client client = builder().build()
     WebTarget service = client.target(uri)
     Invocation.Builder request = service.request(MediaType.TEXT_PLAIN)
-    headers.each { request.header(it.key, it.value) }
+    headers.each { request.header(it[0], it[1]) }
     def reqBody = BODY_METHODS.contains(method) ? Entity.text(body) : null
     Response response = request.method(method, (Entity) reqBody)
     callback?.call()

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/JettyClientDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/JettyClientDecorator.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.jetty_client10;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
+import java.util.List;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 
@@ -38,7 +39,8 @@ public class JettyClientDecorator extends HttpClientDecorator<Request, Response>
 
   @Override
   protected String getRequestHeader(Request request, String headerName) {
-    return request.getHeaders().get(headerName);
+    List<String> result = request.getHeaders().getValuesList(headerName);
+    return String.join(",", result);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/JettyClientDecorator.java
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/main/java11/datadog/trace/instrumentation/jetty_client10/JettyClientDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.jetty_client10;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpClientDecorator;
 import java.net.URI;
-import java.util.List;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
 
@@ -39,8 +38,7 @@ public class JettyClientDecorator extends HttpClientDecorator<Request, Response>
 
   @Override
   protected String getRequestHeader(Request request, String headerName) {
-    List<String> result = request.getHeaders().getValuesList(headerName);
-    return String.join(",", result);
+    return request.getHeaders().get(headerName);
   }
 
   @Override

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/test/groovy/JettyClientTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-10.0/src/test/groovy/JettyClientTest.groovy
@@ -45,12 +45,10 @@ abstract class JettyClientTest extends HttpClientTest {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def proxy = uri.fragment != null && uri.fragment.equals("proxy")
     Request req = (proxy ? proxiedClient : client).newRequest(uri).method(method)
-    headers.entrySet().each {
-      req.header(it.key, it.value)
-    }
+    headers.each { req.header(it[0], it[1]) }
     if (body) {
       req.content(new StringContentProvider(body))
     }

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-12.0/src/test/groovy/JettyClientTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-12.0/src/test/groovy/JettyClientTest.groovy
@@ -45,11 +45,11 @@ abstract class JettyClientTest extends HttpClientTest {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def proxy = uri.fragment != null && uri.fragment.equals("proxy")
     Request req = (proxy ? proxiedClient : client).newRequest(uri).method(method)
-    headers.entrySet().each { h ->
-      req.headers {it.add(h.key, h.value)}
+    headers.each { h ->
+      req.headers {it.add(h[0], h[1])}
     }
     if (body) {
       req.body(new StringRequestContent(body))

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest
+import datadog.trace.agent.test.base.HttpClientTest2
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.HttpProxy
@@ -13,7 +13,7 @@ import spock.lang.Subject
 
 import java.util.concurrent.ExecutionException
 
-abstract class JettyClientTest extends HttpClientTest {
+abstract class JettyClientTest extends HttpClientTest2 {
 
   @Shared
   @Subject

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
@@ -1,4 +1,4 @@
-import datadog.trace.agent.test.base.HttpClientTest2
+import datadog.trace.agent.test.base.HttpClientTest
 import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.HttpProxy
@@ -13,7 +13,7 @@ import spock.lang.Subject
 
 import java.util.concurrent.ExecutionException
 
-abstract class JettyClientTest extends HttpClientTest2 {
+abstract class JettyClientTest extends HttpClientTest {
 
   @Shared
   @Subject

--- a/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-client/jetty-client-9.1/src/test/groovy/JettyClientTest.groovy
@@ -38,12 +38,10 @@ abstract class JettyClientTest extends HttpClientTest2 {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def proxy = uri.fragment != null && uri.fragment.equals("proxy")
     Request req = (proxy ? proxiedClient : client).newRequest(uri).method(method)
-    headers.entrySet().each {
-      req.header(it.key, it.value)
-    }
+    headers.each { req.header(it[0], it[1]) }
     if (body) {
       req.content(new StringContentProvider(body))
     }

--- a/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/datadog/trace/instrumentation/netty38/latestdep/Netty38ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/latestDepTest/groovy/datadog/trace/instrumentation/netty38/latestdep/Netty38ClientTest.groovy
@@ -31,10 +31,10 @@ abstract class Netty38ClientTest extends HttpClientTest {
   AsyncHttpClient asyncHttpClient = new AsyncHttpClient(clientConfig)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def methodName = "prepare" + method.toLowerCase().capitalize()
     def requestBuilder = asyncHttpClient."$methodName"(uri.toString())
-    headers.each { requestBuilder.setHeader(it.key, it.value) }
+    headers.each { requestBuilder.setHeader(it[0], it[1]) }
     def response = requestBuilder.execute(new AsyncCompletionHandler() {
         @Override
         Object onCompleted(Response response) throws Exception {

--- a/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-3.8/src/test/groovy/datadog/trace/instrumentation/netty38/Netty38ClientTest.groovy
@@ -36,10 +36,10 @@ abstract class Netty38ClientTest extends HttpClientTest {
   AsyncHttpClient asyncHttpClient = new AsyncHttpClient(clientConfig)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def methodName = "prepare" + method.toLowerCase().capitalize()
     def requestBuilder = asyncHttpClient."$methodName"(uri.toString())
-    headers.each { requestBuilder.setHeader(it.key, it.value) }
+    headers.each { requestBuilder.setHeader(it[0], it[1]) }
     def response = requestBuilder.execute(new AsyncCompletionHandler() {
         @Override
         Object onCompleted(Response response) throws Exception {

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -50,12 +50,12 @@ abstract class Netty40ClientTest extends HttpClientTest {
   .setProxyServer(new ProxyServer.Builder("localhost", proxy.port).build()))
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def proxy = uri.fragment != null && uri.fragment.equals("proxy")
     def client = proxy ? proxiedAsyncHttpClient : asyncHttpClient
     def methodName = "prepare" + method.toLowerCase().capitalize()
     BoundRequestBuilder requestBuilder = client."$methodName"(uri.toString())
-    headers.each { requestBuilder.setHeader(it.key, it.value) }
+    headers.each { requestBuilder.setHeader(it[0], it[1]) }
     requestBuilder.setBody(body)
     def response = requestBuilder.execute(new AsyncCompletionHandler() {
         @Override

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -46,12 +46,12 @@ abstract class Netty41ClientTest extends HttpClientTest {
   .setProxyServer(new ProxyServer.Builder("localhost", proxy.port).build()))
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def proxy = uri.fragment != null && uri.fragment.equals("proxy")
     def client = proxy ? proxiedAsyncHttpClient : asyncHttpClient
     def methodName = "prepare" + method.toLowerCase().capitalize()
     BoundRequestBuilder requestBuilder = client."$methodName"(uri.toString())
-    headers.each { requestBuilder.setHeader(it.key, it.value) }
+    headers.each { requestBuilder.setHeader(it[0], it[1]) }
     requestBuilder.setBody(body)
     def response = requestBuilder.execute(new AsyncCompletionHandler() {
         @Override

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/ReactorNettyTest.groovy
@@ -59,13 +59,13 @@ class ReactorNettyTest extends HttpClientTest implements TestingNettyHttpNamingC
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     HttpClientResponse resp = HttpClient.create()
       .doAfterRequest({ r, c -> c.addHandler("TimeoutHandler", new ReadTimeoutHandler(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)) })
       .baseUrl(server.address.toString())
       .headers {
         headers.each { h ->
-          it.set(h.key, h.value)
+          it.set(h[0], h[1])
         }
       }
       .request(HttpMethod.valueOf(method))

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/HeadersUtil.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/HeadersUtil.groovy
@@ -1,9 +1,9 @@
 class HeadersUtil {
-  static headersToArray(Map<String, String> headers) {
+  static headersToArray(List<List<String>> headers) {
     String[] headersArr = new String[headers.size() * 2]
-    headers.eachWithIndex { k, v, i ->
-      headersArr[i] = k
-      headersArr[i + 1] = v
+    headers.eachWithIndex { header, i ->
+      headersArr[i] = header[0]
+      headersArr[i + 1] = header[1]
     }
 
     headersArr

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2AsyncTest.groovy
@@ -55,7 +55,7 @@ abstract class OkHttp2AsyncTest extends OkHttp2Test {
     def captured = AgentTracer.noopSpan()
     try {
       TraceUtils.runUnderTrace("parent", {
-        doRequest(method, url, ["Datadog-Meta-Lang": "java"], "", { captured = AgentTracer.activeSpan() })
+        doRequest(method, url, [["Datadog-Meta-Lang", "java"]], "", { captured = AgentTracer.activeSpan() })
       })
     } catch (Exception e) {
       assert error == true

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2AsyncTest.groovy
@@ -17,7 +17,7 @@ abstract class OkHttp2AsyncTest extends OkHttp2Test {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def reqBody = HttpMethod.requiresRequestBody(method) ? RequestBody.create(MediaType.parse("text/plain"), body) : null
     def request = new Request.Builder()
       .url(uri.toURL())

--- a/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-2/src/test/groovy/OkHttp2Test.groovy
@@ -25,7 +25,7 @@ abstract class OkHttp2Test extends HttpClientTest {
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def reqBody = HttpMethod.requiresRequestBody(method) ? RequestBody.create(MediaType.parse("text/plain"), body) : null
 
     def request = new Request.Builder()

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
@@ -66,7 +66,7 @@ abstract class OkHttp3AsyncTest extends OkHttp3Test {
     def captured = AgentTracer.noopSpan()
     try {
       TraceUtils.runUnderTrace("parent", {
-        doRequest(method, url, ["Datadog-Meta-Lang": "java"], "", { captured = AgentTracer.activeSpan() })
+        doRequest(method, url, [["Datadog-Meta-Lang", "java"]], "", { captured = AgentTracer.activeSpan() })
       })
     } catch (Exception e) {
       assert error == true

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3AsyncTest.groovy
@@ -17,12 +17,23 @@ import static java.util.concurrent.TimeUnit.SECONDS
 
 abstract class OkHttp3AsyncTest extends OkHttp3Test {
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def reqBody = HttpMethod.requiresRequestBody(method) ? RequestBody.create(MediaType.parse("text/plain"), body) : null
+    Map<String, String> headersMap = new HashMap<>()
+    for (List<String> header : headers) {
+      String key = header[0]
+      String val = header[1]
+      if (headersMap.containsKey(key)) {
+        String originalVal = headersMap.get(key)
+        headersMap.put(key, originalVal + "," + val)
+      } else {
+        headersMap.put(key, val)
+      }
+    }
     def request = new Request.Builder()
       .url(uri.toURL())
       .method(method, reqBody)
-      .headers(Headers.of(headers))
+      .headers(Headers.of(headersMap))
       .build()
 
     AtomicReference<Response> responseRef = new AtomicReference()

--- a/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
+++ b/dd-java-agent/instrumentation/okhttp-3/src/test/groovy/OkHttp3Test.groovy
@@ -35,12 +35,23 @@ abstract class OkHttp3Test extends HttpClientTest {
   .build()
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def reqBody = HttpMethod.requiresRequestBody(method) ? RequestBody.create(MediaType.parse("text/plain"), body) : null
+    Map<String, String> headersMap = new HashMap<>()
+    for (List<String> header : headers) {
+      String key = header[0]
+      String val = header[1]
+      if (headersMap.containsKey(key)) {
+        String originalVal = headersMap.get(key)
+        headersMap.put(key, originalVal + "," + val)
+      } else {
+        headersMap.put(key, val)
+      }
+    }
     def request = new Request.Builder()
       .url(uri.toURL())
       .method(method, reqBody)
-      .headers(Headers.of(headers)).build()
+      .headers(Headers.of(headersMap)).build()
     def response = client.newCall(request).execute()
     callback?.call()
     return response.code()
@@ -58,7 +69,7 @@ abstract class OkHttp3Test extends HttpClientTest {
 
   def "request to agent not traced"() {
     when:
-    def status = doRequest(method, url, ["Datadog-Meta-Lang": "java"])
+    def status = doRequest(method, url, [["Datadog-Meta-Lang", "java"]])
 
     then:
     status == 200

--- a/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/pekko-http-1.0/src/baseTest/groovy/PekkoHttpClientInstrumentationTest.groovy
@@ -25,10 +25,10 @@ abstract class PekkoHttpClientInstrumentationTest extends HttpClientTest {
   abstract CompletionStage<HttpResponse> doRequest(HttpRequest request)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = HttpRequest.create(uri.toString())
       .withMethod(HttpMethods.lookup(method).get())
-      .addHeaders(headers.collect { RawHeader.create(it.key, it.value) })
+      .addHeaders(headers.collect { RawHeader.create(it[0], it[1]) })
 
     def response
     try {

--- a/dd-java-agent/instrumentation/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/client/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.3/src/test/groovy/datadog/trace/instrumentation/play23/test/client/PlayWSClientTest.groovy
@@ -37,11 +37,9 @@ class PlayWSClientTest extends HttpClientTest implements TestingNettyHttpNamingC
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = client.url(uri.toString())
-    headers.entrySet().each {
-      request.setHeader(it.key, it.value)
-    }
+    headers.each { request.setHeader(it[0], it[1]) }
 
     def status = request.execute(method).map({
       callback?.call()

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/datadog/trace/instrumentation/play25/client/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/datadog/trace/instrumentation/play25/client/PlayWSClientTest.groovy
@@ -18,11 +18,9 @@ abstract class PlayWSClientTest extends HttpClientTest {
   def client = WS.newClient(-1)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = client.url(uri.toString())
-    headers.entrySet().each {
-      request.setHeader(it.key, it.value)
-    }
+    headers.each { request.setHeader(it[0], it[1]) }
 
     def status = request.execute(method).thenApply {
       callback?.call()

--- a/dd-java-agent/instrumentation/play-ws-1/src/test/groovy/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-ws-1/src/test/groovy/PlayWSClientTest.groovy
@@ -18,10 +18,10 @@ abstract class PlayJavaWSClientTest extends PlayWSClientTestBase {
   StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     StandaloneWSRequest wsRequest = wsClient.url(uri.toURL().toString()).setFollowRedirects(true)
 
-    headers.entrySet().each { entry -> wsRequest.addHeader(entry.getKey(), entry.getValue()) }
+    headers.each { wsRequest.addHeader(it[0], it[1]) }
     StandaloneWSResponse wsResponse = wsRequest.setMethod(method).execute()
       .whenComplete({ response, throwable ->
         callback?.call()
@@ -45,10 +45,10 @@ class PlayJavaStreamedWSClientTest extends PlayWSClientTestBase {
   StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     StandaloneWSRequest wsRequest = wsClient.url(uri.toURL().toString()).setFollowRedirects(true)
 
-    headers.entrySet().each { entry -> wsRequest.addHeader(entry.getKey(), entry.getValue()) }
+    headers.each { wsRequest.addHeader(it[0], it[1]) }
     StandaloneWSResponse wsResponse = wsRequest.setMethod(method).stream()
       .whenComplete({ response, throwable ->
         callback?.call()
@@ -75,11 +75,22 @@ class PlayScalaWSClientTest extends PlayWSClientTestBase {
   play.api.libs.ws.StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
+    Map<String, String> headersMap = new HashMap<>()
+    for (List<String> header : headers) {
+      String key = header[0]
+      String val = header[1]
+      if (headersMap.containsKey(key)) {
+        String originalVal = headersMap.get(key)
+        headersMap.put(key, originalVal + "," + val)
+      } else {
+        headersMap.put(key, val)
+      }
+    }
     Future<play.api.libs.ws.StandaloneWSResponse> futureResponse = wsClient.url(uri.toURL().toString())
       .withMethod(method)
       .withFollowRedirects(true)
-      .withHttpHeaders(JavaConverters.mapAsScalaMap(headers).toSeq())
+      .withHttpHeaders(JavaConverters.mapAsScalaMap(headersMap).toSeq())
       .execute()
       .transform({ theTry ->
         callback?.call()
@@ -106,11 +117,22 @@ class PlayScalaStreamedWSClientTest extends PlayWSClientTestBase {
   play.api.libs.ws.StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
+    Map<String, String> headersMap = new HashMap<>()
+    for (List<String> header : headers) {
+      String key = header[0]
+      String val = header[1]
+      if (headersMap.containsKey(key)) {
+        String originalVal = headersMap.get(key)
+        headersMap.put(key, originalVal + "," + val)
+      } else {
+        headersMap.put(key, val)
+      }
+    }
     Future<play.api.libs.ws.StandaloneWSResponse> futureResponse = wsClient.url(uri.toURL().toString())
       .withMethod(method)
       .withFollowRedirects(true)
-      .withHttpHeaders(JavaConverters.mapAsScalaMap(headers).toSeq())
+      .withHttpHeaders(JavaConverters.mapAsScalaMap(headersMap).toSeq())
       .stream()
       .transform({ theTry ->
         callback?.call()

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/test/groovy/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/test/groovy/PlayWSClientTest.groovy
@@ -16,10 +16,10 @@ class PlayJavaWSClientTest extends PlayWSClientTestBase {
   StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     StandaloneWSRequest wsRequest = wsClient.url(uri.toURL().toString()).setFollowRedirects(true)
 
-    headers.entrySet().each { entry -> wsRequest.addHeader(entry.getKey(), entry.getValue()) }
+    headers.each { wsRequest.addHeader(it[0], it[1]) }
     StandaloneWSResponse wsResponse = wsRequest.setMethod(method).execute()
       .whenComplete({ response, throwable ->
         callback?.call()
@@ -42,10 +42,10 @@ class PlayJavaStreamedWSClientTest extends PlayWSClientTestBase {
   StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     StandaloneWSRequest wsRequest = wsClient.url(uri.toURL().toString()).setFollowRedirects(true)
 
-    headers.entrySet().each { entry -> wsRequest.addHeader(entry.getKey(), entry.getValue()) }
+    headers.each { wsRequest.addHeader(it[0], it[1]) }
     StandaloneWSResponse wsResponse = wsRequest.setMethod(method).stream()
       .whenComplete({ response, throwable ->
         callback?.call()
@@ -71,11 +71,22 @@ class PlayScalaWSClientTest extends PlayWSClientTestBase {
   play.api.libs.ws.StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
+    Map<String, String> headersMap = new HashMap<>()
+    for (List<String> header : headers) {
+      String key = header[0]
+      String val = header[1]
+      if (headersMap.containsKey(key)) {
+        String originalVal = headersMap.get(key)
+        headersMap.put(key, originalVal + "," + val)
+      } else {
+        headersMap.put(key, val)
+      }
+    }
     Future<play.api.libs.ws.StandaloneWSResponse> futureResponse = wsClient.url(uri.toURL().toString())
       .withMethod(method)
       .withFollowRedirects(true)
-      .withHttpHeaders(JavaConverters.mapAsScalaMap(headers).toSeq())
+      .withHttpHeaders(JavaConverters.mapAsScalaMap(headersMap).toSeq())
       .execute()
       .transform({ theTry ->
         callback?.call()
@@ -101,11 +112,22 @@ class PlayScalaStreamedWSClientTest extends PlayWSClientTestBase {
   play.api.libs.ws.StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
+    Map<String, String> headersMap = new HashMap<>()
+    for (List<String> header : headers) {
+      String key = header[0]
+      String val = header[1]
+      if (headersMap.containsKey(key)) {
+        String originalVal = headersMap.get(key)
+        headersMap.put(key, originalVal + "," + val)
+      } else {
+        headersMap.put(key, val)
+      }
+    }
     Future<play.api.libs.ws.StandaloneWSResponse> futureResponse = wsClient.url(uri.toURL().toString())
       .withMethod(method)
       .withFollowRedirects(true)
-      .withHttpHeaders(JavaConverters.mapAsScalaMap(headers).toSeq())
+      .withHttpHeaders(JavaConverters.mapAsScalaMap(headersMap).toSeq())
       .stream()
       .transform({ theTry ->
         callback?.call()

--- a/dd-java-agent/instrumentation/play-ws-2/src/test/groovy/PlayWSClientTest.groovy
+++ b/dd-java-agent/instrumentation/play-ws-2/src/test/groovy/PlayWSClientTest.groovy
@@ -17,10 +17,10 @@ abstract class PlayJavaWSClientTest extends PlayWSClientTestBase {
   StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     StandaloneWSRequest wsRequest = wsClient.url(uri.toURL().toString()).setFollowRedirects(true)
 
-    headers.entrySet().each { entry -> wsRequest.addHeader(entry.getKey(), entry.getValue()) }
+    headers.each { wsRequest.addHeader(it[0], it[1]) }
     StandaloneWSResponse wsResponse = wsRequest.setMethod(method).execute()
       .whenComplete({ response, throwable ->
         callback?.call()
@@ -43,10 +43,10 @@ class PlayJavaStreamedWSClientTest extends PlayWSClientTestBase {
   StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     StandaloneWSRequest wsRequest = wsClient.url(uri.toURL().toString()).setFollowRedirects(true)
 
-    headers.entrySet().each { entry -> wsRequest.addHeader(entry.getKey(), entry.getValue()) }
+    headers.each { wsRequest.addHeader(it[0], it[1]) }
     StandaloneWSResponse wsResponse = wsRequest.setMethod(method).stream()
       .whenComplete({ response, throwable ->
         callback?.call()
@@ -72,11 +72,22 @@ class PlayScalaWSClientTest extends PlayWSClientTestBase {
   play.api.libs.ws.StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
+    Map<String, String> headersMap = new HashMap<>()
+    for (List<String> header : headers) {
+      String key = header[0]
+      String val = header[1]
+      if (headersMap.containsKey(key)) {
+        String originalVal = headersMap.get(key)
+        headersMap.put(key, originalVal + "," + val)
+      } else {
+        headersMap.put(key, val)
+      }
+    }
     Future<play.api.libs.ws.StandaloneWSResponse> futureResponse = wsClient.url(uri.toURL().toString())
       .withMethod(method)
       .withFollowRedirects(true)
-      .withHttpHeaders(JavaConverters.mapAsScalaMap(headers).toSeq())
+      .withHttpHeaders(JavaConverters.mapAsScalaMap(headersMap).toSeq())
       .execute()
       .transform({ theTry ->
         callback?.call()
@@ -102,11 +113,22 @@ class PlayScalaStreamedWSClientTest extends PlayWSClientTestBase {
   play.api.libs.ws.StandaloneWSClient wsClient
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
+    Map<String, String> headersMap = new HashMap<>()
+    for (List<String> header : headers) {
+      String key = header[0]
+      String val = header[1]
+      if (headersMap.containsKey(key)) {
+        String originalVal = headersMap.get(key)
+        headersMap.put(key, originalVal + "," + val)
+      } else {
+        headersMap.put(key, val)
+      }
+    }
     Future<play.api.libs.ws.StandaloneWSResponse> futureResponse = wsClient.url(uri.toURL().toString())
       .withMethod(method)
       .withFollowRedirects(true)
-      .withHttpHeaders(JavaConverters.mapAsScalaMap(headers).toSeq())
+      .withHttpHeaders(JavaConverters.mapAsScalaMap(headersMap).toSeq())
       .stream()
       .transform({ theTry ->
         callback?.call()

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/client/RatpackForkedHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/client/RatpackForkedHttpClientTest.groovy
@@ -6,13 +6,13 @@ import ratpack.exec.ExecResult
 class RatpackForkedHttpClientTest extends RatpackHttpClientTest {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     ExecResult<Integer> result = exec.yield {
       def resp = client.request(uri) { spec ->
         spec.method(method)
         spec.headers { headersSpec ->
-          headers.entrySet().each {
-            headersSpec.add(it.key, it.value)
+          headers.each {
+            headersSpec.add(it[0], it[1])
           }
         }
       }

--- a/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/client/RatpackHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.5/src/test/groovy/client/RatpackHttpClientTest.groovy
@@ -30,14 +30,14 @@ class RatpackHttpClientTest extends HttpClientTest implements TestingNettyHttpNa
   }
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     ExecResult<Integer> result = exec.yield {
       def resp = client.request(uri) { spec ->
         spec.connectTimeout(Duration.ofSeconds(2))
         spec.method(method)
         spec.headers { headersSpec ->
-          headers.entrySet().each {
-            headersSpec.add(it.key, it.value)
+          headers.each {
+            headersSpec.add(it[0], it[1])
           }
         }
       }

--- a/dd-java-agent/instrumentation/reactor-netty-1/src/test/groovy/ReactorNettyHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-netty-1/src/test/groovy/ReactorNettyHttpClientTest.groovy
@@ -25,11 +25,11 @@ class ReactorNettyHttpClientTest extends HttpClientTest implements TestingNettyH
   .disableRetry(true)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     httpClient
-      .headers({ hdrs ->
+      .headers({ h ->
         headers.each {
-          hdrs.set(it.key, it.value)
+          h.set(it[0], it[1])
         }
       })
       .request(HttpMethod.valueOf(method))

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientBase.groovy
@@ -32,12 +32,12 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements Tes
   abstract void check()
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.resolve(method))
       .uri(uri)
-      .headers { h -> headers.forEach({ key, value -> h.add(key, value) }) }
+      .headers { h -> headers.each({ h.add(it[0], it[1]) }) }
       .exchange()
       .doAfterSuccessOrError { res, ex ->
         callback?.call()

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoAfterTerminateTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoAfterTerminateTest.groovy
@@ -11,12 +11,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 class SpringWebfluxHttpClientDoAfterTerminateTest extends SpringWebfluxHttpClientBase {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.resolve(method))
       .uri(uri)
-      .headers { h -> headers.forEach({ key, value -> h.add(key, value) }) }
+      .headers { h -> headers.each({ h.add(it[0], it[1]) }) }
       .exchange()
       .doAfterTerminate { runnable ->
         callback?.call()

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoOnSuccessOrErrorTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoOnSuccessOrErrorTest.groovy
@@ -11,12 +11,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 abstract class SpringWebfluxHttpClientDoOnSuccessOrErrorTest extends SpringWebfluxHttpClientBase {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.resolve(method))
       .uri(uri)
-      .headers { h -> headers.forEach({ key, value -> h.add(key, value) }) }
+      .headers { h -> headers.each({ h.add(it[0], it[1]) }) }
       .exchange()
       .doOnSuccessOrError { res, err ->
         callback?.call()

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoOnSuccessTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoOnSuccessTest.groovy
@@ -11,12 +11,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 class SpringWebfluxHttpClientDoOnSuccessTest extends SpringWebfluxHttpClientBase {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.resolve(method))
       .uri(uri)
-      .headers { h -> headers.forEach({ key, value -> h.add(key, value) }) }
+      .headers { h -> headers.each({ h.add(it[0], it[1]) }) }
       .exchange()
       .doOnSuccess { res ->
         callback?.call()

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoOnTerminateTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/dd/trace/instrumentation/springwebflux/client/SpringWebfluxHttpClientDoOnTerminateTest.groovy
@@ -11,12 +11,12 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 class SpringWebfluxHttpClientDoOnTerminateTest extends SpringWebfluxHttpClientBase {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.resolve(method))
       .uri(uri)
-      .headers { h -> headers.forEach({ key, value -> h.add(key, value) }) }
+      .headers { h -> headers.each({ h.add(it[0], it[1]) }) }
       .exchange()
       .doOnTerminate { runnable ->
         callback?.call()

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientBase.groovy
@@ -33,14 +33,14 @@ abstract class SpringWebfluxHttpClientBase extends HttpClientTest implements Tes
   abstract void check()
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.valueOf(method))
     .uri(uri)
     .headers {
-      h -> headers.forEach({
-        key, value -> h.add(key, value)
+      h -> headers.each({
+        h.add(it[0], it[1])
       })
     }
     .exchangeToMono (Mono::just)

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoAfterTerminateTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoAfterTerminateTest.groovy
@@ -12,14 +12,14 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 class SpringWebfluxHttpClientDoAfterTerminateTest extends SpringWebfluxHttpClientBase {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.valueOf(method))
     .uri(uri)
     .headers {
-      h -> headers.forEach({
-        key, value -> h.add(key, value)
+      h -> headers.each({
+        h.add(it[0], it[1])
       })
     }
     .exchangeToMono (Mono::just)

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoOnSuccessOrErrorTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoOnSuccessOrErrorTest.groovy
@@ -12,14 +12,14 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 abstract class SpringWebfluxHttpClientDoOnSuccessOrErrorTest extends SpringWebfluxHttpClientBase {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.valueOf(method))
     .uri(uri)
     .headers {
-      h -> headers.forEach({
-        key, value -> h.add(key, value)
+      h -> headers.each({
+        h.add(it[0], it[1])
       })
     }
     .exchangeToMono (Mono::just)

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoOnSuccessTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoOnSuccessTest.groovy
@@ -12,14 +12,14 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 class SpringWebfluxHttpClientDoOnSuccessTest extends SpringWebfluxHttpClientBase {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.valueOf(method))
     .uri(uri)
     .headers {
-      h -> headers.forEach({
-        key, value -> h.add(key, value)
+      h -> headers.each({
+        h.add(it[0], it[1])
       })
     }
     .exchangeToMono (Mono::just)

--- a/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoOnTerminateTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-6/src/test/groovy/dd/trace/instrumentation/springwebflux6/client/SpringWebfluxHttpClientDoOnTerminateTest.groovy
@@ -12,14 +12,14 @@ import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 class SpringWebfluxHttpClientDoOnTerminateTest extends SpringWebfluxHttpClientBase {
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def hasParent = activeSpan() != null
     def client = createClient(component())
     ClientResponse response = client.method(HttpMethod.valueOf(method))
     .uri(uri)
     .headers {
       h -> headers.forEach({
-        key, value -> h.add(key, value)
+        h.add(it[0], it[1])
       })
     }
     .exchangeToMono (Mono::just)

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxCircuitBreakerWebClientForkedTest.groovy
@@ -43,9 +43,9 @@ class VertxRxCircuitBreakerWebClientForkedTest extends HttpClientTest implements
   )
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = client.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri")
-    headers.each { request.putHeader(it.key, it.value) }
+    headers.each { request.putHeader(it[0], it[1]) }
 
     def future = new CompletableFuture<Integer>()
 

--- a/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-rx-3.5/src/test/groovy/client/VertxRxWebClientForkedTest.groovy
@@ -32,9 +32,9 @@ class VertxRxWebClientForkedTest extends HttpClientTest implements TestingNettyH
   WebClient client = WebClient.create(vertx, clientOptions)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     def request = client.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri")
-    headers.each { request.putHeader(it.key, it.value) }
+    headers.each { request.putHeader(it[0], it[1]) }
     return request
       .rxSend()
       .doOnSuccess { response -> callback?.call() }

--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -33,10 +33,10 @@ class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHt
   def httpClient = vertx.createHttpClient(clientOptions)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     CompletableFuture<HttpClientResponse> future = new CompletableFuture<>()
     def request = httpClient.request(HttpMethod.valueOf(method), uri.port, uri.host, "$uri")
-    headers.each { request.putHeader(it.key, it.value) }
+    headers.each { request.putHeader(it[0], it[1]) }
     request.handler { response ->
       try {
         callback?.call()

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -38,11 +38,11 @@ class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHt
   def httpClient = vertx.createHttpClient(clientOptions)
 
   @Override
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback) {
     return doRequest(method, uri, headers, body, callback, -1)
   }
 
-  int doRequest(String method, URI uri, Map<String, String> headers, String body, Closure callback, long timeout) {
+  int doRequest(String method, URI uri, List<List<String>> headers, String body, Closure callback, long timeout) {
     CompletableFuture<HttpClientResponse> future = new CompletableFuture<>()
 
     RequestOptions requestOptions = new RequestOptions()
@@ -54,7 +54,7 @@ class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHt
 
     httpClient.request(requestOptions, { requestReadyToBeSend ->
       def request = requestReadyToBeSend.result()
-      headers.each { request.putHeader(it.key, it.value) }
+      headers.each { request.putHeader(it[0], it[1]) }
       request.send(body, { response ->
         try {
           callback?.call()

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/test/groovy/client/VertxHttpClientForkedTest.groovy
@@ -91,7 +91,7 @@ class VertxHttpClientForkedTest extends HttpClientTest implements TestingNettyHt
 
   def "handle timeout"() {
     when:
-    def status = doRequest(method, url, [:], "", null, timeout)
+    def status = doRequest(method, url, [], "", null, timeout)
 
     then:
     status == 0

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -142,7 +142,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
    * @param method
    * @return
    */
-  abstract int doRequest(String method, URI uri, Map<String, String> headers = [:], String body = "", Closure callback = null)
+  abstract int doRequest(String method, URI uri, List<List<String>> headers = [], String body = "", Closure callback = null)
 
   String keyStorePath() {
     server.keystorePath
@@ -243,7 +243,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
 
     when:
     def status = runUnderTrace("parent") {
-      doRequest(method, url, [:], body)
+      doRequest(method, url, [], body)
     }
     println("RESPONSE: $status")
     if (isDataStreamsEnabled()) {
@@ -283,7 +283,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
   def "basic #method request with parent"() {
     when:
     def status = runUnderTrace("parent") {
-      doRequest(method, server.address.resolve("/success"), [:], body)
+      doRequest(method, server.address.resolve("/success"), [], body)
     }
     if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
@@ -426,7 +426,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
     when:
     injectSysConfig(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService")
     def status = runUnderTrace("parent") {
-      doRequest(method, server.address.resolve("/success"), ["is-dd-server": "false"])
+      doRequest(method, server.address.resolve("/success"), [["is-dd-server", "false"]])
     }
     if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
@@ -464,7 +464,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
 
     when:
     def status = runUnderTrace("parent") {
-      doRequest(method, server.address.resolve("/success"), ["is-dd-server": "false"], "") {
+      doRequest(method, server.address.resolve("/success"), [["is-dd-server", "false"]], "") {
         runUnderTrace("child") {
           blockUntilChildSpansFinished(1)
         }
@@ -498,7 +498,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
 
   def "trace request with callback and no parent"() {
     when:
-    def status = doRequest(method, server.address.resolve("/success"), ["is-dd-server": "false"], "") {
+    def status = doRequest(method, server.address.resolve("/success"), [["is-dd-server", "false"]], "") {
       runUnderTrace("callback") {
         // FIXME: since in async we may not have the other trace report until the callback is done
         //  we should add a test method to detect that the other trace is finished but waiting for
@@ -650,7 +650,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
     def uri = server.address.resolve("/to-secured")
 
     when:
-    def status = doRequest(method, uri, [(BASIC_AUTH_KEY): BASIC_AUTH_VAL])
+    def status = doRequest(method, uri, [[BASIC_AUTH_KEY, BASIC_AUTH_VAL]])
     if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }
@@ -765,7 +765,7 @@ abstract class HttpClientTest extends VersionedNamingTestBase {
   def "test request header #header tag mapping"() {
     when:
     def url = server.address.resolve("/success")
-    def status = doRequest(method, url, [(header): value])
+    def status = doRequest(method, url, [[header, value]])
     if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)
     }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest2.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest2.groovy
@@ -1,0 +1,42 @@
+package datadog.trace.agent.test.base
+
+import datadog.trace.core.datastreams.StatsGroup
+
+// This class tests multiline multivalue headers for those classes that support it.
+abstract class HttpClientTest2 extends HttpClientTest{
+
+  def "test request header #header tag mapping"() {
+    when:
+    def url = server.address.resolve("/success")
+    def status = (value2 == null) ? doRequest(method, url, [[header, value]]) : doRequest(method, url, [[header, value], [header, value2]])
+    if (isDataStreamsEnabled()) {
+      TEST_DATA_STREAMS_WRITER.waitForGroups(1)
+    }
+
+    then:
+    status == 200
+    assertTraces(2) {
+      trace(size(1)) {
+        clientSpan(it, null, method, false, false, url, status, false, null, false, tags)
+      }
+      server.distributedRequestTrace(it, trace(0).last(), tags)
+    }
+    and:
+    if (isDataStreamsEnabled()) {
+      StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find { it.parentHash == 0 }
+      verifyAll(first) {
+        edgeTags.containsAll(DSM_EDGE_TAGS)
+        edgeTags.size() == DSM_EDGE_TAGS.size()
+      }
+    }
+
+    where:
+    method | header                           | value     | value2 | tags
+    'GET'  | 'X-Datadog-Test-Both-Header'     | 'foo'     | null   | [ 'both_header_tag': 'foo' ]
+    'GET'  | 'X-Datadog-Test-Request-Header'  | 'bar'     | null   | [ 'request_header_tag': 'bar' ]
+    'GET'  | 'X-Datadog-Test-Both-Header'     | 'bar,baz' | null   | [ 'both_header_tag': 'bar,baz' ]
+    'GET'  | 'X-Datadog-Test-Request-Header'  | 'foo,bar' | null   | [ 'request_header_tag': 'foo,bar' ]
+    'GET'  | 'X-Datadog-Test-Both-Header'     | 'bar,baz' | 'foo'  | [ 'both_header_tag': 'bar,baz,foo' ]
+    'GET'  | 'X-Datadog-Test-Request-Header'  | 'foo,bar' | 'baz'  | [ 'request_header_tag': 'foo,bar,baz' ]
+  }
+}

--- a/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/server/http/HttpServletRequestExtractAdapter.java
+++ b/dd-java-agent/testing/src/main/java/datadog/trace/agent/test/server/http/HttpServletRequestExtractAdapter.java
@@ -22,7 +22,15 @@ public class HttpServletRequestExtractAdapter
     Enumeration<String> headerNames = carrier.getHeaderNames();
     while (headerNames.hasMoreElements()) {
       final String header = headerNames.nextElement();
-      if (!classifier.accept(header, carrier.getHeader(header))) {
+      StringBuilder headerVals = new StringBuilder();
+      Enumeration<String> headers = carrier.getHeaders(header);
+      while (headers.hasMoreElements()) {
+        headerVals.append(headers.nextElement());
+        if (headers.hasMoreElements()) {
+          headerVals.append(',');
+        }
+      }
+      if (!classifier.accept(header, headerVals.toString())) {
         return;
       }
     }


### PR DESCRIPTION
# What Does This Do
The goal of this PR is to support multi-value multi-line HTTP header extraction. To do so, it

- Updates the `headers` data struct from `Map<String, String>` to `List<List<String>>` to support multiple values with the same header. The `doRequest` method calls need to be updated as a result.
- Changes the `getRequestHeader` and `getResponseHeader` methods in the client decorators for Apache and Grizzly to retrieve multiple header values instead of just the first.
- Adds a class that extends `HttpClientTest` to test multiple values for the same header.

# Motivation
Currently, HTTP protocol allows splitting the header into multiple lines per value. For example, `header: value1, header: value2, header: value3`. However, the Java tracer extracts only the first value of an http header and will oftentimes override the original header value when trying to set another value. This PR attempts to provide support from the tracer for multiple values under the same header.

# Additional Notes
This is a cleaned up version of #7996.

Not all client decorators support multiple header values (e.g. jetty-client-9.1, spring-webflux-5, google-http-client, netty-4.1, and http-url-connection) because they use a `.set` method or map data structure somewhere that overrides header values when a new value with the same header name is introduced. Open to ideas on how to address this!

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/AIDM-273

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
