### PR TITLE
repo: mandatory issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,61 @@
+name: "Bug Report (Low Priority)"
+description: "Create a public Bug Report. Note that these may not be addressed as it depeonds on capacity and that looking up account information will be difficult."
+title: ""
+labels: "type: bug"
+body:
+  - type: input
+    attributes:
+      label: Tracer Version(s)
+      description: "Version(s) of the tracer affected by this bug"
+      placeholder: "1.44.0"
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Java Version(s)
+      description: "Version(s) of Java (`java --version`) that you've encountered this bug with"
+      placeholder: 21.0.4
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: JVM Vendor
+      description: "Which JVM vendor does your application use"
+      options:
+        - Oracle JDK
+        - Alibaba Dragonwell
+        - Amazon Corretto
+        - Azul Zing / Zulu
+        - BellSoft Liberica JDK
+        - Eclipse Adoptium / Temurin
+        - Eclipse OpenJ9
+        - IBM SDK / Semeru
+        - Oracle GraalVM
+        - RedHat JDK
+        - SapMachine
+        - Other (please specify in comments)
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Bug Report
+      description: Please add a clear and concise description of the bug here
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What is the expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction Code
+      description: Please add code here to help us reproduce the problem
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Bug Report
+  - name: Bug Report (High Priority)
     url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:java
-    about: This option creates an expedited Bug Report via the helpdesk (no login required). This will allow us to look up your account and allows you to provide additional information in private.
-  - name: Feature Request
+    about: Create an expedited Bug Report via the helpdesk (no login required). This will allow us to look up your account and allows you to provide additional information in private.
+  - name: Feature Request (High Priority)
     url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:java&tf_1260825272270=pt_apm_category_feature_request
-    about: This option creates an expedited Feature Request via the helpdesk (no login required). This helps with prioritization and allows you to provide additional information in private.
+    about: Create an expedited Feature Request via the helpdesk (no login required). This helps with prioritization and allows you to provide additional information in private.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,50 @@
+name: Feature Request (Low Priority)
+description: Create a public Feature Request. Note that these may not be addressed as it depeonds on capacity and that looking up account information will be difficult.
+title: ""
+labels: "type: feature request"
+body:
+  - type: input
+    attributes:
+      label: Library Name
+      description: "If your feature request is to add instrumentation support for a library please provide the name here"
+      placeholder: "spring-boot"
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Library Version(s)
+      description: "If your feature request is to add instrumentation support for a library please provide the version you use"
+      placeholder: 1.2
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Describe the feature you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: |
+        Please add a clear and concise description of your problem.
+        E.g. I'm unable to instrument my database queries...
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here
+    validations:
+      required: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,11 @@
-# Security
+# Security Policy
 
-## Security Vulnerabilities
+This document outlines the security policy for the Datadog Java client library (aka Java tracer) and what to do if you discover a security vulnerability in the project.
+Most notably, please do not share the details in a public forum (such as in a discussion, issue, or pull request) but instead reach out to us with the details.
+This gives us an opportunity to release a fix for others to benefit from by the time details are made public.
 
-If you have found a security issue, please contact the security team directly at security@datadoghq.com.
+## Reporting a Vulnerability
+
+If you discover a vulnerability in the Datadog Java client library (or any Datadog product for that matter) please submit details to the following email address:
+
+* [security@datadoghq.com](mailto:security@datadoghq.com)


### PR DESCRIPTION
# What Does This Do
- remakes #8106 since CI was bugged out
- standardizes the issue creation screen
- standardizes the security policy document
- makes issue templates mandatory
- creates a bug report and feature request issue template

# Motivation
- standardizes the create issue screen across tracers

# Additional Notes
- here's an example of how it will look: https://github.com/DataDog/dd-trace-js/issues/new/choose

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [AIDM-429]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[AIDM-429]: https://datadoghq.atlassian.net/browse/AIDM-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ