### PR TITLE
Do not set test framework version tag if the value is null

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/SpanUtils.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/SpanUtils.java
@@ -87,7 +87,9 @@ public class SpanUtils {
       TestFramework framework = frameworks.iterator().next();
       Map<String, String> tags = new HashMap<>();
       tags.put(Tags.TEST_FRAMEWORK, framework.getName());
-      tags.put(Tags.TEST_FRAMEWORK_VERSION, framework.getVersion());
+      if (framework.getVersion() != null) {
+        tags.put(Tags.TEST_FRAMEWORK_VERSION, framework.getVersion());
+      }
       span.setAllTags(tags);
       return;
     }


### PR DESCRIPTION
# What Does This Do

Fixes an issue introduced in https://github.com/DataDog/dd-trace-java/pull/8252
`test.framework_version` tag should not be set on test spans if its value is `null`.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
