### PR TITLE
Decouple test JDK and gradle JDK in testng latestDepTest

### DIFF
--- a/dd-java-agent/instrumentation/testng/testng-7/build.gradle
+++ b/dd-java-agent/instrumentation/testng/testng-7/build.gradle
@@ -2,6 +2,11 @@ plugins {
   id 'java-test-fixtures'
 }
 
+ext {
+  // testng 7.6.0+ requires Java 11 or higher.
+  latestDepTestMinJavaVersionForTests = JavaVersion.VERSION_11
+}
+
 apply from: "$rootDir/gradle/java.gradle"
 
 muzzle {
@@ -21,6 +26,8 @@ muzzle {
 }
 
 addTestSuiteForDir('latestDepTest', 'test')
+// testng 7.5.1 is the latest version compatible with Java 8
+addTestSuiteForDir('testng751Test', 'test')
 
 dependencies {
   compileOnly group: 'org.testng', name: 'testng', version: '7.0.0'
@@ -29,7 +36,7 @@ dependencies {
 
   testImplementation testFixtures(project(':dd-java-agent:instrumentation:testng'))
   testImplementation group: 'org.testng', name: 'testng', version: '7.0.0'
-
+  testng751TestImplementation group: 'org.testng', name: 'testng', version: '7.5.1'
   latestDepTestImplementation group: 'org.testng', name: 'testng', version: '+'
 }
 
@@ -41,9 +48,3 @@ configurations.matching({ it.name.startsWith('test') }).each({
   }
 })
 
-configurations.matching({ it.name.startsWith('latestDepTest') }).each({
-  it.resolutionStrategy {
-    // TestNG 7.6+ is compiled with Java 11
-    force group: 'org.testng', name: 'testng', version: (JavaVersion.current().java11Compatible ? '+' : '7.5')
-  }
-})


### PR DESCRIPTION
# What Does This Do
Similar to https://github.com/DataDog/dd-trace-java/pull/8234 but for testng. Effectively enabled tests for testng 7.6.0+ in CI.

# Motivation
Part of fixes to decouple the JDK used for compile/test from the one used by gradle.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
