### PR TITLE
OTEL: preserve span.kind if set as attributes in the builder

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpanBuilder.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpanBuilder.java
@@ -99,6 +99,8 @@ public class OtelSpanBuilder implements SpanBuilder {
     } else if (ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES.equals(key) && value != null) {
       this.overriddenAnalyticsSampleRate = parseBoolean(value) ? 1 : 0;
       return this;
+    } else if (SPAN_KIND.equals(key) && value != null) {
+      this.spanKindSet = true;
     }
     // Store as object to prevent delegate to remove tag when value is empty
     this.delegate.withTag(key, (Object) value);

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-0.3/src/test/groovy/OpenTelemetryTest.groovy
@@ -1,3 +1,10 @@
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CLIENT
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUMER
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_INTERNAL
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_PRODUCER
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER
+
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.api.DDSpanId
 import datadog.trace.api.DDTags
@@ -94,6 +101,36 @@ class OpenTelemetryTest extends AgentTestRunner {
     true       | true
     false      | false
     false      | true
+  }
+
+  def "test span kinds as attributes"() {
+    setup:
+    def result = tracer.spanBuilder("some-name")
+      .setAttribute("span.kind", otelSpanKind)
+      .startSpan()
+
+    when:
+    result.end()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          tags {
+            defaultTags()
+            "$SPAN_KIND" "$tagSpanKind"
+          }
+        }
+      }
+    }
+
+    where:
+    otelSpanKind | tagSpanKind
+    "internal"     | SPAN_KIND_INTERNAL
+    "server"       | SPAN_KIND_SERVER
+    "client"       | SPAN_KIND_CLIENT
+    "producer"     | SPAN_KIND_PRODUCER
+    "consumer"     | SPAN_KIND_CONSUMER
   }
 
   def "test span exception"() {


### PR DESCRIPTION
# What Does This Do

Some opentelemetry API versions don't allow setting the span kind on the builder (i.e. using `setSpanKind` method)

So things like 

```
tracer.spanBuilder("..").setAttribute("span.kind", "client").start();
```
will have the span created with an `internal` span kind. However, if `setAttribute` is called after the span is started, the `span.kind` is overridden.

This might lead to inconsistencies and we should not set it to internal if set by setAttribute

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
