### PR TITLE
Revert "Add avoid double instrumenting lambda non-streaming handlers."

### DIFF
--- a/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
+++ b/dd-java-agent/agent-tooling/src/main/resources/datadog/trace/agent/tooling/bytebuddy/matcher/ignored_class_name.trie
@@ -223,7 +223,6 @@
 2 javax.xml.*
 # note we do not ignore kotlinx because we instrument coroutines code
 2 kotlin.*
-1 lambdainternal.EventHandlerLoader$PojoHandlerAsStreamHandler
 2 net.sf.cglib.*
 2 org.apache.bcel.*
 2 org.apache.html.*


### PR DESCRIPTION
Reverts DataDog/dd-trace-java#8073

This caused a tracing regression on Lambda (serverless) where AWS inferred spans were no longer being created.

Built and test manually; inferred spans now work on this branch:

<img width="820" alt="Screenshot 2025-01-17 at 4 37 18 PM" src="https://github.com/user-attachments/assets/a0e08d09-221d-4be6-a6d9-051978af8684" />
