### PR TITLE
Generalize tests skipping logic

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestFrameworkModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/TestFrameworkModule.java
@@ -3,6 +3,7 @@ package datadog.trace.civisibility.domain;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -31,12 +32,13 @@ public interface TestFrameworkModule {
   boolean isModified(TestSourceData testSourceData);
 
   /**
-   * Checks if a given test can be skipped with Intelligent Test Runner or not.
+   * Returns the reason for skipping a test, IF it can be skipped.
    *
    * @param test Test to be checked
-   * @return {@code true} if the test can be skipped, {@code false} otherwise
+   * @return skip reason, or {@code null} if the test cannot be skipped
    */
-  boolean isSkippable(TestIdentifier test);
+  @Nullable
+  SkipReason skipReason(TestIdentifier test);
 
   @Nonnull
   TestRetryPolicy retryPolicy(TestIdentifier test, TestSourceData testSource);

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/buildsystem/ProxyTestModule.java
@@ -7,6 +7,7 @@ import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
@@ -102,9 +103,10 @@ public class ProxyTestModule implements TestFrameworkModule {
     return executionStrategy.isModified(testSourceData);
   }
 
+  @Nullable
   @Override
-  public boolean isSkippable(TestIdentifier test) {
-    return executionStrategy.isSkippable(test);
+  public SkipReason skipReason(TestIdentifier test) {
+    return executionStrategy.skipReason(test);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/domain/headless/HeadlessTestModule.java
@@ -8,6 +8,7 @@ import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.coverage.CoverageStore;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpanContext;
@@ -87,9 +88,10 @@ public class HeadlessTestModule extends AbstractTestModule implements TestFramew
     return executionStrategy.isModified(testSourceData);
   }
 
+  @Nullable
   @Override
-  public boolean isSkippable(TestIdentifier test) {
-    return executionStrategy.isSkippable(test);
+  public SkipReason skipReason(TestIdentifier test) {
+    return executionStrategy.skipReason(test);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
@@ -6,6 +6,7 @@ import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.civisibility.retry.NeverRetry;
@@ -91,8 +92,8 @@ public class NoOpTestEventsHandler<SuiteKey, TestKey>
   }
 
   @Override
-  public boolean isSkippable(TestIdentifier test) {
-    return false;
+  public SkipReason skipReason(TestIdentifier test) {
+    return null;
   }
 
   @NotNull

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -12,6 +12,7 @@ import datadog.trace.api.civisibility.retry.TestRetryPolicy;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.tag.EventType;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -187,7 +188,7 @@ public class TestEventsHandlerImpl<SuiteKey, TestKey>
           test.setTag(Tags.TEST_ITR_UNSKIPPABLE, true);
           metricCollector.add(CiVisibilityCountMetric.ITR_UNSKIPPABLE, 1, EventType.TEST);
 
-          if (testModule.isSkippable(thisTest)) {
+          if (testModule.skipReason(thisTest) == SkipReason.ITR) {
             test.setTag(Tags.TEST_ITR_FORCED_RUN, true);
             metricCollector.add(CiVisibilityCountMetric.ITR_FORCED_RUN, 1, EventType.TEST);
           }
@@ -276,9 +277,10 @@ public class TestEventsHandlerImpl<SuiteKey, TestKey>
     return testModule.isFlaky(test);
   }
 
+  @Nullable
   @Override
-  public boolean isSkippable(TestIdentifier test) {
-    return testModule.isSkippable(test);
+  public SkipReason skipReason(TestIdentifier test) {
+    return testModule.skipReason(test);
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTestUtils.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTestUtils.groovy
@@ -7,6 +7,7 @@ import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.Option
 import com.jayway.jsonpath.ReadContext
 import com.jayway.jsonpath.WriteContext
+import freemarker.core.InvalidReferenceException
 import freemarker.template.Template
 import freemarker.template.TemplateExceptionHandler
 import org.skyscreamer.jsonassert.JSONAssert
@@ -130,6 +131,16 @@ abstract class CiVisibilityTestUtils {
       StringWriter coveragesOut = new StringWriter()
       coveragesTemplate.process(replacements, coveragesOut)
       return coveragesOut.toString()
+    } catch (InvalidReferenceException e) {
+      def missingExpression = e.getBlamedExpressionString()
+      if (missingExpression != null) {
+        replacements.put(missingExpression, "<VALUE_MISSING>") // to simplify debugging failures
+        return getFreemarkerTemplate(templatePath, replacements, replacementsSource)
+
+      } else {
+        throw new RuntimeException("Could not get Freemarker template " + templatePath + "; replacements map: " + replacements + "; replacements source: " + replacementsSource, e)
+      }
+
     } catch (Exception e) {
       throw new RuntimeException("Could not get Freemarker template " + templatePath + "; replacements map: " + replacements + "; replacements source: " + replacementsSource, e)
     }

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/JUnit4CucumberInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/JUnit4CucumberInstrumentation.java
@@ -36,7 +36,7 @@ public class JUnit4CucumberInstrumentation extends InstrumenterModule.CiVisibili
     return new String[] {
       packageName + ".CucumberUtils",
       packageName + ".TestEventsHandlerHolder",
-      packageName + ".SkippedByItr",
+      packageName + ".SkippedByDatadog",
       packageName + ".JUnit4Utils",
       packageName + ".TracingListener",
       packageName + ".CucumberTracingListener",

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/retry/Cucumber4RetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/main/java/datadog/trace/instrumentation/junit4/retry/Cucumber4RetryInstrumentation.java
@@ -49,7 +49,7 @@ public class Cucumber4RetryInstrumentation extends InstrumenterModule.CiVisibili
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      parentPackageName + ".SkippedByItr",
+      parentPackageName + ".SkippedByDatadog",
       parentPackageName + ".CucumberUtils",
       parentPackageName + ".JUnit4Utils",
       parentPackageName + ".TracingListener",
@@ -79,6 +79,7 @@ public class Cucumber4RetryInstrumentation extends InstrumenterModule.CiVisibili
   }
 
   public static class RetryAdvice {
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @SuppressFBWarnings("NP_BOOLEAN_RETURN_NULL")
     @Advice.OnMethodEnter(skipOn = Boolean.class)
     public static Boolean retryIfNeeded(

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/main/java/datadog/trace/instrumentation/junit4/MUnitInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/main/java/datadog/trace/instrumentation/junit4/MUnitInstrumentation.java
@@ -33,7 +33,7 @@ public class MUnitInstrumentation extends InstrumenterModule.CiVisibility
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".TestEventsHandlerHolder",
-      packageName + ".SkippedByItr",
+      packageName + ".SkippedByDatadog",
       packageName + ".JUnit4Utils",
       packageName + ".MUnitUtils",
       packageName + ".TracingListener",

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/main/java/datadog/trace/instrumentation/junit4/retry/MUnitRetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/main/java/datadog/trace/instrumentation/junit4/retry/MUnitRetryInstrumentation.java
@@ -50,7 +50,7 @@ public class MUnitRetryInstrumentation extends InstrumenterModule.CiVisibility
   public String[] helperClassNames() {
     return new String[] {
       parentPackageName + ".MUnitUtils",
-      parentPackageName + ".SkippedByItr",
+      parentPackageName + ".SkippedByDatadog",
       parentPackageName + ".JUnit4Utils",
       parentPackageName + ".TracingListener",
       parentPackageName + ".TestEventsHandlerHolder",
@@ -72,6 +72,7 @@ public class MUnitRetryInstrumentation extends InstrumenterModule.CiVisibility
   }
 
   public static class RetryAdvice {
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @Advice.OnMethodEnter(skipOn = Future.class)
     public static Future<?> retryIfNeeded(
         @Advice.Origin Method runTest,
@@ -118,6 +119,7 @@ public class MUnitRetryInstrumentation extends InstrumenterModule.CiVisibility
       return result;
     }
 
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @SuppressFBWarnings(
         value = "UC_USELESS_OBJECT",
         justification = "result is the return value of the original method")

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Instrumentation.java
@@ -65,7 +65,7 @@ public class JUnit4Instrumentation extends InstrumenterModule.CiVisibility
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".TestEventsHandlerHolder",
-      packageName + ".SkippedByItr",
+      packageName + ".SkippedByDatadog",
       packageName + ".JUnit4Utils",
       packageName + ".TracingListener",
       packageName + ".JUnit4TracingListener",

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4SuiteEventsInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4SuiteEventsInstrumentation.java
@@ -40,7 +40,7 @@ public class JUnit4SuiteEventsInstrumentation extends InstrumenterModule.CiVisib
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".TestEventsHandlerHolder",
-      packageName + ".SkippedByItr",
+      packageName + ".SkippedByDatadog",
       packageName + ".JUnit4Utils",
       packageName + ".TracingListener",
       packageName + ".JUnit4TracingListener",

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnit4Utils.java
@@ -6,6 +6,7 @@ import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.util.MethodHandles;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandle;
@@ -276,14 +277,14 @@ public abstract class JUnit4Utils {
     return METHOD_HANDLES.invoke(PARENT_RUNNER_DESCRIBE_CHILD, runner, child);
   }
 
-  public static Description getSkippedDescription(Description description) {
+  public static Description getSkippedDescription(Description description, SkipReason skipReason) {
     Collection<Annotation> annotations = description.getAnnotations();
     Annotation[] updatedAnnotations = new Annotation[annotations.size() + 1];
     int idx = 0;
     for (Annotation annotation : annotations) {
       updatedAnnotations[idx++] = annotation;
     }
-    updatedAnnotations[idx] = new SkippedByItr();
+    updatedAnnotations[idx] = new SkippedByDatadog(skipReason.getDescription());
 
     String displayName = description.getDisplayName();
     Class<?> testClass = description.getTestClass();

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnitLegacySuiteEventsInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/JUnitLegacySuiteEventsInstrumentation.java
@@ -38,7 +38,7 @@ public class JUnitLegacySuiteEventsInstrumentation extends InstrumenterModule.Ci
   public String[] helperClassNames() {
     return new String[] {
       packageName + ".TestEventsHandlerHolder",
-      packageName + ".SkippedByItr",
+      packageName + ".SkippedByDatadog",
       packageName + ".JUnit4Utils",
       packageName + ".TracingListener",
       packageName + ".JUnit4TracingListener",

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/SkippedByDatadog.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/SkippedByDatadog.java
@@ -1,13 +1,19 @@
 package datadog.trace.instrumentation.junit4;
 
-import datadog.trace.api.civisibility.InstrumentationBridge;
 import java.lang.annotation.Annotation;
 import org.junit.Ignore;
 
-public final class SkippedByItr implements Ignore {
+public final class SkippedByDatadog implements Ignore {
+
+  private final String description;
+
+  public SkippedByDatadog(String description) {
+    this.description = description;
+  }
+
   @Override
   public String value() {
-    return InstrumentationBridge.ITR_SKIP_REASON;
+    return description;
   }
 
   @Override

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/retry/JUnit4RetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/retry/JUnit4RetryInstrumentation.java
@@ -57,7 +57,7 @@ public class JUnit4RetryInstrumentation extends InstrumenterModule.CiVisibility
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      parentPackageName + ".SkippedByItr",
+      parentPackageName + ".SkippedByDatadog",
       parentPackageName + ".JUnit4Utils",
       parentPackageName + ".TracingListener",
       parentPackageName + ".TestEventsHandlerHolder",
@@ -82,6 +82,7 @@ public class JUnit4RetryInstrumentation extends InstrumenterModule.CiVisibility
   }
 
   public static class RetryAdvice {
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @SuppressFBWarnings("NP_BOOLEAN_RETURN_NULL")
     @Advice.OnMethodEnter(skipOn = Boolean.class)
     public static Boolean retryIfNeeded(

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockSkipInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SpockSkipInstrumentation.java
@@ -9,30 +9,31 @@ import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.Config;
-import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.config.TestIdentifier;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Collection;
 import java.util.Set;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.junit.platform.engine.TestDescriptor;
-import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.support.hierarchical.Node;
 import org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService;
+import org.spockframework.runtime.SpecNode;
+import org.spockframework.runtime.SpockNode;
 
 @AutoService(InstrumenterModule.class)
-public class JUnit5CucumberItrInstrumentation extends InstrumenterModule.CiVisibility
+public class JUnit5SpockSkipInstrumentation extends InstrumenterModule.CiVisibility
     implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
 
-  public JUnit5CucumberItrInstrumentation() {
-    super("ci-visibility", "junit-5", "junit-5-cucumber");
+  public JUnit5SpockSkipInstrumentation() {
+    super("ci-visibility", "junit-5", "junit-5-spock");
   }
 
   @Override
   public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
-    return hasClassNamed("io.cucumber.junit.platform.engine.CucumberTestEngine");
+    return hasClassNamed("org.spockframework.runtime.SpockEngine");
   }
 
   @Override
@@ -42,22 +43,20 @@ public class JUnit5CucumberItrInstrumentation extends InstrumenterModule.CiVisib
 
   @Override
   public String hierarchyMarkerType() {
-    return "io.cucumber.junit.platform.engine.CucumberTestEngine";
+    return "org.spockframework.runtime.SpockNode";
   }
 
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
-    return extendsClass(named("io.cucumber.junit.platform.engine.NodeDescriptor"))
-        // legacy Cucumber versions
-        .or(extendsClass(named("io.cucumber.junit.platform.engine.PickleDescriptor")));
+    return extendsClass(named(hierarchyMarkerType()));
   }
 
   @Override
   public String[] helperClassNames() {
     return new String[] {
-      packageName + ".TestDataFactory",
       packageName + ".JUnitPlatformUtils",
-      packageName + ".CucumberUtils",
+      packageName + ".TestDataFactory",
+      packageName + ".SpockUtils",
       packageName + ".TestEventsHandlerHolder",
     };
   }
@@ -66,7 +65,7 @@ public class JUnit5CucumberItrInstrumentation extends InstrumenterModule.CiVisib
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("shouldBeSkipped").and(takesArguments(1)),
-        JUnit5CucumberItrInstrumentation.class.getName() + "$JUnit5ItrAdvice");
+        JUnit5SpockSkipInstrumentation.class.getName() + "$JUnit5SkipAdvice");
   }
 
   /**
@@ -74,15 +73,26 @@ public class JUnit5CucumberItrInstrumentation extends InstrumenterModule.CiVisib
    * org.junit.platform.launcher} package in here: in some Gradle projects this package is not
    * available in CL where this instrumentation is injected
    */
-  public static class JUnit5ItrAdvice {
+  public static class JUnit5SkipAdvice {
 
+    @Advice.OnMethodEnter
+    public static void beforeSkipCheck() {
+      CallDepthThreadLocalMap.incrementCallDepth(SpockNode.class);
+    }
+
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @SuppressFBWarnings(
         value = "UC_USELESS_OBJECT",
         justification = "skipResult is the return value of the instrumented method")
     @Advice.OnMethodExit
     public static void shouldBeSkipped(
-        @Advice.This TestDescriptor testDescriptor,
+        @Advice.This SpockNode<?> spockNode,
         @Advice.Return(readOnly = false) Node.SkipResult skipResult) {
+      if (CallDepthThreadLocalMap.decrementCallDepth(SpockNode.class) > 0) {
+        // nested call
+        return;
+      }
+
       if (skipResult.isSkipped()) {
         return;
       }
@@ -93,16 +103,55 @@ public class JUnit5CucumberItrInstrumentation extends InstrumenterModule.CiVisib
         return;
       }
 
-      Collection<TestTag> tags = testDescriptor.getTags();
-      for (TestTag tag : tags) {
-        if (InstrumentationBridge.ITR_UNSKIPPABLE_TAG.equals(tag.getName())) {
+      if (spockNode instanceof SpecNode) {
+        // suite
+        SpecNode specNode = (SpecNode) spockNode;
+        Set<? extends TestDescriptor> features = specNode.getChildren();
+
+        SkipReason suiteSkipReason = null;
+        for (TestDescriptor feature : features) {
+          if (feature instanceof SpockNode && SpockUtils.isItrUnskippable((SpockNode<?>) feature)) {
+            return;
+          }
+
+          TestIdentifier featureIdentifier = SpockUtils.toTestIdentifier(feature);
+          if (featureIdentifier == null) {
+            return;
+          }
+          SkipReason skipReason =
+              TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skipReason(featureIdentifier);
+          if (skipReason == null) {
+            return;
+          }
+          if (suiteSkipReason != null && suiteSkipReason != skipReason) {
+            // we cannot have a mix of skip reasons in the suite for technical reasons
+            return;
+          }
+          suiteSkipReason = skipReason;
+        }
+
+        if (suiteSkipReason == null) {
           return;
         }
-      }
+        if (suiteSkipReason == SkipReason.ITR && SpockUtils.isItrUnskippable(specNode)) {
+          return;
+        }
+        skipResult = Node.SkipResult.skip(suiteSkipReason.getDescription());
 
-      TestIdentifier test = CucumberUtils.toTestIdentifier(testDescriptor);
-      if (test != null && TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(test)) {
-        skipResult = Node.SkipResult.skip(InstrumentationBridge.ITR_SKIP_REASON);
+      } else {
+        // individual test case
+        TestIdentifier test = SpockUtils.toTestIdentifier(spockNode);
+        if (test == null) {
+          return;
+        }
+        SkipReason skipReason = TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skipReason(test);
+        if (skipReason == null) {
+          return;
+        }
+        if (skipReason == SkipReason.ITR && SpockUtils.isItrUnskippable(spockNode)) {
+          return;
+        }
+        skipResult = Node.SkipResult.skip(skipReason.getDescription());
       }
     }
 

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/SpockUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/main/java/datadog/trace/instrumentation/junit5/SpockUtils.java
@@ -66,7 +66,7 @@ public class SpockUtils {
     }
   }
 
-  public static boolean isUnskippable(SpockNode<?> spockNode) {
+  public static boolean isItrUnskippable(SpockNode<?> spockNode) {
     Collection<TestTag> tags = getTags(spockNode);
     for (TestTag tag : tags) {
       if (InstrumentationBridge.ITR_UNSKIPPABLE_TAG.equals(tag.getName())) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SkipInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnit5SkipInstrumentation.java
@@ -12,6 +12,7 @@ import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.api.Config;
 import datadog.trace.api.civisibility.InstrumentationBridge;
 import datadog.trace.api.civisibility.config.TestIdentifier;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collection;
 import java.util.Set;
@@ -24,10 +25,10 @@ import org.junit.platform.engine.support.hierarchical.Node;
 import org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService;
 
 @AutoService(InstrumenterModule.class)
-public class JUnit5ItrInstrumentation extends InstrumenterModule.CiVisibility
+public class JUnit5SkipInstrumentation extends InstrumenterModule.CiVisibility
     implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
 
-  public JUnit5ItrInstrumentation() {
+  public JUnit5SkipInstrumentation() {
     super("ci-visibility", "junit-5");
   }
 
@@ -62,7 +63,7 @@ public class JUnit5ItrInstrumentation extends InstrumenterModule.CiVisibility
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("shouldBeSkipped").and(takesArguments(1)),
-        JUnit5ItrInstrumentation.class.getName() + "$JUnit5ItrAdvice");
+        JUnit5SkipInstrumentation.class.getName() + "$JUnit5SkipAdvice");
   }
 
   /**
@@ -70,7 +71,7 @@ public class JUnit5ItrInstrumentation extends InstrumenterModule.CiVisibility
    * org.junit.platform.launcher} package in here: in some Gradle projects this package is not
    * available in CL where this instrumentation is injected
    */
-  public static class JUnit5ItrAdvice {
+  public static class JUnit5SkipAdvice {
 
     @SuppressFBWarnings(
         value = "UC_USELESS_OBJECT",
@@ -89,17 +90,25 @@ public class JUnit5ItrInstrumentation extends InstrumenterModule.CiVisibility
         return;
       }
 
-      Collection<TestTag> tags = testDescriptor.getTags();
-      for (TestTag tag : tags) {
-        if (InstrumentationBridge.ITR_UNSKIPPABLE_TAG.equals(tag.getName())) {
-          return;
+      TestIdentifier test = JUnitPlatformUtils.toTestIdentifier(testDescriptor);
+      if (test == null) {
+        return;
+      }
+      SkipReason skipReason = TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skipReason(test);
+      if (skipReason == null) {
+        return;
+      }
+
+      if (skipReason == SkipReason.ITR) {
+        Collection<TestTag> tags = testDescriptor.getTags();
+        for (TestTag tag : tags) {
+          if (InstrumentationBridge.ITR_UNSKIPPABLE_TAG.equals(tag.getName())) {
+            return;
+          }
         }
       }
 
-      TestIdentifier test = JUnitPlatformUtils.toTestIdentifier(testDescriptor);
-      if (test != null && TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(test)) {
-        skipResult = Node.SkipResult.skip(InstrumentationBridge.ITR_SKIP_REASON);
-      }
+      skipResult = Node.SkipResult.skip(skipReason.getDescription());
     }
 
     // JUnit 5.3.0 and above

--- a/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateTracingHook.java
+++ b/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateTracingHook.java
@@ -19,6 +19,7 @@ import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
@@ -112,10 +113,13 @@ public class KarateTracingHook implements RuntimeHook {
     String parameters = KarateUtils.getParameters(scenario);
     Collection<String> categories = scenario.getTagsEffective().getTagKeys();
 
-    if (Config.get().isCiVisibilityTestSkippingEnabled()
-        && !categories.contains(InstrumentationBridge.ITR_UNSKIPPABLE_TAG)) {
+    if (Config.get().isCiVisibilityTestSkippingEnabled()) {
       TestIdentifier skippableTest = KarateUtils.toTestIdentifier(scenario);
-      if (TestEventsHandlerHolder.TEST_EVENTS_HANDLER.isSkippable(skippableTest)) {
+      SkipReason skipReason = TestEventsHandlerHolder.TEST_EVENTS_HANDLER.skipReason(skippableTest);
+
+      if (skipReason != null
+          && !(skipReason == SkipReason.ITR
+              && categories.contains(InstrumentationBridge.ITR_UNSKIPPABLE_TAG))) {
         TestEventsHandlerHolder.TEST_EVENTS_HANDLER.onTestIgnore(
             suiteDescriptor,
             testDescriptor,
@@ -125,7 +129,7 @@ public class KarateTracingHook implements RuntimeHook {
             parameters,
             categories,
             TestSourceData.UNKNOWN,
-            InstrumentationBridge.ITR_SKIP_REASON);
+            skipReason.getDescription());
         return false;
       }
     }

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestSkipInstrumentation.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/ScalatestSkipInstrumentation.java
@@ -21,10 +21,10 @@ import org.scalatest.Tracker;
 import scala.Tuple2;
 
 @AutoService(InstrumenterModule.class)
-public class ScalatestItrInstrumentation extends InstrumenterModule.CiVisibility
+public class ScalatestSkipInstrumentation extends InstrumenterModule.CiVisibility
     implements Instrumenter.ForKnownTypes, Instrumenter.HasMethodAdvice {
 
-  public ScalatestItrInstrumentation() {
+  public ScalatestSkipInstrumentation() {
     super("ci-visibility", "scalatest");
   }
 
@@ -59,7 +59,7 @@ public class ScalatestItrInstrumentation extends InstrumenterModule.CiVisibility
         isConstructor()
             .and(takesArgument(2, named("org.scalatest.Filter")))
             .and(takesArgument(5, named("org.scalatest.Tracker"))),
-        ScalatestItrInstrumentation.class.getName() + "$ArgsContructorAdvice");
+        ScalatestSkipInstrumentation.class.getName() + "$ArgsContructorAdvice");
     // org.scalatest.Filter
     transformer.applyAdvice(
         named("apply")
@@ -67,14 +67,14 @@ public class ScalatestItrInstrumentation extends InstrumenterModule.CiVisibility
             .and(takesArgument(0, String.class))
             .and(takesArgument(1, named("scala.collection.immutable.Map")))
             .and(takesArgument(2, String.class)),
-        ScalatestItrInstrumentation.class.getName() + "$SingleTestFilterAdvice");
+        ScalatestSkipInstrumentation.class.getName() + "$SingleTestFilterAdvice");
     transformer.applyAdvice(
         named("apply")
             .and(takesArguments(3))
             .and(takesArgument(0, named("scala.collection.immutable.Set")))
             .and(takesArgument(1, named("scala.collection.immutable.Map")))
             .and(takesArgument(2, String.class)),
-        ScalatestItrInstrumentation.class.getName() + "$MultipleTestsFilterAdvice");
+        ScalatestSkipInstrumentation.class.getName() + "$MultipleTestsFilterAdvice");
   }
 
   public static class ArgsContructorAdvice {

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/InstrumentationBridge.java
@@ -8,7 +8,6 @@ import datadog.trace.bootstrap.ContextStore;
 
 public abstract class InstrumentationBridge {
 
-  public static final String ITR_SKIP_REASON = "Skipped by Datadog Intelligent Test Runner";
   public static final String ITR_UNSKIPPABLE_TAG = "datadog_itr_unskippable";
 
   private static volatile TestEventsHandler.Factory TEST_EVENTS_HANDLER_FACTORY;

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
@@ -5,6 +5,7 @@ import datadog.trace.api.civisibility.DDTestSuite;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
 import java.io.Closeable;
@@ -86,11 +87,18 @@ public interface TestEventsHandler<SuiteKey, TestKey> extends Closeable {
   @Nonnull
   TestRetryPolicy retryPolicy(TestIdentifier test, TestSourceData source);
 
+  /**
+   * Returns the reason for skipping a test IF it can be skipped.
+   *
+   * @param test Test to be checked
+   * @return skip reason, or {@code null} if the test cannot be skipped
+   */
+  @Nullable
+  SkipReason skipReason(TestIdentifier test);
+
   boolean isNew(TestIdentifier test);
 
   boolean isFlaky(TestIdentifier test);
-
-  boolean isSkippable(TestIdentifier test);
 
   @Override
   void close();

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/SkipReason.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/SkipReason.java
@@ -1,0 +1,24 @@
+package datadog.trace.api.civisibility.telemetry.tag;
+
+import datadog.trace.api.civisibility.telemetry.TagValue;
+
+public enum SkipReason implements TagValue {
+  ITR("Skipped by Datadog Intelligent Test Runner");
+
+  private final String s;
+  private final String description;
+
+  SkipReason(String description) {
+    this.description = description;
+    this.s = "retry_reason:" + name().toLowerCase();
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String asString() {
+    return s;
+  }
+}


### PR DESCRIPTION
# What Does This Do

Does some preparatory work for future flaky test management features.
When flaky test management is implemented, the tracer will need to skip quarantined test cases.
This skipping will be done the same way ITR (aka TIA) skips tests at the moment.
So this PR generalises tests skipping logic, separating it from ITR-specific things.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1483]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1483]: https://datadoghq.atlassian.net/browse/SDTEST-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ