### PR TITLE
Remove redundant setJavaVersion calls in gradle

### DIFF
--- a/dd-java-agent/instrumentation/java-lang/build.gradle
+++ b/dd-java-agent/instrumentation/java-lang/build.gradle
@@ -12,8 +12,3 @@ addTestSuiteForDir('latestDepTest', 'test')
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
-
-tasks.compileTestJava.configure {
-  setJavaVersion(it, 8)
-}
-

--- a/dd-java-agent/instrumentation/java-net/build.gradle
+++ b/dd-java-agent/instrumentation/java-net/build.gradle
@@ -12,8 +12,3 @@ addTestSuiteForDir('latestDepTest', 'test')
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
-
-tasks.compileTestJava.configure {
-  setJavaVersion(it, 8)
-}
-

--- a/dd-java-agent/instrumentation/javax-naming/build.gradle
+++ b/dd-java-agent/instrumentation/javax-naming/build.gradle
@@ -12,9 +12,3 @@ addTestSuiteForDir('latestDepTest', 'test')
 dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:iast-instrumenter')
 }
-
-
-tasks.compileTestJava.configure {
-  setJavaVersion(it, 8)
-}
-


### PR DESCRIPTION
# What Does This Do
Remove redundant calls to `setJavaVersion(it, 8)` in `build.gradle` files. This is already the default.

# Motivation
Prep work for decoupling of gradle JDK and build/test JDK.

# Additional Notes

Split out from https://github.com/DataDog/dd-trace-java/pull/7506

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket:  [APMJAVA-1342](https://datadoghq.atlassian.net/browse/APMJAVA-1342)

[APMJAVA-1342]: https://datadoghq.atlassian.net/browse/APMJAVA-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ