### PR TITLE
Add After callsites support for void methods

### DIFF
--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/CallSiteSpecification.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/CallSiteSpecification.java
@@ -570,11 +570,20 @@ public class CallSiteSpecification implements Validatable {
 
     @Override
     protected void validateAdvice(@Nonnull final ValidationContext context) {
-      if (advice.isVoidReturn()) {
-        context.addError(ErrorCode.ADVICE_AFTER_SHOULD_NOT_RETURN_VOID);
-      }
-      if (findReturn() == null) {
-        context.addError(ErrorCode.ADVICE_AFTER_SHOULD_HAVE_RETURN);
+      if (shouldNotUseReturn(pointcut)) {
+        if (!advice.isVoidReturn()) {
+          context.addError(ErrorCode.ADVICE_AFTER_VOID_METHOD_SHOULD_RETURN_VOID);
+        }
+        if (findReturn() != null) {
+          context.addError(ErrorCode.ADVICE_AFTER_VOID_METHOD_SHOULD_NOT_HAVE_RETURN);
+        }
+      } else {
+        if (advice.isVoidReturn()) {
+          context.addError(ErrorCode.ADVICE_AFTER_SHOULD_NOT_RETURN_VOID);
+        }
+        if (findReturn() == null) {
+          context.addError(ErrorCode.ADVICE_AFTER_SHOULD_HAVE_RETURN);
+        }
       }
       if (!pointcut.isConstructor()) {
         if (!isStaticPointcut() && !includeThis()) {
@@ -586,6 +595,10 @@ public class CallSiteSpecification implements Validatable {
         }
       }
       super.validateAdvice(context);
+    }
+
+    private boolean shouldNotUseReturn(final MethodType type) {
+      return !type.isConstructor() && type.isVoidReturn();
     }
 
     @Override

--- a/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/util/ErrorCode.java
+++ b/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/util/ErrorCode.java
@@ -359,6 +359,20 @@ public enum ErrorCode implements Function<Object[], String> {
     }
   },
 
+  ADVICE_AFTER_VOID_METHOD_SHOULD_RETURN_VOID {
+    @Override
+    public String apply(final Object[] objects) {
+      return "After advice for void method should return void";
+    }
+  },
+
+  ADVICE_AFTER_VOID_METHOD_SHOULD_NOT_HAVE_RETURN {
+    @Override
+    public String apply(final Object[] objects) {
+      return "After advice for void method should not contain @Return annotated parameters";
+    }
+  },
+
   ADVICE_AFTER_SHOULD_HAVE_RETURN {
     @Override
     public String apply(final Object[] objects) {

--- a/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/AdviceSpecificationTest.groovy
+++ b/buildSrc/call-site-instrumentation-plugin/src/test/groovy/datadog/trace/plugin/csi/impl/AdviceSpecificationTest.groovy
@@ -542,4 +542,26 @@ class AdviceSpecificationTest extends BaseCsiPluginTest {
     then:
     0 * context.addError(_, _)
   }
+
+
+  @CallSite(spi = CallSites)
+  class AfterWithVoidWrongAdvice {
+    @CallSite.After("void java.lang.String.getChars(int, int, char[], int)")
+    static String after(@CallSite.AllArguments final Object[] args, @CallSite.Return final String result) {
+      return result;
+    }
+  }
+
+  void 'test after advice with void should not use @Return'() {
+    setup:
+    final context = mockValidationContext()
+    final spec = buildClassSpecification(AfterWithVoidWrongAdvice)
+
+    when:
+    spec.advices.each { it.validate(context) }
+
+    then:
+    1 * context.addError(ErrorCode.ADVICE_AFTER_VOID_METHOD_SHOULD_RETURN_VOID, _)
+    1 * context.addError(ErrorCode.ADVICE_AFTER_VOID_METHOD_SHOULD_NOT_HAVE_RETURN, _)
+  }
 }

--- a/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
+++ b/dd-java-agent/agent-tooling/src/test/groovy/datadog/trace/agent/tooling/csi/BaseCallSiteTest.groovy
@@ -83,6 +83,10 @@ class BaseCallSiteTest extends DDSpecification {
     return buildPointcut(String.getDeclaredMethod('concat', String))
   }
 
+  protected static Pointcut stringBuilderSetLengthPointcut() {
+    return buildPointcut(StringBuilder.getDeclaredMethod('setLength', int))
+  }
+
   protected static Pointcut stringReaderPointcut() {
     return buildPointcut(StringReader.getDeclaredConstructor(String))
   }

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringBuilderSetLengthCallSite.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringBuilderSetLengthCallSite.java
@@ -1,0 +1,10 @@
+package datadog.trace.agent.tooling.csi;
+
+public class StringBuilderSetLengthCallSite {
+
+  public static volatile Object[] LAST_CALL;
+
+  public static void after(final StringBuilder builder, int length) {
+    LAST_CALL = new Object[] {builder, length};
+  }
+}

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringBuilderSetLengthExample.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/csi/StringBuilderSetLengthExample.java
@@ -1,0 +1,16 @@
+package datadog.trace.agent.tooling.csi;
+
+import java.util.function.BiConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StringBuilderSetLengthExample implements BiConsumer<StringBuilder, Integer> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StringBuilderSetLengthExample.class);
+
+  public void accept(final StringBuilder builder, final Integer length) {
+    LOGGER.debug("Before apply {} {}", builder, length);
+    builder.setLength(length);
+    LOGGER.debug("After apply {} {}", builder, length);
+  }
+}


### PR DESCRIPTION
# What Does This Do
Adds support for After callsites in void methods, validations have been updated so:

- Void methods should have void callsites not annotated with `@Return`
- Non void methods should have a return parameter compatible with the call site annotated with `@Return`

As an example:

```java
  @CallSite(spi = CallSites)
  class AfterAdviceWithVoidReturn {
    @CallSite.After("void java.lang.StringBuilder.setLength(int)")
    static void after(@CallSite.This StringBuilder self, @CallSite.Argument(0) int length) {
    }
  }
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55359]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55359]: https://datadoghq.atlassian.net/browse/APPSEC-55359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ