### PR TITLE
Use two budgets depending on type

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -43,7 +43,7 @@ public class DebuggerContext {
     BUDGET {
       @Override
       public String tag() {
-        return "cause:budget exceeded";
+        return "cause:budget_exceeded";
       }
     };
 

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/DebuggerContext.java
@@ -39,6 +39,12 @@ public class DebuggerContext {
       public String tag() {
         return "cause:debug session disabled";
       }
+    },
+    BUDGET {
+      @Override
+      public String tag() {
+        return "cause:budget exceeded";
+      }
     };
 
     public abstract String tag();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -63,7 +63,8 @@ public class LogProbe extends ProbeDefinition implements Sampled {
   private static final Limits LIMITS = new Limits(1, 3, 8192, 5);
   private static final int LOG_MSG_LIMIT = 8192;
 
-  public static final int PROBE_BUDGET = 10;
+  public static final int CAPTURING_PROBE_BUDGET = 10;
+  public static final int NON_CAPTURING_PROBE_BUDGET = 1000;
 
   /** Stores part of a templated message either a str or an expression */
   public static class Segment {
@@ -870,7 +871,9 @@ public class LogProbe extends ProbeDefinition implements Sampled {
 
   private boolean inBudget() {
     AtomicInteger budgetLevel = getBudgetLevel();
-    return budgetLevel == null || budgetLevel.get() <= PROBE_BUDGET;
+    return budgetLevel == null
+        || budgetLevel.get()
+            <= (captureSnapshot ? CAPTURING_PROBE_BUDGET : NON_CAPTURING_PROBE_BUDGET);
   }
 
   private AtomicInteger getBudgetLevel() {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/sink/SnapshotSink.java
@@ -53,10 +53,6 @@ public class SnapshotSink {
     this.snapshotUploader = snapshotUploader;
   }
 
-  public BlockingQueue<Snapshot> getLowRateSnapshots() {
-    return lowRateSnapshots;
-  }
-
   public void start() {
     if (started.compareAndSet(false, true)) {
       highRateScheduled =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -110,9 +110,12 @@ public class LogProbeTest {
       logProbe.evaluate(entryContext, new LogStatus(logProbe), MethodLocation.ENTRY);
       logProbe.evaluate(exitContext, new LogStatus(logProbe), MethodLocation.EXIT);
 
-      for (int i = 0; i < 20; i++) {
+      for (int i = 0; i < LogProbe.PROBE_BUDGET * 2; i++) {
         logProbe.commit(entryContext, exitContext, emptyList());
       }
+      assertEquals(
+          LogProbe.PROBE_BUDGET * 2,
+          span.getLocalRootSpan().getTag(format("_dd.ld.probe_id.%s", logProbe.id)));
     }
   }
 


### PR DESCRIPTION
# What Does This Do
This makes distinct budgets for capturing vs non-capture snapshot probes.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DEBUG-3378]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-3378]: https://datadoghq.atlassian.net/browse/DEBUG-3378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ