### PR TITLE
Fix Docker build image update automation

### DIFF
--- a/.github/workflows/update-docker-build-image.yaml
+++ b/.github/workflows/update-docker-build-image.yaml
@@ -9,7 +9,7 @@ on:
       tag:
         description: 'The tag to use for the Docker build image'
         required: true
-        default: 'vYY.MM-base'
+        default: 'vYY.MM'
     
 jobs:
   update-docker-build-image:
@@ -46,7 +46,7 @@ jobs:
               08|09|10) TAG_DATE="${CURRENT_YEAR}.07" ;;
               11|12) TAG_DATE="${CURRENT_YEAR}.10" ;;
             esac
-            TAG="v${TAG_DATE}-base"
+            TAG="v${TAG_DATE}"
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "::notice::Using Docker build image tag: ${TAG}"
@@ -55,7 +55,7 @@ jobs:
           sed -i 's|DOCKER_IMAGE_VERSION=.*|DOCKER_IMAGE_VERSION="${{ steps.define-tag.outputs.tag }}"|' .circleci/render_config.py
       - name: Update the Docker build image in GitLab CI config
         run: |
-          sed -i 's|image: ghcr.io/datadog/dd-trace-java-docker-build:.*|image: ghcr.io/datadog/dd-trace-java-docker-build:${{ steps.define-tag.outputs.tag }}|' .gitlab-ci.yml
+          sed -i 's|image: ghcr.io/datadog/dd-trace-java-docker-build:.*|image: ghcr.io/datadog/dd-trace-java-docker-build:${{ steps.define-tag.outputs.tag }}-base|' .gitlab-ci.yml
       - name: Commit and push changes
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# What Does This Do

This PR fixes the CircleCI builder image configuration (no `-base` should be included, only the base of the tag) 

# Motivation

# Additional Notes

This is a follow up PR of #8206 
I could not find a way to test locally without messing with repository PRs. 
At some point, I stopped testing on prod and this bug slipped in 😬 

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-82]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-82]: https://datadoghq.atlassian.net/browse/LANGPLAT-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ