### PR TITLE
Squash AgentSpan.Attributes with SpanAttributes

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelConventions.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelConventions.java
@@ -249,7 +249,7 @@ public final class OtelConventions {
     return (String) tag;
   }
 
-  public static AgentSpan.Attributes convertAttributes(Attributes attributes) {
+  public static SpanAttributes convertAttributes(Attributes attributes) {
     if (attributes.isEmpty()) {
       return SpanAttributes.EMPTY;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanLink.java
@@ -8,7 +8,6 @@ import com.squareup.moshi.Moshi;
 import com.squareup.moshi.ToJson;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Attributes;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanLink;
 import datadog.trace.bootstrap.instrumentation.api.SpanAttributes;
 import datadog.trace.bootstrap.instrumentation.api.SpanLink;
@@ -26,7 +25,11 @@ public class DDSpanLink extends SpanLink {
   private static final int TAG_MAX_LENGTH = 25_000;
 
   protected DDSpanLink(
-      DDTraceId traceId, long spanId, byte traceFlags, String traceState, Attributes attributes) {
+      DDTraceId traceId,
+      long spanId,
+      byte traceFlags,
+      String traceState,
+      SpanAttributes attributes) {
     super(traceId, spanId, traceFlags, traceState, attributes);
   }
 
@@ -49,7 +52,7 @@ public class DDSpanLink extends SpanLink {
    * @param attributes The span link attributes.
    * @return A span link to the given context with custom attributes.
    */
-  public static SpanLink from(ExtractedContext context, Attributes attributes) {
+  public static SpanLink from(ExtractedContext context, SpanAttributes attributes) {
     byte traceFlags = context.getSamplingPriority() > 0 ? SAMPLED_FLAG : DEFAULT_FLAGS;
     String traceState =
         context.getPropagationTags() == null

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -5,7 +5,6 @@ import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
-import java.util.Map;
 
 public interface AgentSpan extends MutableSpan, IGSpanInfo, WithAgentSpan {
 
@@ -145,21 +144,5 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo, WithAgentSpan {
 
   default AgentSpan asAgentSpan() {
     return this;
-  }
-
-  interface Attributes {
-    /**
-     * Gets the attributes as an immutable map.
-     *
-     * @return The attributes as an immutable map.
-     */
-    Map<String, String> asMap();
-
-    /**
-     * Checks whether the attributes are empty.
-     *
-     * @return {@code true} if the attributes are empty, {@code false} otherwise.
-     */
-    boolean isEmpty();
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpanLink.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpanLink.java
@@ -1,7 +1,6 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.api.DDTraceId;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Attributes;
 
 /**
  * This interface describes a link to another span. The linked span could be part of the same trace
@@ -50,5 +49,5 @@ public interface AgentSpanLink {
    *
    * @return The link attributes.
    */
-  Attributes attributes();
+  SpanAttributes attributes();
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanAttributes.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanAttributes.java
@@ -2,16 +2,14 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import static java.util.Objects.requireNonNull;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan.Attributes;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/** This class is a base implementation of {@link Attributes}. */
-public class SpanAttributes implements Attributes {
+public class SpanAttributes {
   /** Represent an empty attributes. */
-  public static final Attributes EMPTY = new SpanAttributes(Collections.emptyMap());
+  public static final SpanAttributes EMPTY = new SpanAttributes(Collections.emptyMap());
 
   private final Map<String, String> attributes;
 
@@ -38,12 +36,20 @@ public class SpanAttributes implements Attributes {
     return new SpanAttributes(new HashMap<>(map));
   }
 
-  @Override
+  /**
+   * Gets the attributes as an immutable map.
+   *
+   * @return The attributes as an immutable map.
+   */
   public Map<String, String> asMap() {
     return this.attributes;
   }
 
-  @Override
+  /**
+   * Checks whether the attributes are empty.
+   *
+   * @return {@code true} if the attributes are empty, {@code false} otherwise.
+   */
   public boolean isEmpty() {
     return this.attributes.isEmpty();
   }
@@ -115,7 +121,7 @@ public class SpanAttributes implements Attributes {
       return this;
     }
 
-    public Attributes build() {
+    public SpanAttributes build() {
       return new SpanAttributes(this.attributes);
     }
   }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanLink.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SpanLink.java
@@ -10,14 +10,14 @@ public class SpanLink implements AgentSpanLink {
   private final long spanId;
   private final byte traceFlags;
   private final String traceState;
-  private final AgentSpan.Attributes attributes;
+  private final SpanAttributes attributes;
 
   protected SpanLink(
       DDTraceId traceId,
       long spanId,
       byte traceFlags,
       String traceState,
-      AgentSpan.Attributes attributes) {
+      SpanAttributes attributes) {
     this.traceId = traceId == null ? DDTraceId.ZERO : traceId;
     this.spanId = spanId;
     this.traceFlags = traceFlags;
@@ -47,10 +47,7 @@ public class SpanLink implements AgentSpanLink {
    * @return A span link to the given context.
    */
   public static SpanLink from(
-      AgentSpanContext context,
-      byte traceFlags,
-      String traceState,
-      AgentSpan.Attributes attributes) {
+      AgentSpanContext context, byte traceFlags, String traceState, SpanAttributes attributes) {
     if (context.getSamplingPriority() > 0) {
       traceFlags = (byte) (traceFlags | SAMPLED_FLAG);
     }
@@ -79,7 +76,7 @@ public class SpanLink implements AgentSpanLink {
   }
 
   @Override
-  public AgentSpan.Attributes attributes() {
+  public SpanAttributes attributes() {
     return this.attributes;
   }
 


### PR DESCRIPTION
# Motivation

`AgentSpan.Attributes` has only one implementation and isn't likely to have another, so squash it into `SpanAttributes`.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-959]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-959]: https://datadoghq.atlassian.net/browse/APMAPI-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ