### PR TITLE
Make jnr-unixsocket an explicit dependency of dd-trace-ot

### DIFF
--- a/dd-trace-ot/build.gradle
+++ b/dd-trace-ot/build.gradle
@@ -48,6 +48,8 @@ dependencies {
   api group: 'io.opentracing.contrib', name: 'opentracing-tracerresolver', version: '0.1.6'
 
   api libs.slf4j
+  api libs.jnr.unixsocket
+
   implementation project(':dd-trace-ot:correlation-id-injection')
 
   testImplementation project(":dd-java-agent:testing")
@@ -96,16 +98,15 @@ shadowJar {
     exclude(dependency('io.opentracing:'))
     exclude(dependency('io.opentracing.contrib:'))
     exclude(dependency('org.slf4j:'))
+    exclude(dependency('com.github.jnr:'))
   }
 
   relocate('com.', 'ddtrot.com.') {
-    // don't relocate native methods
-    exclude('com.kenai.jffi.*')
-    exclude('com.kenai.jffi.internal.*')
+    // leave our PatchInit class shaded even though its not used in this deployment
+    // unfortunately the shadow plugin doesn't let us completely remove this class
+    exclude('%regex[com/kenai/jffi/(?!PatchInit)[^/]*]')
   }
   relocate('dogstatsd/', 'ddtrot/dogstatsd/')
-  relocate('jni/', 'ddtrot/jni/')
-  relocate('jnr/', 'ddtrot/jnr/')
   relocate('okhttp3.', 'ddtrot.okhttp3.')
   relocate('okio.', 'ddtrot.okio.')
   relocate('org.', 'ddtrot.org.') {

--- a/test-published-dependencies/ot-is-shaded/build.gradle
+++ b/test-published-dependencies/ot-is-shaded/build.gradle
@@ -91,9 +91,6 @@ tasks.register('checkJarContents', CheckJarContentsTask) {
     '^[^/]*\\.version$',
     '^DDSketch.proto$',
     '^META-INF/.*$',
-    '^com/$',
-    '^com/kenai/$',
-    '^com/kenai/jffi/.*$',
     '^datadog/.*$',
     '^ddtrot/.*$'
   ]


### PR DESCRIPTION
# What Does This Do

Makes `jnr-unixsocket` an explicit dependency of `dd-trace-ot` instead of (partially) shading it.

# Motivation

Avoids duplicate class error reported by `maven-enforcer-plugin` when both `dd-trace-ot` and `java-dogstatsd-client` are included in the same Maven project - see https://github.com/DataDog/dd-trace-java/issues/5951

# Additional Notes

There is a single leftover class under `ddtrot/com/kenai/jffi/PatchInit.class` which is our patched `Init` class used when isolating the embedded library in `dd-java-agent`. Unfortunately the shadow plugin stubbornly refuses to remove this dangling class despite trying various options. We therefore leave this class in its shaded location - it won't ever be loaded and won't interact with the classes brought in by the `jnr-unixsocket` dependency.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
