### PR TITLE
Fix source and destination folders computation for Android Gradle projects

### DIFF
--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/AndroidGradleUtils.groovy
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/AndroidGradleUtils.groovy
@@ -8,6 +8,9 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.testing.Test
 
+import java.nio.file.Files
+import java.nio.file.Paths
+
 class AndroidGradleUtils {
 
   private static final Logger LOGGER = Logging.getLogger(AndroidGradleUtils)
@@ -29,7 +32,10 @@ class AndroidGradleUtils {
   }
 
   private static getVariant(Project project, Test task) {
-    def androidPlugin = project.plugins.findPlugin('android') ?: project.plugins.findPlugin('android-library')
+    def androidPlugin = project.plugins.findPlugin('android')
+      ?: project.plugins.findPlugin('android-library')
+      ?: project.plugins.findPlugin('com.android.application')
+      ?: project.plugins.findPlugin('com.android.library')
 
     def variants
     if (androidPlugin.class.simpleName == 'LibraryPlugin') {
@@ -39,7 +45,7 @@ class AndroidGradleUtils {
     }
 
     for (def v : variants) {
-      if (task.path.endsWith("test${v.name.capitalize()}UnitTest")) {
+      if (task.path.endsWith("test${v.name.capitalize()}UnitTest") || task.path.endsWith("test${v.name.capitalize()}")) {
         return v
       }
     }
@@ -75,8 +81,8 @@ class AndroidGradleUtils {
     FileTree javaTree = project.fileTree(dir: javaDestinations, excludes: EXCLUDES)
 
     FileTree destinationsTree
-    if (project.plugins.findPlugin('kotlin-android') != null) {
-      def kotlinDestinations = "${project.buildDir}/tmp/kotlin-classes/${variant.name}"
+    def kotlinDestinations = "${project.buildDir}/tmp/kotlin-classes/${variant.name}"
+    if (Files.exists(Paths.get(kotlinDestinations))) {
       def kotlinTree = project.fileTree(dir: kotlinDestinations, excludes: EXCLUDES)
       destinationsTree = javaTree + kotlinTree
     } else {


### PR DESCRIPTION
# What Does This Do

Does some minor fixes to the logic that determines source and destination folders for Android Gradle projects:
- looks for Kotlin classes if `${project.buildDir}/tmp/kotlin-classes` folder exists; previously only looked for them if the project had `kotlin-android` plugin, which didn't work sometimes (as the project could be using a different Kotlin plugin, e.g. `kotlin-multiplatform`
- besides considering `android` and `android-library` plugins, also considers `com.android.application` and `com.android.library` plugins (which are aliases for the other two)

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1429]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
