### PR TITLE
Retry telemetry requests if CI Visibility is enabled

### DIFF
--- a/communication/src/main/java/datadog/communication/http/HttpRetryPolicy.java
+++ b/communication/src/main/java/datadog/communication/http/HttpRetryPolicy.java
@@ -160,6 +160,8 @@ public class HttpRetryPolicy implements AutoCloseable {
   }
 
   public static class Factory {
+    public static final Factory NEVER_RETRY = new Factory(0, 0, 0);
+
     private final int maxRetries;
     private final long initialDelay;
     private final double delayFactor;

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryClient.java
@@ -1,14 +1,15 @@
 package datadog.telemetry;
 
+import datadog.communication.http.HttpRetryPolicy;
 import datadog.communication.http.OkHttpUtils;
 import datadog.trace.api.Config;
 import datadog.trace.util.Strings;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,16 +18,19 @@ public class TelemetryClient {
   public enum Result {
     SUCCESS,
     FAILURE,
-    NOT_FOUND;
+    NOT_FOUND,
+    INTERRUPTED
   }
 
-  public static TelemetryClient buildAgentClient(OkHttpClient okHttpClient, HttpUrl agentUrl) {
+  public static TelemetryClient buildAgentClient(
+      OkHttpClient okHttpClient, HttpUrl agentUrl, HttpRetryPolicy.Factory httpRetryPolicy) {
     HttpUrl agentTelemetryUrl =
         agentUrl.newBuilder().addPathSegments(AGENT_TELEMETRY_API_ENDPOINT).build();
-    return new TelemetryClient(okHttpClient, agentTelemetryUrl, null);
+    return new TelemetryClient(okHttpClient, httpRetryPolicy, agentTelemetryUrl, null);
   }
 
-  public static TelemetryClient buildIntakeClient(Config config) {
+  public static TelemetryClient buildIntakeClient(
+      Config config, HttpRetryPolicy.Factory httpRetryPolicy) {
     String apiKey = config.getApiKey();
     if (apiKey == null) {
       log.debug("Cannot create Telemetry Intake because DD_API_KEY unspecified.");
@@ -44,7 +48,7 @@ public class TelemetryClient {
 
     long timeoutMillis = TimeUnit.SECONDS.toMillis(config.getAgentTimeout());
     OkHttpClient httpClient = OkHttpUtils.buildHttpClient(url, timeoutMillis);
-    return new TelemetryClient(httpClient, url, apiKey);
+    return new TelemetryClient(httpClient, httpRetryPolicy, url, apiKey);
   }
 
   private static String buildIntakeTelemetryUrl(Config config) {
@@ -71,11 +75,17 @@ public class TelemetryClient {
   private static final String DD_TELEMETRY_REQUEST_TYPE = "DD-Telemetry-Request-Type";
 
   private final OkHttpClient okHttpClient;
+  private final HttpRetryPolicy.Factory httpRetryPolicy;
   private final HttpUrl url;
   private final String apiKey;
 
-  public TelemetryClient(OkHttpClient okHttpClient, HttpUrl url, String apiKey) {
+  public TelemetryClient(
+      OkHttpClient okHttpClient,
+      HttpRetryPolicy.Factory httpRetryPolicy,
+      HttpUrl url,
+      String apiKey) {
     this.okHttpClient = okHttpClient;
+    this.httpRetryPolicy = httpRetryPolicy;
     this.url = url;
     this.apiKey = apiKey;
   }
@@ -92,7 +102,9 @@ public class TelemetryClient {
 
     Request httpRequest = httpRequestBuilder.build();
     String requestType = httpRequest.header(DD_TELEMETRY_REQUEST_TYPE);
-    try (Response response = okHttpClient.newCall(httpRequest).execute()) {
+
+    try (okhttp3.Response response =
+        OkHttpUtils.sendWithRetries(okHttpClient, httpRetryPolicy, httpRequest)) {
       if (response.code() == 404) {
         log.debug("Telemetry endpoint is disabled, dropping {} message.", requestType);
         return Result.NOT_FOUND;
@@ -105,6 +117,10 @@ public class TelemetryClient {
             response.message());
         return Result.FAILURE;
       }
+    } catch (InterruptedIOException e) {
+      log.debug("Telemetry message {} sending interrupted: {}.", requestType, e.toString());
+      return Result.INTERRUPTED;
+
     } catch (IOException e) {
       log.debug("Telemetry message {} failed with exception: {}.", requestType, e.toString());
       return Result.FAILURE;

--- a/telemetry/src/main/java/datadog/telemetry/TelemetryRouter.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetryRouter.java
@@ -36,7 +36,11 @@ public class TelemetryRouter {
     Request.Builder httpRequestBuilder = request.httpRequest();
     TelemetryClient.Result result = currentClient.sendHttpRequest(httpRequestBuilder);
 
-    boolean requestFailed = result != TelemetryClient.Result.SUCCESS;
+    boolean requestFailed =
+        result != TelemetryClient.Result.SUCCESS
+            // interrupted request is most likely due to telemetry system shutdown,
+            // we do not want to log errors and reattempt in this case
+            && result != TelemetryClient.Result.INTERRUPTED;
     if (currentClient == agentClient) {
       if (requestFailed) {
         reportErrorOnce(currentClient.getUrl(), result);

--- a/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
+++ b/telemetry/src/test/groovy/datadog/telemetry/TelemetryClientTest.groovy
@@ -1,6 +1,10 @@
 package datadog.telemetry
 
+import datadog.communication.http.HttpRetryPolicy
+import datadog.telemetry.api.RequestType
 import datadog.trace.api.Config
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import spock.lang.Specification
 
 class TelemetryClientTest extends Specification {
@@ -13,7 +17,7 @@ class TelemetryClientTest extends Specification {
     config.getSite() >> site
 
     when:
-    def intakeClient = TelemetryClient.buildIntakeClient(config)
+    def intakeClient = TelemetryClient.buildIntakeClient(config, HttpRetryPolicy.Factory.NEVER_RETRY)
 
     then:
     intakeClient.getUrl().toString() == expectedUrl
@@ -39,7 +43,7 @@ class TelemetryClientTest extends Specification {
     config.getCiVisibilityAgentlessUrl() >> ciVisAgentlessUrl
 
     when:
-    def intakeClient = TelemetryClient.buildIntakeClient(config)
+    def intakeClient = TelemetryClient.buildIntakeClient(config, HttpRetryPolicy.Factory.NEVER_RETRY)
 
     then:
     intakeClient.getUrl().toString() == expectedUrl
@@ -50,5 +54,24 @@ class TelemetryClientTest extends Specification {
     false        | true                  | "http://ci.visibility.agentless.url" | "https://all-http-intake.logs.datad0g.com/api/v2/apmtelemetry"
     true         | false                 | "http://ci.visibility.agentless.url" | "https://all-http-intake.logs.datad0g.com/api/v2/apmtelemetry"
     true         | true                  | null                                 | "https://all-http-intake.logs.datad0g.com/api/v2/apmtelemetry"
+  }
+
+  def "Intake client retries telemetry request if configured to do so"() {
+    setup:
+    def httpClient = Mock(OkHttpClient)
+    def httpRetryPolicy = new HttpRetryPolicy.Factory(2, 50, 1.5, true)
+    def httpUrl = HttpUrl.get("https://intake.example.com")
+    def intakeClient =  new TelemetryClient(httpClient, httpRetryPolicy, httpUrl, "dummy-api-key")
+
+    when:
+    intakeClient.sendHttpRequest(dummyRequest())
+
+    then:
+    // original request + 2 retries
+    3 * httpClient.newCall(_) >> { throw new ConnectException("exception") }
+  }
+
+  def dummyRequest() {
+    return new TelemetryRequest(Mock(EventSource), Mock(EventSink), 1000, RequestType.APP_STARTED, false).httpRequest()
   }
 }


### PR DESCRIPTION
# What Does This Do

- retries telemetry requests up to 2 times if CI Visibility is enabled
- updates telemetry logging: error message is not printed if a telemetry request is interrupted

# Motivation

Telemetry system is shut down when the JVM terminates. Shutdown interrupts telemetry thread, and if a telemetry request was in progress when the shutdown starts that request is aborted and an `InterruptedIOException` is thrown.

Current behaviour is to log an error in this case, and possibly reattempt the request with a different dispatch method (intake vs agent).

This is not suitable for CI Visibility: oftentimes traced JVMs are short-lived (e.g. they need to run a few unit tests and then terminate). In such cases telemetry will fail to be sent (and we will miss useful data in the backend, for example the number of test start events will not correspond to the number of test finished events), and an error will be logged which is confusing to the customer. The changes in this PR are meant to address these shortcomings.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1411]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
