### PR TITLE
Move Trace/SpanId capture at commit time

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -32,8 +32,6 @@ public class CapturedContext implements ValueReferenceResolver {
   private Map<String, CapturedValue> staticFields;
   private Limits limits = Limits.DEFAULT;
   private String thisClassName;
-  private String traceId;
-  private String spanId;
   private long duration;
   private final Map<String, Status> statusByProbeId = new LinkedHashMap<>();
   private Map<String, CapturedValue> watches;
@@ -239,19 +237,6 @@ public class CapturedContext implements ValueReferenceResolver {
     }
   }
 
-  public void addTraceId(CapturedValue capturedValue) {
-    traceId = extractStringId(capturedValue);
-  }
-
-  public void addSpanId(CapturedValue capturedValue) {
-    spanId = extractStringId(capturedValue);
-  }
-
-  private String extractStringId(CapturedValue capturedValue) {
-    Object value = capturedValue.getValue();
-    return value instanceof String ? (String) value : null;
-  }
-
   public void setLimits(
       int maxReferenceDepth, int maxCollectionSize, int maxLength, int maxFieldCount) {
     this.limits = new Limits(maxReferenceDepth, maxCollectionSize, maxLength, maxFieldCount);
@@ -283,14 +268,6 @@ public class CapturedContext implements ValueReferenceResolver {
 
   public String getThisClassName() {
     return thisClassName;
-  }
-
-  public String getTraceId() {
-    return traceId;
-  }
-
-  public String getSpanId() {
-    return spanId;
   }
 
   /**

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -23,6 +23,7 @@ import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Types;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.CorrelationAccess;
 import datadog.trace.bootstrap.debugger.DebuggerContext;
 import datadog.trace.bootstrap.debugger.EvaluationError;
 import datadog.trace.bootstrap.debugger.Limits;
@@ -549,25 +550,19 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     LogStatus entryStatus = convertStatus(entryContext.getStatus(probeId.getEncodedId()));
     LogStatus exitStatus = convertStatus(exitContext.getStatus(probeId.getEncodedId()));
     String message = null;
-    String traceId = null;
-    String spanId = null;
     switch (evaluateAt) {
       case ENTRY:
       case DEFAULT:
         message = entryStatus.getMessage();
-        traceId = entryContext.getTraceId();
-        spanId = entryContext.getSpanId();
         break;
       case EXIT:
         message = exitStatus.getMessage();
-        traceId = exitContext.getTraceId();
-        spanId = exitContext.getSpanId();
         break;
     }
     boolean shouldCommit = false;
     if (entryStatus.shouldSend() && exitStatus.shouldSend()) {
-      snapshot.setTraceId(traceId);
-      snapshot.setSpanId(spanId);
+      snapshot.setTraceId(CorrelationAccess.instance().getTraceId());
+      snapshot.setSpanId(CorrelationAccess.instance().getSpanId());
       if (isCaptureSnapshot()) {
         snapshot.setEntry(entryContext);
         snapshot.setExit(exitContext);
@@ -643,8 +638,8 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     Snapshot snapshot = createSnapshot();
     boolean shouldCommit = false;
     if (status.shouldSend()) {
-      snapshot.setTraceId(lineContext.getTraceId());
-      snapshot.setSpanId(lineContext.getSpanId());
+      snapshot.setTraceId(CorrelationAccess.instance().getTraceId());
+      snapshot.setSpanId(CorrelationAccess.instance().getSpanId());
       snapshot.setMessage(status.getMessage());
       shouldCommit = true;
     }


### PR DESCRIPTION
# What Does This Do
capture of traceId/SpanId was directly instrumented.
it means that every execution of the probe try to fetch from the span
the traceId and the spanId with eventual conversion to make it a
string. While in the end we may have a condition that is not met or
the sampling does not generate a snapshot. which is wasteful.
We just move the capture at the commit time when we are sure to send a
 snapshot with these information.

# Motivation

optimization

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2550]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2550]: https://datadoghq.atlassian.net/browse/DEBUG-2550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ