### PR TITLE
Add failing Kotlin coroutine tests

### DIFF
--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.3/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.3/src/test/kotlin/KotlinCoroutineTests.kt
@@ -64,6 +64,11 @@ class KotlinCoroutineTests(dispatcher: CoroutineDispatcher) : CoreKotlinCoroutin
   }
 
   @Trace
+  override fun traceAfterTimeout(): Int {
+    return super.traceAfterTimeout()
+  }
+
+  @Trace
   override fun tracedChild(opName: String) {
     super.tracedChild(opName)
   }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/groovy/datadog/trace/instrumentation/kotlin/coroutines/AbstractKotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/groovy/datadog/trace/instrumentation/kotlin/coroutines/AbstractKotlinCoroutineInstrumentationTest.groovy
@@ -5,6 +5,7 @@ import datadog.trace.core.DDSpan
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ThreadPoolDispatcherKt
+import spock.lang.Ignore
 import spock.lang.Shared
 
 abstract class AbstractKotlinCoroutineInstrumentationTest<T extends CoreKotlinCoroutineTests> extends AgentTestRunner {
@@ -357,6 +358,46 @@ abstract class AbstractKotlinCoroutineInstrumentationTest<T extends CoreKotlinCo
         span(0) {
           operationName "top-level"
           parent()
+        }
+      }
+    }
+
+    where:
+    [dispatcherName, dispatcher] << dispatchersToTest
+  }
+
+  @Ignore("Not working: disconnected trace")
+  def "kotlin trace consistent with timeout"() {
+    setup:
+    CoreKotlinCoroutineTests kotlinTest = getCoreKotlinCoroutineTestsInstance(dispatcher)
+    int expectedNumberOfSpans = kotlinTest.traceAfterTimeout()
+
+    expect:
+    assertTraces(1) {
+      trace(expectedNumberOfSpans, true) {
+        span(5) {
+          operationName "top-level"
+          parent()
+        }
+        span(0) {
+          operationName "1-before-timeout"
+          childOf span(5)
+        }
+        span(1) {
+          operationName "2-inside-timeout"
+          childOf span(5)
+        }
+        span(2) {
+          operationName "3-after-timeout"
+          childOf span(5)
+        }
+        span(3) {
+          operationName "4-after-timeout-2"
+          childOf span(5)
+        }
+        span(4) {
+          operationName "5-after-timeout-3"
+          childOf span(5)
         }
       }
     }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
@@ -312,6 +312,30 @@ abstract class CoreKotlinCoroutineTests(private val dispatcher: CoroutineDispatc
   }
 
   @Trace
+  open fun traceAfterTimeout(): Int = runTest {
+    childSpan("1-before-timeout").activateAndUse {
+      delay(10)
+    }
+    withTimeout(50) {
+      childSpan("2-inside-timeout").activateAndUse {
+        delay(10)
+      }
+    }
+    // FIXME: This span is detached
+    childSpan("3-after-timeout").activateAndUse {
+      delay(10)
+    }
+    childSpan("4-after-timeout-2").activateAndUse {
+      delay(10)
+    }
+    childSpan("5-after-timeout-3").activateAndUse {
+      delay(10)
+    }
+
+    6
+  }
+
+  @Trace
   protected open fun tracedChild(opName: String) {
     activeSpan().setSpanName(opName)
   }


### PR DESCRIPTION
# What Does This Do

This PR adds uses case from #7215 to the test suite.

# Motivation

The current context tracking improvements might help with tackling such issues.
Adding them to the test suite to check our improvements against the failing cases.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
