### PR TITLE
Remove flakiness from CustomLogManagerTest and CustomMBeanServerBuilder

### DIFF
--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -9,7 +9,6 @@ import spock.lang.Timeout
 class CustomLogManagerTest extends Specification {
 
   private static final String DEFAULT_LOG_LEVEL = "debug"
-  private static final String API_KEY = "01234567890abcdef123456789ABCDEF"
 
   // Run all tests using forked jvm because groovy has already set the global log manager
   def "agent services starts up in premain with no custom log manager set"() {
@@ -23,7 +22,7 @@ class CustomLogManagerTest extends Specification {
         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , [:]
       , true) == 0
   }
 
@@ -39,7 +38,7 @@ class CustomLogManagerTest extends Specification {
         "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , [:]
       , true) == 0
   }
 
@@ -55,7 +54,7 @@ class CustomLogManagerTest extends Specification {
         "-Djava.util.logging.manager=jvmbootstraptest.MissingLogManager"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY, "DD_SITE": ""]
+      , [:]
       , true) == 0
   }
 
@@ -71,7 +70,7 @@ class CustomLogManagerTest extends Specification {
         "-Ddd.app.customlogmanager=true"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , [:]
       , true) == 0
   }
 
@@ -87,7 +86,7 @@ class CustomLogManagerTest extends Specification {
         "-Ddd.app.customjmxbuilder=false"
       ] as String[]
       , "" as String[]
-      , ["JBOSS_HOME": "/", "DD_API_KEY": API_KEY, "DD_SITE": ""]
+      , ["JBOSS_HOME": "/"]
       , true) == 0
   }
 
@@ -105,7 +104,7 @@ class CustomLogManagerTest extends Specification {
         "-Djava.util.logging.manager=jvmbootstraptest.CustomLogManager"
       ] as String[]
       , "" as String[]
-      , ["JBOSS_HOME": "/", "DD_API_KEY": API_KEY]
+      , ["JBOSS_HOME": "/"]
       , true) == 0
   }
 }

--- a/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
+++ b/dd-java-agent/src/test/groovy/datadog/trace/agent/CustomMBeanServerBuilderTest.groovy
@@ -9,7 +9,6 @@ import spock.lang.Timeout
 class CustomMBeanServerBuilderTest extends Specification {
 
   private static final String DEFAULT_LOG_LEVEL = "debug"
-  private static final String API_KEY = "01234567890abcdef123456789ABCDEF"
 
   // Run all tests using forked jvm so we try different JMX settings
   def "JMXFetch starts up in premain with no custom MBeanServerBuilder set"() {
@@ -24,7 +23,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Ddatadog.slf4j.simpleLogger.defaultLogLevel=$DEFAULT_LOG_LEVEL"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , [:]
       , true) == 0
   }
 
@@ -41,7 +40,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , [:]
       , true) == 0
   }
 
@@ -58,7 +57,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Djavax.management.builder.initial=jvmbootstraptest.MissingMBeanServerBuilder"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , [:]
       , true) == 0
   }
 
@@ -75,7 +74,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Ddd.app.customjmxbuilder=true"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , [:]
       , true) == 0
   }
 
@@ -93,7 +92,7 @@ class CustomMBeanServerBuilderTest extends Specification {
         "-Djavax.management.builder.initial=jvmbootstraptest.CustomMBeanServerBuilder"
       ] as String[]
       , "" as String[]
-      , ["DD_API_KEY": API_KEY]
+      , [:]
       , true) == 0
   }
 }


### PR DESCRIPTION
# What Does This Do

These tests historically set a dummy DD_API_KEY because that was required by the profiler. However setting DD_API_KEY will now result in these tests reaching out to the intake/backend because they won't be able to connect to an agent and the fallback for certain features like telemetry is to try and contact intake (these tests are not run alongside any test agent.)

When the call to intake/backend stalls this can lead to flaky timeouts.

# Motivation

We shouldn't be contacting the real intake during testing so this removes the dummy api-keys from CustomLogManagerTest and CustomMBeanServerBuilder.

This is ok because profiling no longer needs DD_API_KEY set locally.
