### PR TITLE
Enhance log probes to honor debug session tags

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -21,8 +21,26 @@ public class DebuggerContext {
   private static final ThreadLocal<Boolean> IN_PROBE = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
   public enum SkipCause {
-    RATE,
-    CONDITION
+    RATE {
+      @Override
+      public String tag() {
+        return "cause:rate";
+      }
+    },
+    CONDITION {
+      @Override
+      public String tag() {
+        return "cause:condition";
+      }
+    },
+    DEBUG_SESSION_DISABLED {
+      @Override
+      public String tag() {
+        return "cause:debug session disabled";
+      }
+    };
+
+    public abstract String tag();
   }
 
   public interface ProbeResolver {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/DebugSessionStatus.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/DebugSessionStatus.java
@@ -1,0 +1,11 @@
+package com.datadog.debugger.probe;
+
+public enum DebugSessionStatus {
+  NONE,
+  ACTIVE,
+  DISABLED;
+
+  public boolean isDisabled() {
+    return this == DISABLED;
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -712,7 +712,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
   }
 
   protected String getDebugSessionId() {
-    return getTagMap().get("sessionId");
+    return getTagMap().get("session_id");
   }
 
   @Override

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -465,8 +465,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
       // sample when no condition associated
       sample(logStatus, methodLocation);
     }
-    logStatus.setCondition(
-        !logStatus.getDebugSessionStatus().isDisabled() && evaluateCondition(context, logStatus));
+    logStatus.setCondition(evaluateCondition(context, logStatus));
     CapturedContext.CapturedThrowable throwable = context.getCapturedThrowable();
     if (logStatus.hasConditionErrors() && throwable != null) {
       logStatus.addError(
@@ -755,7 +754,11 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     }
 
     public boolean shouldSend() {
-      return sampled && condition && !hasConditionErrors;
+      DebugSessionStatus status = getDebugSessionStatus();
+      // an ACTIVE status overrides the sampling as the sampling decision was made by the trigger
+      // probe
+      return status == DebugSessionStatus.ACTIVE
+          || !status.isDisabled() && sampled && condition && !hasConditionErrors;
     }
 
     public boolean shouldReportError() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinition.java
@@ -26,7 +26,7 @@ public abstract class ProbeDefinition implements ProbeImplementation {
   protected static final String LANGUAGE = "java";
 
   protected final String language;
-  protected String id;
+  protected final String id;
   protected final int version;
   protected transient ProbeId probeId;
   protected final Tag[] tags;
@@ -54,9 +54,6 @@ public abstract class ProbeDefinition implements ProbeImplementation {
 
   @Override
   public String getId() {
-    if (id == null) {
-      id = probeId != null ? probeId.getId() : null;
-    }
     return id;
   }
 

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
@@ -59,6 +59,15 @@ public class TriggerProbe extends ProbeDefinition implements Sampled {
         .instrument();
   }
 
+  public String getSessionId() {
+    return sessionId;
+  }
+
+  public TriggerProbe setSessionId(String sessionId) {
+    this.sessionId = sessionId;
+    return this;
+  }
+
   public Sampling getSampling() {
     return sampling;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/TriggerProbe.java
@@ -110,7 +110,7 @@ public class TriggerProbe extends ProbeDefinition implements Sampled {
     AgentTracer.TracerAPI tracerAPI = AgentTracer.get();
 
     AgentSpan agentSpan = tracerAPI.activeSpan().getLocalRootSpan();
-    agentSpan.setTag(Tags.PROPAGATED_DEBUG, "1");
+    agentSpan.setTag(Tags.PROPAGATED_DEBUG, sessionId + ":1");
     agentSpan.setTag(format("_dd.ld.probe_id.%s", probeId.getId()), true);
   }
 
@@ -148,8 +148,20 @@ public class TriggerProbe extends ProbeDefinition implements Sampled {
 
   @Override
   public String toString() {
-    return format(
-        "TriggerProbe{id='%s', where=%s, sampling=%s, probeCondition=%s}",
-        id, where, sampling, probeCondition);
+    return String.format(
+        "TriggerProbe{id='%s', sessionId='%s', evaluateAt=%s, language='%s', location=%s, probeCondition=%s, probeId=%s,"
+            + " sampling=%s, tagMap=%s, tags=%s, version=%d, where=%s}",
+        id,
+        sessionId,
+        evaluateAt,
+        language,
+        location,
+        probeCondition,
+        probeId,
+        sampling,
+        tagMap,
+        Arrays.toString(tags),
+        version,
+        where);
   }
 }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/DebuggerSink.java
@@ -4,7 +4,7 @@ import com.datadog.debugger.instrumentation.DiagnosticMessage;
 import com.datadog.debugger.uploader.BatchUploader;
 import com.datadog.debugger.util.DebuggerMetrics;
 import datadog.trace.api.Config;
-import datadog.trace.bootstrap.debugger.DebuggerContext;
+import datadog.trace.bootstrap.debugger.DebuggerContext.SkipCause;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.util.AgentTaskScheduler;
 import java.util.List;
@@ -223,20 +223,8 @@ public class DebuggerSink {
   }
 
   /** Notifies the snapshot was skipped for one of the SkipCause reason */
-  public void skipSnapshot(String probeId, DebuggerContext.SkipCause cause) {
-    String causeTag;
-    switch (cause) {
-      case RATE:
-        causeTag = "cause:rate";
-        break;
-      case CONDITION:
-        causeTag = "cause:condition";
-        break;
-      default:
-        throw new IllegalArgumentException("Unknown cause: " + cause);
-    }
-    String probeIdTag = "probe_id:" + probeId;
-    debuggerMetrics.incrementCounter(PREFIX + "skip", causeTag, probeIdTag);
+  public void skipSnapshot(String probeId, SkipCause cause) {
+    debuggerMetrics.incrementCounter(PREFIX + "skip", cause.tag(), "probe_id:" + probeId);
   }
 
   long getCurrentLowRateFlushInterval() {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturingTestBase.java
@@ -352,14 +352,7 @@ public class CapturingTestBase {
   protected TestSnapshotListener installProbes(
       Configuration configuration, ProbeDefinition... probes) {
 
-    config = mock(Config.class);
-    when(config.isDebuggerEnabled()).thenReturn(true);
-    when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
-    when(config.isDebuggerVerifyByteCode()).thenReturn(false);
-    when(config.getFinalDebuggerSnapshotUrl())
-        .thenReturn("http://localhost:8126/debugger/v1/input");
-    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
-    when(config.getDebuggerCodeOriginMaxUserFrames()).thenReturn(20);
+    config = mockConfig();
     instrumentationListener = new MockInstrumentationListener();
     probeStatusSink = mock(ProbeStatusSink.class);
 
@@ -402,6 +395,19 @@ public class CapturingTestBase {
     }
 
     return listener;
+  }
+
+  public static Config mockConfig() {
+    Config config = mock(Config.class);
+    when(config.isDebuggerEnabled()).thenReturn(true);
+    when(config.isDebuggerClassFileDumpEnabled()).thenReturn(true);
+    when(config.isDebuggerVerifyByteCode()).thenReturn(false);
+    when(config.getFinalDebuggerSnapshotUrl())
+        .thenReturn("http://localhost:8126/debugger/v1/input");
+    when(config.getFinalDebuggerSymDBUrl()).thenReturn("http://localhost:8126/symdb/v1/input");
+    when(config.getDebuggerCodeOriginMaxUserFrames()).thenReturn(20);
+
+    return config;
   }
 
   public static ProbeImplementation resolver(

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -95,7 +95,7 @@ public class LogProbeTest {
       Builder builder =
           createLog("I'm in a debug session").probeId(UUID.randomUUID().toString(), 0);
       if (status != DebugSessionStatus.NONE) {
-        builder.tags(format("sessionId:%s", DEBUG_SESSION_ID));
+        builder.tags(format("session_id:%s", DEBUG_SESSION_ID));
       }
 
       LogProbe logProbe = builder.build();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.mock;
 import com.datadog.debugger.agent.DebuggerAgentHelper;
 import com.datadog.debugger.probe.LogProbe.Builder;
 import com.datadog.debugger.probe.LogProbe.LogStatus;
-import com.datadog.debugger.probe.ProbeDefinition.DebugSessionStatus;
 import com.datadog.debugger.sink.DebuggerSink;
 import com.datadog.debugger.sink.ProbeStatusSink;
 import com.datadog.debugger.sink.Snapshot;


### PR DESCRIPTION
# What Does This Do

Enhances log probes to honor session id tags for live debugger support.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-2955]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-2955]: https://datadoghq.atlassian.net/browse/DEBUG-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ