### PR TITLE
Ensure IAST smoke tests wait for the product to be started

### DIFF
--- a/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastServerSmokeTest.groovy
+++ b/dd-smoke-tests/iast-util/src/testFixtures/groovy/datadog/smoketest/AbstractIastServerSmokeTest.groovy
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeoutException
 abstract class AbstractIastServerSmokeTest extends AbstractServerSmokeTest {
 
   private static final String TAG_NAME = '_dd.iast.json'
+  private static final String IAST_STARTED_MSG = 'IAST started'
 
   @Shared
   private final JsonSlurper jsonSlurper = new JsonSlurper()
@@ -30,6 +31,14 @@ abstract class AbstractIastServerSmokeTest extends AbstractServerSmokeTest {
   @Override
   Closure decodedTracesCallback() {
     return {} // force traces decoding
+  }
+
+  def setupSpec() {
+    try {
+      processTestLogLines { it.contains(IAST_STARTED_MSG) }
+    } catch (TimeoutException toe) {
+      throw new AssertionError("'$IAST_STARTED_MSG' not found in logs", toe)
+    }
   }
 
   protected static String withSystemProperty(final String config, final Object value) {


### PR DESCRIPTION
# What Does This Do
Ensures all IAST related smoke tests wait for the product to be fully initialized before triggering any request.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title [according the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any usefull labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) in case of new configuration flag or behavior

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
