### PR TITLE
Decouple test JDK and gradle JDK in karate latestDepTest

### DIFF
--- a/dd-java-agent/instrumentation/karate/build.gradle
+++ b/dd-java-agent/instrumentation/karate/build.gradle
@@ -1,3 +1,8 @@
+ext {
+  // karate 1.4.0+ requires Java 11 or higher.
+  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_11
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 muzzle {
@@ -16,6 +21,8 @@ muzzle {
 }
 
 addTestSuiteForDir('latestDepTest', 'test')
+// karate 1.3.1 is the last version supporting Java 8.
+addTestSuiteForDir('karate131Test', 'test')
 
 dependencies {
   compileOnly group: 'com.intuit.karate', name: 'karate-core', version: '1.0.0'
@@ -29,6 +36,15 @@ dependencies {
     exclude group: 'ch.qos.logback', module: 'logback-classic'
   }
   testImplementation (group: 'com.intuit.karate', name: 'karate-junit5', version: '1.0.0') {
+    // excluding logback to avoid conflicts with libs.bundles.test.logging
+    exclude group: 'ch.qos.logback', module: 'logback-classic'
+  }
+
+  karate131TestImplementation (group: 'com.intuit.karate', name: 'karate-core', version: '1.3.1') {
+    // excluding logback to avoid conflicts with libs.bundles.test.logging
+    exclude group: 'ch.qos.logback', module: 'logback-classic'
+  }
+  karate131TestImplementation (group: 'com.intuit.karate', name: 'karate-junit5', version: '1.3.1') {
     // excluding logback to avoid conflicts with libs.bundles.test.logging
     exclude group: 'ch.qos.logback', module: 'logback-classic'
   }
@@ -51,6 +67,12 @@ sourceSets {
       exclude '**/*.java'
     }
   }
+  karate131Test {
+    resources {
+      srcDir file('src/test/java')
+      exclude '**/*.java'
+    }
+  }
   latestDepTest {
     resources {
       srcDir file('src/test/java')
@@ -58,11 +80,3 @@ sourceSets {
     }
   }
 }
-
-configurations.matching({ it.name.startsWith('latestDepTest') }).each({
-  it.resolutionStrategy {
-    // Karate 1.4.0+ is compiled with Java 11
-    force group: 'com.intuit.karate', name: 'karate-core', version: (JavaVersion.current().java11Compatible ? '+' : '1.3.1')
-    force group: 'com.intuit.karate', name: 'karate-junit5', version: (JavaVersion.current().java11Compatible ? '+' : '1.3.1')
-  }
-})


### PR DESCRIPTION
# What Does This Do
Avoid using the version of the JDK used to run gradle (always 8 in CI) to select karate version to test. Before this PR, `test` tested karate 1.0.0, and `latestDepTest` always tested karate 1.3.1 and never 1.4.0+ (in CI). Now:

* `test` -> 1.0.0
* `karate131Test` -> 1.3.1
* `latestDepTest` -> 1.4.0+

# Motivation
Part of fixes to decouple the JDK used for compile/test from the one used by gradle.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
