### PR TITLE
Use method enter advices for vert.x session blocking

### DIFF
--- a/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextSessionAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-3.4/src/main/java/datadog/trace/instrumentation/vertx_3_4/server/RoutingContextSessionAdvice.java
@@ -17,11 +17,10 @@ import net.bytebuddy.asm.Advice;
 
 @RequiresRequestContext(RequestContextSlot.APPSEC)
 class RoutingContextSessionAdvice {
-  @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  @Advice.OnMethodEnter(suppress = Throwable.class)
   static void after(
       @ActiveRequestContext final RequestContext reqCtx,
-      @Advice.Argument(0) final Session session,
-      @Advice.Thrown(readOnly = false) Throwable throwable) {
+      @Advice.Argument(0) final Session session) {
 
     if (session == null) {
       return;
@@ -47,9 +46,7 @@ class RoutingContextSessionAdvice {
           rba.getStatusCode(),
           rba.getBlockingContentType(),
           rba.getExtraHeaders());
-      if (throwable == null) {
-        throwable = new BlockingException("Blocked request (for session)");
-      }
+      throw new BlockingException("Blocked request (for session)");
     }
   }
 }

--- a/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextSessionAdvice.java
+++ b/dd-java-agent/instrumentation/vertx-web-4.0/src/main/java/datadog/trace/instrumentation/vertx_4_0/server/RoutingContextSessionAdvice.java
@@ -17,11 +17,10 @@ import net.bytebuddy.asm.Advice;
 
 @RequiresRequestContext(RequestContextSlot.APPSEC)
 class RoutingContextSessionAdvice {
-  @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+  @Advice.OnMethodEnter(suppress = Throwable.class)
   static void after(
       @ActiveRequestContext final RequestContext reqCtx,
-      @Advice.Argument(0) final Session session,
-      @Advice.Thrown(readOnly = false) Throwable throwable) {
+      @Advice.Argument(0) final Session session) {
 
     if (session == null) {
       return;
@@ -47,9 +46,7 @@ class RoutingContextSessionAdvice {
           rba.getStatusCode(),
           rba.getBlockingContentType(),
           rba.getExtraHeaders());
-      if (throwable == null) {
-        throwable = new BlockingException("Blocked request (for session)");
-      }
+      throw new BlockingException("Blocked request (for session)");
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
Move blocking behavior to method enter in vert.x session tracking.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
