### PR TITLE
disable telemetry for MethodHandle lookups

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap.debugger.el;
 
+import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 import static java.lang.invoke.MethodType.methodType;
 
 import datadog.trace.bootstrap.debugger.CapturedContext;
@@ -22,7 +23,7 @@ public class ReflectiveFieldValueResolver {
       MethodHandles.Lookup lookup = MethodHandles.lookup();
       methodHandle = lookup.findVirtual(Field.class, "trySetAccessible", methodType(boolean.class));
     } catch (Exception e) {
-      LOGGER.debug("Looking up trySetAccessible failed: ", e);
+      LOGGER.debug(EXCLUDE_TELEMETRY, "Looking up trySetAccessible failed: ", e);
     }
     TRY_SET_ACCESSIBLE = methodHandle;
   }
@@ -35,7 +36,7 @@ public class ReflectiveFieldValueResolver {
     try {
       field = ReflectiveFieldValueResolver.class.getDeclaredField("INACCESSIBLE_FIELD");
     } catch (Exception e) {
-      LOGGER.debug("INACCESSIBLE_FIELD failed: ", e);
+      LOGGER.debug(EXCLUDE_TELEMETRY, "INACCESSIBLE_FIELD failed: ", e);
     }
     INACCESSIBLE_FIELD = field;
   }
@@ -51,7 +52,7 @@ public class ReflectiveFieldValueResolver {
       MethodHandles.Lookup lookup = MethodHandles.lookup();
       methodHandle = lookup.findVirtual(Class.class, "getModule", methodType(moduleClass));
     } catch (Exception e) {
-      LOGGER.debug("Looking up getModule failed: ", e);
+      LOGGER.debug(EXCLUDE_TELEMETRY, "Looking up getModule failed: ", e);
     }
     GET_MODULE = methodHandle;
     MODULE_CLASS = moduleClass;


### PR DESCRIPTION
# What Does This Do
disable telemetry for MethodHandle lookups
can happen frequently (every startup on jdk8)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
