### PR TITLE
Fix tomcat TestAccessLogValve

### DIFF
--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -328,7 +328,7 @@ class ErrorHandlerValve extends ErrorReportValve {
 }
 
 class TestAccessLogValve extends ValveBase implements AccessLog {
-  List<Tuple2<String, String>> loggedIds = []
+  List<Tuple2<String, String>> loggedIds = Collections.<Tuple2<String, String>>synchronizedList([])
 
   TestAccessLogValve() {
     super(true)


### PR DESCRIPTION
# What Does This Do

Fixes flakiness of missing synchronisation on a list. Error:

```
 error.stack=java.lang.ArrayIndexOutOfBoundsException: 2
       	at java.util.ArrayList.add(ArrayList.java:465)
       	at java_util_List$add$7.call(Unknown Source)
       	at TestAccessLogValve.log(TomcatServlet3Test.groovy:339)
       	at org.apache.catalina.core.AccessLogAdapter.log(AccessLogAdapter.java:48)
       	at org.apache.catalina.core.ContainerBase.logAccess(ContainerBase.java:1064)
       	at org.apache.catalina.core.ContainerBase.logAccess(ContainerBase.java:1071)
       	at org.apache.catalina.connector.CoyoteAdapter.asyncDispatch(CoyoteAdapter.java:295)
       	at org.apache.coyote.AbstractProcessor.dispatch(AbstractProcessor.java:241)
       	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:59)
       	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:893)
       	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1723)
       	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49)
       	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
       	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
       	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
       	at java.lang.Thread.run(Thread.java:750)
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
