### PR TITLE
Remove skip and shouldBeSkipped methods from TestEventsHandler in favor of isSkippable

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestFrameworkModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestFrameworkModule.java
@@ -31,21 +31,12 @@ public interface TestFrameworkModule {
   boolean isModified(TestSourceData testSourceData);
 
   /**
-   * Checks if a given test should be skipped with Intelligent Test Runner or not
+   * Checks if a given test can be skipped with Intelligent Test Runner or not.
    *
    * @param test Test to be checked
    * @return {@code true} if the test can be skipped, {@code false} otherwise
    */
-  boolean shouldBeSkipped(TestIdentifier test);
-
-  /**
-   * Checks if a given test can be skipped with Intelligent Test Runner or not. If the test is
-   * considered skippable, the count of skippable tests is incremented.
-   *
-   * @param test Test to be checked
-   * @return {@code true} if the test can be skipped, {@code false} otherwise
-   */
-  boolean skip(TestIdentifier test);
+  boolean isSkippable(TestIdentifier test);
 
   @Nonnull
   TestRetryPolicy retryPolicy(TestIdentifier test, TestSourceData testSource);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestSuiteImpl.java
@@ -22,6 +22,7 @@ import datadog.trace.civisibility.decorator.TestDecorator;
 import datadog.trace.civisibility.source.LinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
 import datadog.trace.civisibility.source.SourceResolutionException;
+import datadog.trace.civisibility.test.ExecutionResults;
 import datadog.trace.civisibility.utils.SpanUtils;
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -49,6 +50,7 @@ public class TestSuiteImpl implements DDTestSuite {
   private final Codeowners codeowners;
   private final LinesResolver linesResolver;
   private final CoverageStore.Factory coverageStoreFactory;
+  private final ExecutionResults executionResults;
   private final boolean parallelized;
   private final Consumer<AgentSpan> onSpanFinish;
 
@@ -69,6 +71,7 @@ public class TestSuiteImpl implements DDTestSuite {
       Codeowners codeowners,
       LinesResolver linesResolver,
       CoverageStore.Factory coverageStoreFactory,
+      ExecutionResults executionResults,
       Consumer<AgentSpan> onSpanFinish) {
     this.moduleSpanContext = moduleSpanContext;
     this.moduleName = moduleName;
@@ -84,6 +87,7 @@ public class TestSuiteImpl implements DDTestSuite {
     this.codeowners = codeowners;
     this.linesResolver = linesResolver;
     this.coverageStoreFactory = coverageStoreFactory;
+    this.executionResults = executionResults;
     this.onSpanFinish = onSpanFinish;
 
     AgentTracer.SpanBuilder spanBuilder =
@@ -254,6 +258,7 @@ public class TestSuiteImpl implements DDTestSuite {
         linesResolver,
         codeowners,
         coverageStoreFactory,
+        executionResults,
         SpanUtils.propagateCiVisibilityTagsTo(span));
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
@@ -22,6 +22,7 @@ import datadog.trace.civisibility.domain.TestFrameworkModule;
 import datadog.trace.civisibility.domain.TestSuiteImpl;
 import datadog.trace.civisibility.source.LinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
+import datadog.trace.civisibility.test.ExecutionResults;
 import datadog.trace.civisibility.test.ExecutionStrategy;
 import datadog.trace.civisibility.utils.SpanUtils;
 import java.util.function.Consumer;
@@ -39,6 +40,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
 
   private final CoverageStore.Factory coverageStoreFactory;
   private final ExecutionStrategy executionStrategy;
+  private final ExecutionResults executionResults;
 
   public HeadlessTestModule(
       AgentSpanContext sessionSpanContext,
@@ -67,6 +69,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
         onSpanFinish);
     this.coverageStoreFactory = coverageStoreFactory;
     this.executionStrategy = executionStrategy;
+    this.executionResults = new ExecutionResults();
   }
 
   @Override
@@ -85,13 +88,8 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
   }
 
   @Override
-  public boolean shouldBeSkipped(TestIdentifier test) {
-    return executionStrategy.shouldBeSkipped(test);
-  }
-
-  @Override
-  public boolean skip(TestIdentifier test) {
-    return executionStrategy.skip(test);
+  public boolean isSkippable(TestIdentifier test) {
+    return executionStrategy.isSkippable(test);
   }
 
   @Override
@@ -111,7 +109,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
       setTag(Tags.TEST_ITR_TESTS_SKIPPING_ENABLED, true);
       setTag(Tags.TEST_ITR_TESTS_SKIPPING_TYPE, "test");
 
-      long testsSkippedTotal = executionStrategy.getTestsSkipped();
+      long testsSkippedTotal = executionResults.getTestsSkippedByItr();
       setTag(Tags.TEST_ITR_TESTS_SKIPPING_COUNT, testsSkippedTotal);
       if (testsSkippedTotal > 0) {
         setTag(DDTags.CI_ITR_TESTS_SKIPPED, true);
@@ -154,6 +152,7 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
         codeowners,
         linesResolver,
         coverageStoreFactory,
+        executionResults,
         SpanUtils.propagateCiVisibilityTagsTo(span));
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/manualapi/ManualApiTestModule.java
@@ -14,6 +14,7 @@ import datadog.trace.civisibility.domain.InstrumentationType;
 import datadog.trace.civisibility.domain.TestSuiteImpl;
 import datadog.trace.civisibility.source.LinesResolver;
 import datadog.trace.civisibility.source.SourcePathResolver;
+import datadog.trace.civisibility.test.ExecutionResults;
 import datadog.trace.civisibility.utils.SpanUtils;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -25,6 +26,7 @@ import javax.annotation.Nullable;
 public class ManualApiTestModule extends AbstractTestModule implements DDTestModule {
 
   private final CoverageStore.Factory coverageStoreFactory;
+  private final ExecutionResults executionResults = new ExecutionResults();
 
   public ManualApiTestModule(
       AgentSpanContext sessionSpanContext,
@@ -76,6 +78,7 @@ public class ManualApiTestModule extends AbstractTestModule implements DDTestMod
         codeowners,
         linesResolver,
         coverageStoreFactory,
+        executionResults,
         SpanUtils.propagateCiVisibilityTagsTo(span));
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
@@ -91,12 +91,7 @@ public class NoOpTestEventsHandler<SuiteKey, TestKey>
   }
 
   @Override
-  public boolean skip(TestIdentifier test) {
-    return false;
-  }
-
-  @Override
-  public boolean shouldBeSkipped(TestIdentifier test) {
+  public boolean isSkippable(TestIdentifier test) {
     return false;
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -187,7 +187,7 @@ public class TestEventsHandlerImpl<SuiteKey, TestKey>
           test.setTag(Tags.TEST_ITR_UNSKIPPABLE, true);
           metricCollector.add(CiVisibilityCountMetric.ITR_UNSKIPPABLE, 1, EventType.TEST);
 
-          if (testModule.shouldBeSkipped(thisTest)) {
+          if (testModule.isSkippable(thisTest)) {
             test.setTag(Tags.TEST_ITR_FORCED_RUN, true);
             metricCollector.add(CiVisibilityCountMetric.ITR_FORCED_RUN, 1, EventType.TEST);
           }
@@ -261,16 +261,6 @@ public class TestEventsHandlerImpl<SuiteKey, TestKey>
   }
 
   @Override
-  public boolean skip(TestIdentifier test) {
-    return testModule.skip(test);
-  }
-
-  @Override
-  public boolean shouldBeSkipped(TestIdentifier test) {
-    return testModule.shouldBeSkipped(test);
-  }
-
-  @Override
   @Nonnull
   public TestRetryPolicy retryPolicy(TestIdentifier test, TestSourceData testSource) {
     return testModule.retryPolicy(test, testSource);
@@ -284,6 +274,11 @@ public class TestEventsHandlerImpl<SuiteKey, TestKey>
   @Override
   public boolean isFlaky(TestIdentifier test) {
     return testModule.isFlaky(test);
+  }
+
+  @Override
+  public boolean isSkippable(TestIdentifier test) {
+    return testModule.isSkippable(test);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionResults.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionResults.java
@@ -1,0 +1,16 @@
+package datadog.trace.civisibility.test;
+
+import java.util.concurrent.atomic.LongAdder;
+
+public class ExecutionResults {
+
+  private final LongAdder testsSkippedByItr = new LongAdder();
+
+  public void incrementTestsSkippedByItr() {
+    testsSkippedByItr.increment();
+  }
+
+  public long getTestsSkippedByItr() {
+    return testsSkippedByItr.sum();
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/test/ExecutionStrategy.java
@@ -16,7 +16,6 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.LongAdder;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +24,6 @@ public class ExecutionStrategy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ExecutionStrategy.class);
 
-  private final LongAdder testsSkipped = new LongAdder();
   private final AtomicInteger earlyFlakeDetectionsUsed = new AtomicInteger(0);
   private final AtomicInteger autoRetriesUsed = new AtomicInteger(0);
 
@@ -50,10 +48,6 @@ public class ExecutionStrategy {
     return executionSettings;
   }
 
-  public long getTestsSkipped() {
-    return testsSkipped.sum();
-  }
-
   public boolean isNew(TestIdentifier test) {
     Collection<TestIdentifier> knownTests = executionSettings.getKnownTests();
     return knownTests != null && !knownTests.contains(test.withoutParameters());
@@ -64,7 +58,7 @@ public class ExecutionStrategy {
     return flakyTests != null && flakyTests.contains(test.withoutParameters());
   }
 
-  public boolean shouldBeSkipped(TestIdentifier test) {
+  public boolean isSkippable(TestIdentifier test) {
     if (test == null) {
       return false;
     }
@@ -76,15 +70,6 @@ public class ExecutionStrategy {
     return testMetadata != null
         && !(config.isCiVisibilityCoverageLinesEnabled()
             && testMetadata.isMissingLineCodeCoverage());
-  }
-
-  public boolean skip(TestIdentifier test) {
-    if (shouldBeSkipped(test)) {
-      testsSkipped.increment();
-      return true;
-    } else {
-      return false;
-    }
   }
 
   @Nonnull

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/TestImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/TestImplTest.groovy
@@ -16,6 +16,7 @@ import datadog.trace.civisibility.decorator.TestDecoratorImpl
 import datadog.trace.civisibility.source.LinesResolver
 import datadog.trace.civisibility.source.NoOpSourcePathResolver
 import datadog.trace.civisibility.telemetry.CiVisibilityMetricCollectorImpl
+import datadog.trace.civisibility.test.ExecutionResults
 import datadog.trace.civisibility.utils.SpanUtils
 
 class TestImplTest extends SpanWriterTest {
@@ -97,6 +98,7 @@ class TestImplTest extends SpanWriterTest {
     def testFramework = TestFrameworkInstrumentation.OTHER
     def config = Config.get()
     def metricCollector = Stub(CiVisibilityMetricCollectorImpl)
+    def executionResults = Stub(ExecutionResults)
     def testDecorator = new TestDecoratorImpl("component", "session-name", "test-command", [:])
 
     def linesResolver = Stub(LinesResolver)
@@ -123,6 +125,7 @@ class TestImplTest extends SpanWriterTest {
       linesResolver,
       codeowners,
       coverageStoreFactory,
+      executionResults,
       SpanUtils.DO_NOT_PROPAGATE_CI_VISIBILITY_TAGS
       )
   }

--- a/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/TestSuiteImplTest.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/test/groovy/datadog/trace/civisibility/domain/TestSuiteImplTest.groovy
@@ -14,6 +14,7 @@ import datadog.trace.civisibility.decorator.TestDecoratorImpl
 import datadog.trace.civisibility.source.LinesResolver
 import datadog.trace.civisibility.source.SourcePathResolver
 import datadog.trace.civisibility.telemetry.CiVisibilityMetricCollectorImpl
+import datadog.trace.civisibility.test.ExecutionResults
 import datadog.trace.civisibility.utils.SpanUtils
 
 class TestSuiteImplTest extends SpanWriterTest {
@@ -53,6 +54,7 @@ class TestSuiteImplTest extends SpanWriterTest {
     def testFramework = TestFrameworkInstrumentation.OTHER
     def config = Config.get()
     def metricCollector = Stub(CiVisibilityMetricCollectorImpl)
+    def executionResults = Stub(ExecutionResults)
     def testDecorator = new TestDecoratorImpl("component", "session-name", "test-command", [:])
 
     def linesResolver = Stub(LinesResolver)
@@ -82,6 +84,7 @@ class TestSuiteImplTest extends SpanWriterTest {
       codeowners,
       linesResolver,
       coverageStoreFactory,
+      executionResults,
       SpanUtils.DO_NOT_PROPAGATE_CI_VISIBILITY_TAGS
       )
   }

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/JUnit4CucumberItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/JUnit4CucumberItrInstrumentation.java
@@ -86,7 +86,7 @@ public class JUnit4CucumberItrInstrumentation extends InstrumenterModule.CiVisib
       }
 
       TestIdentifier test = CucumberUtils.toTestIdentifier(description);
-      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(test)) {
+      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(test)) {
         notifier.fireTestAssumptionFailed(
             new Failure(
                 description,

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4ItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4ItrInstrumentation.java
@@ -99,7 +99,7 @@ public class JUnit4ItrInstrumentation extends InstrumenterModule.CiVisibility
       }
 
       TestIdentifier test = JUnit4Utils.toTestIdentifier(description);
-      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(test)) {
+      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(test)) {
         Description skippedDescription = JUnit4Utils.getSkippedDescription(description);
         notifier.fireTestIgnored(skippedDescription);
         return Boolean.FALSE;

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5CucumberItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5CucumberItrInstrumentation.java
@@ -101,7 +101,7 @@ public class JUnit5CucumberItrInstrumentation extends InstrumenterModule.CiVisib
       }
 
       TestIdentifier test = CucumberUtils.toTestIdentifier(testDescriptor);
-      if (test != null && TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(test)) {
+      if (test != null && TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(test)) {
         skipResult = Node.SkipResult.skip(InstrumentationBridge.ITR_SKIP_REASON);
       }
     }

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockItrInstrumentation.java
@@ -80,6 +80,7 @@ public class JUnit5SpockItrInstrumentation extends InstrumenterModule.CiVisibili
       CallDepthThreadLocalMap.incrementCallDepth(SpockNode.class);
     }
 
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @SuppressFBWarnings(
         value = "UC_USELESS_OBJECT",
         justification = "skipResult is the return value of the instrumented method")
@@ -117,21 +118,17 @@ public class JUnit5SpockItrInstrumentation extends InstrumenterModule.CiVisibili
 
           TestIdentifier featureIdentifier = SpockUtils.toTestIdentifier(feature);
           if (featureIdentifier == null
-              || !TestEventsHandlerHolder.TEST_EVENTS_HANDLER.shouldBeSkipped(featureIdentifier)) {
+              || !TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(featureIdentifier)) {
             return;
           }
         }
 
-        // all children are skippable
-        for (TestDescriptor feature : features) {
-          TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(SpockUtils.toTestIdentifier(feature));
-        }
         skipResult = Node.SkipResult.skip(InstrumentationBridge.ITR_SKIP_REASON);
 
       } else {
         // individual test case
         TestIdentifier test = SpockUtils.toTestIdentifier(spockNode);
-        if (test != null && TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(test)) {
+        if (test != null && TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(test)) {
           skipResult = Node.SkipResult.skip(InstrumentationBridge.ITR_SKIP_REASON);
         }
       }

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/retry/JUnit5SpockParameterizedRetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/retry/JUnit5SpockParameterizedRetryInstrumentation.java
@@ -59,6 +59,7 @@ public class JUnit5SpockParameterizedRetryInstrumentation extends InstrumenterMo
 
   public static class SpockParameterizedRetryAdvice {
 
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @SuppressFBWarnings(
         value = "UC_USELESS_OBJECT",
         justification = "executionListener is a field in the instrumented class")

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5ItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5ItrInstrumentation.java
@@ -97,7 +97,7 @@ public class JUnit5ItrInstrumentation extends InstrumenterModule.CiVisibility
       }
 
       TestIdentifier test = JUnitPlatformUtils.toTestIdentifier(testDescriptor);
-      if (test != null && TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(test)) {
+      if (test != null && TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(test)) {
         skipResult = Node.SkipResult.skip(InstrumentationBridge.ITR_SKIP_REASON);
       }
     }

--- a/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateTracingHook.java
+++ b/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateTracingHook.java
@@ -115,7 +115,7 @@ public class KarateTracingHook implements RuntimeHook {
     if (Config.get().isCiVisibilityTestSkippingEnabled()
         && !categories.contains(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)) {
       TestIdentifier skippableTest = KarateUtils.toTestIdentifier(scenario);
-      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(skippableTest)) {
+      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(skippableTest)) {
         TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestIgnore(
             suiteDescriptor,
             testDescriptor,

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/RunContext.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/RunContext.java
@@ -87,7 +87,7 @@ public class RunContext {
       unskippableTests.add(test);
       return testNameAndSkipStatus;
 
-    } else if (eventHandler.skip(test)) {
+    } else if (eventHandler.isSkippable(test)) {
       skippedTests.add(test);
       return new Tuple2<>(testName, true);
 
@@ -100,7 +100,7 @@ public class RunContext {
     if (isUnskippable(test, tags)) {
       unskippableTests.add(test);
       return false;
-    } else if (eventHandler.skip(test)) {
+    } else if (eventHandler.isSkippable(test)) {
       skippedTests.add(test);
       return true;
     } else {

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGItrInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TestNGItrInstrumentation.java
@@ -69,7 +69,7 @@ public class TestNGItrInstrumentation extends InstrumenterModule.CiVisibility
       }
 
       TestIdentifier skippableTest = TestNGUtils.toTestIdentifier(method, instance, parameters);
-      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skip(skippableTest)) {
+      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(skippableTest)) {
         throw new SkipException(InstrumentationBridge.ITR_SKIP_REASON);
       }
     }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
@@ -83,16 +83,14 @@ public interface TestEventsHandler<SuiteKey, TestKey> extends Closeable {
       @Nonnull TestSourceData testSourceData,
       @Nullable String reason);
 
-  boolean skip(TestIdentifier test);
-
-  boolean shouldBeSkipped(TestIdentifier test);
-
   @Nonnull
   TestRetryPolicy retryPolicy(TestIdentifier test, TestSourceData source);
 
   boolean isNew(TestIdentifier test);
 
   boolean isFlaky(TestIdentifier test);
+
+  boolean isSkippable(TestIdentifier test);
 
   @Override
   void close();


### PR DESCRIPTION
# What Does This Do

Removes `shouldBeSkipped` and `skip` methods from `TestEventsHandler` interface and replaces them with `isSkippable`.

# Motivation

Laying the groundwork for future test quarantining: when test quarantine is implemented, ITR will no longer be the only reason for skipping tests, so some adjustments to skipping logic will have to be made.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1483]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1483]: https://datadoghq.atlassian.net/browse/SDTEST-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ