### PR TITLE
Add GitHub workflow concurrency settings

### DIFF
--- a/.github/workflows/analyze-changes.yaml
+++ b/.github/workflows/analyze-changes.yaml
@@ -7,6 +7,11 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ master ]
 
+# Cancel long-running jobs when a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   datadog-static-analyzer:
     name: Analyze changes with DataDog Static Analyzer

--- a/.github/workflows/check-pull-requests.yaml
+++ b/.github/workflows/check-pull-requests.yaml
@@ -5,6 +5,8 @@ on:
     branches:
     - master
     - release/v*
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   check_pull_requests:
     name: Check pull requests

--- a/.github/workflows/update-download-releases.yaml
+++ b/.github/workflows/update-download-releases.yaml
@@ -4,6 +4,8 @@ on:
     types:
       - released
   workflow_dispatch:
+concurrency: # Avoid running multiple instances to prevent asset conflicts
+  group: ${{ github.workflow }}
 jobs:
   update-releases:
     permissions:


### PR DESCRIPTION
# What Does This Do

This would avoid having some GitHub workflows running in parallel.

# Motivation

The goal is to prevent race conditions (PR checks, release asset upload) and save execution time from long running jobs (CodeQL).

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-116]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-116]: https://datadoghq.atlassian.net/browse/LANGPLAT-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ