### PR TITLE
Move async propagation API from scope to tracer

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -1,7 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -27,7 +27,7 @@ public class AdviceUtils {
       final AgentScope.Continuation continuation = state.getAndResetContinuation();
       if (continuation != null) {
         final AgentScope scope = continuation.activate();
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         // important - stop timing after the scope has been activated so the time in the queue can
         // be attributed to the correct context without duplicating the propagated information
         state.stopTiming();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -1,6 +1,7 @@
 package datadog.trace.bootstrap.instrumentation.java.concurrent;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -26,7 +27,7 @@ public class AdviceUtils {
       final AgentScope.Continuation continuation = state.getAndResetContinuation();
       if (continuation != null) {
         final AgentScope scope = continuation.activate();
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         // important - stop timing after the scope has been activated so the time in the queue can
         // be attributed to the correct context without duplicating the propagated information
         state.stopTiming();

--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -16,7 +16,8 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+
 /**
  * Test executor instrumentation for Akka specific classes.
  * This is to large extent a copy of ExecutorInstrumentationTest.
@@ -45,7 +46,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           // this child will have a span
           m(pool, new AkkaAsyncChild())
           // this child won't
@@ -101,7 +102,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           // this child will have a span
           dispatcher.execute(new AkkaAsyncChild())
           // this child won't
@@ -132,7 +133,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           try {
             for (int i = 0; i < 20; ++i) {
               // Our current instrumentation instrumentation does not behave very well

--- a/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-concurrent/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -16,7 +16,7 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 /**
  * Test executor instrumentation for Akka specific classes.
@@ -46,7 +46,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new AkkaAsyncChild())
           // this child won't
@@ -102,7 +102,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           // this child will have a span
           dispatcher.execute(new AkkaAsyncChild())
           // this child won't
@@ -133,7 +133,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           try {
             for (int i = 0; i < 20; ++i) {
               // Our current instrumentation instrumentation does not behave very well

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -40,7 +40,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       completeDelegate(result);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         completeDelegate(result);
       }
     }
@@ -57,7 +57,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       failDelegate(ex);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         failDelegate(ex);
       }
     }
@@ -73,7 +73,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       cancelDelegate();
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         cancelDelegate();
       }
     }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/main/java/datadog/trace/instrumentation/apachehttpasyncclient/TraceContinuedFutureCallback.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpasyncclient;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -39,7 +40,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       completeDelegate(result);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         completeDelegate(result);
       }
     }
@@ -56,7 +57,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       failDelegate(ex);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         failDelegate(ex);
       }
     }
@@ -72,7 +73,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       cancelDelegate();
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         cancelDelegate();
       }
     }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/TraceContinuedFutureCallback.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -43,7 +43,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       completeDelegate(result);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         completeDelegate(result);
       }
     }
@@ -60,7 +60,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       failDelegate(ex);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         failDelegate(ex);
       }
     }
@@ -76,7 +76,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       cancelDelegate();
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         cancelDelegate();
       }
     }

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/TraceContinuedFutureCallback.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/TraceContinuedFutureCallback.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.apachehttpclient5;
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.apachehttpclient5.ApacheHttpClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -42,7 +43,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       completeDelegate(result);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         completeDelegate(result);
       }
     }
@@ -59,7 +60,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       failDelegate(ex);
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         failDelegate(ex);
       }
     }
@@ -75,7 +76,7 @@ public class TraceContinuedFutureCallback<T> implements FutureCallback<T> {
       cancelDelegate();
     } else {
       try (final AgentScope scope = parentContinuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         cancelDelegate();
       }
     }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixThreadPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixThreadPoolInstrumentation.java
@@ -1,14 +1,14 @@
 package datadog.trace.instrumentation.hystrix;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import net.bytebuddy.asm.Advice;
 
 @AutoService(InstrumenterModule.class)
@@ -35,12 +35,9 @@ public class HystrixThreadPoolInstrumentation extends InstrumenterModule.Tracing
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static boolean enableAsyncTracking() {
-      final AgentScope scope = activeScope();
-      if (scope != null) {
-        if (!scope.isAsyncPropagating()) {
-          scope.setAsyncPropagation(true);
-          return true;
-        }
+      if (!isAsyncPropagation()) {
+        setAsyncPropagation(true);
+        return true;
       }
       return false;
     }
@@ -48,10 +45,7 @@ public class HystrixThreadPoolInstrumentation extends InstrumenterModule.Tracing
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void disableAsyncTracking(@Advice.Enter final boolean wasEnabled) {
       if (wasEnabled) {
-        final AgentScope scope = activeScope();
-        if (scope != null) {
-          scope.setAsyncPropagation(false);
-        }
+        setAsyncPropagation(false);
       }
     }
   }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixThreadPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/main/java/datadog/trace/instrumentation/hystrix/HystrixThreadPoolInstrumentation.java
@@ -1,8 +1,8 @@
 package datadog.trace.instrumentation.hystrix;
 
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagation;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -35,8 +35,8 @@ public class HystrixThreadPoolInstrumentation extends InstrumenterModule.Tracing
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static boolean enableAsyncTracking() {
-      if (!isAsyncPropagation()) {
-        setAsyncPropagation(true);
+      if (!isAsyncPropagationEnabled()) {
+        setAsyncPropagationEnabled(true);
         return true;
       }
       return false;
@@ -45,7 +45,7 @@ public class HystrixThreadPoolInstrumentation extends InstrumenterModule.Tracing
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void disableAsyncTracking(@Advice.Enter final boolean wasEnabled) {
       if (wasEnabled) {
-        setAsyncPropagation(false);
+        setAsyncPropagationEnabled(false);
       }
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
@@ -11,7 +11,7 @@ import java.util.function.Supplier
 
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 
 /**
  * Note: ideally this should live with the rest of ExecutorInstrumentationTest,
@@ -45,7 +45,7 @@ class CompletableFutureTest extends AgentTestRunner {
         @Trace(operationName = "parent")
         CompletableFuture<String> get() {
           try {
-            activeScope().setAsyncPropagation(true)
+            setAsyncPropagation(true)
             return CompletableFuture.supplyAsync(supplier, pool)
               .thenCompose({ s -> CompletableFuture.supplyAsync(new AppendingSupplier(s), differentPool) })
               .thenApply(function)

--- a/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-completablefuture/src/test/groovy/CompletableFutureTest.groovy
@@ -11,7 +11,7 @@ import java.util.function.Supplier
 
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 /**
  * Note: ideally this should live with the rest of ExecutorInstrumentationTest,
@@ -45,7 +45,7 @@ class CompletableFutureTest extends AgentTestRunner {
         @Trace(operationName = "parent")
         CompletableFuture<String> get() {
           try {
-            setAsyncPropagation(true)
+            setAsyncPropagationEnabled(true)
             return CompletableFuture.supplyAsync(supplier, pool)
               .thenCompose({ s -> CompletableFuture.supplyAsync(new AppendingSupplier(s), differentPool) })
               .thenApply(function)

--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/src/test/groovy/VirtualThreadTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/src/test/groovy/VirtualThreadTest.groovy
@@ -8,7 +8,7 @@ import java.util.concurrent.ExecutorCompletionService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 
 class VirtualThreadTest extends AgentTestRunner {
   @Shared
@@ -37,7 +37,7 @@ class VirtualThreadTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't

--- a/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/src/test/groovy/VirtualThreadTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/java-concurrent-21/src/test/groovy/VirtualThreadTest.groovy
@@ -8,7 +8,7 @@ import java.util.concurrent.ExecutorCompletionService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 class VirtualThreadTest extends AgentTestRunner {
   @Shared
@@ -37,7 +37,7 @@ class VirtualThreadTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -5,8 +5,8 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameEnd
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagation;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagationEnabled;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.java.concurrent.ConcurrentInstrumentationNames.EXECUTOR_INSTRUMENTATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
@@ -178,8 +178,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
 
     @Advice.OnMethodEnter
     public static boolean before() {
-      if (isAsyncPropagation()) {
-        setAsyncPropagation(false);
+      if (isAsyncPropagationEnabled()) {
+        setAsyncPropagationEnabled(false);
         return true;
       }
       return false;
@@ -188,7 +188,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
     @Advice.OnMethodExit(onThrowable = Throwable.class)
     public static void after(@Advice.Enter boolean wasDisabled) {
       if (wasDisabled) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
       }
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java-concurrent/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -5,7 +5,8 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameEnd
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.nameStartsWith;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.namedOneOf;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.isAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.java.concurrent.ConcurrentInstrumentationNames.EXECUTOR_INSTRUMENTATION_NAME;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
@@ -13,7 +14,6 @@ import static net.bytebuddy.matcher.ElementMatchers.isTypeInitializer;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -177,19 +177,18 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
   public static class DisableAsyncAdvice {
 
     @Advice.OnMethodEnter
-    public static AgentScope before() {
-      AgentScope scope = activeScope();
-      if (null != scope && scope.isAsyncPropagating()) {
-        scope.setAsyncPropagation(false);
-        return scope;
+    public static boolean before() {
+      if (isAsyncPropagation()) {
+        setAsyncPropagation(false);
+        return true;
       }
-      return null;
+      return false;
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class)
-    public static void after(@Advice.Enter AgentScope scope) {
-      if (null != scope) {
-        scope.setAsyncPropagation(true);
+    public static void after(@Advice.Enter boolean wasDisabled) {
+      if (wasDisabled) {
+        setAsyncPropagation(true);
       }
     }
   }

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/ExecutorInstrumentationTest.groovy
@@ -26,7 +26,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import static org.junit.Assume.assumeTrue
 
 abstract class ExecutorInstrumentationTest extends AgentTestRunner {
@@ -82,7 +82,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't
@@ -256,7 +256,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           def future = m(pool, task)
           sleep(500)
           future.cancel(true)
@@ -317,7 +317,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           // this child will have a span
           pool.execute(new JavaAsyncChild())
           // this child won't
@@ -368,7 +368,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           m(pool, w(child))
         }
       }.run()
@@ -406,7 +406,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           try {
             for (int i = 0; i < 20; ++i) {
               final JavaAsyncChild child = new JavaAsyncChild(false, true)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/ExecutorInstrumentationTest.groovy
@@ -26,7 +26,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 import static org.junit.Assume.assumeTrue
 
 abstract class ExecutorInstrumentationTest extends AgentTestRunner {
@@ -82,7 +82,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't
@@ -256,7 +256,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           def future = m(pool, task)
           sleep(500)
           future.cancel(true)
@@ -317,7 +317,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           // this child will have a span
           pool.execute(new JavaAsyncChild())
           // this child won't
@@ -368,7 +368,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           m(pool, w(child))
         }
       }.run()
@@ -406,7 +406,7 @@ abstract class ExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           try {
             for (int i = 0; i < 20; ++i) {
               final JavaAsyncChild child = new JavaAsyncChild(false, true)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/NettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/NettyExecutorInstrumentationTest.groovy
@@ -17,7 +17,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import static org.junit.Assume.assumeTrue
 
 class NettyExecutorInstrumentationTest extends AgentTestRunner {
@@ -65,7 +65,7 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't
@@ -213,7 +213,7 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           try {
             for (int i = 0; i < 20; ++i) {
               final JavaAsyncChild child = new JavaAsyncChild(false, true)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/NettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/NettyExecutorInstrumentationTest.groovy
@@ -17,7 +17,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 import static org.junit.Assume.assumeTrue
 
 class NettyExecutorInstrumentationTest extends AgentTestRunner {
@@ -65,7 +65,7 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't
@@ -213,7 +213,7 @@ class NettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           try {
             for (int i = 0; i < 20; ++i) {
               final JavaAsyncChild child = new JavaAsyncChild(false, true)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/RejectedExecutionTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/RejectedExecutionTest.groovy
@@ -21,7 +21,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 class RejectedExecutionTest extends AgentTestRunner {
 
@@ -193,7 +193,7 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     when:
     runUnderTrace("parent") {
-      setAsyncPropagation(true)
+      setAsyncPropagationEnabled(true)
       // must be rejected because the queue will be full until some
       // time after the first task is released
       executor.submit((Runnable) new JavaAsyncChild(true, false))
@@ -237,7 +237,7 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     return {
       runUnderTrace("parent") {
-        setAsyncPropagation(true)
+        setAsyncPropagationEnabled(true)
         pool.submit({})
       }
     }
@@ -261,7 +261,7 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     return {
       runUnderTrace("parent") {
-        setAsyncPropagation(true)
+        setAsyncPropagationEnabled(true)
         // must be rejected because the queue will be full until some
         // time after the first task is released
         def testTask = new JavaAsyncChild(true, false)

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/RejectedExecutionTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/executor/RejectedExecutionTest.groovy
@@ -21,7 +21,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 
 class RejectedExecutionTest extends AgentTestRunner {
 
@@ -193,7 +193,7 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     when:
     runUnderTrace("parent") {
-      activeScope().setAsyncPropagation(true)
+      setAsyncPropagation(true)
       // must be rejected because the queue will be full until some
       // time after the first task is released
       executor.submit((Runnable) new JavaAsyncChild(true, false))
@@ -237,7 +237,7 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     return {
       runUnderTrace("parent") {
-        activeScope().setAsyncPropagation(true)
+        setAsyncPropagation(true)
         pool.submit({})
       }
     }
@@ -261,7 +261,7 @@ class RejectedExecutionTest extends AgentTestRunner {
 
     return {
       runUnderTrace("parent") {
-        activeScope().setAsyncPropagation(true)
+        setAsyncPropagation(true)
         // must be rejected because the queue will be full until some
         // time after the first task is released
         def testTask = new JavaAsyncChild(true, false)

--- a/dd-java-agent/instrumentation/jetty-util/src/test/groovy/JettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-util/src/test/groovy/JettyExecutorInstrumentationTest.groovy
@@ -10,7 +10,7 @@ import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import static org.junit.Assume.assumeTrue
 
 class JettyExecutorInstrumentationTest extends AgentTestRunner {
@@ -46,7 +46,7 @@ class JettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't

--- a/dd-java-agent/instrumentation/jetty-util/src/test/groovy/JettyExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jetty-util/src/test/groovy/JettyExecutorInstrumentationTest.groovy
@@ -10,7 +10,7 @@ import java.util.concurrent.Callable
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 import static org.junit.Assume.assumeTrue
 
 class JettyExecutorInstrumentationTest extends AgentTestRunner {
@@ -46,7 +46,7 @@ class JettyExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           // this child will have a span
           m(pool, new JavaAsyncChild())
           // this child won't

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
@@ -2,9 +2,9 @@ package datadog.trace.instrumentation.kotlin.coroutines
 
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.get
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource.INSTRUMENTATION
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import kotlinx.coroutines.CompletableDeferred
@@ -333,7 +333,7 @@ abstract class CoreKotlinCoroutineTests(private val dispatcher: CoroutineDispatc
   }
 
   protected fun <T> runTest(asyncPropagation: Boolean = true, block: suspend CoroutineScope.() -> T): T {
-    activeScope()?.setAsyncPropagation(asyncPropagation)
+    setAsyncPropagation(asyncPropagation)
     return runBlocking(jobName("test") + dispatcher, block = block)
   }
 }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
@@ -4,7 +4,7 @@ import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.get
-import datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import datadog.trace.bootstrap.instrumentation.api.ScopeSource.INSTRUMENTATION
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import kotlinx.coroutines.CompletableDeferred
@@ -333,7 +333,7 @@ abstract class CoreKotlinCoroutineTests(private val dispatcher: CoroutineDispatc
   }
 
   protected fun <T> runTest(asyncPropagation: Boolean = true, block: suspend CoroutineScope.() -> T): T {
-    setAsyncPropagation(asyncPropagation)
+    setAsyncPropagationEnabled(asyncPropagation)
     return runBlocking(jobName("test") + dispatcher, block = block)
   }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelScope.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/main/java/datadog/trace/instrumentation/opentelemetry/OtelScope.java
@@ -25,14 +25,4 @@ public class OtelScope implements Scope, TraceScope {
   public void close() {
     delegate.close();
   }
-
-  @Override
-  public boolean isAsyncPropagating() {
-    return delegate.isAsyncPropagating();
-  }
-
-  @Override
-  public void setAsyncPropagation(final boolean value) {
-    delegate.setAsyncPropagation(value);
-  }
 }

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
@@ -19,6 +19,8 @@ import io.opentelemetry.trace.Status
 import io.opentelemetry.trace.TracingContextUtils
 import spock.lang.Subject
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+
 class OpenTelemetryTest extends AgentTestRunner {
   @Subject
   def tracer = OpenTelemetry.tracerProvider.get("test-inst")
@@ -232,7 +234,7 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def span = tracer.spanBuilder("some name").startSpan()
     TraceScope scope = tracer.withSpan(span)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
 
     expect:
     tracer.currentSpan.delegate == span.delegate

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
@@ -19,7 +19,7 @@ import io.opentelemetry.trace.Status
 import io.opentelemetry.trace.TracingContextUtils
 import spock.lang.Subject
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 class OpenTelemetryTest extends AgentTestRunner {
   @Subject
@@ -234,7 +234,7 @@ class OpenTelemetryTest extends AgentTestRunner {
     setup:
     def span = tracer.spanBuilder("some name").startSpan()
     TraceScope scope = tracer.withSpan(span)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
 
     expect:
     tracer.currentSpan.delegate == span.delegate

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/main/java/datadog/trace/instrumentation/opentracing31/OTScopeManager.java
@@ -73,16 +73,6 @@ public class OTScopeManager implements ScopeManager {
       return delegate.captureConcurrent();
     }
 
-    @Override
-    public boolean isAsyncPropagating() {
-      return delegate.isAsyncPropagating();
-    }
-
-    @Override
-    public void setAsyncPropagation(final boolean value) {
-      delegate.setAsyncPropagation(value);
-    }
-
     public boolean isFinishSpanOnClose() {
       return finishSpanOnClose;
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -3,6 +3,7 @@ import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.interceptor.MutableSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
 import datadog.trace.core.propagation.PropagationTags
 import datadog.trace.instrumentation.opentracing.DefaultLogHandler
@@ -154,24 +155,25 @@ class OpenTracing31Test extends AgentTestRunner {
 
   def "test scopemanager"() {
     setup:
+    AgentTracer.TracerAPI internalTracer = tracer.tracer.tracer
     def span = tracer.buildSpan("some name").start()
     def scope = tracer.scopeManager().activate(span, finishSpan)
-    setAsyncPropagation(false)
+    internalTracer.setAsyncPropagation(false)
 
     expect:
     span instanceof MutableSpan
     scope instanceof TraceScope
-    !(scope as TraceScope).isAsyncPropagating()
+    !internalTracer.isAsyncPropagation()
     (scope as TraceScope).capture() == null
     (tracer.scopeManager().active().span().delegate == span.delegate)
 
     when:
-    setAsyncPropagation(true)
+    internalTracer.setAsyncPropagation(true)
     def continuation = (scope as TraceScope).capture()
     continuation.cancel()
 
     then:
-    (scope as TraceScope).isAsyncPropagating()
+    internalTracer.isAsyncPropagation()
     continuation instanceof TraceScope.Continuation
 
     when: "attempting to close the span this way doesn't work because we lost the 'finishSpan' reference"

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -28,7 +28,7 @@ import io.opentracing.util.GlobalTracer
 import spock.lang.Subject
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 class OpenTracing31Test extends AgentTestRunner {
 
@@ -158,22 +158,22 @@ class OpenTracing31Test extends AgentTestRunner {
     AgentTracer.TracerAPI internalTracer = tracer.tracer.tracer
     def span = tracer.buildSpan("some name").start()
     def scope = tracer.scopeManager().activate(span, finishSpan)
-    internalTracer.setAsyncPropagation(false)
+    internalTracer.setAsyncPropagationEnabled(false)
 
     expect:
     span instanceof MutableSpan
     scope instanceof TraceScope
-    !internalTracer.isAsyncPropagation()
+    !internalTracer.isAsyncPropagationEnabled()
     (scope as TraceScope).capture() == null
     (tracer.scopeManager().active().span().delegate == span.delegate)
 
     when:
-    internalTracer.setAsyncPropagation(true)
+    internalTracer.setAsyncPropagationEnabled(true)
     def continuation = (scope as TraceScope).capture()
     continuation.cancel()
 
     then:
-    internalTracer.isAsyncPropagation()
+    internalTracer.isAsyncPropagationEnabled()
     continuation instanceof TraceScope.Continuation
 
     when: "attempting to close the span this way doesn't work because we lost the 'finishSpan' reference"
@@ -218,7 +218,7 @@ class OpenTracing31Test extends AgentTestRunner {
     setup:
     def span = tracer.buildSpan("some name").start()
     TraceScope scope = tracer.scopeManager().activate(span, false)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
 
     expect:
     tracer.activeSpan().delegate == span.delegate

--- a/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.31/src/test/groovy/OpenTracing31Test.groovy
@@ -27,6 +27,7 @@ import io.opentracing.util.GlobalTracer
 import spock.lang.Subject
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 
 class OpenTracing31Test extends AgentTestRunner {
 
@@ -155,7 +156,7 @@ class OpenTracing31Test extends AgentTestRunner {
     setup:
     def span = tracer.buildSpan("some name").start()
     def scope = tracer.scopeManager().activate(span, finishSpan)
-    (scope as TraceScope).setAsyncPropagation(false)
+    setAsyncPropagation(false)
 
     expect:
     span instanceof MutableSpan
@@ -165,7 +166,7 @@ class OpenTracing31Test extends AgentTestRunner {
     (tracer.scopeManager().active().span().delegate == span.delegate)
 
     when:
-    (scope as TraceScope).setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = (scope as TraceScope).capture()
     continuation.cancel()
 
@@ -215,7 +216,7 @@ class OpenTracing31Test extends AgentTestRunner {
     setup:
     def span = tracer.buildSpan("some name").start()
     TraceScope scope = tracer.scopeManager().activate(span, false)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
 
     expect:
     tracer.activeSpan().delegate == span.delegate

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/main/java/datadog/trace/instrumentation/opentracing32/OTScopeManager.java
@@ -83,16 +83,6 @@ public class OTScopeManager implements ScopeManager {
       return delegate.captureConcurrent();
     }
 
-    @Override
-    public boolean isAsyncPropagating() {
-      return delegate.isAsyncPropagating();
-    }
-
-    @Override
-    public void setAsyncPropagation(final boolean value) {
-      delegate.setAsyncPropagation(value);
-    }
-
     public boolean isFinishSpanOnClose() {
       return finishSpanOnClose;
     }

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -3,6 +3,7 @@ import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
 import datadog.trace.api.DDTraceId
 import datadog.trace.api.interceptor.MutableSpan
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities
 import datadog.trace.context.TraceScope
 import datadog.trace.core.DDSpan
@@ -164,24 +165,25 @@ class OpenTracing32Test extends AgentTestRunner {
 
   def "test scopemanager"() {
     setup:
+    AgentTracer.TracerAPI internalTracer = tracer.tracer.tracer
     def span = tracer.buildSpan("some name").start()
     def scope = tracer.scopeManager().activate(span, finishSpan)
-    setAsyncPropagation(false)
+    internalTracer.setAsyncPropagation(false)
 
     expect:
     span instanceof MutableSpan
     scope instanceof TraceScope
-    !(scope as TraceScope).isAsyncPropagating()
+    !internalTracer.isAsyncPropagation()
     (scope as TraceScope).capture() == null
     (tracer.scopeManager().active().span().delegate == span.delegate)
 
     when:
-    setAsyncPropagation(true)
+    internalTracer.setAsyncPropagation(true)
     def continuation = (scope as TraceScope).capture()
     continuation.cancel()
 
     then:
-    (scope as TraceScope).isAsyncPropagating()
+    internalTracer.isAsyncPropagation()
     continuation instanceof TraceScope.Continuation
 
     when: "attempting to close the span this way doesn't work because we lost the 'finishSpan' reference"

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -33,7 +33,7 @@ import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
 import static datadog.trace.api.sampling.SamplingMechanism.AGENT_RATE
 import static datadog.trace.api.sampling.SamplingMechanism.DEFAULT
 import static datadog.trace.api.sampling.SamplingMechanism.MANUAL
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 class OpenTracing32Test extends AgentTestRunner {
 
@@ -168,22 +168,22 @@ class OpenTracing32Test extends AgentTestRunner {
     AgentTracer.TracerAPI internalTracer = tracer.tracer.tracer
     def span = tracer.buildSpan("some name").start()
     def scope = tracer.scopeManager().activate(span, finishSpan)
-    internalTracer.setAsyncPropagation(false)
+    internalTracer.setAsyncPropagationEnabled(false)
 
     expect:
     span instanceof MutableSpan
     scope instanceof TraceScope
-    !internalTracer.isAsyncPropagation()
+    !internalTracer.isAsyncPropagationEnabled()
     (scope as TraceScope).capture() == null
     (tracer.scopeManager().active().span().delegate == span.delegate)
 
     when:
-    internalTracer.setAsyncPropagation(true)
+    internalTracer.setAsyncPropagationEnabled(true)
     def continuation = (scope as TraceScope).capture()
     continuation.cancel()
 
     then:
-    internalTracer.isAsyncPropagation()
+    internalTracer.isAsyncPropagationEnabled()
     continuation instanceof TraceScope.Continuation
 
     when: "attempting to close the span this way doesn't work because we lost the 'finishSpan' reference"
@@ -233,7 +233,7 @@ class OpenTracing32Test extends AgentTestRunner {
     setup:
     def span = tracer.buildSpan("some name").start()
     TraceScope scope = tracer.scopeManager().activate(span, false)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
 
     expect:
     tracer.activeSpan().delegate == span.delegate

--- a/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
+++ b/dd-java-agent/instrumentation/opentracing/api-0.32/src/test/groovy/OpenTracing32Test.groovy
@@ -32,6 +32,7 @@ import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP
 import static datadog.trace.api.sampling.SamplingMechanism.AGENT_RATE
 import static datadog.trace.api.sampling.SamplingMechanism.DEFAULT
 import static datadog.trace.api.sampling.SamplingMechanism.MANUAL
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 
 class OpenTracing32Test extends AgentTestRunner {
 
@@ -165,7 +166,7 @@ class OpenTracing32Test extends AgentTestRunner {
     setup:
     def span = tracer.buildSpan("some name").start()
     def scope = tracer.scopeManager().activate(span, finishSpan)
-    (scope as TraceScope).setAsyncPropagation(false)
+    setAsyncPropagation(false)
 
     expect:
     span instanceof MutableSpan
@@ -175,7 +176,7 @@ class OpenTracing32Test extends AgentTestRunner {
     (tracer.scopeManager().active().span().delegate == span.delegate)
 
     when:
-    (scope as TraceScope).setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = (scope as TraceScope).capture()
     continuation.cancel()
 
@@ -230,7 +231,7 @@ class OpenTracing32Test extends AgentTestRunner {
     setup:
     def span = tracer.buildSpan("some name").start()
     TraceScope scope = tracer.scopeManager().activate(span, false)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
 
     expect:
     tracer.activeSpan().delegate == span.delegate

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.play23;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
@@ -30,7 +30,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      setAsyncPropagation(false);
+      setAsyncPropagationEnabled(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.3/src/main/java/datadog/trace/instrumentation/play23/RequestCompleteCallback.java
@@ -1,10 +1,9 @@
 package datadog.trace.instrumentation.play23;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play23.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,10 +30,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      final AgentScope scope = activeScope();
-      if (scope != null) {
-        scope.setAsyncPropagation(false);
-      }
+      setAsyncPropagation(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.play24;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
@@ -29,7 +29,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      setAsyncPropagation(false);
+      setAsyncPropagationEnabled(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.4/src/main/java/datadog/trace/instrumentation/play24/RequestCompleteCallback.java
@@ -1,10 +1,9 @@
 package datadog.trace.instrumentation.play24;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play24.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,10 +29,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      final AgentScope scope = activeScope();
-      if (scope != null) {
-        scope.setAsyncPropagation(false);
-      }
+      setAsyncPropagation(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
@@ -1,6 +1,6 @@
 package datadog.trace.instrumentation.play26;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
@@ -31,7 +31,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      setAsyncPropagation(false);
+      setAsyncPropagationEnabled(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
+++ b/dd-java-agent/instrumentation/play-2.6/src/main/java/datadog/trace/instrumentation/play26/RequestCompleteCallback.java
@@ -1,10 +1,9 @@
 package datadog.trace.instrumentation.play26;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.DECORATE;
 import static datadog.trace.instrumentation.play26.PlayHttpServerDecorator.REPORT_HTTP_STATUS;
 
-import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,10 +31,7 @@ public class RequestCompleteCallback extends scala.runtime.AbstractFunction1<Try
         }
       }
       DECORATE.beforeFinish(span);
-      final AgentScope scope = activeScope();
-      if (scope != null) {
-        scope.setAsyncPropagation(false);
-      }
+      setAsyncPropagation(false);
     } catch (final Throwable t) {
       log.debug("error in play instrumentation", t);
     } finally {

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.playws1;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -54,7 +55,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         return delegate.onCompleted();
       }
     } else {
@@ -70,7 +71,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-1/src/main/java/datadog/trace/instrumentation/playws1/AsyncHandlerWrapper.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.playws1;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -55,7 +55,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         return delegate.onCompleted();
       }
     } else {
@@ -71,7 +71,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.playws21;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -59,7 +60,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         return delegate.onCompleted();
       }
     } else {
@@ -75,7 +76,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2.1/src/main/java/datadog/trace/instrumentation/playws21/AsyncHandlerWrapper.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.playws21;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -60,7 +60,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         return delegate.onCompleted();
       }
     } else {
@@ -76,7 +76,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.playws2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -59,7 +59,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         return delegate.onCompleted();
       }
     } else {
@@ -75,7 +75,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        setAsyncPropagation(true);
+        setAsyncPropagationEnabled(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/play-ws-2/src/main/java/datadog/trace/instrumentation/playws2/AsyncHandlerWrapper.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.playws2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.capture;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.instrumentation.playws.PlayWSClientDecorator.DECORATE;
 
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -58,7 +59,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         return delegate.onCompleted();
       }
     } else {
@@ -74,7 +75,7 @@ public class AsyncHandlerWrapper implements AsyncHandler {
 
     if (continuation != null) {
       try (final AgentScope scope = continuation.activate()) {
-        scope.setAsyncPropagation(true);
+        setAsyncPropagation(true);
         delegate.onThrowable(throwable);
       }
     } else {

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/latestDepTest/groovy/ReactorCoreTest.groovy
@@ -1,8 +1,3 @@
-import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
-
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
@@ -22,6 +17,11 @@ import spock.lang.Shared
 
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
 
 class ReactorCoreTest extends AgentTestRunner {
 
@@ -483,12 +483,10 @@ class ReactorCoreTest extends AgentTestRunner {
   def assemblePublisherUnderTrace(def publisherSupplier) {
     def span = startSpan("publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
-    def scope = activateSpan(span)
+    def scope = activateSpan(span, true)
 
     Publisher<Integer> publisher = publisherSupplier()
     try {
-      scope.setAsyncPropagation(true)
-
       // Read all data from publisher
       if (publisher instanceof Mono) {
         return publisher.block()
@@ -506,8 +504,7 @@ class ReactorCoreTest extends AgentTestRunner {
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
     final AgentSpan span = startSpan("publisher-parent")
-    AgentScope scope = activateSpan(span)
-    scope.setAsyncPropagation(true)
+    AgentScope scope = activateSpan(span, true)
 
     def publisher = publisherSupplier()
     publisher.subscribe(new Subscriber<Integer>() {

--- a/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/dd-java-agent/instrumentation/reactor-core-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -1,8 +1,3 @@
-import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
-import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
-
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.Trace
 import datadog.trace.bootstrap.instrumentation.api.AgentScope
@@ -22,6 +17,11 @@ import spock.lang.Shared
 
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+
+import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan
 
 class ReactorCoreTest extends AgentTestRunner {
 
@@ -483,12 +483,10 @@ class ReactorCoreTest extends AgentTestRunner {
   def assemblePublisherUnderTrace(def publisherSupplier) {
     def span = startSpan("publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
-    def scope = activateSpan(span)
+    def scope = activateSpan(span, true)
 
     Publisher<Integer> publisher = publisherSupplier()
     try {
-      scope.setAsyncPropagation(true)
-
       // Read all data from publisher
       if (publisher instanceof Mono) {
         return publisher.block()
@@ -506,8 +504,7 @@ class ReactorCoreTest extends AgentTestRunner {
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
     final AgentSpan span = startSpan("publisher-parent")
-    AgentScope scope = activateSpan(span)
-    scope.setAsyncPropagation(true)
+    AgentScope scope = activateSpan(span, true)
 
     def publisher = publisherSupplier()
     publisher.subscribe(new Subscriber<Integer>() {

--- a/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2Test.groovy
+++ b/dd-java-agent/instrumentation/rxjava-2/src/test/groovy/RxJava2Test.groovy
@@ -384,12 +384,10 @@ class RxJava2Test extends AgentTestRunner {
   def assemblePublisherUnderTrace(def publisherSupplier) {
     def span = startSpan("publisher-parent")
     // After this activation, the "add two" operations below should be children of this span
-    def scope = activateSpan(span)
+    def scope = activateSpan(span, true)
 
     def publisher = publisherSupplier()
     try {
-      scope.setAsyncPropagation(true)
-
       // Read all data from publisher
       if (publisher instanceof Maybe) {
         return ((Maybe) publisher).blockingGet()
@@ -407,8 +405,7 @@ class RxJava2Test extends AgentTestRunner {
   @Trace(operationName = "trace-parent", resourceName = "trace-parent")
   def cancelUnderTrace(def publisherSupplier) {
     final AgentSpan span = startSpan("publisher-parent")
-    AgentScope scope = activateSpan(span)
-    scope.setAsyncPropagation(true)
+    AgentScope scope = activateSpan(span, true)
 
     def publisher = publisherSupplier()
     if (publisher instanceof Maybe) {

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -13,7 +13,7 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 /**
  * Test executor instrumentation for Scala specific classes.
@@ -43,7 +43,7 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           // this child will have a span
           m(pool, new ScalaAsyncChild())
           // this child won't
@@ -94,7 +94,7 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          setAsyncPropagation(true)
+          setAsyncPropagationEnabled(true)
           try {
             for (int i = 0; i < 20; ++i) {
               // Our current instrumentation instrumentation does not behave very well

--- a/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/scala-concurrent/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -13,7 +13,7 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 
 /**
  * Test executor instrumentation for Scala specific classes.
@@ -43,7 +43,7 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           // this child will have a span
           m(pool, new ScalaAsyncChild())
           // this child won't
@@ -94,7 +94,7 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
         @Override
         @Trace(operationName = "parent")
         void run() {
-          activeScope().setAsyncPropagation(true)
+          setAsyncPropagation(true)
           try {
             for (int i = 0; i < 20; ++i) {
               // Our current instrumentation instrumentation does not behave very well

--- a/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaPromiseTestBase.groovy
+++ b/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaPromiseTestBase.groovy
@@ -6,8 +6,8 @@ import spock.lang.Shared
 
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeScope
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 
 abstract class ScalaPromiseTestBase extends AbstractPromiseTest<Promise<Boolean>, Future<String>> {
 
@@ -61,7 +61,7 @@ abstract class ScalaPromiseTestBase extends AbstractPromiseTest<Promise<Boolean>
     }
 
     runUnderTrace("other") {
-      activeScope().setAsyncPropagation(false)
+      setAsyncPropagation(false)
       complete(promise, value)
     }
 

--- a/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaPromiseTestBase.groovy
+++ b/dd-java-agent/instrumentation/scala-promise/src/test/groovy/ScalaPromiseTestBase.groovy
@@ -7,7 +7,7 @@ import spock.lang.Shared
 import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 abstract class ScalaPromiseTestBase extends AbstractPromiseTest<Promise<Boolean>, Future<String>> {
 
@@ -61,7 +61,7 @@ abstract class ScalaPromiseTestBase extends AbstractPromiseTest<Promise<Boolean>
     }
 
     runUnderTrace("other") {
-      setAsyncPropagation(false)
+      setAsyncPropagationEnabled(false)
       complete(promise, value)
     }
 

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.servlet2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet2.Servlet2Decorator.DECORATE;
 
@@ -118,7 +119,7 @@ public class Servlet2Advice {
     }
     DECORATE.beforeFinish(span);
 
-    scope.setAsyncPropagation(false);
+    setAsyncPropagation(false);
     scope.close();
     span.finish();
   }

--- a/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
+++ b/dd-java-agent/instrumentation/servlet/request-2/src/main/java/datadog/trace/instrumentation/servlet2/Servlet2Advice.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.servlet2;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator.DD_SPAN_ATTRIBUTE;
 import static datadog.trace.instrumentation.servlet2.Servlet2Decorator.DECORATE;
 
@@ -119,7 +119,7 @@ public class Servlet2Advice {
     }
     DECORATE.beforeFinish(span);
 
-    setAsyncPropagation(false);
+    setAsyncPropagationEnabled(false);
     scope.close();
     span.finish();
   }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.springscheduling;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.DECORATE;
 
@@ -38,7 +39,7 @@ public class SpannedMethodInvocation implements MethodInvocation {
 
   private Object invokeWithContinuation(CharSequence spanName) throws Throwable {
     try (AgentScope scope = continuation.activate()) {
-      scope.setAsyncPropagation(true);
+      setAsyncPropagation(true);
       return invokeWithSpan(spanName);
     }
   }

--- a/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -1,7 +1,7 @@
 package datadog.trace.instrumentation.springscheduling;
 
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.springscheduling.SpringSchedulingDecorator.DECORATE;
 
@@ -39,7 +39,7 @@ public class SpannedMethodInvocation implements MethodInvocation {
 
   private Object invokeWithContinuation(CharSequence spanName) throws Throwable {
     try (AgentScope scope = continuation.activate()) {
-      setAsyncPropagation(true);
+      setAsyncPropagationEnabled(true);
       return invokeWithSpan(spanName);
     }
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/utils/TraceUtils.groovy
@@ -47,8 +47,7 @@ class TraceUtils {
     final AgentSpan span = inheritCurrent ? startSpan(rootOperationName) : startSpan(rootOperationName, null)
     DECORATOR.afterStart(span)
 
-    AgentScope scope = activateSpan(span)
-    scope.setAsyncPropagation(true)
+    AgentScope scope = activateSpan(span, true)
 
     try {
       return r.call()

--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -36,6 +36,8 @@ excludedClassesCoverage += [
   'datadog.trace.api.experimental.DataStreamsContextCarrier',
   'datadog.trace.api.experimental.DataStreamsContextCarrier.NoOp',
   'datadog.appsec.api.blocking.*',
+  'datadog.trace.context.TraceScope',
+  // Default fallback methods to not break legacy API
   'datadog.trace.context.NoopTraceScope.NoopContinuation',
   'datadog.trace.context.NoopTraceScope',
   'datadog.trace.payloadtags.PayloadTagsData',

--- a/dd-trace-api/build.gradle
+++ b/dd-trace-api/build.gradle
@@ -36,8 +36,8 @@ excludedClassesCoverage += [
   'datadog.trace.api.experimental.DataStreamsContextCarrier',
   'datadog.trace.api.experimental.DataStreamsContextCarrier.NoOp',
   'datadog.appsec.api.blocking.*',
-  'datadog.trace.context.TraceScope',
   // Default fallback methods to not break legacy API
+  'datadog.trace.context.TraceScope',
   'datadog.trace.context.NoopTraceScope.NoopContinuation',
   'datadog.trace.context.NoopTraceScope',
   'datadog.trace.payloadtags.PayloadTagsData',

--- a/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/GlobalTracer.java
@@ -26,6 +26,14 @@ public class GlobalTracer {
         }
 
         @Override
+        public boolean isAsyncPropagationEnabled() {
+          return false;
+        }
+
+        @Override
+        public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {}
+
+        @Override
         public boolean addTraceInterceptor(TraceInterceptor traceInterceptor) {
           return false;
         }

--- a/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
@@ -18,8 +18,10 @@ public interface Tracer {
    * Checks whether asynchronous propagation is enabled, meaning this context will propagate across
    * asynchronous boundaries.
    *
+   * @deprecated Unstable API. Might be removed at any time.
    * @return {@code true} if asynchronous propagation is enabled, {@code false} otherwise.
    */
+  @Deprecated
   boolean isAsyncPropagationEnabled();
 
   /**
@@ -28,9 +30,11 @@ public interface Tracer {
    * <p>Asynchronous propagation is enabled by default from {@link
    * ConfigDefaults#DEFAULT_ASYNC_PROPAGATING}.
    *
+   * @deprecated Unstable API. Might be removed at any time.
    * @param asyncPropagationEnabled @{@code true} to enable asynchronous propagation, {@code false}
    *     to disable it.
    */
+  @Deprecated
   void setAsyncPropagationEnabled(boolean asyncPropagationEnabled);
 
   /**

--- a/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Tracer.java
@@ -15,6 +15,25 @@ public interface Tracer {
   String getSpanId();
 
   /**
+   * Checks whether asynchronous propagation is enabled, meaning this context will propagate across
+   * asynchronous boundaries.
+   *
+   * @return {@code true} if asynchronous propagation is enabled, {@code false} otherwise.
+   */
+  boolean isAsyncPropagationEnabled();
+
+  /**
+   * Enables or disables asynchronous propagation for the active span.
+   *
+   * <p>Asynchronous propagation is enabled by default from {@link
+   * ConfigDefaults#DEFAULT_ASYNC_PROPAGATING}.
+   *
+   * @param asyncPropagationEnabled @{@code true} to enable asynchronous propagation, {@code false}
+   *     to disable it.
+   */
+  void setAsyncPropagationEnabled(boolean asyncPropagationEnabled);
+
+  /**
    * Add a new interceptor to the tracer. Interceptors with duplicate priority to existing ones are
    * ignored.
    *

--- a/dd-trace-api/src/main/java/datadog/trace/context/NoopTraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/NoopTraceScope.java
@@ -31,12 +31,4 @@ public class NoopTraceScope implements TraceScope {
 
   @Override
   public void close() {}
-
-  @Override
-  public boolean isAsyncPropagating() {
-    return false;
-  }
-
-  @Override
-  public void setAsyncPropagation(boolean value) {}
 }

--- a/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
@@ -1,5 +1,7 @@
 package datadog.trace.context;
 
+import datadog.trace.api.GlobalTracer;
+import datadog.trace.api.Tracer;
 import java.io.Closeable;
 
 /** An object which can propagate a datadog trace across multiple threads. */
@@ -30,20 +32,27 @@ public interface TraceScope extends Closeable {
   void close();
 
   /**
-   * Deprecated. Use TracerAPI.isAsyncPropagationEnabled() instead. Will always return {@code false}
+   * @deprecated Replaced by {@link Tracer#isAsyncPropagationEnabled()}.
+   *     <p>Calling this method will check whether asynchronous propagation is active <strong>for
+   *     the active scope</strong>, not this scope instance.
+   * @return {@code true} if asynchronous propagation is enabled <strong>for the active
+   *     scope</strong>, {@code false} otherwise.
    */
   @Deprecated
   default boolean isAsyncPropagating() {
-    return false;
+    return GlobalTracer.get().isAsyncPropagationEnabled();
   }
 
   /**
-   * Deprecated. Use TracerAPI.setAsyncPropagationEnabled(boolean) instead. Will do nothing.
-   *
-   * @param value ignored.
+   * @deprecated Replaced by {@link Tracer#setAsyncPropagationEnabled(boolean)}}.
+   *     <p>Calling this method will enable or disable asynchronous propagation <strong>for the
+   *     active scope</strong>, not this scope instance.
+   * @param value @{@code true} to enable asynchronous propagation, {@code false} to disable it.
    */
   @Deprecated
-  default void setAsyncPropagation(boolean value) {}
+  default void setAsyncPropagation(boolean value) {
+    GlobalTracer.get().setAsyncPropagationEnabled(value);
+  }
 
   /**
    * Used to pass async context between workers. A trace will not be reported until all spans and

--- a/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
@@ -30,14 +30,22 @@ public interface TraceScope extends Closeable {
   void close();
 
   /** If true, this context will propagate across async boundaries. */
-  boolean isAsyncPropagating();
+  default boolean isAsyncPropagating() {
+    // TODO Deprecate and document the new method
+    // TODO Check expected behavior, returning false seems better
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Enable or disable async propagation. Async propagation is initially set to false.
    *
    * @param value The new propagation value. True == propagate. False == don't propagate.
    */
-  void setAsyncPropagation(boolean value);
+  default void setAsyncPropagation(boolean value) {
+    // TODO Deprecate and document the new method
+    // TODO Check expected behavior, doing nothing seems better
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Used to pass async context between workers. A trace will not be reported until all spans and

--- a/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
+++ b/dd-trace-api/src/main/java/datadog/trace/context/TraceScope.java
@@ -29,23 +29,21 @@ public interface TraceScope extends Closeable {
   @Override
   void close();
 
-  /** If true, this context will propagate across async boundaries. */
+  /**
+   * Deprecated. Use TracerAPI.isAsyncPropagationEnabled() instead. Will always return {@code false}
+   */
+  @Deprecated
   default boolean isAsyncPropagating() {
-    // TODO Deprecate and document the new method
-    // TODO Check expected behavior, returning false seems better
-    throw new UnsupportedOperationException();
+    return false;
   }
 
   /**
-   * Enable or disable async propagation. Async propagation is initially set to false.
+   * Deprecated. Use TracerAPI.setAsyncPropagationEnabled(boolean) instead. Will do nothing.
    *
-   * @param value The new propagation value. True == propagate. False == don't propagate.
+   * @param value ignored.
    */
-  default void setAsyncPropagation(boolean value) {
-    // TODO Deprecate and document the new method
-    // TODO Check expected behavior, doing nothing seems better
-    throw new UnsupportedOperationException();
-  }
+  @Deprecated
+  default void setAsyncPropagation(boolean value) {}
 
   /**
    * Used to pass async context between workers. A trace will not be reported until all spans and

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -920,6 +920,20 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
+  public boolean isAsyncPropagation() {
+    AgentScope activeScope = this.scopeManager.active();
+    return activeScope != null && activeScope.isAsyncPropagating();
+  }
+
+  @Override
+  public void setAsyncPropagation(boolean asyncPropagation) {
+    AgentScope activeScope = this.scopeManager.active();
+    if (activeScope != null) {
+      activeScope.setAsyncPropagation(asyncPropagation);
+    }
+  }
+
+  @Override
   public void closePrevious(boolean finishSpan) {
     scopeManager.closePrevious(finishSpan);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -920,16 +920,16 @@ public class CoreTracer implements AgentTracer.TracerAPI {
   }
 
   @Override
-  public boolean isAsyncPropagation() {
+  public boolean isAsyncPropagationEnabled() {
     AgentScope activeScope = this.scopeManager.active();
     return activeScope != null && activeScope.isAsyncPropagating();
   }
 
   @Override
-  public void setAsyncPropagation(boolean asyncPropagation) {
+  public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {
     AgentScope activeScope = this.scopeManager.active();
     if (activeScope != null) {
-      activeScope.setAsyncPropagation(asyncPropagation);
+      activeScope.setAsyncPropagation(asyncPropagationEnabled);
     }
   }
 

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
@@ -1,11 +1,13 @@
 package datadog.trace.core
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+
 class PendingTraceStrictWriteTest extends PendingTraceTestBase {
 
   def "trace is not reported until unfinished continuation is closed"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = scope.capture()
     scope.close()
     rootSpan.finish()
@@ -37,7 +39,7 @@ class PendingTraceStrictWriteTest extends PendingTraceTestBase {
   def "negative reference count throws an exception"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = scope.capture()
     scope.close()
     rootSpan.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceStrictWriteTest.groovy
@@ -1,13 +1,13 @@
 package datadog.trace.core
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 class PendingTraceStrictWriteTest extends PendingTraceTestBase {
 
   def "trace is not reported until unfinished continuation is closed"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation = scope.capture()
     scope.close()
     rootSpan.finish()
@@ -39,7 +39,7 @@ class PendingTraceStrictWriteTest extends PendingTraceTestBase {
   def "negative reference count throws an exception"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation = scope.capture()
     scope.close()
     rootSpan.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -10,7 +10,7 @@ import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 
 class PendingTraceTest extends PendingTraceTestBase {
 
@@ -51,7 +51,7 @@ class PendingTraceTest extends PendingTraceTestBase {
   def "trace is still reported when unfinished continuation discarded"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     scope.capture()
     scope.close()
     rootSpan.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/PendingTraceTest.groovy
@@ -10,6 +10,8 @@ import spock.lang.Timeout
 
 import java.util.concurrent.TimeUnit
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+
 class PendingTraceTest extends PendingTraceTestBase {
 
   @Override
@@ -49,7 +51,7 @@ class PendingTraceTest extends PendingTraceTestBase {
   def "trace is still reported when unfinished continuation discarded"() {
     when:
     def scope = tracer.activateSpan(rootSpan)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     scope.capture()
     scope.close()
     rootSpan.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -278,7 +278,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
@@ -299,7 +299,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scopeRef = new AtomicReference<AgentScope>(tracer.activateSpan(span))
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scopeRef.get().captureConcurrent() : scopeRef.get().capture()
 
     then:
@@ -330,7 +330,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
@@ -367,7 +367,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def parentScope = tracer.activateSpan(parentSpan)
     def childSpan = tracer.buildSpan("child").start()
     def childScope = tracer.activateSpan(childSpan)
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
 
     def continuation = concurrentChild ? childScope.captureConcurrent() : childScope.capture()
     childScope.close()
@@ -434,7 +434,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when: "creating and activating a continuation"
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -726,7 +726,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -814,7 +814,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -841,7 +841,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when: "completing another async scope lifecycle"
     def span2 = tracer.buildSpan("test").start()
     def scope2 = tracer.activateSpan(span2)
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
     def continuation2 = concurrent ? scope2.captureConcurrent() : scope2.capture()
 
     then:
@@ -879,7 +879,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test").start()
     def start = System.nanoTime()
     def scope = (ContinuableScope) tracer.activateSpan(span)
-    setAsyncPropagationEnabled(true)
+    tracer.setAsyncPropagationEnabled(true)
     continuation = scope.captureConcurrent()
     scope.close()
     span.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -276,7 +276,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "Continuation.cancel doesn't close parent scope"() {
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
@@ -297,7 +297,7 @@ class ScopeManagerTest extends DDCoreSpecification {
   // @Flaky("awaitGC is flaky")
   def "test continuation doesn't have hard reference on scope"() {
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def scopeRef = new AtomicReference<AgentScope>(tracer.activateSpan(span))
     tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scopeRef.get().captureConcurrent() : scopeRef.get().capture()
@@ -328,7 +328,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "hard reference on continuation does not prevent trace from reporting"() {
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
@@ -363,9 +363,9 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "continuation restores trace"() {
     when:
-    def parentSpan = tracer.buildSpan("parent").start()
+    def parentSpan = tracer.buildSpan("test", "parent").start()
     def parentScope = tracer.activateSpan(parentSpan)
-    def childSpan = tracer.buildSpan("child").start()
+    def childSpan = tracer.buildSpan("test", "child").start()
     def childScope = tracer.activateSpan(childSpan)
     tracer.setAsyncPropagationEnabled(true)
 
@@ -432,7 +432,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "continuation allows adding spans even after other spans were completed"() {
     when: "creating and activating a continuation"
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
@@ -452,7 +452,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     writer == []
 
     when: "creating a new child span under a continued scope"
-    def childSpan = tracer.buildSpan("child").start()
+    def childSpan = tracer.buildSpan("test", "child").start()
     def childScope = tracer.activateSpan(childSpan)
     childScope.close()
     childSpan.finish()
@@ -476,7 +476,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "test activating same span multiple times"() {
     setup:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def state = Mock(Stateful)
 
     when:
@@ -510,7 +510,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "opening and closing multiple scopes"() {
     when:
-    AgentSpan span = tracer.buildSpan("foo").start()
+    AgentSpan span = tracer.buildSpan("test", "foo").start()
     AgentScope continuableScope = tracer.activateSpan(span)
 
     then:
@@ -518,7 +518,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     assertEvents([ACTIVATE])
 
     when:
-    AgentSpan childSpan = tracer.buildSpan("foo").start()
+    AgentSpan childSpan = tracer.buildSpan("test", "foo").start()
     AgentScope childDDScope = tracer.activateSpan(childSpan)
 
     then:
@@ -542,10 +542,10 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "closing scope out of order - simple"() {
     when:
-    AgentSpan firstSpan = tracer.buildSpan("foo").start()
+    AgentSpan firstSpan = tracer.buildSpan("test", "foo").start()
     AgentScope firstScope = tracer.activateSpan(firstSpan)
 
-    AgentSpan secondSpan = tracer.buildSpan("bar").start()
+    AgentSpan secondSpan = tracer.buildSpan("test", "bar").start()
     AgentScope secondScope = tracer.activateSpan(secondSpan)
 
     firstSpan.finish()
@@ -582,7 +582,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     // tracer.activeScope() or tracer.activeSpan() doesn't change the count
 
     when:
-    AgentSpan firstSpan = tracer.buildSpan("foo").start()
+    AgentSpan firstSpan = tracer.buildSpan("test", "foo").start()
     AgentScope firstScope = tracer.activateSpan(firstSpan)
 
     then:
@@ -597,7 +597,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     0 * _
 
     when:
-    AgentSpan secondSpan = tracer.buildSpan("bar").start()
+    AgentSpan secondSpan = tracer.buildSpan("test", "bar").start()
     AgentScope secondScope = tracer.activateSpan(secondSpan)
 
     then:
@@ -610,7 +610,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     0 * _
 
     when:
-    AgentSpan thirdSpan = tracer.buildSpan("quux").start()
+    AgentSpan thirdSpan = tracer.buildSpan("test", "quux").start()
     AgentScope thirdScope = tracer.activateSpan(thirdSpan)
 
     then:
@@ -672,7 +672,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "closing scope out of order - multiple activations"() {
     setup:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
 
     when:
     AgentScope scope1 = scopeManager.activate(span, ScopeSource.INSTRUMENTATION)
@@ -687,7 +687,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     assertEvents([ACTIVATE])
 
     when:
-    AgentSpan thirdSpan = tracer.buildSpan("quux").start()
+    AgentSpan thirdSpan = tracer.buildSpan("test", "quux").start()
     AgentScope thirdScope = tracer.activateSpan(thirdSpan)
     0 * _
 
@@ -724,7 +724,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "Closing a continued scope out of order cancels the continuation"() {
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
@@ -741,7 +741,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     if (concurrent) {
       continuation.cancel()
     }
-    AgentSpan secondSpan = tracer.buildSpan("test2").start()
+    AgentSpan secondSpan = tracer.buildSpan("test", "test2").start()
     AgentScope secondScope = (ContinuableScope) tracer.activateSpan(secondSpan)
 
     then:
@@ -772,7 +772,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.addTraceInterceptor(interceptor)
 
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     scope.close()
     span.finish()
@@ -787,7 +787,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     writer == [[span]]
 
     when: "completing another scope lifecycle"
-    def span2 = tracer.buildSpan("test").start()
+    def span2 = tracer.buildSpan("test", "test").start()
     def scope2 = tracer.activateSpan(span2)
 
     then:
@@ -812,7 +812,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     tracer.addTraceInterceptor(interceptor)
 
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
@@ -839,7 +839,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     writer == [[span]]
 
     when: "completing another async scope lifecycle"
-    def span2 = tracer.buildSpan("test").start()
+    def span2 = tracer.buildSpan("test", "test").start()
     def scope2 = tracer.activateSpan(span2)
     tracer.setAsyncPropagationEnabled(true)
     def continuation2 = concurrent ? scope2.captureConcurrent() : scope2.capture()
@@ -876,7 +876,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     long sendDelayNanos = TimeUnit.MILLISECONDS.toNanos(500 - 100)
 
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def start = System.nanoTime()
     def scope = (ContinuableScope) tracer.activateSpan(span)
     tracer.setAsyncPropagationEnabled(true)
@@ -918,7 +918,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "scope listener should be notified about the currently active scope"() {
     setup:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
 
     when:
     AgentScope scope = scopeManager.activate(span, ScopeSource.INSTRUMENTATION)
@@ -948,7 +948,7 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "extended scope listener should be notified about the currently active scope"() {
     setup:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
 
     when:
     AgentScope scope = scopeManager.activate(span, ScopeSource.INSTRUMENTATION)
@@ -1001,7 +1001,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     scopeManager.addScopeListener(secondEventCountingListener)
 
     when:
-    AgentSpan span = tracer.buildSpan("foo").start()
+    AgentSpan span = tracer.buildSpan("test", "foo").start()
     AgentScope continuableScope = tracer.activateSpan(span)
 
     then:
@@ -1009,7 +1009,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     secondEventCountingListener.events == [ACTIVATE]
 
     when:
-    AgentSpan childSpan = tracer.buildSpan("foo").start()
+    AgentSpan childSpan = tracer.buildSpan("test", "foo").start()
     AgentScope childDDScope = tracer.activateSpan(childSpan)
 
     then:
@@ -1054,12 +1054,12 @@ class ScopeManagerTest extends DDCoreSpecification {
     0 * profilingContext.onAttach()
 
     when: "scopes activate on threads"
-    AgentSpan span = tracer.buildSpan("foo").start()
+    AgentSpan span = tracer.buildSpan("test", "foo").start()
     def futures = new Future[numTasks]
     for (int i = 0; i < numTasks; i++) {
       futures[i] = executor.submit({
         AgentScope scope = tracer.activateSpan(span)
-        def child = tracer.buildSpan("foo" + i).start()
+        def child = tracer.buildSpan("test", "foo" + i).start()
         def childScope = tracer.activateSpan(child)
         try {
           Thread.sleep(100)

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
 import static datadog.trace.core.scopemanager.EVENT.ACTIVATE
 import static datadog.trace.core.scopemanager.EVENT.CLOSE
 import static datadog.trace.test.util.GCUtils.awaitGC
@@ -253,14 +254,14 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    scope.setAsyncPropagation(false)
+    setAsyncPropagation(false)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
     continuation == null
 
     when:
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
@@ -277,7 +278,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
@@ -298,7 +299,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scopeRef = new AtomicReference<AgentScope>(tracer.activateSpan(span))
-    scopeRef.get().setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = concurrent ? scopeRef.get().captureConcurrent() : scopeRef.get().capture()
 
     then:
@@ -329,7 +330,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
@@ -366,7 +367,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def parentScope = tracer.activateSpan(parentSpan)
     def childSpan = tracer.buildSpan("child").start()
     def childScope = tracer.activateSpan(childSpan)
-    childScope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
 
     def continuation = concurrentChild ? childScope.captureConcurrent() : childScope.capture()
     childScope.close()
@@ -433,7 +434,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when: "creating and activating a continuation"
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -725,7 +726,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -813,7 +814,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -840,7 +841,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when: "completing another async scope lifecycle"
     def span2 = tracer.buildSpan("test").start()
     def scope2 = tracer.activateSpan(span2)
-    scope2.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     def continuation2 = concurrent ? scope2.captureConcurrent() : scope2.capture()
 
     then:
@@ -878,7 +879,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test").start()
     def start = System.nanoTime()
     def scope = (ContinuableScope) tracer.activateSpan(span)
-    scope.setAsyncPropagation(true)
+    setAsyncPropagation(true)
     continuation = scope.captureConcurrent()
     scope.close()
     span.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagation
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import static datadog.trace.core.scopemanager.EVENT.ACTIVATE
 import static datadog.trace.core.scopemanager.EVENT.CLOSE
 import static datadog.trace.test.util.GCUtils.awaitGC
@@ -254,14 +254,14 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
-    tracer.setAsyncPropagation(false)
+    tracer.setAsyncPropagationEnabled(false)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
     continuation == null
 
     when:
-    tracer.setAsyncPropagation(true)
+    tracer.setAsyncPropagationEnabled(true)
     continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
@@ -278,7 +278,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
@@ -299,7 +299,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scopeRef = new AtomicReference<AgentScope>(tracer.activateSpan(span))
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scopeRef.get().captureConcurrent() : scopeRef.get().capture()
 
     then:
@@ -330,7 +330,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
@@ -367,7 +367,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def parentScope = tracer.activateSpan(parentSpan)
     def childSpan = tracer.buildSpan("child").start()
     def childScope = tracer.activateSpan(childSpan)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
 
     def continuation = concurrentChild ? childScope.captureConcurrent() : childScope.capture()
     childScope.close()
@@ -434,7 +434,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when: "creating and activating a continuation"
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -726,7 +726,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -814,7 +814,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when:
     def span = tracer.buildSpan("test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
     scope.close()
     span.finish()
@@ -841,7 +841,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     when: "completing another async scope lifecycle"
     def span2 = tracer.buildSpan("test").start()
     def scope2 = tracer.activateSpan(span2)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     def continuation2 = concurrent ? scope2.captureConcurrent() : scope2.capture()
 
     then:
@@ -879,7 +879,7 @@ class ScopeManagerTest extends DDCoreSpecification {
     def span = tracer.buildSpan("test").start()
     def start = System.nanoTime()
     def scope = (ContinuableScope) tracer.activateSpan(span)
-    setAsyncPropagation(true)
+    setAsyncPropagationEnabled(true)
     continuation = scope.captureConcurrent()
     scope.close()
     span.finish()

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -252,16 +252,16 @@ class ScopeManagerTest extends DDCoreSpecification {
 
   def "DDScope only creates continuations when propagation is set"() {
     when:
-    def span = tracer.buildSpan("test").start()
+    def span = tracer.buildSpan("test", "test").start()
     def scope = tracer.activateSpan(span)
-    setAsyncPropagation(false)
+    tracer.setAsyncPropagation(false)
     def continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:
     continuation == null
 
     when:
-    setAsyncPropagation(true)
+    tracer.setAsyncPropagation(true)
     continuation = concurrent ? scope.captureConcurrent() : scope.capture()
 
     then:

--- a/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
+++ b/dd-trace-core/src/test/groovy/datadog/trace/core/scopemanager/ScopeManagerTest.groovy
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.setAsyncPropagationEnabled
 import static datadog.trace.core.scopemanager.EVENT.ACTIVATE
 import static datadog.trace.core.scopemanager.EVENT.CLOSE
 import static datadog.trace.test.util.GCUtils.awaitGC

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDTracer.java
@@ -427,6 +427,16 @@ public class DDTracer implements Tracer, datadog.trace.api.Tracer, InternalTrace
   }
 
   @Override
+  public boolean isAsyncPropagationEnabled() {
+    return tracer.isAsyncPropagationEnabled();
+  }
+
+  @Override
+  public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {
+    tracer.setAsyncPropagationEnabled(asyncPropagationEnabled);
+  }
+
+  @Override
   public boolean addTraceInterceptor(final TraceInterceptor traceInterceptor) {
     return tracer.addTraceInterceptor(traceInterceptor);
   }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/OTScopeManager.java
@@ -101,20 +101,6 @@ class OTScopeManager implements ScopeManager {
       return delegate.captureConcurrent();
     }
 
-    @Override
-    public boolean isAsyncPropagating() {
-      return delegate.isAsyncPropagating();
-    }
-
-    @Override
-    public void setAsyncPropagation(final boolean value) {
-      delegate.setAsyncPropagation(value);
-    }
-
-    AgentScope unwrap() {
-      return delegate;
-    }
-
     boolean isFinishSpanOnClose() {
       return finishSpanOnClose;
     }

--- a/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
+++ b/dd-trace-ot/src/test/groovy/datadog/opentracing/OpenTracingAPITest.groovy
@@ -229,18 +229,18 @@ class OpenTracingAPITest extends DDSpecification {
     Scope scope = tracer.buildSpan("someOperation")
       .withTag(DDTags.SERVICE_NAME, "someService")
       .startActive(true)
-    internalTracer.setAsyncPropagation(false)
+    internalTracer.setAsyncPropagationEnabled(false)
 
     then:
     scope instanceof TraceScope
-    !internalTracer.isAsyncPropagation()
+    !internalTracer.isAsyncPropagationEnabled()
 
     when:
-    internalTracer.setAsyncPropagation(true)
+    internalTracer.setAsyncPropagationEnabled(true)
     TraceScope.Continuation continuation = ((TraceScope) scope).capture()
 
     then:
-    internalTracer.isAsyncPropagation()
+    internalTracer.isAsyncPropagationEnabled()
     continuation != null
 
     when:
@@ -273,19 +273,19 @@ class OpenTracingAPITest extends DDSpecification {
     Scope outer = tracer.buildSpan("someOperation")
       .withTag(DDTags.SERVICE_NAME, "someService")
       .startActive(true)
-    internalTracer.setAsyncPropagation(false)
+    internalTracer.setAsyncPropagationEnabled(false)
 
     then:
-    !internalTracer.isAsyncPropagation()
+    !internalTracer.isAsyncPropagationEnabled()
 
     when:
-    internalTracer.setAsyncPropagation(true)
+    internalTracer.setAsyncPropagationEnabled(true)
     Scope inner = tracer.buildSpan("otherOperation")
       .withTag(DDTags.SERVICE_NAME, "otherService")
       .startActive(true)
 
     then:
-    internalTracer.isAsyncPropagation()
+    internalTracer.isAsyncPropagationEnabled()
 
     when:
     inner.close()

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentScope.java
@@ -15,9 +15,6 @@ public interface AgentScope extends TraceScope, Closeable {
   Continuation captureConcurrent();
 
   @Override
-  void setAsyncPropagation(boolean value);
-
-  @Override
   void close();
 
   interface Continuation extends TraceScope.Continuation {

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -144,8 +144,8 @@ public class AgentTracer {
    * Checks whether the asynchronous propagation is enabled, meaning this context will propagate
    * across asynchronous boundaries.
    */
-  public static boolean isAsyncPropagation() {
-    return get().isAsyncPropagation();
+  public static boolean isAsyncPropagationEnabled() {
+    return get().isAsyncPropagationEnabled();
   }
 
   /**
@@ -153,11 +153,11 @@ public class AgentTracer {
    *
    * <p>Asynchronous propagation is disabled by default.
    *
-   * @param asyncPropagation @{@code true} to enable asynchronous propagation, {@code false} to
-   *     disable it.
+   * @param asyncPropagationEnabled @{@code true} to enable asynchronous propagation, {@code false}
+   *     to disable it.
    */
-  public static void setAsyncPropagation(boolean asyncPropagation) {
-    get().setAsyncPropagation(asyncPropagation);
+  public static void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {
+    get().setAsyncPropagationEnabled(asyncPropagationEnabled);
   }
 
   public static AgentPropagation propagate() {
@@ -254,17 +254,17 @@ public class AgentTracer {
      * Checks whether the asynchronous propagation is enabled, meaning this context will propagate
      * across asynchronous boundaries.
      */
-    boolean isAsyncPropagation();
+    boolean isAsyncPropagationEnabled();
 
     /**
      * Enables or disables asynchronous propagation for the active span.
      *
      * <p>Asynchronous propagation is disabled by default.
      *
-     * @param asyncPropagation @{@code true} to enable asynchronous propagation, {@code false} to
-     *     disable it.
+     * @param asyncPropagationEnabled @{@code true} to enable asynchronous propagation, {@code
+     *     false} to disable it.
      */
-    void setAsyncPropagation(boolean asyncPropagation);
+    void setAsyncPropagationEnabled(boolean asyncPropagationEnabled);
 
     void closePrevious(boolean finishSpan);
 
@@ -408,12 +408,12 @@ public class AgentTracer {
     }
 
     @Override
-    public boolean isAsyncPropagation() {
+    public boolean isAsyncPropagationEnabled() {
       return false;
     }
 
     @Override
-    public void setAsyncPropagation(boolean asyncPropagation) {}
+    public void setAsyncPropagationEnabled(boolean asyncPropagationEnabled) {}
 
     @Override
     public void closePrevious(final boolean finishSpan) {}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -140,6 +140,26 @@ public class AgentTracer {
     return activeScope == null ? null : activeScope.capture();
   }
 
+  /**
+   * Checks whether the asynchronous propagation is enabled, meaning this context will propagate
+   * across asynchronous boundaries.
+   */
+  public static boolean isAsyncPropagation() {
+    return get().isAsyncPropagation();
+  }
+
+  /**
+   * Enables or disables asynchronous propagation for the active span.
+   *
+   * <p>Asynchronous propagation is disabled by default.
+   *
+   * @param asyncPropagation @{@code true} to enable asynchronous propagation, {@code false} to
+   *     disable it.
+   */
+  public static void setAsyncPropagation(boolean asyncPropagation) {
+    get().setAsyncPropagation(asyncPropagation);
+  }
+
   public static AgentPropagation propagate() {
     return get().propagate();
   }
@@ -230,6 +250,22 @@ public class AgentTracer {
 
     AgentScope.Continuation captureSpan(AgentSpan span);
 
+    /**
+     * Checks whether the asynchronous propagation is enabled, meaning this context will propagate
+     * across asynchronous boundaries.
+     */
+    boolean isAsyncPropagation();
+
+    /**
+     * Enables or disables asynchronous propagation for the active span.
+     *
+     * <p>Asynchronous propagation is disabled by default.
+     *
+     * @param asyncPropagation @{@code true} to enable asynchronous propagation, {@code false} to
+     *     disable it.
+     */
+    void setAsyncPropagation(boolean asyncPropagation);
+
     void closePrevious(boolean finishSpan);
 
     AgentScope activateNext(AgentSpan span);
@@ -284,9 +320,9 @@ public class AgentTracer {
     AgentHistogram newHistogram(double relativeAccuracy, int maxNumBins);
 
     /**
-     * Sets the new service name to be used as a default
+     * Sets the new service name to be used as a default.
      *
-     * @param serviceName
+     * @param serviceName The service name to use as default.
      */
     void updatePreferredServiceName(String serviceName);
   }
@@ -370,6 +406,14 @@ public class AgentTracer {
     public AgentScope.Continuation captureSpan(final AgentSpan span) {
       return NoopContinuation.INSTANCE;
     }
+
+    @Override
+    public boolean isAsyncPropagation() {
+      return false;
+    }
+
+    @Override
+    public void setAsyncPropagation(boolean asyncPropagation) {}
 
     @Override
     public void closePrevious(final boolean finishSpan) {}

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap.instrumentation.api;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 import static java.util.Collections.emptyList;
 
+import datadog.trace.api.ConfigDefaults;
 import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.EndpointCheckpointer;
@@ -141,8 +142,10 @@ public class AgentTracer {
   }
 
   /**
-   * Checks whether the asynchronous propagation is enabled, meaning this context will propagate
-   * across asynchronous boundaries.
+   * Checks whether asynchronous propagation is enabled, meaning this context will propagate across
+   * asynchronous boundaries.
+   *
+   * @return {@code true} if asynchronous propagation is enabled, {@code false} otherwise.
    */
   public static boolean isAsyncPropagationEnabled() {
     return get().isAsyncPropagationEnabled();
@@ -151,7 +154,8 @@ public class AgentTracer {
   /**
    * Enables or disables asynchronous propagation for the active span.
    *
-   * <p>Asynchronous propagation is disabled by default.
+   * <p>Asynchronous propagation is enabled by default from {@link
+   * ConfigDefaults#DEFAULT_ASYNC_PROPAGATING}.
    *
    * @param asyncPropagationEnabled @{@code true} to enable asynchronous propagation, {@code false}
    *     to disable it.
@@ -249,22 +253,6 @@ public class AgentTracer {
     AgentScope activateSpan(AgentSpan span, ScopeSource source, boolean isAsyncPropagating);
 
     AgentScope.Continuation captureSpan(AgentSpan span);
-
-    /**
-     * Checks whether the asynchronous propagation is enabled, meaning this context will propagate
-     * across asynchronous boundaries.
-     */
-    boolean isAsyncPropagationEnabled();
-
-    /**
-     * Enables or disables asynchronous propagation for the active span.
-     *
-     * <p>Asynchronous propagation is disabled by default.
-     *
-     * @param asyncPropagationEnabled @{@code true} to enable asynchronous propagation, {@code
-     *     false} to disable it.
-     */
-    void setAsyncPropagationEnabled(boolean asyncPropagationEnabled);
 
     void closePrevious(boolean finishSpan);
 


### PR DESCRIPTION
# What Does This Do

First part of the refactoring only.
Only moved the API to the tracer, not the internal behavior.
Async flag should move away from the scope itself.

# Motivation

This should help testing if moving the API from the scope to the tracer cause issues as the scope will implicitly be the active scope.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-954]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-954]: https://datadoghq.atlassian.net/browse/APMAPI-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ