### PR TITLE
Add non default propagator registration

### DIFF
--- a/components/context/src/main/java/datadog/context/EmptyContext.java
+++ b/components/context/src/main/java/datadog/context/EmptyContext.java
@@ -24,4 +24,9 @@ final class EmptyContext implements Context {
     }
     return new SingletonContext(key.index, value);
   }
+
+  @Override
+  public String toString() {
+    return "EmptyContext{}";
+  }
 }

--- a/components/context/src/main/java/datadog/context/IndexedContext.java
+++ b/components/context/src/main/java/datadog/context/IndexedContext.java
@@ -23,14 +23,14 @@ final class IndexedContext implements Context {
   public <T> T get(ContextKey<T> key) {
     requireNonNull(key, "Context key cannot be null");
     int index = key.index;
-    return index < store.length ? (T) store[index] : null;
+    return index < this.store.length ? (T) this.store[index] : null;
   }
 
   @Override
   public <T> Context with(ContextKey<T> key, @Nullable T value) {
     requireNonNull(key, "Context key cannot be null");
     int index = key.index;
-    Object[] newStore = copyOfRange(store, 0, max(store.length, index + 1));
+    Object[] newStore = copyOfRange(this.store, 0, max(this.store.length, index + 1));
     newStore[index] = value;
     return new IndexedContext(newStore);
   }
@@ -40,13 +40,18 @@ final class IndexedContext implements Context {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     IndexedContext that = (IndexedContext) o;
-    return Arrays.equals(store, that.store);
+    return Arrays.equals(this.store, that.store);
   }
 
   @Override
   public int hashCode() {
     int result = 31;
-    result = 31 * result + Arrays.hashCode(store);
+    result = 31 * result + Arrays.hashCode(this.store);
     return result;
+  }
+
+  @Override
+  public String toString() {
+    return "IndexedContext{store=" + Arrays.toString(this.store) + '}';
   }
 }

--- a/components/context/src/main/java/datadog/context/SingletonContext.java
+++ b/components/context/src/main/java/datadog/context/SingletonContext.java
@@ -57,4 +57,9 @@ final class SingletonContext implements Context {
     result = 31 * result + Objects.hashCode(this.value);
     return result;
   }
+
+  @Override
+  public String toString() {
+    return "SingletonContext{" + "index=" + this.index + ", value=" + this.value + '}';
+  }
 }

--- a/components/context/src/main/java/datadog/context/propagation/CarrierSetter.java
+++ b/components/context/src/main/java/datadog/context/propagation/CarrierSetter.java
@@ -1,7 +1,5 @@
 package datadog.context.propagation;
 
-import javax.annotation.Nullable;
-
 @FunctionalInterface
 public interface CarrierSetter<C> {
   /**
@@ -11,5 +9,5 @@ public interface CarrierSetter<C> {
    * @param key the key to set.
    * @param value the value to set.
    */
-  void set(@Nullable C carrier, String key, String value);
+  void set(C carrier, String key, String value);
 }

--- a/components/context/src/test/java/datadog/context/ContextTest.java
+++ b/components/context/src/test/java/datadog/context/ContextTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -152,6 +153,16 @@ class ContextTest {
     assertNotEquals(context2.hashCode(), context1.hashCode());
     assertFalse(context4.equals(context1));
     assertNotEquals(context4.hashCode(), context1.hashCode());
+  }
+
+  @ParameterizedTest
+  @MethodSource("contextImplementations")
+  void testToString(Context context) {
+    String debugString = context.toString();
+    assertNotNull(debugString, "Context string representation should not be null");
+    assertTrue(
+        debugString.contains(context.getClass().getSimpleName()),
+        "Context string representation should contain implementation name");
   }
 
   @SuppressWarnings({"SimplifiableAssertion"})


### PR DESCRIPTION
# What Does This Do

This PR introduces the capability for registering propagators that are not used by default.

# Motivation

The goal is to have product to register custom propagators that can be retrieved by concern, but not automatically used for every context extraction / injection by default.

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [LANGPLAT-292]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[LANGPLAT-292]: https://datadoghq.atlassian.net/browse/LANGPLAT-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ