### PR TITLE
Example of how to group related instrumentations under a single module (AwsSdkModule)

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkModule.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkModule.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+/** Groups the instrumentations for AWS SDK 1.11.0+. */
 @AutoService(InstrumenterModule.class)
 public final class AwsSdkModule extends InstrumenterModule.Tracing {
 

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkModule.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkModule.java
@@ -1,0 +1,46 @@
+package datadog.trace.instrumentation.aws.v0;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@AutoService(InstrumenterModule.class)
+public final class AwsSdkModule extends InstrumenterModule.Tracing {
+
+  public AwsSdkModule() {
+    super("aws-sdk");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".AwsSdkClientDecorator",
+      packageName + ".GetterAccess",
+      packageName + ".GetterAccess$1",
+      packageName + ".TracingRequestHandler",
+      packageName + ".AwsNameCache",
+      packageName + ".OnErrorDecorator",
+    };
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    Map<String, String> map = new java.util.HashMap<>();
+    map.put("com.amazonaws.services.sqs.model.ReceiveMessageResult", "java.lang.String");
+    map.put(
+        "com.amazonaws.AmazonWebServiceRequest",
+        "datadog.trace.bootstrap.instrumentation.api.AgentSpan");
+    return map;
+  }
+
+  @Override
+  public List<Instrumenter> typeInstrumentations() {
+    return Arrays.asList(
+        new AWSHttpClientInstrumentation(),
+        new RequestExecutorInstrumentation(),
+        new HandlerChainFactoryInstrumentation());
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/HandlerChainFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/HandlerChainFactoryInstrumentation.java
@@ -4,50 +4,21 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 
 import com.amazonaws.handlers.RequestHandler2;
-import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.bootstrap.InstrumentationContext;
 import java.util.List;
-import java.util.Map;
 import net.bytebuddy.asm.Advice;
 
 /**
  * This instrumentation might work with versions before 1.11.0, but this was the first version that
  * is tested. It could possibly be extended earlier.
  */
-@AutoService(InstrumenterModule.class)
-public final class HandlerChainFactoryInstrumentation extends InstrumenterModule.Tracing
+public final class HandlerChainFactoryInstrumentation
     implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
-
-  public HandlerChainFactoryInstrumentation() {
-    super("aws-sdk");
-  }
 
   @Override
   public String instrumentedType() {
     return "com.amazonaws.handlers.HandlerChainFactory";
-  }
-
-  @Override
-  public String[] helperClassNames() {
-    return new String[] {
-      packageName + ".AwsSdkClientDecorator",
-      packageName + ".GetterAccess",
-      packageName + ".GetterAccess$1",
-      packageName + ".TracingRequestHandler",
-      packageName + ".AwsNameCache",
-    };
-  }
-
-  @Override
-  public Map<String, String> contextStore() {
-    Map<String, String> map = new java.util.HashMap<>();
-    map.put("com.amazonaws.services.sqs.model.ReceiveMessageResult", "java.lang.String");
-    map.put(
-        "com.amazonaws.AmazonWebServiceRequest",
-        "datadog.trace.bootstrap.instrumentation.api.AgentSpan");
-    return map;
   }
 
   @Override

--- a/docs/how_instrumentations_work.md
+++ b/docs/how_instrumentations_work.md
@@ -101,7 +101,7 @@ At this point the instrumentation should override the method `muzzleDirective()`
 
 ## Instrumentation classes
 
-The Instrumentation class is where the Instrumentation begins. It will:
+The Instrumentation class is where the instrumentation begins. It will:
 
 1. Use Matchers to choose target types (i.e., classes)
 2. From only those target types, use Matchers to select the members (i.e., methods) to instrument.
@@ -110,8 +110,9 @@ The Instrumentation class is where the Instrumentation begins. It will:
 Instrumentation classes:
 
 1. Must be annotated with `@AutoService(InstrumenterModule.class)`
-2. Should extend one of the six abstract TargetSystem `InstrumenterModule` classes
-3. Should implement one of the `Instrumenter` interfaces
+2. Should be declared in a file that ends with `Instrumentation.java`
+3. Should extend one of the six abstract TargetSystem `InstrumenterModule` classes
+4. Should implement one of the `Instrumenter` interfaces
 
 For example:
 
@@ -135,6 +136,31 @@ public class RabbitChannelInstrumentation extends InstrumenterModule.Tracing
 | `InstrumenterModule.`[`CiVisibility`](https://github.com/DataDog/dd-trace-java/blob/82a3400cd210f4051b92fe1a86cd1b64a17e005e/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java#L285) |                                                                                                            |
 | `InstrumenterModule.`[`Usm`](https://github.com/DataDog/dd-trace-java/blob/82a3400cd210f4051b92fe1a86cd1b64a17e005e/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java#L273)          |                                                                                                            |
 | [`InstrumenterModule`](https://github.com/DataDog/dd-trace-java/blob/82a3400cd210f4051b92fe1a86cd1b64a17e005e/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java)           | Avoid extending `InstrumenterModule` directly.  When no other TargetGroup is applicable we generally default to `InstrumenterModule.Tracing` |
+
+### Grouping Instrumentations
+
+Related instrumentations may be grouped under a single `InstrumenterModule` to share common details
+such as integration name, helpers, context store use, and optional `classLoaderMatcher()`.
+
+Module classes:
+
+1. Must be annotated with `@AutoService(InstrumenterModule.class)`
+2. Should be declared in a file that ends with `Module.java`
+3. Should extend one of the six abstract TargetSystem `InstrumenterModule` classes
+4. Should have a `typeInstrumentations()` method that returns the instrumentations in the group
+5. Should NOT implement one of the `Instrumenter` interfaces
+
+> [!WARNING]
+> Grouped instrumentations must NOT be annotated with `@AutoService(InstrumenterModule.class)
+> and must NOT extend any of the six abstract TargetSystem `InstrumenterModule` classes
+
+Existing instrumentations can be grouped under a new module, assuming they share the same integration name.
+
+For each member instrumentation:
+1. Remove `@AutoService(InstrumenterModule.class)`
+2. Remove `extends InstrumenterModule...`
+3. Move the list of helpers to the module, merging as necessary
+4. Move the context store map to the module, merging as necessary
 
 ### Type Matching
 


### PR DESCRIPTION
# What Does This Do

Provides an example of how to group related instrumentations under a single module.

# Motivation

Grouping related instrumentations reduces repeated declarations of helpers and context store use.

Grouping also makes it easier to re-use instrumentations.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-860]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-860]: https://datadoghq.atlassian.net/browse/APMAPI-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ