### PR TITLE
Improve Context API null handling and Javadoc

### DIFF
--- a/components/context/src/main/java/datadog/context/ContextBinder.java
+++ b/components/context/src/main/java/datadog/context/ContextBinder.java
@@ -1,26 +1,39 @@
 package datadog.context;
 
-/** Binds context to carrier objects. */
-public interface ContextBinder {
+import javax.annotation.ParametersAreNonnullByDefault;
 
+/** Binds context to carrier objects. */
+@ParametersAreNonnullByDefault
+public interface ContextBinder {
   /**
    * Returns the context attached to the given carrier object.
    *
-   * @return Attached context; {@link Context#root()} if there is none
+   * @param carrier the carrier object to get the context from.
+   * @return the attached context; {@link Context#root()} if there is none.
    */
   Context from(Object carrier);
 
-  /** Attaches the given context to the given carrier object. */
+  /**
+   * Attaches the given context to the given carrier object.
+   *
+   * @param carrier the object to carry the context.
+   * @param context the context to attach.
+   */
   void attachTo(Object carrier, Context context);
 
   /**
    * Detaches the context attached to the given carrier object, leaving it context-less.
    *
-   * @return Previously attached context; {@link Context#root()} if there was none
+   * @param carrier the carrier object to detach its context from.
+   * @return the previously attached context; {@link Context#root()} if there was none.
    */
   Context detachFrom(Object carrier);
 
-  /** Requests use of a custom {@link ContextBinder}. */
+  /**
+   * Requests use of a custom {@link ContextBinder}.
+   *
+   * @param binder the binder to use (will replace any other binder in use).
+   */
   static void register(ContextBinder binder) {
     ContextProviders.customBinder = binder;
   }

--- a/components/context/src/main/java/datadog/context/ContextKey.java
+++ b/components/context/src/main/java/datadog/context/ContextKey.java
@@ -10,8 +10,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class ContextKey<T> {
   private static final AtomicInteger NEXT_INDEX = new AtomicInteger(0);
-
+  /** The key name, for debugging purpose only . */
   private final String name;
+  /** The key unique context, related to {@link IndexedContext} implementation. */
   final int index;
 
   private ContextKey(String name) {
@@ -19,20 +20,25 @@ public final class ContextKey<T> {
     this.index = NEXT_INDEX.getAndIncrement();
   }
 
-  /** Creates a new key with the given name. */
+  /**
+   * Creates a new key with the given name.
+   *
+   * @param name the key name, for debugging purpose only.
+   * @return the newly created unique key.
+   */
   public static <T> ContextKey<T> named(String name) {
     return new ContextKey<>(name);
   }
 
   @Override
   public int hashCode() {
-    return index;
+    return this.index;
   }
 
   // we want identity equality, so no need to override equals()
 
   @Override
   public String toString() {
-    return name;
+    return this.name;
   }
 }

--- a/components/context/src/main/java/datadog/context/ContextManager.java
+++ b/components/context/src/main/java/datadog/context/ContextManager.java
@@ -2,36 +2,41 @@ package datadog.context;
 
 /** Manages context across execution units. */
 public interface ContextManager {
-
   /**
    * Returns the root context.
    *
-   * <p>This is the initial local context that all contexts extend.
+   * @return the initial local context that all contexts extend.
    */
   Context root();
 
   /**
    * Returns the context attached to the current execution unit.
    *
-   * @return Attached context; {@link #root()} if there is none
+   * @return the attached context; {@link #root()} if there is none.
    */
   Context current();
 
   /**
    * Attaches the given context to the current execution unit.
    *
-   * @return Scope to be closed when the context is invalid.
+   * @param context the context to attach.
+   * @return a scope to be closed when the context is invalid.
    */
   ContextScope attach(Context context);
 
   /**
    * Swaps the given context with the one attached to current execution unit.
    *
-   * @return Previously attached context; {@link #root()} if there was none
+   * @param context the context to swap.
+   * @return the previously attached context; {@link #root()} if there was none.
    */
   Context swap(Context context);
 
-  /** Requests use of a custom {@link ContextManager}. */
+  /**
+   * Requests use of a custom {@link ContextManager}.
+   *
+   * @param manager the manager to use (will replace any other manager in use).
+   */
   static void register(ContextManager manager) {
     ContextProviders.customManager = manager;
   }

--- a/components/context/src/main/java/datadog/context/ContextScope.java
+++ b/components/context/src/main/java/datadog/context/ContextScope.java
@@ -2,7 +2,6 @@ package datadog.context;
 
 /** Controls the validity of context attached to an execution unit. */
 public interface ContextScope extends AutoCloseable {
-
   /** Returns the context controlled by this scope. */
   Context context();
 

--- a/components/context/src/main/java/datadog/context/EmptyContext.java
+++ b/components/context/src/main/java/datadog/context/EmptyContext.java
@@ -1,16 +1,27 @@
 package datadog.context;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+
 /** {@link Context} containing no values. */
+@ParametersAreNonnullByDefault
 final class EmptyContext implements Context {
   static final Context INSTANCE = new EmptyContext();
 
   @Override
+  @Nullable
   public <T> T get(ContextKey<T> key) {
     return null;
   }
 
   @Override
-  public <T> Context with(ContextKey<T> key, T value) {
+  public <T> Context with(ContextKey<T> key, @Nullable T value) {
+    requireNonNull(key, "Context key cannot be null");
+    if (value == null) {
+      return this;
+    }
     return new SingletonContext(key.index, value);
   }
 }

--- a/components/context/src/main/java/datadog/context/ImplicitContextKeyed.java
+++ b/components/context/src/main/java/datadog/context/ImplicitContextKeyed.java
@@ -1,12 +1,16 @@
 package datadog.context;
 
-/** {@link Context} value that has its own implicit {@link ContextKey}. */
-public interface ImplicitContextKeyed {
+import javax.annotation.ParametersAreNonnullByDefault;
 
+/** {@link Context} value that has its own implicit {@link ContextKey}. */
+@ParametersAreNonnullByDefault
+public interface ImplicitContextKeyed {
   /**
    * Creates a new context with this value under its chosen key.
    *
-   * @return New context with the implicitly keyed value.
+   * @param context the context to copy the original values from.
+   * @return the new context with the implicitly keyed value.
+   * @see Context#with(ImplicitContextKeyed)
    */
   Context storeInto(Context context);
 }

--- a/components/context/src/main/java/datadog/context/IndexedContext.java
+++ b/components/context/src/main/java/datadog/context/IndexedContext.java
@@ -2,10 +2,14 @@ package datadog.context;
 
 import static java.lang.Math.max;
 import static java.util.Arrays.copyOfRange;
+import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** {@link Context} containing many values. */
+@ParametersAreNonnullByDefault
 final class IndexedContext implements Context {
   private final Object[] store;
 
@@ -14,18 +18,20 @@ final class IndexedContext implements Context {
   }
 
   @Override
+  @Nullable
   @SuppressWarnings("unchecked")
   public <T> T get(ContextKey<T> key) {
+    requireNonNull(key, "Context key cannot be null");
     int index = key.index;
     return index < store.length ? (T) store[index] : null;
   }
 
   @Override
-  public <T> Context with(ContextKey<T> key, T value) {
+  public <T> Context with(ContextKey<T> key, @Nullable T value) {
+    requireNonNull(key, "Context key cannot be null");
     int index = key.index;
     Object[] newStore = copyOfRange(store, 0, max(store.length, index + 1));
     newStore[index] = value;
-
     return new IndexedContext(newStore);
   }
 

--- a/components/context/src/main/java/datadog/context/SingletonContext.java
+++ b/components/context/src/main/java/datadog/context/SingletonContext.java
@@ -1,10 +1,14 @@
 package datadog.context;
 
 import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** {@link Context} containing a single value. */
+@ParametersAreNonnullByDefault
 final class SingletonContext implements Context {
   private final int index;
   private final Object value;
@@ -15,19 +19,24 @@ final class SingletonContext implements Context {
   }
 
   @Override
+  @Nullable
   @SuppressWarnings("unchecked")
   public <V> V get(ContextKey<V> key) {
-    return index == key.index ? (V) value : null;
+    requireNonNull(key, "Context key cannot be null");
+    return this.index == key.index ? (V) this.value : null;
   }
 
   @Override
-  public <V> Context with(ContextKey<V> secondKey, V secondValue) {
+  public <V> Context with(ContextKey<V> secondKey, @Nullable V secondValue) {
+    requireNonNull(secondKey, "Context key cannot be null");
     int secondIndex = secondKey.index;
-    if (index == secondIndex) {
-      return new SingletonContext(index, secondValue);
+    if (this.index == secondIndex) {
+      return secondValue == null
+          ? EmptyContext.INSTANCE
+          : new SingletonContext(this.index, secondValue);
     } else {
-      Object[] store = new Object[max(index, secondIndex) + 1];
-      store[index] = value;
+      Object[] store = new Object[max(this.index, secondIndex) + 1];
+      store[this.index] = this.value;
       store[secondIndex] = secondValue;
       return new IndexedContext(store);
     }
@@ -38,14 +47,14 @@ final class SingletonContext implements Context {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     SingletonContext that = (SingletonContext) o;
-    return index == that.index && Objects.equals(value, that.value);
+    return this.index == that.index && Objects.equals(this.value, that.value);
   }
 
   @Override
   public int hashCode() {
     int result = 31;
-    result = 31 * result + index;
-    result = 31 * result + Objects.hashCode(value);
+    result = 31 * result + this.index;
+    result = 31 * result + Objects.hashCode(this.value);
     return result;
   }
 }

--- a/components/context/src/main/java/datadog/context/ThreadLocalContextManager.java
+++ b/components/context/src/main/java/datadog/context/ThreadLocalContextManager.java
@@ -2,7 +2,6 @@ package datadog.context;
 
 /** {@link ContextManager} that uses a {@link ThreadLocal} to track context per thread. */
 final class ThreadLocalContextManager implements ContextManager {
-
   private static final ThreadLocal<Context[]> CURRENT_HOLDER =
       ThreadLocal.withInitial(() -> new Context[] {EmptyContext.INSTANCE});
 
@@ -18,11 +17,9 @@ final class ThreadLocalContextManager implements ContextManager {
 
   @Override
   public ContextScope attach(Context context) {
-
     Context[] holder = CURRENT_HOLDER.get();
     Context previous = holder[0];
     holder[0] = context;
-
     return new ContextScope() {
       private boolean closed;
 

--- a/components/context/src/main/java/datadog/context/WeakMapContextBinder.java
+++ b/components/context/src/main/java/datadog/context/WeakMapContextBinder.java
@@ -1,29 +1,36 @@
 package datadog.context;
 
-import java.util.Collections;
+import static datadog.context.Context.root;
+import static java.util.Collections.synchronizedMap;
+import static java.util.Objects.requireNonNull;
+
 import java.util.Map;
 import java.util.WeakHashMap;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 /** {@link ContextBinder} that uses a global weak map of carriers to contexts. */
+@ParametersAreNonnullByDefault
 final class WeakMapContextBinder implements ContextBinder {
-
-  private static final Map<Object, Context> TRACKED =
-      Collections.synchronizedMap(new WeakHashMap<>());
+  private static final Map<Object, Context> TRACKED = synchronizedMap(new WeakHashMap<>());
 
   @Override
   public Context from(Object carrier) {
+    requireNonNull(carrier, "Context carrier cannot be null");
     Context bound = TRACKED.get(carrier);
-    return null != bound ? bound : Context.root();
+    return null != bound ? bound : root();
   }
 
   @Override
   public void attachTo(Object carrier, Context context) {
+    requireNonNull(carrier, "Context carrier cannot be null");
+    requireNonNull(context, "Context cannot be null. Use detachFrom() instead.");
     TRACKED.put(carrier, context);
   }
 
   @Override
   public Context detachFrom(Object carrier) {
+    requireNonNull(carrier, "Context key cannot be null");
     Context previous = TRACKED.remove(carrier);
-    return null != previous ? previous : Context.root();
+    return null != previous ? previous : root();
   }
 }

--- a/components/context/src/test/java/datadog/context/ContextBinderTest.java
+++ b/components/context/src/test/java/datadog/context/ContextBinderTest.java
@@ -1,23 +1,57 @@
 package datadog.context;
 
+import static datadog.context.Context.current;
+import static datadog.context.Context.detachFrom;
+import static datadog.context.Context.from;
 import static datadog.context.Context.root;
 import static datadog.context.ContextTest.STRING_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ContextBinderTest {
+  @BeforeEach
+  void setUp() {
+    assertEquals(root(), current(), "No context is expected to be set");
+  }
 
   @Test
   void testAttachAndDetach() {
+    // Setting up test
     Context context = root().with(STRING_KEY, "value");
     Object carrier = new Object();
-    assertEquals(root(), Context.from(carrier));
+    assertEquals(root(), from(carrier), "Carrier expected to hold root context by default");
+    // Attaching context
     context.attachTo(carrier);
-    assertEquals(context, Context.from(carrier));
+    assertEquals(context, from(carrier), "Carrier expected to hold new context");
+    assertEquals(root(), current(), "Current execution expected to stay root");
     // Detaching removes all context
-    assertEquals(context, Context.detachFrom(carrier));
-    assertEquals(root(), Context.detachFrom(carrier));
-    assertEquals(root(), Context.from(carrier));
+    assertEquals(context, detachFrom(carrier), "Detached context expected to new context");
+    assertEquals(root(), detachFrom(carrier), "Carrier expected to hold no more context");
+    assertEquals(root(), from(carrier), "Carrier expected to hold no more context");
+  }
+
+  @Test
+  void testNullCarrier() {
+    assertThrows(
+        NullPointerException.class,
+        () -> assertEquals(root(), from(null), "Binder expected to return non-null context"),
+        "Null carrier expected to hold root context");
+    assertThrows(
+        NullPointerException.class,
+        () -> assertEquals(root(), detachFrom(null), "Binder expected to return non-null context"),
+        "Null carrier expected to hold root context");
+  }
+
+  @Test
+  void testNullContext() {
+    ContextBinder binder = ContextProviders.binder();
+    Object carrier = new Object();
+    assertThrows(
+        NullPointerException.class,
+        () -> binder.attachTo(carrier, null),
+        "Attaching null context not expected to throw");
   }
 }

--- a/components/context/src/test/java/datadog/context/ContextKeyTest.java
+++ b/components/context/src/test/java/datadog/context/ContextKeyTest.java
@@ -9,29 +9,28 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class ContextKeyTest {
-
   @ParameterizedTest
-  @NullSource
-  @ValueSource(strings = {"", "key"})
+  @NullAndEmptySource
+  @ValueSource(strings = {"key"})
   void testConstructor(String name) {
     ContextKey<String> key = ContextKey.named(name);
-    assertNotNull(key);
-    assertEquals(name, key.toString());
+    assertNotNull(key, "created key should not be null");
+    assertEquals(name, key.toString(), name + " label should be supported");
   }
 
   @Test
   void testKeyNameCollision() {
     ContextKey<String> key1 = ContextKey.named("same-name");
     ContextKey<String> key2 = ContextKey.named("same-name");
-    assertNotEquals(key1, key2);
+    assertNotEquals(key1, key2, "distinct keys should not be equal");
     String value = "value";
     Context context = Context.root().with(key1, value);
-    assertEquals(value, context.get(key1));
-    assertNull(context.get(key2));
+    assertEquals(value, context.get(key1), "the original key should be able to retrieve the value");
+    assertNull(context.get(key2), "the distinct keys should not be able to retrieve the value");
   }
 
   @SuppressWarnings({
@@ -42,17 +41,20 @@ class ContextKeyTest {
   })
   @Test
   void testEqualsAndHashCode() {
-    ContextKey<String> key1 = ContextKey.named("same-name");
-    ContextKey<String> key2 = ContextKey.named("same-name");
+    ContextKey<String> key1 = ContextKey.named("some-name");
+    ContextKey<String> key2 = ContextKey.named("some-name");
     // Test equals on self
-    assertTrue(key1.equals(key1));
-    assertEquals(key1.hashCode(), key1.hashCode());
+    assertTrue(key1.equals(key1), "Key should be equal with itself");
+    assertEquals(key1.hashCode(), key1.hashCode(), "key hash should be constant");
     // Test equals on null
-    assertFalse(key1.equals(null));
+    assertFalse(key1.equals(null), "key should not be equal to null value");
     // Test equals on different object type
-    assertFalse(key1.equals("value"));
+    assertFalse(key1.equals("value"), "key should not be equal to a different type");
     // Test equals on different keys with the same name
-    assertFalse(key1.equals(key2));
-    assertNotEquals(key1.hashCode(), key2.hashCode());
+    assertFalse(key1.equals(key2), "different keys with the same name should not be equal");
+    assertNotEquals(
+        key1.hashCode(),
+        key2.hashCode(),
+        "different keys with the same name should have the same hash");
   }
 }

--- a/components/context/src/test/java/datadog/context/ContextManagerTest.java
+++ b/components/context/src/test/java/datadog/context/ContextManagerTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ContextManagerTest {
-
   @BeforeEach
   void init() {
     // Ensure no current context prior starting test

--- a/components/context/src/test/java/datadog/context/ContextProviderForkedTest.java
+++ b/components/context/src/test/java/datadog/context/ContextProviderForkedTest.java
@@ -4,27 +4,27 @@ import static datadog.context.Context.root;
 import static datadog.context.ContextTest.STRING_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
 class ContextProviderForkedTest {
-
   @Test
   void testCustomBinder() {
     // register a NOOP context binder
     ContextBinder.register(
         new ContextBinder() {
           @Override
-          public Context from(Object carrier) {
+          public Context from(@Nonnull Object carrier) {
             return root();
           }
 
           @Override
-          public void attachTo(Object carrier, Context context) {
+          public void attachTo(@Nonnull Object carrier, @Nonnull Context context) {
             // no-op
           }
 
           @Override
-          public Context detachFrom(Object carrier) {
+          public Context detachFrom(@Nonnull Object carrier) {
             return root();
           }
         });

--- a/components/context/src/test/java/datadog/context/ImplicitContextKeyedTest.java
+++ b/components/context/src/test/java/datadog/context/ImplicitContextKeyedTest.java
@@ -1,0 +1,38 @@
+package datadog.context;
+
+import static datadog.context.Context.root;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+class ImplicitContextKeyedTest {
+  /** This class demonstrate how values can hide their context keys. */
+  static class ValueWithKey implements ImplicitContextKeyed {
+    /** The private key used to store and retrieve context value. */
+    private static final ContextKey<ValueWithKey> HIDDEN_KEY = ContextKey.named("hidden-key");
+
+    @Override
+    public Context storeInto(@Nonnull Context context) {
+      return context.with(HIDDEN_KEY, this);
+    }
+
+    @Nullable
+    public static ValueWithKey from(@Nonnull Context context) {
+      return context.get(HIDDEN_KEY);
+    }
+  }
+
+  @Test
+  void testImplicitKey() {
+    // Setup context
+    Context root = root();
+    ValueWithKey valueWithKey = new ValueWithKey();
+    Context context = root.with(valueWithKey);
+    assertNull(ValueWithKey.from(root), "No value expected to be extracted from root context");
+    assertEquals(
+        valueWithKey, ValueWithKey.from(context), "Expected to retrieve the implicit keyed value");
+  }
+}


### PR DESCRIPTION
# What Does This Do

This PR is a follow up of #8117:
* Improve Javadoc about usage and thread safety
* Improve null handling and document parameters and results
* Improve tests to cover all context implementations

# Motivation

The goal is to make the most explicit possible the new API and document how it is supposed to behave with unexpected cases.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-39]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-39]: https://datadoghq.atlassian.net/browse/LANGPLAT-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ