### PR TITLE
Add Exception probe custom instrumentation

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/CapturedContext.java
@@ -299,7 +299,7 @@ public class CapturedContext implements ValueReferenceResolver {
       MethodLocation methodLocation) {
     Status status =
         statusByProbeId.computeIfAbsent(encodedProbeId, key -> probeImplementation.createStatus());
-    if (methodLocation == MethodLocation.EXIT) {
+    if (methodLocation == MethodLocation.EXIT && startTimestamp > 0) {
       duration = System.nanoTime() - startTimestamp;
       addExtension(
           ValueReferences.DURATION_EXTENSION_NAME, duration / 1_000_000.0); // convert to ms

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumentor.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumentor.java
@@ -1,0 +1,37 @@
+package com.datadog.debugger.instrumentation;
+
+import com.datadog.debugger.probe.ProbeDefinition;
+import datadog.trace.bootstrap.debugger.Limits;
+import datadog.trace.bootstrap.debugger.ProbeId;
+import java.util.List;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnList;
+
+public class ExceptionInstrumentor extends CapturedContextInstrumentor {
+
+  public ExceptionInstrumentor(
+      ProbeDefinition definition,
+      MethodInfo methodInfo,
+      List<DiagnosticMessage> diagnostics,
+      List<ProbeId> probeIds) {
+    super(definition, methodInfo, diagnostics, probeIds, true, false, Limits.DEFAULT);
+  }
+
+  @Override
+  public InstrumentationResult.Status instrument() {
+    processInstructions(); // fill returnHandlerLabel
+    addFinallyHandler(methodEnterLabel, returnHandlerLabel);
+    installFinallyBlocks();
+    return InstrumentationResult.Status.INSTALLED;
+  }
+
+  @Override
+  protected InsnList getBeforeReturnInsnList(AbstractInsnNode node) {
+    return null;
+  }
+
+  @Override
+  protected InsnList getReturnHandlerInsnList() {
+    return new InsnList();
+  }
+}


### PR DESCRIPTION
# What Does This Do
When there is only exception probes at a specific ode location we strip down the instrumentation to only capture values inside the catch (when an exception happens). this way, in normal execution no overhead is pay for an exception probe

# Motivation
Decrease overhead for exception probes when no exception

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3348]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3348]: https://datadoghq.atlassian.net/browse/DEBUG-3348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ