### PR TITLE
WIP: Validator

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ExceptionHandlers.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/bytebuddy/ExceptionHandlers.java
@@ -4,7 +4,7 @@ import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.ProductActivation;
 import datadog.trace.bootstrap.ExceptionLogger;
 import net.bytebuddy.ClassFileVersion;
-import net.bytebuddy.asm.Advice.ExceptionHandler;
+import net.bytebuddy.asm.Advice;
 import net.bytebuddy.implementation.Implementation;
 import net.bytebuddy.implementation.bytecode.StackManipulation;
 import net.bytebuddy.jar.asm.Label;
@@ -20,8 +20,8 @@ public class ExceptionHandlers {
   // Bootstrap ExceptionHandler.class will always be resolvable, so we'll use it in the log name
   private static final String HANDLER_NAME = ExceptionLogger.class.getName().replace('.', '/');
 
-  private static final ExceptionHandler EXCEPTION_STACK_HANDLER =
-      new ExceptionHandler.Simple(
+  private static final Advice.ExceptionHandler EXCEPTION_STACK_HANDLER =
+      new Advice.ExceptionHandler.Simple(
           new StackManipulation() {
             // Pops one Throwable off the stack. Maxes the stack to at least 3.
             private final Size size = new StackManipulation.Size(-1, 3);
@@ -131,7 +131,7 @@ public class ExceptionHandlers {
             }
           });
 
-  public static ExceptionHandler defaultExceptionHandler() {
+  public static Advice.ExceptionHandler defaultExceptionHandler() {
     return EXCEPTION_STACK_HANDLER;
   }
 }

--- a/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -5,11 +5,6 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.aws.v1.lambda.LambdaHandlerDecorator.INVOCATION_SPAN_NAME;
-import static net.bytebuddy.asm.Advice.Enter;
-import static net.bytebuddy.asm.Advice.OnMethodEnter;
-import static net.bytebuddy.asm.Advice.OnMethodExit;
-import static net.bytebuddy.asm.Advice.Origin;
-import static net.bytebuddy.asm.Advice.This;
 import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -82,11 +77,11 @@ public class LambdaHandlerInstrumentation extends InstrumenterModule.Tracing
   }
 
   public static class ExtensionCommunicationAdvice {
-    @OnMethodEnter
+    @Advice.OnMethodEnter
     static AgentScope enter(
-        @This final Object that,
+        @Advice.This final Object that,
         @Advice.Argument(0) final Object event,
-        @Origin("#m") final String methodName) {
+        @Advice.Origin("#m") final String methodName) {
 
       if (CallDepthThreadLocalMap.incrementCallDepth(RequestHandler.class) > 0) {
         return null;
@@ -103,10 +98,10 @@ public class LambdaHandlerInstrumentation extends InstrumenterModule.Tracing
       return scope;
     }
 
-    @OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+    @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     static void exit(
-        @Origin String method,
-        @Enter final AgentScope scope,
+        @Advice.Origin String method,
+        @Advice.Enter final AgentScope scope,
         @Advice.Return(typing = DYNAMIC) final Object result,
         @Advice.Thrown final Throwable throwable) {
 

--- a/dd-java-agent/instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/CodeOriginInstrumentation.java
+++ b/dd-java-agent/instrumentation/span-origin/src/main/java/datadog/trace/instrumentation/codeorigin/CodeOriginInstrumentation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.codeorigin;
 
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.agent.tooling.InstrumenterModule.Tracing;
+import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers;
 import datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.OneOf;
@@ -12,7 +12,7 @@ import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-public abstract class CodeOriginInstrumentation extends Tracing
+public abstract class CodeOriginInstrumentation extends InstrumenterModule.Tracing
     implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
 
   private final OneOf<NamedElement> matcher;

--- a/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
+++ b/dd-java-agent/instrumentation/trace-annotation/src/main/java/datadog/trace/instrumentation/trace_annotation/TraceConfigInstrumentation.java
@@ -73,7 +73,7 @@ public class TraceConfigInstrumentation extends InstrumenterModule {
   }
 
   // Not Using AutoService to hook up this instrumentation
-  public static class TracerClassInstrumentation implements ForTypeHierarchy, HasMethodAdvice {
+  public static class TracerClassInstrumentation implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
     private final String className;
     private final Set<String> methodNames;
 

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,96 @@
+import javalang
+import os
+import re
+
+
+# Helper function to validate kebab-case
+def is_kebab_case(name):
+    return re.match(r'^[a-z0-9]+(-[a-z0-9.]+)*$', name) is not None
+
+def find_java_files(directory):
+    java_files = []
+    for root, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".java"):
+                java_files.append(os.path.join(root, file))
+    return java_files
+
+def parse_java_file(file_path):
+    with open(file_path, 'r', encoding='utf-8') as file:
+        return javalang.parse.parse(file.read())
+
+def validate_inheritance(tree, file_name):
+    issues = []
+    for path, node in tree:
+        if isinstance(node, javalang.tree.ClassDeclaration):
+            # Skip static inner classes
+            if any(modifier for modifier in node.modifiers if modifier == "static") and '.' in node.name:
+                continue
+
+            if node.name.endswith("Decorator"):
+                if not node.extends or "Decorator" not in node.extends.name:
+                    issues.append(f"{file_name}: Class '{node.name}' should extend a class with 'Decorator' in its name.")
+            elif node.extends and "Decorator" in node.extends.name:
+                if not node.name.endswith("Decorator"):
+                    issues.append(f"{file_name}: Class '{node.name}' extends a 'Decorator' class but does not end with 'Decorator'.")
+
+            if node.name.endswith("Instrumentation"):
+                # should extend something
+                if not node.extends and not node.implements:
+                    issues.append(f"{file_name}: Class '{node.name}' should extend or implement a class with 'Instrument' in its name.")
+                # if it extends something, it should extend an instrument
+                elif not ((node.extends and "Instrument" in node.extends.name) or (node.implements and any("Instrument" in impl.name for impl in node.implements))):
+                    issues.append(f"{file_name}: Class '{node.name}' should extend a class with 'Instrument' in its name.")
+            elif node.extends and "Instrument" in node.extends.name:
+                if not node.name.endswith("Instrumentation"):
+                    issues.append(f"{file_name}: Class '{node.name}' extends a 'Instrument' class but does not end with 'Instrumentation'.")
+            elif node.implements and any("Instrument" in impl for impl in node.implements):
+                if not node.name.endswith("Instrumentation"):
+                    issues.append(f"{file_name}: Class '{node.name}' implements a 'Instrument' class but does not end with 'Instrumentation'.")
+
+            if node.name.endswith("Advice"):
+                # Check for methods with an @Advice annotation
+                if not any(
+                        isinstance(member, javalang.tree.MethodDeclaration) and
+                        any(anno.name.startswith("Advice") for anno in member.annotations)
+                        for member in node.body
+                ):
+                    issues.append(f"{file_name}: Class '{node.name}' does not have a method tagged with an @Advice annotation.")
+    return issues
+
+def validate_project_structure(base_directory):
+    issues = []
+
+    # Check kebab-case for subdirectories
+    instrumentation_path = os.path.join(base_directory, "dd-java-agent", "instrumentation")
+    if not os.path.exists(instrumentation_path):
+        issues.append(f"Path '{instrumentation_path}' does not exist.")
+        return issues
+
+    for subdir in os.listdir(instrumentation_path):
+        if os.path.isdir(os.path.join(instrumentation_path, subdir)):
+            if not is_kebab_case(subdir):
+                issues.append(f"Subdirectory '{subdir}' is not in kebab-case.")
+
+    # Validate Java files in subdirectories
+    for subdir in os.listdir(instrumentation_path):
+        subdir_path = os.path.join(instrumentation_path, subdir)
+        if os.path.isdir(subdir_path):
+            java_files = find_java_files(os.path.join(subdir_path, "src", "main", "java"))
+            for java_file in java_files:
+                try:
+                    tree = parse_java_file(java_file)
+                    issues.extend(validate_inheritance(tree, java_file))
+                except (javalang.parser.JavaSyntaxError, UnicodeDecodeError):
+                    issues.append(f"Could not parse Java file '{java_file}'.")
+
+    return issues
+
+if __name__ == "__main__":
+    base_directory = "."  # Change this to the root directory of your project
+    problems = validate_project_structure(base_directory)
+
+    if problems:
+        print("\n".join(problems))
+    else:
+        print("All checks passed!")

--- a/validate.py
+++ b/validate.py
@@ -34,7 +34,7 @@ def validate_inheritance(tree, file_name):
                 if not node.name.endswith("Decorator"):
                     issues.append(f"{file_name}: Class '{node.name}' extends a 'Decorator' class but does not end with 'Decorator'.")
 
-            if node.name.endswith("Instrumentation"):
+            if node.name.endswith("Instrumentation") or node.name.endswith("Module"):
                 # should extend something
                 if not node.extends and not node.implements:
                     issues.append(f"{file_name}: Class '{node.name}' should extend or implement a class with 'Instrument' in its name.")
@@ -42,11 +42,11 @@ def validate_inheritance(tree, file_name):
                 elif not ((node.extends and "Instrument" in node.extends.name) or (node.implements and any("Instrument" in impl.name for impl in node.implements))):
                     issues.append(f"{file_name}: Class '{node.name}' should extend a class with 'Instrument' in its name.")
             elif node.extends and "Instrument" in node.extends.name:
-                if not node.name.endswith("Instrumentation"):
-                    issues.append(f"{file_name}: Class '{node.name}' extends a 'Instrument' class but does not end with 'Instrumentation'.")
+                if not node.name.endswith("Instrumentation") or not node.name.endswith("Module"):
+                    issues.append(f"{file_name}: Class '{node.name}' extends a 'Instrument' class but does not end with 'Instrumentation' or 'Module'.")
             elif node.implements and any("Instrument" in impl for impl in node.implements):
-                if not node.name.endswith("Instrumentation"):
-                    issues.append(f"{file_name}: Class '{node.name}' implements a 'Instrument' class but does not end with 'Instrumentation'.")
+                if not node.name.endswith("Instrumentation") or not node.name.endswith("Module"):
+                    issues.append(f"{file_name}: Class '{node.name}' implements a 'Instrument' class but does not end with 'Instrumentation' or 'Module'.")
 
             if node.name.endswith("Advice"):
                 # Check for methods with an @Advice annotation


### PR DESCRIPTION
# What Does This Do
Creates a validator to make sure classes behave as expected

# Motivation

# Additional Notes
Current output
```
./dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client/SqlClientBaseAdvice.java: Class 'SqlClientBaseAdvice' does not have a method tagged with an @Advice annotation.
./dd-java-agent/instrumentation/vertx-mysql-client-3.9/src/main/java/datadog/trace/instrumentation/vertx_sql_client/QueryAdvice.java: Class 'QueryAdvice' does not have a method tagged with an @Advice annotation.
./dd-java-agent/instrumentation/aws-lambda-handler/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerDecorator.java: Class 'LambdaHandlerDecorator' should extend a class with 'Decorator' in its name.
./dd-java-agent/instrumentation/vertx-mysql-client-4.0/src/main/java/datadog/trace/instrumentation/vertx_sql_client_4/SqlClientBaseAdvice.java: Class 'SqlClientBaseAdvice' does not have a method tagged with an @Advice annotation.
./dd-java-agent/instrumentation/vertx-mysql-client-4.0/src/main/java/datadog/trace/instrumentation/vertx_sql_client_4/QueryAdvice.java: Class 'QueryAdvice' does not have a method tagged with an @Advice annotation.
./dd-java-agent/instrumentation/netty-3.8/src/main/java/datadog/trace/instrumentation/netty38/AbstractNettyAdvice.java: Class 'AbstractNettyAdvice' does not have a method tagged with an @Advice annotation.
./dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkModule.java: Class 'AwsSdkModule' extends a 'Instrument' class but does not end with 'Instrumentation'.
./dd-java-agent/instrumentation/spring-security-5/src/main/java/datadog/trace/instrumentation/springsecurity5/SpringSecurityUserEventDecorator.java: Class 'SpringSecurityUserEventDecorator' should extend a class with 'Decorator' in its name.
```

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
