### PR TITLE
Address cookie vulnerability cardinality issues

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -31,12 +31,12 @@ public interface VulnerabilityType {
       type(VulnerabilityTypes.WEAK_HASH).excludedSources(Builder.DB_EXCLUDED).build();
   VulnerabilityType INSECURE_COOKIE =
       type(VulnerabilityTypes.INSECURE_COOKIE)
-          .hash(VulnerabilityType::evidenceHash)
+          .hash(VulnerabilityType::fileAndLineHash)
           .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType NO_HTTPONLY_COOKIE =
       type(VulnerabilityTypes.NO_HTTPONLY_COOKIE)
-          .hash(VulnerabilityType::evidenceHash)
+          .hash(VulnerabilityType::fileAndLineHash)
           .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType HSTS_HEADER_MISSING =
@@ -51,7 +51,7 @@ public interface VulnerabilityType {
           .build();
   VulnerabilityType NO_SAMESITE_COOKIE =
       type(VulnerabilityTypes.NO_SAMESITE_COOKIE)
-          .hash(VulnerabilityType::evidenceHash)
+          .hash(VulnerabilityType::fileAndLineHash)
           .excludedSources(Builder.DB_EXCLUDED)
           .build();
 

--- a/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/VulnerabilityTypeTest.groovy
+++ b/dd-java-agent/agent-iast/src/test/groovy/com/datadog/iast/model/VulnerabilityTypeTest.groovy
@@ -30,15 +30,15 @@ class VulnerabilityTypeTest extends DDSpecification {
     WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(123)  | new Evidence("MD5")                    | 3265519776
     WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(456)  | new Evidence("MD4")                    | 3265519776
     WEAK_CIPHER                 | getSpanAndClassAndMethodLocation(789)  | null                                   | 3265519776
-    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | null                                   | 3471934557
-    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 360083726
-    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 2357141684
-    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | null                                   | 2115643285
-    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 585548920
-    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 3153040834
-    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | null                                   | 3683185539
-    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 881944211
-    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 2912433961
+    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | null                                   | 1156210466
+    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 1156210466
+    INSECURE_COOKIE             | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 1156210466
+    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | null                                   | 1522983769
+    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 1522983769
+    NO_HTTPONLY_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 1522983769
+    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | null                                   | 1090504969
+    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName1")            | 1090504969
+    NO_SAMESITE_COOKIE          | getSpanAndStackLocation(123)           | new Evidence("cookieName2")            | 1090504969
     XCONTENTTYPE_HEADER_MISSING | getSpanAndService(123, null)           | null                                   | 3429203725
     XCONTENTTYPE_HEADER_MISSING | getSpanAndService(123, 'serviceName1') | null                                   | 2718833340
     XCONTENTTYPE_HEADER_MISSING | getSpanAndService(123, 'serviceName2') | null                                   | 990333702


### PR DESCRIPTION
# What Does This Do

Change the evidence hash calculation for the location one

# Motivation

Using evidence for the cookie vulnerabilities hash is not the most effective approach. In some applications, a different cookie name is used per request or session. This leads to a large number of duplicate vulnerabilities. Deduplicating by location leads to a predictably low and bounded number of vulnerabilities.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56366](https://datadoghq.atlassian.net/browse/APPSEC-56366)

[APPSEC-56366]: https://datadoghq.atlassian.net/browse/APPSEC-56366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ