### PR TITLE
Remove tag from backported PR titles

### DIFF
--- a/tooling/backport-pr-to-patch-release.sh
+++ b/tooling/backport-pr-to-patch-release.sh
@@ -94,7 +94,7 @@ git push -u origin "$BRANCH_NAME" --no-verify
 # Create a PR
 gh pr create --base "$PATCH_RELEASE_BRANCH" \
     --head "$BRANCH_NAME" \
-    --title "[🍒 $PR_NUMBER] $PR_TITLE" \
+    --title "🍒 $PR_NUMBER - $PR_TITLE" \
     --body "Backport #$PR_NUMBER to $PATCH_RELEASE_BRANCH" \
     --label "$PR_LABELS"
 


### PR DESCRIPTION
# What Does This Do

This PR fixes the back porting PR script to not use tag in PR names.

# Motivation

PR tags are forbidden from contribution guidelines and the recent PR check automation block them.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-232]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-232]: https://datadoghq.atlassian.net/browse/LANGPLAT-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ