### PR TITLE
Optimize Git repository information computation

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
@@ -23,6 +23,8 @@ public class GitInfoProvider {
     INSTANCE = new GitInfoProvider();
     INSTANCE.registerGitInfoBuilder(new UserSuppliedGitInfoBuilder());
   }
+  
+  static final String NULL_PATH_STRING = Paths.get("").toAbsolutePath().toString();
 
   private volatile Collection<GitInfoBuilder> builders = Collections.emptyList();
 
@@ -42,7 +44,7 @@ public class GitInfoProvider {
 
   public GitInfo getGitInfo(@Nullable String repositoryPath) {
     if (repositoryPath == null) {
-      repositoryPath = Paths.get("").toAbsolutePath().toString();
+      repositoryPath = NULL_PATH_STRING;
     }
     return gitInfoCache.computeIfAbsent(repositoryPath, this::buildGitInfo);
   }

--- a/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
+++ b/internal-api/src/main/java/datadog/trace/api/git/GitInfoProvider.java
@@ -23,7 +23,7 @@ public class GitInfoProvider {
     INSTANCE = new GitInfoProvider();
     INSTANCE.registerGitInfoBuilder(new UserSuppliedGitInfoBuilder());
   }
-  
+
   static final String NULL_PATH_STRING = Paths.get("").toAbsolutePath().toString();
 
   private volatile Collection<GitInfoBuilder> builders = Collections.emptyList();


### PR DESCRIPTION
# What Does This Do

Moves computation of git repository null path into static variable

# Motivation

Provides a 3% improvement on span creation benchmarks
