### PR TITLE
Change hash computation for protobuf to better represent impacting changes + save proto number in schema

### DIFF
--- a/dd-java-agent/instrumentation/avro/src/main/java/datadog/trace/instrumentation/avro/SchemaExtractor.java
+++ b/dd-java-agent/instrumentation/avro/src/main/java/datadog/trace/instrumentation/avro/SchemaExtractor.java
@@ -104,7 +104,7 @@ public class SchemaExtractor implements SchemaIterator {
     }
 
     return builder.addProperty(
-        schemaName, fieldName, array, type, description, ref, format, enumValues);
+        schemaName, fieldName, array, type, description, ref, format, enumValues, null);
   }
 
   public static boolean extractSchema(

--- a/dd-java-agent/instrumentation/protobuf/src/main/java/datadog/trace/instrumentation/protobuf_java/SchemaExtractor.java
+++ b/dd-java-agent/instrumentation/protobuf/src/main/java/datadog/trace/instrumentation/protobuf_java/SchemaExtractor.java
@@ -11,6 +11,7 @@ import datadog.trace.bootstrap.instrumentation.api.Schema;
 import datadog.trace.bootstrap.instrumentation.api.SchemaBuilder;
 import datadog.trace.bootstrap.instrumentation.api.SchemaIterator;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -147,8 +148,10 @@ public class SchemaExtractor implements SchemaIterator {
     builder.addToHash(field.getNumber());
     builder.addToHash(typeCode);
     builder.addToHash(depth);
+    HashMap<String, String> extensions = new HashMap<String, String>(1);
+    extensions.put("x-protobuf-number", Integer.toString(field.getNumber()));
     return builder.addProperty(
-        schemaName, fieldName, array, type, description, ref, format, enumValues);
+        schemaName, fieldName, array, type, description, ref, format, enumValues, extensions);
   }
 
   public static boolean extractSchema(Descriptor descriptor, SchemaBuilder builder, int depth) {

--- a/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/AbstractMessageInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/AbstractMessageInstrumentationTest.groovy
@@ -16,7 +16,7 @@ class AbstractMessageInstrumentationTest extends AgentTestRunner {
     return true
   }
 
-  String expectedSchema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"other_message\":{\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
+  String expectedSchema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"extensions\":{\"x-protobuf-number\":\"1\"},\"type\":\"string\"},\"value\":{\"extensions\":{\"x-protobuf-number\":\"2\"},\"type\":\"string\"},\"other_message\":{\"extensions\":{\"x-protobuf-number\":\"3\"},\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"extensions\":{\"x-protobuf-number\":\"1\"},\"type\":\"string\"},\"age\":{\"extensions\":{\"x-protobuf-number\":\"2\"},\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
   String expectedSchemaID = "4690647329509494987"
 
 

--- a/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/AbstractMessageInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/AbstractMessageInstrumentationTest.groovy
@@ -1,5 +1,7 @@
 package com.datadog.instrumentation.protobuf
 
+import com.datadog.instrumentation.protobuf.generated.Message.MyMessage
+import com.datadog.instrumentation.protobuf.generated.Message.OtherMessage
 import com.google.protobuf.InvalidProtocolBufferException
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
@@ -7,8 +9,6 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
-import com.datadog.instrumentation.protobuf.generated.Message.MyMessage
-import com.datadog.instrumentation.protobuf.generated.Message.OtherMessage
 
 class AbstractMessageInstrumentationTest extends AgentTestRunner {
   @Override
@@ -16,8 +16,8 @@ class AbstractMessageInstrumentationTest extends AgentTestRunner {
     return true
   }
 
-  String schema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"other_message\":{\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
-  String schemaID = "9054678588020233022"
+  String expectedSchema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"other_message\":{\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
+  String expectedSchemaID = "4690647329509494987"
 
 
   void 'test extract protobuf schema on serialize & deserialize'() {
@@ -50,12 +50,12 @@ class AbstractMessageInstrumentationTest extends AgentTestRunner {
           errored false
           measured false
           tags {
-            "$DDTags.SCHEMA_DEFINITION" schema
+            "$DDTags.SCHEMA_DEFINITION" expectedSchema
             "$DDTags.SCHEMA_WEIGHT" 1
             "$DDTags.SCHEMA_TYPE" "protobuf"
             "$DDTags.SCHEMA_NAME" "com.datadog.instrumentation.protobuf.generated.MyMessage"
             "$DDTags.SCHEMA_OPERATION" "serialization"
-            "$DDTags.SCHEMA_ID" schemaID
+            "$DDTags.SCHEMA_ID" expectedSchemaID
             defaultTags(false)
           }
         }
@@ -68,12 +68,12 @@ class AbstractMessageInstrumentationTest extends AgentTestRunner {
           errored false
           measured false
           tags {
-            "$DDTags.SCHEMA_DEFINITION" schema
+            "$DDTags.SCHEMA_DEFINITION" expectedSchema
             "$DDTags.SCHEMA_WEIGHT" 1
             "$DDTags.SCHEMA_TYPE" "protobuf"
             "$DDTags.SCHEMA_NAME" "com.datadog.instrumentation.protobuf.generated.MyMessage"
             "$DDTags.SCHEMA_OPERATION" "deserialization"
-            "$DDTags.SCHEMA_ID" schemaID
+            "$DDTags.SCHEMA_ID" expectedSchemaID
             defaultTags(false)
           }
         }

--- a/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/DynamicMessageInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/DynamicMessageInstrumentationTest.groovy
@@ -22,7 +22,7 @@ class DynamicMessageInstrumentationTest extends AgentTestRunner {
       .setValue("Hello from Protobuf!")
       .build()
     when:
-    String expectedSchema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"other_message\":{\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
+    String expectedSchema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"extensions\":{\"x-protobuf-number\":\"1\"},\"type\":\"string\"},\"value\":{\"extensions\":{\"x-protobuf-number\":\"2\"},\"type\":\"string\"},\"other_message\":{\"extensions\":{\"x-protobuf-number\":\"3\"},\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"extensions\":{\"x-protobuf-number\":\"1\"},\"type\":\"string\"},\"age\":{\"extensions\":{\"x-protobuf-number\":\"2\"},\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
     String expectedSchemaID = "4690647329509494987"
     var bytes
     runUnderTrace("parent_serialize") {

--- a/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/DynamicMessageInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/protobuf/src/test/groovy/com/datadog/instrumentation/protobuf/DynamicMessageInstrumentationTest.groovy
@@ -1,10 +1,10 @@
 package com.datadog.instrumentation.protobuf
 
+import com.datadog.instrumentation.protobuf.generated.Message.MyMessage
 import com.google.protobuf.DynamicMessage
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDTags
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import com.datadog.instrumentation.protobuf.generated.Message.MyMessage
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
@@ -22,8 +22,8 @@ class DynamicMessageInstrumentationTest extends AgentTestRunner {
       .setValue("Hello from Protobuf!")
       .build()
     when:
-    String schema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"other_message\":{\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
-    String schemaID = "9054678588020233022"
+    String expectedSchema = "{\"components\":{\"schemas\":{\"com.datadog.instrumentation.protobuf.generated.MyMessage\":{\"properties\":{\"id\":{\"type\":\"string\"},\"value\":{\"type\":\"string\"},\"other_message\":{\"items\":{\"\$ref\":\"#/components/schemas/com.datadog.instrumentation.protobuf.generated.OtherMessage\"},\"type\":\"array\"}},\"type\":\"object\"},\"com.datadog.instrumentation.protobuf.generated.OtherMessage\":{\"properties\":{\"name\":{\"type\":\"string\"},\"age\":{\"format\":\"int32\",\"type\":\"integer\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}"
+    String expectedSchemaID = "4690647329509494987"
     var bytes
     runUnderTrace("parent_serialize") {
       AgentSpan span = activeSpan()
@@ -46,12 +46,12 @@ class DynamicMessageInstrumentationTest extends AgentTestRunner {
           errored false
           measured false
           tags {
-            "$DDTags.SCHEMA_DEFINITION" schema
+            "$DDTags.SCHEMA_DEFINITION" expectedSchema
             "$DDTags.SCHEMA_WEIGHT" 1
             "$DDTags.SCHEMA_TYPE" "protobuf"
             "$DDTags.SCHEMA_NAME" "com.datadog.instrumentation.protobuf.generated.MyMessage"
             "$DDTags.SCHEMA_OPERATION" "serialization"
-            "$DDTags.SCHEMA_ID" schemaID
+            "$DDTags.SCHEMA_ID" expectedSchemaID
             defaultTags(false)
           }
         }
@@ -64,12 +64,12 @@ class DynamicMessageInstrumentationTest extends AgentTestRunner {
           errored false
           measured false
           tags {
-            "$DDTags.SCHEMA_DEFINITION" schema
+            "$DDTags.SCHEMA_DEFINITION" expectedSchema
             "$DDTags.SCHEMA_WEIGHT" 1
             "$DDTags.SCHEMA_TYPE" "protobuf"
             "$DDTags.SCHEMA_NAME" "com.datadog.instrumentation.protobuf.generated.MyMessage"
             "$DDTags.SCHEMA_OPERATION" "deserialization"
-            "$DDTags.SCHEMA_ID" schemaID
+            "$DDTags.SCHEMA_ID" expectedSchemaID
             defaultTags(false)
           }
         }

--- a/dd-trace-core/src/main/java/datadog/trace/core/datastreams/SchemaBuilder.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/datastreams/SchemaBuilder.java
@@ -35,15 +35,17 @@ public class SchemaBuilder implements datadog.trace.bootstrap.instrumentation.ap
       String description,
       String ref,
       String format,
-      List<String> enumValues) {
+      List<String> enumValues,
+      Map<String, String> extensions) {
     if (properties >= maxProperties) {
       return false;
     }
     properties++;
     OpenApiSchema.Property property =
-        new OpenApiSchema.Property(type, description, ref, format, enumValues, null);
+        new OpenApiSchema.Property(
+            type, description, ref, format, enumValues, isArray ? null : extensions, null);
     if (isArray) {
-      property = new OpenApiSchema.Property("array", null, null, null, null, property);
+      property = new OpenApiSchema.Property("array", null, null, null, null, extensions, property);
     }
     schema.components.schemas.get(schemaName).properties.put(fieldName, property);
     return true;
@@ -107,6 +109,7 @@ public class SchemaBuilder implements datadog.trace.bootstrap.instrumentation.ap
       @Json(name = "enum")
       public List<String> enumValues;
 
+      public final Map<String, String> extensions;
       public Property items;
 
       public Property(
@@ -115,12 +118,14 @@ public class SchemaBuilder implements datadog.trace.bootstrap.instrumentation.ap
           String ref,
           String format,
           List<String> enumValues,
+          Map<String, String> extensions,
           Property items) {
         this.type = type;
         this.description = description;
         this.ref = ref;
         this.format = format;
         this.enumValues = enumValues;
+        this.extensions = extensions;
         this.items = items;
       }
     }

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/SchemaBuilderTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/datastreams/SchemaBuilderTest.groovy
@@ -10,12 +10,15 @@ class SchemaBuilderTest extends DDCoreSpecification {
 
     @Override
     void iterateOverSchema(datadog.trace.bootstrap.instrumentation.api.SchemaBuilder builder) {
-      builder.addProperty("person", "name", false, "string", "name of the person", null, null, null)
-      builder.addProperty("person", "phone_numbers", true, "string", null, null, null, null)
-      builder.addProperty("person", "person_name", false, "string", null, null, null, null)
-      builder.addProperty("person", "address", false, "object", null, "#/components/schemas/address", null, null)
-      builder.addProperty("address", "zip", false, "number", null, null, "int", null)
-      builder.addProperty("address", "street", false, "string", null, null, null, null)
+      HashMap<String, String> extension = new HashMap<String, String>(1)
+      extension.put("x-test-extension-1", "hello")
+      extension.put("x-test-extension-2", "world")
+      builder.addProperty("person", "name", false, "string", "name of the person", null, null, null, null)
+      builder.addProperty("person", "phone_numbers", true, "string", null, null, null, null, null)
+      builder.addProperty("person", "person_name", false, "string", null, null, null, null, null)
+      builder.addProperty("person", "address", false, "object", null, "#/components/schemas/address", null, null, null)
+      builder.addProperty("address", "zip", false, "number", null, null, "int", null, null)
+      builder.addProperty("address", "street", false, "string", null, null, null, null, extension)
     }
   }
 
@@ -31,8 +34,8 @@ class SchemaBuilderTest extends DDCoreSpecification {
     Schema schema = builder.build()
 
     then:
-    "{\"components\":{\"schemas\":{\"person\":{\"properties\":{\"name\":{\"description\":\"name of the person\",\"type\":\"string\"},\"phone_numbers\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"person_name\":{\"type\":\"string\"},\"address\":{\"\$ref\":\"#/components/schemas/address\",\"type\":\"object\"}},\"type\":\"object\"},\"address\":{\"properties\":{\"zip\":{\"format\":\"int\",\"type\":\"number\"},\"street\":{\"type\":\"string\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}" == schema.definition
-    "14950130709604290100" == schema.id
+    "{\"components\":{\"schemas\":{\"person\":{\"properties\":{\"name\":{\"description\":\"name of the person\",\"type\":\"string\"},\"phone_numbers\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"person_name\":{\"type\":\"string\"},\"address\":{\"\$ref\":\"#/components/schemas/address\",\"type\":\"object\"}},\"type\":\"object\"},\"address\":{\"properties\":{\"zip\":{\"format\":\"int\",\"type\":\"number\"},\"street\":{\"extensions\":{\"x-test-extension-1\":\"hello\",\"x-test-extension-2\":\"world\"},\"type\":\"string\"}},\"type\":\"object\"}}},\"openapi\":\"3.0.0\"}" == schema.definition
+    "16548065305426330543" == schema.id
     shouldExtractPerson
     shouldExtractAddress
     !shouldExtractPerson2

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SchemaBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SchemaBuilder.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
 import java.util.List;
+import java.util.Map;
 
 public interface SchemaBuilder {
   boolean addProperty(
@@ -11,7 +12,8 @@ public interface SchemaBuilder {
       String description,
       String ref,
       String format,
-      List<String> enumValues);
+      List<String> enumValue,
+      Map<String, String> extensions);
 
   void addToHash(int value);
 

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SchemaBuilder.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/SchemaBuilder.java
@@ -13,5 +13,9 @@ public interface SchemaBuilder {
       String format,
       List<String> enumValues);
 
+  void addToHash(int value);
+
+  void addToHash(String value);
+
   boolean shouldExtractSchema(String schemaName, int depth);
 }


### PR DESCRIPTION
# What Does This Do

Change the way the hash is computed for protobuf schemas:
- to catch some changes that impact the wire format but were not changing the hash before (like changing a field number for instance)
- to stay constant on changes that don't impact the wire format, but were changing the hash before (like reorganizing fields without changing their number)
It should also be marginally faster as we don't hash a whole string, and also isolates the hash from json shennanigans like the OpenAPI version for instance.

This new hash computation is aligned with what's done in the dotnet version of the instrumentation in https://github.com/DataDog/dd-trace-dotnet/pull/6166

ℹ️  Also add protobuf number to the OpenAPI schema saved, so that we can reconstruct the hash if needed, and also because it's an important component of a protobuf schema.

# Additional Notes

Depending on how schema hashes are used now in DSM, when deploying this, it may look to users as if all their schemas changed

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
