### PR TITLE
Ensure shaded helpers have unique names when injected into class-loaders

### DIFF
--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -119,7 +119,7 @@ public final class CombiningTransformerBuilder
                 new FieldBackedContextRequestRewriter(contextStore, module.name()))
             : null;
 
-    adviceShader = AdviceShader.with(module.adviceShading());
+    adviceShader = AdviceShader.with(module);
 
     String[] helperClassNames = module.helperClassNames();
     if (module.injectHelperDependencies()) {

--- a/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/ShadedAdviceLocator.java
+++ b/dd-java-agent/agent-builder/src/main/java/datadog/trace/agent/tooling/ShadedAdviceLocator.java
@@ -17,7 +17,7 @@ public final class ShadedAdviceLocator implements ClassFileLocator {
   public Resolution locate(String className) throws IOException {
     final Resolution resolution = adviceLocator.locate(className);
     if (resolution.isResolved()) {
-      return new Resolution.Explicit(adviceShader.shade(resolution.resolve()));
+      return new Resolution.Explicit(adviceShader.shadeClass(resolution.resolve()));
     } else {
       return resolution;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AdviceShader.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AdviceShader.java
@@ -10,89 +10,105 @@ import net.bytebuddy.jar.asm.commons.ClassRemapper;
 import net.bytebuddy.jar.asm.commons.Remapper;
 
 /** Shades advice bytecode by applying relocations to all references. */
-public final class AdviceShader extends Remapper {
-  private final DDCache<String, String> cache = DDCaches.newFixedSizeCache(64);
+public final class AdviceShader {
+  private final Map<String, String> relocations;
 
-  /** Flattened sequence of old-prefix, new-prefix relocations. */
-  private final String[] prefixes;
+  private volatile Remapper remapper;
 
   public static AdviceShader with(Map<String, String> relocations) {
-    return relocations != null ? new AdviceShader(relocations) : null;
+    if (relocations != null) {
+      return new AdviceShader(relocations);
+    }
+    return null;
   }
 
-  AdviceShader(Map<String, String> relocations) {
-    // convert relocations to a flattened sequence: old-prefix, new-prefix, etc.
-    this.prefixes = new String[relocations.size() * 2];
-    int i = 0;
-    for (Map.Entry<String, String> e : relocations.entrySet()) {
-      String oldPrefix = e.getKey();
-      String newPrefix = e.getValue();
-      if (oldPrefix.indexOf('.') > 0) {
-        // accept dotted prefixes, but store them in their internal form
-        this.prefixes[i++] = oldPrefix.replace('.', '/');
-        this.prefixes[i++] = newPrefix.replace('.', '/');
-      } else {
-        this.prefixes[i++] = oldPrefix;
-        this.prefixes[i++] = newPrefix;
-      }
-    }
+  private AdviceShader(Map<String, String> relocations) {
+    this.relocations = relocations;
   }
 
   /** Applies shading before calling the given {@link ClassVisitor}. */
-  public ClassVisitor shade(ClassVisitor cv) {
-    return new ClassRemapper(cv, this);
+  public ClassVisitor shadeClass(ClassVisitor cv) {
+    if (null == remapper) {
+      remapper = new AdviceMapper();
+    }
+    return new ClassRemapper(cv, remapper);
   }
 
   /** Returns the result of shading the given bytecode. */
-  public byte[] shade(byte[] bytecode) {
+  public byte[] shadeClass(byte[] bytecode) {
     ClassReader cr = new ClassReader(bytecode);
     ClassWriter cw = new ClassWriter(null, 0);
-    cr.accept(shade(cw), 0);
+    cr.accept(shadeClass(cw), 0);
     return cw.toByteArray();
   }
 
-  @Override
-  public String map(String internalName) {
-    if (internalName.startsWith("java/")
-        || internalName.startsWith("datadog/")
-        || internalName.startsWith("net/bytebuddy/")) {
-      return internalName; // never shade these references
-    }
-    return cache.computeIfAbsent(internalName, this::shade);
-  }
+  final class AdviceMapper extends Remapper {
+    private final DDCache<String, String> mappingCache = DDCaches.newFixedSizeCache(64);
 
-  @Override
-  public Object mapValue(Object value) {
-    if (value instanceof String) {
-      String text = (String) value;
-      if (text.isEmpty()) {
-        return text;
-      } else if (text.indexOf('.') > 0) {
-        return shadeDottedName(text);
+    /** Flattened sequence of old-prefix, new-prefix relocations. */
+    private final String[] prefixes;
+
+    AdviceMapper() {
+      // convert relocations to a flattened sequence: old-prefix, new-prefix, etc.
+      this.prefixes = new String[relocations.size() * 2];
+      int i = 0;
+      for (Map.Entry<String, String> e : relocations.entrySet()) {
+        String oldPrefix = e.getKey();
+        String newPrefix = e.getValue();
+        if (oldPrefix.indexOf('.') > 0) {
+          // accept dotted prefixes, but store them in their internal form
+          this.prefixes[i++] = oldPrefix.replace('.', '/');
+          this.prefixes[i++] = newPrefix.replace('.', '/');
+        } else {
+          this.prefixes[i++] = oldPrefix;
+          this.prefixes[i++] = newPrefix;
+        }
+      }
+    }
+
+    @Override
+    public String map(String internalName) {
+      if (internalName.startsWith("java/")
+          || internalName.startsWith("datadog/")
+          || internalName.startsWith("net/bytebuddy/")) {
+        return internalName; // never shade these references
+      }
+      return mappingCache.computeIfAbsent(internalName, this::shadeInternalName);
+    }
+
+    @Override
+    public Object mapValue(Object value) {
+      if (value instanceof String) {
+        String text = (String) value;
+        if (text.isEmpty()) {
+          return text;
+        } else if (text.indexOf('.') > 0) {
+          return shadeDottedName(text);
+        } else {
+          return shadeInternalName(text);
+        }
       } else {
-        return shade(text);
+        return super.mapValue(value);
       }
-    } else {
-      return super.mapValue(value);
     }
-  }
 
-  private String shade(String internalName) {
-    for (int i = 0; i < prefixes.length; i += 2) {
-      if (internalName.startsWith(prefixes[i])) {
-        return prefixes[i + 1] + internalName.substring(prefixes[i].length());
+    private String shadeInternalName(String internalName) {
+      for (int i = 0; i < prefixes.length; i += 2) {
+        if (internalName.startsWith(prefixes[i])) {
+          return prefixes[i + 1] + internalName.substring(prefixes[i].length());
+        }
       }
+      return internalName;
     }
-    return internalName;
-  }
 
-  private String shadeDottedName(String name) {
-    String internalName = name.replace('.', '/');
-    for (int i = 0; i < prefixes.length; i += 2) {
-      if (internalName.startsWith(prefixes[i])) {
-        return prefixes[i + 1].replace('/', '.') + name.substring(prefixes[i].length());
+    private String shadeDottedName(String name) {
+      String internalName = name.replace('.', '/');
+      for (int i = 0; i < prefixes.length; i += 2) {
+        if (internalName.startsWith(prefixes[i])) {
+          return prefixes[i + 1].replace('/', '.') + name.substring(prefixes[i].length());
+        }
       }
+      return name;
     }
-    return name;
   }
 }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -89,12 +89,12 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
   private Map<String, byte[]> getHelperMap() throws IOException {
     if (dynamicTypeMap.isEmpty()) {
       final Map<String, byte[]> classnameToBytes = new LinkedHashMap<>();
-      for (final String helperClassName : helperClassNames) {
-        byte[] classBytes = classFileLocator.locate(helperClassName).resolve();
+      for (String helperName : helperClassNames) {
+        byte[] classBytes = classFileLocator.locate(helperName).resolve();
         if (adviceShader != null) {
-          classBytes = adviceShader.shade(classBytes);
+          classBytes = adviceShader.shadeClass(classBytes);
         }
-        classnameToBytes.put(helperClassName, classBytes);
+        classnameToBytes.put(helperName, classBytes);
       }
 
       return classnameToBytes;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/HelperInjector.java
@@ -93,6 +93,7 @@ public class HelperInjector implements Instrumenter.TransformingAdvice {
         byte[] classBytes = classFileLocator.locate(helperName).resolve();
         if (adviceShader != null) {
           classBytes = adviceShader.shadeClass(classBytes);
+          helperName = adviceShader.uniqueHelper(helperName);
         }
         classnameToBytes.put(helperName, classBytes);
       }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -132,7 +132,7 @@ public class MuzzleVersionScanPlugin {
           ClassFileLocator.ForClassLoader.of(module.getClass().getClassLoader());
       byte[] classBytes = locator.locate(helperName).resolve();
       if (null != adviceShader) {
-        classBytes = adviceShader.shade(classBytes);
+        classBytes = adviceShader.shadeClass(classBytes);
       }
       helperMap.put(helperName, classBytes);
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/ReferenceCreator.java
@@ -70,7 +70,7 @@ public class ReferenceCreator extends ClassVisitor {
         if (null == adviceShader) {
           reader.accept(cv, ClassReader.SKIP_FRAMES);
         } else {
-          reader.accept(adviceShader.shade(cv), ClassReader.SKIP_FRAMES);
+          reader.accept(adviceShader.shadeClass(cv), ClassReader.SKIP_FRAMES);
         }
 
         final Map<String, Reference> instrumentationReferences = cv.getReferences();


### PR DESCRIPTION
# What Does This Do

Fixes an issue with #8153 where if the original module and relocated module both matched a class-loader then their injected helpers clashed. This could lead to a `ClassCastException` if the wrong helper was used by the injected advice. We now automatically relocate the injected helpers of relocated modules to avoid this scenario.

# Additional Notes

As part of this change we also make some of the processing lazy, so it's only run when required.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-858]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-858]: https://datadoghq.atlassian.net/browse/APMAPI-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ