### PR TITLE
Defer remote components to avoid OkHttp class-loading side-effects

### DIFF
--- a/communication/build.gradle
+++ b/communication/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 }
 
 ext {
-  minimumBranchCoverage = 0.6
+  minimumBranchCoverage = 0.5
   minimumInstructionCoverage = 0.8
   excludedClassesCoverage = [
     'datadog.communication.ddagent.ExternalAgentLauncher',

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -10,7 +10,6 @@ import static datadog.trace.util.AgentThreadFactory.AgentThread.JMX_STARTUP;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.PROFILER_STARTUP;
 import static datadog.trace.util.AgentThreadFactory.AgentThread.TRACE_STARTUP;
 import static datadog.trace.util.AgentThreadFactory.newAgentThread;
-import static datadog.trace.util.Strings.getResourceName;
 import static datadog.trace.util.Strings.propertyNameToSystemPropertyName;
 import static datadog.trace.util.Strings.toEnvVar;
 
@@ -1286,14 +1285,8 @@ public class Agent {
 
     final String logManagerProp = System.getProperty("java.util.logging.manager");
     if (logManagerProp != null) {
-      final boolean onSysClasspath =
-          ClassLoader.getSystemResource(getResourceName(logManagerProp)) != null;
       log.debug("Prop - logging.manager: {}", logManagerProp);
-      log.debug("logging.manager on system classpath: {}", onSysClasspath);
-      // Some applications set java.util.logging.manager but never actually initialize the logger.
-      // Check to see if the configured manager is on the system classpath.
-      // If so, it should be safe to initialize jmxfetch which will setup the log manager.
-      return !onSysClasspath;
+      return true;
     }
 
     return false;
@@ -1324,14 +1317,8 @@ public class Agent {
 
     final String jmxBuilderProp = System.getProperty("javax.management.builder.initial");
     if (jmxBuilderProp != null) {
-      final boolean onSysClasspath =
-          ClassLoader.getSystemResource(getResourceName(jmxBuilderProp)) != null;
       log.debug("Prop - javax.management.builder.initial: {}", jmxBuilderProp);
-      log.debug("javax.management.builder.initial on system classpath: {}", onSysClasspath);
-      // Some applications set javax.management.builder.initial but never actually initialize JMX.
-      // Check to see if the configured JMX builder is on the system classpath.
-      // If so, it should be safe to initialize jmxfetch which will setup JMX.
-      return !onSysClasspath;
+      return true;
     }
 
     return false;

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -499,22 +499,13 @@ public class Agent {
   protected static class InstallDatadogTracerCallback extends ClassLoadCallBack {
     private final InitializationTelemetry initTelemetry;
     private final Instrumentation instrumentation;
+    private final Object sco;
+    private final Class<?> scoClass;
 
     public InstallDatadogTracerCallback(
         InitializationTelemetry initTelemetry, Instrumentation instrumentation) {
       this.initTelemetry = initTelemetry;
       this.instrumentation = instrumentation;
-    }
-
-    @Override
-    public AgentThread agentThread() {
-      return TRACE_STARTUP;
-    }
-
-    @Override
-    public void execute() {
-      Object sco;
-      Class<?> scoClass;
       try {
         scoClass =
             AGENT_CLASSLOADER.loadClass("datadog.communication.ddagent.SharedCommunicationObjects");
@@ -526,7 +517,15 @@ public class Agent {
           | InvocationTargetException e) {
         throw new UndeclaredThrowableException(e);
       }
+    }
 
+    @Override
+    public AgentThread agentThread() {
+      return TRACE_STARTUP;
+    }
+
+    @Override
+    public void execute() {
       installDatadogTracer(initTelemetry, scoClass, sco);
       maybeStartAppSec(scoClass, sco);
       maybeStartIast(instrumentation, scoClass, sco);

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Agent.java
@@ -530,7 +530,7 @@ public class Agent {
       maybeStartAppSec(scoClass, sco);
       maybeStartIast(instrumentation, scoClass, sco);
       maybeStartCiVisibility(instrumentation, scoClass, sco);
-      maybeStartLogsIntake(scoClass, sco);
+      maybeInstallLogsIntake(scoClass, sco);
       // start debugger before remote config to subscribe to it before starting to poll
       maybeStartDebugger(instrumentation, scoClass, sco);
       maybeStartRemoteConfig(scoClass, sco);
@@ -865,17 +865,18 @@ public class Agent {
     }
   }
 
-  private static void maybeStartLogsIntake(Class<?> scoClass, Object sco) {
+  private static void maybeInstallLogsIntake(Class<?> scoClass, Object sco) {
     if (agentlessLogSubmissionEnabled) {
       StaticEventLogger.begin("Logs Intake");
 
       try {
         final Class<?> logsIntakeSystemClass =
             AGENT_CLASSLOADER.loadClass("datadog.trace.logging.intake.LogsIntakeSystem");
-        final Method logsIntakeInstallerMethod = logsIntakeSystemClass.getMethod("start", scoClass);
+        final Method logsIntakeInstallerMethod =
+            logsIntakeSystemClass.getMethod("install", scoClass);
         logsIntakeInstallerMethod.invoke(null, sco);
       } catch (final Throwable e) {
-        log.warn("Not starting Logs Intake subsystem", e);
+        log.warn("Not installing Logs Intake subsystem", e);
       }
 
       StaticEventLogger.end("Logs Intake");

--- a/dd-java-agent/agent-logs-intake/src/main/java/datadog/trace/logging/intake/LogsIntakeSystem.java
+++ b/dd-java-agent/agent-logs-intake/src/main/java/datadog/trace/logging/intake/LogsIntakeSystem.java
@@ -1,6 +1,5 @@
 package datadog.trace.logging.intake;
 
-import datadog.communication.BackendApi;
 import datadog.communication.BackendApiFactory;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
@@ -12,7 +11,7 @@ public class LogsIntakeSystem {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(LogsIntakeSystem.class);
 
-  public static void start(SharedCommunicationObjects sco) {
+  public static void install(SharedCommunicationObjects sco) {
     Config config = Config.get();
     if (!config.isAgentlessLogSubmissionEnabled()) {
       LOGGER.debug("Agentless logs intake is disabled");
@@ -20,10 +19,8 @@ public class LogsIntakeSystem {
     }
 
     BackendApiFactory apiFactory = new BackendApiFactory(config, sco);
-    BackendApi backendApi = apiFactory.createBackendApi(BackendApiFactory.Intake.LOGS);
-    LogsDispatcher dispatcher = new LogsDispatcher(backendApi);
-    LogsWriterImpl writer = new LogsWriterImpl(config, dispatcher);
-    writer.start();
+    LogsWriterImpl writer = new LogsWriterImpl(config, apiFactory);
+    sco.whenReady(writer::start);
 
     LogsIntake.registerWriter(writer);
   }

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -27,7 +27,7 @@ class CustomLogManagerTest extends Specification {
       , true) == 0
   }
 
-  def "agent services starts up in premain if configured log manager on system classpath"() {
+  def "agent services startup is delayed even if configured log manager on system classpath"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
       , [

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
@@ -28,7 +28,7 @@ class CustomMBeanServerBuilderTest extends Specification {
       , true) == 0
   }
 
-  def "JMXFetch starts up in premain if configured MBeanServerBuilder on system classpath"() {
+  def "JMXFetch startup is delayed even if configured MBeanServerBuilder on system classpath"() {
     expect:
     IntegrationTestUtils.runOnSeparateJvm(MBeanServerBuilderSetter.getName()
       , [

--- a/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
@@ -170,10 +170,13 @@ public class LogManagerSetter {
   }
 
   private static boolean isThreadStarted(final String name, final boolean wait) {
+    System.out.println("Checking for thread " + name + "...");
+
     // Wait up to 10 seconds for thread to appear
     for (int i = 0; i < 20; i++) {
       for (final Thread thread : Thread.getAllStackTraces().keySet()) {
         if (name.equals(thread.getName())) {
+          System.out.println("...thread " + name + " has started");
           return true;
         }
       }
@@ -186,6 +189,7 @@ public class LogManagerSetter {
         e.printStackTrace();
       }
     }
+    System.out.println("...thread " + name + " has not started");
     return false;
   }
 
@@ -198,9 +202,12 @@ public class LogManagerSetter {
   }
 
   private static boolean isTracerInstalled(final boolean wait) {
+    System.out.println("Checking for tracer...");
+
     // Wait up to 10 seconds for tracer to get installed
     for (int i = 0; i < 20; i++) {
       if (AgentTracer.isRegistered()) {
+        System.out.println("...tracer is installed");
         return true;
       }
       if (!wait) {
@@ -212,6 +219,7 @@ public class LogManagerSetter {
         e.printStackTrace();
       }
     }
+    System.out.println("...tracer is not installed");
     return false;
   }
 

--- a/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/LogManagerSetter.java
@@ -39,55 +39,38 @@ public class LogManagerSetter {
     } else if (System.getProperty("java.util.logging.manager") != null) {
       System.out.println("java.util.logging.manager != null");
 
-      if (ClassLoader.getSystemResource(
-              System.getProperty("java.util.logging.manager").replaceAll("\\.", "/") + ".class")
-          == null) {
-        assertTraceInstallationDelayed(
-            "tracer install must be delayed when log manager system property is present.");
+      customAssert(
+          isTracerInstalled(false),
+          true,
+          "tracer install is not delayed when log manager system property is present.");
+      customAssert(
+          isJmxfetchStarted(false),
+          false,
+          "jmxfetch startup must be delayed when log manager system property is present.");
+      if (isJFRSupported()) {
+        assertProfilingStartupDelayed(
+            "profiling startup must be delayed when log manager system property is present.");
+      }
+      // Change back to a valid LogManager.
+      System.setProperty("java.util.logging.manager", CUSTOM_LOG_MANAGER_CLASS_NAME);
+      customAssert(
+          LogManager.getLogManager().getClass(),
+          LogManagerSetter.class
+              .getClassLoader()
+              .loadClass(System.getProperty("java.util.logging.manager")),
+          "Javaagent should not prevent setting a custom log manager");
+      customAssert(
+          isJmxfetchStarted(true), true, "jmxfetch should start after loading LogManager.");
+      if (isJFRSupported()) {
         customAssert(
-            isJmxfetchStarted(false),
-            false,
-            "jmxfetch startup must be delayed when log manager system property is present.");
-        if (isJFRSupported()) {
-          assertProfilingStartupDelayed(
-              "profiling startup must be delayed when log manager system property is present.");
-        }
-        // Change back to a valid LogManager.
-        System.setProperty("java.util.logging.manager", CUSTOM_LOG_MANAGER_CLASS_NAME);
-        customAssert(
-            LogManager.getLogManager().getClass(),
-            LogManagerSetter.class
-                .getClassLoader()
-                .loadClass(System.getProperty("java.util.logging.manager")),
-            "Javaagent should not prevent setting a custom log manager");
-        customAssert(
-            isTracerInstalled(true), true, "tracer should be installed after loading LogManager.");
-        customAssert(
-            isJmxfetchStarted(true), true, "jmxfetch should start after loading LogManager.");
-        if (isJFRSupported()) {
-          customAssert(
-              isProfilingStarted(true), true, "profiling should start after loading LogManager.");
-        }
-      } else {
-        customAssert(
-            isTracerInstalled(false),
-            true,
-            "tracer should be installed in premain when custom log manager found on classpath.");
-        customAssert(
-            isJmxfetchStarted(false),
-            true,
-            "jmxfetch should start in premain when custom log manager found on classpath.");
-        if (isJFRSupported()) {
-          customAssert(
-              isProfilingStarted(false),
-              true,
-              "profiling should start in premain when custom log manager found on classpath.");
-        }
+            isProfilingStarted(true), true, "profiling should start after loading LogManager.");
       }
     } else if (System.getenv("JBOSS_HOME") != null) {
       System.out.println("JBOSS_HOME != null");
-      assertTraceInstallationDelayed(
-          "tracer install must be delayed when JBOSS_HOME property is present.");
+      customAssert(
+          isTracerInstalled(false),
+          true,
+          "tracer install is not delayed when JBOSS_HOME property is present.");
       customAssert(
           isJmxfetchStarted(false),
           false,
@@ -104,10 +87,6 @@ public class LogManagerSetter {
               .getClassLoader()
               .loadClass(System.getProperty("java.util.logging.manager")),
           "Javaagent should not prevent setting a custom log manager");
-      customAssert(
-          isTracerInstalled(true),
-          true,
-          "tracer should be installed after loading with JBOSS_HOME set.");
       customAssert(
           isJmxfetchStarted(true),
           true,
@@ -144,17 +123,6 @@ public class LogManagerSetter {
     if (!got.equals(expected)) {
       throw new RuntimeException(
           "Assertion failed. Expected <" + expected + "> got <" + got + "> " + assertionMessage);
-    }
-  }
-
-  private static void assertTraceInstallationDelayed(final String message) {
-    if (okHttpMayIndirectlyLoadJUL()) {
-      customAssert(isTracerInstalled(false), false, message);
-    } else {
-      customAssert(
-          isTracerInstalled(false),
-          true,
-          "We can safely install tracer on java9+ since it doesn't indirectly trigger logger manager init");
     }
   }
 

--- a/dd-java-agent/src/test/java/jvmbootstraptest/MBeanServerBuilderSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/MBeanServerBuilderSetter.java
@@ -26,31 +26,19 @@ public class MBeanServerBuilderSetter {
     } else if (System.getProperty("javax.management.builder.initial") != null) {
       System.out.println("javax.management.builder.initial != null");
 
-      if (ClassLoader.getSystemResource(
-              System.getProperty("javax.management.builder.initial").replaceAll("\\.", "/")
-                  + ".class")
-          == null) {
-        customAssert(
-            isJmxfetchStarted(false),
-            false,
-            "jmxfetch startup must be delayed when management builder system property is present.");
-        // Change back to a valid MBeanServerBuilder.
-        System.setProperty(
-            "javax.management.builder.initial", "jvmbootstraptest.CustomMBeanServerBuilder");
-        customAssert(
-            isCustomMBeanRegistered(),
-            true,
-            "Javaagent should not prevent setting a custom MBeanServerBuilder");
-        customAssert(
-            isJmxfetchStarted(true),
-            true,
-            "jmxfetch should start after loading MBeanServerBuilder.");
-      } else {
-        customAssert(
-            isJmxfetchStarted(false),
-            true,
-            "jmxfetch should start in premain when custom MBeanServerBuilder found on classpath.");
-      }
+      customAssert(
+          isJmxfetchStarted(false),
+          false,
+          "jmxfetch startup must be delayed when management builder system property is present.");
+      // Change back to a valid MBeanServerBuilder.
+      System.setProperty(
+          "javax.management.builder.initial", "jvmbootstraptest.CustomMBeanServerBuilder");
+      customAssert(
+          isCustomMBeanRegistered(),
+          true,
+          "Javaagent should not prevent setting a custom MBeanServerBuilder");
+      customAssert(
+          isJmxfetchStarted(true), true, "jmxfetch should start after loading MBeanServerBuilder.");
     } else {
       System.out.println("No custom MBeanServerBuilder");
 

--- a/dd-java-agent/src/test/java/jvmbootstraptest/MBeanServerBuilderSetter.java
+++ b/dd-java-agent/src/test/java/jvmbootstraptest/MBeanServerBuilderSetter.java
@@ -75,10 +75,13 @@ public class MBeanServerBuilderSetter {
   }
 
   private static boolean isThreadStarted(final String name, final boolean wait) {
+    System.out.println("Checking for thread " + name + "...");
+
     // Wait up to 10 seconds for thread to appear
     for (int i = 0; i < 20; i++) {
       for (final Thread thread : Thread.getAllStackTraces().keySet()) {
         if (name.equals(thread.getName())) {
+          System.out.println("...thread " + name + " has started");
           return true;
         }
       }
@@ -91,6 +94,7 @@ public class MBeanServerBuilderSetter {
         e.printStackTrace();
       }
     }
+    System.out.println("...thread " + name + " has not started");
     return false;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -689,7 +689,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     }
     pendingTraceBuffer.start();
 
-    this.writer.start();
+    sharedCommunicationObjects.whenReady(this.writer::start);
 
     metricsAggregator = createMetricsAggregator(config, sharedCommunicationObjects);
     // Schedule the metrics aggregator to begin reporting after a random delay of 1 to 10 seconds
@@ -705,7 +705,8 @@ public class CoreTracer implements AgentTracer.TracerAPI {
     } else {
       this.dataStreamsMonitoring = dataStreamsMonitoring;
     }
-    this.dataStreamsMonitoring.start();
+
+    sharedCommunicationObjects.whenReady(this.dataStreamsMonitoring::start);
 
     // Create default extractor from config if not provided and decorate it with DSM extractor
     HttpCodec.Extractor builtExtractor =


### PR DESCRIPTION
# What Does This Do

1. Add ability to pause remote components until SharedCommunicationObjects is ready for remote I/O

2. Use this to install tracer and logs-intake as soon as necessary, but still defer any remote components until when use of OkHttp is allowed

3. Remove exemption where we didn't defer if the custom logging manager or JMX builder was on the system classpath (because previously the main thread would find it there if OkHttp triggered initialization of JUL.)

   We now make OkHttp calls from our own background threads to avoid blocking the main thread, but our threads are isolated from the system classloader - so this exemption no longer makes sense and should be removed

# Motivation

Resolves some spurious failures in the log-injection smoke tests for the IBM Java 8 JDK.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
