### PR TITLE
Clean up DSM pathway binary encoding

### DIFF
--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/TextMapExtractAdapter.java
@@ -2,12 +2,10 @@ package datadog.trace.instrumentation.googlepubsub;
 
 import com.google.pubsub.v1.PubsubMessage;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation.ContextVisitor;
 import java.util.Map;
 
-public class TextMapExtractAdapter
-    implements AgentPropagation.ContextVisitor<PubsubMessage>,
-        AgentPropagation.BinaryContextVisitor<PubsubMessage> {
-
+public class TextMapExtractAdapter implements ContextVisitor<PubsubMessage> {
   public static final TextMapExtractAdapter GETTER = new TextMapExtractAdapter();
 
   @Override
@@ -16,18 +14,6 @@ public class TextMapExtractAdapter
       String value = kv.getValue();
       if (null != value) {
         if (!classifier.accept(kv.getKey(), value)) {
-          return;
-        }
-      }
-    }
-  }
-
-  @Override
-  public void forEachKey(PubsubMessage carrier, AgentPropagation.BinaryKeyClassifier classifier) {
-    for (Map.Entry<String, String> kv : carrier.getAttributesMap().entrySet()) {
-      String value = kv.getValue();
-      if (null != value) {
-        if (!classifier.accept(kv.getKey(), value.getBytes())) {
           return;
         }
       }

--- a/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/google-pubsub/src/main/java/datadog/trace/instrumentation/googlepubsub/TextMapInjectAdapter.java
@@ -2,21 +2,13 @@ package datadog.trace.instrumentation.googlepubsub;
 
 import com.google.pubsub.v1.PubsubMessage;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
-import java.nio.charset.StandardCharsets;
 
-public class TextMapInjectAdapter
-    implements AgentPropagation.Setter<PubsubMessage.Builder>,
-        AgentPropagation.BinarySetter<PubsubMessage.Builder> {
+public class TextMapInjectAdapter implements AgentPropagation.Setter<PubsubMessage.Builder> {
 
   public static final TextMapInjectAdapter SETTER = new TextMapInjectAdapter();
 
   @Override
   public void set(final PubsubMessage.Builder msg, final String key, final String value) {
     msg.putAttributes(key, value);
-  }
-
-  @Override
-  public void set(PubsubMessage.Builder msg, String key, byte[] value) {
-    msg.putAttributes(key, new String(value, StandardCharsets.UTF_8));
   }
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/NoopTextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/NoopTextMapInjectAdapter.java
@@ -3,14 +3,10 @@ package datadog.trace.instrumentation.kafka_clients;
 import org.apache.kafka.common.header.Headers;
 
 public class NoopTextMapInjectAdapter implements TextMapInjectAdapterInterface {
-
   public static final NoopTextMapInjectAdapter NOOP_SETTER = new NoopTextMapInjectAdapter();
 
   @Override
   public void set(final Headers headers, final String key, final String value) {}
-
-  @Override
-  public void set(Headers headers, String key, byte[] value) {}
 
   public void injectTimeInQueue(Headers headers) {}
 }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapter.java
@@ -1,9 +1,9 @@
 package datadog.trace.instrumentation.kafka_clients;
 
 import static datadog.trace.instrumentation.kafka_clients.KafkaDecorator.KAFKA_PRODUCED_KEY;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.header.Headers;
 
 public class TextMapInjectAdapter implements TextMapInjectAdapterInterface {
@@ -11,12 +11,7 @@ public class TextMapInjectAdapter implements TextMapInjectAdapterInterface {
 
   @Override
   public void set(final Headers headers, final String key, final String value) {
-    headers.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
-  }
-
-  @Override
-  public void set(Headers headers, String key, byte[] value) {
-    headers.remove(key).add(key, value);
+    headers.remove(key).add(key, value.getBytes(UTF_8));
   }
 
   public void injectTimeInQueue(Headers headers) {

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapterInterface.java
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/TextMapInjectAdapterInterface.java
@@ -3,6 +3,6 @@ package datadog.trace.instrumentation.kafka_clients;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import org.apache.kafka.common.header.Headers;
 
-public interface TextMapInjectAdapterInterface extends AgentPropagation.BinarySetter<Headers> {
-  public void injectTimeInQueue(Headers headers);
+public interface TextMapInjectAdapterInterface extends AgentPropagation.Setter<Headers> {
+  void injectTimeInQueue(Headers headers);
 }

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/NoopTextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/NoopTextMapInjectAdapter.java
@@ -9,8 +9,5 @@ public class NoopTextMapInjectAdapter implements TextMapInjectAdapterInterface {
   @Override
   public void set(final Headers headers, final String key, final String value) {}
 
-  @Override
-  public void set(Headers headers, String key, byte[] value) {}
-
   public void injectTimeInQueue(Headers headers) {}
 }

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TextMapExtractAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TextMapExtractAdapter.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation.ContextVisitor;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import org.apache.kafka.common.header.Header;
@@ -11,10 +12,7 @@ import org.apache.kafka.common.header.Headers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class TextMapExtractAdapter
-    implements AgentPropagation.ContextVisitor<Headers>,
-        AgentPropagation.BinaryContextVisitor<Headers> {
-
+public class TextMapExtractAdapter implements ContextVisitor<Headers> {
   private static final Logger log = LoggerFactory.getLogger(TextMapExtractAdapter.class);
 
   public static final TextMapExtractAdapter GETTER =
@@ -31,27 +29,14 @@ public class TextMapExtractAdapter
     for (Header header : carrier) {
       String key = header.key();
       byte[] value = header.value();
-      if (null != value) {
-        String string =
-            base64 != null
-                ? new String(base64.decode(header.value()), UTF_8)
-                : new String(header.value(), UTF_8);
-        if (!classifier.accept(key, string)) {
-          return;
-        }
+      if (null == value) {
+        continue;
       }
-    }
-  }
-
-  @Override
-  public void forEachKey(Headers carrier, AgentPropagation.BinaryKeyClassifier classifier) {
-    for (Header header : carrier) {
-      String key = header.key();
-      byte[] value = header.value();
-      if (null != value) {
-        if (!classifier.accept(key, value)) {
-          return;
-        }
+      if (base64 != null) {
+        value = base64.decode(value);
+      }
+      if (!classifier.accept(key, new String(value, UTF_8))) {
+        return;
       }
     }
   }

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TextMapInjectAdapter.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TextMapInjectAdapter.java
@@ -1,7 +1,8 @@
 package datadog.trace.instrumentation.kafka_clients38;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.header.Headers;
 
 public class TextMapInjectAdapter implements TextMapInjectAdapterInterface {
@@ -9,12 +10,7 @@ public class TextMapInjectAdapter implements TextMapInjectAdapterInterface {
 
   @Override
   public void set(final Headers headers, final String key, final String value) {
-    headers.remove(key).add(key, value.getBytes(StandardCharsets.UTF_8));
-  }
-
-  @Override
-  public void set(Headers headers, String key, byte[] value) {
-    headers.remove(key).add(key, value);
+    headers.remove(key).add(key, value.getBytes(UTF_8));
   }
 
   public void injectTimeInQueue(Headers headers) {

--- a/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TextMapInjectAdapterInterface.java
+++ b/dd-java-agent/instrumentation/kafka-clients-3.8/src/main/java17/datadog/trace/instrumentation/kafka_clients38/TextMapInjectAdapterInterface.java
@@ -3,6 +3,6 @@ package datadog.trace.instrumentation.kafka_clients38;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import org.apache.kafka.common.header.Headers;
 
-public interface TextMapInjectAdapterInterface extends AgentPropagation.BinarySetter<Headers> {
-  public void injectTimeInQueue(Headers headers);
+public interface TextMapInjectAdapterInterface extends AgentPropagation.Setter<Headers> {
+  void injectTimeInQueue(Headers headers);
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/ProcessorRecordContextSetter.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/ProcessorRecordContextSetter.java
@@ -1,33 +1,28 @@
 package datadog.trace.instrumentation.kafka_streams;
 
 import static datadog.trace.instrumentation.kafka_streams.ProcessorRecordContextHeadersAccess.HEADERS_METHOD;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
-import java.nio.charset.StandardCharsets;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation.Setter;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ProcessorRecordContextSetter
-    implements AgentPropagation.BinarySetter<ProcessorRecordContext> {
+public class ProcessorRecordContextSetter implements Setter<ProcessorRecordContext> {
   private static final Logger log = LoggerFactory.getLogger(ProcessorRecordContextSetter.class);
 
   public static final ProcessorRecordContextSetter PR_SETTER = new ProcessorRecordContextSetter();
 
   @Override
   public void set(ProcessorRecordContext carrier, String key, String value) {
-    set(carrier, key, value.getBytes(StandardCharsets.UTF_8));
-  }
-
-  @Override
-  public void set(ProcessorRecordContext carrier, String key, byte[] value) {
     if (HEADERS_METHOD == null) {
       return;
     }
     try {
       Headers headers = (Headers) HEADERS_METHOD.invokeExact(carrier);
-      headers.remove(key).add(key, value);
+      byte[] bytes = value.getBytes(UTF_8);
+      headers.remove(key).add(key, bytes);
     } catch (Throwable e) {
       log.debug("Unable to set value", e);
     }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/StampedRecordContextSetter.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/StampedRecordContextSetter.java
@@ -1,24 +1,19 @@
 package datadog.trace.instrumentation.kafka_streams;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation.Setter;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.processor.internals.StampedRecord;
 
-public class StampedRecordContextSetter implements AgentPropagation.BinarySetter<StampedRecord> {
-
+public class StampedRecordContextSetter implements Setter<StampedRecord> {
   public static final StampedRecordContextSetter SR_SETTER = new StampedRecordContextSetter();
 
   @Override
   public void set(StampedRecord carrier, String key, String value) {
-    set(carrier, key, value.getBytes(StandardCharsets.UTF_8));
-  }
-
-  @Override
-  public void set(StampedRecord carrier, String key, byte[] value) {
     Headers headers = carrier.value.headers();
     if (headers != null) {
-      headers.remove(key).add(key, value);
+      headers.remove(key).add(key, value.getBytes(UTF_8));
     }
   }
 }

--- a/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/StampedRecordContextVisitor.java
+++ b/dd-java-agent/instrumentation/kafka-streams-0.11/src/main/java/datadog/trace/instrumentation/kafka_streams/StampedRecordContextVisitor.java
@@ -1,18 +1,17 @@
 package datadog.trace.instrumentation.kafka_streams;
 
 import static datadog.trace.instrumentation.kafka_streams.KafkaStreamsDecorator.KAFKA_PRODUCED_KEY;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation.ContextVisitor;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.streams.processor.internals.StampedRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class StampedRecordContextVisitor
-    implements AgentPropagation.ContextVisitor<StampedRecord>,
-        AgentPropagation.BinaryContextVisitor<StampedRecord> {
+public class StampedRecordContextVisitor implements ContextVisitor<StampedRecord> {
 
   private static final Logger log = LoggerFactory.getLogger(StampedRecordContextVisitor.class);
 
@@ -24,20 +23,7 @@ public class StampedRecordContextVisitor
       String key = header.key();
       byte[] value = header.value();
       if (null != value) {
-        if (!classifier.accept(key, new String(header.value(), StandardCharsets.UTF_8))) {
-          return;
-        }
-      }
-    }
-  }
-
-  @Override
-  public void forEachKey(StampedRecord carrier, AgentPropagation.BinaryKeyClassifier classifier) {
-    for (Header header : carrier.value.headers()) {
-      String key = header.key();
-      byte[] value = header.value();
-      if (null != value) {
-        if (!classifier.accept(key, value)) {
+        if (!classifier.accept(key, new String(header.value(), UTF_8))) {
           return;
         }
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamContextInjector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DataStreamContextInjector.java
@@ -66,36 +66,17 @@ public class DataStreamContextInjector {
         defaultTimestamp,
         payloadSizeBytes);
 
-    boolean injected =
-        setter instanceof AgentPropagation.BinarySetter
-            ? injectBinaryPathwayContext(
-                pathwayContext, carrier, (AgentPropagation.BinarySetter<C>) setter)
-            : injectPathwayContext(pathwayContext, carrier, setter);
+    boolean injected = injectPathwayContext(pathwayContext, carrier, setter);
 
     if (injected && pathwayContext.getHash() != 0) {
       span.setTag(PATHWAY_HASH, Long.toUnsignedString(pathwayContext.getHash()));
     }
   }
 
-  private static <C> boolean injectBinaryPathwayContext(
-      PathwayContext pathwayContext, C carrier, AgentPropagation.BinarySetter<C> setter) {
-    try {
-      byte[] encodedContext = pathwayContext.encode();
-      if (encodedContext != null) {
-        LOGGER.debug("Injecting binary pathway context {}", pathwayContext);
-        setter.set(carrier, PROPAGATION_KEY_BASE64, encodedContext);
-        return true;
-      }
-    } catch (IOException e) {
-      LOGGER.debug("Unable to set encode pathway context", e);
-    }
-    return false;
-  }
-
   private static <C> boolean injectPathwayContext(
       PathwayContext pathwayContext, C carrier, AgentPropagation.Setter<C> setter) {
     try {
-      String encodedContext = pathwayContext.strEncode();
+      String encodedContext = pathwayContext.encode();
       if (encodedContext != null) {
         LOGGER.debug("Injecting pathway context {}", pathwayContext);
         setter.set(carrier, PROPAGATION_KEY_BASE64, encodedContext);

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -218,7 +218,7 @@ public class DefaultPathwayContext implements PathwayContext {
   }
 
   @Override
-  public byte[] encode() throws IOException {
+  public String encode() throws IOException {
     lock.lock();
     try {
       if (!started) {
@@ -236,19 +236,11 @@ public class DefaultPathwayContext implements PathwayContext {
               + TimeUnit.NANOSECONDS.toMillis(edgeStartNanoTicks - pathwayStartNanoTicks);
 
       VarEncodingHelper.encodeSignedVarLong(outputBuffer, edgeStartMillis);
-      return Base64.getEncoder().encode(outputBuffer.trimmedCopy());
+      byte[] base64 = Base64.getEncoder().encode(outputBuffer.trimmedCopy());
+      return new String(base64, ISO_8859_1);
     } finally {
       lock.unlock();
     }
-  }
-
-  @Override
-  public String strEncode() throws IOException {
-    byte[] bytes = encode();
-    if (bytes == null) {
-      return null;
-    }
-    return new String(bytes, ISO_8859_1);
   }
 
   @Override
@@ -290,45 +282,9 @@ public class DefaultPathwayContext implements PathwayContext {
 
     @Override
     public boolean accept(String key, String value) {
-      if (PathwayContext.PROPAGATION_KEY_BASE64.equalsIgnoreCase(key)) {
-        try {
-          extractedContext = strDecode(timeSource, hashOfKnownTags, serviceNameOverride, value);
-        } catch (IOException e) {
-          return false;
-        }
-      }
-      return true;
-    }
-  }
-
-  private static class BinaryPathwayContextExtractor
-      implements AgentPropagation.BinaryKeyClassifier {
-    private final TimeSource timeSource;
-    private final long hashOfKnownTags;
-    private final String serviceNameOverride;
-    private DefaultPathwayContext extractedContext;
-
-    BinaryPathwayContextExtractor(
-        TimeSource timeSource, long hashOfKnownTags, String serviceNameOverride) {
-      this.timeSource = timeSource;
-      this.hashOfKnownTags = hashOfKnownTags;
-      this.serviceNameOverride = serviceNameOverride;
-    }
-
-    @Override
-    public boolean accept(String key, byte[] value) {
-      // older versions support, should be removed in the future
-      if (PathwayContext.PROPAGATION_KEY.equalsIgnoreCase(key)) {
+      if (PROPAGATION_KEY_BASE64.equalsIgnoreCase(key)) {
         try {
           extractedContext = decode(timeSource, hashOfKnownTags, serviceNameOverride, value);
-        } catch (IOException e) {
-          return false;
-        }
-      }
-
-      if (PathwayContext.PROPAGATION_KEY_BASE64.equalsIgnoreCase(key)) {
-        try {
-          extractedContext = base64Decode(timeSource, hashOfKnownTags, serviceNameOverride, value);
         } catch (IOException e) {
           return false;
         }
@@ -343,14 +299,6 @@ public class DefaultPathwayContext implements PathwayContext {
       TimeSource timeSource,
       long hashOfKnownTags,
       String serviceNameOverride) {
-    if (getter instanceof AgentPropagation.BinaryContextVisitor) {
-      return extractBinary(
-          carrier,
-          (AgentPropagation.BinaryContextVisitor) getter,
-          timeSource,
-          hashOfKnownTags,
-          serviceNameOverride);
-    }
     PathwayContextExtractor pathwayContextExtractor =
         new PathwayContextExtractor(timeSource, hashOfKnownTags, serviceNameOverride);
     getter.forEachKey(carrier, pathwayContextExtractor);
@@ -362,41 +310,12 @@ public class DefaultPathwayContext implements PathwayContext {
     return pathwayContextExtractor.extractedContext;
   }
 
-  static <C> DefaultPathwayContext extractBinary(
-      C carrier,
-      AgentPropagation.BinaryContextVisitor<C> getter,
-      TimeSource timeSource,
-      long hashOfKnownTags,
-      String serviceNameOverride) {
-    BinaryPathwayContextExtractor pathwayContextExtractor =
-        new BinaryPathwayContextExtractor(timeSource, hashOfKnownTags, serviceNameOverride);
-    getter.forEachKey(carrier, pathwayContextExtractor);
-    if (pathwayContextExtractor.extractedContext == null) {
-      log.debug("No context extracted");
-    } else {
-      log.debug("Extracted context: {} ", pathwayContextExtractor.extractedContext);
-    }
-    return pathwayContextExtractor.extractedContext;
-  }
-
-  private static DefaultPathwayContext strDecode(
-      TimeSource timeSource, long hashOfKnownTags, String serviceNameOverride, String data)
-      throws IOException {
-    byte[] base64Bytes = data.getBytes(UTF_8);
-    return base64Decode(timeSource, hashOfKnownTags, serviceNameOverride, base64Bytes);
-  }
-
-  private static DefaultPathwayContext base64Decode(
-      TimeSource timeSource, long hashOfKnownTags, String serviceNameOverride, byte[] data)
-      throws IOException {
-    return decode(
-        timeSource, hashOfKnownTags, serviceNameOverride, Base64.getDecoder().decode(data));
-  }
-
   private static DefaultPathwayContext decode(
-      TimeSource timeSource, long hashOfKnownTags, String serviceNameOverride, byte[] data)
+      TimeSource timeSource, long hashOfKnownTags, String serviceNameOverride, String base64)
       throws IOException {
-    ByteArrayInput input = ByteArrayInput.wrap(data);
+    byte[] base64Bytes = base64.getBytes(UTF_8);
+    byte[] bytes = Base64.getDecoder().decode(base64Bytes);
+    ByteArrayInput input = ByteArrayInput.wrap(bytes);
 
     long hash = input.readLongLE();
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentPropagation.java
@@ -29,26 +29,13 @@ public interface AgentPropagation {
     void set(C carrier, String key, String value);
   }
 
-  interface BinarySetter<C> extends Setter<C> {
-    void set(C carrier, String key, byte[] value);
-  }
-
   <C> AgentSpanContext.Extracted extract(C carrier, ContextVisitor<C> getter);
 
   interface KeyClassifier {
-
     boolean accept(String key, String value);
-  }
-
-  interface BinaryKeyClassifier {
-    boolean accept(String key, byte[] value);
   }
 
   interface ContextVisitor<C> {
     void forEachKey(C carrier, KeyClassifier classifier);
-  }
-
-  interface BinaryContextVisitor<C> extends ContextVisitor<C> {
-    void forEachKey(C carrier, BinaryKeyClassifier classifier);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -1185,12 +1185,7 @@ public class AgentTracer {
     }
 
     @Override
-    public byte[] encode() {
-      return null;
-    }
-
-    @Override
-    public String strEncode() {
+    public String encode() {
       return null;
     }
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PathwayContext.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/PathwayContext.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashMap;
 import java.util.function.Consumer;
 
 public interface PathwayContext {
-  String PROPAGATION_KEY = "dd-pathway-ctx";
   String PROPAGATION_KEY_BASE64 = "dd-pathway-ctx-base64";
   String DATADOG_KEY = "_datadog";
 
@@ -31,7 +30,5 @@ public interface PathwayContext {
 
   StatsPoint getSavedStats();
 
-  byte[] encode() throws IOException;
-
-  String strEncode() throws IOException;
+  String encode() throws IOException;
 }


### PR DESCRIPTION
# What Does This Do

This PR cleans up the `BinarySetter` API used to inject binary data during context propagation.

# Motivation

This API was only used by DSM for Pathway context injection and is no more used.
Currently, only the `dd-pathway-ctx-base64` key is injected / extracted and is a base64 string.
The legacy `dd-pathway-ctx` was already no more used.

# Additional Notes

This is preliminary refactoring work for the new context propagation API. 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-38]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-38]: https://datadoghq.atlassian.net/browse/LANGPLAT-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ