### PR TITLE
add W3C `baggage` propagator

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -77,6 +77,7 @@ public final class ConfigDefaults {
   static final int DEFAULT_SCOPE_ITERATION_KEEP_ALIVE = 30; // in seconds
   static final int DEFAULT_PARTIAL_FLUSH_MIN_SPANS = 1000;
   static final boolean DEFAULT_PROPAGATION_EXTRACT_LOG_HEADER_NAMES_ENABLED = false;
+  // TODO: add BAGGAGE to the list of default propagation styles
   static final Set<TracePropagationStyle> DEFAULT_TRACE_PROPAGATION_STYLE =
       new LinkedHashSet<>(asList(DATADOG, TRACECONTEXT));
   static final Set<PropagationStyle> DEFAULT_PROPAGATION_STYLE =

--- a/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java
@@ -21,6 +21,9 @@ public enum TracePropagationStyle {
   // W3C trace context propagation style
   // https://www.w3.org/TR/trace-context-1/
   TRACECONTEXT,
+  // W3C baggage propagation style
+  // https://www.w3.org/TR/baggage/
+  BAGGAGE,
   // None does not extract or inject
   NONE;
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -233,6 +233,7 @@ public class HttpCodec {
             context = extractedContext;
             // Stop extraction if only extracting first valid context and drop everything else
             if (this.extractFirst) {
+              // TODO: change this logic to always extract baggage
               break;
             }
           }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -125,6 +125,8 @@ public class HttpCodec {
         case TRACECONTEXT:
           result.put(style, W3CHttpCodec.newInjector(reverseBaggageMapping));
           break;
+        case BAGGAGE:
+            result.put(style, W3CBaggageHttpCodec.newInjector(reverseBaggageMapping));
         default:
           log.debug("No implementation found to inject propagation style: {}", style);
           break;
@@ -159,6 +161,9 @@ public class HttpCodec {
         case TRACECONTEXT:
           extractors.add(W3CHttpCodec.newExtractor(config, traceConfigSupplier));
           break;
+        case BAGGAGE:
+            extractors.add(W3CBaggageHttpCodec.newExtractor(config, traceConfigSupplier));
+            break;
         default:
           log.debug("No implementation found to extract propagation style: {}", style);
           break;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CBaggageHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CBaggageHttpCodec.java
@@ -1,0 +1,169 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.api.TracePropagationStyle.BAGGAGE;
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
+import static datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
+import static datadog.trace.core.propagation.PropagationTags.HeaderType.W3C;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.DD128bTraceId;
+import datadog.trace.api.DDSpanId;
+import datadog.trace.api.DDTags;
+import datadog.trace.api.DDTraceId;
+import datadog.trace.api.TraceConfig;
+import datadog.trace.api.TracePropagationStyle;
+import datadog.trace.api.internal.util.LongStringUtils;
+import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.sampling.SamplingMechanism;
+import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
+import datadog.trace.core.DDSpanContext;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A codec designed for HTTP transport via headers using W3C "baggage" header */
+class W3CBaggageHttpCodec {
+  private static final Logger log = LoggerFactory.getLogger(W3CHttpCodec.class);
+
+  static final String BAGGAGE_KEY = "baggage";
+
+  private W3CBaggageHttpCodec() {
+    // This class should not be created. This also makes code coverage checks happy.
+  }
+
+  public static HttpCodec.Injector newInjector(Map<String, String> invertedBaggageMapping) {
+    return new Injector(invertedBaggageMapping);
+  }
+
+  private static class Injector implements HttpCodec.Injector {
+
+    private final Map<String, String> invertedBaggageMapping;
+
+    public Injector(Map<String, String> invertedBaggageMapping) {
+      assert invertedBaggageMapping != null;
+      this.invertedBaggageMapping = invertedBaggageMapping;
+    }
+
+    @Override
+    public <C> void inject(
+        final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
+      StringBuilder baggageHeader = new StringBuilder();
+
+      for (final Map.Entry<String, String> entry : context.baggageItems()) {
+        if (baggageHeader.length() > 0) {
+            baggageHeader.append(",");
+        }
+
+        String header = invertedBaggageMapping.get(entry.getKey());
+        header = header != null ? header : entry.getKey();
+        String value = HttpCodec.encodeBaggage(entry.getValue());
+
+        baggageHeader.append(header).append("=").append(value);
+      }
+
+      setter.set(carrier, BAGGAGE_KEY, baggageHeader.toString());
+    }
+  }
+
+  public static HttpCodec.Extractor newExtractor(
+      Config config, Supplier<TraceConfig> traceConfigSupplier) {
+    return new TagContextExtractor(traceConfigSupplier, () -> new W3CBaggageContextInterpreter(config));
+  }
+
+  private static class W3CBaggageContextInterpreter extends ContextInterpreter {
+
+    private W3CBaggageContextInterpreter(Config config) {
+      super(config);
+    }
+
+    @Override
+    public TracePropagationStyle style() {
+      return BAGGAGE;
+    }
+
+    @Override
+    public boolean accept(String key, String value) {
+      if (null == key || key.isEmpty()) {
+        return true;
+      }
+      if (LOG_EXTRACT_HEADER_NAMES) {
+        log.debug("Header: {}", key);
+      }
+
+      char first = Character.toLowerCase(key.charAt(0));
+
+      if (first == 'b' && BAGGAGE_KEY.equalsIgnoreCase(key)) {
+        try {
+          if (baggage.isEmpty()) {
+            baggage = new TreeMap<>();
+          }
+
+          for (String entry : value.split(",")) {
+            String[] keyValue = entry.split("=", 2);
+            if (keyValue.length == 2) {
+                baggage.put(
+                    HttpCodec.decode(keyValue[0].trim()),
+                    HttpCodec.decode(keyValue[1].trim())
+                );
+            }
+          }
+        } catch (RuntimeException e) {
+          invalidateContext();
+          log.debug("Exception when extracting baggage", e);
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private long extractEndToEndStartTime(String value) {
+      try {
+        return MILLISECONDS.toNanos(Long.parseLong(value));
+      } catch (RuntimeException e) {
+        log.debug("Ignoring invalid end-to-end start time {}", value, e);
+        return 0;
+      }
+    }
+
+    private static String trim(String input) {
+      if (input == null) {
+        return "";
+      }
+      final int last = input.length() - 1;
+      if (last == 0) {
+        return input;
+      }
+      int start;
+      for (start = 0; start <= last; start++) {
+        char c = input.charAt(start);
+        if (c != '\t' && c != ' ') {
+          break;
+        }
+      }
+      int end;
+      for (end = last; end > start; end--) {
+        char c = input.charAt(end);
+        if (c != '\t' && c != ' ') {
+          break;
+        }
+      }
+      if (start == 0 && end == last) {
+        return input;
+      } else {
+        return input.substring(start, end + 1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
# What Does This Do

Add support for propagating baggage using the W3C `baggage` header (compatible with OpenTelemetry).

https://www.w3.org/TR/baggage/

# Motivation

This is a user-requested feature that we are adding to all tracing libraries for OpenTelemetry compatibility.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-214]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-214]: https://datadoghq.atlassian.net/browse/APMAPI-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ