### PR TITLE
Instrument EMR's relocated AWS SDK

### DIFF
--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AWSHttpClientInstrumentation.java
@@ -22,10 +22,15 @@ import net.bytebuddy.asm.Advice;
  */
 public class AWSHttpClientInstrumentation
     implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+  private final String namespace;
+
+  public AWSHttpClientInstrumentation(String namespace) {
+    this.namespace = namespace;
+  }
 
   @Override
   public String instrumentedType() {
-    return "com.amazonaws.http.AmazonHttpClient";
+    return namespace + ".http.AmazonHttpClient";
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkModule.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/AwsSdkModule.java
@@ -9,10 +9,16 @@ import java.util.Map;
 
 /** Groups the instrumentations for AWS SDK 1.11.0+. */
 @AutoService(InstrumenterModule.class)
-public final class AwsSdkModule extends InstrumenterModule.Tracing {
+public class AwsSdkModule extends InstrumenterModule.Tracing {
+  private final String namespace;
 
   public AwsSdkModule() {
-    super("aws-sdk");
+    this("com.amazonaws", "aws-sdk");
+  }
+
+  protected AwsSdkModule(String namespace, String instrumentationName) {
+    super(instrumentationName);
+    this.namespace = namespace;
   }
 
   @Override
@@ -30,9 +36,9 @@ public final class AwsSdkModule extends InstrumenterModule.Tracing {
   @Override
   public Map<String, String> contextStore() {
     Map<String, String> map = new java.util.HashMap<>();
-    map.put("com.amazonaws.services.sqs.model.ReceiveMessageResult", "java.lang.String");
+    map.put(namespace + ".services.sqs.model.ReceiveMessageResult", "java.lang.String");
     map.put(
-        "com.amazonaws.AmazonWebServiceRequest",
+        namespace + ".AmazonWebServiceRequest",
         "datadog.trace.bootstrap.instrumentation.api.AgentSpan");
     return map;
   }
@@ -40,8 +46,8 @@ public final class AwsSdkModule extends InstrumenterModule.Tracing {
   @Override
   public List<Instrumenter> typeInstrumentations() {
     return Arrays.asList(
-        new AWSHttpClientInstrumentation(),
-        new RequestExecutorInstrumentation(),
-        new HandlerChainFactoryInstrumentation());
+        new AWSHttpClientInstrumentation(namespace),
+        new RequestExecutorInstrumentation(namespace),
+        new HandlerChainFactoryInstrumentation(namespace));
   }
 }

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/EmrSdkModule.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/EmrSdkModule.java
@@ -1,0 +1,25 @@
+package datadog.trace.instrumentation.aws.v0;
+
+import static java.util.Collections.singletonMap;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import java.util.Map;
+
+/** Repackaged AWS SDK instrumentations for Amazon EMR. */
+@AutoService(InstrumenterModule.class)
+public class EmrSdkModule extends AwsSdkModule {
+  public EmrSdkModule() {
+    super("com.amazon.ws.emr.hadoop.fs.shaded.com.amazonaws", "emr-aws-sdk");
+  }
+
+  @Override
+  public String muzzleDirective() {
+    return "emr-aws-sdk";
+  }
+
+  @Override
+  public Map<String, String> adviceShading() {
+    return singletonMap("com.amazonaws", "com.amazon.ws.emr.hadoop.fs.shaded.com.amazonaws");
+  }
+}

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/HandlerChainFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/HandlerChainFactoryInstrumentation.java
@@ -15,10 +15,15 @@ import net.bytebuddy.asm.Advice;
  */
 public final class HandlerChainFactoryInstrumentation
     implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+  private final String namespace;
+
+  public HandlerChainFactoryInstrumentation(String namespace) {
+    this.namespace = namespace;
+  }
 
   @Override
   public String instrumentedType() {
-    return "com.amazonaws.handlers.HandlerChainFactory";
+    return namespace + ".handlers.HandlerChainFactory";
   }
 
   @Override

--- a/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/RequestExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java-sdk-1.11.0/src/main/java/datadog/trace/instrumentation/aws/v0/RequestExecutorInstrumentation.java
@@ -19,10 +19,15 @@ import net.bytebuddy.asm.Advice;
  */
 public final class RequestExecutorInstrumentation
     implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+  private final String namespace;
+
+  public RequestExecutorInstrumentation(String namespace) {
+    this.namespace = namespace;
+  }
 
   @Override
   public String instrumentedType() {
-    return "com.amazonaws.http.AmazonHttpClient$RequestExecutor";
+    return namespace + ".http.AmazonHttpClient$RequestExecutor";
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Uses the new  [support for instrumentation of repackaged libraries](https://github.com/DataDog/dd-trace-java/pull/8153) to instrument EMR's relocated AWS SDK under `com.amazon.ws.emr.hadoop.fs.shaded`.

# Motivation

Provides observability of AWS SDK calls made from EMR.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-860]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-860]: https://datadoghq.atlassian.net/browse/APMAPI-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ