### PR TITLE
Add support for SymDB to scan directories

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBReport.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBReport.java
@@ -14,16 +14,11 @@ public class SymDBReport {
   private static final Logger LOGGER = LoggerFactory.getLogger(SymDBReport.class);
 
   private final Set<String> missingJars = new HashSet<>();
-  private final Set<String> directoryJars = new HashSet<>();
   private final Map<String, String> ioExceptions = new HashMap<>();
   private final List<String> locationErrors = new ArrayList<>();
 
   public void addMissingJar(String jarPath) {
     missingJars.add(jarPath);
-  }
-
-  public void addDirectoryJar(String jarPath) {
-    directoryJars.add(jarPath);
   }
 
   public void addIOException(String jarPath, IOException e) {
@@ -40,8 +35,6 @@ public class SymDBReport {
             + locationErrors
             + " Missing jars: "
             + missingJars
-            + " Directory jars: "
-            + directoryJars
             + " IOExceptions: "
             + ioExceptions;
     LOGGER.info(content);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -117,6 +119,28 @@ class SymDBEnablementTest {
     assertEquals(
         "BOOT-INF/classes/org/springframework/samples/petclinic/vet/VetController.class",
         captor.getAllValues().get(1));
+  }
+
+  @Test
+  public void parseLoadedClassFromDirectory()
+      throws ClassNotFoundException, IOException, URISyntaxException {
+    URL classFilesUrl = getClass().getResource("/");
+    URLClassLoader urlClassLoader = new URLClassLoader(new URL[] {classFilesUrl}, null);
+    Class<?> testClass = urlClassLoader.loadClass(getClass().getTypeName());
+    when(instr.getAllLoadedClasses()).thenReturn(new Class[] {testClass});
+    when(config.getThirdPartyIncludes())
+        .thenReturn(
+            Stream.of("com.datadog.debugger.", "org.springframework.samples.")
+                .collect(Collectors.toSet()));
+    SymbolAggregator symbolAggregator = mock(SymbolAggregator.class);
+    SymDBEnablement symDBEnablement =
+        new SymDBEnablement(instr, config, symbolAggregator, ClassNameFiltering.allowAll());
+    symDBEnablement.startSymbolExtraction();
+    verify(instr).addTransformer(any(SymbolExtractionTransformer.class));
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(symbolAggregator, atLeastOnce()).parseClass(captor.capture(), any(), anyString());
+    // verify that we called parseClass on this test class
+    assertTrue(captor.getAllValues().contains(getClass().getSimpleName() + ".class"));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do
When the location of loaded class is a directory (directory provided into the classpath or war extracted into a temp dir) we need to walk the directory for scanning class files.
We avoid following the file link to prevent cycles.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
