### PR TITLE
Fix BitSet builder in VulnerabilityTypes

### DIFF
--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -273,6 +273,8 @@ public interface VulnerabilityType {
   }
 
   class Builder {
+    private static final BitSet BIT_SET = new BitSet(SourceTypes.STRINGS.length + 1);
+
     private final byte type;
     private char separator = ' ';
     private int mark = NOT_MARKED;
@@ -301,7 +303,7 @@ public interface VulnerabilityType {
     }
 
     public Builder excludedSources(final byte... excludedSources) {
-      BitSet bitSet = new BitSet(SourceTypes.STRINGS.length + 1);
+      BitSet bitSet = BIT_SET;
       for (byte value : excludedSources) {
         bitSet.set(value);
       }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -26,33 +26,33 @@ import javax.annotation.Nonnull;
 public interface VulnerabilityType {
 
   VulnerabilityType WEAK_CIPHER =
-      type(VulnerabilityTypes.WEAK_CIPHER).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.WEAK_CIPHER).excludedSources(Builder.DB_EXCLUDED).build();
   VulnerabilityType WEAK_HASH =
-      type(VulnerabilityTypes.WEAK_HASH).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.WEAK_HASH).excludedSources(Builder.DB_EXCLUDED).build();
   VulnerabilityType INSECURE_COOKIE =
       type(VulnerabilityTypes.INSECURE_COOKIE)
           .hash(VulnerabilityType::evidenceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType NO_HTTPONLY_COOKIE =
       type(VulnerabilityTypes.NO_HTTPONLY_COOKIE)
           .hash(VulnerabilityType::evidenceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType HSTS_HEADER_MISSING =
       type(VulnerabilityTypes.HSTS_HEADER_MISSING)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType XCONTENTTYPE_HEADER_MISSING =
       type(VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType NO_SAMESITE_COOKIE =
       type(VulnerabilityTypes.NO_SAMESITE_COOKIE)
           .hash(VulnerabilityType::evidenceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType SQL_INJECTION =
@@ -60,39 +60,39 @@ public interface VulnerabilityType {
   VulnerabilityType COMMAND_INJECTION =
       type(VulnerabilityTypes.COMMAND_INJECTION)
           .mark(COMMAND_INJECTION_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType PATH_TRAVERSAL =
       type(VulnerabilityTypes.PATH_TRAVERSAL)
           .separator(File.separatorChar)
           .mark(PATH_TRAVERSAL_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType LDAP_INJECTION =
       type(VulnerabilityTypes.LDAP_INJECTION)
           .mark(LDAP_INJECTION_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType SSRF =
-      type(VulnerabilityTypes.SSRF).mark(SSRF_MARK).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.SSRF).mark(SSRF_MARK).excludedSources(Builder.DB_EXCLUDED).build();
   VulnerabilityType UNVALIDATED_REDIRECT =
       type(VulnerabilityTypes.UNVALIDATED_REDIRECT)
           .mark(UNVALIDATED_REDIRECT_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
   VulnerabilityType WEAK_RANDOMNESS =
-      type(VulnerabilityTypes.WEAK_RANDOMNESS).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.WEAK_RANDOMNESS).excludedSources(Builder.DB_EXCLUDED).build();
 
   VulnerabilityType XPATH_INJECTION =
       type(VulnerabilityTypes.XPATH_INJECTION)
           .mark(XPATH_INJECTION_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType TRUST_BOUNDARY_VIOLATION =
       type(VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION)
           .mark(TRUST_BOUNDARY_VIOLATION_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType XSS = type(VulnerabilityTypes.XSS).mark(XSS_MARK).build();
@@ -100,70 +100,68 @@ public interface VulnerabilityType {
   VulnerabilityType HEADER_INJECTION =
       type(VulnerabilityTypes.HEADER_INJECTION)
           .mark(HEADER_INJECTION_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType STACKTRACE_LEAK =
-      type(VulnerabilityTypes.STACKTRACE_LEAK).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.STACKTRACE_LEAK).excludedSources(Builder.DB_EXCLUDED).build();
 
   VulnerabilityType VERB_TAMPERING =
-      type(VulnerabilityTypes.VERB_TAMPERING).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.VERB_TAMPERING).excludedSources(Builder.DB_EXCLUDED).build();
 
   VulnerabilityType ADMIN_CONSOLE_ACTIVE =
       type(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE)
           .deduplicable(false)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType DEFAULT_HTML_ESCAPE_INVALID =
       type(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType SESSION_TIMEOUT =
-      type(VulnerabilityTypes.SESSION_TIMEOUT).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.SESSION_TIMEOUT).excludedSources(Builder.DB_EXCLUDED).build();
 
   VulnerabilityType DIRECTORY_LISTING_LEAK =
-      type(VulnerabilityTypes.DIRECTORY_LISTING_LEAK)
-          .excludedSources(SourceTypes.SQL_TABLE)
-          .build();
+      type(VulnerabilityTypes.DIRECTORY_LISTING_LEAK).excludedSources(Builder.DB_EXCLUDED).build();
   VulnerabilityType INSECURE_JSP_LAYOUT =
-      type(VulnerabilityTypes.INSECURE_JSP_LAYOUT).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.INSECURE_JSP_LAYOUT).excludedSources(Builder.DB_EXCLUDED).build();
 
   VulnerabilityType HARDCODED_SECRET =
-      type(VulnerabilityTypes.HARDCODED_SECRET).excludedSources(SourceTypes.SQL_TABLE).build();
+      type(VulnerabilityTypes.HARDCODED_SECRET).excludedSources(Builder.DB_EXCLUDED).build();
 
   VulnerabilityType INSECURE_AUTH_PROTOCOL =
       type(VulnerabilityTypes.INSECURE_AUTH_PROTOCOL)
           .hash(VulnerabilityType::evidenceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType REFLECTION_INJECTION =
       type(VulnerabilityTypes.REFLECTION_INJECTION)
           .mark(REFLECTION_INJECTION_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType SESSION_REWRITING =
       type(VulnerabilityTypes.SESSION_REWRITING)
           .deduplicable(false)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType DEFAULT_APP_DEPLOYED =
       type(VulnerabilityTypes.DEFAULT_APP_DEPLOYED)
           .deduplicable(false)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   VulnerabilityType UNTRUSTED_DESERIALIZATION =
       type(VulnerabilityTypes.UNTRUSTED_DESERIALIZATION)
           .mark(UNTRUSTED_DESERIALIZATION_MARK)
-          .excludedSources(SourceTypes.SQL_TABLE)
+          .excludedSources(Builder.DB_EXCLUDED)
           .build();
 
   /* All vulnerability types that have a mark. Should be updated if new vulnerabilityType with mark is added */
@@ -273,7 +271,12 @@ public interface VulnerabilityType {
   }
 
   class Builder {
-    private static final BitSet BIT_SET = new BitSet(SourceTypes.STRINGS.length + 1);
+    private static final BitSet DB_EXCLUDED;
+
+    static {
+      DB_EXCLUDED = new BitSet(SourceTypes.STRINGS.length + 1);
+      DB_EXCLUDED.set(SourceTypes.SQL_TABLE);
+    }
 
     private final byte type;
     private char separator = ' ';
@@ -302,12 +305,8 @@ public interface VulnerabilityType {
       return this;
     }
 
-    public Builder excludedSources(final byte... excludedSources) {
-      BitSet bitSet = BIT_SET;
-      for (byte value : excludedSources) {
-        bitSet.set(value);
-      }
-      this.excludedSources = bitSet;
+    public Builder excludedSources(final BitSet excludedSources) {
+      this.excludedSources = excludedSources;
       return this;
     }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -301,7 +301,7 @@ public interface VulnerabilityType {
     }
 
     public Builder excludedSources(final byte... excludedSources) {
-      BitSet bitSet = new BitSet();
+      BitSet bitSet = new BitSet(SourceTypes.STRINGS.length + 1);
       for (byte value : excludedSources) {
         bitSet.set(value);
       }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/model/VulnerabilityType.java
@@ -25,36 +25,34 @@ import javax.annotation.Nonnull;
 
 public interface VulnerabilityType {
 
-  BitSet DB_EXCLUDED = new BitSet(SourceTypes.SQL_TABLE);
-
   VulnerabilityType WEAK_CIPHER =
-      type(VulnerabilityTypes.WEAK_CIPHER).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.WEAK_CIPHER).excludedSources(SourceTypes.SQL_TABLE).build();
   VulnerabilityType WEAK_HASH =
-      type(VulnerabilityTypes.WEAK_HASH).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.WEAK_HASH).excludedSources(SourceTypes.SQL_TABLE).build();
   VulnerabilityType INSECURE_COOKIE =
       type(VulnerabilityTypes.INSECURE_COOKIE)
           .hash(VulnerabilityType::evidenceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
   VulnerabilityType NO_HTTPONLY_COOKIE =
       type(VulnerabilityTypes.NO_HTTPONLY_COOKIE)
           .hash(VulnerabilityType::evidenceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
   VulnerabilityType HSTS_HEADER_MISSING =
       type(VulnerabilityTypes.HSTS_HEADER_MISSING)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
   VulnerabilityType XCONTENTTYPE_HEADER_MISSING =
       type(VulnerabilityTypes.XCONTENTTYPE_HEADER_MISSING)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
   VulnerabilityType NO_SAMESITE_COOKIE =
       type(VulnerabilityTypes.NO_SAMESITE_COOKIE)
           .hash(VulnerabilityType::evidenceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType SQL_INJECTION =
@@ -62,39 +60,39 @@ public interface VulnerabilityType {
   VulnerabilityType COMMAND_INJECTION =
       type(VulnerabilityTypes.COMMAND_INJECTION)
           .mark(COMMAND_INJECTION_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
   VulnerabilityType PATH_TRAVERSAL =
       type(VulnerabilityTypes.PATH_TRAVERSAL)
           .separator(File.separatorChar)
           .mark(PATH_TRAVERSAL_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
   VulnerabilityType LDAP_INJECTION =
       type(VulnerabilityTypes.LDAP_INJECTION)
           .mark(LDAP_INJECTION_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
   VulnerabilityType SSRF =
-      type(VulnerabilityTypes.SSRF).mark(SSRF_MARK).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.SSRF).mark(SSRF_MARK).excludedSources(SourceTypes.SQL_TABLE).build();
   VulnerabilityType UNVALIDATED_REDIRECT =
       type(VulnerabilityTypes.UNVALIDATED_REDIRECT)
           .mark(UNVALIDATED_REDIRECT_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
   VulnerabilityType WEAK_RANDOMNESS =
-      type(VulnerabilityTypes.WEAK_RANDOMNESS).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.WEAK_RANDOMNESS).excludedSources(SourceTypes.SQL_TABLE).build();
 
   VulnerabilityType XPATH_INJECTION =
       type(VulnerabilityTypes.XPATH_INJECTION)
           .mark(XPATH_INJECTION_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType TRUST_BOUNDARY_VIOLATION =
       type(VulnerabilityTypes.TRUST_BOUNDARY_VIOLATION)
           .mark(TRUST_BOUNDARY_VIOLATION_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType XSS = type(VulnerabilityTypes.XSS).mark(XSS_MARK).build();
@@ -102,66 +100,70 @@ public interface VulnerabilityType {
   VulnerabilityType HEADER_INJECTION =
       type(VulnerabilityTypes.HEADER_INJECTION)
           .mark(HEADER_INJECTION_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType STACKTRACE_LEAK =
-      type(VulnerabilityTypes.STACKTRACE_LEAK).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.STACKTRACE_LEAK).excludedSources(SourceTypes.SQL_TABLE).build();
 
   VulnerabilityType VERB_TAMPERING =
-      type(VulnerabilityTypes.VERB_TAMPERING).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.VERB_TAMPERING).excludedSources(SourceTypes.SQL_TABLE).build();
 
   VulnerabilityType ADMIN_CONSOLE_ACTIVE =
       type(VulnerabilityTypes.ADMIN_CONSOLE_ACTIVE)
           .deduplicable(false)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType DEFAULT_HTML_ESCAPE_INVALID =
-      type(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.DEFAULT_HTML_ESCAPE_INVALID)
+          .excludedSources(SourceTypes.SQL_TABLE)
+          .build();
 
   VulnerabilityType SESSION_TIMEOUT =
-      type(VulnerabilityTypes.SESSION_TIMEOUT).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.SESSION_TIMEOUT).excludedSources(SourceTypes.SQL_TABLE).build();
 
   VulnerabilityType DIRECTORY_LISTING_LEAK =
-      type(VulnerabilityTypes.DIRECTORY_LISTING_LEAK).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.DIRECTORY_LISTING_LEAK)
+          .excludedSources(SourceTypes.SQL_TABLE)
+          .build();
   VulnerabilityType INSECURE_JSP_LAYOUT =
-      type(VulnerabilityTypes.INSECURE_JSP_LAYOUT).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.INSECURE_JSP_LAYOUT).excludedSources(SourceTypes.SQL_TABLE).build();
 
   VulnerabilityType HARDCODED_SECRET =
-      type(VulnerabilityTypes.HARDCODED_SECRET).excludedSources(DB_EXCLUDED).build();
+      type(VulnerabilityTypes.HARDCODED_SECRET).excludedSources(SourceTypes.SQL_TABLE).build();
 
   VulnerabilityType INSECURE_AUTH_PROTOCOL =
       type(VulnerabilityTypes.INSECURE_AUTH_PROTOCOL)
           .hash(VulnerabilityType::evidenceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType REFLECTION_INJECTION =
       type(VulnerabilityTypes.REFLECTION_INJECTION)
           .mark(REFLECTION_INJECTION_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType SESSION_REWRITING =
       type(VulnerabilityTypes.SESSION_REWRITING)
           .deduplicable(false)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType DEFAULT_APP_DEPLOYED =
       type(VulnerabilityTypes.DEFAULT_APP_DEPLOYED)
           .deduplicable(false)
           .hash(VulnerabilityType::serviceHash)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   VulnerabilityType UNTRUSTED_DESERIALIZATION =
       type(VulnerabilityTypes.UNTRUSTED_DESERIALIZATION)
           .mark(UNTRUSTED_DESERIALIZATION_MARK)
-          .excludedSources(DB_EXCLUDED)
+          .excludedSources(SourceTypes.SQL_TABLE)
           .build();
 
   /* All vulnerability types that have a mark. Should be updated if new vulnerabilityType with mark is added */
@@ -298,8 +300,12 @@ public interface VulnerabilityType {
       return this;
     }
 
-    public Builder excludedSources(final BitSet excludedSources) {
-      this.excludedSources = excludedSources;
+    public Builder excludedSources(final byte... excludedSources) {
+      BitSet bitSet = new BitSet();
+      for (byte value : excludedSources) {
+        bitSet.set(value);
+      }
+      this.excludedSources = bitSet;
       return this;
     }
 

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/Ranges.java
@@ -438,7 +438,8 @@ public final class Ranges {
     RangeBuilder newRanges = new RangeBuilder(ranges.length);
 
     for (Range range : ranges) {
-      if (!source.get(range.getSource().getOrigin())) {
+      if (range.getSource().getOrigin() == SourceTypes.NONE
+          || !source.get(range.getSource().getOrigin())) {
         newRanges.add(range);
       }
     }


### PR DESCRIPTION
# What Does This Do
This modifies how excluded sources are added to the builder.

# Motivation
The previous implementation was flawed because the constructor’s parameter represented the size of the bitset in bits, corresponding to the largest bit addressable.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-55328]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-55328]: https://datadoghq.atlassian.net/browse/APPSEC-55328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ