### PR TITLE
Prevents a NPE when there is no subscriber for user events

### DIFF
--- a/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/AppSecEventTrackerSpecification.groovy
+++ b/dd-java-agent/appsec/src/test/groovy/com/datadog/appsec/user/AppSecEventTrackerSpecification.groovy
@@ -268,6 +268,15 @@ class AppSecEventTrackerSpecification extends DDSpecification {
     thrown(BlockingException)
   }
 
+  void 'should not fail on null callback'() {
+    when:
+    tracker.onUserEvent(UserIdCollectionMode.IDENTIFICATION, 'test-user')
+
+    then:
+    noExceptionThrown()
+    provider.getCallback(EVENTS.user()) >> null
+  }
+
   private static class ActionFlow<T> implements Flow<T> {
 
     private Action action

--- a/dd-java-agent/instrumentation/spring-security-5/src/main/java/datadog/trace/instrumentation/springsecurity5/AppSecDeferredContext.java
+++ b/dd-java-agent/instrumentation/spring-security-5/src/main/java/datadog/trace/instrumentation/springsecurity5/AppSecDeferredContext.java
@@ -1,9 +1,13 @@
 package datadog.trace.instrumentation.springsecurity5;
 
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.context.SecurityContext;
 
 public class AppSecDeferredContext implements Supplier<SecurityContext> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AppSecDeferredContext.class);
 
   private final Supplier<SecurityContext> delegate;
 
@@ -15,7 +19,11 @@ public class AppSecDeferredContext implements Supplier<SecurityContext> {
   public SecurityContext get() {
     SecurityContext context = delegate.get();
     if (context != null) {
-      SpringSecurityUserEventDecorator.DECORATE.onUser(context.getAuthentication());
+      try {
+        SpringSecurityUserEventDecorator.DECORATE.onUser(context.getAuthentication());
+      } catch (Throwable e) {
+        LOGGER.debug("Error handling user event", e);
+      }
     }
     return context;
   }

--- a/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
+++ b/internal-api/src/main/java/datadog/trace/api/appsec/AppSecEventTracker.java
@@ -142,6 +142,9 @@ public class AppSecEventTracker extends EventTracker {
       return;
     }
     final T callback = cbp.getCallback(event);
+    if (callback == null) {
+      return;
+    }
     final Flow<Void> flow = consumer.apply(ctx, callback);
     if (flow == null) {
       return;


### PR DESCRIPTION
# What Does This Do
Prevents a NPE reported by a customer when a user login action is triggered and no callbacks have been subscribed for the user event.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56463]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-56463]: https://datadoghq.atlassian.net/browse/APPSEC-56463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ