### PR TITLE
Remove expected traces count param from CI Vis snapshot tests

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTestUtils.groovy
+++ b/dd-java-agent/agent-ci-visibility/src/testFixtures/groovy/datadog/trace/civisibility/CiVisibilityTestUtils.groovy
@@ -7,8 +7,10 @@ import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.Option
 import com.jayway.jsonpath.ReadContext
 import com.jayway.jsonpath.WriteContext
+import freemarker.core.Environment
 import freemarker.core.InvalidReferenceException
 import freemarker.template.Template
+import freemarker.template.TemplateException
 import freemarker.template.TemplateExceptionHandler
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
@@ -114,11 +116,22 @@ abstract class CiVisibilityTestUtils {
     }
   }
 
+  static final TemplateExceptionHandler SUPPRESS_EXCEPTION_HANDLER = new TemplateExceptionHandler() {
+    @Override
+    void handleTemplateException(TemplateException e, Environment environment, Writer writer) throws TemplateException {
+      if (e instanceof InvalidReferenceException) {
+        writer.write('"<VALUE_MISSING>"')
+      } else {
+        throw e
+      }
+    }
+  }
+
   static final freemarker.template.Configuration FREEMARKER = new freemarker.template.Configuration(freemarker.template.Configuration.VERSION_2_3_30) { {
       setClassLoaderForTemplateLoading(CiVisibilityTestUtils.classLoader, "")
       setDefaultEncoding("UTF-8")
-      setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER)
-      setLogTemplateExceptions(true)
+      setTemplateExceptionHandler(SUPPRESS_EXCEPTION_HANDLER)
+      setLogTemplateExceptions(false)
       setWrapUncheckedExceptions(true)
       setFallbackOnNullLoopVariable(false)
       setNumberFormat("0.######")
@@ -131,15 +144,6 @@ abstract class CiVisibilityTestUtils {
       StringWriter coveragesOut = new StringWriter()
       coveragesTemplate.process(replacements, coveragesOut)
       return coveragesOut.toString()
-    } catch (InvalidReferenceException e) {
-      def missingExpression = e.getBlamedExpressionString()
-      if (missingExpression != null) {
-        replacements.put(missingExpression, "<VALUE_MISSING>") // to simplify debugging failures
-        return getFreemarkerTemplate(templatePath, replacements, replacementsSource)
-
-      } else {
-        throw new RuntimeException("Could not get Freemarker template " + templatePath + "; replacements map: " + replacements + "; replacements source: " + replacementsSource, e)
-      }
 
     } catch (Exception e) {
       throw new RuntimeException("Could not get Freemarker template " + templatePath + "; replacements map: " + replacements + "; replacements source: " + replacementsSource, e)

--- a/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/cucumber-junit-4/src/test/groovy/CucumberTest.groovy
@@ -17,19 +17,19 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runFeatures(features)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                          | features                                                                   | expectedTracesCount
-    "test-succeed"                        | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | 2
-    "test-scenario-outline-${version()}"  | ["org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"] | 5
-    "test-failure"                        | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]        | 2
+    testcaseName                          | features
+    "test-succeed"                        | ["org/example/cucumber/calculator/basic_arithmetic.feature"]
+    "test-scenario-outline-${version()}"  | ["org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"]
+    "test-failure"                        | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]
     "test-multiple-features-${version()}" | [
       "org/example/cucumber/calculator/basic_arithmetic.feature",
       "org/example/cucumber/calculator/basic_arithmetic_failed.feature"
-    ]                                                                                                                  | 3
-    "test-name-with-brackets"             | ["org/example/cucumber/calculator/name_with_brackets.feature"]             | 2
-    "test-empty-name-${version()}"        | ["org/example/cucumber/calculator/empty_scenario_name.feature"]            | 2
+    ]
+    "test-name-with-brackets"             | ["org/example/cucumber/calculator/name_with_brackets.feature"]
+    "test-empty-name-${version()}"        | ["org/example/cucumber/calculator/empty_scenario_name.feature"]
   }
 
   def "test ITR #testcaseName"() {
@@ -37,17 +37,17 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
 
     runFeatures(features)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                 | features                                                                       | expectedTracesCount | skippedTests
-    "test-itr-skipping"          | ["org/example/cucumber/calculator/basic_arithmetic.feature"]                   | 2                   | [
+    testcaseName                 | features                                                                       | skippedTests
+    "test-itr-skipping"          | ["org/example/cucumber/calculator/basic_arithmetic.feature"]                   | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-itr-unskippable"       | ["org/example/cucumber/calculator/basic_arithmetic_unskippable.feature"]       | 2                   | [
+    "test-itr-unskippable"       | ["org/example/cucumber/calculator/basic_arithmetic_unskippable.feature"]       | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_unskippable.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-itr-unskippable-suite" | ["org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature"] | 2                   | [
+    "test-itr-unskippable-suite" | ["org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature"] | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature:Basic Arithmetic", "Addition", null)
     ]
   }
@@ -58,15 +58,15 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
 
     runFeatures(features)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                               | features                                                                          | expectedTracesCount | retriedTests
-    "test-failure"                             | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]               | 2                   | []
-    "test-retry-failure"                       | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]               | 6                   | [
+    testcaseName                               | features                                                                          | retriedTests
+    "test-failure"                             | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]               | []
+    "test-retry-failure"                       | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]               | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_failed.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-retry-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"] | 5                   | [
+    "test-retry-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature"] | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_with_examples_failed.feature:Basic Arithmetic With Examples", "Many additions", null)
     ]
   }
@@ -77,16 +77,16 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
 
     runFeatures(features)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                 | features                                                                   | expectedTracesCount | knownTestsList
-    "test-efd-known-test"                        | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | 2                   | [
+    testcaseName                                 | features                                                                   | knownTestsList
+    "test-efd-known-test"                        | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-efd-new-test"                          | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | 4                   | []
-    "test-efd-new-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"] | 9                   | []
-    "test-efd-new-slow-test"                     | ["org/example/cucumber/calculator/basic_arithmetic_slow.feature"]          | 3                   | []
+    "test-efd-new-test"                          | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | []
+    "test-efd-new-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"] | []
+    "test-efd-new-slow-test"                     | ["org/example/cucumber/calculator/basic_arithmetic_slow.feature"]          | []
   }
 
   private String version() {

--- a/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/groovy/JUnit413Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/junit-4.13/src/test/groovy/JUnit413Test.groovy
@@ -21,19 +21,19 @@ class JUnit413Test extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                            | tests                              | expectedTracesCount
-    "test-succeed-before-after"             | [TestSucceedBeforeAfter]           | 3
-    "test-succeed-before-class-after-class" | [TestSucceedBeforeClassAfterClass] | 3
-    "test-succeed-before-param-after-param" | [TestSucceedBeforeParamAfterParam] | 2
-    "test-failed-before-class"              | [TestFailedBeforeClass]            | 1
-    "test-failed-after-class"               | [TestFailedAfterClass]             | 3
-    "test-failed-before"                    | [TestFailedBefore]                 | 3
-    "test-failed-after"                     | [TestFailedAfter]                  | 3
-    "test-failed-before-param"              | [TestFailedBeforeParam]            | 2
-    "test-failed-after-param"               | [TestFailedAfterParam]             | 2
+    testcaseName                            | tests
+    "test-succeed-before-after"             | [TestSucceedBeforeAfter]
+    "test-succeed-before-class-after-class" | [TestSucceedBeforeClassAfterClass]
+    "test-succeed-before-param-after-param" | [TestSucceedBeforeParamAfterParam]
+    "test-failed-before-class"              | [TestFailedBeforeClass]
+    "test-failed-after-class"               | [TestFailedAfterClass]
+    "test-failed-before"                    | [TestFailedBefore]
+    "test-failed-after"                     | [TestFailedAfter]
+    "test-failed-before-param"              | [TestFailedBeforeParam]
+    "test-failed-after-param"               | [TestFailedAfterParam]
   }
 
   private void runTests(Collection<Class<?>> tests) {

--- a/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/groovy/MUnitTest.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/munit-junit-4/src/test/groovy/MUnitTest.groovy
@@ -22,14 +22,14 @@ class MUnitTest extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                          | tests                       | expectedTracesCount
-    "test-succeed"                        | [TestSucceedMUnit]          | 2
-    "test-skipped"                        | [TestSkippedMUnit]          | 2
-    "test-skipped-suite"                  | [TestSkippedSuiteMUnit]     | 3
-    "test-failed-assumption-${version()}" | [TestFailedAssumptionMUnit] | 2
+    testcaseName                          | tests
+    "test-succeed"                        | [TestSucceedMUnit]
+    "test-skipped"                        | [TestSkippedMUnit]
+    "test-skipped-suite"                  | [TestSkippedSuiteMUnit]
+    "test-failed-assumption-${version()}" | [TestFailedAssumptionMUnit]
   }
 
   def "test flaky retries #testcaseName"() {
@@ -38,13 +38,13 @@ class MUnitTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName               | tests                        | expectedTracesCount | retriedTests
-    "test-failed"              | [TestFailedMUnit]            | 2                   | []
-    "test-retry-failed"        | [TestFailedMUnit]            | 6                   | [new TestIdentifier("org.example.TestFailedMUnit", "Calculator.add", null)]
-    "test-failed-then-succeed" | [TestFailedThenSucceedMUnit] | 4                   | [new TestIdentifier("org.example.TestFailedThenSucceedMUnit", "Calculator.add", null)]
+    testcaseName               | tests                        | retriedTests
+    "test-failed"              | [TestFailedMUnit]            | []
+    "test-retry-failed"        | [TestFailedMUnit]            | [new TestIdentifier("org.example.TestFailedMUnit", "Calculator.add", null)]
+    "test-failed-then-succeed" | [TestFailedThenSucceedMUnit] | [new TestIdentifier("org.example.TestFailedThenSucceedMUnit", "Calculator.add", null)]
   }
 
   def "test early flakiness detection #testcaseName"() {
@@ -53,13 +53,13 @@ class MUnitTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName             | tests                  | expectedTracesCount | knownTestsList
-    "test-efd-known-test"    | [TestSucceedMUnit]     | 2                   | [new TestIdentifier("org.example.TestSucceedMUnit", "Calculator.add", null)]
-    "test-efd-new-test"      | [TestSucceedMUnit]     | 4                   | []
-    "test-efd-new-slow-test" | [TestSucceedMUnitSlow] | 3                   | [] // is executed only twice
+    testcaseName             | tests                  | knownTestsList
+    "test-efd-known-test"    | [TestSucceedMUnit]     | [new TestIdentifier("org.example.TestSucceedMUnit", "Calculator.add", null)]
+    "test-efd-new-test"      | [TestSucceedMUnit]     | []
+    "test-efd-new-slow-test" | [TestSucceedMUnitSlow] | [] // is executed only twice
   }
 
   def "test impacted tests detection #testcaseName"() {
@@ -68,15 +68,15 @@ class MUnitTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName            | tests              | expectedTracesCount | prDiff
-    "test-succeed"          | [TestSucceedMUnit] | 2                   | LineDiff.EMPTY
-    "test-succeed"          | [TestSucceedMUnit] | 2                   | new FileDiff(new HashSet())
-    "test-succeed-impacted" | [TestSucceedMUnit] | 2                   | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
-    "test-succeed"          | [TestSucceedMUnit] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
-    "test-succeed-impacted" | [TestSucceedMUnit] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
+    testcaseName            | tests              | prDiff
+    "test-succeed"          | [TestSucceedMUnit] | LineDiff.EMPTY
+    "test-succeed"          | [TestSucceedMUnit] | new FileDiff(new HashSet())
+    "test-succeed-impacted" | [TestSucceedMUnit] | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
+    "test-succeed"          | [TestSucceedMUnit] | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
+    "test-succeed-impacted" | [TestSucceedMUnit] | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
   }
 
   private void runTests(Collection<Class<?>> tests) {

--- a/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
+++ b/dd-java-agent/instrumentation/junit-4.10/src/test/groovy/JUnit4Test.groovy
@@ -42,32 +42,32 @@ class JUnit4Test extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                         | tests                                | expectedTracesCount
-    "test-succeed"                                       | [TestSucceed]                        | 2
-    "test-inheritance"                                   | [TestInheritance]                    | 2
-    "test-failed"                                        | [TestFailed]                         | 2
-    "test-error"                                         | [TestError]                          | 2
-    "test-skipped"                                       | [TestSkipped]                        | 2
-    "test-class-skipped"                                 | [TestSkippedClass]                   | 3
-    "test-success-and-skipped"                           | [TestSucceedAndSkipped]              | 3
-    "test-success-and-failure"                           | [TestFailedAndSucceed]               | 4
-    "test-suite-teardown-failure"                        | [TestFailedSuiteTearDown]            | 1
-    "test-suite-setup-failure"                           | [TestFailedSuiteSetup]               | 1
-    "test-assumption-failure"                            | [TestAssumption]                     | 2
-    "test-categories-are-included-in-spans"              | [TestSucceedWithCategories]          | 2
-    "test-assumption-failure-during-suite-setup"         | [TestFailedSuiteSetUpAssumption]     | 2
-    "test-assumption-failure-in-a-multi-test-case-suite" | [TestAssumptionAndSucceed]           | 3
-    "test-multiple-successful-suites"                    | [TestSucceed, TestSucceedAndSkipped] | 4
-    "test-successful-suite-and-failing-suite"            | [TestSucceed, TestFailedAndSucceed]  | 5
-    "test-parameterized"                                 | [TestParameterized]                  | 3
-    "test-suite-runner"                                  | [TestSucceedSuite]                   | 3
-    "test-legacy"                                        | [TestSucceedLegacy]                  | 2
-    "test-parameterized-junit-params"                    | [TestParameterizedJUnitParams]       | 3
-    "test-succeed-kotlin"                                | [TestSucceedKotlin]                  | 2
-    "test-succeed-parameterized-kotlin"                  | [TestSucceedParameterizedKotlin]     | 3
+    testcaseName                                         | tests
+    "test-succeed"                                       | [TestSucceed]
+    "test-inheritance"                                   | [TestInheritance]
+    "test-failed"                                        | [TestFailed]
+    "test-error"                                         | [TestError]
+    "test-skipped"                                       | [TestSkipped]
+    "test-class-skipped"                                 | [TestSkippedClass]
+    "test-success-and-skipped"                           | [TestSucceedAndSkipped]
+    "test-success-and-failure"                           | [TestFailedAndSucceed]
+    "test-suite-teardown-failure"                        | [TestFailedSuiteTearDown]
+    "test-suite-setup-failure"                           | [TestFailedSuiteSetup]
+    "test-assumption-failure"                            | [TestAssumption]
+    "test-categories-are-included-in-spans"              | [TestSucceedWithCategories]
+    "test-assumption-failure-during-suite-setup"         | [TestFailedSuiteSetUpAssumption]
+    "test-assumption-failure-in-a-multi-test-case-suite" | [TestAssumptionAndSucceed]
+    "test-multiple-successful-suites"                    | [TestSucceed, TestSucceedAndSkipped]
+    "test-successful-suite-and-failing-suite"            | [TestSucceed, TestFailedAndSucceed]
+    "test-parameterized"                                 | [TestParameterized]
+    "test-suite-runner"                                  | [TestSucceedSuite]
+    "test-legacy"                                        | [TestSucceedLegacy]
+    "test-parameterized-junit-params"                    | [TestParameterizedJUnitParams]
+    "test-succeed-kotlin"                                | [TestSucceedKotlin]
+    "test-succeed-parameterized-kotlin"                  | [TestSucceedParameterizedKotlin]
   }
 
   def "test ITR #testcaseName"() {
@@ -75,20 +75,20 @@ class JUnit4Test extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                       | tests                         | expectedTracesCount | skippedTests
-    "test-itr-skipping"                | [TestFailedAndSucceed]        | 4                   | [
+    testcaseName                       | tests                         | skippedTests
+    "test-itr-skipping"                | [TestFailedAndSucceed]        | [
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_another_succeed", null),
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_failed", null)
     ]
-    "test-itr-skipping-parameterized"  | [TestParameterized]           | 3                   | [
+    "test-itr-skipping-parameterized"  | [TestParameterized]           | [
       new TestIdentifier("org.example.TestParameterized", "parameterized_test_succeed", '{"metadata":{"test_name":"parameterized_test_succeed[str1]"}}')
     ]
-    "test-itr-unskippable"             | [TestSucceedUnskippable]      | 2                   | [new TestIdentifier("org.example.TestSucceedUnskippable", "test_succeed", null)]
-    "test-itr-unskippable-suite"       | [TestSucceedUnskippableSuite] | 2                   | [new TestIdentifier("org.example.TestSucceedUnskippableSuite", "test_succeed", null)]
-    "test-itr-unskippable-not-skipped" | [TestSucceedUnskippable]      | 2                   | []
+    "test-itr-unskippable"             | [TestSucceedUnskippable]      | [new TestIdentifier("org.example.TestSucceedUnskippable", "test_succeed", null)]
+    "test-itr-unskippable-suite"       | [TestSucceedUnskippableSuite] | [new TestIdentifier("org.example.TestSucceedUnskippableSuite", "test_succeed", null)]
+    "test-itr-unskippable-not-skipped" | [TestSucceedUnskippable]      | []
   }
 
   def "test flaky retries #testcaseName"() {
@@ -97,19 +97,19 @@ class JUnit4Test extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                             | tests                          | expectedTracesCount | retriedTests
-    "test-failed"                            | [TestFailed]                   | 2                   | []
-    "test-retry-failed"                      | [TestFailed]                   | 6                   | [new TestIdentifier("org.example.TestFailed", "test_failed", null)]
-    "test-failed-then-succeed"               | [TestFailedThenSucceed]        | 5                   | [new TestIdentifier("org.example.TestFailedThenSucceed", "test_failed_then_succeed", null)]
-    "test-assumption-is-not-retried"         | [TestAssumption]               | 2                   | [new TestIdentifier("org.example.TestAssumption", "test_fail_assumption", null)]
-    "test-skipped-is-not-retried"            | [TestSkipped]                  | 2                   | [new TestIdentifier("org.example.TestSkipped", "test_skipped", null)]
-    "test-retry-parameterized"               | [TestFailedParameterized]      | 7                   | [
+    testcaseName                             | tests                          | retriedTests
+    "test-failed"                            | [TestFailed]                   | []
+    "test-retry-failed"                      | [TestFailed]                   | [new TestIdentifier("org.example.TestFailed", "test_failed", null)]
+    "test-failed-then-succeed"               | [TestFailedThenSucceed]        | [new TestIdentifier("org.example.TestFailedThenSucceed", "test_failed_then_succeed", null)]
+    "test-assumption-is-not-retried"         | [TestAssumption]               | [new TestIdentifier("org.example.TestAssumption", "test_fail_assumption", null)]
+    "test-skipped-is-not-retried"            | [TestSkipped]                  | [new TestIdentifier("org.example.TestSkipped", "test_skipped", null)]
+    "test-retry-parameterized"               | [TestFailedParameterized]      | [
       new TestIdentifier("org.example.TestFailedParameterized", "test_failed_parameterized", /* backend cannot provide parameters for flaky parameterized tests yet */ null)
     ]
-    "test-expected-exception-is-not-retried" | [TestSucceedExpectedException] | 2                   | [new TestIdentifier("org.example.TestSucceedExpectedException", "test_succeed", null)]
+    "test-expected-exception-is-not-retried" | [TestSucceedExpectedException] | [new TestIdentifier("org.example.TestSucceedExpectedException", "test_succeed", null)]
   }
 
   def "test early flakiness detection #testcaseName"() {
@@ -118,21 +118,21 @@ class JUnit4Test extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                        | tests                  | expectedTracesCount | knownTestsList
-    "test-efd-known-test"               | [TestSucceed]          | 2                   | [new TestIdentifier("org.example.TestSucceed", "test_succeed", null)]
-    "test-efd-known-parameterized-test" | [TestParameterized]    | 3                   | [new TestIdentifier("org.example.TestParameterized", "parameterized_test_succeed", null)]
-    "test-efd-new-test"                 | [TestSucceed]          | 4                   | []
-    "test-efd-new-parameterized-test"   | [TestParameterized]    | 7                   | []
-    "test-efd-known-tests-and-new-test" | [TestFailedAndSucceed] | 6                   | [
+    testcaseName                        | tests                  | knownTestsList
+    "test-efd-known-test"               | [TestSucceed]          | [new TestIdentifier("org.example.TestSucceed", "test_succeed", null)]
+    "test-efd-known-parameterized-test" | [TestParameterized]    | [new TestIdentifier("org.example.TestParameterized", "parameterized_test_succeed", null)]
+    "test-efd-new-test"                 | [TestSucceed]          | []
+    "test-efd-new-parameterized-test"   | [TestParameterized]    | []
+    "test-efd-known-tests-and-new-test" | [TestFailedAndSucceed] | [
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_failed", null),
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_succeed", null)
     ]
-    "test-efd-new-slow-test"            | [TestSucceedSlow]      | 3                   | [] // is executed only twice
-    "test-efd-new-very-slow-test"       | [TestSucceedVerySlow]  | 2                   | [] // is executed only once
-    "test-efd-faulty-session-threshold" | [TestFailedAndSucceed] | 8                   | []
+    "test-efd-new-slow-test"            | [TestSucceedSlow]      | [] // is executed only twice
+    "test-efd-new-very-slow-test"       | [TestSucceedVerySlow]  | [] // is executed only once
+    "test-efd-faulty-session-threshold" | [TestFailedAndSucceed] | []
   }
 
   def "test impacted tests detection #testcaseName"() {
@@ -141,15 +141,15 @@ class JUnit4Test extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName            | tests         | expectedTracesCount | prDiff
-    "test-succeed"          | [TestSucceed] | 2                   | LineDiff.EMPTY
-    "test-succeed"          | [TestSucceed] | 2                   | new FileDiff(new HashSet())
-    "test-succeed-impacted" | [TestSucceed] | 2                   | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
-    "test-succeed"          | [TestSucceed] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
-    "test-succeed-impacted" | [TestSucceed] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
+    testcaseName            | tests         | prDiff
+    "test-succeed"          | [TestSucceed] | LineDiff.EMPTY
+    "test-succeed"          | [TestSucceed] | new FileDiff(new HashSet())
+    "test-succeed-impacted" | [TestSucceed] | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
+    "test-succeed"          | [TestSucceed] | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
+    "test-succeed-impacted" | [TestSucceed] | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
   }
 
   private void runTests(Collection<Class<?>> tests) {

--- a/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/groovy/CucumberTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/cucumber-junit-5/src/test/groovy/CucumberTest.groovy
@@ -19,19 +19,19 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runFeatures(features, parallel)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                 | features                                                                           | parallel | expectedTracesCount
-    "test-succeed"                               | ["org/example/cucumber/calculator/basic_arithmetic.feature"]                       | false    | 2
-    "test-scenario-outline-${version()}"         | ["org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"]         | false    | 5
-    "test-skipped"                               | ["org/example/cucumber/calculator/basic_arithmetic_skipped.feature"]               | false    | 3
-    "test-skipped-feature"                       | ["org/example/cucumber/calculator/basic_arithmetic_skipped_feature.feature"]       | false    | 3
-    "test-skipped-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_examples_skipped.feature"] | false    | 5
+    testcaseName                                 | features                                                                                                                         | parallel
+    "test-succeed"                               | ["org/example/cucumber/calculator/basic_arithmetic.feature"]                                                                     | false
+    "test-scenario-outline-${version()}"         | ["org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"]                                                       | false
+    "test-skipped"                               | ["org/example/cucumber/calculator/basic_arithmetic_skipped.feature"]                                                             | false
+    "test-skipped-feature"                       | ["org/example/cucumber/calculator/basic_arithmetic_skipped_feature.feature"]                                                     | false
+    "test-skipped-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_examples_skipped.feature"]                                               | false
     "test-parallel"                              | [
       "org/example/cucumber/calculator/basic_arithmetic.feature",
       "org/example/cucumber/calculator/basic_arithmetic_skipped.feature"
-    ]                                                                                                                                 | true     | 4
+    ] | true
   }
 
   def "test ITR #testcaseName"() {
@@ -39,17 +39,17 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
 
     runFeatures(features, false)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                 | features                                                                       | expectedTracesCount | skippedTests
-    "test-itr-skipping"          | ["org/example/cucumber/calculator/basic_arithmetic.feature"]                   | 2                   | [
+    testcaseName                 | features                                                                       | skippedTests
+    "test-itr-skipping"          | ["org/example/cucumber/calculator/basic_arithmetic.feature"]                   | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-itr-unskippable"       | ["org/example/cucumber/calculator/basic_arithmetic_unskippable.feature"]       | 2                   | [
+    "test-itr-unskippable"       | ["org/example/cucumber/calculator/basic_arithmetic_unskippable.feature"]       | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_unskippable.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-itr-unskippable-suite" | ["org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature"] | 2                   | [
+    "test-itr-unskippable-suite" | ["org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature"] | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_unskippable_suite.feature:Basic Arithmetic", "Addition", null)
     ]
   }
@@ -60,18 +60,18 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
 
     runFeatures(features, false)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                | features                                                                          | expectedTracesCount | retriedTests
-    "test-failed"                               | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]               | 2                   | []
-    "test-retry-failed"                         | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]               | 5                   | [
+    testcaseName                                | features                                                                          | retriedTests
+    "test-failed"                               | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]               | []
+    "test-retry-failed"                         | ["org/example/cucumber/calculator/basic_arithmetic_failed.feature"]               | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_failed.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-failed-then-succeed"                  | ["org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature"]  | 4                   | [
+    "test-failed-then-succeed"                  | ["org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature"]  | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_failed_then_succeed.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-failed-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"] | 2                   | [
+    "test-failed-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature"] | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic_with_failed_examples.feature:Basic Arithmetic With Examples", "Many additions.Single digits.${parameterizedTestNameSuffix()}", null)
     ]
   }
@@ -82,16 +82,16 @@ class CucumberTest extends CiVisibilityInstrumentationTest {
 
     runFeatures(features, false)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                 | features                                                                   | expectedTracesCount | knownTestsList
-    "test-efd-known-test"                        | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | 2                   | [
+    testcaseName                                 | features                                                                   | knownTestsList
+    "test-efd-known-test"                        | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | [
       new TestIdentifier("classpath:org/example/cucumber/calculator/basic_arithmetic.feature:Basic Arithmetic", "Addition", null)
     ]
-    "test-efd-new-test"                          | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | 4                   | []
-    "test-efd-new-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"] | 9                   | []
-    "test-efd-new-slow-test"                     | ["org/example/cucumber/calculator/basic_arithmetic_slow.feature"]          | 3                   | []
+    "test-efd-new-test"                          | ["org/example/cucumber/calculator/basic_arithmetic.feature"]               | []
+    "test-efd-new-scenario-outline-${version()}" | ["org/example/cucumber/calculator/basic_arithmetic_with_examples.feature"] | []
+    "test-efd-new-slow-test"                     | ["org/example/cucumber/calculator/basic_arithmetic_slow.feature"]          | []
   }
 
   private String parameterizedTestNameSuffix() {

--- a/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/groovy/JUnit58Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/junit-5.8/src/test/groovy/JUnit58Test.groovy
@@ -26,16 +26,16 @@ class JUnit58Test extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                  | tests                            | expectedTracesCount
-    "test-before-each-after-each" | [TestSucceedBeforeEachAfterEach] | 2
-    "test-before-all-after-all"   | [TestSucceedBeforeAllAfterAll]   | 2
-    "test-failed-before-all"      | [TestFailedBeforeAll]            | 2
-    "test-failed-after-all"       | [TestFailedAfterAll]             | 2
-    "test-failed-before-each"     | [TestFailedBeforeEach]           | 2
-    "test-failed-after-each"      | [TestFailedAfterEach]            | 2
+    testcaseName                  | tests
+    "test-before-each-after-each" | [TestSucceedBeforeEachAfterEach]
+    "test-before-all-after-all"   | [TestSucceedBeforeAllAfterAll]
+    "test-failed-before-all"      | [TestFailedBeforeAll]
+    "test-failed-after-all"       | [TestFailedAfterAll]
+    "test-failed-before-each"     | [TestFailedBeforeEach]
+    "test-failed-after-each"      | [TestFailedAfterEach]
   }
 
   def "test known tests ordering #testcaseName"() {

--- a/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/SpockTest.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/spock-junit-5/src/test/groovy/SpockTest.groovy
@@ -39,34 +39,34 @@ class SpockTest extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                 | tests                    | expectedTracesCount
-    "test-succeed"               | [TestSucceedSpock]       | 2
-    "test-succeed-parameterized" | [TestParameterizedSpock] | 3
+    testcaseName                 | tests
+    "test-succeed"               | [TestSucceedSpock]
+    "test-succeed-parameterized" | [TestParameterizedSpock]
   }
 
   def "test ITR #testcaseName"() {
     givenSkippableTests(skippedTests)
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                     | tests                              | expectedTracesCount | skippedTests
-    "test-itr-skipping"                              | [TestSucceedSpock]                 | 2                   | [new TestIdentifier("org.example.TestSucceedSpock", "test success", null)]
-    "test-itr-skipping-parameterized"                | [TestParameterizedSpock]           | 3                   | [
+    testcaseName                                     | tests                              | skippedTests
+    "test-itr-skipping"                              | [TestSucceedSpock]                 | [new TestIdentifier("org.example.TestSucceedSpock", "test success", null)]
+    "test-itr-skipping-parameterized"                | [TestParameterizedSpock]           | [
       new TestIdentifier("org.example.TestParameterizedSpock", "test add 1 and 2", '{"metadata":{"test_name":"test add 1 and 2"}}')
     ]
-    "test-itr-unskippable"                           | [TestSucceedSpockUnskippable]      | 2                   | [new TestIdentifier("org.example.TestSucceedSpockUnskippable", "test success", null)]
-    "test-itr-unskippable-suite"                     | [TestSucceedSpockUnskippableSuite] | 2                   | [new TestIdentifier("org.example.TestSucceedSpockUnskippableSuite", "test success", null)]
-    "test-itr-skipping-spec-setup"                   | [TestSucceedSetupSpecSpock]        | 2                   | [
+    "test-itr-unskippable"                           | [TestSucceedSpockUnskippable]      | [new TestIdentifier("org.example.TestSucceedSpockUnskippable", "test success", null)]
+    "test-itr-unskippable-suite"                     | [TestSucceedSpockUnskippableSuite] | [new TestIdentifier("org.example.TestSucceedSpockUnskippableSuite", "test success", null)]
+    "test-itr-skipping-spec-setup"                   | [TestSucceedSetupSpecSpock]        | [
       new TestIdentifier("org.example.TestSucceedSetupSpecSpock", "test success", null),
       new TestIdentifier("org.example.TestSucceedSetupSpecSpock", "test another success", null)
     ]
-    "test-itr-not-skipping-spec-setup"               | [TestSucceedSetupSpecSpock]        | 2                   | [new TestIdentifier("org.example.TestSucceedSetupSpecSpock", "test success", null)]
-    "test-itr-not-skipping-parameterized-spec-setup" | [TestParameterizedSetupSpecSpock]  | 2                   | [
+    "test-itr-not-skipping-spec-setup"               | [TestSucceedSetupSpecSpock]        | [new TestIdentifier("org.example.TestSucceedSetupSpecSpock", "test success", null)]
+    "test-itr-not-skipping-parameterized-spec-setup" | [TestParameterizedSetupSpecSpock]  | [
       new TestIdentifier("org.example.TestParameterizedSetupSpecSpock", "test add 1 and 2", '{"metadata":{"test_name":"test add 1 and 2"}}')
     ]
   }
@@ -77,19 +77,15 @@ class SpockTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                             | tests                                     | expectedTracesCount | retriedTests
-    "test-failed"                            | [TestFailedSpock]                         | 2                   | []
-    "test-retry-failed"                      | [TestFailedSpock]                         | 6                   | [new TestIdentifier("org.example.TestFailedSpock", "test failed", null)]
-    "test-failed-then-succeed"               | [TestFailedThenSucceedSpock]              | 5                   | [
-      new TestIdentifier("org.example.TestFailedThenSucceedSpock", "test failed then succeed", null)
-    ]
-    "test-retry-parameterized"               | [TestFailedParameterizedSpock]            | 3                   | [new TestIdentifier("org.example.TestFailedParameterizedSpock", "test add 4 and 4", null)]
-    "test-parameterized-failed-then-succeed" | [TestFailedThenSucceedParameterizedSpock] | 5                   | [
-      new TestIdentifier("org.example.TestFailedThenSucceedParameterizedSpock", "test add 1 and 2", null)
-    ]
+    testcaseName                             | tests                                     | retriedTests
+    "test-failed"                            | [TestFailedSpock]                         | []
+    "test-retry-failed"                      | [TestFailedSpock]                         | [new TestIdentifier("org.example.TestFailedSpock", "test failed", null)]
+    "test-failed-then-succeed"               | [TestFailedThenSucceedSpock]              | [new TestIdentifier("org.example.TestFailedThenSucceedSpock", "test failed then succeed", null)]
+    "test-retry-parameterized"               | [TestFailedParameterizedSpock]            | [new TestIdentifier("org.example.TestFailedParameterizedSpock", "test add 4 and 4", null)]
+    "test-parameterized-failed-then-succeed" | [TestFailedThenSucceedParameterizedSpock] | [new TestIdentifier("org.example.TestFailedThenSucceedParameterizedSpock", "test add 1 and 2", null)]
   }
 
   def "test early flakiness detection #testcaseName"() {
@@ -98,21 +94,21 @@ class SpockTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                        | tests                       | expectedTracesCount | knownTestsList
-    "test-efd-known-test"               | [TestSucceedSpock]          | 2                   | [new TestIdentifier("org.example.TestSucceedSpock", "test success", null)]
-    "test-efd-known-parameterized-test" | [TestParameterizedSpock]    | 3                   | [
+    testcaseName                        | tests                       | knownTestsList
+    "test-efd-known-test"               | [TestSucceedSpock]          | [new TestIdentifier("org.example.TestSucceedSpock", "test success", null)]
+    "test-efd-known-parameterized-test" | [TestParameterizedSpock]    | [
       new TestIdentifier("org.example.TestParameterizedSpock", "test add 1 and 2", null),
       new TestIdentifier("org.example.TestParameterizedSpock", "test add 4 and 4", null)
     ]
-    "test-efd-new-test"                 | [TestSucceedSpock]          | 4                   | []
-    "test-efd-new-parameterized-test"   | [TestParameterizedSpock]    | 7                   | []
-    "test-efd-known-tests-and-new-test" | [TestParameterizedSpock]    | 5                   | [new TestIdentifier("org.example.TestParameterizedSpock", "test add 1 and 2", null)]
-    "test-efd-new-slow-test"            | [TestSucceedSpockSlow]      | 3                   | [] // is executed only twice
-    "test-efd-new-very-slow-test"       | [TestSucceedSpockVerySlow]  | 2                   | [] // is executed only once
-    "test-efd-faulty-session-threshold" | [TestSucceedAndFailedSpock] | 8                   | []
+    "test-efd-new-test"                 | [TestSucceedSpock]          | []
+    "test-efd-new-parameterized-test"   | [TestParameterizedSpock]    | []
+    "test-efd-known-tests-and-new-test" | [TestParameterizedSpock]    | [new TestIdentifier("org.example.TestParameterizedSpock", "test add 1 and 2", null)]
+    "test-efd-new-slow-test"            | [TestSucceedSpockSlow]      | [] // is executed only twice
+    "test-efd-new-very-slow-test"       | [TestSucceedSpockVerySlow]  | [] // is executed only once
+    "test-efd-faulty-session-threshold" | [TestSucceedAndFailedSpock] | []
   }
 
   def "test impacted tests detection #testcaseName"() {
@@ -121,15 +117,15 @@ class SpockTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName            | tests         | expectedTracesCount | prDiff
-    "test-succeed"          | [TestSucceedSpock] | 2                   | LineDiff.EMPTY
-    "test-succeed"          | [TestSucceedSpock] | 2                   | new FileDiff(new HashSet())
-    "test-succeed-impacted" | [TestSucceedSpock] | 2                   | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
-    "test-succeed"          | [TestSucceedSpock] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
-    "test-succeed-impacted" | [TestSucceedSpock] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
+    testcaseName            | tests              | prDiff
+    "test-succeed"          | [TestSucceedSpock] | LineDiff.EMPTY
+    "test-succeed"          | [TestSucceedSpock] | new FileDiff(new HashSet())
+    "test-succeed-impacted" | [TestSucceedSpock] | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
+    "test-succeed"          | [TestSucceedSpock] | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
+    "test-succeed-impacted" | [TestSucceedSpock] | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
   }
 
   private static void runTests(List<Class<?>> classes) {

--- a/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
+++ b/dd-java-agent/instrumentation/junit-5.3/src/test/groovy/JUnit5Test.groovy
@@ -48,33 +48,33 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                         | tests                                | expectedTracesCount
-    "test-succeed"                                       | [TestSucceed]                        | 2
-    "test-inheritance"                                   | [TestInheritance]                    | 2
-    "test-parameterized"                                 | [TestParameterized]                  | 3
-    "test-repeated"                                      | [TestRepeated]                       | 3
-    "test-template"                                      | [TestTemplate]                       | 3
-    "test-factory"                                       | [TestFactory]                        | 3
-    "test-failed"                                        | [TestFailed]                         | 2
-    "test-error"                                         | [TestError]                          | 2
-    "test-skipped"                                       | [TestSkipped]                        | 2
-    "test-skipped-class"                                 | [TestSkippedClass]                   | 5
-    "test-assumption-failed"                             | [TestAssumption]                     | 2
-    "test-assumption-failed-legacy"                      | [TestAssumptionLegacy]               | 2
-    "test-succeed-and-skipped"                           | [TestSucceedAndSkipped]              | 3
-    "test-succeed-and-failed"                            | [TestFailedAndSucceed]               | 4
-    "test-suite-teardown-failed"                         | [TestFailedSuiteTearDown]            | 3
-    "test-suite-setup-failed"                            | [TestFailedSuiteSetup]               | 1
-    "test-categories"                                    | [TestSucceedWithCategories]          | 2
-    "test-suite-setup-assumption-failed"                 | [TestSuiteSetUpAssumption]           | 2
-    "test-suite-setup-assumption-failed-multi-test-case" | [TestAssumptionAndSucceed]           | 3
-    "test-succeed-multiple-suites"                       | [TestSucceed, TestSucceedAndSkipped] | 4
-    "test-succeed-and-failed-multiple-suites"            | [TestSucceed, TestFailedAndSucceed]  | 5
-    "test-succeed-nested-suites"                         | [TestSucceedNested]                  | 3
-    "test-skipped-nested-suites"                         | [TestSkippedNested]                  | 3
+    testcaseName                                         | tests
+    "test-succeed"                                       | [TestSucceed]
+    "test-inheritance"                                   | [TestInheritance]
+    "test-parameterized"                                 | [TestParameterized]
+    "test-repeated"                                      | [TestRepeated]
+    "test-template"                                      | [TestTemplate]
+    "test-factory"                                       | [TestFactory]
+    "test-failed"                                        | [TestFailed]
+    "test-error"                                         | [TestError]
+    "test-skipped"                                       | [TestSkipped]
+    "test-skipped-class"                                 | [TestSkippedClass]
+    "test-assumption-failed"                             | [TestAssumption]
+    "test-assumption-failed-legacy"                      | [TestAssumptionLegacy]
+    "test-succeed-and-skipped"                           | [TestSucceedAndSkipped]
+    "test-succeed-and-failed"                            | [TestFailedAndSucceed]
+    "test-suite-teardown-failed"                         | [TestFailedSuiteTearDown]
+    "test-suite-setup-failed"                            | [TestFailedSuiteSetup]
+    "test-categories"                                    | [TestSucceedWithCategories]
+    "test-suite-setup-assumption-failed"                 | [TestSuiteSetUpAssumption]
+    "test-suite-setup-assumption-failed-multi-test-case" | [TestAssumptionAndSucceed]
+    "test-succeed-multiple-suites"                       | [TestSucceed, TestSucceedAndSkipped]
+    "test-succeed-and-failed-multiple-suites"            | [TestSucceed, TestFailedAndSucceed]
+    "test-succeed-nested-suites"                         | [TestSucceedNested]
+    "test-skipped-nested-suites"                         | [TestSkippedNested]
   }
 
   def "test ITR #testcaseName"() {
@@ -82,20 +82,20 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                       | tests                         | expectedTracesCount | skippedTests
-    "test-itr-skipping"                | [TestFailedAndSucceed]        | 4                   | [
+    testcaseName                       | tests                         | skippedTests
+    "test-itr-skipping"                | [TestFailedAndSucceed]        | [
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_another_succeed", null),
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_failed", null)
     ]
-    "test-itr-skipping-parametrized"   | [TestParameterized]           | 3                   | [
+    "test-itr-skipping-parametrized"   | [TestParameterized]           | [
       new TestIdentifier("org.example.TestParameterized", "test_parameterized", '{"metadata":{"test_name":"[1] 0, 0, 0, some:\\\"parameter\\\""}}')
     ]
-    "test-itr-unskippable"             | [TestSucceedUnskippable]      | 2                   | [new TestIdentifier("org.example.TestSucceedUnskippable", "test_succeed", null)]
-    "test-itr-unskippable-suite"       | [TestSucceedUnskippableSuite] | 2                   | [new TestIdentifier("org.example.TestSucceedUnskippableSuite", "test_succeed", null)]
-    "test-itr-unskippable-not-skipped" | [TestSucceedUnskippable]      | 2                   | []
+    "test-itr-unskippable"             | [TestSucceedUnskippable]      | [new TestIdentifier("org.example.TestSucceedUnskippable", "test_succeed", null)]
+    "test-itr-unskippable-suite"       | [TestSucceedUnskippableSuite] | [new TestIdentifier("org.example.TestSucceedUnskippableSuite", "test_succeed", null)]
+    "test-itr-unskippable-not-skipped" | [TestSucceedUnskippable]      | []
   }
 
   def "test flaky retries #testcaseName"() {
@@ -104,19 +104,19 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                             | tests                          | expectedTracesCount | retriedTests
-    "test-failed"                            | [TestFailed]                   | 2                   | []
-    "test-retry-failed"                      | [TestFailed]                   | 6                   | [new TestIdentifier("org.example.TestFailed", "test_failed", null)]
-    "test-failed-then-succeed"               | [TestFailedThenSucceed]        | 5                   | [new TestIdentifier("org.example.TestFailedThenSucceed", "test_failed_then_succeed", null)]
-    "test-retry-template"                    | [TestFailedTemplate]           | 7                   | [new TestIdentifier("org.example.TestFailedTemplate", "test_template", null)]
-    "test-retry-factory"                     | [TestFailedFactory]            | 7                   | [new TestIdentifier("org.example.TestFailedFactory", "test_factory", null)]
-    "test-assumption-is-not-retried"         | [TestAssumption]               | 2                   | [new TestIdentifier("org.example.TestAssumption", "test_fail_assumption", null)]
-    "test-skipped-is-not-retried"            | [TestSkipped]                  | 2                   | [new TestIdentifier("org.example.TestSkipped", "test_skipped", null)]
-    "test-retry-parameterized"               | [TestFailedParameterized]      | 11                  | [new TestIdentifier("org.example.TestFailedParameterized", "test_failed_parameterized", null)]
-    "test-expected-exception-is-not-retried" | [TestSucceedExpectedException] | 2                   | [new TestIdentifier("org.example.TestSucceedExpectedException", "test_succeed", null)]
+    testcaseName                             | tests                          | retriedTests
+    "test-failed"                            | [TestFailed]                   | []
+    "test-retry-failed"                      | [TestFailed]                   | [new TestIdentifier("org.example.TestFailed", "test_failed", null)]
+    "test-failed-then-succeed"               | [TestFailedThenSucceed]        | [new TestIdentifier("org.example.TestFailedThenSucceed", "test_failed_then_succeed", null)]
+    "test-retry-template"                    | [TestFailedTemplate]           | [new TestIdentifier("org.example.TestFailedTemplate", "test_template", null)]
+    "test-retry-factory"                     | [TestFailedFactory]            | [new TestIdentifier("org.example.TestFailedFactory", "test_factory", null)]
+    "test-assumption-is-not-retried"         | [TestAssumption]               | [new TestIdentifier("org.example.TestAssumption", "test_fail_assumption", null)]
+    "test-skipped-is-not-retried"            | [TestSkipped]                  | [new TestIdentifier("org.example.TestSkipped", "test_skipped", null)]
+    "test-retry-parameterized"               | [TestFailedParameterized]      | [new TestIdentifier("org.example.TestFailedParameterized", "test_failed_parameterized", null)]
+    "test-expected-exception-is-not-retried" | [TestSucceedExpectedException] | [new TestIdentifier("org.example.TestSucceedExpectedException", "test_succeed", null)]
   }
 
   def "test early flakiness detection #testcaseName"() {
@@ -125,21 +125,21 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                        | tests                  | expectedTracesCount | knownTestsList
-    "test-efd-known-test"               | [TestSucceed]          | 2                   | [new TestIdentifier("org.example.TestSucceed", "test_succeed", null)]
-    "test-efd-known-parameterized-test" | [TestParameterized]    | 3                   | [new TestIdentifier("org.example.TestParameterized", "test_parameterized", null)]
-    "test-efd-new-test"                 | [TestSucceed]          | 4                   | []
-    "test-efd-new-parameterized-test"   | [TestParameterized]    | 7                   | []
-    "test-efd-known-tests-and-new-test" | [TestFailedAndSucceed] | 6                   | [
+    testcaseName                        | tests                  | knownTestsList
+    "test-efd-known-test"               | [TestSucceed]          | [new TestIdentifier("org.example.TestSucceed", "test_succeed", null)]
+    "test-efd-known-parameterized-test" | [TestParameterized]    | [new TestIdentifier("org.example.TestParameterized", "test_parameterized", null)]
+    "test-efd-new-test"                 | [TestSucceed]          | []
+    "test-efd-new-parameterized-test"   | [TestParameterized]    | []
+    "test-efd-known-tests-and-new-test" | [TestFailedAndSucceed] | [
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_failed", null),
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_succeed", null)
     ]
-    "test-efd-new-slow-test"            | [TestSucceedSlow]      | 3                   | [] // is executed only twice
-    "test-efd-new-very-slow-test"       | [TestSucceedVerySlow]  | 2                   | [] // is executed only once
-    "test-efd-faulty-session-threshold" | [TestFailedAndSucceed] | 8                   | []
+    "test-efd-new-slow-test"            | [TestSucceedSlow]      | [] // is executed only twice
+    "test-efd-new-very-slow-test"       | [TestSucceedVerySlow]  | [] // is executed only once
+    "test-efd-faulty-session-threshold" | [TestFailedAndSucceed] | []
   }
 
   def "test impacted tests detection #testcaseName"() {
@@ -148,15 +148,15 @@ class JUnit5Test extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName            | tests         | expectedTracesCount | prDiff
-    "test-succeed"          | [TestSucceed] | 2                   | LineDiff.EMPTY
-    "test-succeed"          | [TestSucceed] | 2                   | new FileDiff(new HashSet())
-    "test-succeed-impacted" | [TestSucceed] | 2                   | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
-    "test-succeed"          | [TestSucceed] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
-    "test-succeed-impacted" | [TestSucceed] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
+    testcaseName            | tests         | prDiff
+    "test-succeed"          | [TestSucceed] | LineDiff.EMPTY
+    "test-succeed"          | [TestSucceed] | new FileDiff(new HashSet())
+    "test-succeed-impacted" | [TestSucceed] | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
+    "test-succeed"          | [TestSucceed] | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
+    "test-succeed-impacted" | [TestSucceed] | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
   }
 
   private static void runTests(List<Class<?>> tests) {

--- a/dd-java-agent/instrumentation/karate/src/test/groovy/KarateTest.groovy
+++ b/dd-java-agent/instrumentation/karate/src/test/groovy/KarateTest.groovy
@@ -33,17 +33,17 @@ class KarateTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName            | tests                          | expectedTracesCount | assumption
-    "test-succeed"          | [TestSucceedKarate]            | 3                   | true
-    "test-succeed-parallel" | [TestSucceedParallelKarate]    | 3                   | true
-    "test-with-setup"       | [TestWithSetupKarate]          | 3                   | isSetupTagSupported(FileUtils.KARATE_VERSION)
-    "test-parameterized"    | [TestParameterizedKarate]      | 3                   | true
-    "test-failed"           | [TestFailedKarate]             | 3                   | true
-    "test-skipped-feature"  | [TestSkippedFeatureKarate]     | 1                   | true
-    "test-built-in-retry"   | [TestFailedBuiltInRetryKarate] | 4                   | true
+    testcaseName            | tests                          | assumption
+    "test-succeed"          | [TestSucceedKarate]            | true
+    "test-succeed-parallel" | [TestSucceedParallelKarate]    | true
+    "test-with-setup"       | [TestWithSetupKarate]          | isSetupTagSupported(FileUtils.KARATE_VERSION)
+    "test-parameterized"    | [TestParameterizedKarate]      | true
+    "test-failed"           | [TestFailedKarate]             | true
+    "test-skipped-feature"  | [TestSkippedFeatureKarate]     | true
+    "test-built-in-retry"   | [TestFailedBuiltInRetryKarate] | true
   }
 
   def "test ITR #testcaseName"() {
@@ -53,15 +53,15 @@ class KarateTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                      | tests                     | expectedTracesCount | skippedTests
-    "test-itr-skipping"               | [TestSucceedKarate]       | 3                   | [new TestIdentifier("[org/example/test_succeed] test succeed", "first scenario", null)]
-    "test-itr-skipping-parameterized" | [TestParameterizedKarate] | 3                   | [
+    testcaseName                      | tests                     | skippedTests
+    "test-itr-skipping"               | [TestSucceedKarate]       | [new TestIdentifier("[org/example/test_succeed] test succeed", "first scenario", null)]
+    "test-itr-skipping-parameterized" | [TestParameterizedKarate] | [
       new TestIdentifier("[org/example/test_parameterized] test parameterized", "first scenario as an outline", '{"param":"\'a\'","value":"aa"}')
     ]
-    "test-itr-unskippable"            | [TestUnskippableKarate]   | 3                   | [new TestIdentifier("[org/example/test_unskippable] test unskippable", "first scenario", null)]
+    "test-itr-unskippable"            | [TestUnskippableKarate]   | [new TestIdentifier("[org/example/test_unskippable] test unskippable", "first scenario", null)]
   }
 
   def "test flaky retries #testcaseName"() {
@@ -70,16 +70,14 @@ class KarateTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName               | tests                           | expectedTracesCount | retriedTests
-    "test-failed"              | [TestFailedKarate]              | 3                   | []
-    "test-retry-failed"        | [TestFailedKarate]              | 3                   | [new TestIdentifier("[org/example/test_failed] test failed", "second scenario", null)]
-    "test-failed-then-succeed" | [TestFailedThenSucceedKarate]   | 3                   | [
-      new TestIdentifier("[org/example/test_failed_then_succeed] test failed", "flaky scenario", null)
-    ]
-    "test-retry-parameterized" | [TestFailedParameterizedKarate] | 3                   | [
+    testcaseName               | tests                           | retriedTests
+    "test-failed"              | [TestFailedKarate]              | []
+    "test-retry-failed"        | [TestFailedKarate]              | [new TestIdentifier("[org/example/test_failed] test failed", "second scenario", null)]
+    "test-failed-then-succeed" | [TestFailedThenSucceedKarate]   | [new TestIdentifier("[org/example/test_failed_then_succeed] test failed", "flaky scenario", null)]
+    "test-retry-parameterized" | [TestFailedParameterizedKarate] | [
       new TestIdentifier("[org/example/test_failed_parameterized] test parameterized", "first scenario as an outline", null)
     ]
   }
@@ -90,20 +88,18 @@ class KarateTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                        | tests                              | expectedTracesCount | knownTestsList
-    "test-efd-known-test"               | [TestSucceedOneCaseKarate]         | 2                   | [
-      new TestIdentifier("[org/example/test_succeed_one_case] test succeed", "first scenario", null)
-    ]
-    "test-efd-known-parameterized-test" | [TestParameterizedKarate]          | 3                   | [
+    testcaseName                        | tests                              | knownTestsList
+    "test-efd-known-test"               | [TestSucceedOneCaseKarate]         | [new TestIdentifier("[org/example/test_succeed_one_case] test succeed", "first scenario", null)]
+    "test-efd-known-parameterized-test" | [TestParameterizedKarate]          | [
       new TestIdentifier("[org/example/test_parameterized] test parameterized", "first scenario as an outline", null)
     ]
-    "test-efd-new-test"                 | [TestSucceedOneCaseKarate]         | 4                   | []
-    "test-efd-new-parameterized-test"   | [TestParameterizedKarate]          | 7                   | []
-    "test-efd-new-slow-test"            | [TestSucceedKarateSlow]            | 3                   | [] // is executed only twice
-    "test-efd-faulty-session-threshold" | [TestParameterizedMoreCasesKarate] | 8                   | []
+    "test-efd-new-test"                 | [TestSucceedOneCaseKarate]         | []
+    "test-efd-new-parameterized-test"   | [TestParameterizedKarate]          | []
+    "test-efd-new-slow-test"            | [TestSucceedKarateSlow]            | [] // is executed only twice
+    "test-efd-faulty-session-threshold" | [TestParameterizedMoreCasesKarate] | []
   }
 
   private void runTests(List<Class<?>> tests) {

--- a/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/MavenInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/maven-3.2.1/src/test/groovy/MavenInstrumentationTest.groovy
@@ -36,18 +36,18 @@ class MavenInstrumentationTest extends CiVisibilityInstrumentationTest {
     def exitCode = new MavenCli().doMain(args.toArray(new String[0]), workingDirectory, null, null)
 
     assertEquals(expectedExitCode, exitCode)
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                                                      | args                           | expectedExitCode | expectedTracesCount
-    "test_maven_build_with_no_tests_generates_spans"                                  | ["-B", "verify"]               | 0                | 1
-    "test_maven_build_with_incorrect_command_generates_spans"                         | ["-B", "unknownPhase"]         | 1                | 1
-    "test_maven_build_with_tests_generates_spans"                                     | ["-B", "clean", "test"]        | 0                | 1
-    "test_maven_build_with_failed_tests_generates_spans"                              | ["-B", "clean", "test"]        | 1                | 1
-    "test_maven_build_with_tests_in_multiple_modules_generates_spans"                 | ["-B", "clean", "test"]        | 1                | 1
-    "test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans" | ["-B", "-T4", "clean", "test"] | 0                | 1
-    "test_maven_build_with_unit_and_integration_tests_generates_spans"                | ["-B", "verify"]               | 0                | 1
-    "test_maven_build_with_no_fork_generates_spans"                                   | ["-B", "clean", "test"]        | 0                | 1
+    testcaseName                                                                      | args                           | expectedExitCode
+    "test_maven_build_with_no_tests_generates_spans"                                  | ["-B", "verify"]               | 0
+    "test_maven_build_with_incorrect_command_generates_spans"                         | ["-B", "unknownPhase"]         | 1
+    "test_maven_build_with_tests_generates_spans"                                     | ["-B", "clean", "test"]        | 0
+    "test_maven_build_with_failed_tests_generates_spans"                              | ["-B", "clean", "test"]        | 1
+    "test_maven_build_with_tests_in_multiple_modules_generates_spans"                 | ["-B", "clean", "test"]        | 1
+    "test_maven_build_with_tests_in_multiple_modules_run_in_parallel_generates_spans" | ["-B", "-T4", "clean", "test"] | 0
+    "test_maven_build_with_unit_and_integration_tests_generates_spans"                | ["-B", "verify"]               | 0
+    "test_maven_build_with_no_fork_generates_spans"                                   | ["-B", "clean", "test"]        | 0
   }
 
   private void givenMavenProjectFiles(String projectFilesSources) {

--- a/dd-java-agent/instrumentation/scalatest/src/test/groovy/ScalatestTest.groovy
+++ b/dd-java-agent/instrumentation/scalatest/src/test/groovy/ScalatestTest.groovy
@@ -23,33 +23,31 @@ class ScalatestTest extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                 | tests                      | expectedTracesCount
-    "test-succeed"               | [TestSucceed]              | 2
-    "test-succeed-flat-spec"     | [TestSucceedFlatSpec]      | 2
-    "test-succeed-parameterized" | [TestSucceedParameterized] | 2
-    "test-failed"                | [TestFailed]               | 2
-    "test-ignored"               | [TestIgnored]              | 2
-    "test-canceled"              | [TestIgnoredCanceled]      | 2
-    "test-pending"               | [TestIgnoredPending]       | 2
-    "test-failed-suite"          | [TestFailedSuite]          | 1
+    testcaseName                 | tests
+    "test-succeed"               | [TestSucceed]
+    "test-succeed-flat-spec"     | [TestSucceedFlatSpec]
+    "test-succeed-parameterized" | [TestSucceedParameterized]
+    "test-failed"                | [TestFailed]
+    "test-ignored"               | [TestIgnored]
+    "test-canceled"              | [TestIgnoredCanceled]
+    "test-pending"               | [TestIgnoredPending]
+    "test-failed-suite"          | [TestFailedSuite]
   }
 
   def "test ITR #testcaseName"() {
     givenSkippableTests(skippedTests)
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                       | tests                    | expectedTracesCount | skippedTests
-    "test-itr-skipping"                | [TestSucceed]            | 2                   | [new TestIdentifier("org.example.TestSucceed", "Example.add adds two numbers", null)]
-    "test-itr-unskippable"             | [TestSucceedUnskippable] | 2                   | [
-      new TestIdentifier("org.example.TestSucceedUnskippable", "test should assert something", null)
-    ]
-    "test-itr-unskippable-not-skipped" | [TestSucceedUnskippable] | 2                   | []
+    testcaseName                       | tests                    | skippedTests
+    "test-itr-skipping"                | [TestSucceed]            | [new TestIdentifier("org.example.TestSucceed", "Example.add adds two numbers", null)]
+    "test-itr-unskippable"             | [TestSucceedUnskippable] | [new TestIdentifier("org.example.TestSucceedUnskippable", "test should assert something", null)]
+    "test-itr-unskippable-not-skipped" | [TestSucceedUnskippable] | []
   }
 
   def "test flaky retries #testcaseName"() {
@@ -58,16 +56,16 @@ class ScalatestTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName               | tests                     | expectedTracesCount | retriedTests
-    "test-failed"              | [TestFailed]              | 2                   | []
-    "test-retry-failed"        | [TestFailed]              | 6                   | [new TestIdentifier("org.example.TestFailed", "Example.add adds two numbers", null)]
-    "test-retry-parameterized" | [TestFailedParameterized] | 2                   | [
+    testcaseName               | tests                     | retriedTests
+    "test-failed"              | [TestFailed]              | []
+    "test-retry-failed"        | [TestFailed]              | [new TestIdentifier("org.example.TestFailed", "Example.add adds two numbers", null)]
+    "test-retry-parameterized" | [TestFailedParameterized] | [
       new TestIdentifier("org.example.TestFailedParameterized", "addition should correctly add two numbers", null)
     ]
-    "test-failed-then-succeed" | [TestFailedThenSucceed]   | 4                   | [new TestIdentifier("org.example.TestFailedThenSucceed", "Example.add adds two numbers", null)]
+    "test-failed-then-succeed" | [TestFailedThenSucceed]   | [new TestIdentifier("org.example.TestFailedThenSucceed", "Example.add adds two numbers", null)]
   }
 
   def "test early flakiness detection #testcaseName"() {
@@ -76,14 +74,14 @@ class ScalatestTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                        | tests                  | expectedTracesCount | knownTestsList
-    "test-efd-known-test"               | [TestSucceed]          | 2                   | [new TestIdentifier("org.example.TestSucceed", "Example.add adds two numbers", null)]
-    "test-efd-new-test"                 | [TestSucceed]          | 4                   | []
-    "test-efd-new-slow-test"            | [TestSucceedSlow]      | 3                   | [] // is executed only twice
-    "test-efd-faulty-session-threshold" | [TestSucceedMoreCases] | 8                   | []
+    testcaseName                        | tests                  | knownTestsList
+    "test-efd-known-test"               | [TestSucceed]          | [new TestIdentifier("org.example.TestSucceed", "Example.add adds two numbers", null)]
+    "test-efd-new-test"                 | [TestSucceed]          | []
+    "test-efd-new-slow-test"            | [TestSucceedSlow]      | [] // is executed only twice
+    "test-efd-faulty-session-threshold" | [TestSucceedMoreCases] | []
   }
 
   def "test impacted tests detection #testcaseName"() {
@@ -92,15 +90,15 @@ class ScalatestTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName            | tests         | expectedTracesCount | prDiff
-    "test-succeed"          | [TestSucceed] | 2                   | LineDiff.EMPTY
-    "test-succeed"          | [TestSucceed] | 2                   | new FileDiff(new HashSet())
-    "test-succeed-impacted" | [TestSucceed] | 2                   | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
-    "test-succeed"          | [TestSucceed] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
-    "test-succeed-impacted" | [TestSucceed] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
+    testcaseName            | tests         | prDiff
+    "test-succeed"          | [TestSucceed] | LineDiff.EMPTY
+    "test-succeed"          | [TestSucceed] | new FileDiff(new HashSet())
+    "test-succeed-impacted" | [TestSucceed] | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
+    "test-succeed"          | [TestSucceed] | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
+    "test-succeed-impacted" | [TestSucceed] | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
   }
 
   @Override

--- a/dd-java-agent/instrumentation/selenium/src/latestDepTest/groovy/datadog/trace/instrumentation/selenium/SeleniumLatestTest.groovy
+++ b/dd-java-agent/instrumentation/selenium/src/latestDepTest/groovy/datadog/trace/instrumentation/selenium/SeleniumLatestTest.groovy
@@ -13,9 +13,9 @@ class SeleniumLatestTest extends AbstractSeleniumTest {
 
     runTests(tests)
 
-    def dynamicData = assertSpansData(testcaseName, testCasesCount + 1, [
+    def dynamicData = assertSpansData(testcaseName, [
       "content.meta.['test.browser.driver_version']": SeleniumUtils.SELENIUM_VERSION,
-      "content.meta.['test.browser.version']": Version.getProductVersion()
+      "content.meta.['test.browser.version']"       : Version.getProductVersion()
     ])
     assertRumData(testCasesCount, dynamicData)
 

--- a/dd-java-agent/instrumentation/selenium/src/test/groovy/datadog/trace/instrumentation/selenium/SeleniumTest.groovy
+++ b/dd-java-agent/instrumentation/selenium/src/test/groovy/datadog/trace/instrumentation/selenium/SeleniumTest.groovy
@@ -7,7 +7,7 @@ class SeleniumTest extends AbstractSeleniumTest {
   def "test Selenium #testcaseName"() {
     runTests(tests)
 
-    def dynamicData = assertSpansData(testcaseName, testCasesCount + 1)
+    def dynamicData = assertSpansData(testcaseName)
     assertRumData(testCasesCount, dynamicData)
 
     where:

--- a/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
+++ b/dd-java-agent/instrumentation/testng/src/testFixtures/groovy/datadog/trace/instrumentation/testng/TestNGTest.groovy
@@ -39,40 +39,40 @@ abstract class TestNGTest extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests, null)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                          | tests                                              | expectedTracesCount
-    "test-succeed"                                        | [TestSucceed]                                      | 2
-    "test-inheritance"                                    | [TestInheritance]                                  | 2
-    "test-failed-${version()}"                            | [TestFailed]                                       | 2
-    "test-failed-with-success-percentage-${version()}"    | [TestFailedWithSuccessPercentage]                  | 6
-    "test-error"                                          | [TestError]                                        | 2
-    "test-skipped"                                        | [TestSkipped]                                      | 2
-    "test-parameterized"                                  | [TestParameterized]                                | 3
-    "test-parameterized-modifies-params"                  | [TestParameterizedModifiesParams]                  | 2
-    "test-success-with-groups"                            | [TestSucceedGroups]                                | 2
-    "test-class-skipped"                                  | [TestSkippedClass]                                 | 3
-    "test-success-and-skipped"                            | [TestSucceedAndSkipped]                            | 3
-    "test-success-and-failure-${version()}"               | [TestFailedAndSucceed]                             | 4
-    "test-suite-teardown-failure"                         | [TestFailedSuiteTearDown]                          | 3
-    "test-suite-setup-failure"                            | [TestFailedSuiteSetup]                             | 3
-    "test-multiple-successful-suites"                     | [TestSucceed, TestSucceedAndSkipped]               | 4
-    "test-successful-suite-and-failed-suite-${version()}" | [TestSucceed, TestFailedAndSucceed]                | 5
-    "test-nested-successful-suites"                       | [TestSucceedNested, TestSucceedNested.NestedSuite] | 3
-    "test-nested-skipped-suites-${version()}"             | [TestSkippedNested]                                | 3
-    "test-factory-data-provider"                          | [TestSucceedDataProvider]                          | 2
+    testcaseName                                          | tests
+    "test-succeed"                                        | [TestSucceed]
+    "test-inheritance"                                    | [TestInheritance]
+    "test-failed-${version()}"                            | [TestFailed]
+    "test-failed-with-success-percentage-${version()}"    | [TestFailedWithSuccessPercentage]
+    "test-error"                                          | [TestError]
+    "test-skipped"                                        | [TestSkipped]
+    "test-parameterized"                                  | [TestParameterized]
+    "test-parameterized-modifies-params"                  | [TestParameterizedModifiesParams]
+    "test-success-with-groups"                            | [TestSucceedGroups]
+    "test-class-skipped"                                  | [TestSkippedClass]
+    "test-success-and-skipped"                            | [TestSucceedAndSkipped]
+    "test-success-and-failure-${version()}"               | [TestFailedAndSucceed]
+    "test-suite-teardown-failure"                         | [TestFailedSuiteTearDown]
+    "test-suite-setup-failure"                            | [TestFailedSuiteSetup]
+    "test-multiple-successful-suites"                     | [TestSucceed, TestSucceedAndSkipped]
+    "test-successful-suite-and-failed-suite-${version()}" | [TestSucceed, TestFailedAndSucceed]
+    "test-nested-successful-suites"                       | [TestSucceedNested, TestSucceedNested.NestedSuite]
+    "test-nested-skipped-suites-${version()}"             | [TestSkippedNested]
+    "test-factory-data-provider"                          | [TestSucceedDataProvider]
   }
 
   def "test parallel execution #testcaseName"() {
     runTests(tests, parallelMode)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                | tests                 | expectedTracesCount | parallelMode
-    "test-successful-test-cases-in-parallel"    | [TestSucceedMultiple] | 3                   | "methods"
-    "test-parameterized-test-cases-in-parallel" | [TestParameterized]   | 3                   | "methods"
+    testcaseName                                | tests                 | parallelMode
+    "test-successful-test-cases-in-parallel"    | [TestSucceedMultiple] | "methods"
+    "test-parameterized-test-cases-in-parallel" | [TestParameterized]   | "methods"
   }
 
   def "test XML suites #testcaseName"() {
@@ -82,33 +82,33 @@ abstract class TestNGTest extends CiVisibilityInstrumentationTest {
     }
     runXmlSuites([xmlSuite], parallelMode)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                                                                      | expectedTracesCount | parallelMode
-    "test-successful-test-cases-in-TESTS-parallel-mode"                               | 3                   | "tests"
-    "test-successful-test-cases-in-TESTS-parallel-mode-not-all-test-methods-included" | 3                   | "tests"
-    "test-successful-test-cases-in-TESTS-parallel-mode-same-test-case"                | 4                   | "tests"
+    testcaseName                                                                      | parallelMode
+    "test-successful-test-cases-in-TESTS-parallel-mode"                               | "tests"
+    "test-successful-test-cases-in-TESTS-parallel-mode-not-all-test-methods-included" | "tests"
+    "test-successful-test-cases-in-TESTS-parallel-mode-same-test-case"                | "tests"
   }
 
   def "test ITR #testcaseName"() {
     givenSkippableTests(skippedTests)
     runTests(tests, null)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                              | tests                     | expectedTracesCount | skippedTests
-    "test-itr-skipping"                       | [TestFailedAndSucceed]    | 4                   | [
+    testcaseName                              | tests                     | skippedTests
+    "test-itr-skipping"                       | [TestFailedAndSucceed]    | [
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_another_succeed", null),
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_failed", null)
     ]
-    "test-itr-skipping-parameterized"         | [TestParameterized]       | 3                   | [
+    "test-itr-skipping-parameterized"         | [TestParameterized]       | [
       new TestIdentifier("org.example.TestParameterized", "parameterized_test_succeed", '{"arguments":{"0":"hello","1":"true"}}')
     ]
-    "test-itr-skipping-factory-data-provider" | [TestSucceedDataProvider] | 2                   | [new TestIdentifier("org.example.TestSucceedDataProvider", "testMethod", null)]
-    "test-itr-unskippable"                    | [TestSucceedUnskippable]  | 2                   | [new TestIdentifier("org.example.TestSucceedUnskippable", "test_succeed", null)]
-    "test-itr-unskippable-not-skipped"        | [TestSucceedUnskippable]  | 2                   | []
+    "test-itr-skipping-factory-data-provider" | [TestSucceedDataProvider] | [new TestIdentifier("org.example.TestSucceedDataProvider", "testMethod", null)]
+    "test-itr-unskippable"                    | [TestSucceedUnskippable]  | [new TestIdentifier("org.example.TestSucceedUnskippable", "test_succeed", null)]
+    "test-itr-unskippable-not-skipped"        | [TestSucceedUnskippable]  | []
   }
 
   def "test flaky retries #testcaseName"() {
@@ -116,16 +116,16 @@ abstract class TestNGTest extends CiVisibilityInstrumentationTest {
     givenFlakyTests(retriedTests)
     runTests(tests, null)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                            | tests                     | expectedTracesCount | retriedTests
-    "test-failed-${version()}"              | [TestFailed]              | 2                   | []
-    "test-skipped"                          | [TestSkipped]             | 2                   | [new TestIdentifier("org.example.TestSkipped", "test_skipped", null)]
-    "test-retry-failed-${version()}"        | [TestFailed]              | 6                   | [new TestIdentifier("org.example.TestFailed", "test_failed", null)]
-    "test-retry-error"                      | [TestError]               | 6                   | [new TestIdentifier("org.example.TestError", "test_error", null)]
-    "test-retry-parameterized"              | [TestFailedParameterized] | 7                   | [new TestIdentifier("org.example.TestFailedParameterized", "parameterized_test_succeed", null)]
-    "test-failed-then-succeed-${version()}" | [TestFailedThenSucceed]   | 4                   | [new TestIdentifier("org.example.TestFailedThenSucceed", "test_failed", null)]
+    testcaseName                            | tests                     | retriedTests
+    "test-failed-${version()}"              | [TestFailed]              | []
+    "test-skipped"                          | [TestSkipped]             | [new TestIdentifier("org.example.TestSkipped", "test_skipped", null)]
+    "test-retry-failed-${version()}"        | [TestFailed]              | [new TestIdentifier("org.example.TestFailed", "test_failed", null)]
+    "test-retry-error"                      | [TestError]               | [new TestIdentifier("org.example.TestError", "test_error", null)]
+    "test-retry-parameterized"              | [TestFailedParameterized] | [new TestIdentifier("org.example.TestFailedParameterized", "parameterized_test_succeed", null)]
+    "test-failed-then-succeed-${version()}" | [TestFailedThenSucceed]   | [new TestIdentifier("org.example.TestFailedThenSucceed", "test_failed", null)]
   }
 
   def "test early flakiness detection #testcaseName"() {
@@ -136,21 +136,21 @@ abstract class TestNGTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                        | tests                  | expectedTracesCount | knownTestsList
-    "test-efd-known-test"               | [TestSucceed]          | 2                   | [new TestIdentifier("org.example.TestSucceed", "test_succeed", null)]
-    "test-efd-known-parameterized-test" | [TestParameterized]    | 3                   | [new TestIdentifier("org.example.TestParameterized", "parameterized_test_succeed", null)]
-    "test-efd-new-test"                 | [TestSucceed]          | 4                   | []
-    "test-efd-new-parameterized-test"   | [TestParameterized]    | 7                   | []
-    "test-efd-known-tests-and-new-test" | [TestFailedAndSucceed] | 6                   | [
+    testcaseName                        | tests                  | knownTestsList
+    "test-efd-known-test"               | [TestSucceed]          | [new TestIdentifier("org.example.TestSucceed", "test_succeed", null)]
+    "test-efd-known-parameterized-test" | [TestParameterized]    | [new TestIdentifier("org.example.TestParameterized", "parameterized_test_succeed", null)]
+    "test-efd-new-test"                 | [TestSucceed]          | []
+    "test-efd-new-parameterized-test"   | [TestParameterized]    | []
+    "test-efd-known-tests-and-new-test" | [TestFailedAndSucceed] | [
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_failed", null),
       new TestIdentifier("org.example.TestFailedAndSucceed", "test_succeed", null)
     ]
-    "test-efd-new-slow-test"            | [TestSucceedSlow]      | 3                   | [] // is executed only twice
-    "test-efd-new-very-slow-test"       | [TestSucceedVerySlow]  | 2                   | [] // is executed only once
-    "test-efd-faulty-session-threshold" | [TestFailedAndSucceed] | 8                   | []
+    "test-efd-new-slow-test"            | [TestSucceedSlow]      | [] // is executed only twice
+    "test-efd-new-very-slow-test"       | [TestSucceedVerySlow]  | [] // is executed only once
+    "test-efd-faulty-session-threshold" | [TestFailedAndSucceed] | []
   }
 
   def "test impacted tests detection #testcaseName"() {
@@ -159,15 +159,15 @@ abstract class TestNGTest extends CiVisibilityInstrumentationTest {
 
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName            | tests         | expectedTracesCount | prDiff
-    "test-succeed"          | [TestSucceed] | 2                   | LineDiff.EMPTY
-    "test-succeed"          | [TestSucceed] | 2                   | new FileDiff(new HashSet())
-    "test-succeed-impacted" | [TestSucceed] | 2                   | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
-    "test-succeed"          | [TestSucceed] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
-    "test-succeed-impacted" | [TestSucceed] | 2                   | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
+    testcaseName            | tests         | prDiff
+    "test-succeed"          | [TestSucceed] | LineDiff.EMPTY
+    "test-succeed"          | [TestSucceed] | new FileDiff(new HashSet())
+    "test-succeed-impacted" | [TestSucceed] | new FileDiff(new HashSet([DUMMY_SOURCE_PATH]))
+    "test-succeed"          | [TestSucceed] | new LineDiff([(DUMMY_SOURCE_PATH): lines()])
+    "test-succeed-impacted" | [TestSucceed] | new LineDiff([(DUMMY_SOURCE_PATH): lines(DUMMY_TEST_METHOD_START)])
   }
 
   private static boolean isEFDSupported() {

--- a/dd-java-agent/instrumentation/weaver/src/test/groovy/WeaverTest.groovy
+++ b/dd-java-agent/instrumentation/weaver/src/test/groovy/WeaverTest.groovy
@@ -19,19 +19,19 @@ class WeaverTest extends CiVisibilityInstrumentationTest {
   def "test #testcaseName"() {
     runTests(tests)
 
-    assertSpansData(testcaseName, expectedTracesCount)
+    assertSpansData(testcaseName)
 
     where:
-    testcaseName                   | tests                       | expectedTracesCount
-    "test-succeed-pure"            | [TestSucceedPure]           | 2
-    "test-failed-pure"             | [TestFailedPure]            | 2
-    "test-failed-exception-pure"   | [TestFailedExceptionPure]   | 2
-    "test-succeeded"               | [TestSucceed]               | 2
-    "test-failed"                  | [TestFailed]                | 2
-    "test-ignored"                 | [TestIgnored]               | 2
-    "test-canceled"                | [TestCanceled]              | 2
-    "test-succeed-suite-resource"  | [TestSucceedSuiteResource]  | 3
-    "test-succeed-global-resource" | [TestSucceedGlobalResource] | 2
+    testcaseName                   | tests
+    "test-succeed-pure"            | [TestSucceedPure]
+    "test-failed-pure"             | [TestFailedPure]
+    "test-failed-exception-pure"   | [TestFailedExceptionPure]
+    "test-succeeded"               | [TestSucceed]
+    "test-failed"                  | [TestFailed]
+    "test-ignored"                 | [TestIgnored]
+    "test-canceled"                | [TestCanceled]
+    "test-succeed-suite-resource"  | [TestSucceedSuiteResource]
+    "test-succeed-global-resource" | [TestSucceedGlobalResource]
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

Removes `expectedTraceCount` parameter from CI Visibility instrumentation tests.
Instead of requiring the expected count to be specified manually, the tests will use expected data to calculate for how many spans to wait.

# Motivation

Simplify writing tests.

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [SDTEST-1483](https://datadoghq.atlassian.net/browse/SDTEST-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
