### PR TITLE
Update metrics: appsec.waf.updates and appsec.waf.init

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/WafMetricCollector.java
@@ -55,16 +55,17 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
    */
   private static String rulesVersion = "";
 
-  public void wafInit(final String wafVersion, final String rulesVersion) {
+  public void wafInit(final String wafVersion, final String rulesVersion, final boolean success) {
     WafMetricCollector.wafVersion = wafVersion;
     WafMetricCollector.rulesVersion = rulesVersion;
     rawMetricsQueue.offer(
-        new WafInitRawMetric(wafInitCounter.incrementAndGet(), wafVersion, rulesVersion));
+        new WafInitRawMetric(wafInitCounter.incrementAndGet(), wafVersion, rulesVersion, success));
   }
 
-  public void wafUpdates(final String rulesVersion) {
+  public void wafUpdates(final String rulesVersion, final boolean success) {
     rawMetricsQueue.offer(
-        new WafUpdatesRawMetric(wafUpdatesCounter.incrementAndGet(), wafVersion, rulesVersion));
+        new WafUpdatesRawMetric(
+            wafUpdatesCounter.incrementAndGet(), wafVersion, rulesVersion, success));
 
     // Flush request metrics to get the new version.
     if (rulesVersion != null
@@ -249,20 +250,31 @@ public class WafMetricCollector implements MetricCollector<WafMetricCollector.Wa
 
   public static class WafInitRawMetric extends WafMetric {
     public WafInitRawMetric(
-        final long counter, final String wafVersion, final String rulesVersion) {
+        final long counter,
+        final String wafVersion,
+        final String rulesVersion,
+        final boolean success) {
       super(
-          "waf.init", counter, "waf_version:" + wafVersion, "event_rules_version:" + rulesVersion);
+          "waf.init",
+          counter,
+          "waf_version:" + wafVersion,
+          "event_rules_version:" + rulesVersion,
+          "success:" + success);
     }
   }
 
   public static class WafUpdatesRawMetric extends WafMetric {
     public WafUpdatesRawMetric(
-        final long counter, final String wafVersion, final String rulesVersion) {
+        final long counter,
+        final String wafVersion,
+        final String rulesVersion,
+        final boolean success) {
       super(
           "waf.updates",
           counter,
           "waf_version:" + wafVersion,
-          "event_rules_version:" + rulesVersion);
+          "event_rules_version:" + rulesVersion,
+          "success:" + success);
     }
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/WafMetricCollectorTest.groovy
@@ -18,9 +18,9 @@ class WafMetricCollectorTest extends DDSpecification {
 
   def "put-get waf/rasp metrics"() {
     when:
-    WafMetricCollector.get().wafInit('waf_ver1', 'rules.1')
-    WafMetricCollector.get().wafUpdates('rules.2')
-    WafMetricCollector.get().wafUpdates('rules.3')
+    WafMetricCollector.get().wafInit('waf_ver1', 'rules.1', true)
+    WafMetricCollector.get().wafUpdates('rules.2', true)
+    WafMetricCollector.get().wafUpdates('rules.3', false)
     WafMetricCollector.get().wafRequest()
     WafMetricCollector.get().wafRequest()
     WafMetricCollector.get().wafRequest()
@@ -43,21 +43,21 @@ class WafMetricCollectorTest extends DDSpecification {
     initMetric.value == 1
     initMetric.namespace == 'appsec'
     initMetric.metricName == 'waf.init'
-    initMetric.tags.toSet() == ['waf_version:waf_ver1', 'event_rules_version:rules.1'].toSet()
+    initMetric.tags.toSet() == ['waf_version:waf_ver1', 'event_rules_version:rules.1', 'success:true'].toSet()
 
     def updateMetric1 = (WafMetricCollector.WafUpdatesRawMetric)metrics[1]
     updateMetric1.type == 'count'
     updateMetric1.value == 1
     updateMetric1.namespace == 'appsec'
     updateMetric1.metricName == 'waf.updates'
-    updateMetric1.tags.toSet() == ['waf_version:waf_ver1', 'event_rules_version:rules.2'].toSet()
+    updateMetric1.tags.toSet() == ['waf_version:waf_ver1', 'event_rules_version:rules.2', 'success:true'].toSet()
 
     def updateMetric2 = (WafMetricCollector.WafUpdatesRawMetric)metrics[2]
     updateMetric2.type == 'count'
     updateMetric2.value == 2
     updateMetric2.namespace == 'appsec'
     updateMetric2.metricName == 'waf.updates'
-    updateMetric2.tags.toSet() == ['waf_version:waf_ver1', 'event_rules_version:rules.3'].toSet()
+    updateMetric2.tags.toSet() == ['waf_version:waf_ver1', 'event_rules_version:rules.3', 'success:false'].toSet()
 
     def requestMetric = (WafMetricCollector.WafRequestsRawMetric)metrics[3]
     requestMetric.namespace == 'appsec'
@@ -140,7 +140,7 @@ class WafMetricCollectorTest extends DDSpecification {
 
     when:
     (0..limit*2).each {
-      collector.wafInit("foo", "bar")
+      collector.wafInit("foo", "bar", true)
     }
 
     then:
@@ -149,7 +149,7 @@ class WafMetricCollectorTest extends DDSpecification {
 
     when:
     (0..limit*2).each {
-      collector.wafUpdates("bar")
+      collector.wafUpdates("bar", true)
     }
 
     then:
@@ -298,7 +298,7 @@ class WafMetricCollectorTest extends DDSpecification {
 
   def "test Rasp #ruleType metrics"() {
     when:
-    WafMetricCollector.get().wafInit('waf_ver1', 'rules.1')
+    WafMetricCollector.get().wafInit('waf_ver1', 'rules.1', true)
     WafMetricCollector.get().raspRuleEval(ruleType)
     WafMetricCollector.get().raspRuleEval(ruleType)
     WafMetricCollector.get().raspRuleMatch(ruleType)


### PR DESCRIPTION
# What Does This Do
This adds a new value to some metrics which is necessary for the consolidation of ASM Span Tags, Metrics, and Logs across all supported languages. The newly value will be implemented in the following metrics:
- **appsec.waf.updates**:
  - _success_: Whether the update resulted in a usable WAF handle
- **appsec.waf.init**:
  - _success_: Whether the initialization resulted in a usable WAF handle

# Motivation
Our goal is to implement all the missing ASM Span Tags, Metrics, and Logs.

# Additional Notes
Also, this PR adds tests that were missing and some improvements to the previous ones.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [APPSEC-56478]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
