### PR TITLE
Fix test name uniqueness

### DIFF
--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/MetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/MetricCollectorTest.groovy
@@ -4,7 +4,7 @@ import spock.lang.Specification
 
 class MetricCollectorTest extends Specification {
 
-  void 'test metric equality'() {
+  void 'test metric equality #iterationIndex'() {
     when:
     final sameMetric = first == second
 
@@ -21,6 +21,14 @@ class MetricCollectorTest extends Specification {
     counter(tags: ['a:b'], value: 2)        | counter(tags: ['a:b'], value: 6)        | true
     counter(tags: ['a:b'], value: 2)        | counter(tags: ['c:d'], value: 6)        | false
     counter(tags: ['a:b', 'c:d'], value: 2) | counter(tags: ['a:b', 'c:d'], value: 6) | true
+  }
+
+  void 'test metric toString'() {
+    expect:
+    metric.toString() != null
+
+    where:
+    metric << [counter(value: 2), counter(namespace: 'other', value: 6), counter(tags: ['a:b', 'c:d'], value: 2)]
   }
 
   private static MetricCollector.Metric counter(final Map metric) {


### PR DESCRIPTION
# What Does This Do

This PR fixes test name uniqueness.

# Motivation

This will help with CI monitoring to keep track of test execution.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
