### PR TITLE
Generalize test retry logic

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/NoOpTestEventsHandler.java
@@ -6,6 +6,7 @@ import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
@@ -57,7 +58,7 @@ public class NoOpTestEventsHandler<SuiteKey, TestKey>
       @Nullable String testParameters,
       @Nullable Collection<String> categories,
       @Nonnull TestSourceData testSourceData,
-      String retryReason,
+      RetryReason retryReason,
       @Nullable Long startTime) {
     // do nothing
   }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/events/TestEventsHandlerImpl.java
@@ -12,6 +12,7 @@ import datadog.trace.api.civisibility.retry.TestRetryPolicy;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityCountMetric;
 import datadog.trace.api.civisibility.telemetry.CiVisibilityMetricCollector;
 import datadog.trace.api.civisibility.telemetry.tag.EventType;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
@@ -138,7 +139,7 @@ public class TestEventsHandlerImpl<SuiteKey, TestKey>
       final @Nullable String testParameters,
       final @Nullable Collection<String> categories,
       final @Nonnull TestSourceData testSourceData,
-      final @Nullable String retryReason,
+      final @Nullable RetryReason retryReason,
       final @Nullable Long startTime) {
     if (skipTrace(testSourceData.getTestClass())) {
       return;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/NeverRetry.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/NeverRetry.java
@@ -1,6 +1,7 @@
 package datadog.trace.civisibility.retry;
 
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import org.jetbrains.annotations.Nullable;
 
 public class NeverRetry implements TestRetryPolicy {
@@ -20,7 +21,7 @@ public class NeverRetry implements TestRetryPolicy {
   }
 
   @Override
-  public boolean retry(boolean successful, long duration) {
+  public boolean retry(boolean successful, long durationMillis) {
     return false;
   }
 
@@ -31,7 +32,7 @@ public class NeverRetry implements TestRetryPolicy {
 
   @Nullable
   @Override
-  public String currentExecutionRetryReason() {
+  public RetryReason currentExecutionRetryReason() {
     return null;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/NeverRetry.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/NeverRetry.java
@@ -25,11 +25,6 @@ public class NeverRetry implements TestRetryPolicy {
     return false;
   }
 
-  @Override
-  public boolean currentExecutionIsRetry() {
-    return false;
-  }
-
   @Nullable
   @Override
   public RetryReason currentExecutionRetryReason() {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/RetryIfFailed.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/RetryIfFailed.java
@@ -27,7 +27,9 @@ public class RetryIfFailed implements TestRetryPolicy {
 
   @Override
   public boolean suppressFailures() {
-    return true;
+    // if this isn't the last attempt,
+    // possible failures should be suppressed
+    return retriesLeft();
   }
 
   @Override
@@ -40,14 +42,13 @@ public class RetryIfFailed implements TestRetryPolicy {
     }
   }
 
-  @Override
-  public boolean currentExecutionIsRetry() {
-    return executions > 0;
-  }
-
   @Nullable
   @Override
   public RetryReason currentExecutionRetryReason() {
     return currentExecutionIsRetry() ? RetryReason.atr : null;
+  }
+
+  private boolean currentExecutionIsRetry() {
+    return executions > 0;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/RetryIfFailed.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/RetryIfFailed.java
@@ -1,13 +1,12 @@
 package datadog.trace.civisibility.retry;
 
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jetbrains.annotations.Nullable;
 
 /** Retries a test case if it failed, up to a maximum number of times. */
 public class RetryIfFailed implements TestRetryPolicy {
-
-  private static final String AUTO_TEST_RETRIES = "atr";
 
   private final int maxExecutions;
   private int executions;
@@ -32,7 +31,7 @@ public class RetryIfFailed implements TestRetryPolicy {
   }
 
   @Override
-  public boolean retry(boolean successful, long duration) {
+  public boolean retry(boolean successful, long durationMillis) {
     if (!successful && ++executions < maxExecutions) {
       totalExecutions.incrementAndGet();
       return true;
@@ -48,7 +47,7 @@ public class RetryIfFailed implements TestRetryPolicy {
 
   @Nullable
   @Override
-  public String currentExecutionRetryReason() {
-    return currentExecutionIsRetry() ? AUTO_TEST_RETRIES : null;
+  public RetryReason currentExecutionRetryReason() {
+    return currentExecutionIsRetry() ? RetryReason.atr : null;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/RetryNTimes.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/RetryNTimes.java
@@ -36,14 +36,13 @@ public class RetryNTimes implements TestRetryPolicy {
     return ++executions < maxExecutions;
   }
 
-  @Override
-  public boolean currentExecutionIsRetry() {
-    return executions > 0;
-  }
-
   @Nullable
   @Override
   public RetryReason currentExecutionRetryReason() {
     return currentExecutionIsRetry() ? RetryReason.efd : null;
+  }
+
+  private boolean currentExecutionIsRetry() {
+    return executions > 0;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/RetryNTimes.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/retry/RetryNTimes.java
@@ -1,13 +1,12 @@
 package datadog.trace.civisibility.retry;
 
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.civisibility.config.EarlyFlakeDetectionSettings;
 import org.jetbrains.annotations.Nullable;
 
 /** Retries a test case N times (N depends on test duration) regardless of success or failure. */
 public class RetryNTimes implements TestRetryPolicy {
-
-  private static final String EARLY_FLAKINESS_DETECTION = "efd";
 
   private final EarlyFlakeDetectionSettings earlyFlakeDetectionSettings;
   private int executions;
@@ -30,9 +29,9 @@ public class RetryNTimes implements TestRetryPolicy {
   }
 
   @Override
-  public boolean retry(boolean successful, long duration) {
+  public boolean retry(boolean successful, long durationMillis) {
     // adjust maximum retries based on the now known test duration
-    int maxExecutionsForGivenDuration = earlyFlakeDetectionSettings.getExecutions(duration);
+    int maxExecutionsForGivenDuration = earlyFlakeDetectionSettings.getExecutions(durationMillis);
     maxExecutions = Math.min(maxExecutions, maxExecutionsForGivenDuration);
     return ++executions < maxExecutions;
   }
@@ -44,7 +43,7 @@ public class RetryNTimes implements TestRetryPolicy {
 
   @Nullable
   @Override
-  public String currentExecutionRetryReason() {
-    return currentExecutionIsRetry() ? EARLY_FLAKINESS_DETECTION : null;
+  public RetryReason currentExecutionRetryReason() {
+    return currentExecutionIsRetry() ? RetryReason.efd : null;
   }
 }

--- a/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/retry/RetryAwareNotifier.java
+++ b/dd-java-agent/instrumentation/junit-4.10/src/main/java/datadog/trace/instrumentation/junit4/retry/RetryAwareNotifier.java
@@ -27,7 +27,7 @@ public class RetryAwareNotifier extends RunNotifier {
   public void fireTestFailure(Failure failure) {
     this.failed = true;
 
-    if (!retryPolicy.retriesLeft() || !retryPolicy.suppressFailures()) {
+    if (!retryPolicy.suppressFailures()) {
       super.fireTestFailure(failure);
       return;
     }

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformUtils.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/JUnitPlatformUtils.java
@@ -4,6 +4,7 @@ import static datadog.json.JsonMapper.toJson;
 
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
@@ -185,8 +186,9 @@ public abstract class JUnitPlatformUtils {
     return "test-template".equals(lastSegment.getType());
   }
 
-  public static String retryReason(TestDescriptor testDescriptor) {
-    return getIDSegmentValue(testDescriptor, RETRY_DESCRIPTOR_REASON_SUFFIX);
+  public static RetryReason retryReason(TestDescriptor testDescriptor) {
+    String retryReasonSegment = getIDSegmentValue(testDescriptor, RETRY_DESCRIPTOR_REASON_SUFFIX);
+    return retryReasonSegment != null ? RetryReason.valueOf(retryReasonSegment) : null;
   }
 
   public static boolean isRetry(TestDescriptor testDescriptor) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/retry/JUnit5RetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/retry/JUnit5RetryInstrumentation.java
@@ -158,7 +158,7 @@ public class JUnit5RetryInstrumentation extends InstrumenterModule.CiVisibility
       int retryAttemptIdx = 0;
       boolean retry;
       while (true) {
-        factory.setSuppressFailures(retryPolicy.retriesLeft() && retryPolicy.suppressFailures());
+        factory.setSuppressFailures(retryPolicy.suppressFailures());
 
         long startTimestamp = System.currentTimeMillis();
         CallDepthThreadLocalMap.incrementCallDepth(HierarchicalTestExecutorService.TestTask.class);

--- a/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/retry/TestDescriptorHandle.java
+++ b/dd-java-agent/instrumentation/junit-5.3/src/main/java/datadog/trace/instrumentation/junit5/retry/TestDescriptorHandle.java
@@ -43,10 +43,12 @@ public class TestDescriptorHandle {
   }
 
   public TestDescriptor withIdSuffix(
-      String segmentName, String segmentValue, String otherSegmentName, String otherSegmentValue) {
+      String segmentName, Object segmentValue, String otherSegmentName, Object otherSegmentValue) {
     UniqueId uniqueId = testDescriptor.getUniqueId();
     UniqueId updatedId =
-        uniqueId.append(segmentName, segmentValue).append(otherSegmentName, otherSegmentValue);
+        uniqueId
+            .append(segmentName, String.valueOf(segmentValue))
+            .append(otherSegmentName, String.valueOf(otherSegmentValue));
     TestDescriptor descriptorClone = UnsafeUtils.tryShallowClone(testDescriptor);
     METHOD_HANDLES.invoke(UNIQUE_ID_SETTER, descriptorClone, updatedId);
     return descriptorClone;

--- a/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateRetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateRetryInstrumentation.java
@@ -124,7 +124,7 @@ public class KarateRetryInstrumentation extends InstrumenterModule.CiVisibility
         retryContext.setFailed(true);
 
         TestRetryPolicy retryPolicy = retryContext.getRetryPolicy();
-        if (retryPolicy.suppressFailures() && retryPolicy.retriesLeft()) {
+        if (retryPolicy.suppressFailures()) {
           stepResult = new StepResult(stepResult.getStep(), KarateUtils.abortedResult());
           stepResult.setFailedReason(result.getError());
           stepResult.setErrorIgnored(true);

--- a/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateTracingHook.java
+++ b/dd-java-agent/instrumentation/karate/src/main/java/datadog/trace/instrumentation/karate/KarateTracingHook.java
@@ -19,6 +19,7 @@ import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
@@ -143,7 +144,7 @@ public class KarateTracingHook implements RuntimeHook {
         parameters,
         categories,
         TestSourceData.UNKNOWN,
-        (String) sr.magicVariables.get(KarateUtils.RETRY_MAGIC_VARIABLE),
+        (RetryReason) sr.magicVariables.get(KarateUtils.RETRY_MAGIC_VARIABLE),
         null);
     return true;
   }

--- a/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/retry/TestExecutionWrapper.java
+++ b/dd-java-agent/instrumentation/scalatest/src/main/java/datadog/trace/instrumentation/scalatest/retry/TestExecutionWrapper.java
@@ -29,7 +29,7 @@ public class TestExecutionWrapper implements scala.Function1<SuperEngine<?>.Test
 
     if (outcome.isFailed()) {
       executionFailed = true;
-      if (retryPolicy.retriesLeft() && retryPolicy.suppressFailures()) {
+      if (retryPolicy.suppressFailures()) {
         Throwable t = outcome.toOption().get();
         return Canceled.apply(
             new SuppressedTestFailedException("Test failed and will be retried", t, 0));

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/TracingListener.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.testng;
 
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.instrumentation.testng.retry.RetryAnalyzer;
 import java.util.List;
@@ -94,7 +95,7 @@ public class TracingListener extends TestNGClassListener
         null);
   }
 
-  private String retryReason(final ITestResult result) {
+  private RetryReason retryReason(final ITestResult result) {
     IRetryAnalyzer retryAnalyzer = TestNGUtils.getRetryAnalyzer(result);
     if (retryAnalyzer instanceof RetryAnalyzer) {
       RetryAnalyzer datadogAnalyzer = (RetryAnalyzer) retryAnalyzer;

--- a/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/retry/RetryAnalyzer.java
+++ b/dd-java-agent/instrumentation/testng/src/main/java/datadog/trace/instrumentation/testng/retry/RetryAnalyzer.java
@@ -3,6 +3,7 @@ package datadog.trace.instrumentation.testng.retry;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.instrumentation.testng.TestEventsHandlerHolder;
 import datadog.trace.instrumentation.testng.TestNGUtils;
 import org.testng.IRetryAnalyzer;
@@ -31,7 +32,7 @@ public class RetryAnalyzer implements IRetryAnalyzer {
     return retryPolicy.retry(result.isSuccess(), result.getEndMillis() - result.getStartMillis());
   }
 
-  public String currentExecutionRetryReason() {
+  public RetryReason currentExecutionRetryReason() {
     return retryPolicy != null ? retryPolicy.currentExecutionRetryReason() : null;
   }
 }

--- a/dd-java-agent/instrumentation/testng/testng-7/src/main/java/datadog/trace/instrumentation/testng7/TestNGClassListenerInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/main/java/datadog/trace/instrumentation/testng7/TestNGClassListenerInstrumentation.java
@@ -60,6 +60,7 @@ public class TestNGClassListenerInstrumentation extends InstrumenterModule.CiVis
   }
 
   public static class InvokeBeforeClassAdvice {
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @Advice.OnMethodEnter
     public static void invokeBeforeClass(
         @Advice.FieldValue("m_testContext") final ITestContext testContext,
@@ -81,6 +82,7 @@ public class TestNGClassListenerInstrumentation extends InstrumenterModule.CiVis
   }
 
   public static class InvokeAfterClassAdvice {
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @Advice.OnMethodExit
     public static void invokeAfterClass(
         @Advice.FieldValue("m_testContext") final ITestContext testContext,

--- a/dd-java-agent/instrumentation/testng/testng-7/src/main/java/datadog/trace/instrumentation/testng7/TestNGRetryInstrumentation.java
+++ b/dd-java-agent/instrumentation/testng/testng-7/src/main/java/datadog/trace/instrumentation/testng7/TestNGRetryInstrumentation.java
@@ -55,6 +55,7 @@ public class TestNGRetryInstrumentation extends InstrumenterModule.CiVisibility
   }
 
   public static class RetryAdvice {
+    @SuppressWarnings("bytebuddy-exception-suppression")
     @SuppressFBWarnings("NP_BOOLEAN_RETURN_NULL")
     @Advice.OnMethodExit
     public static void shouldRetryTestMethod(

--- a/dd-java-agent/instrumentation/weaver/src/main/java/datadog/trace/instrumentation/weaver/DatadogWeaverReporter.java
+++ b/dd-java-agent/instrumentation/weaver/src/main/java/datadog/trace/instrumentation/weaver/DatadogWeaverReporter.java
@@ -5,6 +5,7 @@ import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.events.TestDescriptor;
 import datadog.trace.api.civisibility.events.TestEventsHandler;
 import datadog.trace.api.civisibility.events.TestSuiteDescriptor;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.util.AgentThreadFactory;
@@ -91,7 +92,7 @@ public class DatadogWeaverReporter {
         new TestDescriptor(testSuiteName, testClass, testName, testParameters, testQualifier);
     String testMethodName = null;
     Method testMethod = null;
-    String retryReason = null;
+    RetryReason retryReason = null;
 
     // Only test finish is reported, so fake test start timestamp
     long endMicros = SystemTimeSource.INSTANCE.getCurrentTimeMicros();

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/events/TestEventsHandler.java
@@ -5,6 +5,7 @@ import datadog.trace.api.civisibility.DDTestSuite;
 import datadog.trace.api.civisibility.config.TestIdentifier;
 import datadog.trace.api.civisibility.config.TestSourceData;
 import datadog.trace.api.civisibility.retry.TestRetryPolicy;
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import datadog.trace.api.civisibility.telemetry.tag.SkipReason;
 import datadog.trace.api.civisibility.telemetry.tag.TestFrameworkInstrumentation;
 import datadog.trace.bootstrap.ContextStore;
@@ -64,7 +65,7 @@ public interface TestEventsHandler<SuiteKey, TestKey> extends Closeable {
       @Nullable String testParameters,
       @Nullable Collection<String> categories,
       @Nonnull TestSourceData testSourceData,
-      @Nullable String retryReason,
+      @Nullable RetryReason retryReason,
       @Nullable Long startTime);
 
   void onTestSkip(TestKey descriptor, @Nullable String reason);

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/retry/TestRetryPolicy.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/retry/TestRetryPolicy.java
@@ -1,14 +1,26 @@
 package datadog.trace.api.civisibility.retry;
 
+import datadog.trace.api.civisibility.telemetry.tag.RetryReason;
 import javax.annotation.Nullable;
 
 public interface TestRetryPolicy {
-  boolean retriesLeft();
 
+  /** @return {@code true} if failure of this test should not affect the build result */
   boolean suppressFailures();
 
-  boolean retry(boolean successful, long duration);
+  /**
+   * @return {@code true} if this test can be retried. Current execution is NOT taken into account
+   */
+  boolean retriesLeft();
 
+  /**
+   * @param successful {@code true} if test passed or was skipped, {@code false} otherwise
+   * @param durationMillis test duration in milliseconds
+   * @return {@code true} if this test should be retried
+   */
+  boolean retry(boolean successful, long durationMillis);
+
+  /** @return {@code true} if current execution is a retry */
   boolean currentExecutionIsRetry();
 
   /**
@@ -16,5 +28,5 @@ public interface TestRetryPolicy {
    * retry)
    */
   @Nullable
-  String currentExecutionRetryReason();
+  RetryReason currentExecutionRetryReason();
 }

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/retry/TestRetryPolicy.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/retry/TestRetryPolicy.java
@@ -20,9 +20,6 @@ public interface TestRetryPolicy {
    */
   boolean retry(boolean successful, long durationMillis);
 
-  /** @return {@code true} if current execution is a retry */
-  boolean currentExecutionIsRetry();
-
   /**
    * Returns retry reason for current execution (will be {@code null} if current execution is not a
    * retry)

--- a/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/RetryReason.java
+++ b/internal-api/src/main/java/datadog/trace/api/civisibility/telemetry/tag/RetryReason.java
@@ -3,13 +3,19 @@ package datadog.trace.api.civisibility.telemetry.tag;
 import datadog.trace.api.civisibility.telemetry.TagValue;
 
 public enum RetryReason implements TagValue {
-  ATR,
-  EFD;
+  atr("Auto Test Retries"),
+  efd("Early Flakiness Detection");
 
   private final String s;
+  private final String description;
 
-  RetryReason() {
-    s = "retry_reason:" + name().toLowerCase();
+  RetryReason(String description) {
+    this.description = description;
+    this.s = "retry_reason:" + name();
+  }
+
+  public String getDescription() {
+    return description;
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Does some updates to `TestRetryPolicy` and the code that uses it:
- retry reason is now an enum instead of a String
- the contract of `suppressFailures()` method is changed to return whether failures should be suppressed for the __current__ execution 
- `currentExecutionIsRetry()` method is removed

# Motivation

Preparing for future flaky tests management changes: quarantined tests will have to be executed without affecting the status of the build.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1483]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[SDTEST-1483]: https://datadoghq.atlassian.net/browse/SDTEST-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ