### PR TITLE
Add debug logging to Android Gradle module layout logic

### DIFF
--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/AndroidGradleUtils.groovy
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/AndroidGradleUtils.groovy
@@ -14,7 +14,7 @@ import java.nio.file.Paths
 
 class AndroidGradleUtils {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(AndroidGradleUtils.class)
+  private static final Logger LOGGER = LoggerFactory.getLogger(AndroidGradleUtils)
 
   static BuildModuleLayout getAndroidModuleLayout(Project project, Test task) {
     try {

--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/AndroidGradleUtils.groovy
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/AndroidGradleUtils.groovy
@@ -1,19 +1,20 @@
 package datadog.trace.instrumentation.gradle
 
+
 import datadog.trace.api.civisibility.domain.BuildModuleLayout
 import datadog.trace.api.civisibility.domain.SourceSet
 import org.gradle.api.Project
 import org.gradle.api.file.FileTree
-import org.gradle.api.logging.Logger
-import org.gradle.api.logging.Logging
 import org.gradle.api.tasks.testing.Test
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import java.nio.file.Files
 import java.nio.file.Paths
 
 class AndroidGradleUtils {
 
-  private static final Logger LOGGER = Logging.getLogger(AndroidGradleUtils)
+  private static final Logger LOGGER = LoggerFactory.getLogger(AndroidGradleUtils.class)
 
   static BuildModuleLayout getAndroidModuleLayout(Project project, Test task) {
     try {
@@ -22,6 +23,7 @@ class AndroidGradleUtils {
         return null
       }
 
+      LOGGER.debug("Found Android plugin variant: {} for task {}", variant.name, task.path)
       def sources = getSources(variant)
       def destinations = getDestinations(variant, project)
       return new BuildModuleLayout(Collections.singletonList(new SourceSet(SourceSet.Type.CODE, sources, destinations)))
@@ -37,6 +39,7 @@ class AndroidGradleUtils {
       ?: project.plugins.findPlugin('com.android.application')
       ?: project.plugins.findPlugin('com.android.library')
 
+    LOGGER.debug("Found Android plugin: {}", androidPlugin.getClass().getName())
     def variants
     if (androidPlugin.class.simpleName == 'LibraryPlugin') {
       variants = project.android.libraryVariants
@@ -88,6 +91,8 @@ class AndroidGradleUtils {
     } else {
       destinationsTree = javaTree
     }
+
+    LOGGER.debug("Using destination tree: {}", destinationsTree.sourceTrees)
     return destinationsTree.files
   }
 

--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListenerInjector_8_10.java
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListenerInjector_8_10.java
@@ -3,17 +3,17 @@ package datadog.trace.instrumentation.gradle;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CiVisibilityGradleListenerInjector_8_10 {
 
   private static final Logger LOGGER =
-      Logging.getLogger(CiVisibilityGradleListenerInjector_8_10.class);
+      LoggerFactory.getLogger(CiVisibilityGradleListenerInjector_8_10.class);
 
   /**
    * Performs listener injection for Gradle v8.10+. As the tracer currently uses v8.4, some of the

--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListenerInjector_8_3.java
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityGradleListenerInjector_8_3.java
@@ -1,16 +1,16 @@
 package datadog.trace.instrumentation.gradle;
 
 import java.util.Arrays;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.initialization.ClassLoaderRegistry;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CiVisibilityGradleListenerInjector_8_3 {
 
   private static final Logger LOGGER =
-      Logging.getLogger(CiVisibilityGradleListenerInjector_8_3.class);
+      LoggerFactory.getLogger(CiVisibilityGradleListenerInjector_8_3.class);
 
   /** Performs listener injection for Gradle v8.3 - 8.9 */
   public static void injectCiVisibilityGradleListener(

--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityPlugin.java
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityPlugin.java
@@ -15,18 +15,18 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class CiVisibilityPlugin implements Plugin<Project> {
 
-  private static final Logger LOGGER = Logging.getLogger(CiVisibilityPlugin.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CiVisibilityPlugin.class);
 
   private static final String PLUGIN_EXTENSION_NAME = "dd-ci-visibility";
   private static final String JACOCO_PLUGIN_ID = "jacoco";

--- a/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityPluginExtension.java
+++ b/dd-java-agent/instrumentation/gradle-8.3/src/main/groovy/datadog/trace/instrumentation/gradle/CiVisibilityPluginExtension.java
@@ -11,8 +11,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.ServiceReference;
@@ -24,10 +22,12 @@ import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class CiVisibilityPluginExtension {
 
-  private static final Logger LOGGER = Logging.getLogger(CiVisibilityPluginExtension.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(CiVisibilityPluginExtension.class);
 
   public static final String MODULE_LAYOUT_PROPERTY = "moduleLayout";
 


### PR DESCRIPTION
# What Does This Do

Adds some debug logging to the logic that determines module layouts for Android Gradle projects.

# Motivation

Simplify debugging issues in Android Gradle projects.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
