### PR TITLE
Introduce id-based line probe source matching

### DIFF
--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/LogProbesInstrumentationTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static utils.InstrumentationTestHelper.compileAndLoadClass;
+import static utils.InstrumentationTestHelper.getLineForLineProbe;
 
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
@@ -38,6 +39,10 @@ public class LogProbesInstrumentationTest {
   private static final ProbeId LOG_ID = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f8", 0);
   private static final ProbeId LOG_ID1 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f8", 0);
   private static final ProbeId LOG_ID2 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f9", 0);
+  private static final ProbeId LINE_PROBE_ID1 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000001", 0);
+  private static final ProbeId LINE_PROBE_ID2 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000002", 0);
   private static final String SERVICE_NAME = "service-name";
   private static final String STR_8K =
       "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
@@ -57,7 +62,7 @@ public class LogProbesInstrumentationTest {
   public void methodPlainLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     TestSnapshotListener listener =
-        installSingleProbe("this is log line", CLASS_NAME, "main", "int (java.lang.String)");
+        installMethodProbe("this is log line", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -71,7 +76,7 @@ public class LogProbesInstrumentationTest {
   public void methodLargePlainLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     TestSnapshotListener listener =
-        installSingleProbe(STR_8K + "123", CLASS_NAME, "main", "int (java.lang.String)");
+        installMethodProbe(STR_8K + "123", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -84,7 +89,7 @@ public class LogProbesInstrumentationTest {
   public void methodTemplateArgLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     TestSnapshotListener listener =
-        installSingleProbe(
+        installMethodProbe(
             "this is log line with arg={arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -98,7 +103,7 @@ public class LogProbesInstrumentationTest {
   public void methodTemplateArgLogLarge() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     TestSnapshotListener listener =
-        installSingleProbe(STR_8K + "{arg}", CLASS_NAME, "main", "int (java.lang.String)");
+        installMethodProbe(STR_8K + "{arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
@@ -111,7 +116,7 @@ public class LogProbesInstrumentationTest {
   public void methodTemplateLargeArgLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     TestSnapshotListener listener =
-        installSingleProbe(
+        installMethodProbe(
             "this is log line with arg={arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", STR_8K).get();
@@ -128,7 +133,7 @@ public class LogProbesInstrumentationTest {
   public void methodTemplateTooLargeArgLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     TestSnapshotListener listener =
-        installSingleProbe("{arg}", CLASS_NAME, "main", "int (java.lang.String)");
+        installMethodProbe("{arg}", CLASS_NAME, "main", "int (java.lang.String)");
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", STR_8K + "123").get();
     Assertions.assertEquals(3, result);
@@ -162,14 +167,14 @@ public class LogProbesInstrumentationTest {
   public void mergedMethodTemplateArgLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     LogProbe logProbe1 =
-        createProbe(
+        createMethodProbe(
             LOG_ID1,
             "this is log line #1 with arg={arg}",
             CLASS_NAME,
             "main",
             "int (java.lang.String)");
     LogProbe logProbe2 =
-        createProbe(
+        createMethodProbe(
             LOG_ID2,
             "this is log line #2 with arg={arg}",
             CLASS_NAME,
@@ -250,12 +255,13 @@ public class LogProbesInstrumentationTest {
   @Test
   public void linePlainLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID2);
     TestSnapshotListener listener =
-        installSingleProbe("this is log line", CLASS_NAME, null, null, "9");
+        installLineProbe(LINE_PROBE_ID2, "this is log line", CLASS_NAME, line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID2, listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line", snapshot.getMessage());
   }
@@ -263,12 +269,14 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateVarLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID2);
     TestSnapshotListener listener =
-        installSingleProbe("this is log line with local var={var1}", CLASS_NAME, null, null, "9");
+        installLineProbe(
+            LINE_PROBE_ID2, "this is log line with local var={var1}", CLASS_NAME, line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID2, listener);
     assertCapturesNull(snapshot);
     assertEquals("this is log line with local var=3", snapshot.getMessage());
   }
@@ -276,17 +284,17 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateMultipleVarLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot04";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
     TestSnapshotListener listener =
-        installSingleProbe(
+        installLineProbe(
+            LINE_PROBE_ID1,
             "nullObject={nullObject} sdata={sdata.strValue} cdata={cdata.s1.intValue}",
             CLASS_NAME,
-            null,
-            null,
-            "25");
+            line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(143, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID1, listener);
     assertCapturesNull(snapshot);
     assertEquals("nullObject=null sdata=foo cdata=101", snapshot.getMessage());
   }
@@ -294,17 +302,17 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateEscapeLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID2);
     TestSnapshotListener listener =
-        installSingleProbe(
+        installLineProbe(
+            LINE_PROBE_ID2,
             "this is log line with {{curly braces}} and with local var={{{var1}}}",
             CLASS_NAME,
-            null,
-            null,
-            "9");
+            line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID2, listener);
     assertCapturesNull(snapshot);
     assertEquals(
         "this is log line with {curly braces} and with local var={3}", snapshot.getMessage());
@@ -313,12 +321,14 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateInvalidVarLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID2);
     TestSnapshotListener listener =
-        installSingleProbe("this is log line with local var={var42}", CLASS_NAME, null, null, "9");
+        installLineProbe(
+            LINE_PROBE_ID2, "this is log line with local var={var42}", CLASS_NAME, line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     Assertions.assertEquals(3, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID2, listener);
     assertCapturesNull(snapshot);
     assertEquals(
         "this is log line with local var={Cannot find symbol: var42}", snapshot.getMessage());
@@ -330,13 +340,14 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateNullFieldLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot04";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
     TestSnapshotListener listener =
-        installSingleProbe(
-            "this is log line with field={nullObject.intValue}", CLASS_NAME, null, null, "25");
+        installLineProbe(
+            LINE_PROBE_ID1, "this is log line with field={nullObject.intValue}", CLASS_NAME, line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
     Assertions.assertEquals(143, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID1, listener);
     assertCapturesNull(snapshot);
     assertEquals(
         "this is log line with field={Cannot dereference field: intValue}", snapshot.getMessage());
@@ -349,13 +360,17 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateIndexOutOfBoundsLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot06";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
     TestSnapshotListener listener =
-        installSingleProbe(
-            "this is log line with element of list={strList[10]}", CLASS_NAME, null, null, "24");
+        installLineProbe(
+            LINE_PROBE_ID1,
+            "this is log line with element of list={strList[10]}",
+            CLASS_NAME,
+            line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
     Assertions.assertEquals(42, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID1, listener);
     assertEquals(
         "this is log line with element of list={index[10] out of bounds: [0-3]}",
         snapshot.getMessage());
@@ -368,12 +383,13 @@ public class LogProbesInstrumentationTest {
   @Test
   public void lineTemplateThisLog() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot06";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
     TestSnapshotListener listener =
-        installSingleProbe("this is log line for this={this}", CLASS_NAME, null, null, "24");
+        installLineProbe(LINE_PROBE_ID1, "this is log line for this={this}", CLASS_NAME, line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
     Assertions.assertEquals(42, result);
-    Snapshot snapshot = assertOneSnapshot(listener);
+    Snapshot snapshot = assertOneSnapshot(LINE_PROBE_ID1, listener);
     assertEquals(
         "this is log line for this={intValue=48, doubleValue=3.14, strValue=done, strList=..., strMap=...}",
         snapshot.getMessage());
@@ -496,9 +512,15 @@ public class LogProbesInstrumentationTest {
     return listener.snapshots;
   }
 
-  private TestSnapshotListener installSingleProbe(
-      String template, String typeName, String methodName, String signature, String... lines) {
-    LogProbe logProbe = createProbe(LOG_ID, template, typeName, methodName, signature, lines);
+  private TestSnapshotListener installMethodProbe(
+      String template, String typeName, String methodName, String signature) {
+    LogProbe logProbe = createMethodProbe(LOG_ID, template, typeName, methodName, signature);
+    return installProbes(Configuration.builder().setService(SERVICE_NAME).add(logProbe).build());
+  }
+
+  private TestSnapshotListener installLineProbe(
+      ProbeId probeId, String template, String sourceFile, int line) {
+    LogProbe logProbe = createLineProbe(probeId, template, sourceFile, line);
     return installProbes(Configuration.builder().setService(SERVICE_NAME).add(logProbe).build());
   }
 
@@ -507,27 +529,31 @@ public class LogProbesInstrumentationTest {
   }
 
   private static LogProbe.Builder createProbeBuilder(
-      ProbeId id,
-      String template,
-      String typeName,
-      String methodName,
-      String signature,
-      String... lines) {
+      ProbeId id, String template, String typeName, String methodName, String signature) {
     return LogProbe.builder()
         .language(LANGUAGE)
         .probeId(id)
-        .where(typeName, methodName, signature, lines)
+        .where(typeName, methodName, signature)
         .template(template, parseTemplate(template));
   }
 
-  private static LogProbe createProbe(
-      ProbeId id,
-      String template,
-      String typeName,
-      String methodName,
-      String signature,
-      String... lines) {
-    return createProbeBuilder(id, template, typeName, methodName, signature, lines).build();
+  private static LogProbe.Builder createProbeBuilder(
+      ProbeId id, String template, String sourceFile, int line) {
+    return LogProbe.builder()
+        .language(LANGUAGE)
+        .probeId(id)
+        .where(sourceFile, line)
+        .template(template, parseTemplate(template));
+  }
+
+  private static LogProbe createMethodProbe(
+      ProbeId id, String template, String typeName, String methodName, String signature) {
+    return createProbeBuilder(id, template, typeName, methodName, signature).build();
+  }
+
+  private static LogProbe createLineProbe(
+      ProbeId id, String template, String sourceFile, int line) {
+    return createProbeBuilder(id, template, sourceFile, line).build();
   }
 
   private TestSnapshotListener installProbes(Configuration configuration) {
@@ -560,10 +586,14 @@ public class LogProbesInstrumentationTest {
   }
 
   private Snapshot assertOneSnapshot(TestSnapshotListener listener) {
+    return assertOneSnapshot(LOG_ID, listener);
+  }
+
+  private Snapshot assertOneSnapshot(ProbeId probeId, TestSnapshotListener listener) {
     Assertions.assertFalse(listener.skipped, "Snapshot skipped because " + listener.cause);
     Assertions.assertEquals(1, listener.snapshots.size());
     Snapshot snapshot = listener.snapshots.get(0);
-    Assertions.assertEquals(LOG_ID.getId(), snapshot.getProbe().getId());
+    Assertions.assertEquals(probeId.getId(), snapshot.getProbe().getId());
     return snapshot;
   }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/MetricProbesInstrumentationTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static utils.InstrumentationTestHelper.compileAndLoadClass;
+import static utils.InstrumentationTestHelper.getLineForLineProbe;
 import static utils.InstrumentationTestHelper.loadClass;
 
 import com.datadog.debugger.el.DSL;
@@ -41,6 +42,7 @@ import java.util.Map;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.joor.Reflect;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -50,6 +52,14 @@ public class MetricProbesInstrumentationTest {
   private static final ProbeId METRIC_ID1 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f6", 0);
   private static final ProbeId METRIC_ID2 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f7", 0);
   private static final ProbeId METRIC_ID3 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f9", 0);
+  private static final ProbeId LINE_METRIC_ID1 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000001", 0);
+  private static final ProbeId LINE_METRIC_ID2 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000002", 0);
+  private static final ProbeId LINE_METRIC_ID3 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000003", 0);
+  private static final ProbeId LINE_METRIC_ID4 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000004", 0);
   private static final String SERVICE_NAME = "service-name";
   private static final String METRIC_PROBEID_TAG =
       "debugger.probeid:beae1807-f3b0-4ea8-a74f-826790c5e6f8";
@@ -71,7 +81,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "call_count";
     MetricForwarderListener listener =
-        installSingleMetric(METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null);
+        installMethodMetric(METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -85,7 +95,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "call_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -107,7 +117,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot01";
     final String METRIC_NAME = "call_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -126,7 +136,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "call_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -146,7 +156,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "call_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -196,7 +206,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -215,7 +225,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_gauge";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             GAUGE,
             CLASS_NAME,
@@ -235,7 +245,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot06";
     String METRIC_NAME = "field_double_gauge";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             GAUGE,
             CLASS_NAME,
@@ -255,7 +265,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_gauge";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             GAUGE,
             CLASS_NAME,
@@ -273,7 +283,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_histogram";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             HISTOGRAM,
             CLASS_NAME,
@@ -293,7 +303,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot06";
     String METRIC_NAME = "field_double_histogram";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             HISTOGRAM,
             CLASS_NAME,
@@ -314,7 +324,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_histogram";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             HISTOGRAM,
             CLASS_NAME,
@@ -335,7 +345,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_distribution";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             DISTRIBUTION,
             CLASS_NAME,
@@ -355,7 +365,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot06";
     String METRIC_NAME = "field_double_distribution";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             DISTRIBUTION,
             CLASS_NAME,
@@ -454,14 +464,15 @@ public class MetricProbesInstrumentationTest {
   public void lineArgumentRefValueCountMetric() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_count";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID1);
     MetricProbe metricProbe =
-        createMetric(
-            METRIC_ID,
+        createLineMetric(
+            LINE_METRIC_ID1,
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
             new ValueScript(DSL.ref("value"), "value"),
-            4);
+            line);
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -475,7 +486,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -494,7 +505,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot03";
     String METRIC_NAME = "argument_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -515,9 +526,15 @@ public class MetricProbesInstrumentationTest {
   public void lineLocalRefValueCountMetric() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "localvar_count";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID2);
     MetricProbe metricProbe =
-        createMetric(
-            METRIC_ID, METRIC_NAME, COUNT, CLASS_NAME, new ValueScript(DSL.ref("var1"), "var1"), 9);
+        createLineMetric(
+            LINE_METRIC_ID2,
+            METRIC_NAME,
+            COUNT,
+            CLASS_NAME,
+            new ValueScript(DSL.ref("var1"), "var1"),
+            line);
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -530,24 +547,36 @@ public class MetricProbesInstrumentationTest {
   public void invalidNameLocalRefValueCountMetric() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "localvar_count";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID2);
     MetricProbe metricProbe =
-        createMetric(
-            METRIC_ID, METRIC_NAME, COUNT, CLASS_NAME, new ValueScript(DSL.ref("foo"), "foo"), 9);
+        createLineMetric(
+            LINE_METRIC_ID2,
+            METRIC_NAME,
+            COUNT,
+            CLASS_NAME,
+            new ValueScript(DSL.ref("foo"), "foo"),
+            line);
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
     assertFalse(listener.counters.containsKey(METRIC_NAME));
-    verify(probeStatusSink).addError(eq(METRIC_ID), eq("Cannot resolve symbol foo"));
+    verify(probeStatusSink).addError(eq(LINE_METRIC_ID2), eq("Cannot resolve symbol foo"));
   }
 
   @Test
   public void invalidTypeLocalRefValueCountMetric() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "localvar_count";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID2);
     MetricProbe metricProbe =
-        createMetric(
-            METRIC_ID, METRIC_NAME, COUNT, CLASS_NAME, new ValueScript(DSL.ref("arg"), "arg"), 9);
+        createLineMetric(
+            LINE_METRIC_ID2,
+            METRIC_NAME,
+            COUNT,
+            CLASS_NAME,
+            new ValueScript(DSL.ref("arg"), "arg"),
+            line);
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
@@ -555,7 +584,7 @@ public class MetricProbesInstrumentationTest {
     assertFalse(listener.counters.containsKey(METRIC_NAME));
     verify(probeStatusSink)
         .addError(
-            eq(METRIC_ID),
+            eq(LINE_METRIC_ID2),
             eq("Incompatible type for expression: java.lang.String with expected types: [long]"));
   }
 
@@ -564,7 +593,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot06";
     String METRIC_NAME = "field_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -584,7 +613,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot06";
     String METRIC_NAME = "field_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -603,14 +632,15 @@ public class MetricProbesInstrumentationTest {
   public void lineFieldRefValueCountMetric() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot06";
     String METRIC_NAME = "field_count";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID1);
     MetricProbe metricProbe =
-        createMetric(
-            METRIC_ID,
+        createLineMetric(
+            LINE_METRIC_ID1,
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
             new ValueScript(DSL.getMember(DSL.ref("this"), "intValue"), "intValue"),
-            24);
+            line);
     MetricForwarderListener listener = installMetricProbes(metricProbe);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "f").get();
@@ -624,24 +654,26 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot04";
     String METRIC_NAME1 = "field1_count";
     String METRIC_NAME2 = "field2_count";
+    int line3 = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID3);
+    int line4 = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID4);
     MetricProbe metricProbe1 =
-        createMetric(
-            METRIC_ID1,
+        createLineMetric(
+            LINE_METRIC_ID3,
             METRIC_NAME1,
             COUNT,
             CLASS_NAME,
             new ValueScript(DSL.getMember(DSL.ref("sdata"), "intValue"), "sdata.intValue"),
-            24);
+            line3);
     MetricProbe metricProbe2 =
-        createMetric(
-            METRIC_ID2,
+        createLineMetric(
+            LINE_METRIC_ID4,
             METRIC_NAME2,
             COUNT,
             CLASS_NAME,
             new ValueScript(
                 DSL.getMember(DSL.getMember(DSL.ref("cdata"), "s1"), "intValue"),
                 "cdata.s1.intValue"),
-            24);
+            line4);
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -657,25 +689,27 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot04";
     String METRIC_NAME1 = "field1_count";
     String METRIC_NAME2 = "field2_count";
+    int line1 = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID1);
+    int line2 = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID2);
     MetricProbe metricProbe1 =
-        createMetric(
-            METRIC_ID1,
+        createLineMetric(
+            LINE_METRIC_ID1,
             METRIC_NAME1,
             COUNT,
             CLASS_NAME,
             new ValueScript(
                 DSL.getMember(DSL.ref("nullObject"), "intValue"), "nullObject.intValue"),
-            25);
+            line1);
     MetricProbe metricProbe2 =
-        createMetric(
-            METRIC_ID2,
+        createLineMetric(
+            LINE_METRIC_ID2,
             METRIC_NAME2,
             COUNT,
             CLASS_NAME,
             new ValueScript(
                 DSL.getMember(DSL.getMember(DSL.ref("cdata"), "nullsd"), "intValue"),
                 "cdata.nullsd.intValue"),
-            25);
+            line2);
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -690,24 +724,26 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot04";
     String METRIC_NAME1 = "field1_count";
     String METRIC_NAME2 = "field2_count";
+    int line3 = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID3);
+    int line4 = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID4);
     MetricProbe metricProbe1 =
-        createMetric(
-            METRIC_ID1,
+        createLineMetric(
+            LINE_METRIC_ID3,
             METRIC_NAME1,
             COUNT,
             CLASS_NAME,
             new ValueScript(DSL.getMember(DSL.ref("sdata"), "foovalue"), "sdata.foovalue"),
-            24);
+            line3);
     MetricProbe metricProbe2 =
-        createMetric(
-            METRIC_ID2,
+        createLineMetric(
+            LINE_METRIC_ID4,
             METRIC_NAME2,
             COUNT,
             CLASS_NAME,
             new ValueScript(
                 DSL.getMember(DSL.getMember(DSL.ref("cdata"), "s1"), "foovalue"),
                 "cdata.s1.foovalue"),
-            24);
+            line4);
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -725,24 +761,26 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot04";
     String METRIC_NAME1 = "field1_count";
     String METRIC_NAME2 = "field2_count";
+    int line3 = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID3);
+    int line4 = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID4);
     MetricProbe metricProbe1 =
-        createMetric(
-            METRIC_ID1,
+        createLineMetric(
+            LINE_METRIC_ID3,
             METRIC_NAME1,
             COUNT,
             CLASS_NAME,
             new ValueScript(DSL.getMember(DSL.ref("sdata"), "strValue"), "sdata.strValue"),
-            24);
+            line3);
     MetricProbe metricProbe2 =
-        createMetric(
-            METRIC_ID2,
+        createLineMetric(
+            LINE_METRIC_ID4,
             METRIC_NAME2,
             COUNT,
             CLASS_NAME,
             new ValueScript(
                 DSL.getMember(DSL.getMember(DSL.ref("cdata"), "s1"), "strValue"),
                 "cdata.s1.strValue"),
-            24);
+            line4);
     MetricForwarderListener listener = installMetricProbes(metricProbe1, metricProbe2);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "").get();
@@ -764,7 +802,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot06";
     String METRIC_NAME = "field_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -784,7 +822,7 @@ public class MetricProbesInstrumentationTest {
     final String CLASS_NAME = "CapturedSnapshot06";
     String METRIC_NAME = "field_count";
     MetricForwarderListener listener =
-        installSingleMetric(
+        installMethodMetric(
             METRIC_NAME,
             COUNT,
             CLASS_NAME,
@@ -807,11 +845,13 @@ public class MetricProbesInstrumentationTest {
     ValueScript valueScript =
         new ValueScript(DSL.getMember(DSL.ref("this"), "intValue"), "intValue");
     MetricProbe countProbe =
-        createMetric(METRIC_ID1, "field_count", COUNT, CLASS_NAME, "f", "()", valueScript, null);
+        createMethodMetric(
+            METRIC_ID1, "field_count", COUNT, CLASS_NAME, "f", "()", valueScript, null);
     MetricProbe gaugeProbe =
-        createMetric(METRIC_ID2, "field_gauge", GAUGE, CLASS_NAME, "f", "()", valueScript, null);
+        createMethodMetric(
+            METRIC_ID2, "field_gauge", GAUGE, CLASS_NAME, "f", "()", valueScript, null);
     MetricProbe histogramProbe =
-        createMetric(
+        createMethodMetric(
             METRIC_ID3, "field_histo", HISTOGRAM, CLASS_NAME, "f", "()", valueScript, null);
     MetricForwarderListener listener = installMetricProbes(countProbe, gaugeProbe, histogramProbe);
     listener.setThrowing(true);
@@ -824,9 +864,10 @@ public class MetricProbesInstrumentationTest {
   public void singleLineIncCountMetric() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "call_count";
+    int line = getLineForLineProbe(CLASS_NAME, LINE_METRIC_ID1);
     MetricForwarderListener listener =
-        installSingleMetric(
-            METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null, null, "8");
+        installMetricProbes(
+            createLineMetric(LINE_METRIC_ID1, METRIC_NAME, COUNT, CLASS_NAME, null, line));
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -835,12 +876,15 @@ public class MetricProbesInstrumentationTest {
   }
 
   @Test
+  @Disabled("no more support of line range")
   public void multiLineIncCountMetric() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot01";
     String METRIC_NAME = "call_count";
     MetricForwarderListener listener =
-        installSingleMetric(
-            METRIC_NAME, COUNT, CLASS_NAME, "main", "int (java.lang.String)", null, null, "4-8");
+        installMetricProbes(
+            createMetricBuilder(METRIC_ID, METRIC_NAME, COUNT)
+                .where("main", "int (java.lang.String)", null, null, "4-8")
+                .build());
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(3, result);
@@ -1216,7 +1260,7 @@ public class MetricProbesInstrumentationTest {
     assertFalse(listener.gauges.containsKey(METRIC_NAME));
   }
 
-  private MetricForwarderListener installSingleMetric(
+  private MetricForwarderListener installMethodMetric(
       String metricName,
       MetricProbe.MetricKind metricKind,
       String typeName,
@@ -1224,35 +1268,26 @@ public class MetricProbesInstrumentationTest {
       String signature,
       ValueScript valueScript) {
     MetricProbe metricProbe =
-        createMetric(
+        createMethodMetric(
             METRIC_ID, metricName, metricKind, typeName, methodName, signature, valueScript, null);
     return installMetricProbes(metricProbe);
   }
 
-  private MetricForwarderListener installSingleMetric(
+  private MetricForwarderListener installMethodMetric(
       String metricName,
       MetricProbe.MetricKind metricKind,
       String typeName,
       String methodName,
       String signature,
       ValueScript valueScript,
-      String[] tags,
-      String... lines) {
+      String[] tags) {
     MetricProbe metricProbe =
-        createMetric(
-            METRIC_ID,
-            metricName,
-            metricKind,
-            typeName,
-            methodName,
-            signature,
-            valueScript,
-            tags,
-            lines);
+        createMethodMetric(
+            METRIC_ID, metricName, metricKind, typeName, methodName, signature, valueScript, tags);
     return installMetricProbes(metricProbe);
   }
 
-  private static MetricProbe createMetric(
+  private static MetricProbe createMethodMetric(
       ProbeId id,
       String metricName,
       MetricProbe.MetricKind metricKind,
@@ -1260,16 +1295,15 @@ public class MetricProbesInstrumentationTest {
       String methodName,
       String signature,
       ValueScript valueScript,
-      String[] tags,
-      String... lines) {
+      String[] tags) {
     return createMetricBuilder(id, metricName, metricKind)
-        .where(typeName, methodName, signature, lines)
+        .where(typeName, methodName, signature)
         .valueScript(valueScript)
         .tags(tags)
         .build();
   }
 
-  private static MetricProbe createMetric(
+  private static MetricProbe createLineMetric(
       ProbeId id,
       String metricName,
       MetricProbe.MetricKind metricKind,

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SpanDecorationProbeInstrumentationTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static utils.InstrumentationTestHelper.compileAndLoadClass;
+import static utils.InstrumentationTestHelper.getLineForLineProbe;
 
 import com.datadog.debugger.el.DSL;
 import com.datadog.debugger.el.ProbeCondition;
@@ -60,6 +61,8 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   private static final ProbeId PROBE_ID2 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f7", 0);
   private static final ProbeId PROBE_ID3 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f8", 0);
   private static final ProbeId PROBE_ID4 = new ProbeId("beae1807-f3b0-4ea8-a74f-826790c5e6f9", 0);
+  private static final ProbeId LINE_PROBE_ID1 =
+      new ProbeId("beae1817-f3b0-4ea8-a74f-000000000001", 0);
 
   private TestTraceInterceptor traceInterceptor = new TestTraceInterceptor();
 
@@ -259,14 +262,16 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   public void lineActiveSpanSimpleTag() throws IOException, URISyntaxException {
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration = createDecoration("tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 47);
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
+    installSingleSpanDecoration(
+        LINE_PROBE_ID1, CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(84, result);
     MutableSpan span = traceInterceptor.getFirstSpan();
     assertEquals("1", span.getTags().get("tag1"));
-    assertEquals(PROBE_ID.getId(), span.getTags().get("_dd.di.tag1.probe_id"));
-    verify(probeStatusSink).addEmitting(ArgumentMatchers.eq(PROBE_ID));
+    assertEquals(LINE_PROBE_ID1.getId(), span.getTags().get("_dd.di.tag1.probe_id"));
+    verify(probeStatusSink).addEmitting(ArgumentMatchers.eq(LINE_PROBE_ID1));
   }
 
   @Test
@@ -275,8 +280,14 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     SpanDecorationProbe.Decoration deco1 = createDecoration("tag1", "{arg}");
     SpanDecorationProbe.Decoration deco2 = createDecoration("tag2", "{this.intField}");
     SpanDecorationProbe.Decoration deco3 = createDecoration("tag3", "{strField}");
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
     installSingleSpanDecoration(
-        CLASS_NAME, ROOT, asList(deco1, deco2, deco3), "CapturedSnapshot21.java", 67);
+        LINE_PROBE_ID1,
+        CLASS_NAME,
+        ROOT,
+        asList(deco1, deco2, deco3),
+        "CapturedSnapshot21.java",
+        line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "1").get();
     assertEquals(45, result);
@@ -292,7 +303,9 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
         createDecoration(eq(ref("arg"), value("5")), "arg == '5'", "tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 47);
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
+    installSingleSpanDecoration(
+        LINE_PROBE_ID1, CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     for (int i = 0; i < 10; i++) {
       int result = Reflect.on(testClass).call("main", String.valueOf(i)).get();
@@ -308,7 +321,9 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     final String CLASS_NAME = "com.datadog.debugger.CapturedSnapshot20";
     SpanDecorationProbe.Decoration decoration =
         createDecoration(eq(ref("noarg"), value("5")), "arg == '5'", "tag1", "{arg}");
-    installSingleSpanDecoration(CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", 47);
+    int line = getLineForLineProbe(CLASS_NAME, LINE_PROBE_ID1);
+    installSingleSpanDecoration(
+        LINE_PROBE_ID1, CLASS_NAME, ACTIVE, decoration, "CapturedSnapshot20.java", line);
     Class<?> testClass = compileAndLoadClass(CLASS_NAME);
     int result = Reflect.on(testClass).call("main", "5").get();
     assertEquals(84, result);
@@ -338,24 +353,12 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     SpanDecorationProbe.Decoration decoration2 = createDecoration("tag2", "{arg}");
     SpanDecorationProbe spanDecoProbe1 =
         createProbeBuilder(
-                PROBE_ID1,
-                ACTIVE,
-                singletonList(decoration1),
-                CLASS_NAME,
-                "process",
-                null,
-                (String[]) null)
+                PROBE_ID1, ACTIVE, singletonList(decoration1), CLASS_NAME, "process", null)
             .evaluateAt(MethodLocation.EXIT)
             .build();
     SpanDecorationProbe spanDecoProbe2 =
         createProbeBuilder(
-                PROBE_ID2,
-                ACTIVE,
-                singletonList(decoration2),
-                CLASS_NAME,
-                "process",
-                null,
-                (String[]) null)
+                PROBE_ID2, ACTIVE, singletonList(decoration2), CLASS_NAME, "process", null)
             .evaluateAt(MethodLocation.ENTRY)
             .build();
     LogProbe logProbe1 =
@@ -403,24 +406,12 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
     SpanDecorationProbe.Decoration decoration2 = createDecoration("tag2", "{arg}");
     SpanDecorationProbe spanDecoProbe1 =
         createProbeBuilder(
-                PROBE_ID1,
-                ACTIVE,
-                singletonList(decoration1),
-                CLASS_NAME,
-                "process",
-                null,
-                (String[]) null)
+                PROBE_ID1, ACTIVE, singletonList(decoration1), CLASS_NAME, "process", null)
             .evaluateAt(MethodLocation.EXIT)
             .build();
     SpanDecorationProbe spanDecoProbe2 =
         createProbeBuilder(
-                PROBE_ID2,
-                ACTIVE,
-                singletonList(decoration2),
-                CLASS_NAME,
-                "process",
-                null,
-                (String[]) null)
+                PROBE_ID2, ACTIVE, singletonList(decoration2), CLASS_NAME, "process", null)
             .evaluateAt(MethodLocation.ENTRY)
             .build();
     Configuration configuration =
@@ -624,12 +615,14 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   }
 
   private void installSingleSpanDecoration(
+      ProbeId probeId,
       String typeName,
       SpanDecorationProbe.TargetSpan targetSpan,
       SpanDecorationProbe.Decoration decoration,
       String sourceFile,
       int line) {
-    installSingleSpanDecoration(typeName, targetSpan, asList(decoration), sourceFile, line);
+    installSingleSpanDecoration(
+        probeId, typeName, targetSpan, asList(decoration), sourceFile, line);
   }
 
   private void installSingleSpanDecoration(
@@ -645,12 +638,13 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
   }
 
   private void installSingleSpanDecoration(
+      ProbeId probeId,
       String typeName,
       SpanDecorationProbe.TargetSpan targetSpan,
       List<SpanDecorationProbe.Decoration> decorations,
       String sourceFile,
       int line) {
-    SpanDecorationProbe probe = createProbe(PROBE_ID, targetSpan, decorations, sourceFile, line);
+    SpanDecorationProbe probe = createProbe(probeId, targetSpan, decorations, sourceFile, line);
     installSpanDecorationProbes(
         typeName, Configuration.builder().setService(SERVICE_NAME).add(probe).build());
   }
@@ -661,10 +655,8 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
       List<SpanDecorationProbe.Decoration> decorationList,
       String typeName,
       String methodName,
-      String signature,
-      String... lines) {
-    return createProbeBuilder(
-            id, targetSpan, decorationList, typeName, methodName, signature, lines)
+      String signature) {
+    return createProbeBuilder(id, targetSpan, decorationList, typeName, methodName, signature)
         .evaluateAt(MethodLocation.EXIT)
         .build();
   }
@@ -684,12 +676,11 @@ public class SpanDecorationProbeInstrumentationTest extends ProbeInstrumentation
       List<SpanDecorationProbe.Decoration> decorationList,
       String typeName,
       String methodName,
-      String signature,
-      String... lines) {
+      String signature) {
     return SpanDecorationProbe.builder()
         .language(LANGUAGE)
         .probeId(id)
-        .where(typeName, methodName, signature, lines)
+        .where(typeName, methodName, signature)
         .evaluateAt(MethodLocation.EXIT)
         .targetSpan(targetSpan)
         .decorate(decorationList);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/trigger/TriggerProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/trigger/TriggerProbeTest.java
@@ -173,9 +173,8 @@ public class TriggerProbeTest extends CapturingTestBase {
       String methodName,
       String signature,
       ProbeCondition probeCondition,
-      Sampling sampling,
-      String... lines) {
-    return new TriggerProbe(id, Where.of(typeName, methodName, signature, lines))
+      Sampling sampling) {
+    return new TriggerProbe(id, Where.of(typeName, methodName, signature))
         .setSessionId(sessionId)
         .setProbeCondition(probeCondition)
         .setSampling(sampling);

--- a/dd-java-agent/agent-debugger/src/test/java/utils/InstrumentationTestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/utils/InstrumentationTestHelper.java
@@ -1,8 +1,10 @@
 package utils;
 
 import static utils.TestHelper.getFixtureContent;
+import static utils.TestHelper.getFixtureLines;
 
 import com.datadog.debugger.agent.CapturedSnapshotTest;
+import datadog.trace.bootstrap.debugger.ProbeId;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -11,6 +13,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class InstrumentationTestHelper {
@@ -65,5 +68,22 @@ public class InstrumentationTestHelper {
     URLClassLoader jarClassLoader =
         new URLClassLoader(new URL[] {new URL("file://" + jarFileName)});
     return jarClassLoader.loadClass(className);
+  }
+
+  public static int getLineForLineProbe(String className, ProbeId lineProbeId)
+      throws IOException, URISyntaxException {
+    return getLineForLineProbe(className, ".java", lineProbeId);
+  }
+
+  public static int getLineForLineProbe(String className, String ext, ProbeId lineProbeId)
+      throws IOException, URISyntaxException {
+    List<String> lines = getFixtureLines("/" + className.replace('.', '/') + ext);
+    for (int i = 0; i < lines.size(); i++) {
+      String line = lines.get(i);
+      if (line.contains("//") && line.contains(lineProbeId.getId())) {
+        return i + 1;
+      }
+    }
+    return -1;
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/java/utils/TestHelper.java
+++ b/dd-java-agent/agent-debugger/src/test/java/utils/TestHelper.java
@@ -4,9 +4,15 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 
 public class TestHelper {
   public static String getFixtureContent(String fixture) throws IOException, URISyntaxException {
     return new String(Files.readAllBytes(Paths.get(TestHelper.class.getResource(fixture).toURI())));
+  }
+
+  public static List<String> getFixtureLines(String fixture)
+      throws IOException, URISyntaxException {
+    return Files.readAllLines(Paths.get(TestHelper.class.getResource(fixture).toURI()));
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot01.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot01.java
@@ -5,7 +5,7 @@ public class CapturedSnapshot01 {
       var1 = 2;
       return var1;
     }
-    var1 = 3;
-    return var1;
+    var1 = 3; // beae1817-f3b0-4ea8-a74f-000000000001
+    return var1; // beae1817-f3b0-4ea8-a74f-000000000002
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot02.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot02.java
@@ -43,7 +43,7 @@ public class CapturedSnapshot02 {
   int synchronizedBlock(int input) {
     int count = input;
     synchronized (this) {
-      for (int i = 0; i < 10; i++) {
+      for (int i = 0; i < 10; i++) { // beae1817-f3b0-4ea8-a74f-000000000001
         count += i;
       }
     }

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot03.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot03.java
@@ -1,7 +1,7 @@
 public class CapturedSnapshot03 {
 
   int f1(int value) {
-    return value;
+    return value; // beae1817-f3b0-4ea8-a74f-000000000001
   }
 
   int f2(int value) {

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot04.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot04.java
@@ -21,8 +21,8 @@ public class CapturedSnapshot04 {
     CapturedSnapshot04 cs4 = new CapturedSnapshot04();
     SimpleData sdata = cs4.createSimpleData();
     CompositeData cdata = cs4.createCompositeData();
-    SimpleData nullObject = null;
-    return sdata.intValue + cdata.s1.intValue;
+    SimpleData nullObject = null; // beae1817-f3b0-4ea8-a74f-000000000003, beae1817-f3b0-4ea8-a74f-000000000004
+    return sdata.intValue + cdata.s1.intValue; // beae1817-f3b0-4ea8-a74f-000000000001, beae1817-f3b0-4ea8-a74f-000000000002
   }
 
   public static class SimpleData {

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot05.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot05.java
@@ -23,13 +23,13 @@ public class CapturedSnapshot05 {
       if (arg == 1)
         throw new IllegalArgumentException("nope!");
       throw new FileNotFoundException("not there");
-    } catch (IllegalStateException ex) {
+    } catch (IllegalStateException ex) { // beae1817-f3b0-4ea8-a74f-000000000001
       // swallowed with empty catch block
     } catch (IllegalArgumentException ex) {
-      ex.printStackTrace();
+      ex.printStackTrace(); // beae1817-f3b0-4ea8-a74f-000000000002
       return 0;
     } catch (Throwable ex) {
-      return -1;
+      return -1; // beae1817-f3b0-4ea8-a74f-000000000003
     }
     return 42;
   }

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot06.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot06.java
@@ -21,7 +21,7 @@ public class CapturedSnapshot06 {
     strValue = "done";
     strList.add(strValue);
     strMap.put("foo", "bar");
-    return 42;
+    return 42; // beae1817-f3b0-4ea8-a74f-000000000001
   }
 
   public static int main(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot07.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot07.java
@@ -34,7 +34,7 @@ public class CapturedSnapshot07 {
   private int staticLambda(String arg) {
     Function<String, String> func = s -> {
       int idx = s.indexOf('@');
-      if (idx >= 0) {
+      if (idx >= 0) { // beae1817-f3b0-4ea8-a74f-000000000001
         return s.substring(idx);
       }
       return s.substring(0);
@@ -45,7 +45,7 @@ public class CapturedSnapshot07 {
   private int capturingLambda(String arg) {
     Function<String, String> func = s -> {
       int idx = strValue.indexOf('@');
-      if (idx >= 0) {
+      if (idx >= 0) { // beae1817-f3b0-4ea8-a74f-000000000002
         return strValue.substring(idx);
       }
       return strValue.substring(0);
@@ -55,7 +55,7 @@ public class CapturedSnapshot07 {
 
   private int multiLambda(String arg) {
     return (int)Arrays.stream(arg.split(","))
-        .map(s -> s.toUpperCase()).filter(s -> s.startsWith("FOO"))
+        .map(s -> s.toUpperCase()).filter(s -> s.startsWith("FOO")) // beae1817-f3b0-4ea8-a74f-000000000003
         .count();
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot08.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot08.java
@@ -5,13 +5,13 @@ public class CapturedSnapshot08 {
     return INSTANCE.doit(arg);
   }
 
-  private int doit(String arg) {
-    int var1 = 1;
+  private int doit(String arg) { // beae1817-f3b0-4ea8-a74f-000000000002
+    int var1 = 1; // beae1817-f3b0-4ea8-a74f-000000000001
     if (Integer.parseInt(arg) == 2) {
       var1 = 2;
       return var1;
     }
-    var1 = 3;
+    var1 = 3; // beae1817-f3b0-4ea8-a74f-000000000003, beae1817-f3b0-4ea8-a74f-000000000004
     return var1;
   }
 

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot101.scala
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot101.scala
@@ -1,6 +1,6 @@
 class CapturedSnapshot101 {
   def f1(value: Int) = {
-    value
+    value // beae1817-f3b0-4ea8-a74f-000000000001
   }
   def f2(value: Int) = {
     value

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot201.groovy
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot201.groovy
@@ -1,7 +1,7 @@
 class CapturedSnapshot201 {
 
   def f1(int value) {
-    value
+    value // beae1817-f3b0-4ea8-a74f-000000000001
   }
 
   def f2(int value) {

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot301.kt
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot301.kt
@@ -1,7 +1,7 @@
 class CapturedSnapshot301 {
 
   fun f1(value: Int): Int {
-    return value
+    return value // beae1817-f3b0-4ea8-a74f-000000000001
   }
 
   fun f2(value: Int): Int {

--- a/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot302.kt
+++ b/dd-java-agent/agent-debugger/src/test/resources/CapturedSnapshot302.kt
@@ -6,7 +6,7 @@ class CapturedSnapshot302 {
   val list: MutableList<Int> = mutableListOf()
 
   suspend fun process(arg: String): Int {
-    println(intField)
+    println(intField) // beae1817-f3b0-4ea8-a74f-000000000001
     try {
       list.add(1)
       val content = download(arg)

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot10.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot10.java
@@ -8,7 +8,7 @@ public class CapturedSnapshot10 {
       return topLevel01.process(42);
     }
     if (Integer.parseInt(arg) == 2) {
-      var1 = 2;
+      var1 = 2; // beae1817-f3b0-4ea8-a74f-000000000001
       return var1;
     }
     var1 = 3;
@@ -18,6 +18,6 @@ public class CapturedSnapshot10 {
 
 class TopLevel01 {
   public int process(int arg) {
-    return arg * arg;
+    return arg * arg; // beae1817-f3b0-4ea8-a74f-000000000002
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot11.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot11.java
@@ -7,7 +7,7 @@ public class CapturedSnapshot11 {
       return var1;
     }
     if (Integer.parseInt(arg) == 2) {
-      var1 = 2;
+      var1 = 2; // beae1817-f3b0-4ea8-a74f-000000000001
       return var1;
     }
     var1 = 3;

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot18.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot18.java
@@ -11,7 +11,7 @@ public class CapturedSnapshot18 {
       Integer.parseInt("a");
     } catch (Exception ex) {
       ex.fillInStackTrace();
-      ex.printStackTrace();
+      ex.printStackTrace(); // beae1817-f3b0-4ea8-a74f-000000000001
     }
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot20.java
@@ -44,7 +44,7 @@ public class CapturedSnapshot20 {
 
   private int process(String arg) {
     int intLocal = intField + 42;
-    return intLocal;
+    return intLocal; // beae1817-f3b0-4ea8-a74f-000000000001
   }
 
   private int processWithException(String arg) {

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot21.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot21.java
@@ -64,6 +64,6 @@ public class CapturedSnapshot21 {
   }
 
   private int process3(String arg) {
-    return intField;
+    return intField; // beae1817-f3b0-4ea8-a74f-000000000001
   }
 }

--- a/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot29.java
+++ b/dd-java-agent/agent-debugger/src/test/resources/com/datadog/debugger/CapturedSnapshot29.java
@@ -26,7 +26,7 @@ record MyRecord1(String firstName, String lastName, int age) {}
 record MyRecord2(String firstName, String lastName, int age) {
 
   MyRecord2 {
-    Objects.requireNonNull(firstName);
+    Objects.requireNonNull(firstName); // beae1817-f3b0-4ea8-a74f-000000000001
     Objects.requireNonNull(lastName);
     if (age < 0) {
       throw new IllegalArgumentException("age < 0");


### PR DESCRIPTION
# What Does This Do
line probe in unit tests are created by searching probe id (UUID) inside the targeted source file.
uuid are added as comment on the line we want to put a line probe. Add helper method to search a uuid inside the targeted source file and returns the line number used to create the line probe


# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
