### PR TITLE
Ensure cached subscriptions are cleared on reconfiguration via RC

### DIFF
--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/AppSecSystem.java
@@ -129,9 +129,12 @@ public class AppSecSystem {
       return;
     }
     REPLACEABLE_EVENT_PRODUCER = null;
-    STOP_SUBSCRIPTION_SERVICE.run();
-    STOP_SUBSCRIPTION_SERVICE = null;
-    RESET_SUBSCRIPTION_SERVICE = null;
+    final Runnable stop = STOP_SUBSCRIPTION_SERVICE;
+    if (stop != null) {
+      stop.run();
+      STOP_SUBSCRIPTION_SERVICE = null;
+      RESET_SUBSCRIPTION_SERVICE = null;
+    }
     Blocking.setBlockingService(BlockingService.NOOP);
 
     APP_SEC_CONFIG_SERVICE.close();
@@ -180,8 +183,9 @@ public class AppSecSystem {
 
     replaceableEventProducerService.replaceEventProducerService(newEd);
 
-    if (RESET_SUBSCRIPTION_SERVICE != null) {
-      RESET_SUBSCRIPTION_SERVICE.run();
+    final Runnable reset = RESET_SUBSCRIPTION_SERVICE;
+    if (reset != null) {
+      reset.run();
     }
   }
 

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/gateway/GatewayBridge.java
@@ -173,6 +173,30 @@ public class GatewayBridge {
     }
   }
 
+  /**
+   * This method clears all the cached subscriptions, should be used everytime the configuration
+   * changes and new addresses might appear or disappear from the config.
+   */
+  public void reset() {
+    initialReqDataSubInfo = null;
+    rawRequestBodySubInfo = null;
+    requestBodySubInfo = null;
+    pathParamsSubInfo = null;
+    respDataSubInfo = null;
+    grpcServerMethodSubInfo = null;
+    grpcServerRequestMsgSubInfo = null;
+    graphqlServerRequestMsgSubInfo = null;
+    requestEndSubInfo = null;
+    dbSqlQuerySubInfo = null;
+    ioNetUrlSubInfo = null;
+    ioFileSubInfo = null;
+    sessionIdSubInfo = null;
+    userIdSubInfo = null;
+    loginEventSubInfo.clear();
+    execCmdSubInfo = null;
+    shellCmdSubInfo = null;
+  }
+
   private Flow<Void> onUser(
       final RequestContext ctx_, final UserIdCollectionMode mode, final String originalUser) {
     if (mode == DISABLED) {


### PR DESCRIPTION
# What Does This Do
Clears all cached subscriptions when a new configuration is pulled from RC.

# Motivation
In certain scenarios (specially in system-tests) configs might contain rules only for a subset of addresses, meanwhile a future config might change them completely. Every time we pull a new configuration from RC we must clear all cached subscriptions to ensure consistency.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56377]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56377]: https://datadoghq.atlassian.net/browse/APPSEC-56377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ