### PR TITLE
Increase timeout in Gradle Launcher smoke tests

### DIFF
--- a/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleLauncherSmokeTest.groovy
+++ b/dd-smoke-tests/gradle/src/test/groovy/datadog/smoketest/GradleLauncherSmokeTest.groovy
@@ -9,7 +9,7 @@ import datadog.trace.civisibility.utils.ShellCommandExecutor
  */
 class GradleLauncherSmokeTest extends AbstractGradleTest {
 
-  private static final int GRADLE_BUILD_TIMEOUT_MILLIS = 30_000
+  private static final int GRADLE_BUILD_TIMEOUT_MILLIS = 60_000
 
   private static final String AGENT_JAR = System.getProperty("datadog.smoketest.agent.shadowJar.path")
 


### PR DESCRIPTION
# What Does This Do

Increase Gradle build timeout in Gradle Launcher smoke tests from 30s to 60s.

# Motivation

Reduce tests flakiness.
When running the test on IBM Semeru 17 Gradle builds may take longer than 30 seconds.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1409]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1409]: https://datadoghq.atlassian.net/browse/SDTEST-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ