### PR TITLE
Prevent possible NPE calculating Kafka record header size

### DIFF
--- a/dd-java-agent/instrumentation/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/Utils.java
+++ b/dd-java-agent/instrumentation/kafka-common/src/main/java/datadog/trace/instrumentation/kafka_common/Utils.java
@@ -14,7 +14,8 @@ public final class Utils {
     Headers headers = val.headers();
     if (headers != null)
       for (Header h : headers) {
-        headersSize += h.value().length + h.key().getBytes(StandardCharsets.UTF_8).length;
+        int valueSize = h.value() == null ? 0 : h.value().length;
+        headersSize += valueSize + h.key().getBytes(StandardCharsets.UTF_8).length;
       }
     return headersSize + val.serializedKeySize() + val.serializedValueSize();
   }


### PR DESCRIPTION
# What Does This Do

Prevents possible NPE

```java
java.lang.NullPointerException: Cannot read the array length because the return value of “org.apache.kafka.common.header.Header.value()” is null
  at datadog.trace.instrumentation.kafka_common.Utils.computePayloadSizeBytes(Utils.java:17)
  at datadog.trace.instrumentation.kafka_clients38.TracingIterator.startNewRecordSpan(TracingIterator.java:107)
  at datadog.trace.instrumentation.kafka_clients38.TracingIterator.next(TracingIterator.java:69)
  at datadog.trace.instrumentation.kafka_clients38.TracingIterator.next(TracingIterator.java:30)
  at (redacted: 6 frames)
  at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
  at java.base/java.lang.Thread.run(Unknown Source)
```

# Motivation

When a Kafka record header has a null value, it fails to silently create a span

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [DSMS-25]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DSMS-25]: https://datadoghq.atlassian.net/browse/DSMS-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ