### PR TITLE
Avoid double snapshots for Exception Replay

### DIFF
--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 9039f27868f0f7d6db344ca2f0631071a1b9de6f
+default_system_tests_commit: &default_system_tests_commit c706e333ef06800b866ac300e4b6cdb7566cc5e5
 
 parameters:
   nightly:

--- a/.circleci/config.continue.yml.j2
+++ b/.circleci/config.continue.yml.j2
@@ -36,7 +36,7 @@ instrumentation_modules: &instrumentation_modules "dd-java-agent/instrumentation
 debugger_modules: &debugger_modules "dd-java-agent/agent-debugger|dd-java-agent/agent-bootstrap|dd-java-agent/agent-builder|internal-api|communication|dd-trace-core"
 profiling_modules: &profiling_modules "dd-java-agent/agent-profiling"
 
-default_system_tests_commit: &default_system_tests_commit 8b05076e897fe62206d7704f2e8e650ed83ebd1f
+default_system_tests_commit: &default_system_tests_commit 9039f27868f0f7d6db344ca2f0631071a1b9de6f
 
 parameters:
   nightly:

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -158,10 +158,13 @@ public class DefaultExceptionDebugger implements DebuggerContext.ExceptionDebugg
       String tagName = String.format(SNAPSHOT_ID_TAG_FMT, frameIndex);
       span.setTag(tagName, snapshot.getId());
       LOGGER.debug("add tag to span[{}]: {}: {}", span.getSpanId(), tagName, snapshot.getId());
-      DebuggerAgent.getSink().addSnapshot(snapshot);
+      if (!state.isSnapshotSent()) {
+        DebuggerAgent.getSink().addSnapshot(snapshot);
+      }
       snapshotAssigned = true;
     }
     if (snapshotAssigned) {
+      state.markAsSnapshotSent();
       span.setTag(DD_DEBUG_ERROR_EXCEPTION_ID, state.getExceptionId());
       LOGGER.debug(
           "add tag to span[{}]: {}: {}",

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/ExceptionProbeManager.java
@@ -183,6 +183,7 @@ public class ExceptionProbeManager {
   public static class ThrowableState {
     private final String exceptionId;
     private List<Snapshot> snapshots;
+    private boolean snapshotSent;
 
     private ThrowableState(String exceptionId) {
       this.exceptionId = exceptionId;
@@ -205,6 +206,14 @@ public class ExceptionProbeManager {
         snapshots = new ArrayList<>();
       }
       snapshots.add(snapshot);
+    }
+
+    public boolean isSnapshotSent() {
+      return snapshotSent;
+    }
+
+    public void markAsSnapshotSent() {
+      snapshotSent = true;
     }
   }
 }


### PR DESCRIPTION
# What Does This Do
As Exception replay is supported by default for intermediate spans we can end up in a situation where 2 spans are attaching the same exception with the snapshots. in that case
DebuggerContext::handleException is called twice, once for each span and we are also sending the same snapshots to the backend while only one version is necessary and we tag it to the according spans. We can just make sure we are sending the snapshots only once.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3285]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3285]: https://datadoghq.atlassian.net/browse/DEBUG-3285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ