### PR TITLE
Support instrumentation of repackaged libraries

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -71,6 +71,7 @@ public final class CombiningTransformerBuilder
   private ElementMatcher<ClassLoader> classLoaderMatcher;
   private Map<String, String> contextStore;
   private AgentBuilder.Transformer contextRequestRewriter;
+  private AdviceShader adviceShader;
   private HelperTransformer helperTransformer;
   private Advice.PostProcessor.Factory postProcessor;
   private MuzzleCheck muzzle;
@@ -118,6 +119,8 @@ public final class CombiningTransformerBuilder
                 new FieldBackedContextRequestRewriter(contextStore, module.name()))
             : null;
 
+    adviceShader = AdviceShader.with(module.adviceShading());
+
     String[] helperClassNames = module.helperClassNames();
     if (module.injectHelperDependencies()) {
       helperClassNames = HelperScanner.withClassDependencies(helperClassNames);
@@ -125,7 +128,10 @@ public final class CombiningTransformerBuilder
     helperTransformer =
         helperClassNames.length > 0
             ? new HelperTransformer(
-                module.useAgentCodeSource(), module.getClass().getSimpleName(), helperClassNames)
+                module.useAgentCodeSource(),
+                adviceShader,
+                module.getClass().getSimpleName(),
+                helperClassNames)
             : null;
 
     postProcessor = module.postProcessor();
@@ -238,11 +244,17 @@ public final class CombiningTransformerBuilder
     if (postProcessor != null) {
       customMapping = customMapping.with(postProcessor);
     }
-    advice.add(
+    AgentBuilder.Transformer.ForAdvice forAdvice =
         new AgentBuilder.Transformer.ForAdvice(customMapping)
-            .include(Utils.getBootstrapProxy(), Utils.getExtendedClassLoader())
             .withExceptionHandler(ExceptionHandlers.defaultExceptionHandler())
-            .advice(not(ignoredMethods).and(matcher), adviceClass));
+            .include(Utils.getBootstrapProxy());
+    ClassLoader adviceLoader = Utils.getExtendedClassLoader();
+    if (adviceShader != null) {
+      forAdvice = forAdvice.include(new ShadedAdviceLocator(adviceLoader, adviceShader));
+    } else {
+      forAdvice = forAdvice.include(adviceLoader);
+    }
+    advice.add(forAdvice.advice(not(ignoredMethods).and(matcher), adviceClass));
   }
 
   public ClassFileTransformer installOn(Instrumentation instrumentation) {
@@ -342,8 +354,11 @@ public final class CombiningTransformerBuilder
 
   static final class HelperTransformer extends HelperInjector implements AgentBuilder.Transformer {
     HelperTransformer(
-        boolean useAgentCodeSource, String requestingName, String... helperClassNames) {
-      super(useAgentCodeSource, requestingName, helperClassNames);
+        boolean useAgentCodeSource,
+        AdviceShader adviceShader,
+        String requestingName,
+        String... helperClassNames) {
+      super(useAgentCodeSource, adviceShader, requestingName, helperClassNames);
     }
   }
 

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/ShadedAdviceLocator.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/ShadedAdviceLocator.java
@@ -1,0 +1,30 @@
+package datadog.trace.agent.tooling;
+
+import java.io.IOException;
+import net.bytebuddy.dynamic.ClassFileLocator;
+
+/** Locates and shades class-file resources from the advice class-loader. */
+public final class ShadedAdviceLocator implements ClassFileLocator {
+  private final ClassFileLocator adviceLocator;
+  private final AdviceShader adviceShader;
+
+  public ShadedAdviceLocator(ClassLoader adviceLoader, AdviceShader adviceShader) {
+    this.adviceLocator = ClassFileLocator.ForClassLoader.of(adviceLoader);
+    this.adviceShader = adviceShader;
+  }
+
+  @Override
+  public Resolution locate(String className) throws IOException {
+    final Resolution resolution = adviceLocator.locate(className);
+    if (resolution.isResolved()) {
+      return new Resolution.Explicit(adviceShader.shade(resolution.resolve()));
+    } else {
+      return resolution;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    adviceLocator.close();
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AdviceShader.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AdviceShader.java
@@ -1,0 +1,98 @@
+package datadog.trace.agent.tooling;
+
+import datadog.trace.api.cache.DDCache;
+import datadog.trace.api.cache.DDCaches;
+import java.util.Map;
+import net.bytebuddy.jar.asm.ClassReader;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.jar.asm.ClassWriter;
+import net.bytebuddy.jar.asm.commons.ClassRemapper;
+import net.bytebuddy.jar.asm.commons.Remapper;
+
+/** Shades advice bytecode by applying relocations to all references. */
+public final class AdviceShader extends Remapper {
+  private final DDCache<String, String> cache = DDCaches.newFixedSizeCache(64);
+
+  /** Flattened sequence of old-prefix, new-prefix relocations. */
+  private final String[] prefixes;
+
+  public static AdviceShader with(Map<String, String> relocations) {
+    return relocations != null ? new AdviceShader(relocations) : null;
+  }
+
+  AdviceShader(Map<String, String> relocations) {
+    // convert relocations to a flattened sequence: old-prefix, new-prefix, etc.
+    this.prefixes = new String[relocations.size() * 2];
+    int i = 0;
+    for (Map.Entry<String, String> e : relocations.entrySet()) {
+      String oldPrefix = e.getKey();
+      String newPrefix = e.getValue();
+      if (oldPrefix.indexOf('.') > 0) {
+        // accept dotted prefixes, but store them in their internal form
+        this.prefixes[i++] = oldPrefix.replace('.', '/');
+        this.prefixes[i++] = newPrefix.replace('.', '/');
+      } else {
+        this.prefixes[i++] = oldPrefix;
+        this.prefixes[i++] = newPrefix;
+      }
+    }
+  }
+
+  /** Applies shading before calling the given {@link ClassVisitor}. */
+  public ClassVisitor shade(ClassVisitor cv) {
+    return new ClassRemapper(cv, this);
+  }
+
+  /** Returns the result of shading the given bytecode. */
+  public byte[] shade(byte[] bytecode) {
+    ClassReader cr = new ClassReader(bytecode);
+    ClassWriter cw = new ClassWriter(null, 0);
+    cr.accept(shade(cw), 0);
+    return cw.toByteArray();
+  }
+
+  @Override
+  public String map(String internalName) {
+    if (internalName.startsWith("java/")
+        || internalName.startsWith("datadog/")
+        || internalName.startsWith("net/bytebuddy/")) {
+      return internalName; // never shade these references
+    }
+    return cache.computeIfAbsent(internalName, this::shade);
+  }
+
+  @Override
+  public Object mapValue(Object value) {
+    if (value instanceof String) {
+      String text = (String) value;
+      if (text.isEmpty()) {
+        return text;
+      } else if (text.indexOf('.') > 0) {
+        return shadeDottedName(text);
+      } else {
+        return shade(text);
+      }
+    } else {
+      return super.mapValue(value);
+    }
+  }
+
+  private String shade(String internalName) {
+    for (int i = 0; i < prefixes.length; i += 2) {
+      if (internalName.startsWith(prefixes[i])) {
+        return prefixes[i + 1] + internalName.substring(prefixes[i].length());
+      }
+    }
+    return internalName;
+  }
+
+  private String shadeDottedName(String name) {
+    String internalName = name.replace('.', '/');
+    for (int i = 0; i < prefixes.length; i += 2) {
+      if (internalName.startsWith(prefixes[i])) {
+        return prefixes[i + 1].replace('/', '.') + name.substring(prefixes[i].length());
+      }
+    }
+    return name;
+  }
+}

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -33,6 +33,7 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
       ClassFileLocator.ForClassLoader.of(Utils.getExtendedClassLoader());
 
   private final boolean useAgentCodeSource;
+  private final AdviceShader adviceShader;
   private final String requestingName;
 
   private final Set<String> helperClassNames;
@@ -58,8 +59,17 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
       final boolean useAgentCodeSource,
       final String requestingName,
       final String... helperClassNames) {
+    this(useAgentCodeSource, null, requestingName, helperClassNames);
+  }
+
+  public HelperInjector(
+      final boolean useAgentCodeSource,
+      final AdviceShader adviceShader,
+      final String requestingName,
+      final String... helperClassNames) {
     this.useAgentCodeSource = useAgentCodeSource;
     this.requestingName = requestingName;
+    this.adviceShader = adviceShader;
 
     this.helperClassNames = new LinkedHashSet<>(Arrays.asList(helperClassNames));
   }
@@ -70,6 +80,7 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
       final Map<String, byte[]> helperMap) {
     this.useAgentCodeSource = useAgentCodeSource;
     this.requestingName = requestingName;
+    this.adviceShader = null;
 
     helperClassNames = helperMap.keySet();
     dynamicTypeMap.putAll(helperMap);
@@ -78,9 +89,11 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
   private Map<String, byte[]> getHelperMap() throws IOException {
     if (dynamicTypeMap.isEmpty()) {
       final Map<String, byte[]> classnameToBytes = new LinkedHashMap<>();
-
       for (final String helperClassName : helperClassNames) {
-        final byte[] classBytes = classFileLocator.locate(helperClassName).resolve();
+        byte[] classBytes = classFileLocator.locate(helperClassName).resolve();
+        if (adviceShader != null) {
+          classBytes = adviceShader.shade(classBytes);
+        }
         classnameToBytes.put(helperClassName, classBytes);
       }
 

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -156,6 +156,11 @@ public abstract class InstrumenterModule implements Instrumenter {
     return isSynthetic();
   }
 
+  /** Override this to apply shading to method advice and injected helpers. */
+  public Map<String, String> adviceShading() {
+    return null;
+  }
+
   /** Override this to post-process the operand stack of any transformed methods. */
   public Advice.PostProcessor.Factory postProcessor() {
     return null;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -1,5 +1,6 @@
 package datadog.trace.agent.tooling.muzzle;
 
+import datadog.trace.agent.tooling.AdviceShader;
 import datadog.trace.agent.tooling.HelperInjector;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
@@ -109,6 +110,7 @@ public class MuzzleVersionScanPlugin {
     String[] helperClasses = module.helperClassNames();
     final Map<String, byte[]> helperMap = new LinkedHashMap<>(helperClasses.length);
     Set<String> helperClassNames = new HashSet<>(Arrays.asList(helperClasses));
+    AdviceShader adviceShader = AdviceShader.with(module.adviceShading());
     for (final String helperName : helperClasses) {
       int nestedClassIndex = helperName.lastIndexOf('$');
       if (nestedClassIndex > 0) {
@@ -128,7 +130,10 @@ public class MuzzleVersionScanPlugin {
       }
       final ClassFileLocator locator =
           ClassFileLocator.ForClassLoader.of(module.getClass().getClassLoader());
-      final byte[] classBytes = locator.locate(helperName).resolve();
+      byte[] classBytes = locator.locate(helperName).resolve();
+      if (null != adviceShader) {
+        classBytes = adviceShader.shade(classBytes);
+      }
       helperMap.put(helperName, classBytes);
     }
     return helperMap;


### PR DESCRIPTION
# What Does This Do

Introduces the concept of an advice "shader" that can relocate type references before applying the advice or injecting advice helpers into the library/application class-loader.

This makes it possible to share and re-use advice for libraries which may appear under different namespaces, for example `javax.jms` vs. `jakarta.jms`. (Reminder that advice is never loaded directly, instead its bytecode is parsed and patched into the target class.)

# Motivation

We can already account for relocated packages in matchers by providing a namespace when creating `Instrumenter`s from an `InstrumenterModule`, but doing the same for advice bytecode requires using an ASM based remapper.

# Additional Notes

This is tested by https://github.com/DataDog/dd-trace-java/pull/8155 which uses it to share the `javax` JMS instrumentation with the `jakarta` namespace.

An alternative approach would be to create a complete copy of the `InstrumenterModule` class, its `Instrumenter`s, and all its advice/helpers at build-time. These classes would be pre-processed to use the relocated namespace - an additional relocation would be required to move these copies to a different instrumenter package to avoid conflicting with the original classes. The pre-processing would need to happen before we create the various instrumenter indices.

Doing the relocation at build-time would require no runtime changes, but would use more space in the final jar. It is also not possible to support ad-hoc relocations when processing types at build-time. This limitation led us to prefer a runtime solution, once we'd checked that the relocation overhead was acceptable (and only applied for relocated advice.)

Note: relocating matchers at runtime by passing in the relevant namespace from the `InstrumenterModule` to its `Instrumenter`s is also consistent with how OpenTelemetry handles relocated libraries.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-858]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-858]: https://datadoghq.atlassian.net/browse/APMAPI-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ