### PR TITLE
Skip jacoco coverage for internal class

### DIFF
--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -36,6 +36,8 @@ excludedClassesCoverage += [
   "datadog.trace.api.WithGlobalTracer.1",
   "datadog.trace.api.naming.**",
   "datadog.trace.api.gateway.RequestContext.Noop",
+  "datadog.trace.api.ClassloaderConfigurationOverrides",
+  "datadog.trace.api.ClassloaderConfigurationOverrides.Lazy",
   // an enum
   "datadog.trace.api.sampling.AdaptiveSampler",
   "datadog.trace.api.sampling.ConstantSampler",


### PR DESCRIPTION
# What Does This Do

Skip coverage checks for `ClassloaderConfigurationOverrides`

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
