### PR TITLE
Add check_debugger job to CI

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -1107,12 +1107,20 @@ build_test_jobs: &build_test_jobs
       gradleTarget: ":profilingCheck"
       cacheType: profiling
 
+  - check:
+      requires:
+        - ok_to_test
+      name: check_debugger
+      gradleTarget: ":debuggerCheck"
+      cacheType: base
+
   - fan_in:
       requires:
         - check_base
         - check_inst
         - check_smoke
         - check_profiling
+        - check_debugger
       name: check
       stage: check
 

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/el/ReflectiveFieldValueResolver.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.telemetry.LogCollector.EXCLUDE_TELEMETRY;
 import static java.lang.invoke.MethodType.methodType;
 
 import datadog.trace.bootstrap.debugger.CapturedContext;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
@@ -12,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A helper class to resolve a reference path using reflection. */
+@SuppressForbidden // Class#forName(String)
 public class ReflectiveFieldValueResolver {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReflectiveFieldValueResolver.class);
   // This is a workaround for the fact that Field.trySetAccessible is not available in Java 8

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -37,6 +37,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.DDSpanContext;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.time.Duration;
@@ -58,6 +59,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
   private static final Limits LIMITS = new Limits(1, 3, 8192, 5);
   private static final int LOG_MSG_LIMIT = 8192;
 
+  @SuppressForbidden // String#split(String)
   private static Map<String, String> getDebugSessions() {
     HashMap<String, String> sessions = new HashMap<>();
     TracerAPI tracer = AgentTracer.get();
@@ -365,6 +367,7 @@ public class LogProbe extends ProbeDefinition implements Sampled {
     this.sampling = sampling;
   }
 
+  @SuppressForbidden // String#split(String)
   private static List<ValueScript> parseWatchesFromTags(Tag[] tags) {
     if (tags == null || tags.length == 0) {
       return Collections.emptyList();


### PR DESCRIPTION
# What Does This Do
Adds a `check_debugger` job to CI.

Add forbidden apis suppressions required to pass.

# Motivation
It seems that ever since we split the `check` job, the debugger variant was never added.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
