### PR TITLE
Add failing Kotlin coroutine tests

### DIFF
--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.3/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.3/src/test/kotlin/KotlinCoroutineTests.kt
@@ -69,6 +69,11 @@ class KotlinCoroutineTests(dispatcher: CoroutineDispatcher) : CoreKotlinCoroutin
   }
 
   @Trace
+  override fun traceAfterDelay(): Int {
+    return super.traceAfterDelay()
+  }
+
+  @Trace
   override fun tracedChild(opName: String) {
     super.tracedChild(opName)
   }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/coroutines-1.5/src/test/kotlin/KotlinCoroutineTests.kt
@@ -90,6 +90,11 @@ class KotlinCoroutineTests(dispatcher: CoroutineDispatcher) : CoreKotlinCoroutin
   }
 
   @Trace
+  override fun traceAfterDelay(): Int {
+    return super.traceAfterDelay()
+  }
+
+  @Trace
   override fun tracedChild(opName: String) {
     super.tracedChild(opName)
   }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/groovy/datadog/trace/instrumentation/kotlin/coroutines/AbstractKotlinCoroutineInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/groovy/datadog/trace/instrumentation/kotlin/coroutines/AbstractKotlinCoroutineInstrumentationTest.groovy
@@ -376,7 +376,7 @@ abstract class AbstractKotlinCoroutineInstrumentationTest<T extends CoreKotlinCo
     assertTraces(1) {
       trace(expectedNumberOfSpans, true) {
         span(5) {
-          operationName "top-level"
+          operationName "trace.annotation"
           parent()
         }
         span(0) {
@@ -397,6 +397,46 @@ abstract class AbstractKotlinCoroutineInstrumentationTest<T extends CoreKotlinCo
         }
         span(4) {
           operationName "5-after-timeout-3"
+          childOf span(5)
+        }
+      }
+    }
+
+    where:
+    [dispatcherName, dispatcher] << dispatchersToTest
+  }
+
+  @Ignore("Not working: disconnected trace")
+  def "kotlin trace consistent after delay"() {
+    setup:
+    CoreKotlinCoroutineTests kotlinTest = getCoreKotlinCoroutineTestsInstance(dispatcher)
+    int expectedNumberOfSpans = kotlinTest.traceAfterDelay()
+
+    expect:
+    assertTraces(1) {
+      trace(expectedNumberOfSpans, true) {
+        span(5) {
+          operationName "trace.annotation"
+          parent()
+        }
+        span(1) {
+          operationName "before-process"
+          childOf span(5)
+        }
+        span(2) {
+          operationName "process-url-a"
+          childOf span(5)
+        }
+        span(3) {
+          operationName "process-url-b"
+          childOf span(5)
+        }
+        span(4) {
+          operationName "process-url-c"
+          childOf span(5)
+        }
+        span(0) {
+          operationName "after-process"
           childOf span(5)
         }
       }

--- a/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
+++ b/dd-java-agent/instrumentation/kotlin-coroutines/src/testFixtures/kotlin/datadog/trace/instrumentation/kotlin/coroutines/CoreKotlinCoroutineTests.kt
@@ -336,6 +336,39 @@ abstract class CoreKotlinCoroutineTests(private val dispatcher: CoroutineDispatc
   }
 
   @Trace
+  open fun traceAfterDelay(): Int = runTest {
+    tracedChild("before-process")
+
+    val inputs = listOf("a", "b", "c")
+
+    coroutineScope {
+      inputs.map { data ->
+        async {
+          upload(data)
+        }
+      }.awaitAll().map {
+        tracedChild("process-$it")
+        encrypt(it)
+      }
+    }
+
+    // FIXME: This span is detached
+    tracedChild("after-process")
+
+    6
+  }
+
+  private suspend fun upload(data: String): String {
+    delay(100)
+    return "url-$data"
+  }
+
+  private suspend fun encrypt(message: String): String {
+    delay(100)
+    return "encrypted-$message"
+  }
+
+  @Trace
   protected open fun tracedChild(opName: String) {
     activeSpan().setSpanName(opName)
   }


### PR DESCRIPTION
# What Does This Do

This PR is a follow up PR of #8238 to add more failing test cases of kotlin coroutine context tracking instrumentation.

# Motivation

The current context tracking improvements might help with tackling such issues.
Adding them to the test suite to check our improvements against the failing cases.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-40]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-40]: https://datadoghq.atlassian.net/browse/LANGPLAT-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ