### PR TITLE
Add a config flag to make ITR skip every test

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
@@ -52,6 +52,9 @@ public class ExecutionStrategy {
     if (test == null) {
       return false;
     }
+    if (config.isCiVisibilitySkipAllTests()) {
+      return true;
+    }
     if (!executionSettings.isTestSkippingEnabled()) {
       return false;
     }

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/CiVisibilityConfig.java
@@ -39,6 +39,7 @@ public final class CiVisibilityConfig {
   public static final String CIVISIBILITY_ITR_ENABLED = "civisibility.itr.enabled";
   public static final String CIVISIBILITY_TEST_SKIPPING_ENABLED =
       "civisibility.test.skipping.enabled";
+  public static final String CIVISIBILITY_SKIP_ALL_TESTS = "civisibility.skip.all.tests";
   public static final String CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED =
       "civisibility.ciprovider.integration.enabled";
   public static final String CIVISIBILITY_REPO_INDEX_DUPLICATE_KEY_CHECK_ENABLED =

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -348,6 +348,7 @@ public class Config {
   private final int ciVisibilitySignalClientTimeoutMillis;
   private final boolean ciVisibilityItrEnabled;
   private final boolean ciVisibilityTestSkippingEnabled;
+  private final boolean ciVisibilitySkipAllTests;
   private final boolean ciVisibilityCiProviderIntegrationEnabled;
   private final boolean ciVisibilityRepoIndexDuplicateKeyCheckEnabled;
   private final int ciVisibilityExecutionSettingsCacheSize;
@@ -1453,6 +1454,7 @@ public class Config {
     ciVisibilityItrEnabled = configProvider.getBoolean(CIVISIBILITY_ITR_ENABLED, true);
     ciVisibilityTestSkippingEnabled =
         configProvider.getBoolean(CIVISIBILITY_TEST_SKIPPING_ENABLED, true);
+    ciVisibilitySkipAllTests = configProvider.getBoolean(CIVISIBILITY_SKIP_ALL_TESTS, false);
     ciVisibilityCiProviderIntegrationEnabled =
         configProvider.getBoolean(CIVISIBILITY_CIPROVIDER_INTEGRATION_ENABLED, true);
     ciVisibilityRepoIndexDuplicateKeyCheckEnabled =
@@ -2851,6 +2853,10 @@ public class Config {
 
   public boolean isCiVisibilityTestSkippingEnabled() {
     return ciVisibilityTestSkippingEnabled;
+  }
+
+  public boolean isCiVisibilitySkipAllTests() {
+    return ciVisibilitySkipAllTests;
   }
 
   public boolean isCiVisibilityCiProviderIntegrationEnabled() {


### PR DESCRIPTION
# What Does This Do

Adds `DD_CIVISIBILITY_SKIP_ALL_TESTS` diagnostic flag to make ITR skip everything.

# Motivation

Debugging ITR issues.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->

[LANGTOOLS-3125]


[LANGTOOLS-3125]: https://datadoghq.atlassian.net/browse/LANGTOOLS-3125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ