### PR TITLE
Allow use of span as a primordial context

### DIFF
--- a/components/context/src/main/java/datadog/context/Context.java
+++ b/components/context/src/main/java/datadog/context/Context.java
@@ -114,7 +114,7 @@ public interface Context {
   /**
    * Creates a copy of this context with the given key-value set.
    *
-   * <p>Existing value with the given key will be replaced, and mapping to a {@code null} value will
+   * <p>Existing value with the given key will be replaced. Mapping to a {@code null} value will
    * remove the key-value from the context copy.
    *
    * @param <T> the type of the value.
@@ -123,6 +123,28 @@ public interface Context {
    * @return a new context with the key-value set.
    */
   <T> Context with(ContextKey<T> key, @Nullable T value);
+
+  /**
+   * Creates a copy of this context with the given pair of key-values.
+   *
+   * <p>Existing values with the given keys will be replaced. Mapping to a {@code null} value will
+   * remove the key-value from the context copy.
+   *
+   * @param <T> the type of the first value.
+   * @param <U> the type of the second value.
+   * @param firstKey the first key to store the first value.
+   * @param firstValue the first value to store.
+   * @param secondKey the second key to store the second value.
+   * @param secondValue the second value to store.
+   * @return a new context with the pair of key-values set.
+   */
+  default <T, U> Context with(
+      ContextKey<T> firstKey,
+      @Nullable T firstValue,
+      ContextKey<U> secondKey,
+      @Nullable U secondValue) {
+    return with(firstKey, firstValue).with(secondKey, secondValue);
+  }
 
   /**
    * Creates a copy of this context with the implicit key is mapped to the value.

--- a/components/context/src/test/java/datadog/context/ContextTest.java
+++ b/components/context/src/test/java/datadog/context/ContextTest.java
@@ -65,6 +65,41 @@ class ContextTest {
 
   @ParameterizedTest
   @MethodSource("contextImplementations")
+  void testWithPair(Context context) {
+    // Test retrieving value
+    String stringValue = "value";
+    Context context1 = context.with(BOOLEAN_KEY, false, STRING_KEY, stringValue);
+    assertEquals(stringValue, context1.get(STRING_KEY));
+    assertEquals(false, context1.get(BOOLEAN_KEY));
+    // Test overriding value
+    String stringValue2 = "value2";
+    Context context2 = context1.with(STRING_KEY, stringValue2, BOOLEAN_KEY, true);
+    assertEquals(stringValue2, context2.get(STRING_KEY));
+    assertEquals(true, context2.get(BOOLEAN_KEY));
+    // Test clearing value
+    Context context3 = context2.with(BOOLEAN_KEY, null, STRING_KEY, null);
+    assertNull(context3.get(STRING_KEY));
+    assertNull(context3.get(BOOLEAN_KEY));
+    // Test null key handling
+    assertThrows(
+        NullPointerException.class,
+        () -> context.with(null, "test", STRING_KEY, "test"),
+        "Context forbids null keys");
+    assertThrows(
+        NullPointerException.class,
+        () -> context.with(STRING_KEY, "test", null, "test"),
+        "Context forbids null keys");
+    // Test null value handling
+    assertDoesNotThrow(
+        () -> context.with(BOOLEAN_KEY, null, STRING_KEY, "test"),
+        "Null value should not throw exception");
+    assertDoesNotThrow(
+        () -> context.with(STRING_KEY, "test", BOOLEAN_KEY, null),
+        "Null value should not throw exception");
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextImplementations")
   void testGet(Context original) {
     // Setup context
     String value = "value";

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Constants.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/Constants.java
@@ -15,6 +15,7 @@ public final class Constants {
    */
   public static final String[] BOOTSTRAP_PACKAGE_PREFIXES = {
     "datadog.slf4j",
+    "datadog.context",
     "datadog.appsec.api",
     "datadog.trace.api",
     "datadog.trace.bootstrap",

--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -135,6 +135,7 @@ def sharedShadowJar = tasks.register('sharedShadowJar', ShadowJar) {
     exclude(project(':dd-java-agent:agent-logging'))
     exclude(project(':dd-trace-api'))
     exclude(project(':internal-api'))
+    exclude(project(':components:context'))
     exclude(project(':utils:time-utils'))
     exclude(dependency('org.slf4j::'))
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/SpockRunner.java
@@ -38,6 +38,7 @@ public class SpockRunner extends JUnitPlatform {
    */
   public static final String[] BOOTSTRAP_PACKAGE_PREFIXES_COPY = {
     "datadog.slf4j",
+    "datadog.context",
     "datadog.appsec.api",
     "datadog.trace.api",
     "datadog.trace.bootstrap",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -16,6 +16,7 @@ final class CachedData {
       exclude(project(':internal-api'))
       exclude(project(':internal-api:internal-api-9'))
       exclude(project(':communication'))
+      exclude(project(':components:context'))
       exclude(project(':components:json'))
       exclude(project(':remote-config:remote-config-api'))
       exclude(project(':remote-config:remote-config-core'))

--- a/internal-api/build.gradle
+++ b/internal-api/build.gradle
@@ -81,6 +81,7 @@ excludedClassesCoverage += [
   "datadog.trace.bootstrap.instrumentation.api.StatsPoint",
   "datadog.trace.bootstrap.instrumentation.api.Schema",
   "datadog.trace.bootstrap.instrumentation.api.ScopeSource",
+  "datadog.trace.bootstrap.instrumentation.api.InternalContextKeys",
   "datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes",
   "datadog.trace.bootstrap.instrumentation.api.TagContext",
   "datadog.trace.bootstrap.instrumentation.api.TagContext.HttpHeaders",
@@ -210,6 +211,7 @@ dependencies {
   // references TraceScope and Continuation from public api
   api project(':dd-trace-api')
   api libs.slf4j
+  api project(':components:context')
   api project(":utils:time-utils")
 
   // has to be loaded by system classloader:

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -167,6 +167,6 @@ public interface AgentSpan
 
   @Override
   default <T> Context with(ContextKey<T> key, @Nullable T value) {
-    return Context.root().with(SPAN_KEY, this).with(key, value);
+    return Context.root().with(SPAN_KEY, this, key, value);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -1,12 +1,16 @@
 package datadog.trace.bootstrap.instrumentation.api;
 
+import static datadog.trace.bootstrap.instrumentation.api.InternalContextKeys.SPAN_KEY;
+
+import datadog.context.Context;
+import datadog.context.ImplicitContextKeyed;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
 
-public interface AgentSpan extends MutableSpan, IGSpanInfo, WithAgentSpan {
+public interface AgentSpan extends MutableSpan, ImplicitContextKeyed, IGSpanInfo, WithAgentSpan {
 
   DDTraceId getTraceId();
 
@@ -144,5 +148,10 @@ public interface AgentSpan extends MutableSpan, IGSpanInfo, WithAgentSpan {
 
   default AgentSpan asAgentSpan() {
     return this;
+  }
+
+  @Override
+  default Context storeInto(Context context) {
+    return context.with(SPAN_KEY, this);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentSpan.java
@@ -3,14 +3,17 @@ package datadog.trace.bootstrap.instrumentation.api;
 import static datadog.trace.bootstrap.instrumentation.api.InternalContextKeys.SPAN_KEY;
 
 import datadog.context.Context;
+import datadog.context.ContextKey;
 import datadog.context.ImplicitContextKeyed;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.api.gateway.IGSpanInfo;
 import datadog.trace.api.gateway.RequestContext;
 import datadog.trace.api.interceptor.MutableSpan;
+import javax.annotation.Nullable;
 
-public interface AgentSpan extends MutableSpan, ImplicitContextKeyed, IGSpanInfo, WithAgentSpan {
+public interface AgentSpan
+    extends MutableSpan, ImplicitContextKeyed, Context, IGSpanInfo, WithAgentSpan {
 
   DDTraceId getTraceId();
 
@@ -153,5 +156,17 @@ public interface AgentSpan extends MutableSpan, ImplicitContextKeyed, IGSpanInfo
   @Override
   default Context storeInto(Context context) {
     return context.with(SPAN_KEY, this);
+  }
+
+  @Nullable
+  @Override
+  default <T> T get(ContextKey<T> key) {
+    // noinspection unchecked
+    return SPAN_KEY == key ? (T) this : Context.root().get(key);
+  }
+
+  @Override
+  default <T> Context with(ContextKey<T> key, @Nullable T value) {
+    return Context.root().with(SPAN_KEY, this).with(key, value);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalContextKeys.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/InternalContextKeys.java
@@ -1,0 +1,9 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import datadog.context.ContextKey;
+
+final class InternalContextKeys {
+  static final ContextKey<AgentSpan> SPAN_KEY = ContextKey.named("dd-span-key");
+
+  private InternalContextKeys() {}
+}


### PR DESCRIPTION
# What Does This Do

Supports using implementations of `AgentSpan` as `Context`.

# Motivation

Helps migration of tracing towards the context-based approach.

# Additional Notes

A convenience method was added to `Context` that accepts a pair of key-value mappings. This lets custom root context implementations skip creation of the interim context when adding two entries at the same time, for example a span and a baggage holder. We do not expect to require further variants of this method, but this particular case is worth adding to reduce copying when inflating spans into full contexts.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMAPI-959]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMAPI-959]: https://datadoghq.atlassian.net/browse/APMAPI-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ