### PR TITLE
Consistency: instrumentation classes should be in files ending with `Instrumentation.java`

### DIFF
--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/CommonsFileuploadInstrumentation.java
@@ -22,10 +22,10 @@ import java.util.Map;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(InstrumenterModule.class)
-public class CommonsFileuploadInstrumenter extends InstrumenterModule.Iast
+public class CommonsFileuploadInstrumentation extends InstrumenterModule.Iast
     implements Instrumenter.ForKnownTypes, Instrumenter.HasMethodAdvice {
 
-  public CommonsFileuploadInstrumenter() {
+  public CommonsFileuploadInstrumentation() {
     super("commons-fileupload");
   }
 

--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/FileItemInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/FileItemInstrumentation.java
@@ -19,19 +19,19 @@ import java.io.InputStream;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.apache.commons.fileupload.FileItemStream;
+import org.apache.commons.fileupload.FileItem;
 
 @AutoService(InstrumenterModule.class)
-public class FileItemStreamInstrumenter extends InstrumenterModule.Iast
+public class FileItemInstrumentation extends InstrumenterModule.Iast
     implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
 
-  public FileItemStreamInstrumenter() {
-    super("commons-fileupload", "fileitemstream");
+  public FileItemInstrumentation() {
+    super("commons-fileupload", "fileitem");
   }
 
   @Override
   public String hierarchyMarkerType() {
-    return "org.apache.commons.fileupload.FileItemStream";
+    return "org.apache.commons.fileupload.FileItem";
   }
 
   @Override
@@ -42,16 +42,16 @@ public class FileItemStreamInstrumenter extends InstrumenterModule.Iast
   @Override
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
-        named("openStream").and(isPublic()).and(takesArguments(0)),
-        getClass().getName() + "$OpenStreamAdvice");
+        named("getInputStream").and(isPublic()).and(takesArguments(0)),
+        getClass().getName() + "$GetInputStreamAdvice");
   }
 
   @RequiresRequestContext(RequestContextSlot.IAST)
-  public static class OpenStreamAdvice {
+  public static class GetInputStreamAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void onExit(
         @Advice.Return final InputStream inputStream,
-        @Advice.This final FileItemStream self,
+        @Advice.This final FileItem self,
         @ActiveRequestContext RequestContext reqCtx) {
       final PropagationModule module = InstrumentationBridge.PROPAGATION;
       if (module != null) {

--- a/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/ServletFileUploadInstrumentation.java
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/main/java/datadog/trace/instrumentation/commons/fileupload/ServletFileUploadInstrumentation.java
@@ -23,10 +23,10 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemIterator;
 
 @AutoService(InstrumenterModule.class)
-public class ServletFileUploadInstrumenter extends InstrumenterModule.Iast
+public class ServletFileUploadInstrumentation extends InstrumenterModule.Iast
     implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
 
-  public ServletFileUploadInstrumenter() {
+  public ServletFileUploadInstrumentation() {
     super("commons-fileupload", "servlet");
   }
 

--- a/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/FileItemInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/FileItemInstrumentationTest.groovy
@@ -6,7 +6,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.TagContext
 import foo.bar.smoketest.MockFileItem
 
-class FileItemInstrumenterTest extends AgentTestRunner {
+class FileItemInstrumentationTest extends AgentTestRunner {
 
   private Object iastCtx
 

--- a/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/FileItemIteratorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/FileItemIteratorInstrumentationTest.groovy
@@ -7,7 +7,7 @@ import datadog.trace.bootstrap.instrumentation.api.TagContext
 import foo.bar.smoketest.MockFileItemIterator
 import foo.bar.smoketest.MockFileItemStream
 
-class FileItemIteratorInstrumenterTest extends AgentTestRunner {
+class FileItemIteratorInstrumentationTest extends AgentTestRunner {
 
   private Object iastCtx
 

--- a/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/FileItemStreamInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/FileItemStreamInstrumentationTest.groovy
@@ -6,7 +6,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.TagContext
 import foo.bar.smoketest.MockFileItemStream
 
-class FileItemStreamInstrumenterTest extends AgentTestRunner {
+class FileItemStreamInstrumentationTest extends AgentTestRunner {
 
   private Object iastCtx
 

--- a/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/ServletFileUploadInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/commons-fileupload/src/test/groovy/ServletFileUploadInstrumentationTest.groovy
@@ -11,7 +11,7 @@ import org.apache.commons.fileupload.FileItemIterator
 import org.apache.commons.fileupload.disk.DiskFileItemFactory
 import org.apache.commons.fileupload.servlet.ServletFileUpload
 
-class ServletFileUploadInstrumenterTest extends AgentTestRunner {
+class ServletFileUploadInstrumentationTest extends AgentTestRunner {
 
   private Object iastCtx
 


### PR DESCRIPTION
# Motivation

This is so we can direct load requests to a special class-loader that can be unloaded after use.

# Additional Notes

See https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java#L97

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-117]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-117]: https://datadoghq.atlassian.net/browse/LANGPLAT-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ