### PR TITLE
Fix blocked PR checks 

### DIFF
--- a/.github/workflows/check-pull-requests.yaml
+++ b/.github/workflows/check-pull-requests.yaml
@@ -1,7 +1,7 @@
 name: Check pull requests
 on:
   pull_request:
-    types: [opened, edited, ready_for_review, labeled, unlabeled]
+    types: [opened, edited, ready_for_review, labeled, unlabeled, synchronize]
     branches:
     - master
     - release/v*


### PR DESCRIPTION
# What Does This Do

Try to fix blocked PR with waiting checks.

# Motivation

With better concurrency setting, try to add synchronize event back to prevent blocked PR checks.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-116]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-116]: https://datadoghq.atlassian.net/browse/LANGPLAT-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ