### PR TITLE
Remove restriction to not run vertx4 latest tests on java 17

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
@@ -1,3 +1,9 @@
+// Set properties before any plugins get loaded
+ext {
+  // TODO Java 17: This version of vertx-web doesn't support Java 17
+  maxJavaVersionForTests = JavaVersion.VERSION_15
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 muzzle {

--- a/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
@@ -1,7 +1,8 @@
 // Set properties before any plugins get loaded
 ext {
-  // TODO Java 17: This version of vertx-web doesn't support Java 17
+  // vertx-web doesn't support Java 17 until v4.2
   maxJavaVersionForTests = JavaVersion.VERSION_15
+  latestDepTestMaxJavaVersionForTests = JavaVersion.VERSION_17
 }
 
 apply from: "$rootDir/gradle/java.gradle"
@@ -29,7 +30,7 @@ artifacts {
 dependencies {
   api project(':dd-java-agent:instrumentation:netty-4.1-shared')
 
-  compileOnly group: 'io.vertx', name: 'vertx-web', version: '4.2.7'
+  compileOnly group: 'io.vertx', name: 'vertx-web', version: '4.0.0'
 
   testImplementation project(':dd-java-agent:instrumentation:netty-4.1')
   testImplementation project(':dd-java-agent:instrumentation:trace-annotation')
@@ -44,6 +45,7 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:jackson-core')
   testRuntimeOnly project(':dd-java-agent:instrumentation:netty-buffer-4')
 
+  // TODO support v>=4.5
   latestDepTestImplementation group: 'io.vertx', name: 'vertx-web', version: '4.4.+'
   latestDepTestImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.4.+'
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/build.gradle
@@ -1,9 +1,3 @@
-// Set properties before any plugins get loaded
-ext {
-  // TODO Java 17: This version of vertx-web doesn't support Java 17
-  maxJavaVersionForTests = JavaVersion.VERSION_15
-}
-
 apply from: "$rootDir/gradle/java.gradle"
 
 muzzle {


### PR DESCRIPTION
# What Does This Do

edit gradle file to remove exclusion for java 17 for latest dep tests

# Motivation

this restriction was probably copy-pasted from the previous version's gradle file:
https://github.com/DataDog/dd-trace-java/blob/ec18d0e8627c7a4e4f6040778d54685fb99709f4/dd-java-agent/instrumentation/vertx-web-3.9/build.gradle#L3
But vertx supports java 17 now, so we need to test the latest version with it.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
