### PR TITLE
[WIP] Add file attribute to JUnit reports

### DIFF
--- a/components/context/build.gradle.kts
+++ b/components/context/build.gradle.kts
@@ -11,3 +11,7 @@ jmh {
 val excludedClassesInstructionCoverage by extra {
   listOf("datadog.context.ContextProviders") // covered by forked test
 }
+
+tasks.test {
+  systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
+}

--- a/components/context/build.gradle.kts
+++ b/components/context/build.gradle.kts
@@ -13,5 +13,5 @@ val excludedClassesInstructionCoverage by extra {
 }
 
 tasks.test {
-  systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
+  jvmArgs("-Djunit.jupiter.extensions.autodetection.enabled=true")
 }

--- a/components/context/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/components/context/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+datadog.context.GetSourceFileInfoExtension

--- a/components/context/src/test/java/datadog/context/GetSourceFileInfoExtension.java
+++ b/components/context/src/test/java/datadog/context/GetSourceFileInfoExtension.java
@@ -1,6 +1,7 @@
 package datadog.context;
 
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -33,9 +34,11 @@ public class GetSourceFileInfoExtension implements TestInstancePostProcessor {
 
     // print to sourceFiles.xml only if source file has not already been added
     if (!sourceFiles.containsKey(testClassName)) {
-      BufferedWriter writer =
-          new BufferedWriter(
-              new FileWriter(root + "/build/test-results/test/sourceFiles.xml", true));
+      File sourceFile = new File(root + "/build/test-results/sourceFiles.xml");
+      if (!sourceFile.exists()) {
+        sourceFile.createNewFile();
+      }
+      BufferedWriter writer = new BufferedWriter(new FileWriter(sourceFile, true));
       writer.write(testClassName + ":" + subPath);
       writer.newLine();
       writer.close();

--- a/components/context/src/test/java/datadog/context/GetSourceFileInfoExtension.java
+++ b/components/context/src/test/java/datadog/context/GetSourceFileInfoExtension.java
@@ -30,12 +30,16 @@ public class GetSourceFileInfoExtension implements TestInstancePostProcessor {
     String absolutePath = root + "/src/test/java/" + testClassPath;
     String subPath =
         absolutePath.substring(absolutePath.indexOf("dd-trace-java") + "dd-trace-java".length());
-    // add info to sourceFiles map
+
+    // print to sourceFiles.xml only if source file has not already been added
+    if (!sourceFiles.containsKey(testClassName)) {
+      BufferedWriter writer =
+          new BufferedWriter(
+              new FileWriter(root + "/build/test-results/test/sourceFiles.xml", true));
+      writer.write(testClassName + ":" + subPath);
+      writer.newLine();
+      writer.close();
+    }
     sourceFiles.put(testClassName, subPath);
-    // print to sourceFiles.xml
-    BufferedWriter writer =
-        new BufferedWriter(new FileWriter(root + "/build/test-results/test/sourceFiles.xml"));
-    writer.write(sourceFiles.toString());
-    writer.close();
   }
 }

--- a/components/context/src/test/java/datadog/context/GetSourceFileInfoExtension.java
+++ b/components/context/src/test/java/datadog/context/GetSourceFileInfoExtension.java
@@ -1,0 +1,41 @@
+package datadog.context;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+public class GetSourceFileInfoExtension implements TestInstancePostProcessor {
+  private static Map<String, String> sourceFiles = new HashMap<String, String>();
+
+  @Override
+  public void postProcessTestInstance(Object testInstance, ExtensionContext context)
+      throws IOException {
+    getTestData(context);
+  }
+
+  public static Map<String, String> getSourceFiles() {
+    return sourceFiles;
+  }
+
+  private static void getTestData(ExtensionContext context) throws IOException {
+    // get test classname and source file
+    String testClassName = context.getTestClass().get().getName();
+    String testClassPath = testClassName.replace(".", "/") + ".java";
+    String root = Paths.get("").toAbsolutePath().toString();
+    String absolutePath = root + "/src/test/java/" + testClassPath;
+    String subPath =
+        absolutePath.substring(absolutePath.indexOf("dd-trace-java") + "dd-trace-java".length());
+    // add info to sourceFiles map
+    sourceFiles.put(testClassName, subPath);
+    // print to sourceFiles.xml
+    BufferedWriter writer =
+        new BufferedWriter(new FileWriter(root + "/build/test-results/test/sourceFiles.xml"));
+    writer.write(sourceFiles.toString());
+    writer.close();
+  }
+}

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -2,3 +2,20 @@ apply plugin: 'datadog.dependency-locking'
 
 apply from: "$rootDir/gradle/java_deps.gradle"
 apply from: "$rootDir/gradle/java_no_deps.gradle"
+
+tasks.named("test") {
+  finalizedBy("myCustomTask")
+}
+
+tasks.named("forkedTest") {
+  finalizedBy("myCustomTask")
+}
+
+tasks.register('myCustomTask') {
+  group = "Custom Tasks" // Optional, for better organization
+  description = "This is a custom task that prints a message"
+
+  doLast {
+    println("Running my custom task!")
+  }
+}

--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -19,6 +19,7 @@ ext.testcontainersLimit = gradle.sharedServices.registerIfAbsent("testcontainers
 if (tasks.matching({it.name == 'forkedTest'}).empty) {
   tasks.register('forkedTest', Test).configure {
     useJUnitPlatform()
+    jvmArgs("-Djunit.jupiter.extensions.autodetection.enabled=true")
   }
 }
 


### PR DESCRIPTION
# What Does This Do
Continues experimentation from #8143. Instead of using two custom extensions, it uses one extension to output sourcefile information into `sourceFiles.xml`, then uses this information in `collect_results.sh` to reformat the XML files. A solution to keep all logic in `collect_results.sh` without the use of any extension is in the works....

# Motivation
The eventual goal of this PR is to add the source file attribute to the <testcase> elements in the JUnit XML report that is produced after tests are run. This will eventually allow us to assign codeowner data. However, this PR is experimental.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: https://datadoghq.atlassian.net/browse/LANGPLAT-147

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
