### PR TITLE
Retry open connection on lettuce 5 tests

### DIFF
--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/Lettuce5ReactiveClientTest.groovy
@@ -8,13 +8,14 @@ import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import io.lettuce.core.ClientOptions
 import io.lettuce.core.RedisClient
-import io.lettuce.core.api.StatefulConnection
+import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.reactive.RedisReactiveCommands
 import io.lettuce.core.api.sync.RedisCommands
 import org.testcontainers.containers.wait.strategy.Wait
 import reactor.core.scheduler.Schedulers
 import spock.lang.Shared
 import spock.util.concurrent.AsyncConditions
+import spock.util.concurrent.PollingConditions
 
 import java.util.function.Consumer
 
@@ -40,7 +41,7 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
   .waitingFor(Wait.forListeningPort())
 
   RedisClient redisClient
-  StatefulConnection connection
+  StatefulRedisConnection connection
   RedisReactiveCommands<String, ?> reactiveCommands
   RedisCommands<String, ?> syncCommands
 
@@ -54,7 +55,9 @@ abstract class Lettuce5ReactiveClientTest extends VersionedNamingTestBase {
 
     redisClient.setOptions(CLIENT_OPTIONS)
 
-    connection = redisClient.connect()
+    new PollingConditions(delay: 3, timeout: 15).eventually {
+      (connection = redisClient.connect()) != null
+    }
     reactiveCommands = connection.reactive()
     syncCommands = connection.sync()
 


### PR DESCRIPTION
# What Does This Do

Retry opening a connection on lettuce 5 reactive tests

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
