### PR TITLE
Add mechanism to remove exception probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/exception/ExceptionProbeManagerTest.java
@@ -1,23 +1,42 @@
 package com.datadog.debugger.exception;
 
+import static com.datadog.debugger.util.TestHelper.assertWithTimeout;
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.datadog.debugger.probe.ExceptionProbe;
 import com.datadog.debugger.util.ClassNameFiltering;
 import datadog.trace.api.Config;
+import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.MethodLocation;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 class ExceptionProbeManagerTest {
+  private static final @NotNull Set<String> FILTERED_PACKAGES =
+      new HashSet<>(
+          asList(
+              "java.",
+              "jdk.",
+              "sun.",
+              "com.sun.",
+              "org.gradle.",
+              "worker.org.gradle.",
+              "org.junit."));
   private final RuntimeException exception = new RuntimeException("test");
 
   @Test
@@ -25,28 +44,17 @@ class ExceptionProbeManagerTest {
     ClassNameFiltering classNameFiltering = ClassNameFiltering.allowAll();
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
     RuntimeException exception = new RuntimeException("test");
-    String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     exceptionProbeManager.createProbesForException(exception.getStackTrace(), 0);
     assertFalse(exceptionProbeManager.getProbes().isEmpty());
   }
 
   @Test
   void instrumentSingleFrame() {
-    ClassNameFiltering classNameFiltering =
-        new ClassNameFiltering(
-            Stream.of(
-                    "java.",
-                    "jdk.",
-                    "sun.",
-                    "com.sun.",
-                    "org.gradle.",
-                    "worker.org.gradle.",
-                    "org.junit.")
-                .collect(Collectors.toSet()));
+    ClassNameFiltering classNameFiltering = new ClassNameFiltering(FILTERED_PACKAGES);
     ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
 
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
-    assertEquals("4974b2b4853e6152d8f218fb79a42a761a45335447e22e53d75f5325e742655", fingerprint);
+    assertEquals("44cbdcfe32eea21c3523e4a5885daabf5b8c9428cc0f613be5ff29663465ff9", fingerprint);
     exceptionProbeManager.createProbesForException(exception.getStackTrace(), 0);
     assertEquals(1, exceptionProbeManager.getProbes().size());
     ExceptionProbe exceptionProbe = exceptionProbeManager.getProbes().iterator().next();
@@ -82,32 +90,51 @@ class ExceptionProbeManagerTest {
     RuntimeException exception = new RuntimeException("test");
     String fingerprint = Fingerprinter.fingerprint(exception, classNameFiltering);
     exceptionProbeManager.addFingerprint(fingerprint);
-    assertTrue(exceptionProbeManager.shouldCaptureException(fingerprint));
+    Instant lastCapture = exceptionProbeManager.getLastCapture(fingerprint);
+    assertTrue(exceptionProbeManager.shouldCaptureException(lastCapture));
     exceptionProbeManager.updateLastCapture(fingerprint);
-    assertFalse(exceptionProbeManager.shouldCaptureException(fingerprint));
+    lastCapture = exceptionProbeManager.getLastCapture(fingerprint);
+    assertFalse(exceptionProbeManager.shouldCaptureException(lastCapture));
     Clock clock =
         Clock.fixed(Instant.now().plus(Duration.ofMinutes(61)), Clock.systemUTC().getZone());
-    assertTrue(exceptionProbeManager.shouldCaptureException(fingerprint, clock));
+    lastCapture = exceptionProbeManager.getLastCapture(fingerprint);
+    assertTrue(exceptionProbeManager.shouldCaptureException(lastCapture, clock));
   }
 
   @Test
   void maxFrames() {
     RuntimeException deepException = level1();
-    ClassNameFiltering classNameFiltering =
-        new ClassNameFiltering(
-            Stream.of(
-                    "java.",
-                    "jdk.",
-                    "sun.",
-                    "com.sun.",
-                    "org.gradle.",
-                    "worker.org.gradle.",
-                    "org.junit.")
-                .collect(Collectors.toSet()));
+    ClassNameFiltering classNameFiltering = new ClassNameFiltering(FILTERED_PACKAGES);
     ExceptionProbeManager exceptionProbeManager =
         new ExceptionProbeManager(classNameFiltering, Duration.ofHours(1), Clock.systemUTC(), 3);
     exceptionProbeManager.createProbesForException(deepException.getStackTrace(), 0);
     assertEquals(3, exceptionProbeManager.getProbes().size());
+  }
+
+  @Test
+  public void removeExceptionProbeOnHotLoop() {
+    ClassNameFiltering classNameFiltering = new ClassNameFiltering(FILTERED_PACKAGES);
+    ExceptionProbeManager exceptionProbeManager = new ExceptionProbeManager(classNameFiltering);
+    AtomicBoolean configApplied = new AtomicBoolean(false);
+    DefaultExceptionDebugger defaultExceptionDebugger = mock(DefaultExceptionDebugger.class);
+    doAnswer(
+            invocationOnMock -> {
+              configApplied.set(true);
+              return null;
+            })
+        .when(defaultExceptionDebugger)
+        .applyExceptionConfiguration();
+    exceptionProbeManager.setDefaultExceptionDebugger(defaultExceptionDebugger);
+    exceptionProbeManager.createProbesForException(exception.getStackTrace(), 0);
+    assertEquals(1, exceptionProbeManager.getProbes().size());
+    ExceptionProbe exceptionProbe = exceptionProbeManager.getProbes().iterator().next();
+    // simulate a code hot loop
+    for (int i = 0; i < 2000; i++) {
+      CapturedContext context = mock(CapturedContext.class);
+      exceptionProbe.evaluate(context, exceptionProbe.createStatus(), MethodLocation.EXIT);
+    }
+    assertEquals(0, exceptionProbeManager.getProbes().size());
+    assertWithTimeout(configApplied::get, Duration.ofSeconds(30));
   }
 
   RuntimeException level1() {


### PR DESCRIPTION
# What Does This Do
Add circuit breaker when evaluating exception probe to detect when an exception probe is executed in a hot path only waiting for exception to happen.
when circuit breaker is open after 1000 calls in 10 seconds window, we check if there is no exception captured during this period too and remove the probe from the configuration and un-instrument it. This will prevent too much overhead for hot path

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3308]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3308]: https://datadoghq.atlassian.net/browse/DEBUG-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ