### PR TITLE
Test http server requests in parallel

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -439,6 +439,11 @@ class JettyServlet3TestSyncDispatchOnAsyncTimeout extends JettyServlet3Test {
   }
 
   @Override
+  boolean testParallelRequest() {
+    false
+  }
+
+  @Override
   void handlerSpan(TraceAssert trace, ServerEndpoint endpoint = SUCCESS) {
     dispatchSpan(trace, endpoint)
   }
@@ -472,6 +477,11 @@ class JettyServlet3TestAsyncDispatchOnAsyncTimeout extends JettyServlet3Test {
   @Override
   boolean isDispatch() {
     true
+  }
+
+  @Override
+  boolean testParallelRequest() {
+    false
   }
 
   @Override
@@ -530,6 +540,11 @@ class JettyServlet3ServeFromAsyncTimeout extends JettyServlet3Test {
 
   @Override
   boolean testException() {
+    false
+  }
+
+  @Override
+  boolean testParallelRequest() {
     false
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -529,7 +529,7 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   def "test success with #count requests"() {
     setup:
     def request = request(SUCCESS, method, body).build()
-    List<Response> responses = (1..count).collect {
+    List<Response> responses = (1..count).parallelStream().collect {
       return client.newCall(request).execute()
     }
     if (isDataStreamsEnabled()) {

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -384,6 +384,10 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     false // not all servers support session ids
   }
 
+  boolean testParallelRequest() {
+    true
+  }
+
   @Override
   int version() {
     return 0
@@ -530,15 +534,20 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
   @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/4690", suites = ["MuleHttpServerForkedTest"])
   def "test success with #count requests"() {
     setup:
+    def responses
     def request = request(SUCCESS, method, body).build()
-    def executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors())
-    def completionService = new ExecutorCompletionService(executor)
-    (1..count).each {
-      completionService.submit {
-        client.newCall(request).execute()
+    if (testParallelRequest()) {
+      def executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors())
+      def completionService = new ExecutorCompletionService(executor)
+      (1..count).each {
+        completionService.submit {
+          client.newCall(request).execute()
+        }
       }
+      responses = (1..count).collect { completionService.take().get() }
+    } else {
+      responses = (1..count).collect {client.newCall(request).execute()}
     }
-    def responses = (1..count).collect {completionService.take().get()}
 
     if (isDataStreamsEnabled()) {
       TEST_DATA_STREAMS_WRITER.waitForGroups(1)


### PR DESCRIPTION
# What Does This Do

Use parallelism to execute http server request for the scenario `test success with #count requests` 

# Motivation

Improves issue detection of multithreaded cases. I'll need also to test a fix for vertx worker context propagation in case of multiple parallel requests

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
