### PR TITLE
Properly finish spans and support latest apache httpclient5

### DIFF
--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/main/java/datadog/trace/instrumentation/apachehttpclient5/ApacheHttpAsyncClientInstrumentation.java
@@ -21,6 +21,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.nio.AsyncRequestProducer;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
 import org.apache.hc.core5.http.protocol.HttpContext;
 
 @AutoService(InstrumenterModule.class)
@@ -91,13 +92,17 @@ public class ApacheHttpAsyncClientInstrumentation extends InstrumenterModule.Tra
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static AgentScope methodEnter(
         @Advice.Argument(value = 0, readOnly = false) AsyncRequestProducer requestProducer,
-        @Advice.Argument(3) HttpContext context,
+        @Advice.Argument(value = 3, readOnly = false) HttpContext context,
         @Advice.Argument(value = 4, readOnly = false) FutureCallback<?> futureCallback) {
 
       final AgentScope parentScope = activeScope();
       final AgentSpan clientSpan = startSpan(HTTP_REQUEST);
       final AgentScope clientScope = activateSpan(clientSpan);
       DECORATE.afterStart(clientSpan);
+
+      if (context == null) {
+        context = new BasicHttpContext();
+      }
 
       requestProducer = new DelegatingRequestProducer(clientSpan, requestProducer);
       futureCallback =

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpAsyncClient5Test.groovy
@@ -57,7 +57,7 @@ abstract class ApacheHttpAsyncClient5Test<T extends HttpRequest> extends HttpCli
   }
 }
 
-class ApacheHttpAsyncClient5NamingV0ForkedTest extends ApacheHttpAsyncClient5Test implements TestingGenericHttpNamingConventions.ClientV0 {
+class ApacheHttpAsyncClient5NamingV0Test extends ApacheHttpAsyncClient5Test implements TestingGenericHttpNamingConventions.ClientV0 {
 }
 
 class ApacheHttpAsyncClient5NamingV1ForkedTest extends ApacheHttpAsyncClient5Test implements TestingGenericHttpNamingConventions.ClientV1 {

--- a/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpclient-5/src/test/groovy/ApacheHttpClientTest.groovy
@@ -208,7 +208,7 @@ abstract class ApacheClientResponseHandlerAll extends ApacheHttpClientTest<Class
 }
 
 @Timeout(5)
-class ApacheClientResponseHandlerAllV0ForkedTest extends ApacheClientResponseHandlerAll {
+class ApacheClientResponseHandlerAllV0Test extends ApacheClientResponseHandlerAll {
 }
 
 @Timeout(5)


### PR DESCRIPTION
# What Does This Do

Re-enable testing of latestDep for the async client case. In fact, because all those tests was forked, we were not executing them on the latestDep since there was no declaration of `latestDepForkedTest`
Instead adding a task we can run not forked the V0 naming test cases since they do not need to run forked. There is no need to run the v1 naming test on the latestDep since the naming is not depending to the version we're testing.

Running the tests I observed that the async test cases were timeouting because the spans was never finished. In fact, `extractResponseFromContext` was not protecting the context object access with a null check. The latest versions of http client 5 seems not to provide a context. However the future contains the response that can be used. That fix mitigate this issue

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
