### PR TITLE
fix github issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,5 @@
 name: "Bug Report (Low Priority)"
 description: "Create a public Bug Report. Note that these may not be addressed as it depeonds on capacity and that looking up account information will be difficult."
-title: ""
 labels: "type: bug"
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,5 @@
 name: Feature Request (Low Priority)
 description: Create a public Feature Request. Note that these may not be addressed as it depeonds on capacity and that looking up account information will be difficult.
-title: ""
 labels: "type: feature request"
 body:
   - type: input
@@ -15,7 +14,7 @@ body:
     attributes:
       label: Library Version(s)
       description: "If your feature request is to add instrumentation support for a library please provide the version you use"
-      placeholder: 1.2
+      placeholder: "1.2"
     validations:
       required: false
 


### PR DESCRIPTION
# What Does This Do

- fixes the issue create screen to allow github issues
- note the errors on these two screens
  - https://github.com/DataDog/dd-trace-java/blob/master/.github/ISSUE_TEMPLATE/bug_report.yaml
  - https://github.com/DataDog/dd-trace-java/blob/master/.github/ISSUE_TEMPLATE/feature_request.yaml


# Motivation

- seems to be a parsing issue of the YAML files
- missing entries on this screen
  - https://github.com/DataDog/dd-trace-java/issues/new/choose

![Screenshot 2025-01-10 at 09 00 42](https://github.com/user-attachments/assets/a89f398e-5e37-420f-8b7a-5df1f31e5e06)

# Additional Notes

- YAML is horrible

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
