### PR TITLE
Avoid performing blocking I/O operation on application thread

### DIFF
--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -1,6 +1,7 @@
 package datadog.communication.ddagent;
 
 import static datadog.communication.ddagent.TracerVersion.TRACER_VERSION;
+import static datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 
 import datadog.common.container.ContainerInfo;
 import datadog.common.socket.SocketUtils;
@@ -9,6 +10,7 @@ import datadog.communication.monitor.Monitoring;
 import datadog.remoteconfig.ConfigurationPoller;
 import datadog.remoteconfig.DefaultConfigurationPoller;
 import datadog.trace.api.Config;
+import datadog.trace.util.AgentTaskScheduler;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import okhttp3.HttpUrl;
@@ -98,8 +100,11 @@ public class SharedCommunicationObjects {
               agentUrl,
               config.isTraceAgentV05Enabled(),
               config.isTracerMetricsEnabled());
-      if (!"true".equalsIgnoreCase(System.getProperty("dd.test.no.early.discovery"))) {
-        featuresDiscovery.discover();
+      if (AGENT_THREAD_GROUP.equals(Thread.currentThread().getThreadGroup())) {
+        featuresDiscovery.discover(); // safe to run on same thread
+      } else {
+        // avoid performing blocking I/O operation on application thread
+        AgentTaskScheduler.INSTANCE.execute(featuresDiscovery::discover);
       }
     }
     return featuresDiscovery;

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerAgentTest.java
@@ -122,11 +122,11 @@ public class DebuggerAgentTest {
     ConfigurationPoller configurationPoller =
         (ConfigurationPoller) sharedCommunicationObjects.configurationPoller(Config.get());
     configurationPoller.start();
-    RecordedRequest request = datadogAgentServer.takeRequest(5, TimeUnit.SECONDS);
-    assertNotNull(request);
-    assertEquals("/info", request.getPath());
-    request = datadogAgentServer.takeRequest(5, TimeUnit.SECONDS);
-    assertNotNull(request);
+    RecordedRequest request;
+    do {
+      request = datadogAgentServer.takeRequest(5, TimeUnit.SECONDS);
+      assertNotNull(request);
+    } while ("/info".equals(request.getPath()));
     assertEquals("/v0.7/config", request.getPath());
     DebuggerAgent.stop();
     datadogAgentServer.shutdown();

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -136,21 +136,6 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
 
   @Override
   public void start() {
-    if (features.getDataStreamsEndpoint() == null) {
-      features.discoverIfOutdated();
-    }
-
-    agentSupportsDataStreams = features.supportsDataStreams();
-    checkDynamicConfig();
-
-    if (!configSupportsDataStreams) {
-      log.debug("Data streams is disabled");
-    } else if (!agentSupportsDataStreams) {
-      log.debug("Data streams is disabled or not supported by agent");
-    }
-
-    nextFeatureCheck = timeSource.getCurrentTimeNanos() + FEATURE_CHECK_INTERVAL_NANOS;
-
     cancellation =
         AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
             new ReportTask(), this, bucketDurationNanos, bucketDurationNanos, TimeUnit.NANOSECONDS);
@@ -341,6 +326,22 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
 
     @Override
     public void run() {
+
+      if (features.getDataStreamsEndpoint() == null) {
+        features.discoverIfOutdated();
+      }
+
+      agentSupportsDataStreams = features.supportsDataStreams();
+      checkDynamicConfig();
+
+      if (!configSupportsDataStreams) {
+        log.debug("Data streams is disabled");
+      } else if (!agentSupportsDataStreams) {
+        log.debug("Data streams is disabled or not supported by agent");
+      }
+
+      nextFeatureCheck = timeSource.getCurrentTimeNanos() + FEATURE_CHECK_INTERVAL_NANOS;
+
       Thread currentThread = Thread.currentThread();
       while (!currentThread.isInterrupted()) {
         try {

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultDataStreamsMonitoring.java
@@ -136,6 +136,7 @@ public class DefaultDataStreamsMonitoring implements DataStreamsMonitoring, Even
 
   @Override
   public void start() {
+    checkDynamicConfig();
     cancellation =
         AgentTaskScheduler.INSTANCE.scheduleAtFixedRate(
             new ReportTask(), this, bucketDurationNanos, bucketDurationNanos, TimeUnit.NANOSECONDS);

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/propagation/XRayHttpInjectorTest.groovy
@@ -6,6 +6,7 @@ import datadog.trace.api.DDTraceId
 import datadog.trace.api.DynamicConfig
 import datadog.trace.api.time.TimeSource
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.NoopPathwayContext
+import datadog.trace.core.datastreams.DataStreamsMonitoring
 
 import static datadog.trace.api.sampling.PrioritySampling.*
 import static datadog.trace.api.sampling.SamplingMechanism.*
@@ -25,7 +26,11 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
     setup:
     def writer = new ListWriter()
     def timeSource = Mock(TimeSource)
-    def tracer = tracerBuilder().writer(writer).timeSource(timeSource).build()
+    def tracer = tracerBuilder()
+      .dataStreamsMonitoring(Mock(DataStreamsMonitoring))
+      .writer(writer)
+      .timeSource(timeSource)
+      .build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
       DDTraceId.from("$traceId"),
@@ -76,7 +81,11 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
     setup:
     def writer = new ListWriter()
     def timeSource = Mock(TimeSource)
-    def tracer = tracerBuilder().writer(writer).timeSource(timeSource).build()
+    def tracer = tracerBuilder()
+      .dataStreamsMonitoring(Mock(DataStreamsMonitoring))
+      .writer(writer)
+      .timeSource(timeSource)
+      .build()
     def headers = [
       'X-Amzn-Trace-Id' : "Root=1-00000000-00000000${traceId.padLeft(16, '0')};Parent=${spanId.padLeft(16, '0')}"
     ]
@@ -136,7 +145,11 @@ class XRayHttpInjectorTest extends DDCoreSpecification {
     setup:
     def writer = new ListWriter()
     def timeSource = Mock(TimeSource)
-    def tracer = tracerBuilder().writer(writer).timeSource(timeSource).build()
+    def tracer = tracerBuilder()
+      .dataStreamsMonitoring(Mock(DataStreamsMonitoring))
+      .writer(writer)
+      .timeSource(timeSource)
+      .build()
     final DDSpanContext mockedContext =
       new DDSpanContext(
       DDTraceId.from("1"),


### PR DESCRIPTION
# Motivation

Agent discovery potentially involves a blocking I/O operation. This should only be run from our own background threads and not from application threads. Note we shouldn't need to wait for the result on the application thread because the tracer code already handles asynchronous upgrade/downgrade scenarios.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMLP-326]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-326]: https://datadoghq.atlassian.net/browse/APMLP-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ