### PR TITLE
Replace UUID.randomUUID() with RandomUtils.randomUUID()

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/config/ConfigurationApiImpl.java
@@ -22,6 +22,7 @@ import datadog.trace.api.civisibility.telemetry.tag.ItrSkipEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.KnownTestsEnabled;
 import datadog.trace.api.civisibility.telemetry.tag.RequireGit;
 import datadog.trace.civisibility.communication.TelemetryListener;
+import datadog.trace.util.RandomUtils;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
@@ -32,7 +33,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import okhttp3.MediaType;
@@ -64,7 +64,7 @@ public class ConfigurationApiImpl implements ConfigurationApi {
   private final JsonAdapter<EnvelopeDto<ChangedFiles>> changedFilesResponseAdapter;
 
   public ConfigurationApiImpl(BackendApi backendApi, CiVisibilityMetricCollector metricCollector) {
-    this(backendApi, metricCollector, () -> UUID.randomUUID().toString());
+    this(backendApi, metricCollector, () -> RandomUtils.randomUUID().toString());
   }
 
   ConfigurationApiImpl(

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/CrashUploader.java
@@ -16,6 +16,7 @@ import datadog.trace.api.Config;
 import datadog.trace.api.DDTags;
 import datadog.trace.bootstrap.config.provider.ConfigProvider;
 import datadog.trace.util.PidHelper;
+import datadog.trace.util.RandomUtils;
 import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.io.*;
 import java.nio.charset.Charset;
@@ -28,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -283,7 +283,7 @@ public final class CrashUploader {
             .name("runtime_id")
             // this is unknowable at this point because the process has crashed
             // though we may be able to save it in the tmpdir
-            .value(UUID.randomUUID().toString());
+            .value(RandomUtils.randomUUID().toString());
         writer.name("tracer_time").value(Instant.now().getEpochSecond());
         writer.name("seq_id").value(1);
         writer.name("debug").value(true);

--- a/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/dto/CrashLog.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/com/datadog/crashtracking/dto/CrashLog.java
@@ -3,9 +3,9 @@ package com.datadog.crashtracking.dto;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
+import datadog.trace.util.RandomUtils;
 import java.io.IOException;
 import java.util.Objects;
-import java.util.UUID;
 
 public final class CrashLog {
   private static final int VERSION = 0;
@@ -17,7 +17,7 @@ public final class CrashLog {
     ADAPTER = moshi.adapter(CrashLog.class);
   }
 
-  public final String uuid = UUID.randomUUID().toString();
+  public final String uuid = RandomUtils.randomUUID().toString();
   public final String timestamp;
   public final boolean incomplete;
   public final ErrorData error;

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeId.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/ProbeId.java
@@ -1,6 +1,6 @@
 package datadog.trace.bootstrap.debugger;
 
-import java.util.UUID;
+import datadog.trace.util.RandomUtils;
 
 public class ProbeId {
   private static final String ID_SEPARATOR = ":";
@@ -32,7 +32,7 @@ public class ProbeId {
   }
 
   public static ProbeId newId() {
-    return new ProbeId(UUID.randomUUID().toString(), 0);
+    return new ProbeId(RandomUtils.randomUUID().toString(), 0);
   }
 
   public String getId() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DebuggerTransformer.java
@@ -29,6 +29,7 @@ import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.MethodLocation;
 import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import datadog.trace.util.RandomUtils;
 import datadog.trace.util.Strings;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -50,7 +51,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import net.bytebuddy.description.type.TypeDescription;
@@ -301,7 +301,7 @@ public class DebuggerTransformer implements ClassFileTransformer {
         if (isMethodIncludedForTransformation(methodNode, classNode, methodNames)) {
           LogProbe probe =
               LogProbe.builder()
-                  .probeId(UUID.randomUUID().toString(), 0)
+                  .probeId(RandomUtils.randomUUID().toString(), 0)
                   .where(classNode.name, methodNode.name)
                   .captureSnapshot(false)
                   .build();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -8,6 +8,7 @@ import com.datadog.debugger.util.WeakIdentityHashMap;
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.debugger.DebuggerContext.ClassNameFilter;
 import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.util.RandomUtils;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -17,7 +18,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,7 +116,7 @@ public class ExceptionProbeManager {
 
   private static ExceptionProbe createMethodProbe(
       ExceptionProbeManager exceptionProbeManager, Where where, int chainedExceptionIdx) {
-    String probeId = UUID.randomUUID().toString();
+    String probeId = RandomUtils.randomUUID().toString();
     return new ExceptionProbe(
         new ProbeId(probeId, 0), where, null, null, exceptionProbeManager, chainedExceptionIdx);
   }
@@ -159,7 +159,7 @@ public class ExceptionProbeManager {
     }
     ThrowableState state =
         snapshotsByThrowable.computeIfAbsent(
-            throwable, key -> new ThrowableState(UUID.randomUUID().toString()));
+            throwable, key -> new ThrowableState(RandomUtils.randomUUID().toString()));
     snapshot.setExceptionId(state.getExceptionId());
     state.addSnapshot(snapshot);
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Snapshot.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/Snapshot.java
@@ -6,12 +6,12 @@ import datadog.trace.bootstrap.debugger.CapturedContext.CapturedThrowable;
 import datadog.trace.bootstrap.debugger.CapturedStackFrame;
 import datadog.trace.bootstrap.debugger.EvaluationError;
 import datadog.trace.bootstrap.debugger.ProbeImplementation;
+import datadog.trace.util.RandomUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 
 /** Data class representing all data collected at a probe location */
 public class Snapshot {
@@ -112,7 +112,7 @@ public class Snapshot {
   public String getId() {
     // lazily generates snapshot id
     if (id == null) {
-      id = UUID.randomUUID().toString();
+      id = RandomUtils.randomUUID().toString();
     }
     return id;
   }

--- a/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
+++ b/dd-java-agent/agent-iast/src/main/java/com/datadog/iast/taint/TaintedObjects.java
@@ -6,6 +6,7 @@ import com.datadog.iast.IastSystem;
 import com.datadog.iast.model.Range;
 import com.datadog.iast.model.json.TaintedObjectEncoding;
 import com.datadog.iast.util.Wrapper;
+import datadog.trace.util.RandomUtils;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -86,7 +87,7 @@ public interface TaintedObjects extends Iterable<TaintedObject> {
 
     public TaintedObjectsDebugAdapter(final TaintedObjectsImpl delegated) {
       this.delegated = delegated;
-      id = UUID.randomUUID();
+      id = RandomUtils.randomUUID();
       LOGGER.debug("new: id={}", id);
     }
 

--- a/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
+++ b/dd-java-agent/appsec/src/main/java/com/datadog/appsec/powerwaf/PowerWAFModule.java
@@ -33,6 +33,7 @@ import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.util.RandomUtils;
 import datadog.trace.util.stacktrace.StackTraceEvent;
 import datadog.trace.util.stacktrace.StackTraceFrame;
 import datadog.trace.util.stacktrace.StackUtils;
@@ -64,7 +65,6 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -228,7 +228,7 @@ public class PowerWAFModule implements AppSecModule {
     AppSecConfig ruleConfig = config.getMergedUpdateConfig();
     PowerwafContext newPwafCtx = null;
     try {
-      String uniqueId = UUID.randomUUID().toString();
+      String uniqueId = RandomUtils.randomUUID().toString();
 
       if (prevContextAndAddresses == null) {
         PowerwafConfig pwConfig = createPowerwafConfig();

--- a/gradle/forbiddenApiFilters/main.txt
+++ b/gradle/forbiddenApiFilters/main.txt
@@ -7,6 +7,9 @@ java.lang.String#split(java.lang.String,int)
 java.lang.String#replaceAll(java.lang.String,java.lang.String)
 java.lang.String#replaceFirst(java.lang.String,java.lang.String)
 
+# can initialize java.util.logging when ACCP is installed, prefer RandomUtils instead
+java.util.UUID.randomUUID()
+
 # prefer the NameMatchers/HierarchyMatchers equivalent instead
 net.bytebuddy.matcher.ElementMatchers#named(java.lang.String)
 net.bytebuddy.matcher.ElementMatchers#namedOneOf(java.lang.String[])

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -39,6 +39,7 @@ import datadog.trace.bootstrap.config.provider.SystemPropertiesConfigSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.context.TraceScope;
 import datadog.trace.util.PidHelper;
+import datadog.trace.util.RandomUtils;
 import datadog.trace.util.Strings;
 import datadog.trace.util.throwable.FatalAgentMisconfigurationError;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -97,7 +98,7 @@ public class Config {
    * and every JMX metric that is sent out.
    */
   static class RuntimeIdHolder {
-    static final String runtimeId = UUID.randomUUID().toString();
+    static final String runtimeId = RandomUtils.randomUUID().toString();
   }
 
   static class HostNameHolder {

--- a/internal-api/src/main/java/datadog/trace/util/RandomUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/RandomUtils.java
@@ -1,0 +1,16 @@
+package datadog.trace.util;
+
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class RandomUtils {
+  private RandomUtils() {}
+
+  public static UUID randomUUID() {
+    Random rnd = ThreadLocalRandom.current();
+    long msb = (rnd.nextLong() & 0xffff_ffff_ffff_0fffL) | 0x0000_0000_0000_4000L;
+    long lsb = (rnd.nextLong() & 0x3fff_ffff_ffff_ffffL) | 0x8000_0000_0000_0000L;
+    return new UUID(msb, lsb);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/util/RandomUtils.java
+++ b/internal-api/src/main/java/datadog/trace/util/RandomUtils.java
@@ -1,5 +1,6 @@
 package datadog.trace.util;
 
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -7,10 +8,22 @@ import java.util.concurrent.ThreadLocalRandom;
 public final class RandomUtils {
   private RandomUtils() {}
 
+  /** Returns a random UUID. */
   public static UUID randomUUID() {
     Random rnd = ThreadLocalRandom.current();
     long msb = (rnd.nextLong() & 0xffff_ffff_ffff_0fffL) | 0x0000_0000_0000_4000L;
     long lsb = (rnd.nextLong() & 0x3fff_ffff_ffff_ffffL) | 0x8000_0000_0000_0000L;
     return new UUID(msb, lsb);
+  }
+
+  /**
+   * Returns a cryptographically strong random UUID.
+   *
+   * <p>Note on some systems this may have a side effect of initializing java.util.logging, so its
+   * use should be avoided during premain.
+   */
+  @SuppressForbidden
+  public static UUID secureRandomUUID() {
+    return UUID.randomUUID();
   }
 }

--- a/internal-api/src/test/java/datadog/trace/util/RandomUtilsTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/RandomUtilsTest.java
@@ -15,4 +15,11 @@ public class RandomUtilsTest {
       assertThat(RandomUtils.randomUUID().toString()).matches(VERSION_4_UUID);
     }
   }
+
+  @Test
+  public void testSecureRandomUUIDMatchesSpec() {
+    for (int i = 0; i < 8; i++) {
+      assertThat(RandomUtils.secureRandomUUID().toString()).matches(VERSION_4_UUID);
+    }
+  }
 }

--- a/internal-api/src/test/java/datadog/trace/util/RandomUtilsTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/RandomUtilsTest.java
@@ -1,0 +1,18 @@
+package datadog.trace.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+public class RandomUtilsTest {
+  private static final Pattern VERSION_4_UUID =
+      Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[8-9a-f][0-9a-f]{3}-[0-9a-f]{12}");
+
+  @Test
+  public void testRandomUUIDMatchesSpec() {
+    for (int i = 0; i < 8; i++) {
+      assertThat(RandomUtils.randomUUID().toString()).matches(VERSION_4_UUID);
+    }
+  }
+}

--- a/remote-config/remote-config-core/src/main/java/datadog/remoteconfig/PollerRequestFactory.java
+++ b/remote-config/remote-config-core/src/main/java/datadog/remoteconfig/PollerRequestFactory.java
@@ -9,11 +9,11 @@ import datadog.trace.api.git.GitInfo;
 import datadog.trace.api.git.GitInfoProvider;
 import datadog.trace.api.remoteconfig.ServiceNameCollector;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.util.RandomUtils;
 import datadog.trace.util.TagsHelper;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -30,7 +30,7 @@ public class PollerRequestFactory {
 
   private static final Logger log = LoggerFactory.getLogger(PollerRequestFactory.class);
 
-  private final String clientId = UUID.randomUUID().toString();
+  private final String clientId = RandomUtils.randomUUID().toString();
   private final String runtimeId;
   private final String serviceName;
   private final String apiKey;
@@ -66,9 +66,9 @@ public class PollerRequestFactory {
 
   private static String getRuntimeId(Config config) {
     String runtimeId = config.getRuntimeId();
-    if (runtimeId == null || runtimeId.length() == 0) {
+    if (runtimeId == null || runtimeId.isEmpty()) {
       log.debug("runtimeId not configured, generating a new UUID");
-      runtimeId = UUID.randomUUID().toString();
+      runtimeId = RandomUtils.randomUUID().toString();
     }
     return runtimeId;
   }


### PR DESCRIPTION
# Motivation

This avoids a potential side-effect of loading `java.util.logging` too early when the Amazon Corretto Crypto Provider (ACCP) is plugged into `SecureRandom`

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APMS-14233]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMS-14233]: https://datadoghq.atlassian.net/browse/APMS-14233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ