### PR TITLE
Remove flakiness from field-injection smoke test

### DIFF
--- a/dd-smoke-tests/field-injection/src/main/java/datadog/smoketest/fieldinjection/FieldInjectionApp.java
+++ b/dd-smoke-tests/field-injection/src/main/java/datadog/smoketest/fieldinjection/FieldInjectionApp.java
@@ -15,11 +15,11 @@ public class FieldInjectionApp {
         while (klass != null) {
           for (Field field : klass.getDeclaredFields()) {
             if (field.getName().startsWith("__datadogContext")) {
-              System.err.println("___FIELD___:" + className + ":" + field.getName());
+              System.out.println("___FIELD___:" + className + ":" + field.getName());
             }
           }
           for (Class<?> intf : klass.getInterfaces()) {
-            System.err.println("___INTERFACE___:" + className + ":" + intf.getName());
+            System.out.println("___INTERFACE___:" + className + ":" + intf.getName());
           }
           for (Type genericIntf : klass.getGenericInterfaces()) {
             Class<?> intf;
@@ -28,7 +28,7 @@ public class FieldInjectionApp {
             } else {
               intf = (Class<?>) genericIntf;
             }
-            System.err.println("___GENERIC_INTERFACE___:" + className + ":" + intf.getName());
+            System.out.println("___GENERIC_INTERFACE___:" + className + ":" + intf.getName());
           }
           klass = klass.getSuperclass();
         }


### PR DESCRIPTION
# What Does This Do

Separate stdout from stderr to avoid tracer logging from interfering with smoke-test parsing

# Motivation

Avoids tracer logging (which goes to stderr) from interfering with the test application logging. For example an I/O exception stack trace caused by there not being an agent to connect to might break up logging from the test application, making those lines non-parseable and failing the test.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
