### PR TITLE
TempLocationManager Fixes and Improvements

### DIFF
--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
@@ -20,6 +20,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,8 @@ import org.slf4j.LoggerFactory;
  */
 public final class TempLocationManager {
   private static final Logger log = LoggerFactory.getLogger(TempLocationManager.class);
+  // accessible to tests
+  static final String TEMPDIR_PREFIX = "pid_";
 
   private static final class SingletonHolder {
     private static final TempLocationManager INSTANCE = new TempLocationManager();
@@ -106,7 +109,7 @@ public final class TempLocationManager {
       }
       String fileName = dir.getFileName().toString();
       // the JFR repository directories are under <basedir>/pid_<pid>
-      String pid = fileName.startsWith("pid_") ? fileName.substring(4) : null;
+      String pid = fileName.startsWith(TEMPDIR_PREFIX) ? fileName.substring(4) : null;
       boolean isSelfPid = pid != null && pid.equals(PidHelper.getPid());
       shouldClean |= cleanSelf ? isSelfPid : !isSelfPid && !pidSet.contains(pid);
       if (shouldClean) {
@@ -168,7 +171,7 @@ public final class TempLocationManager {
         }
         String fileName = dir.getFileName().toString();
         // reset the flag only if we are done cleaning the top-level directory
-        shouldClean = !fileName.startsWith("pid_");
+        shouldClean = !fileName.startsWith(TEMPDIR_PREFIX);
       }
       return FileVisitResult.CONTINUE;
     }
@@ -236,10 +239,11 @@ public final class TempLocationManager {
   }
 
   TempLocationManager(ConfigProvider configProvider) {
-    this(configProvider, CleanupHook.EMPTY);
+    this(configProvider, true, CleanupHook.EMPTY);
   }
 
-  TempLocationManager(ConfigProvider configProvider, CleanupHook testHook) {
+  TempLocationManager(
+      ConfigProvider configProvider, boolean runStartupCleanup, CleanupHook testHook) {
     cleanupTestHook = testHook;
 
     // In order to avoid racy attempts to clean up files which are currently being processed in a
@@ -278,8 +282,11 @@ public final class TempLocationManager {
     baseTempDir = configuredTempDir.resolve("ddprof");
     baseTempDir.toFile().deleteOnExit();
 
-    tempDir = baseTempDir.resolve("pid_" + pid);
-    AgentTaskScheduler.INSTANCE.execute(() -> cleanup(false));
+    tempDir = baseTempDir.resolve(TEMPDIR_PREFIX + pid);
+    if (runStartupCleanup) {
+      // do not execute the background cleanup task when running in tests
+      AgentTaskScheduler.INSTANCE.execute(() -> cleanup(false));
+    }
 
     Thread selfCleanup =
         new Thread(
@@ -364,6 +371,19 @@ public final class TempLocationManager {
    */
   boolean cleanup(boolean cleanSelf, long timeout, TimeUnit unit) {
     try {
+      if (!Files.exists(baseTempDir)) {
+        // not event the main temp location exists; nothing to clean up
+        return true;
+      }
+      try (Stream<Path> paths = Files.walk(baseTempDir)) {
+        if (paths.noneMatch(
+            path ->
+                Files.isDirectory(path)
+                    && path.getFileName().toString().startsWith(TEMPDIR_PREFIX))) {
+          // nothing to clean up; bail out early
+          return true;
+        }
+      }
       cleanupTestHook.onCleanupStart(cleanSelf, timeout, unit);
       CleanupVisitor visitor = new CleanupVisitor(cleanSelf, timeout, unit);
       Files.walkFileTree(baseTempDir, visitor);
@@ -393,5 +413,10 @@ public final class TempLocationManager {
       }
     }
     return false;
+  }
+
+  // accessible for tests
+  void createDirStructure() throws IOException {
+    Files.createDirectories(baseTempDir);
   }
 }

--- a/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
+++ b/dd-java-agent/agent-profiling/profiling-controller/src/main/java/com/datadog/profiling/controller/TempLocationManager.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
 
 import datadog.trace.api.config.ProfilingConfig;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
+import datadog.trace.util.AgentTaskScheduler;
 import datadog.trace.util.PidHelper;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -17,10 +18,8 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +63,7 @@ public final class TempLocationManager {
     default void onCleanupStart(boolean selfCleanup, long timeout, TimeUnit unit) {}
   }
 
-  private class CleanupVisitor implements FileVisitor<Path> {
+  private final class CleanupVisitor implements FileVisitor<Path> {
     private boolean shouldClean;
 
     private final Set<String> pidSet = PidHelper.getJavaPids();
@@ -175,12 +174,37 @@ public final class TempLocationManager {
     }
   }
 
+  private final class CleanupTask implements Runnable {
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private volatile Throwable throwable = null;
+
+    @Override
+    public void run() {
+      try {
+        cleanup(false);
+      } catch (OutOfMemoryError oom) {
+        throw oom;
+      } catch (Throwable t) {
+        throwable = t;
+      } finally {
+        latch.countDown();
+      }
+    }
+
+    boolean await(long timeout, TimeUnit unit) throws Throwable {
+      boolean ret = latch.await(timeout, unit);
+      if (throwable != null) {
+        throw throwable;
+      }
+      return ret;
+    }
+  }
+
   private final Path baseTempDir;
   private final Path tempDir;
   private final long cutoffSeconds;
 
-  private final CompletableFuture<Void> cleanupTask;
-
+  private final CleanupTask cleanupTask = new CleanupTask();
   private final CleanupHook cleanupTestHook;
 
   /**
@@ -202,11 +226,7 @@ public final class TempLocationManager {
   static TempLocationManager getInstance(boolean waitForCleanup) {
     TempLocationManager instance = SingletonHolder.INSTANCE;
     if (waitForCleanup) {
-      try {
-        instance.waitForCleanup(5, TimeUnit.SECONDS);
-      } catch (TimeoutException ignored) {
-
-      }
+      instance.waitForCleanup(5, TimeUnit.SECONDS);
     }
     return instance;
   }
@@ -259,20 +279,17 @@ public final class TempLocationManager {
     baseTempDir.toFile().deleteOnExit();
 
     tempDir = baseTempDir.resolve("pid_" + pid);
-    cleanupTask = CompletableFuture.runAsync(() -> cleanup(false));
+    AgentTaskScheduler.INSTANCE.execute(() -> cleanup(false));
 
     Thread selfCleanup =
         new Thread(
             () -> {
-              try {
-                waitForCleanup(1, TimeUnit.SECONDS);
-              } catch (TimeoutException e) {
+              if (!waitForCleanup(1, TimeUnit.SECONDS)) {
                 log.info(
                     "Cleanup task timed out. {} temp directory might not have been cleaned up properly",
                     tempDir);
-              } finally {
-                cleanup(true);
               }
+              cleanup(true);
             },
             "Temp Location Manager Cleanup");
     Runtime.getRuntime().addShutdownHook(selfCleanup);
@@ -362,21 +379,19 @@ public final class TempLocationManager {
   }
 
   // accessible for tests
-  void waitForCleanup(long timeout, TimeUnit unit) throws TimeoutException {
+  boolean waitForCleanup(long timeout, TimeUnit unit) {
     try {
-      cleanupTask.get(timeout, unit);
+      return cleanupTask.await(timeout, unit);
     } catch (InterruptedException e) {
-      cleanupTask.cancel(true);
+      log.debug("Temp directory cleanup was interrupted");
       Thread.currentThread().interrupt();
-    } catch (TimeoutException e) {
-      cleanupTask.cancel(true);
-      throw e;
-    } catch (ExecutionException e) {
+    } catch (Throwable t) {
       if (log.isDebugEnabled()) {
-        log.debug("Failed to cleanup temp directory: {}", tempDir, e);
+        log.debug("Failed to cleanup temp directory: {}", tempDir, t);
       } else {
         log.debug("Failed to cleanup temp directory: {}", tempDir);
       }
     }
+    return false;
   }
 }


### PR DESCRIPTION
# What Does This Do
It fixes the the problem caused by the usage of `CompletableFuture` in the manager.
It avoids forking `jps` unless there is something to clean up.
It avoids removing JFR repository during self-cleanup in order to avoid clashing with the JFR shutdown.

# Motivation
Prevent unexpected behaviour, reduce the overhead.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROF-11072]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[PROF-11072]: https://datadoghq.atlassian.net/browse/PROF-11072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ