### PR TITLE
Small improvement to agent feedback sampling

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceTraceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceTraceSampler.java
@@ -1,13 +1,12 @@
 package datadog.trace.common.sampling;
 
-import datadog.trace.api.cache.DDCache;
-import datadog.trace.api.cache.DDCaches;
-import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.api.sampling.SamplingMechanism;
 import datadog.trace.common.writer.RemoteResponseListener;
 import datadog.trace.core.CoreSpan;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
+import java.util.TreeMap;
+
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,8 +70,8 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
     }
 
     log.debug("Update service sampler rates: {} -> {}", endpoint, responseJson);
-    final Map<String, Map<String, RateSampler>> updatedEnvServiceRates =
-        new HashMap<>(newServiceRates.size() * 2);
+    final TreeMap<String, TreeMap<String, RateSampler>> updatedEnvServiceRates =
+        new TreeMap<>(String::compareToIgnoreCase);
 
     RateSampler fallbackSampler = RateSamplersByEnvAndService.DEFAULT_SAMPLER;
     for (final Map.Entry<String, Number> entry : newServiceRates.entrySet()) {
@@ -87,7 +86,7 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
       } else {
         Map<String, RateSampler> serviceRates =
             updatedEnvServiceRates.computeIfAbsent(
-                envAndService.lowerEnv, env -> new HashMap<>(newServiceRates.size() * 2));
+                envAndService.lowerEnv, env -> new TreeMap<>(String::compareToIgnoreCase));
 
         serviceRates.computeIfAbsent(
             envAndService.lowerService,
@@ -114,38 +113,34 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
   private static final class RateSamplersByEnvAndService {
     private static final RateSampler DEFAULT_SAMPLER = createRateSampler(DEFAULT_RATE);
 
-    private final Map<String, Map<String, RateSampler>> envServiceRates;
+    private final Map<String, TreeMap<String, RateSampler>> envServiceRates;
     private final RateSampler fallbackSampler;
 
     RateSamplersByEnvAndService() {
-      this(new HashMap<>(0), DEFAULT_SAMPLER);
+      this(Collections.emptyMap(), DEFAULT_SAMPLER);
     }
 
     RateSamplersByEnvAndService(
-        Map<String, Map<String, RateSampler>> envServiceRates, RateSampler fallbackSampler) {
+        Map<String, TreeMap<String, RateSampler>> envServiceRates, RateSampler fallbackSampler) {
       this.envServiceRates = envServiceRates;
       this.fallbackSampler = fallbackSampler;
     }
 
     // used in tests only
     RateSampler getSampler(EnvAndService envAndService) {
-      return getSamplerImpl(envAndService.lowerEnv, envAndService.lowerService);
+      return getSampler(envAndService.lowerEnv, envAndService.lowerService);
     }
 
     public RateSampler getSampler(String env, String service) {
-      return getSamplerImpl(env.toLowerCase(), service.toLowerCase());
-    }
-
-    private RateSampler getSamplerImpl(String lowerEnv, String lowerService) {
-      if (EnvAndService.isFallback(lowerEnv, lowerService)) {
+      if (EnvAndService.isFallback(env, service)) {
         return fallbackSampler;
       }
 
-      Map<String, RateSampler> serviceRates = envServiceRates.get(lowerEnv);
+      Map<String, RateSampler> serviceRates = envServiceRates.get(env);
       if (serviceRates == null) {
         return fallbackSampler;
       }
-      RateSampler sampler = serviceRates.get(lowerService);
+      RateSampler sampler = serviceRates.get(service);
       return null == sampler ? fallbackSampler : sampler;
     }
   }


### PR DESCRIPTION
Previously, I updated this code to be case-insensitive.

In doing so, I introduced a call to String.toLowerCase which had a negative impact on response time and allocation.

By switching to TreeMap, I can use String::compareToIgnoreCase which avoids the allocation and has a better average complexity than toLowerCase.

This change provides a 1-1.5% improvement in a span creation throughput stress tests.

# What Does This Do

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
