### PR TITLE
Add SymDB report for any jar scanning failures

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/JarScanner.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/JarScanner.java
@@ -19,11 +19,12 @@ public class JarScanner {
   private static final String SPRING_CLASSES_PREFIX = "BOOT-INF/classes/";
   private static final String SPRING_DEPS_PREFIX = "BOOT-INF/lib/";
 
-  public static Path extractJarPath(Class<?> clazz) throws URISyntaxException {
-    return extractJarPath(clazz.getProtectionDomain());
+  public static Path extractJarPath(Class<?> clazz, SymDBReport symDBReport)
+      throws URISyntaxException {
+    return extractJarPath(clazz.getProtectionDomain(), symDBReport);
   }
 
-  public static Path extractJarPath(ProtectionDomain protectionDomain) throws URISyntaxException {
+  public static Path extractJarPath(ProtectionDomain protectionDomain, SymDBReport symDBReport) {
     if (protectionDomain == null) {
       return null;
     }
@@ -49,6 +50,9 @@ public class JarScanner {
       }
     } else if (locationStr.startsWith(FILE_PREFIX)) {
       return getPathFromPrefixedFileName(locationStr, FILE_PREFIX, locationStr.length());
+    }
+    if (symDBReport != null) {
+      symDBReport.addLocationError(locationStr);
     }
     return null;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBReport.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBReport.java
@@ -1,0 +1,49 @@
+package com.datadog.debugger.symbol;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SymDBReport {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SymDBReport.class);
+
+  private final Set<String> missingJars = new HashSet<>();
+  private final Set<String> directoryJars = new HashSet<>();
+  private final Map<String, String> ioExceptions = new HashMap<>();
+  private final List<String> locationErrors = new ArrayList<>();
+
+  public void addMissingJar(String jarPath) {
+    missingJars.add(jarPath);
+  }
+
+  public void addDirectoryJar(String jarPath) {
+    directoryJars.add(jarPath);
+  }
+
+  public void addIOException(String jarPath, IOException e) {
+    ioExceptions.put(jarPath, e.toString());
+  }
+
+  public void addLocationError(String locationStr) {
+    locationErrors.add(locationStr);
+  }
+
+  public void report() {
+    String content =
+        "== SymDB Report == Location errors:"
+            + locationErrors
+            + " Missing jars: "
+            + missingJars
+            + " Directory jars: "
+            + directoryJars
+            + " IOExceptions: "
+            + ioExceptions;
+    LOGGER.info(content);
+  }
+}

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolAggregator.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymbolAggregator.java
@@ -43,7 +43,7 @@ public class SymbolAggregator {
       String className, byte[] classfileBuffer, ProtectionDomain protectionDomain) {
     try {
       String jarName = "DEFAULT";
-      Path jarPath = JarScanner.extractJarPath(protectionDomain);
+      Path jarPath = JarScanner.extractJarPath(protectionDomain, null);
       if (jarPath != null && Files.exists(jarPath)) {
         LOGGER.debug("jarpath: {}", jarPath);
         jarName = jarPath.toString();

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/JarScannerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/JarScannerTest.java
@@ -22,10 +22,10 @@ class JarScannerTest {
     URL jarUrl = new URL("jar:file:" + jarFileUrl.getFile() + "!/");
     URLClassLoader urlClassLoader = new URLClassLoader(new URL[] {jarUrl}, null);
     Class<?> testClass = urlClassLoader.loadClass(CLASS_NAME);
-    assertEquals(jarFileUrl.getFile(), JarScanner.extractJarPath(testClass).toString());
+    assertEquals(jarFileUrl.getFile(), JarScanner.extractJarPath(testClass, null).toString());
     assertEquals(
         jarFileUrl.getFile(),
-        JarScanner.extractJarPath(testClass.getProtectionDomain()).toString());
+        JarScanner.extractJarPath(testClass.getProtectionDomain(), null).toString());
   }
 
   @Test
@@ -34,7 +34,7 @@ class JarScannerTest {
     URL jarFileUrl = getClass().getResource("/debugger-symbol.jar");
     URLClassLoader urlClassLoader = new URLClassLoader(new URL[] {jarFileUrl}, null);
     Class<?> testClass = urlClassLoader.loadClass(CLASS_NAME);
-    assertEquals(jarFileUrl.getFile(), JarScanner.extractJarPath(testClass).toString());
+    assertEquals(jarFileUrl.getFile(), JarScanner.extractJarPath(testClass, null).toString());
   }
 
   @Test
@@ -45,6 +45,7 @@ class JarScannerTest {
         .thenReturn("jar:nested:" + jarFileUrl.getFile() + "/!BOOT-INF/classes/!");
     CodeSource codeSource = new CodeSource(mockLocation, (Certificate[]) null);
     ProtectionDomain protectionDomain = new ProtectionDomain(codeSource, null);
-    assertEquals(jarFileUrl.getFile(), JarScanner.extractJarPath(protectionDomain).toString());
+    assertEquals(
+        jarFileUrl.getFile(), JarScanner.extractJarPath(protectionDomain, null).toString());
   }
 }


### PR DESCRIPTION

# What Does This Do
Any bail out when resolving or scanning for jars will be reported into SymDBReport and logged as a single INFO log line at the end of SYMDB extraction process from SymDB enablement


example:
```
[dd.trace 2025-01-29 14:32:07:763 +0100] [dd-task-scheduler] INFO com.datadog.debugger.symbol.SymDBReport - == SymDB Report == Location errors:[jrt:/java.xml.crypto, jrt:/java.xml.crypto, jrt:/java.xml.crypto, jrt:/java.xml.crypto] Missing jars: [] Directory jars: [/private/var/folders/_n/13tq16fx0f32x08gb9cszskc0000gp/T/jetty-0_0_0_0-8080-ee10-demo-simple_war-_ee10-demo-simple-any-5827001407483628327/webapp/WEB-INF/classes] IOExceptions: {}
```
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
